### PR TITLE
pkg: gecko_sdk: update version

### DIFF
--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg990f1024.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg990f1024.h
@@ -2,10 +2,10 @@
  * @file efm32gg990f1024.h
  * @brief CMSIS Cortex-M Peripheral Access Layer Header File
  *        for EFM32GG990F1024
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,
@@ -194,10 +194,10 @@ typedef enum IRQn{
 #define EXT_IRQ_COUNT        39             /**< Number of External (NVIC) interrupts */
 
 /** AF channels connect the different on-chip peripherals with the af-mux */
-#define AFCHAN_MAX           163
-#define AFCHANLOC_MAX        7
+#define AFCHAN_MAX           163U
+#define AFCHANLOC_MAX        7U
 /** Analog AF channels */
-#define AFACHAN_MAX          53
+#define AFACHAN_MAX          53U
 
 /* Part number capabilities */
 

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_acmp.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_acmp.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32gg_acmp.h
  * @brief EFM32GG_ACMP register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_adc.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_adc.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32gg_adc.h
  * @brief EFM32GG_ADC register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_aes.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_aes.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32gg_aes.h
  * @brief EFM32GG_AES register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_af_pins.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_af_pins.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32gg_af_pins.h
  * @brief EFM32GG_AF_PINS register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_af_ports.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_af_ports.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32gg_af_ports.h
  * @brief EFM32GG_AF_PORTS register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_burtc.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_burtc.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32gg_burtc.h
  * @brief EFM32GG_BURTC register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_burtc_ret.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_burtc_ret.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32gg_burtc_ret.h
  * @brief EFM32GG_BURTC_RET register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_calibrate.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_calibrate.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32gg_calibrate.h
  * @brief EFM32GG_CALIBRATE register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_cmu.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_cmu.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32gg_cmu.h
  * @brief EFM32GG_CMU register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_dac.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_dac.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32gg_dac.h
  * @brief EFM32GG_DAC register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_devinfo.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_devinfo.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32gg_devinfo.h
  * @brief EFM32GG_DEVINFO register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_dma.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_dma.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32gg_dma.h
  * @brief EFM32GG_DMA register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_dma_ch.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_dma_ch.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32gg_dma_ch.h
  * @brief EFM32GG_DMA_CH register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_dma_descriptor.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_dma_descriptor.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32gg_dma_descriptor.h
  * @brief EFM32GG_DMA_DESCRIPTOR register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_dmactrl.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_dmactrl.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32gg_dmactrl.h
  * @brief EFM32GG_DMACTRL register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_dmareq.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_dmareq.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32gg_dmareq.h
  * @brief EFM32GG_DMAREQ register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_ebi.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_ebi.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32gg_ebi.h
  * @brief EFM32GG_EBI register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_emu.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_emu.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32gg_emu.h
  * @brief EFM32GG_EMU register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_etm.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_etm.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32gg_etm.h
  * @brief EFM32GG_ETM register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_gpio.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_gpio.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32gg_gpio.h
  * @brief EFM32GG_GPIO register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_gpio_p.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_gpio_p.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32gg_gpio_p.h
  * @brief EFM32GG_GPIO_P register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_i2c.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_i2c.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32gg_i2c.h
  * @brief EFM32GG_I2C register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_lcd.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_lcd.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32gg_lcd.h
  * @brief EFM32GG_LCD register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_lesense.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_lesense.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32gg_lesense.h
  * @brief EFM32GG_LESENSE register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_lesense_buf.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_lesense_buf.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32gg_lesense_buf.h
  * @brief EFM32GG_LESENSE_BUF register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_lesense_ch.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_lesense_ch.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32gg_lesense_ch.h
  * @brief EFM32GG_LESENSE_CH register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_lesense_st.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_lesense_st.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32gg_lesense_st.h
  * @brief EFM32GG_LESENSE_ST register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_letimer.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_letimer.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32gg_letimer.h
  * @brief EFM32GG_LETIMER register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_leuart.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_leuart.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32gg_leuart.h
  * @brief EFM32GG_LEUART register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_msc.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_msc.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32gg_msc.h
  * @brief EFM32GG_MSC register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_pcnt.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_pcnt.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32gg_pcnt.h
  * @brief EFM32GG_PCNT register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_prs.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_prs.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32gg_prs.h
  * @brief EFM32GG_PRS register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_prs_ch.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_prs_ch.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32gg_prs_ch.h
  * @brief EFM32GG_PRS_CH register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_prs_signals.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_prs_signals.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32gg_prs_signals.h
  * @brief EFM32GG_PRS_SIGNALS register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_rmu.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_rmu.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32gg_rmu.h
  * @brief EFM32GG_RMU register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_romtable.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_romtable.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32gg_romtable.h
  * @brief EFM32GG_ROMTABLE register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_rtc.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_rtc.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32gg_rtc.h
  * @brief EFM32GG_RTC register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_timer.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_timer.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32gg_timer.h
  * @brief EFM32GG_TIMER register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_timer_cc.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_timer_cc.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32gg_timer_cc.h
  * @brief EFM32GG_TIMER_CC register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_uart.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_uart.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32gg_uart.h
  * @brief EFM32GG_UART register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_usart.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_usart.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32gg_usart.h
  * @brief EFM32GG_USART register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_usb.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_usb.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32gg_usb.h
  * @brief EFM32GG_USB register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_usb_diep.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_usb_diep.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32gg_usb_diep.h
  * @brief EFM32GG_USB_DIEP register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_usb_doep.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_usb_doep.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32gg_usb_doep.h
  * @brief EFM32GG_USB_DOEP register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_usb_hc.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_usb_hc.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32gg_usb_hc.h
  * @brief EFM32GG_USB_HC register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_vcmp.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_vcmp.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32gg_vcmp.h
  * @brief EFM32GG_VCMP register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32gg/include/vendor/efm32gg_wdog.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/efm32gg_wdog.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32gg_wdog.h
  * @brief EFM32GG_WDOG register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32gg/include/vendor/em_device.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/em_device.h
@@ -12,10 +12,10 @@
 
  *
  * @endverbatim
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32gg/include/vendor/system_efm32gg.h
+++ b/cpu/efm32/families/efm32gg/include/vendor/system_efm32gg.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file system_efm32gg.h
  * @brief CMSIS Cortex-M3 System Layer for EFM32GG devices.
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,
@@ -129,7 +129,7 @@ uint32_t SystemMaxCoreClockGet(void);
  *****************************************************************************/
 static __INLINE void SystemCoreClockUpdate(void)
 {
-  SystemCoreClockGet();
+  (void)SystemCoreClockGet();
 }
 
 void SystemInit(void);

--- a/cpu/efm32/families/efm32gg/system.c
+++ b/cpu/efm32/families/efm32gg/system.c
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file system_efm32gg.c
  * @brief CMSIS Cortex-M3 System Layer for EFM32GG devices.
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,
@@ -86,8 +86,8 @@ static uint32_t SystemLFXOClock = EFM32_LFXO_FREQ;
 /* Inline function to get the chip's Production Revision. */
 __STATIC_INLINE uint8_t GetProdRev(void)
 {
-  return ((DEVINFO->PART & _DEVINFO_PART_PROD_REV_MASK)
-          >> _DEVINFO_PART_PROD_REV_SHIFT);
+  return (uint8_t)((DEVINFO->PART & _DEVINFO_PART_PROD_REV_MASK)
+                   >> _DEVINFO_PART_PROD_REV_SHIFT);
 }
 
 /*******************************************************************************
@@ -150,8 +150,11 @@ uint32_t SystemCoreClockGet(void)
  ******************************************************************************/
 uint32_t SystemMaxCoreClockGet(void)
 {
-  return (EFM32_HFRCO_MAX_FREQ > EFM32_HFXO_FREQ \
-          ? EFM32_HFRCO_MAX_FREQ : EFM32_HFXO_FREQ);
+#if (EFM32_HFRCO_MAX_FREQ > EFM32_HFXO_FREQ)
+  return EFM32_HFRCO_MAX_FREQ;
+#else
+  return EFM32_HFXO_FREQ;
+#endif
 }
 
 /***************************************************************************//**
@@ -197,34 +200,34 @@ uint32_t SystemHFClockGet(void)
     default: /* CMU_STATUS_HFRCOSEL */
       switch (CMU->HFRCOCTRL & _CMU_HFRCOCTRL_BAND_MASK) {
         case CMU_HFRCOCTRL_BAND_28MHZ:
-          ret = 28000000;
+          ret = 28000000U;
           break;
 
         case CMU_HFRCOCTRL_BAND_21MHZ:
-          ret = 21000000;
+          ret = 21000000U;
           break;
 
         case CMU_HFRCOCTRL_BAND_14MHZ:
-          ret = 14000000;
+          ret = 14000000U;
           break;
 
         case CMU_HFRCOCTRL_BAND_11MHZ:
-          ret = 11000000;
+          ret = 11000000U;
           break;
 
         case CMU_HFRCOCTRL_BAND_7MHZ:
-          if ( GetProdRev() >= 19 ) {
-            ret = 6600000;
+          if ( GetProdRev() >= 19U ) {
+            ret = 6600000U;
           } else {
-            ret = 7000000;
+            ret = 7000000U;
           }
           break;
 
         case CMU_HFRCOCTRL_BAND_1MHZ:
-          if ( GetProdRev() >= 19 ) {
-            ret = 1200000;
+          if ( GetProdRev() >= 19U ) {
+            ret = 1200000U;
           } else {
-            ret = 1000000;
+            ret = 1000000U;
           }
           break;
 
@@ -281,9 +284,9 @@ void SystemHFXOClockSet(uint32_t freq)
   SystemHFXOClock = freq;
 
   /* Update core clock frequency if HFXO is used to clock core */
-  if (CMU->STATUS & CMU_STATUS_HFXOSEL) {
+  if ((CMU->STATUS & CMU_STATUS_HFXOSEL) != 0U) {
     /* The function will update the global variable */
-    SystemCoreClockGet();
+    (void)SystemCoreClockGet();
   }
 #else
   (void)freq; /* Unused parameter */
@@ -382,9 +385,9 @@ void SystemLFXOClockSet(uint32_t freq)
   SystemLFXOClock = freq;
 
   /* Update core clock frequency if LFXO is used to clock core */
-  if (CMU->STATUS & CMU_STATUS_LFXOSEL) {
+  if ((CMU->STATUS & CMU_STATUS_LFXOSEL) != 0U) {
     /* The function will update the global variable */
-    SystemCoreClockGet();
+    (void)SystemCoreClockGet();
   }
 #else
   (void)freq; /* Unused parameter */

--- a/cpu/efm32/families/efm32gg/vectors.c
+++ b/cpu/efm32/families/efm32gg/vectors.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2017 Freie Universität Berlin
+ * Copyright (C) 2015-2018 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg990f256.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg990f256.h
@@ -2,10 +2,10 @@
  * @file efm32lg990f256.h
  * @brief CMSIS Cortex-M Peripheral Access Layer Header File
  *        for EFM32LG990F256
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,
@@ -195,10 +195,10 @@ typedef enum IRQn{
 #define EXT_IRQ_COUNT        40             /**< Number of External (NVIC) interrupts */
 
 /** AF channels connect the different on-chip peripherals with the af-mux */
-#define AFCHAN_MAX           163
-#define AFCHANLOC_MAX        7
+#define AFCHAN_MAX           163U
+#define AFCHANLOC_MAX        7U
 /** Analog AF channels */
-#define AFACHAN_MAX          53
+#define AFACHAN_MAX          53U
 
 /* Part number capabilities */
 

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_acmp.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_acmp.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32lg_acmp.h
  * @brief EFM32LG_ACMP register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_adc.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_adc.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32lg_adc.h
  * @brief EFM32LG_ADC register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_aes.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_aes.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32lg_aes.h
  * @brief EFM32LG_AES register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_af_pins.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_af_pins.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32lg_af_pins.h
  * @brief EFM32LG_AF_PINS register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_af_ports.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_af_ports.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32lg_af_ports.h
  * @brief EFM32LG_AF_PORTS register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_burtc.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_burtc.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32lg_burtc.h
  * @brief EFM32LG_BURTC register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_burtc_ret.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_burtc_ret.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32lg_burtc_ret.h
  * @brief EFM32LG_BURTC_RET register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_calibrate.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_calibrate.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32lg_calibrate.h
  * @brief EFM32LG_CALIBRATE register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_cmu.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_cmu.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32lg_cmu.h
  * @brief EFM32LG_CMU register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_dac.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_dac.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32lg_dac.h
  * @brief EFM32LG_DAC register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_devinfo.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_devinfo.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32lg_devinfo.h
  * @brief EFM32LG_DEVINFO register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_dma.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_dma.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32lg_dma.h
  * @brief EFM32LG_DMA register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_dma_ch.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_dma_ch.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32lg_dma_ch.h
  * @brief EFM32LG_DMA_CH register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_dma_descriptor.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_dma_descriptor.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32lg_dma_descriptor.h
  * @brief EFM32LG_DMA_DESCRIPTOR register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_dmactrl.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_dmactrl.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32lg_dmactrl.h
  * @brief EFM32LG_DMACTRL register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_dmareq.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_dmareq.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32lg_dmareq.h
  * @brief EFM32LG_DMAREQ register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_ebi.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_ebi.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32lg_ebi.h
  * @brief EFM32LG_EBI register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_emu.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_emu.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32lg_emu.h
  * @brief EFM32LG_EMU register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_etm.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_etm.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32lg_etm.h
  * @brief EFM32LG_ETM register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_gpio.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_gpio.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32lg_gpio.h
  * @brief EFM32LG_GPIO register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_gpio_p.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_gpio_p.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32lg_gpio_p.h
  * @brief EFM32LG_GPIO_P register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_i2c.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_i2c.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32lg_i2c.h
  * @brief EFM32LG_I2C register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_lcd.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_lcd.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32lg_lcd.h
  * @brief EFM32LG_LCD register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_lesense.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_lesense.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32lg_lesense.h
  * @brief EFM32LG_LESENSE register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_lesense_buf.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_lesense_buf.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32lg_lesense_buf.h
  * @brief EFM32LG_LESENSE_BUF register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_lesense_ch.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_lesense_ch.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32lg_lesense_ch.h
  * @brief EFM32LG_LESENSE_CH register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_lesense_st.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_lesense_st.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32lg_lesense_st.h
  * @brief EFM32LG_LESENSE_ST register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_letimer.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_letimer.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32lg_letimer.h
  * @brief EFM32LG_LETIMER register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_leuart.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_leuart.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32lg_leuart.h
  * @brief EFM32LG_LEUART register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_msc.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_msc.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32lg_msc.h
  * @brief EFM32LG_MSC register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_pcnt.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_pcnt.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32lg_pcnt.h
  * @brief EFM32LG_PCNT register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_prs.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_prs.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32lg_prs.h
  * @brief EFM32LG_PRS register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_prs_ch.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_prs_ch.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32lg_prs_ch.h
  * @brief EFM32LG_PRS_CH register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_prs_signals.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_prs_signals.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32lg_prs_signals.h
  * @brief EFM32LG_PRS_SIGNALS register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_rmu.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_rmu.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32lg_rmu.h
  * @brief EFM32LG_RMU register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_romtable.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_romtable.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32lg_romtable.h
  * @brief EFM32LG_ROMTABLE register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_rtc.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_rtc.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32lg_rtc.h
  * @brief EFM32LG_RTC register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_timer.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_timer.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32lg_timer.h
  * @brief EFM32LG_TIMER register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_timer_cc.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_timer_cc.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32lg_timer_cc.h
  * @brief EFM32LG_TIMER_CC register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_uart.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_uart.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32lg_uart.h
  * @brief EFM32LG_UART register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_usart.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_usart.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32lg_usart.h
  * @brief EFM32LG_USART register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_usb.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_usb.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32lg_usb.h
  * @brief EFM32LG_USB register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_usb_diep.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_usb_diep.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32lg_usb_diep.h
  * @brief EFM32LG_USB_DIEP register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_usb_doep.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_usb_doep.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32lg_usb_doep.h
  * @brief EFM32LG_USB_DOEP register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_usb_hc.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_usb_hc.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32lg_usb_hc.h
  * @brief EFM32LG_USB_HC register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_vcmp.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_vcmp.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32lg_vcmp.h
  * @brief EFM32LG_VCMP register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32lg/include/vendor/efm32lg_wdog.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/efm32lg_wdog.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32lg_wdog.h
  * @brief EFM32LG_WDOG register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32lg/include/vendor/em_device.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/em_device.h
@@ -12,10 +12,10 @@
 
  *
  * @endverbatim
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32lg/include/vendor/system_efm32lg.h
+++ b/cpu/efm32/families/efm32lg/include/vendor/system_efm32lg.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file system_efm32lg.h
  * @brief CMSIS Cortex-M3 System Layer for EFM32LG devices.
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,
@@ -129,7 +129,7 @@ uint32_t SystemMaxCoreClockGet(void);
  *****************************************************************************/
 static __INLINE void SystemCoreClockUpdate(void)
 {
-  SystemCoreClockGet();
+  (void)SystemCoreClockGet();
 }
 
 void SystemInit(void);

--- a/cpu/efm32/families/efm32lg/system.c
+++ b/cpu/efm32/families/efm32lg/system.c
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file system_efm32lg.c
  * @brief CMSIS Cortex-M3 System Layer for EFM32LG devices.
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,
@@ -86,8 +86,8 @@ static uint32_t SystemLFXOClock = EFM32_LFXO_FREQ;
 /* Inline function to get the chip's Production Revision. */
 __STATIC_INLINE uint8_t GetProdRev(void)
 {
-  return ((DEVINFO->PART & _DEVINFO_PART_PROD_REV_MASK)
-          >> _DEVINFO_PART_PROD_REV_SHIFT);
+  return (uint8_t)((DEVINFO->PART & _DEVINFO_PART_PROD_REV_MASK)
+                   >> _DEVINFO_PART_PROD_REV_SHIFT);
 }
 
 /*******************************************************************************
@@ -150,8 +150,11 @@ uint32_t SystemCoreClockGet(void)
  ******************************************************************************/
 uint32_t SystemMaxCoreClockGet(void)
 {
-  return (EFM32_HFRCO_MAX_FREQ > EFM32_HFXO_FREQ \
-          ? EFM32_HFRCO_MAX_FREQ : EFM32_HFXO_FREQ);
+#if (EFM32_HFRCO_MAX_FREQ > EFM32_HFXO_FREQ)
+  return EFM32_HFRCO_MAX_FREQ;
+#else
+  return EFM32_HFXO_FREQ;
+#endif
 }
 
 /***************************************************************************//**
@@ -197,34 +200,34 @@ uint32_t SystemHFClockGet(void)
     default: /* CMU_STATUS_HFRCOSEL */
       switch (CMU->HFRCOCTRL & _CMU_HFRCOCTRL_BAND_MASK) {
         case CMU_HFRCOCTRL_BAND_28MHZ:
-          ret = 28000000;
+          ret = 28000000U;
           break;
 
         case CMU_HFRCOCTRL_BAND_21MHZ:
-          ret = 21000000;
+          ret = 21000000U;
           break;
 
         case CMU_HFRCOCTRL_BAND_14MHZ:
-          ret = 14000000;
+          ret = 14000000U;
           break;
 
         case CMU_HFRCOCTRL_BAND_11MHZ:
-          ret = 11000000;
+          ret = 11000000U;
           break;
 
         case CMU_HFRCOCTRL_BAND_7MHZ:
-          if ( GetProdRev() >= 19 ) {
-            ret = 6600000;
+          if ( GetProdRev() >= 19U ) {
+            ret = 6600000U;
           } else {
-            ret = 7000000;
+            ret = 7000000U;
           }
           break;
 
         case CMU_HFRCOCTRL_BAND_1MHZ:
-          if ( GetProdRev() >= 19 ) {
-            ret = 1200000;
+          if ( GetProdRev() >= 19U ) {
+            ret = 1200000U;
           } else {
-            ret = 1000000;
+            ret = 1000000U;
           }
           break;
 
@@ -281,9 +284,9 @@ void SystemHFXOClockSet(uint32_t freq)
   SystemHFXOClock = freq;
 
   /* Update core clock frequency if HFXO is used to clock core */
-  if (CMU->STATUS & CMU_STATUS_HFXOSEL) {
+  if ((CMU->STATUS & CMU_STATUS_HFXOSEL) != 0U) {
     /* The function will update the global variable */
-    SystemCoreClockGet();
+    (void)SystemCoreClockGet();
   }
 #else
   (void)freq; /* Unused parameter */
@@ -382,9 +385,9 @@ void SystemLFXOClockSet(uint32_t freq)
   SystemLFXOClock = freq;
 
   /* Update core clock frequency if LFXO is used to clock core */
-  if (CMU->STATUS & CMU_STATUS_LFXOSEL) {
+  if ((CMU->STATUS & CMU_STATUS_LFXOSEL) != 0U) {
     /* The function will update the global variable */
-    SystemCoreClockGet();
+    (void)SystemCoreClockGet();
   }
 #else
   (void)freq; /* Unused parameter */

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b200f256gm48.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b200f256gm48.h
@@ -2,10 +2,10 @@
  * @file efm32pg1b200f256gm48.h
  * @brief CMSIS Cortex-M Peripheral Access Layer Header File
  *        for EFM32PG1B200F256GM48
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,
@@ -189,11 +189,11 @@ typedef enum IRQn{
 #define EXT_IRQ_COUNT             34             /**< Number of External (NVIC) interrupts */
 
 /** AF channels connect the different on-chip peripherals with the af-mux */
-#define AFCHAN_MAX                72
+#define AFCHAN_MAX                72U
 /** AF channel maximum location number */
-#define AFCHANLOC_MAX             32
+#define AFCHANLOC_MAX             32U
 /** Analog AF channels */
-#define AFACHAN_MAX               61
+#define AFACHAN_MAX               61U
 
 /* Part number capabilities */
 

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_acmp.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_acmp.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32pg1b_acmp.h
  * @brief EFM32PG1B_ACMP register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,
@@ -113,7 +113,7 @@ typedef struct {
 #define _ACMP_CTRL_APORTYMASTERDIS_MASK                0x200UL                                    /**< Bit mask for ACMP_APORTYMASTERDIS */
 #define _ACMP_CTRL_APORTYMASTERDIS_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for ACMP_CTRL */
 #define ACMP_CTRL_APORTYMASTERDIS_DEFAULT              (_ACMP_CTRL_APORTYMASTERDIS_DEFAULT << 9)  /**< Shifted mode DEFAULT for ACMP_CTRL */
-#define ACMP_CTRL_APORTVMASTERDIS                      (0x1UL << 10)                              /**< APORT Bus Master Disable for Bus selected by VASEL */
+#define ACMP_CTRL_APORTVMASTERDIS                      (0x1UL << 10)                              /**< APORT Bus Master Disable for Bus Selected By VASEL */
 #define _ACMP_CTRL_APORTVMASTERDIS_SHIFT               10                                         /**< Shift value for ACMP_APORTVMASTERDIS */
 #define _ACMP_CTRL_APORTVMASTERDIS_MASK                0x400UL                                    /**< Bit mask for ACMP_APORTVMASTERDIS */
 #define _ACMP_CTRL_APORTVMASTERDIS_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for ACMP_CTRL */
@@ -122,15 +122,15 @@ typedef struct {
 #define _ACMP_CTRL_PWRSEL_MASK                         0x7000UL                                   /**< Bit mask for ACMP_PWRSEL */
 #define _ACMP_CTRL_PWRSEL_DEFAULT                      0x00000000UL                               /**< Mode DEFAULT for ACMP_CTRL */
 #define _ACMP_CTRL_PWRSEL_AVDD                         0x00000000UL                               /**< Mode AVDD for ACMP_CTRL */
-#define _ACMP_CTRL_PWRSEL_VREGVDD                      0x00000001UL                               /**< Mode VREGVDD for ACMP_CTRL */
+#define _ACMP_CTRL_PWRSEL_DVDD                         0x00000001UL                               /**< Mode DVDD for ACMP_CTRL */
 #define _ACMP_CTRL_PWRSEL_IOVDD0                       0x00000002UL                               /**< Mode IOVDD0 for ACMP_CTRL */
 #define _ACMP_CTRL_PWRSEL_IOVDD1                       0x00000004UL                               /**< Mode IOVDD1 for ACMP_CTRL */
 #define ACMP_CTRL_PWRSEL_DEFAULT                       (_ACMP_CTRL_PWRSEL_DEFAULT << 12)          /**< Shifted mode DEFAULT for ACMP_CTRL */
 #define ACMP_CTRL_PWRSEL_AVDD                          (_ACMP_CTRL_PWRSEL_AVDD << 12)             /**< Shifted mode AVDD for ACMP_CTRL */
-#define ACMP_CTRL_PWRSEL_VREGVDD                       (_ACMP_CTRL_PWRSEL_VREGVDD << 12)          /**< Shifted mode VREGVDD for ACMP_CTRL */
+#define ACMP_CTRL_PWRSEL_DVDD                          (_ACMP_CTRL_PWRSEL_DVDD << 12)             /**< Shifted mode DVDD for ACMP_CTRL */
 #define ACMP_CTRL_PWRSEL_IOVDD0                        (_ACMP_CTRL_PWRSEL_IOVDD0 << 12)           /**< Shifted mode IOVDD0 for ACMP_CTRL */
 #define ACMP_CTRL_PWRSEL_IOVDD1                        (_ACMP_CTRL_PWRSEL_IOVDD1 << 12)           /**< Shifted mode IOVDD1 for ACMP_CTRL */
-#define ACMP_CTRL_ACCURACY                             (0x1UL << 15)                              /**< ACMP accuracy mode */
+#define ACMP_CTRL_ACCURACY                             (0x1UL << 15)                              /**< ACMP Accuracy Mode */
 #define _ACMP_CTRL_ACCURACY_SHIFT                      15                                         /**< Shift value for ACMP_ACCURACY */
 #define _ACMP_CTRL_ACCURACY_MASK                       0x8000UL                                   /**< Bit mask for ACMP_ACCURACY */
 #define _ACMP_CTRL_ACCURACY_DEFAULT                    0x00000000UL                               /**< Mode DEFAULT for ACMP_CTRL */
@@ -1092,52 +1092,52 @@ typedef struct {
 /* Bit fields for ACMP APORTREQ */
 #define _ACMP_APORTREQ_RESETVALUE                      0x00000000UL                             /**< Default value for ACMP_APORTREQ */
 #define _ACMP_APORTREQ_MASK                            0x000003FFUL                             /**< Mask for ACMP_APORTREQ */
-#define ACMP_APORTREQ_APORT0XREQ                       (0x1UL << 0)                             /**< 1 if the bus connected to APORT0X is requested */
+#define ACMP_APORTREQ_APORT0XREQ                       (0x1UL << 0)                             /**< 1 If the Bus Connected to APORT0X is Requested */
 #define _ACMP_APORTREQ_APORT0XREQ_SHIFT                0                                        /**< Shift value for ACMP_APORT0XREQ */
 #define _ACMP_APORTREQ_APORT0XREQ_MASK                 0x1UL                                    /**< Bit mask for ACMP_APORT0XREQ */
 #define _ACMP_APORTREQ_APORT0XREQ_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for ACMP_APORTREQ */
 #define ACMP_APORTREQ_APORT0XREQ_DEFAULT               (_ACMP_APORTREQ_APORT0XREQ_DEFAULT << 0) /**< Shifted mode DEFAULT for ACMP_APORTREQ */
-#define ACMP_APORTREQ_APORT0YREQ                       (0x1UL << 1)                             /**< 1 if the bus connected to APORT0Y is requested */
+#define ACMP_APORTREQ_APORT0YREQ                       (0x1UL << 1)                             /**< 1 If the Bus Connected to APORT0Y is Requested */
 #define _ACMP_APORTREQ_APORT0YREQ_SHIFT                1                                        /**< Shift value for ACMP_APORT0YREQ */
 #define _ACMP_APORTREQ_APORT0YREQ_MASK                 0x2UL                                    /**< Bit mask for ACMP_APORT0YREQ */
 #define _ACMP_APORTREQ_APORT0YREQ_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for ACMP_APORTREQ */
 #define ACMP_APORTREQ_APORT0YREQ_DEFAULT               (_ACMP_APORTREQ_APORT0YREQ_DEFAULT << 1) /**< Shifted mode DEFAULT for ACMP_APORTREQ */
-#define ACMP_APORTREQ_APORT1XREQ                       (0x1UL << 2)                             /**< 1 if the bus connected to APORT2X is requested */
+#define ACMP_APORTREQ_APORT1XREQ                       (0x1UL << 2)                             /**< 1 If the Bus Connected to APORT2X is Requested */
 #define _ACMP_APORTREQ_APORT1XREQ_SHIFT                2                                        /**< Shift value for ACMP_APORT1XREQ */
 #define _ACMP_APORTREQ_APORT1XREQ_MASK                 0x4UL                                    /**< Bit mask for ACMP_APORT1XREQ */
 #define _ACMP_APORTREQ_APORT1XREQ_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for ACMP_APORTREQ */
 #define ACMP_APORTREQ_APORT1XREQ_DEFAULT               (_ACMP_APORTREQ_APORT1XREQ_DEFAULT << 2) /**< Shifted mode DEFAULT for ACMP_APORTREQ */
-#define ACMP_APORTREQ_APORT1YREQ                       (0x1UL << 3)                             /**< 1 if the bus connected to APORT1X is requested */
+#define ACMP_APORTREQ_APORT1YREQ                       (0x1UL << 3)                             /**< 1 If the Bus Connected to APORT1X is Requested */
 #define _ACMP_APORTREQ_APORT1YREQ_SHIFT                3                                        /**< Shift value for ACMP_APORT1YREQ */
 #define _ACMP_APORTREQ_APORT1YREQ_MASK                 0x8UL                                    /**< Bit mask for ACMP_APORT1YREQ */
 #define _ACMP_APORTREQ_APORT1YREQ_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for ACMP_APORTREQ */
 #define ACMP_APORTREQ_APORT1YREQ_DEFAULT               (_ACMP_APORTREQ_APORT1YREQ_DEFAULT << 3) /**< Shifted mode DEFAULT for ACMP_APORTREQ */
-#define ACMP_APORTREQ_APORT2XREQ                       (0x1UL << 4)                             /**< 1 if the bus connected to APORT2X is requested */
+#define ACMP_APORTREQ_APORT2XREQ                       (0x1UL << 4)                             /**< 1 If the Bus Connected to APORT2X is Requested */
 #define _ACMP_APORTREQ_APORT2XREQ_SHIFT                4                                        /**< Shift value for ACMP_APORT2XREQ */
 #define _ACMP_APORTREQ_APORT2XREQ_MASK                 0x10UL                                   /**< Bit mask for ACMP_APORT2XREQ */
 #define _ACMP_APORTREQ_APORT2XREQ_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for ACMP_APORTREQ */
 #define ACMP_APORTREQ_APORT2XREQ_DEFAULT               (_ACMP_APORTREQ_APORT2XREQ_DEFAULT << 4) /**< Shifted mode DEFAULT for ACMP_APORTREQ */
-#define ACMP_APORTREQ_APORT2YREQ                       (0x1UL << 5)                             /**< 1 if the bus connected to APORT2Y is requested */
+#define ACMP_APORTREQ_APORT2YREQ                       (0x1UL << 5)                             /**< 1 If the Bus Connected to APORT2Y is Requested */
 #define _ACMP_APORTREQ_APORT2YREQ_SHIFT                5                                        /**< Shift value for ACMP_APORT2YREQ */
 #define _ACMP_APORTREQ_APORT2YREQ_MASK                 0x20UL                                   /**< Bit mask for ACMP_APORT2YREQ */
 #define _ACMP_APORTREQ_APORT2YREQ_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for ACMP_APORTREQ */
 #define ACMP_APORTREQ_APORT2YREQ_DEFAULT               (_ACMP_APORTREQ_APORT2YREQ_DEFAULT << 5) /**< Shifted mode DEFAULT for ACMP_APORTREQ */
-#define ACMP_APORTREQ_APORT3XREQ                       (0x1UL << 6)                             /**< 1 if the bus connected to APORT3X is requested */
+#define ACMP_APORTREQ_APORT3XREQ                       (0x1UL << 6)                             /**< 1 If the Bus Connected to APORT3X is Requested */
 #define _ACMP_APORTREQ_APORT3XREQ_SHIFT                6                                        /**< Shift value for ACMP_APORT3XREQ */
 #define _ACMP_APORTREQ_APORT3XREQ_MASK                 0x40UL                                   /**< Bit mask for ACMP_APORT3XREQ */
 #define _ACMP_APORTREQ_APORT3XREQ_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for ACMP_APORTREQ */
 #define ACMP_APORTREQ_APORT3XREQ_DEFAULT               (_ACMP_APORTREQ_APORT3XREQ_DEFAULT << 6) /**< Shifted mode DEFAULT for ACMP_APORTREQ */
-#define ACMP_APORTREQ_APORT3YREQ                       (0x1UL << 7)                             /**< 1 if the bus connected to APORT3Y is requested */
+#define ACMP_APORTREQ_APORT3YREQ                       (0x1UL << 7)                             /**< 1 If the Bus Connected to APORT3Y is Requested */
 #define _ACMP_APORTREQ_APORT3YREQ_SHIFT                7                                        /**< Shift value for ACMP_APORT3YREQ */
 #define _ACMP_APORTREQ_APORT3YREQ_MASK                 0x80UL                                   /**< Bit mask for ACMP_APORT3YREQ */
 #define _ACMP_APORTREQ_APORT3YREQ_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for ACMP_APORTREQ */
 #define ACMP_APORTREQ_APORT3YREQ_DEFAULT               (_ACMP_APORTREQ_APORT3YREQ_DEFAULT << 7) /**< Shifted mode DEFAULT for ACMP_APORTREQ */
-#define ACMP_APORTREQ_APORT4XREQ                       (0x1UL << 8)                             /**< 1 if the bus connected to APORT4X is requested */
+#define ACMP_APORTREQ_APORT4XREQ                       (0x1UL << 8)                             /**< 1 If the Bus Connected to APORT4X is Requested */
 #define _ACMP_APORTREQ_APORT4XREQ_SHIFT                8                                        /**< Shift value for ACMP_APORT4XREQ */
 #define _ACMP_APORTREQ_APORT4XREQ_MASK                 0x100UL                                  /**< Bit mask for ACMP_APORT4XREQ */
 #define _ACMP_APORTREQ_APORT4XREQ_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for ACMP_APORTREQ */
 #define ACMP_APORTREQ_APORT4XREQ_DEFAULT               (_ACMP_APORTREQ_APORT4XREQ_DEFAULT << 8) /**< Shifted mode DEFAULT for ACMP_APORTREQ */
-#define ACMP_APORTREQ_APORT4YREQ                       (0x1UL << 9)                             /**< 1 if the bus connected to APORT4Y is requested */
+#define ACMP_APORTREQ_APORT4YREQ                       (0x1UL << 9)                             /**< 1 If the Bus Connected to APORT4Y is Requested */
 #define _ACMP_APORTREQ_APORT4YREQ_SHIFT                9                                        /**< Shift value for ACMP_APORT4YREQ */
 #define _ACMP_APORTREQ_APORT4YREQ_MASK                 0x200UL                                  /**< Bit mask for ACMP_APORT4YREQ */
 #define _ACMP_APORTREQ_APORT4YREQ_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for ACMP_APORTREQ */
@@ -1146,52 +1146,52 @@ typedef struct {
 /* Bit fields for ACMP APORTCONFLICT */
 #define _ACMP_APORTCONFLICT_RESETVALUE                 0x00000000UL                                       /**< Default value for ACMP_APORTCONFLICT */
 #define _ACMP_APORTCONFLICT_MASK                       0x000003FFUL                                       /**< Mask for ACMP_APORTCONFLICT */
-#define ACMP_APORTCONFLICT_APORT0XCONFLICT             (0x1UL << 0)                                       /**< 1 if the bus connected to APORT0X is in conflict with another peripheral */
+#define ACMP_APORTCONFLICT_APORT0XCONFLICT             (0x1UL << 0)                                       /**< 1 If the Bus Connected to APORT0X is in Conflict With Another Peripheral */
 #define _ACMP_APORTCONFLICT_APORT0XCONFLICT_SHIFT      0                                                  /**< Shift value for ACMP_APORT0XCONFLICT */
 #define _ACMP_APORTCONFLICT_APORT0XCONFLICT_MASK       0x1UL                                              /**< Bit mask for ACMP_APORT0XCONFLICT */
 #define _ACMP_APORTCONFLICT_APORT0XCONFLICT_DEFAULT    0x00000000UL                                       /**< Mode DEFAULT for ACMP_APORTCONFLICT */
 #define ACMP_APORTCONFLICT_APORT0XCONFLICT_DEFAULT     (_ACMP_APORTCONFLICT_APORT0XCONFLICT_DEFAULT << 0) /**< Shifted mode DEFAULT for ACMP_APORTCONFLICT */
-#define ACMP_APORTCONFLICT_APORT0YCONFLICT             (0x1UL << 1)                                       /**< 1 if the bus connected to APORT0Y is in conflict with another peripheral */
+#define ACMP_APORTCONFLICT_APORT0YCONFLICT             (0x1UL << 1)                                       /**< 1 If the Bus Connected to APORT0Y is in Conflict With Another Peripheral */
 #define _ACMP_APORTCONFLICT_APORT0YCONFLICT_SHIFT      1                                                  /**< Shift value for ACMP_APORT0YCONFLICT */
 #define _ACMP_APORTCONFLICT_APORT0YCONFLICT_MASK       0x2UL                                              /**< Bit mask for ACMP_APORT0YCONFLICT */
 #define _ACMP_APORTCONFLICT_APORT0YCONFLICT_DEFAULT    0x00000000UL                                       /**< Mode DEFAULT for ACMP_APORTCONFLICT */
 #define ACMP_APORTCONFLICT_APORT0YCONFLICT_DEFAULT     (_ACMP_APORTCONFLICT_APORT0YCONFLICT_DEFAULT << 1) /**< Shifted mode DEFAULT for ACMP_APORTCONFLICT */
-#define ACMP_APORTCONFLICT_APORT1XCONFLICT             (0x1UL << 2)                                       /**< 1 if the bus connected to APORT1X is in conflict with another peripheral */
+#define ACMP_APORTCONFLICT_APORT1XCONFLICT             (0x1UL << 2)                                       /**< 1 If the Bus Connected to APORT1X is in Conflict With Another Peripheral */
 #define _ACMP_APORTCONFLICT_APORT1XCONFLICT_SHIFT      2                                                  /**< Shift value for ACMP_APORT1XCONFLICT */
 #define _ACMP_APORTCONFLICT_APORT1XCONFLICT_MASK       0x4UL                                              /**< Bit mask for ACMP_APORT1XCONFLICT */
 #define _ACMP_APORTCONFLICT_APORT1XCONFLICT_DEFAULT    0x00000000UL                                       /**< Mode DEFAULT for ACMP_APORTCONFLICT */
 #define ACMP_APORTCONFLICT_APORT1XCONFLICT_DEFAULT     (_ACMP_APORTCONFLICT_APORT1XCONFLICT_DEFAULT << 2) /**< Shifted mode DEFAULT for ACMP_APORTCONFLICT */
-#define ACMP_APORTCONFLICT_APORT1YCONFLICT             (0x1UL << 3)                                       /**< 1 if the bus connected to APORT1X is in conflict with another peripheral */
+#define ACMP_APORTCONFLICT_APORT1YCONFLICT             (0x1UL << 3)                                       /**< 1 If the Bus Connected to APORT1X is in Conflict With Another Peripheral */
 #define _ACMP_APORTCONFLICT_APORT1YCONFLICT_SHIFT      3                                                  /**< Shift value for ACMP_APORT1YCONFLICT */
 #define _ACMP_APORTCONFLICT_APORT1YCONFLICT_MASK       0x8UL                                              /**< Bit mask for ACMP_APORT1YCONFLICT */
 #define _ACMP_APORTCONFLICT_APORT1YCONFLICT_DEFAULT    0x00000000UL                                       /**< Mode DEFAULT for ACMP_APORTCONFLICT */
 #define ACMP_APORTCONFLICT_APORT1YCONFLICT_DEFAULT     (_ACMP_APORTCONFLICT_APORT1YCONFLICT_DEFAULT << 3) /**< Shifted mode DEFAULT for ACMP_APORTCONFLICT */
-#define ACMP_APORTCONFLICT_APORT2XCONFLICT             (0x1UL << 4)                                       /**< 1 if the bus connected to APORT2X is in conflict with another peripheral */
+#define ACMP_APORTCONFLICT_APORT2XCONFLICT             (0x1UL << 4)                                       /**< 1 If the Bus Connected to APORT2X is in Conflict With Another Peripheral */
 #define _ACMP_APORTCONFLICT_APORT2XCONFLICT_SHIFT      4                                                  /**< Shift value for ACMP_APORT2XCONFLICT */
 #define _ACMP_APORTCONFLICT_APORT2XCONFLICT_MASK       0x10UL                                             /**< Bit mask for ACMP_APORT2XCONFLICT */
 #define _ACMP_APORTCONFLICT_APORT2XCONFLICT_DEFAULT    0x00000000UL                                       /**< Mode DEFAULT for ACMP_APORTCONFLICT */
 #define ACMP_APORTCONFLICT_APORT2XCONFLICT_DEFAULT     (_ACMP_APORTCONFLICT_APORT2XCONFLICT_DEFAULT << 4) /**< Shifted mode DEFAULT for ACMP_APORTCONFLICT */
-#define ACMP_APORTCONFLICT_APORT2YCONFLICT             (0x1UL << 5)                                       /**< 1 if the bus connected to APORT2Y is in conflict with another peripheral */
+#define ACMP_APORTCONFLICT_APORT2YCONFLICT             (0x1UL << 5)                                       /**< 1 If the Bus Connected to APORT2Y is in Conflict With Another Peripheral */
 #define _ACMP_APORTCONFLICT_APORT2YCONFLICT_SHIFT      5                                                  /**< Shift value for ACMP_APORT2YCONFLICT */
 #define _ACMP_APORTCONFLICT_APORT2YCONFLICT_MASK       0x20UL                                             /**< Bit mask for ACMP_APORT2YCONFLICT */
 #define _ACMP_APORTCONFLICT_APORT2YCONFLICT_DEFAULT    0x00000000UL                                       /**< Mode DEFAULT for ACMP_APORTCONFLICT */
 #define ACMP_APORTCONFLICT_APORT2YCONFLICT_DEFAULT     (_ACMP_APORTCONFLICT_APORT2YCONFLICT_DEFAULT << 5) /**< Shifted mode DEFAULT for ACMP_APORTCONFLICT */
-#define ACMP_APORTCONFLICT_APORT3XCONFLICT             (0x1UL << 6)                                       /**< 1 if the bus connected to APORT3X is in conflict with another peripheral */
+#define ACMP_APORTCONFLICT_APORT3XCONFLICT             (0x1UL << 6)                                       /**< 1 If the Bus Connected to APORT3X is in Conflict With Another Peripheral */
 #define _ACMP_APORTCONFLICT_APORT3XCONFLICT_SHIFT      6                                                  /**< Shift value for ACMP_APORT3XCONFLICT */
 #define _ACMP_APORTCONFLICT_APORT3XCONFLICT_MASK       0x40UL                                             /**< Bit mask for ACMP_APORT3XCONFLICT */
 #define _ACMP_APORTCONFLICT_APORT3XCONFLICT_DEFAULT    0x00000000UL                                       /**< Mode DEFAULT for ACMP_APORTCONFLICT */
 #define ACMP_APORTCONFLICT_APORT3XCONFLICT_DEFAULT     (_ACMP_APORTCONFLICT_APORT3XCONFLICT_DEFAULT << 6) /**< Shifted mode DEFAULT for ACMP_APORTCONFLICT */
-#define ACMP_APORTCONFLICT_APORT3YCONFLICT             (0x1UL << 7)                                       /**< 1 if the bus connected to APORT3Y is in conflict with another peripheral */
+#define ACMP_APORTCONFLICT_APORT3YCONFLICT             (0x1UL << 7)                                       /**< 1 If the Bus Connected to APORT3Y is in Conflict With Another Peripheral */
 #define _ACMP_APORTCONFLICT_APORT3YCONFLICT_SHIFT      7                                                  /**< Shift value for ACMP_APORT3YCONFLICT */
 #define _ACMP_APORTCONFLICT_APORT3YCONFLICT_MASK       0x80UL                                             /**< Bit mask for ACMP_APORT3YCONFLICT */
 #define _ACMP_APORTCONFLICT_APORT3YCONFLICT_DEFAULT    0x00000000UL                                       /**< Mode DEFAULT for ACMP_APORTCONFLICT */
 #define ACMP_APORTCONFLICT_APORT3YCONFLICT_DEFAULT     (_ACMP_APORTCONFLICT_APORT3YCONFLICT_DEFAULT << 7) /**< Shifted mode DEFAULT for ACMP_APORTCONFLICT */
-#define ACMP_APORTCONFLICT_APORT4XCONFLICT             (0x1UL << 8)                                       /**< 1 if the bus connected to APORT4X is in conflict with another peripheral */
+#define ACMP_APORTCONFLICT_APORT4XCONFLICT             (0x1UL << 8)                                       /**< 1 If the Bus Connected to APORT4X is in Conflict With Another Peripheral */
 #define _ACMP_APORTCONFLICT_APORT4XCONFLICT_SHIFT      8                                                  /**< Shift value for ACMP_APORT4XCONFLICT */
 #define _ACMP_APORTCONFLICT_APORT4XCONFLICT_MASK       0x100UL                                            /**< Bit mask for ACMP_APORT4XCONFLICT */
 #define _ACMP_APORTCONFLICT_APORT4XCONFLICT_DEFAULT    0x00000000UL                                       /**< Mode DEFAULT for ACMP_APORTCONFLICT */
 #define ACMP_APORTCONFLICT_APORT4XCONFLICT_DEFAULT     (_ACMP_APORTCONFLICT_APORT4XCONFLICT_DEFAULT << 8) /**< Shifted mode DEFAULT for ACMP_APORTCONFLICT */
-#define ACMP_APORTCONFLICT_APORT4YCONFLICT             (0x1UL << 9)                                       /**< 1 if the bus connected to APORT4Y is in conflict with another peripheral */
+#define ACMP_APORTCONFLICT_APORT4YCONFLICT             (0x1UL << 9)                                       /**< 1 If the Bus Connected to APORT4Y is in Conflict With Another Peripheral */
 #define _ACMP_APORTCONFLICT_APORT4YCONFLICT_SHIFT      9                                                  /**< Shift value for ACMP_APORT4YCONFLICT */
 #define _ACMP_APORTCONFLICT_APORT4YCONFLICT_MASK       0x200UL                                            /**< Bit mask for ACMP_APORT4YCONFLICT */
 #define _ACMP_APORTCONFLICT_APORT4YCONFLICT_DEFAULT    0x00000000UL                                       /**< Mode DEFAULT for ACMP_APORTCONFLICT */

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_adc.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_adc.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32pg1b_adc.h
  * @brief EFM32PG1B_ADC register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,
@@ -57,14 +57,14 @@ typedef struct {
   __IOM uint32_t CMD;             /**< Command Register  */
   __IM uint32_t  STATUS;          /**< Status Register  */
   __IOM uint32_t SINGLECTRL;      /**< Single Channel Control Register  */
-  __IOM uint32_t SINGLECTRLX;     /**< Single Channel Control Register continued  */
+  __IOM uint32_t SINGLECTRLX;     /**< Single Channel Control Register Continued  */
   __IOM uint32_t SCANCTRL;        /**< Scan Control Register  */
-  __IOM uint32_t SCANCTRLX;       /**< Scan Control Register continued  */
+  __IOM uint32_t SCANCTRLX;       /**< Scan Control Register Continued  */
   __IOM uint32_t SCANMASK;        /**< Scan Sequence Input Mask Register  */
-  __IOM uint32_t SCANINPUTSEL;    /**< Input Selection register for Scan mode  */
-  __IOM uint32_t SCANNEGSEL;      /**< Negative Input select register for Scan  */
+  __IOM uint32_t SCANINPUTSEL;    /**< Input Selection Register for Scan Mode  */
+  __IOM uint32_t SCANNEGSEL;      /**< Negative Input Select Register for Scan  */
   __IOM uint32_t CMPTHR;          /**< Compare Threshold Register  */
-  __IOM uint32_t BIASPROG;        /**< Bias Programming Register for various analog blocks used in ADC operation.  */
+  __IOM uint32_t BIASPROG;        /**< Bias Programming Register for Various Analog Blocks Used in ADC Operation  */
   __IOM uint32_t CAL;             /**< Calibration Register  */
   __IM uint32_t  IF;              /**< Interrupt Flag Register  */
   __IOM uint32_t IFS;             /**< Interrupt Flag Set Register  */
@@ -125,7 +125,7 @@ typedef struct {
 #define _ADC_CTRL_TAILGATE_MASK                            0x10UL                                    /**< Bit mask for ADC_TAILGATE */
 #define _ADC_CTRL_TAILGATE_DEFAULT                         0x00000000UL                              /**< Mode DEFAULT for ADC_CTRL */
 #define ADC_CTRL_TAILGATE_DEFAULT                          (_ADC_CTRL_TAILGATE_DEFAULT << 4)         /**< Shifted mode DEFAULT for ADC_CTRL */
-#define ADC_CTRL_ASYNCCLKEN                                (0x1UL << 6)                              /**< Selects ASYNC CLK enable mode when ADCCLKMODE=1 */
+#define ADC_CTRL_ASYNCCLKEN                                (0x1UL << 6)                              /**< Selects ASYNC CLK Enable Mode When ADCCLKMODE=1 */
 #define _ADC_CTRL_ASYNCCLKEN_SHIFT                         6                                         /**< Shift value for ADC_ASYNCCLKEN */
 #define _ADC_CTRL_ASYNCCLKEN_MASK                          0x40UL                                    /**< Bit mask for ADC_ASYNCCLKEN */
 #define _ADC_CTRL_ASYNCCLKEN_DEFAULT                       0x00000000UL                              /**< Mode DEFAULT for ADC_CTRL */
@@ -1062,7 +1062,7 @@ typedef struct {
 #define ADC_SINGLECTRLX_VREFSEL_VREFPNWATT                 (_ADC_SINGLECTRLX_VREFSEL_VREFPNWATT << 0)        /**< Shifted mode VREFPNWATT for ADC_SINGLECTRLX */
 #define ADC_SINGLECTRLX_VREFSEL_VREFPN                     (_ADC_SINGLECTRLX_VREFSEL_VREFPN << 0)            /**< Shifted mode VREFPN for ADC_SINGLECTRLX */
 #define ADC_SINGLECTRLX_VREFSEL_VBGRLOW                    (_ADC_SINGLECTRLX_VREFSEL_VBGRLOW << 0)           /**< Shifted mode VBGRLOW for ADC_SINGLECTRLX */
-#define ADC_SINGLECTRLX_VREFATTFIX                         (0x1UL << 3)                                      /**< Enable fixed scaling on VREF */
+#define ADC_SINGLECTRLX_VREFATTFIX                         (0x1UL << 3)                                      /**< Enable Fixed Scaling on VREF */
 #define _ADC_SINGLECTRLX_VREFATTFIX_SHIFT                  3                                                 /**< Shift value for ADC_VREFATTFIX */
 #define _ADC_SINGLECTRLX_VREFATTFIX_MASK                   0x8UL                                             /**< Bit mask for ADC_VREFATTFIX */
 #define _ADC_SINGLECTRLX_VREFATTFIX_DEFAULT                0x00000000UL                                      /**< Mode DEFAULT for ADC_SINGLECTRLX */
@@ -1129,7 +1129,7 @@ typedef struct {
 #define _ADC_SINGLECTRLX_CONVSTARTDELAY_MASK               0x7000000UL                                       /**< Bit mask for ADC_CONVSTARTDELAY */
 #define _ADC_SINGLECTRLX_CONVSTARTDELAY_DEFAULT            0x00000000UL                                      /**< Mode DEFAULT for ADC_SINGLECTRLX */
 #define ADC_SINGLECTRLX_CONVSTARTDELAY_DEFAULT             (_ADC_SINGLECTRLX_CONVSTARTDELAY_DEFAULT << 24)   /**< Shifted mode DEFAULT for ADC_SINGLECTRLX */
-#define ADC_SINGLECTRLX_CONVSTARTDELAYEN                   (0x1UL << 27)                                     /**< Enable delaying next conversion start */
+#define ADC_SINGLECTRLX_CONVSTARTDELAYEN                   (0x1UL << 27)                                     /**< Enable Delaying Next Conversion Start */
 #define _ADC_SINGLECTRLX_CONVSTARTDELAYEN_SHIFT            27                                                /**< Shift value for ADC_CONVSTARTDELAYEN */
 #define _ADC_SINGLECTRLX_CONVSTARTDELAYEN_MASK             0x8000000UL                                       /**< Bit mask for ADC_CONVSTARTDELAYEN */
 #define _ADC_SINGLECTRLX_CONVSTARTDELAYEN_DEFAULT          0x00000000UL                                      /**< Mode DEFAULT for ADC_SINGLECTRLX */
@@ -1245,7 +1245,7 @@ typedef struct {
 #define ADC_SCANCTRLX_VREFSEL_VREFPNWATT                   (_ADC_SCANCTRLX_VREFSEL_VREFPNWATT << 0)        /**< Shifted mode VREFPNWATT for ADC_SCANCTRLX */
 #define ADC_SCANCTRLX_VREFSEL_VREFPN                       (_ADC_SCANCTRLX_VREFSEL_VREFPN << 0)            /**< Shifted mode VREFPN for ADC_SCANCTRLX */
 #define ADC_SCANCTRLX_VREFSEL_VBGRLOW                      (_ADC_SCANCTRLX_VREFSEL_VBGRLOW << 0)           /**< Shifted mode VBGRLOW for ADC_SCANCTRLX */
-#define ADC_SCANCTRLX_VREFATTFIX                           (0x1UL << 3)                                    /**< Enable fixed scaling on VREF */
+#define ADC_SCANCTRLX_VREFATTFIX                           (0x1UL << 3)                                    /**< Enable Fixed Scaling on VREF */
 #define _ADC_SCANCTRLX_VREFATTFIX_SHIFT                    3                                               /**< Shift value for ADC_VREFATTFIX */
 #define _ADC_SCANCTRLX_VREFATTFIX_MASK                     0x8UL                                           /**< Bit mask for ADC_VREFATTFIX */
 #define _ADC_SCANCTRLX_VREFATTFIX_DEFAULT                  0x00000000UL                                    /**< Mode DEFAULT for ADC_SCANCTRLX */
@@ -1312,7 +1312,7 @@ typedef struct {
 #define _ADC_SCANCTRLX_CONVSTARTDELAY_MASK                 0x7000000UL                                     /**< Bit mask for ADC_CONVSTARTDELAY */
 #define _ADC_SCANCTRLX_CONVSTARTDELAY_DEFAULT              0x00000000UL                                    /**< Mode DEFAULT for ADC_SCANCTRLX */
 #define ADC_SCANCTRLX_CONVSTARTDELAY_DEFAULT               (_ADC_SCANCTRLX_CONVSTARTDELAY_DEFAULT << 24)   /**< Shifted mode DEFAULT for ADC_SCANCTRLX */
-#define ADC_SCANCTRLX_CONVSTARTDELAYEN                     (0x1UL << 27)                                   /**< Enable delaying next conversion start */
+#define ADC_SCANCTRLX_CONVSTARTDELAYEN                     (0x1UL << 27)                                   /**< Enable Delaying Next Conversion Start */
 #define _ADC_SCANCTRLX_CONVSTARTDELAYEN_SHIFT              27                                              /**< Shift value for ADC_CONVSTARTDELAYEN */
 #define _ADC_SCANCTRLX_CONVSTARTDELAYEN_MASK               0x8000000UL                                     /**< Bit mask for ADC_CONVSTARTDELAYEN */
 #define _ADC_SCANCTRLX_CONVSTARTDELAYEN_DEFAULT            0x00000000UL                                    /**< Mode DEFAULT for ADC_SCANCTRLX */
@@ -1749,12 +1749,12 @@ typedef struct {
 #define ADC_BIASPROG_ADCBIASPROG_SCALE8                    (_ADC_BIASPROG_ADCBIASPROG_SCALE8 << 0)  /**< Shifted mode SCALE8 for ADC_BIASPROG */
 #define ADC_BIASPROG_ADCBIASPROG_SCALE16                   (_ADC_BIASPROG_ADCBIASPROG_SCALE16 << 0) /**< Shifted mode SCALE16 for ADC_BIASPROG */
 #define ADC_BIASPROG_ADCBIASPROG_SCALE32                   (_ADC_BIASPROG_ADCBIASPROG_SCALE32 << 0) /**< Shifted mode SCALE32 for ADC_BIASPROG */
-#define ADC_BIASPROG_VFAULTCLR                             (0x1UL << 12)                            /**< Clear VREFOF flag */
+#define ADC_BIASPROG_VFAULTCLR                             (0x1UL << 12)                            /**< Clear VREFOF Flag */
 #define _ADC_BIASPROG_VFAULTCLR_SHIFT                      12                                       /**< Shift value for ADC_VFAULTCLR */
 #define _ADC_BIASPROG_VFAULTCLR_MASK                       0x1000UL                                 /**< Bit mask for ADC_VFAULTCLR */
 #define _ADC_BIASPROG_VFAULTCLR_DEFAULT                    0x00000000UL                             /**< Mode DEFAULT for ADC_BIASPROG */
 #define ADC_BIASPROG_VFAULTCLR_DEFAULT                     (_ADC_BIASPROG_VFAULTCLR_DEFAULT << 12)  /**< Shifted mode DEFAULT for ADC_BIASPROG */
-#define ADC_BIASPROG_GPBIASACC                             (0x1UL << 16)                            /**< Accuracy setting for the system bias during ADC operation */
+#define ADC_BIASPROG_GPBIASACC                             (0x1UL << 16)                            /**< Accuracy Setting for the System Bias During ADC Operation */
 #define _ADC_BIASPROG_GPBIASACC_SHIFT                      16                                       /**< Shift value for ADC_GPBIASACC */
 #define _ADC_BIASPROG_GPBIASACC_MASK                       0x10000UL                                /**< Bit mask for ADC_GPBIASACC */
 #define _ADC_BIASPROG_GPBIASACC_DEFAULT                    0x00000000UL                             /**< Mode DEFAULT for ADC_BIASPROG */
@@ -1779,7 +1779,7 @@ typedef struct {
 #define _ADC_CAL_SINGLEGAIN_MASK                           0x7F00UL                                /**< Bit mask for ADC_SINGLEGAIN */
 #define _ADC_CAL_SINGLEGAIN_DEFAULT                        0x00000040UL                            /**< Mode DEFAULT for ADC_CAL */
 #define ADC_CAL_SINGLEGAIN_DEFAULT                         (_ADC_CAL_SINGLEGAIN_DEFAULT << 8)      /**< Shifted mode DEFAULT for ADC_CAL */
-#define ADC_CAL_OFFSETINVMODE                              (0x1UL << 15)                           /**< Negative single-ended offset calibration is enabled */
+#define ADC_CAL_OFFSETINVMODE                              (0x1UL << 15)                           /**< Negative Single-ended Offset Calibration is Enabled */
 #define _ADC_CAL_OFFSETINVMODE_SHIFT                       15                                      /**< Shift value for ADC_OFFSETINVMODE */
 #define _ADC_CAL_OFFSETINVMODE_MASK                        0x8000UL                                /**< Bit mask for ADC_OFFSETINVMODE */
 #define _ADC_CAL_OFFSETINVMODE_DEFAULT                     0x00000000UL                            /**< Mode DEFAULT for ADC_CAL */
@@ -1796,7 +1796,7 @@ typedef struct {
 #define _ADC_CAL_SCANGAIN_MASK                             0x7F000000UL                            /**< Bit mask for ADC_SCANGAIN */
 #define _ADC_CAL_SCANGAIN_DEFAULT                          0x00000040UL                            /**< Mode DEFAULT for ADC_CAL */
 #define ADC_CAL_SCANGAIN_DEFAULT                           (_ADC_CAL_SCANGAIN_DEFAULT << 24)       /**< Shifted mode DEFAULT for ADC_CAL */
-#define ADC_CAL_CALEN                                      (0x1UL << 31)                           /**< Calibration mode is enabled */
+#define ADC_CAL_CALEN                                      (0x1UL << 31)                           /**< Calibration Mode is Enabled */
 #define _ADC_CAL_CALEN_SHIFT                               31                                      /**< Shift value for ADC_CALEN */
 #define _ADC_CAL_CALEN_MASK                                0x80000000UL                            /**< Bit mask for ADC_CALEN */
 #define _ADC_CAL_CALEN_DEFAULT                             0x00000000UL                            /**< Mode DEFAULT for ADC_CAL */
@@ -2057,52 +2057,52 @@ typedef struct {
 /* Bit fields for ADC APORTREQ */
 #define _ADC_APORTREQ_RESETVALUE                           0x00000000UL                            /**< Default value for ADC_APORTREQ */
 #define _ADC_APORTREQ_MASK                                 0x000003FFUL                            /**< Mask for ADC_APORTREQ */
-#define ADC_APORTREQ_APORT0XREQ                            (0x1UL << 0)                            /**< 1 if the bus connected to APORT0X is requested */
+#define ADC_APORTREQ_APORT0XREQ                            (0x1UL << 0)                            /**< 1 If the Bus Connected to APORT0X is Requested */
 #define _ADC_APORTREQ_APORT0XREQ_SHIFT                     0                                       /**< Shift value for ADC_APORT0XREQ */
 #define _ADC_APORTREQ_APORT0XREQ_MASK                      0x1UL                                   /**< Bit mask for ADC_APORT0XREQ */
 #define _ADC_APORTREQ_APORT0XREQ_DEFAULT                   0x00000000UL                            /**< Mode DEFAULT for ADC_APORTREQ */
 #define ADC_APORTREQ_APORT0XREQ_DEFAULT                    (_ADC_APORTREQ_APORT0XREQ_DEFAULT << 0) /**< Shifted mode DEFAULT for ADC_APORTREQ */
-#define ADC_APORTREQ_APORT0YREQ                            (0x1UL << 1)                            /**< 1 if the bus connected to APORT0Y is requested */
+#define ADC_APORTREQ_APORT0YREQ                            (0x1UL << 1)                            /**< 1 If the Bus Connected to APORT0Y is Requested */
 #define _ADC_APORTREQ_APORT0YREQ_SHIFT                     1                                       /**< Shift value for ADC_APORT0YREQ */
 #define _ADC_APORTREQ_APORT0YREQ_MASK                      0x2UL                                   /**< Bit mask for ADC_APORT0YREQ */
 #define _ADC_APORTREQ_APORT0YREQ_DEFAULT                   0x00000000UL                            /**< Mode DEFAULT for ADC_APORTREQ */
 #define ADC_APORTREQ_APORT0YREQ_DEFAULT                    (_ADC_APORTREQ_APORT0YREQ_DEFAULT << 1) /**< Shifted mode DEFAULT for ADC_APORTREQ */
-#define ADC_APORTREQ_APORT1XREQ                            (0x1UL << 2)                            /**< 1 if the bus connected to APORT1X is requested */
+#define ADC_APORTREQ_APORT1XREQ                            (0x1UL << 2)                            /**< 1 If the Bus Connected to APORT1X is Requested */
 #define _ADC_APORTREQ_APORT1XREQ_SHIFT                     2                                       /**< Shift value for ADC_APORT1XREQ */
 #define _ADC_APORTREQ_APORT1XREQ_MASK                      0x4UL                                   /**< Bit mask for ADC_APORT1XREQ */
 #define _ADC_APORTREQ_APORT1XREQ_DEFAULT                   0x00000000UL                            /**< Mode DEFAULT for ADC_APORTREQ */
 #define ADC_APORTREQ_APORT1XREQ_DEFAULT                    (_ADC_APORTREQ_APORT1XREQ_DEFAULT << 2) /**< Shifted mode DEFAULT for ADC_APORTREQ */
-#define ADC_APORTREQ_APORT1YREQ                            (0x1UL << 3)                            /**< 1 if the bus connected to APORT1Y is requested */
+#define ADC_APORTREQ_APORT1YREQ                            (0x1UL << 3)                            /**< 1 If the Bus Connected to APORT1Y is Requested */
 #define _ADC_APORTREQ_APORT1YREQ_SHIFT                     3                                       /**< Shift value for ADC_APORT1YREQ */
 #define _ADC_APORTREQ_APORT1YREQ_MASK                      0x8UL                                   /**< Bit mask for ADC_APORT1YREQ */
 #define _ADC_APORTREQ_APORT1YREQ_DEFAULT                   0x00000000UL                            /**< Mode DEFAULT for ADC_APORTREQ */
 #define ADC_APORTREQ_APORT1YREQ_DEFAULT                    (_ADC_APORTREQ_APORT1YREQ_DEFAULT << 3) /**< Shifted mode DEFAULT for ADC_APORTREQ */
-#define ADC_APORTREQ_APORT2XREQ                            (0x1UL << 4)                            /**< 1 if the bus connected to APORT2X is requested */
+#define ADC_APORTREQ_APORT2XREQ                            (0x1UL << 4)                            /**< 1 If the Bus Connected to APORT2X is Requested */
 #define _ADC_APORTREQ_APORT2XREQ_SHIFT                     4                                       /**< Shift value for ADC_APORT2XREQ */
 #define _ADC_APORTREQ_APORT2XREQ_MASK                      0x10UL                                  /**< Bit mask for ADC_APORT2XREQ */
 #define _ADC_APORTREQ_APORT2XREQ_DEFAULT                   0x00000000UL                            /**< Mode DEFAULT for ADC_APORTREQ */
 #define ADC_APORTREQ_APORT2XREQ_DEFAULT                    (_ADC_APORTREQ_APORT2XREQ_DEFAULT << 4) /**< Shifted mode DEFAULT for ADC_APORTREQ */
-#define ADC_APORTREQ_APORT2YREQ                            (0x1UL << 5)                            /**< 1 if the bus connected to APORT2Y is requested */
+#define ADC_APORTREQ_APORT2YREQ                            (0x1UL << 5)                            /**< 1 If the Bus Connected to APORT2Y is Requested */
 #define _ADC_APORTREQ_APORT2YREQ_SHIFT                     5                                       /**< Shift value for ADC_APORT2YREQ */
 #define _ADC_APORTREQ_APORT2YREQ_MASK                      0x20UL                                  /**< Bit mask for ADC_APORT2YREQ */
 #define _ADC_APORTREQ_APORT2YREQ_DEFAULT                   0x00000000UL                            /**< Mode DEFAULT for ADC_APORTREQ */
 #define ADC_APORTREQ_APORT2YREQ_DEFAULT                    (_ADC_APORTREQ_APORT2YREQ_DEFAULT << 5) /**< Shifted mode DEFAULT for ADC_APORTREQ */
-#define ADC_APORTREQ_APORT3XREQ                            (0x1UL << 6)                            /**< 1 if the bus connected to APORT3X is requested */
+#define ADC_APORTREQ_APORT3XREQ                            (0x1UL << 6)                            /**< 1 If the Bus Connected to APORT3X is Requested */
 #define _ADC_APORTREQ_APORT3XREQ_SHIFT                     6                                       /**< Shift value for ADC_APORT3XREQ */
 #define _ADC_APORTREQ_APORT3XREQ_MASK                      0x40UL                                  /**< Bit mask for ADC_APORT3XREQ */
 #define _ADC_APORTREQ_APORT3XREQ_DEFAULT                   0x00000000UL                            /**< Mode DEFAULT for ADC_APORTREQ */
 #define ADC_APORTREQ_APORT3XREQ_DEFAULT                    (_ADC_APORTREQ_APORT3XREQ_DEFAULT << 6) /**< Shifted mode DEFAULT for ADC_APORTREQ */
-#define ADC_APORTREQ_APORT3YREQ                            (0x1UL << 7)                            /**< 1 if the bus connected to APORT3Y is requested */
+#define ADC_APORTREQ_APORT3YREQ                            (0x1UL << 7)                            /**< 1 If the Bus Connected to APORT3Y is Requested */
 #define _ADC_APORTREQ_APORT3YREQ_SHIFT                     7                                       /**< Shift value for ADC_APORT3YREQ */
 #define _ADC_APORTREQ_APORT3YREQ_MASK                      0x80UL                                  /**< Bit mask for ADC_APORT3YREQ */
 #define _ADC_APORTREQ_APORT3YREQ_DEFAULT                   0x00000000UL                            /**< Mode DEFAULT for ADC_APORTREQ */
 #define ADC_APORTREQ_APORT3YREQ_DEFAULT                    (_ADC_APORTREQ_APORT3YREQ_DEFAULT << 7) /**< Shifted mode DEFAULT for ADC_APORTREQ */
-#define ADC_APORTREQ_APORT4XREQ                            (0x1UL << 8)                            /**< 1 if the bus connected to APORT4X is requested */
+#define ADC_APORTREQ_APORT4XREQ                            (0x1UL << 8)                            /**< 1 If the Bus Connected to APORT4X is Requested */
 #define _ADC_APORTREQ_APORT4XREQ_SHIFT                     8                                       /**< Shift value for ADC_APORT4XREQ */
 #define _ADC_APORTREQ_APORT4XREQ_MASK                      0x100UL                                 /**< Bit mask for ADC_APORT4XREQ */
 #define _ADC_APORTREQ_APORT4XREQ_DEFAULT                   0x00000000UL                            /**< Mode DEFAULT for ADC_APORTREQ */
 #define ADC_APORTREQ_APORT4XREQ_DEFAULT                    (_ADC_APORTREQ_APORT4XREQ_DEFAULT << 8) /**< Shifted mode DEFAULT for ADC_APORTREQ */
-#define ADC_APORTREQ_APORT4YREQ                            (0x1UL << 9)                            /**< 1 if the bus connected to APORT4Y is requested */
+#define ADC_APORTREQ_APORT4YREQ                            (0x1UL << 9)                            /**< 1 If the Bus Connected to APORT4Y is Requested */
 #define _ADC_APORTREQ_APORT4YREQ_SHIFT                     9                                       /**< Shift value for ADC_APORT4YREQ */
 #define _ADC_APORTREQ_APORT4YREQ_MASK                      0x200UL                                 /**< Bit mask for ADC_APORT4YREQ */
 #define _ADC_APORTREQ_APORT4YREQ_DEFAULT                   0x00000000UL                            /**< Mode DEFAULT for ADC_APORTREQ */
@@ -2111,52 +2111,52 @@ typedef struct {
 /* Bit fields for ADC APORTCONFLICT */
 #define _ADC_APORTCONFLICT_RESETVALUE                      0x00000000UL                                      /**< Default value for ADC_APORTCONFLICT */
 #define _ADC_APORTCONFLICT_MASK                            0x000003FFUL                                      /**< Mask for ADC_APORTCONFLICT */
-#define ADC_APORTCONFLICT_APORT0XCONFLICT                  (0x1UL << 0)                                      /**< 1 if the bus connected to APORT0X is in conflict with another peripheral */
+#define ADC_APORTCONFLICT_APORT0XCONFLICT                  (0x1UL << 0)                                      /**< 1 If the Bus Connected to APORT0X is in Conflict With Another Peripheral */
 #define _ADC_APORTCONFLICT_APORT0XCONFLICT_SHIFT           0                                                 /**< Shift value for ADC_APORT0XCONFLICT */
 #define _ADC_APORTCONFLICT_APORT0XCONFLICT_MASK            0x1UL                                             /**< Bit mask for ADC_APORT0XCONFLICT */
 #define _ADC_APORTCONFLICT_APORT0XCONFLICT_DEFAULT         0x00000000UL                                      /**< Mode DEFAULT for ADC_APORTCONFLICT */
 #define ADC_APORTCONFLICT_APORT0XCONFLICT_DEFAULT          (_ADC_APORTCONFLICT_APORT0XCONFLICT_DEFAULT << 0) /**< Shifted mode DEFAULT for ADC_APORTCONFLICT */
-#define ADC_APORTCONFLICT_APORT0YCONFLICT                  (0x1UL << 1)                                      /**< 1 if the bus connected to APORT0Y is in conflict with another peripheral */
+#define ADC_APORTCONFLICT_APORT0YCONFLICT                  (0x1UL << 1)                                      /**< 1 If the Bus Connected to APORT0Y is in Conflict With Another Peripheral */
 #define _ADC_APORTCONFLICT_APORT0YCONFLICT_SHIFT           1                                                 /**< Shift value for ADC_APORT0YCONFLICT */
 #define _ADC_APORTCONFLICT_APORT0YCONFLICT_MASK            0x2UL                                             /**< Bit mask for ADC_APORT0YCONFLICT */
 #define _ADC_APORTCONFLICT_APORT0YCONFLICT_DEFAULT         0x00000000UL                                      /**< Mode DEFAULT for ADC_APORTCONFLICT */
 #define ADC_APORTCONFLICT_APORT0YCONFLICT_DEFAULT          (_ADC_APORTCONFLICT_APORT0YCONFLICT_DEFAULT << 1) /**< Shifted mode DEFAULT for ADC_APORTCONFLICT */
-#define ADC_APORTCONFLICT_APORT1XCONFLICT                  (0x1UL << 2)                                      /**< 1 if the bus connected to APORT1X is in conflict with another peripheral */
+#define ADC_APORTCONFLICT_APORT1XCONFLICT                  (0x1UL << 2)                                      /**< 1 If the Bus Connected to APORT1X is in Conflict With Another Peripheral */
 #define _ADC_APORTCONFLICT_APORT1XCONFLICT_SHIFT           2                                                 /**< Shift value for ADC_APORT1XCONFLICT */
 #define _ADC_APORTCONFLICT_APORT1XCONFLICT_MASK            0x4UL                                             /**< Bit mask for ADC_APORT1XCONFLICT */
 #define _ADC_APORTCONFLICT_APORT1XCONFLICT_DEFAULT         0x00000000UL                                      /**< Mode DEFAULT for ADC_APORTCONFLICT */
 #define ADC_APORTCONFLICT_APORT1XCONFLICT_DEFAULT          (_ADC_APORTCONFLICT_APORT1XCONFLICT_DEFAULT << 2) /**< Shifted mode DEFAULT for ADC_APORTCONFLICT */
-#define ADC_APORTCONFLICT_APORT1YCONFLICT                  (0x1UL << 3)                                      /**< 1 if the bus connected to APORT1Y is in conflict with another peripheral */
+#define ADC_APORTCONFLICT_APORT1YCONFLICT                  (0x1UL << 3)                                      /**< 1 If the Bus Connected to APORT1Y is in Conflict With Another Peripheral */
 #define _ADC_APORTCONFLICT_APORT1YCONFLICT_SHIFT           3                                                 /**< Shift value for ADC_APORT1YCONFLICT */
 #define _ADC_APORTCONFLICT_APORT1YCONFLICT_MASK            0x8UL                                             /**< Bit mask for ADC_APORT1YCONFLICT */
 #define _ADC_APORTCONFLICT_APORT1YCONFLICT_DEFAULT         0x00000000UL                                      /**< Mode DEFAULT for ADC_APORTCONFLICT */
 #define ADC_APORTCONFLICT_APORT1YCONFLICT_DEFAULT          (_ADC_APORTCONFLICT_APORT1YCONFLICT_DEFAULT << 3) /**< Shifted mode DEFAULT for ADC_APORTCONFLICT */
-#define ADC_APORTCONFLICT_APORT2XCONFLICT                  (0x1UL << 4)                                      /**< 1 if the bus connected to APORT2X is in conflict with another peripheral */
+#define ADC_APORTCONFLICT_APORT2XCONFLICT                  (0x1UL << 4)                                      /**< 1 If the Bus Connected to APORT2X is in Conflict With Another Peripheral */
 #define _ADC_APORTCONFLICT_APORT2XCONFLICT_SHIFT           4                                                 /**< Shift value for ADC_APORT2XCONFLICT */
 #define _ADC_APORTCONFLICT_APORT2XCONFLICT_MASK            0x10UL                                            /**< Bit mask for ADC_APORT2XCONFLICT */
 #define _ADC_APORTCONFLICT_APORT2XCONFLICT_DEFAULT         0x00000000UL                                      /**< Mode DEFAULT for ADC_APORTCONFLICT */
 #define ADC_APORTCONFLICT_APORT2XCONFLICT_DEFAULT          (_ADC_APORTCONFLICT_APORT2XCONFLICT_DEFAULT << 4) /**< Shifted mode DEFAULT for ADC_APORTCONFLICT */
-#define ADC_APORTCONFLICT_APORT2YCONFLICT                  (0x1UL << 5)                                      /**< 1 if the bus connected to APORT2Y is in conflict with another peripheral */
+#define ADC_APORTCONFLICT_APORT2YCONFLICT                  (0x1UL << 5)                                      /**< 1 If the Bus Connected to APORT2Y is in Conflict With Another Peripheral */
 #define _ADC_APORTCONFLICT_APORT2YCONFLICT_SHIFT           5                                                 /**< Shift value for ADC_APORT2YCONFLICT */
 #define _ADC_APORTCONFLICT_APORT2YCONFLICT_MASK            0x20UL                                            /**< Bit mask for ADC_APORT2YCONFLICT */
 #define _ADC_APORTCONFLICT_APORT2YCONFLICT_DEFAULT         0x00000000UL                                      /**< Mode DEFAULT for ADC_APORTCONFLICT */
 #define ADC_APORTCONFLICT_APORT2YCONFLICT_DEFAULT          (_ADC_APORTCONFLICT_APORT2YCONFLICT_DEFAULT << 5) /**< Shifted mode DEFAULT for ADC_APORTCONFLICT */
-#define ADC_APORTCONFLICT_APORT3XCONFLICT                  (0x1UL << 6)                                      /**< 1 if the bus connected to APORT3X is in conflict with another peripheral */
+#define ADC_APORTCONFLICT_APORT3XCONFLICT                  (0x1UL << 6)                                      /**< 1 If the Bus Connected to APORT3X is in Conflict With Another Peripheral */
 #define _ADC_APORTCONFLICT_APORT3XCONFLICT_SHIFT           6                                                 /**< Shift value for ADC_APORT3XCONFLICT */
 #define _ADC_APORTCONFLICT_APORT3XCONFLICT_MASK            0x40UL                                            /**< Bit mask for ADC_APORT3XCONFLICT */
 #define _ADC_APORTCONFLICT_APORT3XCONFLICT_DEFAULT         0x00000000UL                                      /**< Mode DEFAULT for ADC_APORTCONFLICT */
 #define ADC_APORTCONFLICT_APORT3XCONFLICT_DEFAULT          (_ADC_APORTCONFLICT_APORT3XCONFLICT_DEFAULT << 6) /**< Shifted mode DEFAULT for ADC_APORTCONFLICT */
-#define ADC_APORTCONFLICT_APORT3YCONFLICT                  (0x1UL << 7)                                      /**< 1 if the bus connected to APORT3Y is in conflict with another peripheral */
+#define ADC_APORTCONFLICT_APORT3YCONFLICT                  (0x1UL << 7)                                      /**< 1 If the Bus Connected to APORT3Y is in Conflict With Another Peripheral */
 #define _ADC_APORTCONFLICT_APORT3YCONFLICT_SHIFT           7                                                 /**< Shift value for ADC_APORT3YCONFLICT */
 #define _ADC_APORTCONFLICT_APORT3YCONFLICT_MASK            0x80UL                                            /**< Bit mask for ADC_APORT3YCONFLICT */
 #define _ADC_APORTCONFLICT_APORT3YCONFLICT_DEFAULT         0x00000000UL                                      /**< Mode DEFAULT for ADC_APORTCONFLICT */
 #define ADC_APORTCONFLICT_APORT3YCONFLICT_DEFAULT          (_ADC_APORTCONFLICT_APORT3YCONFLICT_DEFAULT << 7) /**< Shifted mode DEFAULT for ADC_APORTCONFLICT */
-#define ADC_APORTCONFLICT_APORT4XCONFLICT                  (0x1UL << 8)                                      /**< 1 if the bus connected to APORT4X is in conflict with another peripheral */
+#define ADC_APORTCONFLICT_APORT4XCONFLICT                  (0x1UL << 8)                                      /**< 1 If the Bus Connected to APORT4X is in Conflict With Another Peripheral */
 #define _ADC_APORTCONFLICT_APORT4XCONFLICT_SHIFT           8                                                 /**< Shift value for ADC_APORT4XCONFLICT */
 #define _ADC_APORTCONFLICT_APORT4XCONFLICT_MASK            0x100UL                                           /**< Bit mask for ADC_APORT4XCONFLICT */
 #define _ADC_APORTCONFLICT_APORT4XCONFLICT_DEFAULT         0x00000000UL                                      /**< Mode DEFAULT for ADC_APORTCONFLICT */
 #define ADC_APORTCONFLICT_APORT4XCONFLICT_DEFAULT          (_ADC_APORTCONFLICT_APORT4XCONFLICT_DEFAULT << 8) /**< Shifted mode DEFAULT for ADC_APORTCONFLICT */
-#define ADC_APORTCONFLICT_APORT4YCONFLICT                  (0x1UL << 9)                                      /**< 1 if the bus connected to APORT4Y is in conflict with another peripheral */
+#define ADC_APORTCONFLICT_APORT4YCONFLICT                  (0x1UL << 9)                                      /**< 1 If the Bus Connected to APORT4Y is in Conflict With Another Peripheral */
 #define _ADC_APORTCONFLICT_APORT4YCONFLICT_SHIFT           9                                                 /**< Shift value for ADC_APORT4YCONFLICT */
 #define _ADC_APORTCONFLICT_APORT4YCONFLICT_MASK            0x200UL                                           /**< Bit mask for ADC_APORT4YCONFLICT */
 #define _ADC_APORTCONFLICT_APORT4YCONFLICT_DEFAULT         0x00000000UL                                      /**< Mode DEFAULT for ADC_APORTCONFLICT */
@@ -2181,7 +2181,7 @@ typedef struct {
 /* Bit fields for ADC SINGLEFIFOCLEAR */
 #define _ADC_SINGLEFIFOCLEAR_RESETVALUE                    0x00000000UL                                        /**< Default value for ADC_SINGLEFIFOCLEAR */
 #define _ADC_SINGLEFIFOCLEAR_MASK                          0x00000001UL                                        /**< Mask for ADC_SINGLEFIFOCLEAR */
-#define ADC_SINGLEFIFOCLEAR_SINGLEFIFOCLEAR                (0x1UL << 0)                                        /**< Clear Single FIFO content */
+#define ADC_SINGLEFIFOCLEAR_SINGLEFIFOCLEAR                (0x1UL << 0)                                        /**< Clear Single FIFO Content */
 #define _ADC_SINGLEFIFOCLEAR_SINGLEFIFOCLEAR_SHIFT         0                                                   /**< Shift value for ADC_SINGLEFIFOCLEAR */
 #define _ADC_SINGLEFIFOCLEAR_SINGLEFIFOCLEAR_MASK          0x1UL                                               /**< Bit mask for ADC_SINGLEFIFOCLEAR */
 #define _ADC_SINGLEFIFOCLEAR_SINGLEFIFOCLEAR_DEFAULT       0x00000000UL                                        /**< Mode DEFAULT for ADC_SINGLEFIFOCLEAR */
@@ -2190,7 +2190,7 @@ typedef struct {
 /* Bit fields for ADC SCANFIFOCLEAR */
 #define _ADC_SCANFIFOCLEAR_RESETVALUE                      0x00000000UL                                    /**< Default value for ADC_SCANFIFOCLEAR */
 #define _ADC_SCANFIFOCLEAR_MASK                            0x00000001UL                                    /**< Mask for ADC_SCANFIFOCLEAR */
-#define ADC_SCANFIFOCLEAR_SCANFIFOCLEAR                    (0x1UL << 0)                                    /**< Clear Scan FIFO content */
+#define ADC_SCANFIFOCLEAR_SCANFIFOCLEAR                    (0x1UL << 0)                                    /**< Clear Scan FIFO Content */
 #define _ADC_SCANFIFOCLEAR_SCANFIFOCLEAR_SHIFT             0                                               /**< Shift value for ADC_SCANFIFOCLEAR */
 #define _ADC_SCANFIFOCLEAR_SCANFIFOCLEAR_MASK              0x1UL                                           /**< Bit mask for ADC_SCANFIFOCLEAR */
 #define _ADC_SCANFIFOCLEAR_SCANFIFOCLEAR_DEFAULT           0x00000000UL                                    /**< Mode DEFAULT for ADC_SCANFIFOCLEAR */

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_af_pins.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_af_pins.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32pg1b_af_pins.h
  * @brief EFM32PG1B_AF_PINS register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_af_ports.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_af_ports.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32pg1b_af_ports.h
  * @brief EFM32PG1B_AF_PORTS register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_cmu.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_cmu.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32pg1b_cmu.h
  * @brief EFM32PG1B_CMU register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,
@@ -65,7 +65,7 @@ typedef struct {
   __IOM uint32_t HFXOCTRL;            /**< HFXO Control Register  */
   __IOM uint32_t HFXOCTRL1;           /**< HFXO Control 1  */
   __IOM uint32_t HFXOSTARTUPCTRL;     /**< HFXO Startup Control  */
-  __IOM uint32_t HFXOSTEADYSTATECTRL; /**< HFXO Steady State control  */
+  __IOM uint32_t HFXOSTEADYSTATECTRL; /**< HFXO Steady State Control  */
   __IOM uint32_t HFXOTIMEOUTCTRL;     /**< HFXO Timeout Control  */
   __IOM uint32_t LFXOCTRL;            /**< LFXO Control Register  */
   __IOM uint32_t ULFRCOCTRL;          /**< ULFRCO Control Register  */
@@ -99,7 +99,7 @@ typedef struct {
   __IOM uint32_t HFPERCLKEN0;         /**< High Frequency Peripheral Clock Enable Register 0  */
 
   uint32_t       RESERVED10[7];       /**< Reserved for future use **/
-  __IOM uint32_t LFACLKEN0;           /**< Low Frequency A Clock Enable Register 0  (Async Reg)  */
+  __IOM uint32_t LFACLKEN0;           /**< Low Frequency a Clock Enable Register 0  (Async Reg)  */
   uint32_t       RESERVED11[1];       /**< Reserved for future use **/
   __IOM uint32_t LFBCLKEN0;           /**< Low Frequency B Clock Enable Register 0 (Async Reg)  */
 
@@ -116,7 +116,7 @@ typedef struct {
   __IOM uint32_t HFEXPPRESC;          /**< High Frequency Export Clock Prescaler Register  */
 
   uint32_t       RESERVED16[2];       /**< Reserved for future use **/
-  __IOM uint32_t LFAPRESC0;           /**< Low Frequency A Prescaler Register 0 (Async Reg)  */
+  __IOM uint32_t LFAPRESC0;           /**< Low Frequency a Prescaler Register 0 (Async Reg)  */
   uint32_t       RESERVED17[1];       /**< Reserved for future use **/
   __IOM uint32_t LFBPRESC0;           /**< Low Frequency B Prescaler Register 0  (Async Reg)  */
   uint32_t       RESERVED18[1];       /**< Reserved for future use **/
@@ -254,7 +254,7 @@ typedef struct {
 #define CMU_HFRCOCTRL_CLKDIV_DIV1                         (_CMU_HFRCOCTRL_CLKDIV_DIV1 << 25)          /**< Shifted mode DIV1 for CMU_HFRCOCTRL */
 #define CMU_HFRCOCTRL_CLKDIV_DIV2                         (_CMU_HFRCOCTRL_CLKDIV_DIV2 << 25)          /**< Shifted mode DIV2 for CMU_HFRCOCTRL */
 #define CMU_HFRCOCTRL_CLKDIV_DIV4                         (_CMU_HFRCOCTRL_CLKDIV_DIV4 << 25)          /**< Shifted mode DIV4 for CMU_HFRCOCTRL */
-#define CMU_HFRCOCTRL_FINETUNINGEN                        (0x1UL << 27)                               /**< Enable reference for fine tuning */
+#define CMU_HFRCOCTRL_FINETUNINGEN                        (0x1UL << 27)                               /**< Enable Reference for Fine Tuning */
 #define _CMU_HFRCOCTRL_FINETUNINGEN_SHIFT                 27                                          /**< Shift value for CMU_FINETUNINGEN */
 #define _CMU_HFRCOCTRL_FINETUNINGEN_MASK                  0x8000000UL                                 /**< Bit mask for CMU_FINETUNINGEN */
 #define _CMU_HFRCOCTRL_FINETUNINGEN_DEFAULT               0x00000000UL                                /**< Mode DEFAULT for CMU_HFRCOCTRL */
@@ -298,7 +298,7 @@ typedef struct {
 #define CMU_AUXHFRCOCTRL_CLKDIV_DIV1                      (_CMU_AUXHFRCOCTRL_CLKDIV_DIV1 << 25)          /**< Shifted mode DIV1 for CMU_AUXHFRCOCTRL */
 #define CMU_AUXHFRCOCTRL_CLKDIV_DIV2                      (_CMU_AUXHFRCOCTRL_CLKDIV_DIV2 << 25)          /**< Shifted mode DIV2 for CMU_AUXHFRCOCTRL */
 #define CMU_AUXHFRCOCTRL_CLKDIV_DIV4                      (_CMU_AUXHFRCOCTRL_CLKDIV_DIV4 << 25)          /**< Shifted mode DIV4 for CMU_AUXHFRCOCTRL */
-#define CMU_AUXHFRCOCTRL_FINETUNINGEN                     (0x1UL << 27)                                  /**< Enable reference for fine tuning */
+#define CMU_AUXHFRCOCTRL_FINETUNINGEN                     (0x1UL << 27)                                  /**< Enable Reference for Fine Tuning */
 #define _CMU_AUXHFRCOCTRL_FINETUNINGEN_SHIFT              27                                             /**< Shift value for CMU_FINETUNINGEN */
 #define _CMU_AUXHFRCOCTRL_FINETUNINGEN_MASK               0x8000000UL                                    /**< Bit mask for CMU_FINETUNINGEN */
 #define _CMU_AUXHFRCOCTRL_FINETUNINGEN_DEFAULT            0x00000000UL                                   /**< Mode DEFAULT for CMU_AUXHFRCOCTRL */
@@ -315,17 +315,17 @@ typedef struct {
 #define _CMU_LFRCOCTRL_TUNING_MASK                        0x1FFUL                                   /**< Bit mask for CMU_TUNING */
 #define _CMU_LFRCOCTRL_TUNING_DEFAULT                     0x00000100UL                              /**< Mode DEFAULT for CMU_LFRCOCTRL */
 #define CMU_LFRCOCTRL_TUNING_DEFAULT                      (_CMU_LFRCOCTRL_TUNING_DEFAULT << 0)      /**< Shifted mode DEFAULT for CMU_LFRCOCTRL */
-#define CMU_LFRCOCTRL_ENVREF                              (0x1UL << 16)                             /**< Enable duty cycling of vref */
+#define CMU_LFRCOCTRL_ENVREF                              (0x1UL << 16)                             /**< Enable Duty Cycling of Vref */
 #define _CMU_LFRCOCTRL_ENVREF_SHIFT                       16                                        /**< Shift value for CMU_ENVREF */
 #define _CMU_LFRCOCTRL_ENVREF_MASK                        0x10000UL                                 /**< Bit mask for CMU_ENVREF */
 #define _CMU_LFRCOCTRL_ENVREF_DEFAULT                     0x00000000UL                              /**< Mode DEFAULT for CMU_LFRCOCTRL */
 #define CMU_LFRCOCTRL_ENVREF_DEFAULT                      (_CMU_LFRCOCTRL_ENVREF_DEFAULT << 16)     /**< Shifted mode DEFAULT for CMU_LFRCOCTRL */
-#define CMU_LFRCOCTRL_ENCHOP                              (0x1UL << 17)                             /**< Enable comparator chopping */
+#define CMU_LFRCOCTRL_ENCHOP                              (0x1UL << 17)                             /**< Enable Comparator Chopping */
 #define _CMU_LFRCOCTRL_ENCHOP_SHIFT                       17                                        /**< Shift value for CMU_ENCHOP */
 #define _CMU_LFRCOCTRL_ENCHOP_MASK                        0x20000UL                                 /**< Bit mask for CMU_ENCHOP */
 #define _CMU_LFRCOCTRL_ENCHOP_DEFAULT                     0x00000001UL                              /**< Mode DEFAULT for CMU_LFRCOCTRL */
 #define CMU_LFRCOCTRL_ENCHOP_DEFAULT                      (_CMU_LFRCOCTRL_ENCHOP_DEFAULT << 17)     /**< Shifted mode DEFAULT for CMU_LFRCOCTRL */
-#define CMU_LFRCOCTRL_ENDEM                               (0x1UL << 18)                             /**< Enable dynamic element matching */
+#define CMU_LFRCOCTRL_ENDEM                               (0x1UL << 18)                             /**< Enable Dynamic Element Matching */
 #define _CMU_LFRCOCTRL_ENDEM_SHIFT                        18                                        /**< Shift value for CMU_ENDEM */
 #define _CMU_LFRCOCTRL_ENDEM_MASK                         0x40000UL                                 /**< Bit mask for CMU_ENDEM */
 #define _CMU_LFRCOCTRL_ENDEM_DEFAULT                      0x00000001UL                              /**< Mode DEFAULT for CMU_LFRCOCTRL */
@@ -367,17 +367,17 @@ typedef struct {
 #define CMU_HFXOCTRL_PEAKDETSHUNTOPTMODE_AUTOCMD          (_CMU_HFXOCTRL_PEAKDETSHUNTOPTMODE_AUTOCMD << 4) /**< Shifted mode AUTOCMD for CMU_HFXOCTRL */
 #define CMU_HFXOCTRL_PEAKDETSHUNTOPTMODE_CMD              (_CMU_HFXOCTRL_PEAKDETSHUNTOPTMODE_CMD << 4)     /**< Shifted mode CMD for CMU_HFXOCTRL */
 #define CMU_HFXOCTRL_PEAKDETSHUNTOPTMODE_MANUAL           (_CMU_HFXOCTRL_PEAKDETSHUNTOPTMODE_MANUAL << 4)  /**< Shifted mode MANUAL for CMU_HFXOCTRL */
-#define CMU_HFXOCTRL_LOWPOWER                             (0x1UL << 8)                                     /**< Low power mode control. PSR performance is reduced to enable low current consumption. */
+#define CMU_HFXOCTRL_LOWPOWER                             (0x1UL << 8)                                     /**< Low Power Mode Control */
 #define _CMU_HFXOCTRL_LOWPOWER_SHIFT                      8                                                /**< Shift value for CMU_LOWPOWER */
 #define _CMU_HFXOCTRL_LOWPOWER_MASK                       0x100UL                                          /**< Bit mask for CMU_LOWPOWER */
 #define _CMU_HFXOCTRL_LOWPOWER_DEFAULT                    0x00000000UL                                     /**< Mode DEFAULT for CMU_HFXOCTRL */
 #define CMU_HFXOCTRL_LOWPOWER_DEFAULT                     (_CMU_HFXOCTRL_LOWPOWER_DEFAULT << 8)            /**< Shifted mode DEFAULT for CMU_HFXOCTRL */
-#define CMU_HFXOCTRL_XTI2GND                              (0x1UL << 9)                                     /**< Clamp HFXTAL_N pin to ground when HFXO oscillator is off. */
+#define CMU_HFXOCTRL_XTI2GND                              (0x1UL << 9)                                     /**< Clamp HFXTAL_N Pin to Ground When HFXO Oscillator is Off */
 #define _CMU_HFXOCTRL_XTI2GND_SHIFT                       9                                                /**< Shift value for CMU_XTI2GND */
 #define _CMU_HFXOCTRL_XTI2GND_MASK                        0x200UL                                          /**< Bit mask for CMU_XTI2GND */
 #define _CMU_HFXOCTRL_XTI2GND_DEFAULT                     0x00000000UL                                     /**< Mode DEFAULT for CMU_HFXOCTRL */
 #define CMU_HFXOCTRL_XTI2GND_DEFAULT                      (_CMU_HFXOCTRL_XTI2GND_DEFAULT << 9)             /**< Shifted mode DEFAULT for CMU_HFXOCTRL */
-#define CMU_HFXOCTRL_XTO2GND                              (0x1UL << 10)                                    /**< Clamp HFXTAL_P pin to ground when HFXO oscillator is off. */
+#define CMU_HFXOCTRL_XTO2GND                              (0x1UL << 10)                                    /**< Clamp HFXTAL_P Pin to Ground When HFXO Oscillator is Off */
 #define _CMU_HFXOCTRL_XTO2GND_SHIFT                       10                                               /**< Shift value for CMU_XTO2GND */
 #define _CMU_HFXOCTRL_XTO2GND_MASK                        0x400UL                                          /**< Bit mask for CMU_XTO2GND */
 #define _CMU_HFXOCTRL_XTO2GND_DEFAULT                     0x00000000UL                                     /**< Mode DEFAULT for CMU_HFXOCTRL */
@@ -402,12 +402,12 @@ typedef struct {
 #define CMU_HFXOCTRL_LFTIMEOUT_64CYCLES                   (_CMU_HFXOCTRL_LFTIMEOUT_64CYCLES << 24)         /**< Shifted mode 64CYCLES for CMU_HFXOCTRL */
 #define CMU_HFXOCTRL_LFTIMEOUT_1KCYCLES                   (_CMU_HFXOCTRL_LFTIMEOUT_1KCYCLES << 24)         /**< Shifted mode 1KCYCLES for CMU_HFXOCTRL */
 #define CMU_HFXOCTRL_LFTIMEOUT_4KCYCLES                   (_CMU_HFXOCTRL_LFTIMEOUT_4KCYCLES << 24)         /**< Shifted mode 4KCYCLES for CMU_HFXOCTRL */
-#define CMU_HFXOCTRL_AUTOSTARTEM0EM1                      (0x1UL << 28)                                    /**< Automatically start of HFXO upon EM0/EM1 entry from EM2/EM3 */
+#define CMU_HFXOCTRL_AUTOSTARTEM0EM1                      (0x1UL << 28)                                    /**< Automatically Start of HFXO Upon EM0/EM1 Entry From EM2/EM3 */
 #define _CMU_HFXOCTRL_AUTOSTARTEM0EM1_SHIFT               28                                               /**< Shift value for CMU_AUTOSTARTEM0EM1 */
 #define _CMU_HFXOCTRL_AUTOSTARTEM0EM1_MASK                0x10000000UL                                     /**< Bit mask for CMU_AUTOSTARTEM0EM1 */
 #define _CMU_HFXOCTRL_AUTOSTARTEM0EM1_DEFAULT             0x00000000UL                                     /**< Mode DEFAULT for CMU_HFXOCTRL */
 #define CMU_HFXOCTRL_AUTOSTARTEM0EM1_DEFAULT              (_CMU_HFXOCTRL_AUTOSTARTEM0EM1_DEFAULT << 28)    /**< Shifted mode DEFAULT for CMU_HFXOCTRL */
-#define CMU_HFXOCTRL_AUTOSTARTSELEM0EM1                   (0x1UL << 29)                                    /**< Automatically start and select of HFXO upon EM0/EM1 entry from EM2/EM3 */
+#define CMU_HFXOCTRL_AUTOSTARTSELEM0EM1                   (0x1UL << 29)                                    /**< Automatically Start and Select of HFXO Upon EM0/EM1 Entry From EM2/EM3 */
 #define _CMU_HFXOCTRL_AUTOSTARTSELEM0EM1_SHIFT            29                                               /**< Shift value for CMU_AUTOSTARTSELEM0EM1 */
 #define _CMU_HFXOCTRL_AUTOSTARTSELEM0EM1_MASK             0x20000000UL                                     /**< Bit mask for CMU_AUTOSTARTSELEM0EM1 */
 #define _CMU_HFXOCTRL_AUTOSTARTSELEM0EM1_DEFAULT          0x00000000UL                                     /**< Mode DEFAULT for CMU_HFXOCTRL */
@@ -469,7 +469,7 @@ typedef struct {
 #define _CMU_HFXOSTEADYSTATECTRL_REGSELILOW_MASK          0x3000000UL                                          /**< Bit mask for CMU_REGSELILOW */
 #define _CMU_HFXOSTEADYSTATECTRL_REGSELILOW_DEFAULT       0x00000003UL                                         /**< Mode DEFAULT for CMU_HFXOSTEADYSTATECTRL */
 #define CMU_HFXOSTEADYSTATECTRL_REGSELILOW_DEFAULT        (_CMU_HFXOSTEADYSTATECTRL_REGSELILOW_DEFAULT << 24)  /**< Shifted mode DEFAULT for CMU_HFXOSTEADYSTATECTRL */
-#define CMU_HFXOSTEADYSTATECTRL_PEAKDETEN                 (0x1UL << 26)                                        /**< Enables oscillator peak detectors */
+#define CMU_HFXOSTEADYSTATECTRL_PEAKDETEN                 (0x1UL << 26)                                        /**< Enables Oscillator Peak Detectors */
 #define _CMU_HFXOSTEADYSTATECTRL_PEAKDETEN_SHIFT          26                                                   /**< Shift value for CMU_PEAKDETEN */
 #define _CMU_HFXOSTEADYSTATECTRL_PEAKDETEN_MASK           0x4000000UL                                          /**< Bit mask for CMU_PEAKDETEN */
 #define _CMU_HFXOSTEADYSTATECTRL_PEAKDETEN_DEFAULT        0x00000000UL                                         /**< Mode DEFAULT for CMU_HFXOSTEADYSTATECTRL */
@@ -997,7 +997,7 @@ typedef struct {
 #define _CMU_STATUS_CALRDY_MASK                           0x10000UL                                   /**< Bit mask for CMU_CALRDY */
 #define _CMU_STATUS_CALRDY_DEFAULT                        0x00000001UL                                /**< Mode DEFAULT for CMU_STATUS */
 #define CMU_STATUS_CALRDY_DEFAULT                         (_CMU_STATUS_CALRDY_DEFAULT << 16)          /**< Shifted mode DEFAULT for CMU_STATUS */
-#define CMU_STATUS_HFXOREQ                                (0x1UL << 21)                               /**< HFXO is Required by Hardware */
+#define CMU_STATUS_HFXOREQ                                (0x1UL << 21)                               /**< HFXO is Required By Hardware */
 #define _CMU_STATUS_HFXOREQ_SHIFT                         21                                          /**< Shift value for CMU_HFXOREQ */
 #define _CMU_STATUS_HFXOREQ_MASK                          0x200000UL                                  /**< Bit mask for CMU_HFXOREQ */
 #define _CMU_STATUS_HFXOREQ_DEFAULT                       0x00000000UL                                /**< Mode DEFAULT for CMU_STATUS */
@@ -1007,22 +1007,22 @@ typedef struct {
 #define _CMU_STATUS_HFXOPEAKDETRDY_MASK                   0x400000UL                                  /**< Bit mask for CMU_HFXOPEAKDETRDY */
 #define _CMU_STATUS_HFXOPEAKDETRDY_DEFAULT                0x00000000UL                                /**< Mode DEFAULT for CMU_STATUS */
 #define CMU_STATUS_HFXOPEAKDETRDY_DEFAULT                 (_CMU_STATUS_HFXOPEAKDETRDY_DEFAULT << 22)  /**< Shifted mode DEFAULT for CMU_STATUS */
-#define CMU_STATUS_HFXOSHUNTOPTRDY                        (0x1UL << 23)                               /**< HFXO Shunt Current Optimization ready */
+#define CMU_STATUS_HFXOSHUNTOPTRDY                        (0x1UL << 23)                               /**< HFXO Shunt Current Optimization Ready */
 #define _CMU_STATUS_HFXOSHUNTOPTRDY_SHIFT                 23                                          /**< Shift value for CMU_HFXOSHUNTOPTRDY */
 #define _CMU_STATUS_HFXOSHUNTOPTRDY_MASK                  0x800000UL                                  /**< Bit mask for CMU_HFXOSHUNTOPTRDY */
 #define _CMU_STATUS_HFXOSHUNTOPTRDY_DEFAULT               0x00000000UL                                /**< Mode DEFAULT for CMU_STATUS */
 #define CMU_STATUS_HFXOSHUNTOPTRDY_DEFAULT                (_CMU_STATUS_HFXOSHUNTOPTRDY_DEFAULT << 23) /**< Shifted mode DEFAULT for CMU_STATUS */
-#define CMU_STATUS_HFXOAMPHIGH                            (0x1UL << 24)                               /**< HFXO oscillation amplitude is too high */
+#define CMU_STATUS_HFXOAMPHIGH                            (0x1UL << 24)                               /**< HFXO Oscillation Amplitude is Too High */
 #define _CMU_STATUS_HFXOAMPHIGH_SHIFT                     24                                          /**< Shift value for CMU_HFXOAMPHIGH */
 #define _CMU_STATUS_HFXOAMPHIGH_MASK                      0x1000000UL                                 /**< Bit mask for CMU_HFXOAMPHIGH */
 #define _CMU_STATUS_HFXOAMPHIGH_DEFAULT                   0x00000000UL                                /**< Mode DEFAULT for CMU_STATUS */
 #define CMU_STATUS_HFXOAMPHIGH_DEFAULT                    (_CMU_STATUS_HFXOAMPHIGH_DEFAULT << 24)     /**< Shifted mode DEFAULT for CMU_STATUS */
-#define CMU_STATUS_HFXOAMPLOW                             (0x1UL << 25)                               /**< HFXO amplitude tuning value too low */
+#define CMU_STATUS_HFXOAMPLOW                             (0x1UL << 25)                               /**< HFXO Amplitude Tuning Value Too Low */
 #define _CMU_STATUS_HFXOAMPLOW_SHIFT                      25                                          /**< Shift value for CMU_HFXOAMPLOW */
 #define _CMU_STATUS_HFXOAMPLOW_MASK                       0x2000000UL                                 /**< Bit mask for CMU_HFXOAMPLOW */
 #define _CMU_STATUS_HFXOAMPLOW_DEFAULT                    0x00000000UL                                /**< Mode DEFAULT for CMU_STATUS */
 #define CMU_STATUS_HFXOAMPLOW_DEFAULT                     (_CMU_STATUS_HFXOAMPLOW_DEFAULT << 25)      /**< Shifted mode DEFAULT for CMU_STATUS */
-#define CMU_STATUS_HFXOREGILOW                            (0x1UL << 26)                               /**< HFXO regulator shunt current too low */
+#define CMU_STATUS_HFXOREGILOW                            (0x1UL << 26)                               /**< HFXO Regulator Shunt Current Too Low */
 #define _CMU_STATUS_HFXOREGILOW_SHIFT                     26                                          /**< Shift value for CMU_HFXOREGILOW */
 #define _CMU_STATUS_HFXOREGILOW_MASK                      0x4000000UL                                 /**< Bit mask for CMU_HFXOREGILOW */
 #define _CMU_STATUS_HFXOREGILOW_DEFAULT                   0x00000000UL                                /**< Mode DEFAULT for CMU_STATUS */
@@ -1598,12 +1598,12 @@ typedef struct {
 /* Bit fields for CMU SYNCBUSY */
 #define _CMU_SYNCBUSY_RESETVALUE                          0x00000000UL                               /**< Default value for CMU_SYNCBUSY */
 #define _CMU_SYNCBUSY_MASK                                0x3F050055UL                               /**< Mask for CMU_SYNCBUSY */
-#define CMU_SYNCBUSY_LFACLKEN0                            (0x1UL << 0)                               /**< Low Frequency A Clock Enable 0 Busy */
+#define CMU_SYNCBUSY_LFACLKEN0                            (0x1UL << 0)                               /**< Low Frequency a Clock Enable 0 Busy */
 #define _CMU_SYNCBUSY_LFACLKEN0_SHIFT                     0                                          /**< Shift value for CMU_LFACLKEN0 */
 #define _CMU_SYNCBUSY_LFACLKEN0_MASK                      0x1UL                                      /**< Bit mask for CMU_LFACLKEN0 */
 #define _CMU_SYNCBUSY_LFACLKEN0_DEFAULT                   0x00000000UL                               /**< Mode DEFAULT for CMU_SYNCBUSY */
 #define CMU_SYNCBUSY_LFACLKEN0_DEFAULT                    (_CMU_SYNCBUSY_LFACLKEN0_DEFAULT << 0)     /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
-#define CMU_SYNCBUSY_LFAPRESC0                            (0x1UL << 2)                               /**< Low Frequency A Prescaler 0 Busy */
+#define CMU_SYNCBUSY_LFAPRESC0                            (0x1UL << 2)                               /**< Low Frequency a Prescaler 0 Busy */
 #define _CMU_SYNCBUSY_LFAPRESC0_SHIFT                     2                                          /**< Shift value for CMU_LFAPRESC0 */
 #define _CMU_SYNCBUSY_LFAPRESC0_MASK                      0x4UL                                      /**< Bit mask for CMU_LFAPRESC0 */
 #define _CMU_SYNCBUSY_LFAPRESC0_DEFAULT                   0x00000000UL                               /**< Mode DEFAULT for CMU_SYNCBUSY */
@@ -1705,7 +1705,7 @@ typedef struct {
 #define CMU_ADCCTRL_ADC0CLKSEL_AUXHFRCO                   (_CMU_ADCCTRL_ADC0CLKSEL_AUXHFRCO << 4) /**< Shifted mode AUXHFRCO for CMU_ADCCTRL */
 #define CMU_ADCCTRL_ADC0CLKSEL_HFXO                       (_CMU_ADCCTRL_ADC0CLKSEL_HFXO << 4)     /**< Shifted mode HFXO for CMU_ADCCTRL */
 #define CMU_ADCCTRL_ADC0CLKSEL_HFSRCCLK                   (_CMU_ADCCTRL_ADC0CLKSEL_HFSRCCLK << 4) /**< Shifted mode HFSRCCLK for CMU_ADCCTRL */
-#define CMU_ADCCTRL_ADC0CLKINV                            (0x1UL << 8)                            /**< Invert clock selected by ADC0CLKSEL */
+#define CMU_ADCCTRL_ADC0CLKINV                            (0x1UL << 8)                            /**< Invert Clock Selected By ADC0CLKSEL */
 #define _CMU_ADCCTRL_ADC0CLKINV_SHIFT                     8                                       /**< Shift value for CMU_ADC0CLKINV */
 #define _CMU_ADCCTRL_ADC0CLKINV_MASK                      0x100UL                                 /**< Bit mask for CMU_ADC0CLKINV */
 #define _CMU_ADCCTRL_ADC0CLKINV_DEFAULT                   0x00000000UL                            /**< Mode DEFAULT for CMU_ADCCTRL */

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_cryotimer.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_cryotimer.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32pg1b_cryotimer.h
  * @brief EFM32PG1B_CRYOTIMER register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,
@@ -132,7 +132,7 @@ typedef struct {
 /* Bit fields for CRYOTIMER EM4WUEN */
 #define _CRYOTIMER_EM4WUEN_RESETVALUE             0x00000000UL                            /**< Default value for CRYOTIMER_EM4WUEN */
 #define _CRYOTIMER_EM4WUEN_MASK                   0x00000001UL                            /**< Mask for CRYOTIMER_EM4WUEN */
-#define CRYOTIMER_EM4WUEN_EM4WU                   (0x1UL << 0)                            /**< EM4 Wake-up enable */
+#define CRYOTIMER_EM4WUEN_EM4WU                   (0x1UL << 0)                            /**< EM4 Wake-up Enable */
 #define _CRYOTIMER_EM4WUEN_EM4WU_SHIFT            0                                       /**< Shift value for CRYOTIMER_EM4WU */
 #define _CRYOTIMER_EM4WUEN_EM4WU_MASK             0x1UL                                   /**< Bit mask for CRYOTIMER_EM4WU */
 #define _CRYOTIMER_EM4WUEN_EM4WU_DEFAULT          0x00000000UL                            /**< Mode DEFAULT for CRYOTIMER_EM4WUEN */
@@ -141,7 +141,7 @@ typedef struct {
 /* Bit fields for CRYOTIMER IF */
 #define _CRYOTIMER_IF_RESETVALUE                  0x00000000UL                        /**< Default value for CRYOTIMER_IF */
 #define _CRYOTIMER_IF_MASK                        0x00000001UL                        /**< Mask for CRYOTIMER_IF */
-#define CRYOTIMER_IF_PERIOD                       (0x1UL << 0)                        /**< Wakeup event/Interrupt */
+#define CRYOTIMER_IF_PERIOD                       (0x1UL << 0)                        /**< Wakeup Event/Interrupt */
 #define _CRYOTIMER_IF_PERIOD_SHIFT                0                                   /**< Shift value for CRYOTIMER_PERIOD */
 #define _CRYOTIMER_IF_PERIOD_MASK                 0x1UL                               /**< Bit mask for CRYOTIMER_PERIOD */
 #define _CRYOTIMER_IF_PERIOD_DEFAULT              0x00000000UL                        /**< Mode DEFAULT for CRYOTIMER_IF */

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_crypto.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_crypto.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32pg1b_crypto.h
  * @brief EFM32PG1B_CRYPTO register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,
@@ -70,7 +70,7 @@ typedef struct {
   __IOM uint32_t IFS;            /**< Interrupt Flag Set Register  */
   __IOM uint32_t IFC;            /**< Interrupt Flag Clear Register  */
   __IOM uint32_t IEN;            /**< Interrupt Enable Register  */
-  __IOM uint32_t SEQ0;           /**< Sequence register 0  */
+  __IOM uint32_t SEQ0;           /**< Sequence Register 0  */
   __IOM uint32_t SEQ1;           /**< Sequence Register 1  */
   __IOM uint32_t SEQ2;           /**< Sequence Register 2  */
   __IOM uint32_t SEQ3;           /**< Sequence Register 3  */
@@ -102,7 +102,7 @@ typedef struct {
   uint32_t       RESERVED10[3];  /**< Reserved for future use **/
   __IOM uint32_t DDATA0BYTE;     /**< DDATA0 Register Byte Access  */
   __IOM uint32_t DDATA1BYTE;     /**< DDATA1 Register Byte Access  */
-  __IOM uint32_t DDATA0BYTE32;   /**< DDATA0 Register Byte 32 access.  */
+  __IOM uint32_t DDATA0BYTE32;   /**< DDATA0 Register Byte 32 Access  */
   uint32_t       RESERVED11[13]; /**< Reserved for future use **/
   __IOM uint32_t QDATA0;         /**< QDATA0 Register Access  */
   __IOM uint32_t QDATA1;         /**< QDATA1 Register Access  */
@@ -659,12 +659,12 @@ typedef struct {
 #define _CRYPTO_STATUS_SEQRUNNING_MASK               0x1UL                                      /**< Bit mask for CRYPTO_SEQRUNNING */
 #define _CRYPTO_STATUS_SEQRUNNING_DEFAULT            0x00000000UL                               /**< Mode DEFAULT for CRYPTO_STATUS */
 #define CRYPTO_STATUS_SEQRUNNING_DEFAULT             (_CRYPTO_STATUS_SEQRUNNING_DEFAULT << 0)   /**< Shifted mode DEFAULT for CRYPTO_STATUS */
-#define CRYPTO_STATUS_INSTRRUNNING                   (0x1UL << 1)                               /**< Action is active */
+#define CRYPTO_STATUS_INSTRRUNNING                   (0x1UL << 1)                               /**< Action is Active */
 #define _CRYPTO_STATUS_INSTRRUNNING_SHIFT            1                                          /**< Shift value for CRYPTO_INSTRRUNNING */
 #define _CRYPTO_STATUS_INSTRRUNNING_MASK             0x2UL                                      /**< Bit mask for CRYPTO_INSTRRUNNING */
 #define _CRYPTO_STATUS_INSTRRUNNING_DEFAULT          0x00000000UL                               /**< Mode DEFAULT for CRYPTO_STATUS */
 #define CRYPTO_STATUS_INSTRRUNNING_DEFAULT           (_CRYPTO_STATUS_INSTRRUNNING_DEFAULT << 1) /**< Shifted mode DEFAULT for CRYPTO_STATUS */
-#define CRYPTO_STATUS_DMAACTIVE                      (0x1UL << 2)                               /**< DMA Action is active */
+#define CRYPTO_STATUS_DMAACTIVE                      (0x1UL << 2)                               /**< DMA Action is Active */
 #define _CRYPTO_STATUS_DMAACTIVE_SHIFT               2                                          /**< Shift value for CRYPTO_DMAACTIVE */
 #define _CRYPTO_STATUS_DMAACTIVE_MASK                0x4UL                                      /**< Bit mask for CRYPTO_DMAACTIVE */
 #define _CRYPTO_STATUS_DMAACTIVE_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for CRYPTO_STATUS */
@@ -807,12 +807,12 @@ typedef struct {
 #define _CRYPTO_SEQCTRL_DMA1SKIP_MASK                0xC000000UL                               /**< Bit mask for CRYPTO_DMA1SKIP */
 #define _CRYPTO_SEQCTRL_DMA1SKIP_DEFAULT             0x00000000UL                              /**< Mode DEFAULT for CRYPTO_SEQCTRL */
 #define CRYPTO_SEQCTRL_DMA1SKIP_DEFAULT              (_CRYPTO_SEQCTRL_DMA1SKIP_DEFAULT << 26)  /**< Shifted mode DEFAULT for CRYPTO_SEQCTRL */
-#define CRYPTO_SEQCTRL_DMA0PRESA                     (0x1UL << 28)                             /**< DMA0 Preserve A */
+#define CRYPTO_SEQCTRL_DMA0PRESA                     (0x1UL << 28)                             /**< DMA0 Preserve a */
 #define _CRYPTO_SEQCTRL_DMA0PRESA_SHIFT              28                                        /**< Shift value for CRYPTO_DMA0PRESA */
 #define _CRYPTO_SEQCTRL_DMA0PRESA_MASK               0x10000000UL                              /**< Bit mask for CRYPTO_DMA0PRESA */
 #define _CRYPTO_SEQCTRL_DMA0PRESA_DEFAULT            0x00000000UL                              /**< Mode DEFAULT for CRYPTO_SEQCTRL */
 #define CRYPTO_SEQCTRL_DMA0PRESA_DEFAULT             (_CRYPTO_SEQCTRL_DMA0PRESA_DEFAULT << 28) /**< Shifted mode DEFAULT for CRYPTO_SEQCTRL */
-#define CRYPTO_SEQCTRL_DMA1PRESA                     (0x1UL << 29)                             /**< DMA1 Preserve A */
+#define CRYPTO_SEQCTRL_DMA1PRESA                     (0x1UL << 29)                             /**< DMA1 Preserve a */
 #define _CRYPTO_SEQCTRL_DMA1PRESA_SHIFT              29                                        /**< Shift value for CRYPTO_DMA1PRESA */
 #define _CRYPTO_SEQCTRL_DMA1PRESA_MASK               0x20000000UL                              /**< Bit mask for CRYPTO_DMA1PRESA */
 #define _CRYPTO_SEQCTRL_DMA1PRESA_DEFAULT            0x00000000UL                              /**< Mode DEFAULT for CRYPTO_SEQCTRL */
@@ -844,7 +844,7 @@ typedef struct {
 /* Bit fields for CRYPTO IF */
 #define _CRYPTO_IF_RESETVALUE                        0x00000000UL                        /**< Default value for CRYPTO_IF */
 #define _CRYPTO_IF_MASK                              0x00000003UL                        /**< Mask for CRYPTO_IF */
-#define CRYPTO_IF_INSTRDONE                          (0x1UL << 0)                        /**< Instruction done */
+#define CRYPTO_IF_INSTRDONE                          (0x1UL << 0)                        /**< Instruction Done */
 #define _CRYPTO_IF_INSTRDONE_SHIFT                   0                                   /**< Shift value for CRYPTO_INSTRDONE */
 #define _CRYPTO_IF_INSTRDONE_MASK                    0x1UL                               /**< Bit mask for CRYPTO_INSTRDONE */
 #define _CRYPTO_IF_INSTRDONE_DEFAULT                 0x00000000UL                        /**< Mode DEFAULT for CRYPTO_IF */

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_devinfo.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_devinfo.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32pg1b_devinfo.h
  * @brief EFM32PG1B_DEVINFO register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,
@@ -244,8 +244,6 @@ typedef struct {
 #define _DEVINFO_PART_DEVICE_FAMILY_EFM32JG1B                    0x00000053UL                                   /**< Mode EFM32JG1B for DEVINFO_PART */
 #define _DEVINFO_PART_DEVICE_FAMILY_EFM32PG12B                   0x00000055UL                                   /**< Mode EFM32PG12B for DEVINFO_PART */
 #define _DEVINFO_PART_DEVICE_FAMILY_EFM32JG12B                   0x00000057UL                                   /**< Mode EFM32JG12B for DEVINFO_PART */
-#define _DEVINFO_PART_DEVICE_FAMILY_EFM32PG13B                   0x00000059UL                                   /**< Mode EFM32PG13B for DEVINFO_PART */
-#define _DEVINFO_PART_DEVICE_FAMILY_EFM32JG13B                   0x0000005BUL                                   /**< Mode EFM32JG13B for DEVINFO_PART */
 #define _DEVINFO_PART_DEVICE_FAMILY_EFM32GG11B                   0x00000064UL                                   /**< Mode EFM32GG11B for DEVINFO_PART */
 #define _DEVINFO_PART_DEVICE_FAMILY_EFM32TG11B                   0x00000067UL                                   /**< Mode EFM32TG11B for DEVINFO_PART */
 #define _DEVINFO_PART_DEVICE_FAMILY_EZR32LG                      0x00000078UL                                   /**< Mode EZR32LG for DEVINFO_PART */
@@ -305,8 +303,6 @@ typedef struct {
 #define DEVINFO_PART_DEVICE_FAMILY_EFM32JG1B                     (_DEVINFO_PART_DEVICE_FAMILY_EFM32JG1B << 16)  /**< Shifted mode EFM32JG1B for DEVINFO_PART */
 #define DEVINFO_PART_DEVICE_FAMILY_EFM32PG12B                    (_DEVINFO_PART_DEVICE_FAMILY_EFM32PG12B << 16) /**< Shifted mode EFM32PG12B for DEVINFO_PART */
 #define DEVINFO_PART_DEVICE_FAMILY_EFM32JG12B                    (_DEVINFO_PART_DEVICE_FAMILY_EFM32JG12B << 16) /**< Shifted mode EFM32JG12B for DEVINFO_PART */
-#define DEVINFO_PART_DEVICE_FAMILY_EFM32PG13B                    (_DEVINFO_PART_DEVICE_FAMILY_EFM32PG13B << 16) /**< Shifted mode EFM32PG13B for DEVINFO_PART */
-#define DEVINFO_PART_DEVICE_FAMILY_EFM32JG13B                    (_DEVINFO_PART_DEVICE_FAMILY_EFM32JG13B << 16) /**< Shifted mode EFM32JG13B for DEVINFO_PART */
 #define DEVINFO_PART_DEVICE_FAMILY_EFM32GG11B                    (_DEVINFO_PART_DEVICE_FAMILY_EFM32GG11B << 16) /**< Shifted mode EFM32GG11B for DEVINFO_PART */
 #define DEVINFO_PART_DEVICE_FAMILY_EFM32TG11B                    (_DEVINFO_PART_DEVICE_FAMILY_EFM32TG11B << 16) /**< Shifted mode EFM32TG11B for DEVINFO_PART */
 #define DEVINFO_PART_DEVICE_FAMILY_EZR32LG                       (_DEVINFO_PART_DEVICE_FAMILY_EZR32LG << 16)    /**< Shifted mode EZR32LG for DEVINFO_PART */

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_dma_descriptor.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_dma_descriptor.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32pg1b_dma_descriptor.h
  * @brief EFM32PG1B_DMA_DESCRIPTOR register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_dmareq.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_dmareq.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32pg1b_dmareq.h
  * @brief EFM32PG1B_DMAREQ register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_emu.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_emu.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32pg1b_emu.h
  * @brief EFM32PG1B_EMU register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,
@@ -60,15 +60,15 @@ typedef struct {
 
   uint32_t       RESERVED0[1];    /**< Reserved for future use **/
   __IOM uint32_t EM4CTRL;         /**< EM4 Control Register  */
-  __IOM uint32_t TEMPLIMITS;      /**< Temperature limits for interrupt generation  */
-  __IM uint32_t  TEMP;            /**< Value of last temperature measurement  */
+  __IOM uint32_t TEMPLIMITS;      /**< Temperature Limits for Interrupt Generation  */
+  __IM uint32_t  TEMP;            /**< Value of Last Temperature Measurement  */
   __IM uint32_t  IF;              /**< Interrupt Flag Register  */
   __IOM uint32_t IFS;             /**< Interrupt Flag Set Register  */
   __IOM uint32_t IFC;             /**< Interrupt Flag Clear Register  */
   __IOM uint32_t IEN;             /**< Interrupt Enable Register  */
   __IOM uint32_t PWRLOCK;         /**< Regulator and Supply Lock Register  */
   __IOM uint32_t PWRCFG;          /**< Power Configuration Register  */
-  __IOM uint32_t PWRCTRL;         /**< Power Control Register.  */
+  __IOM uint32_t PWRCTRL;         /**< Power Control Register  */
   __IOM uint32_t DCDCCTRL;        /**< DCDC Control  */
 
   uint32_t       RESERVED1[2];    /**< Reserved for future use **/
@@ -100,7 +100,7 @@ typedef struct {
   __IOM uint32_t TESTLOCK;        /**< Test Lock Register  */
 
   uint32_t       RESERVED7[2];    /**< Reserved for future use **/
-  __IOM uint32_t BIASTESTCTRL;    /**< Test Control Register for regulator and BIAS  */
+  __IOM uint32_t BIASTESTCTRL;    /**< Test Control Register for Regulator and BIAS  */
 } EMU_TypeDef;                    /** @} */
 
 /**************************************************************************//**
@@ -122,32 +122,32 @@ typedef struct {
 /* Bit fields for EMU STATUS */
 #define _EMU_STATUS_RESETVALUE                       0x00000000UL                           /**< Default value for EMU_STATUS */
 #define _EMU_STATUS_MASK                             0x0010011FUL                           /**< Mask for EMU_STATUS */
-#define EMU_STATUS_VMONRDY                           (0x1UL << 0)                           /**< VMON ready */
+#define EMU_STATUS_VMONRDY                           (0x1UL << 0)                           /**< VMON Ready */
 #define _EMU_STATUS_VMONRDY_SHIFT                    0                                      /**< Shift value for EMU_VMONRDY */
 #define _EMU_STATUS_VMONRDY_MASK                     0x1UL                                  /**< Bit mask for EMU_VMONRDY */
 #define _EMU_STATUS_VMONRDY_DEFAULT                  0x00000000UL                           /**< Mode DEFAULT for EMU_STATUS */
 #define EMU_STATUS_VMONRDY_DEFAULT                   (_EMU_STATUS_VMONRDY_DEFAULT << 0)     /**< Shifted mode DEFAULT for EMU_STATUS */
-#define EMU_STATUS_VMONAVDD                          (0x1UL << 1)                           /**< VMON AVDD Channel. */
+#define EMU_STATUS_VMONAVDD                          (0x1UL << 1)                           /**< VMON AVDD Channel */
 #define _EMU_STATUS_VMONAVDD_SHIFT                   1                                      /**< Shift value for EMU_VMONAVDD */
 #define _EMU_STATUS_VMONAVDD_MASK                    0x2UL                                  /**< Bit mask for EMU_VMONAVDD */
 #define _EMU_STATUS_VMONAVDD_DEFAULT                 0x00000000UL                           /**< Mode DEFAULT for EMU_STATUS */
 #define EMU_STATUS_VMONAVDD_DEFAULT                  (_EMU_STATUS_VMONAVDD_DEFAULT << 1)    /**< Shifted mode DEFAULT for EMU_STATUS */
-#define EMU_STATUS_VMONALTAVDD                       (0x1UL << 2)                           /**< Alternate VMON AVDD Channel. */
+#define EMU_STATUS_VMONALTAVDD                       (0x1UL << 2)                           /**< Alternate VMON AVDD Channel */
 #define _EMU_STATUS_VMONALTAVDD_SHIFT                2                                      /**< Shift value for EMU_VMONALTAVDD */
 #define _EMU_STATUS_VMONALTAVDD_MASK                 0x4UL                                  /**< Bit mask for EMU_VMONALTAVDD */
 #define _EMU_STATUS_VMONALTAVDD_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for EMU_STATUS */
 #define EMU_STATUS_VMONALTAVDD_DEFAULT               (_EMU_STATUS_VMONALTAVDD_DEFAULT << 2) /**< Shifted mode DEFAULT for EMU_STATUS */
-#define EMU_STATUS_VMONDVDD                          (0x1UL << 3)                           /**< VMON DVDD Channel. */
+#define EMU_STATUS_VMONDVDD                          (0x1UL << 3)                           /**< VMON DVDD Channel */
 #define _EMU_STATUS_VMONDVDD_SHIFT                   3                                      /**< Shift value for EMU_VMONDVDD */
 #define _EMU_STATUS_VMONDVDD_MASK                    0x8UL                                  /**< Bit mask for EMU_VMONDVDD */
 #define _EMU_STATUS_VMONDVDD_DEFAULT                 0x00000000UL                           /**< Mode DEFAULT for EMU_STATUS */
 #define EMU_STATUS_VMONDVDD_DEFAULT                  (_EMU_STATUS_VMONDVDD_DEFAULT << 3)    /**< Shifted mode DEFAULT for EMU_STATUS */
-#define EMU_STATUS_VMONIO0                           (0x1UL << 4)                           /**< VMON IOVDD0 Channel. */
+#define EMU_STATUS_VMONIO0                           (0x1UL << 4)                           /**< VMON IOVDD0 Channel */
 #define _EMU_STATUS_VMONIO0_SHIFT                    4                                      /**< Shift value for EMU_VMONIO0 */
 #define _EMU_STATUS_VMONIO0_MASK                     0x10UL                                 /**< Bit mask for EMU_VMONIO0 */
 #define _EMU_STATUS_VMONIO0_DEFAULT                  0x00000000UL                           /**< Mode DEFAULT for EMU_STATUS */
 #define EMU_STATUS_VMONIO0_DEFAULT                   (_EMU_STATUS_VMONIO0_DEFAULT << 4)     /**< Shifted mode DEFAULT for EMU_STATUS */
-#define EMU_STATUS_VMONFVDD                          (0x1UL << 8)                           /**< VMON VDDFLASH Channel. */
+#define EMU_STATUS_VMONFVDD                          (0x1UL << 8)                           /**< VMON VDDFLASH Channel */
 #define _EMU_STATUS_VMONFVDD_SHIFT                   8                                      /**< Shift value for EMU_VMONFVDD */
 #define _EMU_STATUS_VMONFVDD_MASK                    0x100UL                                /**< Bit mask for EMU_VMONFVDD */
 #define _EMU_STATUS_VMONFVDD_DEFAULT                 0x00000000UL                           /**< Mode DEFAULT for EMU_STATUS */
@@ -217,17 +217,17 @@ typedef struct {
 #define EMU_EM4CTRL_EM4STATE_DEFAULT                 (_EMU_EM4CTRL_EM4STATE_DEFAULT << 0)       /**< Shifted mode DEFAULT for EMU_EM4CTRL */
 #define EMU_EM4CTRL_EM4STATE_EM4S                    (_EMU_EM4CTRL_EM4STATE_EM4S << 0)          /**< Shifted mode EM4S for EMU_EM4CTRL */
 #define EMU_EM4CTRL_EM4STATE_EM4H                    (_EMU_EM4CTRL_EM4STATE_EM4H << 0)          /**< Shifted mode EM4H for EMU_EM4CTRL */
-#define EMU_EM4CTRL_RETAINLFRCO                      (0x1UL << 1)                               /**< LFRCO Retain during EM4 */
+#define EMU_EM4CTRL_RETAINLFRCO                      (0x1UL << 1)                               /**< LFRCO Retain During EM4 */
 #define _EMU_EM4CTRL_RETAINLFRCO_SHIFT               1                                          /**< Shift value for EMU_RETAINLFRCO */
 #define _EMU_EM4CTRL_RETAINLFRCO_MASK                0x2UL                                      /**< Bit mask for EMU_RETAINLFRCO */
 #define _EMU_EM4CTRL_RETAINLFRCO_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for EMU_EM4CTRL */
 #define EMU_EM4CTRL_RETAINLFRCO_DEFAULT              (_EMU_EM4CTRL_RETAINLFRCO_DEFAULT << 1)    /**< Shifted mode DEFAULT for EMU_EM4CTRL */
-#define EMU_EM4CTRL_RETAINLFXO                       (0x1UL << 2)                               /**< LFXO Retain during EM4 */
+#define EMU_EM4CTRL_RETAINLFXO                       (0x1UL << 2)                               /**< LFXO Retain During EM4 */
 #define _EMU_EM4CTRL_RETAINLFXO_SHIFT                2                                          /**< Shift value for EMU_RETAINLFXO */
 #define _EMU_EM4CTRL_RETAINLFXO_MASK                 0x4UL                                      /**< Bit mask for EMU_RETAINLFXO */
 #define _EMU_EM4CTRL_RETAINLFXO_DEFAULT              0x00000000UL                               /**< Mode DEFAULT for EMU_EM4CTRL */
 #define EMU_EM4CTRL_RETAINLFXO_DEFAULT               (_EMU_EM4CTRL_RETAINLFXO_DEFAULT << 2)     /**< Shifted mode DEFAULT for EMU_EM4CTRL */
-#define EMU_EM4CTRL_RETAINULFRCO                     (0x1UL << 3)                               /**< ULFRCO Retain during EM4S */
+#define EMU_EM4CTRL_RETAINULFRCO                     (0x1UL << 3)                               /**< ULFRCO Retain During EM4S */
 #define _EMU_EM4CTRL_RETAINULFRCO_SHIFT              3                                          /**< Shift value for EMU_RETAINULFRCO */
 #define _EMU_EM4CTRL_RETAINULFRCO_MASK               0x8UL                                      /**< Bit mask for EMU_RETAINULFRCO */
 #define _EMU_EM4CTRL_RETAINULFRCO_DEFAULT            0x00000000UL                               /**< Mode DEFAULT for EMU_EM4CTRL */
@@ -258,7 +258,7 @@ typedef struct {
 #define _EMU_TEMPLIMITS_TEMPHIGH_MASK                0xFF00UL                                /**< Bit mask for EMU_TEMPHIGH */
 #define _EMU_TEMPLIMITS_TEMPHIGH_DEFAULT             0x000000FFUL                            /**< Mode DEFAULT for EMU_TEMPLIMITS */
 #define EMU_TEMPLIMITS_TEMPHIGH_DEFAULT              (_EMU_TEMPLIMITS_TEMPHIGH_DEFAULT << 8) /**< Shifted mode DEFAULT for EMU_TEMPLIMITS */
-#define EMU_TEMPLIMITS_EM4WUEN                       (0x1UL << 16)                           /**< Enable EM4 Wakeup due to low/high temperature */
+#define EMU_TEMPLIMITS_EM4WUEN                       (0x1UL << 16)                           /**< Enable EM4 Wakeup Due to Low/high Temperature */
 #define _EMU_TEMPLIMITS_EM4WUEN_SHIFT                16                                      /**< Shift value for EMU_EM4WUEN */
 #define _EMU_TEMPLIMITS_EM4WUEN_MASK                 0x10000UL                               /**< Bit mask for EMU_EM4WUEN */
 #define _EMU_TEMPLIMITS_EM4WUEN_DEFAULT              0x00000000UL                            /**< Mode DEFAULT for EMU_TEMPLIMITS */
@@ -325,32 +325,32 @@ typedef struct {
 #define _EMU_IF_VMONFVDDRISE_MASK                    0x8000UL                                     /**< Bit mask for EMU_VMONFVDDRISE */
 #define _EMU_IF_VMONFVDDRISE_DEFAULT                 0x00000000UL                                 /**< Mode DEFAULT for EMU_IF */
 #define EMU_IF_VMONFVDDRISE_DEFAULT                  (_EMU_IF_VMONFVDDRISE_DEFAULT << 15)         /**< Shifted mode DEFAULT for EMU_IF */
-#define EMU_IF_PFETOVERCURRENTLIMIT                  (0x1UL << 16)                                /**< PFET current limit hit */
+#define EMU_IF_PFETOVERCURRENTLIMIT                  (0x1UL << 16)                                /**< PFET Current Limit Hit */
 #define _EMU_IF_PFETOVERCURRENTLIMIT_SHIFT           16                                           /**< Shift value for EMU_PFETOVERCURRENTLIMIT */
 #define _EMU_IF_PFETOVERCURRENTLIMIT_MASK            0x10000UL                                    /**< Bit mask for EMU_PFETOVERCURRENTLIMIT */
 #define _EMU_IF_PFETOVERCURRENTLIMIT_DEFAULT         0x00000000UL                                 /**< Mode DEFAULT for EMU_IF */
 #define EMU_IF_PFETOVERCURRENTLIMIT_DEFAULT          (_EMU_IF_PFETOVERCURRENTLIMIT_DEFAULT << 16) /**< Shifted mode DEFAULT for EMU_IF */
-#define EMU_IF_NFETOVERCURRENTLIMIT                  (0x1UL << 17)                                /**< NFET current limit hit */
+#define EMU_IF_NFETOVERCURRENTLIMIT                  (0x1UL << 17)                                /**< NFET Current Limit Hit */
 #define _EMU_IF_NFETOVERCURRENTLIMIT_SHIFT           17                                           /**< Shift value for EMU_NFETOVERCURRENTLIMIT */
 #define _EMU_IF_NFETOVERCURRENTLIMIT_MASK            0x20000UL                                    /**< Bit mask for EMU_NFETOVERCURRENTLIMIT */
 #define _EMU_IF_NFETOVERCURRENTLIMIT_DEFAULT         0x00000000UL                                 /**< Mode DEFAULT for EMU_IF */
 #define EMU_IF_NFETOVERCURRENTLIMIT_DEFAULT          (_EMU_IF_NFETOVERCURRENTLIMIT_DEFAULT << 17) /**< Shifted mode DEFAULT for EMU_IF */
-#define EMU_IF_DCDCLPRUNNING                         (0x1UL << 18)                                /**< LP mode is running */
+#define EMU_IF_DCDCLPRUNNING                         (0x1UL << 18)                                /**< LP Mode is Running */
 #define _EMU_IF_DCDCLPRUNNING_SHIFT                  18                                           /**< Shift value for EMU_DCDCLPRUNNING */
 #define _EMU_IF_DCDCLPRUNNING_MASK                   0x40000UL                                    /**< Bit mask for EMU_DCDCLPRUNNING */
 #define _EMU_IF_DCDCLPRUNNING_DEFAULT                0x00000000UL                                 /**< Mode DEFAULT for EMU_IF */
 #define EMU_IF_DCDCLPRUNNING_DEFAULT                 (_EMU_IF_DCDCLPRUNNING_DEFAULT << 18)        /**< Shifted mode DEFAULT for EMU_IF */
-#define EMU_IF_DCDCLNRUNNING                         (0x1UL << 19)                                /**< LN mode is running */
+#define EMU_IF_DCDCLNRUNNING                         (0x1UL << 19)                                /**< LN Mode is Running */
 #define _EMU_IF_DCDCLNRUNNING_SHIFT                  19                                           /**< Shift value for EMU_DCDCLNRUNNING */
 #define _EMU_IF_DCDCLNRUNNING_MASK                   0x80000UL                                    /**< Bit mask for EMU_DCDCLNRUNNING */
 #define _EMU_IF_DCDCLNRUNNING_DEFAULT                0x00000000UL                                 /**< Mode DEFAULT for EMU_IF */
 #define EMU_IF_DCDCLNRUNNING_DEFAULT                 (_EMU_IF_DCDCLNRUNNING_DEFAULT << 19)        /**< Shifted mode DEFAULT for EMU_IF */
-#define EMU_IF_DCDCINBYPASS                          (0x1UL << 20)                                /**< DCDC is in bypass */
+#define EMU_IF_DCDCINBYPASS                          (0x1UL << 20)                                /**< DCDC is in Bypass */
 #define _EMU_IF_DCDCINBYPASS_SHIFT                   20                                           /**< Shift value for EMU_DCDCINBYPASS */
 #define _EMU_IF_DCDCINBYPASS_MASK                    0x100000UL                                   /**< Bit mask for EMU_DCDCINBYPASS */
 #define _EMU_IF_DCDCINBYPASS_DEFAULT                 0x00000000UL                                 /**< Mode DEFAULT for EMU_IF */
 #define EMU_IF_DCDCINBYPASS_DEFAULT                  (_EMU_IF_DCDCINBYPASS_DEFAULT << 20)         /**< Shifted mode DEFAULT for EMU_IF */
-#define EMU_IF_EM23WAKEUP                            (0x1UL << 24)                                /**< Wakeup IRQ from EM2 and EM3 */
+#define EMU_IF_EM23WAKEUP                            (0x1UL << 24)                                /**< Wakeup IRQ From EM2 and EM3 */
 #define _EMU_IF_EM23WAKEUP_SHIFT                     24                                           /**< Shift value for EMU_EM23WAKEUP */
 #define _EMU_IF_EM23WAKEUP_MASK                      0x1000000UL                                  /**< Bit mask for EMU_EM23WAKEUP */
 #define _EMU_IF_EM23WAKEUP_DEFAULT                   0x00000000UL                                 /**< Mode DEFAULT for EMU_IF */
@@ -746,7 +746,7 @@ typedef struct {
 /* Bit fields for EMU DCDCMISCCTRL */
 #define _EMU_DCDCMISCCTRL_RESETVALUE                 0x33307700UL                                    /**< Default value for EMU_DCDCMISCCTRL */
 #define _EMU_DCDCMISCCTRL_MASK                       0x377FFF01UL                                    /**< Mask for EMU_DCDCMISCCTRL */
-#define EMU_DCDCMISCCTRL_LNFORCECCM                  (0x1UL << 0)                                    /**< Force DCDC into CCM mode in low noise operation */
+#define EMU_DCDCMISCCTRL_LNFORCECCM                  (0x1UL << 0)                                    /**< Force DCDC Into CCM Mode in Low Noise Operation */
 #define _EMU_DCDCMISCCTRL_LNFORCECCM_SHIFT           0                                               /**< Shift value for EMU_LNFORCECCM */
 #define _EMU_DCDCMISCCTRL_LNFORCECCM_MASK            0x1UL                                           /**< Bit mask for EMU_LNFORCECCM */
 #define _EMU_DCDCMISCCTRL_LNFORCECCM_DEFAULT         0x00000000UL                                    /**< Mode DEFAULT for EMU_DCDCMISCCTRL */
@@ -861,7 +861,7 @@ typedef struct {
 #define _EMU_DCDCTIMING_LPINITWAIT_MASK              0xFFUL                                        /**< Bit mask for EMU_LPINITWAIT */
 #define _EMU_DCDCTIMING_LPINITWAIT_DEFAULT           0x000000FFUL                                  /**< Mode DEFAULT for EMU_DCDCTIMING */
 #define EMU_DCDCTIMING_LPINITWAIT_DEFAULT            (_EMU_DCDCTIMING_LPINITWAIT_DEFAULT << 0)     /**< Shifted mode DEFAULT for EMU_DCDCTIMING */
-#define EMU_DCDCTIMING_COMPENPRCHGEN                 (0x1UL << 11)                                 /**< LN mode precharge enable */
+#define EMU_DCDCTIMING_COMPENPRCHGEN                 (0x1UL << 11)                                 /**< LN Mode Precharge Enable */
 #define _EMU_DCDCTIMING_COMPENPRCHGEN_SHIFT          11                                            /**< Shift value for EMU_COMPENPRCHGEN */
 #define _EMU_DCDCTIMING_COMPENPRCHGEN_MASK           0x800UL                                       /**< Bit mask for EMU_COMPENPRCHGEN */
 #define _EMU_DCDCTIMING_COMPENPRCHGEN_DEFAULT        0x00000001UL                                  /**< Mode DEFAULT for EMU_DCDCTIMING */
@@ -882,7 +882,7 @@ typedef struct {
 /* Bit fields for EMU DCDCLPVCTRL */
 #define _EMU_DCDCLPVCTRL_RESETVALUE                  0x00000168UL                           /**< Default value for EMU_DCDCLPVCTRL */
 #define _EMU_DCDCLPVCTRL_MASK                        0x000001FFUL                           /**< Mask for EMU_DCDCLPVCTRL */
-#define EMU_DCDCLPVCTRL_LPATT                        (0x1UL << 0)                           /**< Low power feedback attenuation */
+#define EMU_DCDCLPVCTRL_LPATT                        (0x1UL << 0)                           /**< Low Power Feedback Attenuation */
 #define _EMU_DCDCLPVCTRL_LPATT_SHIFT                 0                                      /**< Shift value for EMU_LPATT */
 #define _EMU_DCDCLPVCTRL_LPATT_MASK                  0x1UL                                  /**< Bit mask for EMU_LPATT */
 #define _EMU_DCDCLPVCTRL_LPATT_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for EMU_DCDCLPVCTRL */
@@ -903,7 +903,7 @@ typedef struct {
 #define _EMU_DCDCLPCTRL_LPCMPHYSSEL_MASK             0xF000UL                                     /**< Bit mask for EMU_LPCMPHYSSEL */
 #define _EMU_DCDCLPCTRL_LPCMPHYSSEL_DEFAULT          0x00000007UL                                 /**< Mode DEFAULT for EMU_DCDCLPCTRL */
 #define EMU_DCDCLPCTRL_LPCMPHYSSEL_DEFAULT           (_EMU_DCDCLPCTRL_LPCMPHYSSEL_DEFAULT << 12)  /**< Shifted mode DEFAULT for EMU_DCDCLPCTRL */
-#define EMU_DCDCLPCTRL_LPVREFDUTYEN                  (0x1UL << 24)                                /**< LP mode duty cycling enable */
+#define EMU_DCDCLPCTRL_LPVREFDUTYEN                  (0x1UL << 24)                                /**< LP Mode Duty Cycling Enable */
 #define _EMU_DCDCLPCTRL_LPVREFDUTYEN_SHIFT           24                                           /**< Shift value for EMU_LPVREFDUTYEN */
 #define _EMU_DCDCLPCTRL_LPVREFDUTYEN_MASK            0x1000000UL                                  /**< Bit mask for EMU_LPVREFDUTYEN */
 #define _EMU_DCDCLPCTRL_LPVREFDUTYEN_DEFAULT         0x00000000UL                                 /**< Mode DEFAULT for EMU_DCDCLPCTRL */
@@ -928,7 +928,7 @@ typedef struct {
 /* Bit fields for EMU DCDCSYNC */
 #define _EMU_DCDCSYNC_RESETVALUE                     0x00000000UL                              /**< Default value for EMU_DCDCSYNC */
 #define _EMU_DCDCSYNC_MASK                           0x00000001UL                              /**< Mask for EMU_DCDCSYNC */
-#define EMU_DCDCSYNC_DCDCCTRLBUSY                    (0x1UL << 0)                              /**< DCDC CTRL Register Transfer Busy. */
+#define EMU_DCDCSYNC_DCDCCTRLBUSY                    (0x1UL << 0)                              /**< DCDC CTRL Register Transfer Busy */
 #define _EMU_DCDCSYNC_DCDCCTRLBUSY_SHIFT             0                                         /**< Shift value for EMU_DCDCCTRLBUSY */
 #define _EMU_DCDCSYNC_DCDCCTRLBUSY_MASK              0x1UL                                     /**< Bit mask for EMU_DCDCCTRLBUSY */
 #define _EMU_DCDCSYNC_DCDCCTRLBUSY_DEFAULT           0x00000000UL                              /**< Mode DEFAULT for EMU_DCDCSYNC */
@@ -1041,7 +1041,7 @@ typedef struct {
 #define _EMU_VMONIO0CTRL_FALLWU_MASK                 0x8UL                                        /**< Bit mask for EMU_FALLWU */
 #define _EMU_VMONIO0CTRL_FALLWU_DEFAULT              0x00000000UL                                 /**< Mode DEFAULT for EMU_VMONIO0CTRL */
 #define EMU_VMONIO0CTRL_FALLWU_DEFAULT               (_EMU_VMONIO0CTRL_FALLWU_DEFAULT << 3)       /**< Shifted mode DEFAULT for EMU_VMONIO0CTRL */
-#define EMU_VMONIO0CTRL_RETDIS                       (0x1UL << 4)                                 /**< EM4 IO0 Retention disable */
+#define EMU_VMONIO0CTRL_RETDIS                       (0x1UL << 4)                                 /**< EM4 IO0 Retention Disable */
 #define _EMU_VMONIO0CTRL_RETDIS_SHIFT                4                                            /**< Shift value for EMU_RETDIS */
 #define _EMU_VMONIO0CTRL_RETDIS_MASK                 0x10UL                                       /**< Bit mask for EMU_RETDIS */
 #define _EMU_VMONIO0CTRL_RETDIS_DEFAULT              0x00000000UL                                 /**< Mode DEFAULT for EMU_VMONIO0CTRL */

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_fpueh.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_fpueh.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32pg1b_fpueh.h
  * @brief EFM32PG1B_FPUEH register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_gpcrc.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_gpcrc.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32pg1b_gpcrc.h
  * @brief EFM32PG1B_GPCRC register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_gpio.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_gpio.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32pg1b_gpio.h
  * @brief EFM32PG1B_GPIO register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,
@@ -66,7 +66,7 @@ typedef struct {
   __IOM uint32_t IFS;            /**< Interrupt Flag Set Register  */
   __IOM uint32_t IFC;            /**< Interrupt Flag Clear Register  */
   __IOM uint32_t IEN;            /**< Interrupt Enable Register  */
-  __IOM uint32_t EM4WUEN;        /**< EM4 wake up Enable Register  */
+  __IOM uint32_t EM4WUEN;        /**< EM4 Wake Up Enable Register  */
 
   uint32_t       RESERVED1[4];   /**< Reserved for future use **/
   __IOM uint32_t ROUTEPEN;       /**< I/O Routing Pin Enable Register  */
@@ -87,7 +87,7 @@ typedef struct {
 /* Bit fields for GPIO P_CTRL */
 #define _GPIO_P_CTRL_RESETVALUE                         0x00500050UL                                  /**< Default value for GPIO_P_CTRL */
 #define _GPIO_P_CTRL_MASK                               0x10711071UL                                  /**< Mask for GPIO_P_CTRL */
-#define GPIO_P_CTRL_DRIVESTRENGTH                       (0x1UL << 0)                                  /**< Drive strength for port */
+#define GPIO_P_CTRL_DRIVESTRENGTH                       (0x1UL << 0)                                  /**< Drive Strength for Port */
 #define _GPIO_P_CTRL_DRIVESTRENGTH_SHIFT                0                                             /**< Shift value for GPIO_DRIVESTRENGTH */
 #define _GPIO_P_CTRL_DRIVESTRENGTH_MASK                 0x1UL                                         /**< Bit mask for GPIO_DRIVESTRENGTH */
 #define _GPIO_P_CTRL_DRIVESTRENGTH_DEFAULT              0x00000000UL                                  /**< Mode DEFAULT for GPIO_P_CTRL */
@@ -100,12 +100,12 @@ typedef struct {
 #define _GPIO_P_CTRL_SLEWRATE_MASK                      0x70UL                                        /**< Bit mask for GPIO_SLEWRATE */
 #define _GPIO_P_CTRL_SLEWRATE_DEFAULT                   0x00000005UL                                  /**< Mode DEFAULT for GPIO_P_CTRL */
 #define GPIO_P_CTRL_SLEWRATE_DEFAULT                    (_GPIO_P_CTRL_SLEWRATE_DEFAULT << 4)          /**< Shifted mode DEFAULT for GPIO_P_CTRL */
-#define GPIO_P_CTRL_DINDIS                              (0x1UL << 12)                                 /**< Data In Disable */
+#define GPIO_P_CTRL_DINDIS                              (0x1UL << 12)                                 /**< Data in Disable */
 #define _GPIO_P_CTRL_DINDIS_SHIFT                       12                                            /**< Shift value for GPIO_DINDIS */
 #define _GPIO_P_CTRL_DINDIS_MASK                        0x1000UL                                      /**< Bit mask for GPIO_DINDIS */
 #define _GPIO_P_CTRL_DINDIS_DEFAULT                     0x00000000UL                                  /**< Mode DEFAULT for GPIO_P_CTRL */
 #define GPIO_P_CTRL_DINDIS_DEFAULT                      (_GPIO_P_CTRL_DINDIS_DEFAULT << 12)           /**< Shifted mode DEFAULT for GPIO_P_CTRL */
-#define GPIO_P_CTRL_DRIVESTRENGTHALT                    (0x1UL << 16)                                 /**< Alternate drive strength for port */
+#define GPIO_P_CTRL_DRIVESTRENGTHALT                    (0x1UL << 16)                                 /**< Alternate Drive Strength for Port */
 #define _GPIO_P_CTRL_DRIVESTRENGTHALT_SHIFT             16                                            /**< Shift value for GPIO_DRIVESTRENGTHALT */
 #define _GPIO_P_CTRL_DRIVESTRENGTHALT_MASK              0x10000UL                                     /**< Bit mask for GPIO_DRIVESTRENGTHALT */
 #define _GPIO_P_CTRL_DRIVESTRENGTHALT_DEFAULT           0x00000000UL                                  /**< Mode DEFAULT for GPIO_P_CTRL */
@@ -118,7 +118,7 @@ typedef struct {
 #define _GPIO_P_CTRL_SLEWRATEALT_MASK                   0x700000UL                                    /**< Bit mask for GPIO_SLEWRATEALT */
 #define _GPIO_P_CTRL_SLEWRATEALT_DEFAULT                0x00000005UL                                  /**< Mode DEFAULT for GPIO_P_CTRL */
 #define GPIO_P_CTRL_SLEWRATEALT_DEFAULT                 (_GPIO_P_CTRL_SLEWRATEALT_DEFAULT << 20)      /**< Shifted mode DEFAULT for GPIO_P_CTRL */
-#define GPIO_P_CTRL_DINDISALT                           (0x1UL << 28)                                 /**< Alternate Data In Disable */
+#define GPIO_P_CTRL_DINDISALT                           (0x1UL << 28)                                 /**< Alternate Data in Disable */
 #define _GPIO_P_CTRL_DINDISALT_SHIFT                    28                                            /**< Shift value for GPIO_DINDISALT */
 #define _GPIO_P_CTRL_DINDISALT_MASK                     0x10000000UL                                  /**< Bit mask for GPIO_DINDISALT */
 #define _GPIO_P_CTRL_DINDISALT_DEFAULT                  0x00000000UL                                  /**< Mode DEFAULT for GPIO_P_CTRL */

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_gpio_p.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_gpio_p.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32pg1b_gpio_p.h
  * @brief EFM32PG1B_GPIO_P register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,
@@ -56,10 +56,10 @@ typedef struct {
   __IOM uint32_t DOUT;         /**< Port Data Out Register  */
   uint32_t       RESERVED0[2]; /**< Reserved for future use **/
   __IOM uint32_t DOUTTGL;      /**< Port Data Out Toggle Register  */
-  __IM uint32_t  DIN;          /**< Port Data In Register  */
+  __IM uint32_t  DIN;          /**< Port Data in Register  */
   __IOM uint32_t PINLOCKN;     /**< Port Unlocked Pins Register  */
   uint32_t       RESERVED1[1]; /**< Reserved for future use **/
-  __IOM uint32_t OVTDIS;       /**< Over Voltage Disable for all modes  */
+  __IOM uint32_t OVTDIS;       /**< Over Voltage Disable for All Modes  */
   uint32_t       RESERVED2[1]; /**< Reserved future */
 } GPIO_P_TypeDef;
 

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_i2c.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_i2c.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32pg1b_i2c.h
  * @brief EFM32PG1B_I2C register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,
@@ -98,7 +98,7 @@ typedef struct {
 #define _I2C_CTRL_AUTOACK_MASK             0x4UL                            /**< Bit mask for I2C_AUTOACK */
 #define _I2C_CTRL_AUTOACK_DEFAULT          0x00000000UL                     /**< Mode DEFAULT for I2C_CTRL */
 #define I2C_CTRL_AUTOACK_DEFAULT           (_I2C_CTRL_AUTOACK_DEFAULT << 2) /**< Shifted mode DEFAULT for I2C_CTRL */
-#define I2C_CTRL_AUTOSE                    (0x1UL << 3)                     /**< Automatic STOP when Empty */
+#define I2C_CTRL_AUTOSE                    (0x1UL << 3)                     /**< Automatic STOP When Empty */
 #define _I2C_CTRL_AUTOSE_SHIFT             3                                /**< Shift value for I2C_AUTOSE */
 #define _I2C_CTRL_AUTOSE_MASK              0x8UL                            /**< Bit mask for I2C_AUTOSE */
 #define _I2C_CTRL_AUTOSE_DEFAULT           0x00000000UL                     /**< Mode DEFAULT for I2C_CTRL */
@@ -149,7 +149,7 @@ typedef struct {
 #define I2C_CTRL_BITO_40PCC                (_I2C_CTRL_BITO_40PCC << 12)     /**< Shifted mode 40PCC for I2C_CTRL */
 #define I2C_CTRL_BITO_80PCC                (_I2C_CTRL_BITO_80PCC << 12)     /**< Shifted mode 80PCC for I2C_CTRL */
 #define I2C_CTRL_BITO_160PCC               (_I2C_CTRL_BITO_160PCC << 12)    /**< Shifted mode 160PCC for I2C_CTRL */
-#define I2C_CTRL_GIBITO                    (0x1UL << 15)                    /**< Go Idle on Bus Idle Timeout  */
+#define I2C_CTRL_GIBITO                    (0x1UL << 15)                    /**< Go Idle on Bus Idle Timeout */
 #define _I2C_CTRL_GIBITO_SHIFT             15                               /**< Shift value for I2C_GIBITO */
 #define _I2C_CTRL_GIBITO_MASK              0x8000UL                         /**< Bit mask for I2C_GIBITO */
 #define _I2C_CTRL_GIBITO_DEFAULT           0x00000000UL                     /**< Mode DEFAULT for I2C_CTRL */
@@ -174,12 +174,12 @@ typedef struct {
 /* Bit fields for I2C CMD */
 #define _I2C_CMD_RESETVALUE                0x00000000UL                    /**< Default value for I2C_CMD */
 #define _I2C_CMD_MASK                      0x000000FFUL                    /**< Mask for I2C_CMD */
-#define I2C_CMD_START                      (0x1UL << 0)                    /**< Send start condition */
+#define I2C_CMD_START                      (0x1UL << 0)                    /**< Send Start Condition */
 #define _I2C_CMD_START_SHIFT               0                               /**< Shift value for I2C_START */
 #define _I2C_CMD_START_MASK                0x1UL                           /**< Bit mask for I2C_START */
 #define _I2C_CMD_START_DEFAULT             0x00000000UL                    /**< Mode DEFAULT for I2C_CMD */
 #define I2C_CMD_START_DEFAULT              (_I2C_CMD_START_DEFAULT << 0)   /**< Shifted mode DEFAULT for I2C_CMD */
-#define I2C_CMD_STOP                       (0x1UL << 1)                    /**< Send stop condition */
+#define I2C_CMD_STOP                       (0x1UL << 1)                    /**< Send Stop Condition */
 #define _I2C_CMD_STOP_SHIFT                1                               /**< Shift value for I2C_STOP */
 #define _I2C_CMD_STOP_MASK                 0x2UL                           /**< Bit mask for I2C_STOP */
 #define _I2C_CMD_STOP_DEFAULT              0x00000000UL                    /**< Mode DEFAULT for I2C_CMD */
@@ -194,12 +194,12 @@ typedef struct {
 #define _I2C_CMD_NACK_MASK                 0x8UL                           /**< Bit mask for I2C_NACK */
 #define _I2C_CMD_NACK_DEFAULT              0x00000000UL                    /**< Mode DEFAULT for I2C_CMD */
 #define I2C_CMD_NACK_DEFAULT               (_I2C_CMD_NACK_DEFAULT << 3)    /**< Shifted mode DEFAULT for I2C_CMD */
-#define I2C_CMD_CONT                       (0x1UL << 4)                    /**< Continue transmission */
+#define I2C_CMD_CONT                       (0x1UL << 4)                    /**< Continue Transmission */
 #define _I2C_CMD_CONT_SHIFT                4                               /**< Shift value for I2C_CONT */
 #define _I2C_CMD_CONT_MASK                 0x10UL                          /**< Bit mask for I2C_CONT */
 #define _I2C_CMD_CONT_DEFAULT              0x00000000UL                    /**< Mode DEFAULT for I2C_CMD */
 #define I2C_CMD_CONT_DEFAULT               (_I2C_CMD_CONT_DEFAULT << 4)    /**< Shifted mode DEFAULT for I2C_CMD */
-#define I2C_CMD_ABORT                      (0x1UL << 5)                    /**< Abort transmission */
+#define I2C_CMD_ABORT                      (0x1UL << 5)                    /**< Abort Transmission */
 #define _I2C_CMD_ABORT_SHIFT               5                               /**< Shift value for I2C_ABORT */
 #define _I2C_CMD_ABORT_MASK                0x20UL                          /**< Bit mask for I2C_ABORT */
 #define _I2C_CMD_ABORT_DEFAULT             0x00000000UL                    /**< Mode DEFAULT for I2C_CMD */
@@ -285,12 +285,12 @@ typedef struct {
 #define _I2C_STATUS_PNACK_MASK             0x8UL                              /**< Bit mask for I2C_PNACK */
 #define _I2C_STATUS_PNACK_DEFAULT          0x00000000UL                       /**< Mode DEFAULT for I2C_STATUS */
 #define I2C_STATUS_PNACK_DEFAULT           (_I2C_STATUS_PNACK_DEFAULT << 3)   /**< Shifted mode DEFAULT for I2C_STATUS */
-#define I2C_STATUS_PCONT                   (0x1UL << 4)                       /**< Pending continue */
+#define I2C_STATUS_PCONT                   (0x1UL << 4)                       /**< Pending Continue */
 #define _I2C_STATUS_PCONT_SHIFT            4                                  /**< Shift value for I2C_PCONT */
 #define _I2C_STATUS_PCONT_MASK             0x10UL                             /**< Bit mask for I2C_PCONT */
 #define _I2C_STATUS_PCONT_DEFAULT          0x00000000UL                       /**< Mode DEFAULT for I2C_STATUS */
 #define I2C_STATUS_PCONT_DEFAULT           (_I2C_STATUS_PCONT_DEFAULT << 4)   /**< Shifted mode DEFAULT for I2C_STATUS */
-#define I2C_STATUS_PABORT                  (0x1UL << 5)                       /**< Pending abort */
+#define I2C_STATUS_PABORT                  (0x1UL << 5)                       /**< Pending Abort */
 #define _I2C_STATUS_PABORT_SHIFT           5                                  /**< Shift value for I2C_PABORT */
 #define _I2C_STATUS_PABORT_MASK            0x20UL                             /**< Bit mask for I2C_PABORT */
 #define _I2C_STATUS_PABORT_DEFAULT         0x00000000UL                       /**< Mode DEFAULT for I2C_STATUS */
@@ -403,12 +403,12 @@ typedef struct {
 /* Bit fields for I2C IF */
 #define _I2C_IF_RESETVALUE                 0x00000010UL                    /**< Default value for I2C_IF */
 #define _I2C_IF_MASK                       0x0007FFFFUL                    /**< Mask for I2C_IF */
-#define I2C_IF_START                       (0x1UL << 0)                    /**< START condition Interrupt Flag */
+#define I2C_IF_START                       (0x1UL << 0)                    /**< START Condition Interrupt Flag */
 #define _I2C_IF_START_SHIFT                0                               /**< Shift value for I2C_START */
 #define _I2C_IF_START_MASK                 0x1UL                           /**< Bit mask for I2C_START */
 #define _I2C_IF_START_DEFAULT              0x00000000UL                    /**< Mode DEFAULT for I2C_IF */
 #define I2C_IF_START_DEFAULT               (_I2C_IF_START_DEFAULT << 0)    /**< Shifted mode DEFAULT for I2C_IF */
-#define I2C_IF_RSTART                      (0x1UL << 1)                    /**< Repeated START condition Interrupt Flag */
+#define I2C_IF_RSTART                      (0x1UL << 1)                    /**< Repeated START Condition Interrupt Flag */
 #define _I2C_IF_RSTART_SHIFT               1                               /**< Shift value for I2C_RSTART */
 #define _I2C_IF_RSTART_MASK                0x2UL                           /**< Bit mask for I2C_RSTART */
 #define _I2C_IF_RSTART_DEFAULT             0x00000000UL                    /**< Mode DEFAULT for I2C_IF */
@@ -483,7 +483,7 @@ typedef struct {
 #define _I2C_IF_CLTO_MASK                  0x8000UL                        /**< Bit mask for I2C_CLTO */
 #define _I2C_IF_CLTO_DEFAULT               0x00000000UL                    /**< Mode DEFAULT for I2C_IF */
 #define I2C_IF_CLTO_DEFAULT                (_I2C_IF_CLTO_DEFAULT << 15)    /**< Shifted mode DEFAULT for I2C_IF */
-#define I2C_IF_SSTOP                       (0x1UL << 16)                   /**< Slave STOP condition Interrupt Flag */
+#define I2C_IF_SSTOP                       (0x1UL << 16)                   /**< Slave STOP Condition Interrupt Flag */
 #define _I2C_IF_SSTOP_SHIFT                16                              /**< Shift value for I2C_SSTOP */
 #define _I2C_IF_SSTOP_MASK                 0x10000UL                       /**< Bit mask for I2C_SSTOP */
 #define _I2C_IF_SSTOP_DEFAULT              0x00000000UL                    /**< Mode DEFAULT for I2C_IF */

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_idac.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_idac.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32pg1b_idac.h
  * @brief EFM32PG1B_IDAC register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,
@@ -247,7 +247,7 @@ typedef struct {
 /* Bit fields for IDAC DUTYCONFIG */
 #define _IDAC_DUTYCONFIG_RESETVALUE                    0x00000000UL                                    /**< Default value for IDAC_DUTYCONFIG */
 #define _IDAC_DUTYCONFIG_MASK                          0x00000002UL                                    /**< Mask for IDAC_DUTYCONFIG */
-#define IDAC_DUTYCONFIG_EM2DUTYCYCLEDIS                (0x1UL << 1)                                    /**< Duty Cycle Enable. */
+#define IDAC_DUTYCONFIG_EM2DUTYCYCLEDIS                (0x1UL << 1)                                    /**< Duty Cycle Enable */
 #define _IDAC_DUTYCONFIG_EM2DUTYCYCLEDIS_SHIFT         1                                               /**< Shift value for IDAC_EM2DUTYCYCLEDIS */
 #define _IDAC_DUTYCONFIG_EM2DUTYCYCLEDIS_MASK          0x2UL                                           /**< Bit mask for IDAC_EM2DUTYCYCLEDIS */
 #define _IDAC_DUTYCONFIG_EM2DUTYCYCLEDIS_DEFAULT       0x00000000UL                                    /**< Mode DEFAULT for IDAC_DUTYCONFIG */
@@ -301,12 +301,12 @@ typedef struct {
 /* Bit fields for IDAC APORTREQ */
 #define _IDAC_APORTREQ_RESETVALUE                      0x00000000UL                             /**< Default value for IDAC_APORTREQ */
 #define _IDAC_APORTREQ_MASK                            0x0000000CUL                             /**< Mask for IDAC_APORTREQ */
-#define IDAC_APORTREQ_APORT1XREQ                       (0x1UL << 2)                             /**< 1 if the APORT bus connected to APORT1X is requested */
+#define IDAC_APORTREQ_APORT1XREQ                       (0x1UL << 2)                             /**< 1 If the APORT Bus Connected to APORT1X is Requested */
 #define _IDAC_APORTREQ_APORT1XREQ_SHIFT                2                                        /**< Shift value for IDAC_APORT1XREQ */
 #define _IDAC_APORTREQ_APORT1XREQ_MASK                 0x4UL                                    /**< Bit mask for IDAC_APORT1XREQ */
 #define _IDAC_APORTREQ_APORT1XREQ_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for IDAC_APORTREQ */
 #define IDAC_APORTREQ_APORT1XREQ_DEFAULT               (_IDAC_APORTREQ_APORT1XREQ_DEFAULT << 2) /**< Shifted mode DEFAULT for IDAC_APORTREQ */
-#define IDAC_APORTREQ_APORT1YREQ                       (0x1UL << 3)                             /**< 1 if the bus connected to APORT1Y is requested */
+#define IDAC_APORTREQ_APORT1YREQ                       (0x1UL << 3)                             /**< 1 If the Bus Connected to APORT1Y is Requested */
 #define _IDAC_APORTREQ_APORT1YREQ_SHIFT                3                                        /**< Shift value for IDAC_APORT1YREQ */
 #define _IDAC_APORTREQ_APORT1YREQ_MASK                 0x8UL                                    /**< Bit mask for IDAC_APORT1YREQ */
 #define _IDAC_APORTREQ_APORT1YREQ_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for IDAC_APORTREQ */
@@ -315,12 +315,12 @@ typedef struct {
 /* Bit fields for IDAC APORTCONFLICT */
 #define _IDAC_APORTCONFLICT_RESETVALUE                 0x00000000UL                                       /**< Default value for IDAC_APORTCONFLICT */
 #define _IDAC_APORTCONFLICT_MASK                       0x0000000CUL                                       /**< Mask for IDAC_APORTCONFLICT */
-#define IDAC_APORTCONFLICT_APORT1XCONFLICT             (0x1UL << 2)                                       /**< 1 if the bus connected to APORT1X is in conflict with another peripheral */
+#define IDAC_APORTCONFLICT_APORT1XCONFLICT             (0x1UL << 2)                                       /**< 1 If the Bus Connected to APORT1X is in Conflict With Another Peripheral */
 #define _IDAC_APORTCONFLICT_APORT1XCONFLICT_SHIFT      2                                                  /**< Shift value for IDAC_APORT1XCONFLICT */
 #define _IDAC_APORTCONFLICT_APORT1XCONFLICT_MASK       0x4UL                                              /**< Bit mask for IDAC_APORT1XCONFLICT */
 #define _IDAC_APORTCONFLICT_APORT1XCONFLICT_DEFAULT    0x00000000UL                                       /**< Mode DEFAULT for IDAC_APORTCONFLICT */
 #define IDAC_APORTCONFLICT_APORT1XCONFLICT_DEFAULT     (_IDAC_APORTCONFLICT_APORT1XCONFLICT_DEFAULT << 2) /**< Shifted mode DEFAULT for IDAC_APORTCONFLICT */
-#define IDAC_APORTCONFLICT_APORT1YCONFLICT             (0x1UL << 3)                                       /**< 1 if the bus connected to APORT1Y is in conflict with another peripheral */
+#define IDAC_APORTCONFLICT_APORT1YCONFLICT             (0x1UL << 3)                                       /**< 1 If the Bus Connected to APORT1Y is in Conflict With Another Peripheral */
 #define _IDAC_APORTCONFLICT_APORT1YCONFLICT_SHIFT      3                                                  /**< Shift value for IDAC_APORT1YCONFLICT */
 #define _IDAC_APORTCONFLICT_APORT1YCONFLICT_MASK       0x8UL                                              /**< Bit mask for IDAC_APORT1YCONFLICT */
 #define _IDAC_APORTCONFLICT_APORT1YCONFLICT_DEFAULT    0x00000000UL                                       /**< Mode DEFAULT for IDAC_APORTCONFLICT */

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_ldma.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_ldma.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32pg1b_ldma.h
  * @brief EFM32PG1B_LDMA register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,
@@ -69,7 +69,7 @@ typedef struct {
   __IM uint32_t   IF;           /**< Interrupt Flag Register  */
   __IOM uint32_t  IFS;          /**< Interrupt Flag Set Register  */
   __IOM uint32_t  IFC;          /**< Interrupt Flag Clear Register  */
-  __IOM uint32_t  IEN;          /**< Interrupt Enable register  */
+  __IOM uint32_t  IEN;          /**< Interrupt Enable Register  */
 
   uint32_t        RESERVED2[4]; /**< Reserved registers */
   LDMA_CH_TypeDef CH[8];        /**< DMA Channel Registers */

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_ldma_ch.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_ldma_ch.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32pg1b_ldma_ch.h
  * @brief EFM32PG1B_LDMA_CH register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_letimer.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_letimer.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32pg1b_letimer.h
  * @brief EFM32PG1B_LETIMER register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,
@@ -137,7 +137,7 @@ typedef struct {
 #define _LETIMER_CTRL_BUFTOP_MASK               0x100UL                                /**< Bit mask for LETIMER_BUFTOP */
 #define _LETIMER_CTRL_BUFTOP_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for LETIMER_CTRL */
 #define LETIMER_CTRL_BUFTOP_DEFAULT             (_LETIMER_CTRL_BUFTOP_DEFAULT << 8)    /**< Shifted mode DEFAULT for LETIMER_CTRL */
-#define LETIMER_CTRL_COMP0TOP                   (0x1UL << 9)                           /**< Compare Value 0 Is Top Value */
+#define LETIMER_CTRL_COMP0TOP                   (0x1UL << 9)                           /**< Compare Value 0 is Top Value */
 #define _LETIMER_CTRL_COMP0TOP_SHIFT            9                                      /**< Shift value for LETIMER_COMP0TOP */
 #define _LETIMER_CTRL_COMP0TOP_MASK             0x200UL                                /**< Bit mask for LETIMER_COMP0TOP */
 #define _LETIMER_CTRL_COMP0TOP_DEFAULT          0x00000000UL                           /**< Mode DEFAULT for LETIMER_CTRL */

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_leuart.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_leuart.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32pg1b_leuart.h
  * @brief EFM32PG1B_LEUART register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,
@@ -122,12 +122,12 @@ typedef struct {
 #define LEUART_CTRL_STOPBITS_DEFAULT             (_LEUART_CTRL_STOPBITS_DEFAULT << 4) /**< Shifted mode DEFAULT for LEUART_CTRL */
 #define LEUART_CTRL_STOPBITS_ONE                 (_LEUART_CTRL_STOPBITS_ONE << 4)     /**< Shifted mode ONE for LEUART_CTRL */
 #define LEUART_CTRL_STOPBITS_TWO                 (_LEUART_CTRL_STOPBITS_TWO << 4)     /**< Shifted mode TWO for LEUART_CTRL */
-#define LEUART_CTRL_INV                          (0x1UL << 5)                         /**< Invert Input And Output */
+#define LEUART_CTRL_INV                          (0x1UL << 5)                         /**< Invert Input and Output */
 #define _LEUART_CTRL_INV_SHIFT                   5                                    /**< Shift value for LEUART_INV */
 #define _LEUART_CTRL_INV_MASK                    0x20UL                               /**< Bit mask for LEUART_INV */
 #define _LEUART_CTRL_INV_DEFAULT                 0x00000000UL                         /**< Mode DEFAULT for LEUART_CTRL */
 #define LEUART_CTRL_INV_DEFAULT                  (_LEUART_CTRL_INV_DEFAULT << 5)      /**< Shifted mode DEFAULT for LEUART_CTRL */
-#define LEUART_CTRL_ERRSDMA                      (0x1UL << 6)                         /**< Clear RX DMA On Error */
+#define LEUART_CTRL_ERRSDMA                      (0x1UL << 6)                         /**< Clear RX DMA on Error */
 #define _LEUART_CTRL_ERRSDMA_SHIFT               6                                    /**< Shift value for LEUART_ERRSDMA */
 #define _LEUART_CTRL_ERRSDMA_MASK                0x40UL                               /**< Bit mask for LEUART_ERRSDMA */
 #define _LEUART_CTRL_ERRSDMA_DEFAULT             0x00000000UL                         /**< Mode DEFAULT for LEUART_CTRL */
@@ -338,7 +338,7 @@ typedef struct {
 #define _LEUART_TXDATAX_TXDATA_MASK              0x1FFUL                                 /**< Bit mask for LEUART_TXDATA */
 #define _LEUART_TXDATAX_TXDATA_DEFAULT           0x00000000UL                            /**< Mode DEFAULT for LEUART_TXDATAX */
 #define LEUART_TXDATAX_TXDATA_DEFAULT            (_LEUART_TXDATAX_TXDATA_DEFAULT << 0)   /**< Shifted mode DEFAULT for LEUART_TXDATAX */
-#define LEUART_TXDATAX_TXBREAK                   (0x1UL << 13)                           /**< Transmit Data As Break */
+#define LEUART_TXDATAX_TXBREAK                   (0x1UL << 13)                           /**< Transmit Data as Break */
 #define _LEUART_TXDATAX_TXBREAK_SHIFT            13                                      /**< Shift value for LEUART_TXBREAK */
 #define _LEUART_TXDATAX_TXBREAK_MASK             0x2000UL                                /**< Bit mask for LEUART_TXBREAK */
 #define _LEUART_TXDATAX_TXBREAK_DEFAULT          0x00000000UL                            /**< Mode DEFAULT for LEUART_TXDATAX */

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_msc.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_msc.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32pg1b_msc.h
  * @brief EFM32PG1B_MSC register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,
@@ -101,7 +101,7 @@ typedef struct {
 #define _MSC_CTRL_CLKDISFAULTEN_MASK            0x2UL                                  /**< Bit mask for MSC_CLKDISFAULTEN */
 #define _MSC_CTRL_CLKDISFAULTEN_DEFAULT         0x00000000UL                           /**< Mode DEFAULT for MSC_CTRL */
 #define MSC_CTRL_CLKDISFAULTEN_DEFAULT          (_MSC_CTRL_CLKDISFAULTEN_DEFAULT << 1) /**< Shifted mode DEFAULT for MSC_CTRL */
-#define MSC_CTRL_PWRUPONDEMAND                  (0x1UL << 2)                           /**< Power Up On Demand During Wake Up */
+#define MSC_CTRL_PWRUPONDEMAND                  (0x1UL << 2)                           /**< Power Up on Demand During Wake Up */
 #define _MSC_CTRL_PWRUPONDEMAND_SHIFT           2                                      /**< Shift value for MSC_PWRUPONDEMAND */
 #define _MSC_CTRL_PWRUPONDEMAND_MASK            0x4UL                                  /**< Bit mask for MSC_PWRUPONDEMAND */
 #define _MSC_CTRL_PWRUPONDEMAND_DEFAULT         0x00000000UL                           /**< Mode DEFAULT for MSC_CTRL */
@@ -157,7 +157,7 @@ typedef struct {
 /* Bit fields for MSC WRITECTRL */
 #define _MSC_WRITECTRL_RESETVALUE               0x00000000UL                                /**< Default value for MSC_WRITECTRL */
 #define _MSC_WRITECTRL_MASK                     0x00000003UL                                /**< Mask for MSC_WRITECTRL */
-#define MSC_WRITECTRL_WREN                      (0x1UL << 0)                                /**< Enable Write/Erase Controller  */
+#define MSC_WRITECTRL_WREN                      (0x1UL << 0)                                /**< Enable Write/Erase Controller */
 #define _MSC_WRITECTRL_WREN_SHIFT               0                                           /**< Shift value for MSC_WREN */
 #define _MSC_WRITECTRL_WREN_MASK                0x1UL                                       /**< Bit mask for MSC_WREN */
 #define _MSC_WRITECTRL_WREN_DEFAULT             0x00000000UL                                /**< Mode DEFAULT for MSC_WRITECTRL */
@@ -171,7 +171,7 @@ typedef struct {
 /* Bit fields for MSC WRITECMD */
 #define _MSC_WRITECMD_RESETVALUE                0x00000000UL                             /**< Default value for MSC_WRITECMD */
 #define _MSC_WRITECMD_MASK                      0x0000113FUL                             /**< Mask for MSC_WRITECMD */
-#define MSC_WRITECMD_LADDRIM                    (0x1UL << 0)                             /**< Load MSC_ADDRB into ADDR */
+#define MSC_WRITECMD_LADDRIM                    (0x1UL << 0)                             /**< Load MSC_ADDRB Into ADDR */
 #define _MSC_WRITECMD_LADDRIM_SHIFT             0                                        /**< Shift value for MSC_LADDRIM */
 #define _MSC_WRITECMD_LADDRIM_MASK              0x1UL                                    /**< Bit mask for MSC_LADDRIM */
 #define _MSC_WRITECMD_LADDRIM_DEFAULT           0x00000000UL                             /**< Mode DEFAULT for MSC_WRITECMD */
@@ -196,17 +196,17 @@ typedef struct {
 #define _MSC_WRITECMD_WRITETRIG_MASK            0x10UL                                   /**< Bit mask for MSC_WRITETRIG */
 #define _MSC_WRITECMD_WRITETRIG_DEFAULT         0x00000000UL                             /**< Mode DEFAULT for MSC_WRITECMD */
 #define MSC_WRITECMD_WRITETRIG_DEFAULT          (_MSC_WRITECMD_WRITETRIG_DEFAULT << 4)   /**< Shifted mode DEFAULT for MSC_WRITECMD */
-#define MSC_WRITECMD_ERASEABORT                 (0x1UL << 5)                             /**< Abort erase sequence */
+#define MSC_WRITECMD_ERASEABORT                 (0x1UL << 5)                             /**< Abort Erase Sequence */
 #define _MSC_WRITECMD_ERASEABORT_SHIFT          5                                        /**< Shift value for MSC_ERASEABORT */
 #define _MSC_WRITECMD_ERASEABORT_MASK           0x20UL                                   /**< Bit mask for MSC_ERASEABORT */
 #define _MSC_WRITECMD_ERASEABORT_DEFAULT        0x00000000UL                             /**< Mode DEFAULT for MSC_WRITECMD */
 #define MSC_WRITECMD_ERASEABORT_DEFAULT         (_MSC_WRITECMD_ERASEABORT_DEFAULT << 5)  /**< Shifted mode DEFAULT for MSC_WRITECMD */
-#define MSC_WRITECMD_ERASEMAIN0                 (0x1UL << 8)                             /**< Mass erase region 0 */
+#define MSC_WRITECMD_ERASEMAIN0                 (0x1UL << 8)                             /**< Mass Erase Region 0 */
 #define _MSC_WRITECMD_ERASEMAIN0_SHIFT          8                                        /**< Shift value for MSC_ERASEMAIN0 */
 #define _MSC_WRITECMD_ERASEMAIN0_MASK           0x100UL                                  /**< Bit mask for MSC_ERASEMAIN0 */
 #define _MSC_WRITECMD_ERASEMAIN0_DEFAULT        0x00000000UL                             /**< Mode DEFAULT for MSC_WRITECMD */
 #define MSC_WRITECMD_ERASEMAIN0_DEFAULT         (_MSC_WRITECMD_ERASEMAIN0_DEFAULT << 8)  /**< Shifted mode DEFAULT for MSC_WRITECMD */
-#define MSC_WRITECMD_CLEARWDATA                 (0x1UL << 12)                            /**< Clear WDATA state */
+#define MSC_WRITECMD_CLEARWDATA                 (0x1UL << 12)                            /**< Clear WDATA State */
 #define _MSC_WRITECMD_CLEARWDATA_SHIFT          12                                       /**< Shift value for MSC_CLEARWDATA */
 #define _MSC_WRITECMD_CLEARWDATA_MASK           0x1000UL                                 /**< Bit mask for MSC_CLEARWDATA */
 #define _MSC_WRITECMD_CLEARWDATA_DEFAULT        0x00000000UL                             /**< Mode DEFAULT for MSC_WRITECMD */
@@ -295,7 +295,7 @@ typedef struct {
 #define _MSC_IF_PWRUPF_MASK                     0x10UL                          /**< Bit mask for MSC_PWRUPF */
 #define _MSC_IF_PWRUPF_DEFAULT                  0x00000000UL                    /**< Mode DEFAULT for MSC_IF */
 #define MSC_IF_PWRUPF_DEFAULT                   (_MSC_IF_PWRUPF_DEFAULT << 4)   /**< Shifted mode DEFAULT for MSC_IF */
-#define MSC_IF_ICACHERR                         (0x1UL << 5)                    /**< iCache RAM Parity Error Flag */
+#define MSC_IF_ICACHERR                         (0x1UL << 5)                    /**< ICache RAM Parity Error Flag */
 #define _MSC_IF_ICACHERR_SHIFT                  5                               /**< Shift value for MSC_ICACHERR */
 #define _MSC_IF_ICACHERR_MASK                   0x20UL                          /**< Bit mask for MSC_ICACHERR */
 #define _MSC_IF_ICACHERR_DEFAULT                0x00000000UL                    /**< Mode DEFAULT for MSC_IF */

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_pcnt.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_pcnt.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32pg1b_pcnt.h
  * @brief EFM32PG1B_PCNT register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,
@@ -133,7 +133,7 @@ typedef struct {
 #define _PCNT_CTRL_HYST_MASK               0x100UL                               /**< Bit mask for PCNT_HYST */
 #define _PCNT_CTRL_HYST_DEFAULT            0x00000000UL                          /**< Mode DEFAULT for PCNT_CTRL */
 #define PCNT_CTRL_HYST_DEFAULT             (_PCNT_CTRL_HYST_DEFAULT << 8)        /**< Shifted mode DEFAULT for PCNT_CTRL */
-#define PCNT_CTRL_S1CDIR                   (0x1UL << 9)                          /**< Count direction determined by S1 */
+#define PCNT_CTRL_S1CDIR                   (0x1UL << 9)                          /**< Count Direction Determined By S1 */
 #define _PCNT_CTRL_S1CDIR_SHIFT            9                                     /**< Shift value for PCNT_S1CDIR */
 #define _PCNT_CTRL_S1CDIR_MASK             0x200UL                               /**< Bit mask for PCNT_S1CDIR */
 #define _PCNT_CTRL_S1CDIR_DEFAULT          0x00000000UL                          /**< Mode DEFAULT for PCNT_CTRL */
@@ -212,12 +212,12 @@ typedef struct {
 #define PCNT_CTRL_TCCCOMP_LTOE             (_PCNT_CTRL_TCCCOMP_LTOE << 22)       /**< Shifted mode LTOE for PCNT_CTRL */
 #define PCNT_CTRL_TCCCOMP_GTOE             (_PCNT_CTRL_TCCCOMP_GTOE << 22)       /**< Shifted mode GTOE for PCNT_CTRL */
 #define PCNT_CTRL_TCCCOMP_RANGE            (_PCNT_CTRL_TCCCOMP_RANGE << 22)      /**< Shifted mode RANGE for PCNT_CTRL */
-#define PCNT_CTRL_PRSGATEEN                (0x1UL << 24)                         /**< PRS gate enable */
+#define PCNT_CTRL_PRSGATEEN                (0x1UL << 24)                         /**< PRS Gate Enable */
 #define _PCNT_CTRL_PRSGATEEN_SHIFT         24                                    /**< Shift value for PCNT_PRSGATEEN */
 #define _PCNT_CTRL_PRSGATEEN_MASK          0x1000000UL                           /**< Bit mask for PCNT_PRSGATEEN */
 #define _PCNT_CTRL_PRSGATEEN_DEFAULT       0x00000000UL                          /**< Mode DEFAULT for PCNT_CTRL */
 #define PCNT_CTRL_PRSGATEEN_DEFAULT        (_PCNT_CTRL_PRSGATEEN_DEFAULT << 24)  /**< Shifted mode DEFAULT for PCNT_CTRL */
-#define PCNT_CTRL_TCCPRSPOL                (0x1UL << 25)                         /**< TCC PRS polarity select */
+#define PCNT_CTRL_TCCPRSPOL                (0x1UL << 25)                         /**< TCC PRS Polarity Select */
 #define _PCNT_CTRL_TCCPRSPOL_SHIFT         25                                    /**< Shift value for PCNT_TCCPRSPOL */
 #define _PCNT_CTRL_TCCPRSPOL_MASK          0x2000000UL                           /**< Bit mask for PCNT_TCCPRSPOL */
 #define _PCNT_CTRL_TCCPRSPOL_DEFAULT       0x00000000UL                          /**< Mode DEFAULT for PCNT_CTRL */
@@ -254,7 +254,7 @@ typedef struct {
 #define PCNT_CTRL_TCCPRSSEL_PRSCH9         (_PCNT_CTRL_TCCPRSSEL_PRSCH9 << 26)   /**< Shifted mode PRSCH9 for PCNT_CTRL */
 #define PCNT_CTRL_TCCPRSSEL_PRSCH10        (_PCNT_CTRL_TCCPRSSEL_PRSCH10 << 26)  /**< Shifted mode PRSCH10 for PCNT_CTRL */
 #define PCNT_CTRL_TCCPRSSEL_PRSCH11        (_PCNT_CTRL_TCCPRSSEL_PRSCH11 << 26)  /**< Shifted mode PRSCH11 for PCNT_CTRL */
-#define PCNT_CTRL_TOPBHFSEL                (0x1UL << 31)                         /**< TOPB High frequency value select */
+#define PCNT_CTRL_TOPBHFSEL                (0x1UL << 31)                         /**< TOPB High Frequency Value Select */
 #define _PCNT_CTRL_TOPBHFSEL_SHIFT         31                                    /**< Shift value for PCNT_TOPBHFSEL */
 #define _PCNT_CTRL_TOPBHFSEL_MASK          0x80000000UL                          /**< Bit mask for PCNT_TOPBHFSEL */
 #define _PCNT_CTRL_TOPBHFSEL_DEFAULT       0x00000000UL                          /**< Mode DEFAULT for PCNT_CTRL */
@@ -334,7 +334,7 @@ typedef struct {
 #define _PCNT_IF_AUXOF_MASK                0x8UL                           /**< Bit mask for PCNT_AUXOF */
 #define _PCNT_IF_AUXOF_DEFAULT             0x00000000UL                    /**< Mode DEFAULT for PCNT_IF */
 #define PCNT_IF_AUXOF_DEFAULT              (_PCNT_IF_AUXOF_DEFAULT << 3)   /**< Shifted mode DEFAULT for PCNT_IF */
-#define PCNT_IF_TCC                        (0x1UL << 4)                    /**< Triggered compare Interrupt Read Flag */
+#define PCNT_IF_TCC                        (0x1UL << 4)                    /**< Triggered Compare Interrupt Read Flag */
 #define _PCNT_IF_TCC_SHIFT                 4                               /**< Shift value for PCNT_TCC */
 #define _PCNT_IF_TCC_MASK                  0x10UL                          /**< Bit mask for PCNT_TCC */
 #define _PCNT_IF_TCC_DEFAULT               0x00000000UL                    /**< Mode DEFAULT for PCNT_IF */

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_prs.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_prs.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32pg1b_prs.h
  * @brief EFM32PG1B_PRS register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,
@@ -958,7 +958,7 @@ typedef struct {
 #define _PRS_CH_CTRL_ANDNEXT_MASK              0x10000000UL                               /**< Bit mask for PRS_ANDNEXT */
 #define _PRS_CH_CTRL_ANDNEXT_DEFAULT           0x00000000UL                               /**< Mode DEFAULT for PRS_CH_CTRL */
 #define PRS_CH_CTRL_ANDNEXT_DEFAULT            (_PRS_CH_CTRL_ANDNEXT_DEFAULT << 28)       /**< Shifted mode DEFAULT for PRS_CH_CTRL */
-#define PRS_CH_CTRL_ASYNC                      (0x1UL << 30)                              /**< Asynchronous reflex */
+#define PRS_CH_CTRL_ASYNC                      (0x1UL << 30)                              /**< Asynchronous Reflex */
 #define _PRS_CH_CTRL_ASYNC_SHIFT               30                                         /**< Shift value for PRS_ASYNC */
 #define _PRS_CH_CTRL_ASYNC_MASK                0x40000000UL                               /**< Bit mask for PRS_ASYNC */
 #define _PRS_CH_CTRL_ASYNC_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for PRS_CH_CTRL */

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_prs_ch.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_prs_ch.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32pg1b_prs_ch.h
  * @brief EFM32PG1B_PRS_CH register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_prs_signals.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_prs_signals.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32pg1b_prs_signals.h
  * @brief EFM32PG1B_PRS_SIGNALS register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_rmu.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_rmu.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32pg1b_rmu.h
  * @brief EFM32PG1B_RMU register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,
@@ -125,7 +125,7 @@ typedef struct {
 /* Bit fields for RMU RSTCAUSE */
 #define _RMU_RSTCAUSE_RESETVALUE           0x00000000UL                            /**< Default value for RMU_RSTCAUSE */
 #define _RMU_RSTCAUSE_MASK                 0x00010F1DUL                            /**< Mask for RMU_RSTCAUSE */
-#define RMU_RSTCAUSE_PORST                 (0x1UL << 0)                            /**< Power On Reset */
+#define RMU_RSTCAUSE_PORST                 (0x1UL << 0)                            /**< Power on Reset */
 #define _RMU_RSTCAUSE_PORST_SHIFT          0                                       /**< Shift value for RMU_PORST */
 #define _RMU_RSTCAUSE_PORST_MASK           0x1UL                                   /**< Bit mask for RMU_PORST */
 #define _RMU_RSTCAUSE_PORST_DEFAULT        0x00000000UL                            /**< Mode DEFAULT for RMU_RSTCAUSE */

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_romtable.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_romtable.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32pg1b_romtable.h
  * @brief EFM32PG1B_ROMTABLE register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_rtcc.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_rtcc.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32pg1b_rtcc.h
  * @brief EFM32PG1B_RTCC register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,
@@ -56,16 +56,16 @@ typedef struct {
   __IOM uint32_t   PRECNT;        /**< Pre-Counter Value Register  */
   __IOM uint32_t   CNT;           /**< Counter Value Register  */
   __IM uint32_t    COMBCNT;       /**< Combined Pre-Counter and Counter Value Register  */
-  __IOM uint32_t   TIME;          /**< Time of day register  */
-  __IOM uint32_t   DATE;          /**< Date register  */
+  __IOM uint32_t   TIME;          /**< Time of Day Register  */
+  __IOM uint32_t   DATE;          /**< Date Register  */
   __IM uint32_t    IF;            /**< RTCC Interrupt Flags  */
   __IOM uint32_t   IFS;           /**< Interrupt Flag Set Register  */
   __IOM uint32_t   IFC;           /**< Interrupt Flag Clear Register  */
   __IOM uint32_t   IEN;           /**< Interrupt Enable Register  */
-  __IM uint32_t    STATUS;        /**< Status register  */
+  __IM uint32_t    STATUS;        /**< Status Register  */
   __IOM uint32_t   CMD;           /**< Command Register  */
   __IM uint32_t    SYNCBUSY;      /**< Synchronization Busy Register  */
-  __IOM uint32_t   POWERDOWN;     /**< Retention RAM power-down register  */
+  __IOM uint32_t   POWERDOWN;     /**< Retention RAM Power-down Register  */
   __IOM uint32_t   LOCK;          /**< Configuration Lock Register  */
   __IOM uint32_t   EM4WUEN;       /**< Wake Up Enable  */
 
@@ -95,12 +95,12 @@ typedef struct {
 #define _RTCC_CTRL_DEBUGRUN_MASK            0x4UL                                   /**< Bit mask for RTCC_DEBUGRUN */
 #define _RTCC_CTRL_DEBUGRUN_DEFAULT         0x00000000UL                            /**< Mode DEFAULT for RTCC_CTRL */
 #define RTCC_CTRL_DEBUGRUN_DEFAULT          (_RTCC_CTRL_DEBUGRUN_DEFAULT << 2)      /**< Shifted mode DEFAULT for RTCC_CTRL */
-#define RTCC_CTRL_PRECCV0TOP                (0x1UL << 4)                            /**< Pre-counter CCV0 top value enable. */
+#define RTCC_CTRL_PRECCV0TOP                (0x1UL << 4)                            /**< Pre-counter CCV0 Top Value Enable */
 #define _RTCC_CTRL_PRECCV0TOP_SHIFT         4                                       /**< Shift value for RTCC_PRECCV0TOP */
 #define _RTCC_CTRL_PRECCV0TOP_MASK          0x10UL                                  /**< Bit mask for RTCC_PRECCV0TOP */
 #define _RTCC_CTRL_PRECCV0TOP_DEFAULT       0x00000000UL                            /**< Mode DEFAULT for RTCC_CTRL */
 #define RTCC_CTRL_PRECCV0TOP_DEFAULT        (_RTCC_CTRL_PRECCV0TOP_DEFAULT << 4)    /**< Shifted mode DEFAULT for RTCC_CTRL */
-#define RTCC_CTRL_CCV1TOP                   (0x1UL << 5)                            /**< CCV1 top value enable */
+#define RTCC_CTRL_CCV1TOP                   (0x1UL << 5)                            /**< CCV1 Top Value Enable */
 #define _RTCC_CTRL_CCV1TOP_SHIFT            5                                       /**< Shift value for RTCC_CCV1TOP */
 #define _RTCC_CTRL_CCV1TOP_MASK             0x20UL                                  /**< Bit mask for RTCC_CCV1TOP */
 #define _RTCC_CTRL_CCV1TOP_DEFAULT          0x00000000UL                            /**< Mode DEFAULT for RTCC_CTRL */
@@ -141,7 +141,7 @@ typedef struct {
 #define RTCC_CTRL_CNTPRESC_DIV8192          (_RTCC_CTRL_CNTPRESC_DIV8192 << 8)      /**< Shifted mode DIV8192 for RTCC_CTRL */
 #define RTCC_CTRL_CNTPRESC_DIV16384         (_RTCC_CTRL_CNTPRESC_DIV16384 << 8)     /**< Shifted mode DIV16384 for RTCC_CTRL */
 #define RTCC_CTRL_CNTPRESC_DIV32768         (_RTCC_CTRL_CNTPRESC_DIV32768 << 8)     /**< Shifted mode DIV32768 for RTCC_CTRL */
-#define RTCC_CTRL_CNTTICK                   (0x1UL << 12)                           /**< Counter prescaler mode. */
+#define RTCC_CTRL_CNTTICK                   (0x1UL << 12)                           /**< Counter Prescaler Mode */
 #define _RTCC_CTRL_CNTTICK_SHIFT            12                                      /**< Shift value for RTCC_CNTTICK */
 #define _RTCC_CTRL_CNTTICK_MASK             0x1000UL                                /**< Bit mask for RTCC_CNTTICK */
 #define _RTCC_CTRL_CNTTICK_DEFAULT          0x00000000UL                            /**< Mode DEFAULT for RTCC_CTRL */
@@ -150,12 +150,12 @@ typedef struct {
 #define RTCC_CTRL_CNTTICK_DEFAULT           (_RTCC_CTRL_CNTTICK_DEFAULT << 12)      /**< Shifted mode DEFAULT for RTCC_CTRL */
 #define RTCC_CTRL_CNTTICK_PRESC             (_RTCC_CTRL_CNTTICK_PRESC << 12)        /**< Shifted mode PRESC for RTCC_CTRL */
 #define RTCC_CTRL_CNTTICK_CCV0MATCH         (_RTCC_CTRL_CNTTICK_CCV0MATCH << 12)    /**< Shifted mode CCV0MATCH for RTCC_CTRL */
-#define RTCC_CTRL_OSCFDETEN                 (0x1UL << 15)                           /**< Oscillator failure detection enable */
+#define RTCC_CTRL_OSCFDETEN                 (0x1UL << 15)                           /**< Oscillator Failure Detection Enable */
 #define _RTCC_CTRL_OSCFDETEN_SHIFT          15                                      /**< Shift value for RTCC_OSCFDETEN */
 #define _RTCC_CTRL_OSCFDETEN_MASK           0x8000UL                                /**< Bit mask for RTCC_OSCFDETEN */
 #define _RTCC_CTRL_OSCFDETEN_DEFAULT        0x00000000UL                            /**< Mode DEFAULT for RTCC_CTRL */
 #define RTCC_CTRL_OSCFDETEN_DEFAULT         (_RTCC_CTRL_OSCFDETEN_DEFAULT << 15)    /**< Shifted mode DEFAULT for RTCC_CTRL */
-#define RTCC_CTRL_CNTMODE                   (0x1UL << 16)                           /**< Main counter mode */
+#define RTCC_CTRL_CNTMODE                   (0x1UL << 16)                           /**< Main Counter Mode */
 #define _RTCC_CTRL_CNTMODE_SHIFT            16                                      /**< Shift value for RTCC_CNTMODE */
 #define _RTCC_CTRL_CNTMODE_MASK             0x10000UL                               /**< Bit mask for RTCC_CNTMODE */
 #define _RTCC_CTRL_CNTMODE_DEFAULT          0x00000000UL                            /**< Mode DEFAULT for RTCC_CTRL */
@@ -164,7 +164,7 @@ typedef struct {
 #define RTCC_CTRL_CNTMODE_DEFAULT           (_RTCC_CTRL_CNTMODE_DEFAULT << 16)      /**< Shifted mode DEFAULT for RTCC_CTRL */
 #define RTCC_CTRL_CNTMODE_NORMAL            (_RTCC_CTRL_CNTMODE_NORMAL << 16)       /**< Shifted mode NORMAL for RTCC_CTRL */
 #define RTCC_CTRL_CNTMODE_CALENDAR          (_RTCC_CTRL_CNTMODE_CALENDAR << 16)     /**< Shifted mode CALENDAR for RTCC_CTRL */
-#define RTCC_CTRL_LYEARCORRDIS              (0x1UL << 17)                           /**< Leap year correction disabled. */
+#define RTCC_CTRL_LYEARCORRDIS              (0x1UL << 17)                           /**< Leap Year Correction Disabled */
 #define _RTCC_CTRL_LYEARCORRDIS_SHIFT       17                                      /**< Shift value for RTCC_LYEARCORRDIS */
 #define _RTCC_CTRL_LYEARCORRDIS_MASK        0x20000UL                               /**< Bit mask for RTCC_LYEARCORRDIS */
 #define _RTCC_CTRL_LYEARCORRDIS_DEFAULT     0x00000000UL                            /**< Mode DEFAULT for RTCC_CTRL */
@@ -241,7 +241,7 @@ typedef struct {
 #define _RTCC_DATE_MONTHU_MASK              0xF00UL                           /**< Bit mask for RTCC_MONTHU */
 #define _RTCC_DATE_MONTHU_DEFAULT           0x00000000UL                      /**< Mode DEFAULT for RTCC_DATE */
 #define RTCC_DATE_MONTHU_DEFAULT            (_RTCC_DATE_MONTHU_DEFAULT << 8)  /**< Shifted mode DEFAULT for RTCC_DATE */
-#define RTCC_DATE_MONTHT                    (0x1UL << 12)                     /**< Month, tens. */
+#define RTCC_DATE_MONTHT                    (0x1UL << 12)                     /**< Month, Tens */
 #define _RTCC_DATE_MONTHT_SHIFT             12                                /**< Shift value for RTCC_MONTHT */
 #define _RTCC_DATE_MONTHT_MASK              0x1000UL                          /**< Bit mask for RTCC_MONTHT */
 #define _RTCC_DATE_MONTHT_DEFAULT           0x00000000UL                      /**< Mode DEFAULT for RTCC_DATE */
@@ -282,37 +282,37 @@ typedef struct {
 #define _RTCC_IF_CC2_MASK                   0x8UL                              /**< Bit mask for RTCC_CC2 */
 #define _RTCC_IF_CC2_DEFAULT                0x00000000UL                       /**< Mode DEFAULT for RTCC_IF */
 #define RTCC_IF_CC2_DEFAULT                 (_RTCC_IF_CC2_DEFAULT << 3)        /**< Shifted mode DEFAULT for RTCC_IF */
-#define RTCC_IF_OSCFAIL                     (0x1UL << 4)                       /**< Oscillator failure Interrupt Flag */
+#define RTCC_IF_OSCFAIL                     (0x1UL << 4)                       /**< Oscillator Failure Interrupt Flag */
 #define _RTCC_IF_OSCFAIL_SHIFT              4                                  /**< Shift value for RTCC_OSCFAIL */
 #define _RTCC_IF_OSCFAIL_MASK               0x10UL                             /**< Bit mask for RTCC_OSCFAIL */
 #define _RTCC_IF_OSCFAIL_DEFAULT            0x00000000UL                       /**< Mode DEFAULT for RTCC_IF */
 #define RTCC_IF_OSCFAIL_DEFAULT             (_RTCC_IF_OSCFAIL_DEFAULT << 4)    /**< Shifted mode DEFAULT for RTCC_IF */
-#define RTCC_IF_CNTTICK                     (0x1UL << 5)                       /**< Main counter tick */
+#define RTCC_IF_CNTTICK                     (0x1UL << 5)                       /**< Main Counter Tick */
 #define _RTCC_IF_CNTTICK_SHIFT              5                                  /**< Shift value for RTCC_CNTTICK */
 #define _RTCC_IF_CNTTICK_MASK               0x20UL                             /**< Bit mask for RTCC_CNTTICK */
 #define _RTCC_IF_CNTTICK_DEFAULT            0x00000000UL                       /**< Mode DEFAULT for RTCC_IF */
 #define RTCC_IF_CNTTICK_DEFAULT             (_RTCC_IF_CNTTICK_DEFAULT << 5)    /**< Shifted mode DEFAULT for RTCC_IF */
-#define RTCC_IF_MINTICK                     (0x1UL << 6)                       /**< Minute tick */
+#define RTCC_IF_MINTICK                     (0x1UL << 6)                       /**< Minute Tick */
 #define _RTCC_IF_MINTICK_SHIFT              6                                  /**< Shift value for RTCC_MINTICK */
 #define _RTCC_IF_MINTICK_MASK               0x40UL                             /**< Bit mask for RTCC_MINTICK */
 #define _RTCC_IF_MINTICK_DEFAULT            0x00000000UL                       /**< Mode DEFAULT for RTCC_IF */
 #define RTCC_IF_MINTICK_DEFAULT             (_RTCC_IF_MINTICK_DEFAULT << 6)    /**< Shifted mode DEFAULT for RTCC_IF */
-#define RTCC_IF_HOURTICK                    (0x1UL << 7)                       /**< Hour tick */
+#define RTCC_IF_HOURTICK                    (0x1UL << 7)                       /**< Hour Tick */
 #define _RTCC_IF_HOURTICK_SHIFT             7                                  /**< Shift value for RTCC_HOURTICK */
 #define _RTCC_IF_HOURTICK_MASK              0x80UL                             /**< Bit mask for RTCC_HOURTICK */
 #define _RTCC_IF_HOURTICK_DEFAULT           0x00000000UL                       /**< Mode DEFAULT for RTCC_IF */
 #define RTCC_IF_HOURTICK_DEFAULT            (_RTCC_IF_HOURTICK_DEFAULT << 7)   /**< Shifted mode DEFAULT for RTCC_IF */
-#define RTCC_IF_DAYTICK                     (0x1UL << 8)                       /**< Day tick */
+#define RTCC_IF_DAYTICK                     (0x1UL << 8)                       /**< Day Tick */
 #define _RTCC_IF_DAYTICK_SHIFT              8                                  /**< Shift value for RTCC_DAYTICK */
 #define _RTCC_IF_DAYTICK_MASK               0x100UL                            /**< Bit mask for RTCC_DAYTICK */
 #define _RTCC_IF_DAYTICK_DEFAULT            0x00000000UL                       /**< Mode DEFAULT for RTCC_IF */
 #define RTCC_IF_DAYTICK_DEFAULT             (_RTCC_IF_DAYTICK_DEFAULT << 8)    /**< Shifted mode DEFAULT for RTCC_IF */
-#define RTCC_IF_DAYOWOF                     (0x1UL << 9)                       /**< Day of week overflow */
+#define RTCC_IF_DAYOWOF                     (0x1UL << 9)                       /**< Day of Week Overflow */
 #define _RTCC_IF_DAYOWOF_SHIFT              9                                  /**< Shift value for RTCC_DAYOWOF */
 #define _RTCC_IF_DAYOWOF_MASK               0x200UL                            /**< Bit mask for RTCC_DAYOWOF */
 #define _RTCC_IF_DAYOWOF_DEFAULT            0x00000000UL                       /**< Mode DEFAULT for RTCC_IF */
 #define RTCC_IF_DAYOWOF_DEFAULT             (_RTCC_IF_DAYOWOF_DEFAULT << 9)    /**< Shifted mode DEFAULT for RTCC_IF */
-#define RTCC_IF_MONTHTICK                   (0x1UL << 10)                      /**< Month tick */
+#define RTCC_IF_MONTHTICK                   (0x1UL << 10)                      /**< Month Tick */
 #define _RTCC_IF_MONTHTICK_SHIFT            10                                 /**< Shift value for RTCC_MONTHTICK */
 #define _RTCC_IF_MONTHTICK_MASK             0x400UL                            /**< Bit mask for RTCC_MONTHTICK */
 #define _RTCC_IF_MONTHTICK_DEFAULT          0x00000000UL                       /**< Mode DEFAULT for RTCC_IF */
@@ -502,7 +502,7 @@ typedef struct {
 /* Bit fields for RTCC CMD */
 #define _RTCC_CMD_RESETVALUE                0x00000000UL                       /**< Default value for RTCC_CMD */
 #define _RTCC_CMD_MASK                      0x00000001UL                       /**< Mask for RTCC_CMD */
-#define RTCC_CMD_CLRSTATUS                  (0x1UL << 0)                       /**< Clear RTCC_STATUS register. */
+#define RTCC_CMD_CLRSTATUS                  (0x1UL << 0)                       /**< Clear RTCC_STATUS Register */
 #define _RTCC_CMD_CLRSTATUS_SHIFT           0                                  /**< Shift value for RTCC_CLRSTATUS */
 #define _RTCC_CMD_CLRSTATUS_MASK            0x1UL                              /**< Bit mask for RTCC_CLRSTATUS */
 #define _RTCC_CMD_CLRSTATUS_DEFAULT         0x00000000UL                       /**< Mode DEFAULT for RTCC_CMD */
@@ -520,7 +520,7 @@ typedef struct {
 /* Bit fields for RTCC POWERDOWN */
 #define _RTCC_POWERDOWN_RESETVALUE          0x00000000UL                       /**< Default value for RTCC_POWERDOWN */
 #define _RTCC_POWERDOWN_MASK                0x00000001UL                       /**< Mask for RTCC_POWERDOWN */
-#define RTCC_POWERDOWN_RAM                  (0x1UL << 0)                       /**< Retention RAM power-down */
+#define RTCC_POWERDOWN_RAM                  (0x1UL << 0)                       /**< Retention RAM Power-down */
 #define _RTCC_POWERDOWN_RAM_SHIFT           0                                  /**< Shift value for RTCC_RAM */
 #define _RTCC_POWERDOWN_RAM_MASK            0x1UL                              /**< Bit mask for RTCC_RAM */
 #define _RTCC_POWERDOWN_RAM_DEFAULT         0x00000000UL                       /**< Mode DEFAULT for RTCC_POWERDOWN */
@@ -545,7 +545,7 @@ typedef struct {
 /* Bit fields for RTCC EM4WUEN */
 #define _RTCC_EM4WUEN_RESETVALUE            0x00000000UL                       /**< Default value for RTCC_EM4WUEN */
 #define _RTCC_EM4WUEN_MASK                  0x00000001UL                       /**< Mask for RTCC_EM4WUEN */
-#define RTCC_EM4WUEN_EM4WU                  (0x1UL << 0)                       /**< EM4 Wake-up enable */
+#define RTCC_EM4WUEN_EM4WU                  (0x1UL << 0)                       /**< EM4 Wake-up Enable */
 #define _RTCC_EM4WUEN_EM4WU_SHIFT           0                                  /**< Shift value for RTCC_EM4WU */
 #define _RTCC_EM4WUEN_EM4WU_MASK            0x1UL                              /**< Bit mask for RTCC_EM4WU */
 #define _RTCC_EM4WUEN_EM4WU_DEFAULT         0x00000000UL                       /**< Mode DEFAULT for RTCC_EM4WUEN */
@@ -616,7 +616,7 @@ typedef struct {
 #define RTCC_CC_CTRL_PRSSEL_PRSCH9          (_RTCC_CC_CTRL_PRSSEL_PRSCH9 << 6)      /**< Shifted mode PRSCH9 for RTCC_CC_CTRL */
 #define RTCC_CC_CTRL_PRSSEL_PRSCH10         (_RTCC_CC_CTRL_PRSSEL_PRSCH10 << 6)     /**< Shifted mode PRSCH10 for RTCC_CC_CTRL */
 #define RTCC_CC_CTRL_PRSSEL_PRSCH11         (_RTCC_CC_CTRL_PRSSEL_PRSCH11 << 6)     /**< Shifted mode PRSCH11 for RTCC_CC_CTRL */
-#define RTCC_CC_CTRL_COMPBASE               (0x1UL << 11)                           /**< Capture compare channel comparison base. */
+#define RTCC_CC_CTRL_COMPBASE               (0x1UL << 11)                           /**< Capture Compare Channel Comparison Base */
 #define _RTCC_CC_CTRL_COMPBASE_SHIFT        11                                      /**< Shift value for CC_COMPBASE */
 #define _RTCC_CC_CTRL_COMPBASE_MASK         0x800UL                                 /**< Bit mask for CC_COMPBASE */
 #define _RTCC_CC_CTRL_COMPBASE_DEFAULT      0x00000000UL                            /**< Mode DEFAULT for RTCC_CC_CTRL */
@@ -629,7 +629,7 @@ typedef struct {
 #define _RTCC_CC_CTRL_COMPMASK_MASK         0x1F000UL                               /**< Bit mask for CC_COMPMASK */
 #define _RTCC_CC_CTRL_COMPMASK_DEFAULT      0x00000000UL                            /**< Mode DEFAULT for RTCC_CC_CTRL */
 #define RTCC_CC_CTRL_COMPMASK_DEFAULT       (_RTCC_CC_CTRL_COMPMASK_DEFAULT << 12)  /**< Shifted mode DEFAULT for RTCC_CC_CTRL */
-#define RTCC_CC_CTRL_DAYCC                  (0x1UL << 17)                           /**< Day Capture/Compare selection */
+#define RTCC_CC_CTRL_DAYCC                  (0x1UL << 17)                           /**< Day Capture/Compare Selection */
 #define _RTCC_CC_CTRL_DAYCC_SHIFT           17                                      /**< Shift value for CC_DAYCC */
 #define _RTCC_CC_CTRL_DAYCC_MASK            0x20000UL                               /**< Bit mask for CC_DAYCC */
 #define _RTCC_CC_CTRL_DAYCC_DEFAULT         0x00000000UL                            /**< Mode DEFAULT for RTCC_CC_CTRL */
@@ -690,7 +690,7 @@ typedef struct {
 #define _RTCC_CC_DATE_MONTHU_MASK           0xF00UL                              /**< Bit mask for CC_MONTHU */
 #define _RTCC_CC_DATE_MONTHU_DEFAULT        0x00000000UL                         /**< Mode DEFAULT for RTCC_CC_DATE */
 #define RTCC_CC_DATE_MONTHU_DEFAULT         (_RTCC_CC_DATE_MONTHU_DEFAULT << 8)  /**< Shifted mode DEFAULT for RTCC_CC_DATE */
-#define RTCC_CC_DATE_MONTHT                 (0x1UL << 12)                        /**< Month, tens. */
+#define RTCC_CC_DATE_MONTHT                 (0x1UL << 12)                        /**< Month, Tens */
 #define _RTCC_CC_DATE_MONTHT_SHIFT          12                                   /**< Shift value for CC_MONTHT */
 #define _RTCC_CC_DATE_MONTHT_MASK           0x1000UL                             /**< Bit mask for CC_MONTHT */
 #define _RTCC_CC_DATE_MONTHT_DEFAULT        0x00000000UL                         /**< Mode DEFAULT for RTCC_CC_DATE */

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_rtcc_cc.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_rtcc_cc.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32pg1b_rtcc_cc.h
  * @brief EFM32PG1B_RTCC_CC register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_rtcc_ret.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_rtcc_ret.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32pg1b_rtcc_ret.h
  * @brief EFM32PG1B_RTCC_RET register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,
@@ -50,7 +50,7 @@ extern "C" {
  * @ingroup EFM32PG1B_RTCC
  *****************************************************************************/
 typedef struct {
-  __IOM uint32_t REG; /**< Retention register  */
+  __IOM uint32_t REG; /**< Retention Register  */
 } RTCC_RET_TypeDef;
 
 /** @} End of group Parts */

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_timer.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_timer.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32pg1b_timer.h
  * @brief EFM32PG1B_TIMER register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,
@@ -202,7 +202,7 @@ typedef struct {
 #define _TIMER_CTRL_ATI_MASK                       0x10000000UL                             /**< Bit mask for TIMER_ATI */
 #define _TIMER_CTRL_ATI_DEFAULT                    0x00000000UL                             /**< Mode DEFAULT for TIMER_CTRL */
 #define TIMER_CTRL_ATI_DEFAULT                     (_TIMER_CTRL_ATI_DEFAULT << 28)          /**< Shifted mode DEFAULT for TIMER_CTRL */
-#define TIMER_CTRL_RSSCOIST                        (0x1UL << 29)                            /**< Reload-Start Sets Compare Output initial State */
+#define TIMER_CTRL_RSSCOIST                        (0x1UL << 29)                            /**< Reload-Start Sets Compare Output Initial State */
 #define _TIMER_CTRL_RSSCOIST_SHIFT                 29                                       /**< Shift value for TIMER_RSSCOIST */
 #define _TIMER_CTRL_RSSCOIST_MASK                  0x20000000UL                             /**< Bit mask for TIMER_RSSCOIST */
 #define _TIMER_CTRL_RSSCOIST_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for TIMER_CTRL */
@@ -1307,7 +1307,7 @@ typedef struct {
 #define _TIMER_DTCTRL_DTIPOL_MASK                  0x4UL                                 /**< Bit mask for TIMER_DTIPOL */
 #define _TIMER_DTCTRL_DTIPOL_DEFAULT               0x00000000UL                          /**< Mode DEFAULT for TIMER_DTCTRL */
 #define TIMER_DTCTRL_DTIPOL_DEFAULT                (_TIMER_DTCTRL_DTIPOL_DEFAULT << 2)   /**< Shifted mode DEFAULT for TIMER_DTCTRL */
-#define TIMER_DTCTRL_DTCINV                        (0x1UL << 3)                          /**< DTI Complementary Output Invert. */
+#define TIMER_DTCTRL_DTCINV                        (0x1UL << 3)                          /**< DTI Complementary Output Invert */
 #define _TIMER_DTCTRL_DTCINV_SHIFT                 3                                     /**< Shift value for TIMER_DTCINV */
 #define _TIMER_DTCTRL_DTCINV_MASK                  0x8UL                                 /**< Bit mask for TIMER_DTCINV */
 #define _TIMER_DTCTRL_DTCINV_DEFAULT               0x00000000UL                          /**< Mode DEFAULT for TIMER_DTCTRL */

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_timer_cc.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_timer_cc.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32pg1b_timer_cc.h
  * @brief EFM32PG1B_TIMER_CC register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_usart.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_usart.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32pg1b_usart.h
  * @brief EFM32PG1B_USART register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,
@@ -54,7 +54,7 @@ extern "C" {
 typedef struct {
   __IOM uint32_t CTRL;         /**< Control Register  */
   __IOM uint32_t FRAME;        /**< USART Frame Format Register  */
-  __IOM uint32_t TRIGCTRL;     /**< USART Trigger Control register  */
+  __IOM uint32_t TRIGCTRL;     /**< USART Trigger Control Register  */
   __IOM uint32_t CMD;          /**< Command Register  */
   __IM uint32_t  STATUS;       /**< USART Status Register  */
   __IOM uint32_t CLKDIV;       /**< Clock Control Register  */
@@ -78,9 +78,9 @@ typedef struct {
   __IOM uint32_t I2SCTRL;      /**< I2S Control Register  */
   __IOM uint32_t TIMING;       /**< Timing Register  */
   __IOM uint32_t CTRLX;        /**< Control Register Extended  */
-  __IOM uint32_t TIMECMP0;     /**< Used to generate interrupts and various delays  */
-  __IOM uint32_t TIMECMP1;     /**< Used to generate interrupts and various delays  */
-  __IOM uint32_t TIMECMP2;     /**< Used to generate interrupts and various delays  */
+  __IOM uint32_t TIMECMP0;     /**< Used to Generate Interrupts and Various Delays  */
+  __IOM uint32_t TIMECMP1;     /**< Used to Generate Interrupts and Various Delays  */
+  __IOM uint32_t TIMECMP2;     /**< Used to Generate Interrupts and Various Delays  */
   __IOM uint32_t ROUTEPEN;     /**< I/O Routing Pin Enable Register  */
   __IOM uint32_t ROUTELOC0;    /**< I/O Routing Location Register  */
   __IOM uint32_t ROUTELOC1;    /**< I/O Routing Location Register  */
@@ -142,7 +142,7 @@ typedef struct {
 #define USART_CTRL_CLKPOL_DEFAULT               (_USART_CTRL_CLKPOL_DEFAULT << 8)        /**< Shifted mode DEFAULT for USART_CTRL */
 #define USART_CTRL_CLKPOL_IDLELOW               (_USART_CTRL_CLKPOL_IDLELOW << 8)        /**< Shifted mode IDLELOW for USART_CTRL */
 #define USART_CTRL_CLKPOL_IDLEHIGH              (_USART_CTRL_CLKPOL_IDLEHIGH << 8)       /**< Shifted mode IDLEHIGH for USART_CTRL */
-#define USART_CTRL_CLKPHA                       (0x1UL << 9)                             /**< Clock Edge For Setup/Sample */
+#define USART_CTRL_CLKPHA                       (0x1UL << 9)                             /**< Clock Edge for Setup/Sample */
 #define _USART_CTRL_CLKPHA_SHIFT                9                                        /**< Shift value for USART_CLKPHA */
 #define _USART_CTRL_CLKPHA_MASK                 0x200UL                                  /**< Bit mask for USART_CLKPHA */
 #define _USART_CTRL_CLKPHA_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for USART_CTRL */
@@ -156,7 +156,7 @@ typedef struct {
 #define _USART_CTRL_MSBF_MASK                   0x400UL                                  /**< Bit mask for USART_MSBF */
 #define _USART_CTRL_MSBF_DEFAULT                0x00000000UL                             /**< Mode DEFAULT for USART_CTRL */
 #define USART_CTRL_MSBF_DEFAULT                 (_USART_CTRL_MSBF_DEFAULT << 10)         /**< Shifted mode DEFAULT for USART_CTRL */
-#define USART_CTRL_CSMA                         (0x1UL << 11)                            /**< Action On Slave-Select In Master Mode */
+#define USART_CTRL_CSMA                         (0x1UL << 11)                            /**< Action on Slave-Select in Master Mode */
 #define _USART_CTRL_CSMA_SHIFT                  11                                       /**< Shift value for USART_CSMA */
 #define _USART_CTRL_CSMA_MASK                   0x800UL                                  /**< Bit mask for USART_CSMA */
 #define _USART_CTRL_CSMA_DEFAULT                0x00000000UL                             /**< Mode DEFAULT for USART_CTRL */
@@ -179,7 +179,7 @@ typedef struct {
 #define _USART_CTRL_RXINV_MASK                  0x2000UL                                 /**< Bit mask for USART_RXINV */
 #define _USART_CTRL_RXINV_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for USART_CTRL */
 #define USART_CTRL_RXINV_DEFAULT                (_USART_CTRL_RXINV_DEFAULT << 13)        /**< Shifted mode DEFAULT for USART_CTRL */
-#define USART_CTRL_TXINV                        (0x1UL << 14)                            /**< Transmitter output Invert */
+#define USART_CTRL_TXINV                        (0x1UL << 14)                            /**< Transmitter Output Invert */
 #define _USART_CTRL_TXINV_SHIFT                 14                                       /**< Shift value for USART_TXINV */
 #define _USART_CTRL_TXINV_MASK                  0x4000UL                                 /**< Bit mask for USART_TXINV */
 #define _USART_CTRL_TXINV_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for USART_CTRL */
@@ -219,17 +219,17 @@ typedef struct {
 #define _USART_CTRL_BIT8DV_MASK                 0x200000UL                               /**< Bit mask for USART_BIT8DV */
 #define _USART_CTRL_BIT8DV_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for USART_CTRL */
 #define USART_CTRL_BIT8DV_DEFAULT               (_USART_CTRL_BIT8DV_DEFAULT << 21)       /**< Shifted mode DEFAULT for USART_CTRL */
-#define USART_CTRL_ERRSDMA                      (0x1UL << 22)                            /**< Halt DMA On Error */
+#define USART_CTRL_ERRSDMA                      (0x1UL << 22)                            /**< Halt DMA on Error */
 #define _USART_CTRL_ERRSDMA_SHIFT               22                                       /**< Shift value for USART_ERRSDMA */
 #define _USART_CTRL_ERRSDMA_MASK                0x400000UL                               /**< Bit mask for USART_ERRSDMA */
 #define _USART_CTRL_ERRSDMA_DEFAULT             0x00000000UL                             /**< Mode DEFAULT for USART_CTRL */
 #define USART_CTRL_ERRSDMA_DEFAULT              (_USART_CTRL_ERRSDMA_DEFAULT << 22)      /**< Shifted mode DEFAULT for USART_CTRL */
-#define USART_CTRL_ERRSRX                       (0x1UL << 23)                            /**< Disable RX On Error */
+#define USART_CTRL_ERRSRX                       (0x1UL << 23)                            /**< Disable RX on Error */
 #define _USART_CTRL_ERRSRX_SHIFT                23                                       /**< Shift value for USART_ERRSRX */
 #define _USART_CTRL_ERRSRX_MASK                 0x800000UL                               /**< Bit mask for USART_ERRSRX */
 #define _USART_CTRL_ERRSRX_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for USART_CTRL */
 #define USART_CTRL_ERRSRX_DEFAULT               (_USART_CTRL_ERRSRX_DEFAULT << 23)       /**< Shifted mode DEFAULT for USART_CTRL */
-#define USART_CTRL_ERRSTX                       (0x1UL << 24)                            /**< Disable TX On Error */
+#define USART_CTRL_ERRSTX                       (0x1UL << 24)                            /**< Disable TX on Error */
 #define _USART_CTRL_ERRSTX_SHIFT                24                                       /**< Shift value for USART_ERRSTX */
 #define _USART_CTRL_ERRSTX_MASK                 0x1000000UL                              /**< Bit mask for USART_ERRSTX */
 #define _USART_CTRL_ERRSTX_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for USART_CTRL */
@@ -239,7 +239,7 @@ typedef struct {
 #define _USART_CTRL_SSSEARLY_MASK               0x2000000UL                              /**< Bit mask for USART_SSSEARLY */
 #define _USART_CTRL_SSSEARLY_DEFAULT            0x00000000UL                             /**< Mode DEFAULT for USART_CTRL */
 #define USART_CTRL_SSSEARLY_DEFAULT             (_USART_CTRL_SSSEARLY_DEFAULT << 25)     /**< Shifted mode DEFAULT for USART_CTRL */
-#define USART_CTRL_BYTESWAP                     (0x1UL << 28)                            /**< Byteswap In Double Accesses */
+#define USART_CTRL_BYTESWAP                     (0x1UL << 28)                            /**< Byteswap in Double Accesses */
 #define _USART_CTRL_BYTESWAP_SHIFT              28                                       /**< Shift value for USART_BYTESWAP */
 #define _USART_CTRL_BYTESWAP_MASK               0x10000000UL                             /**< Bit mask for USART_BYTESWAP */
 #define _USART_CTRL_BYTESWAP_DEFAULT            0x00000000UL                             /**< Mode DEFAULT for USART_CTRL */
@@ -334,32 +334,32 @@ typedef struct {
 #define _USART_TRIGCTRL_AUTOTXTEN_MASK          0x40UL                                   /**< Bit mask for USART_AUTOTXTEN */
 #define _USART_TRIGCTRL_AUTOTXTEN_DEFAULT       0x00000000UL                             /**< Mode DEFAULT for USART_TRIGCTRL */
 #define USART_TRIGCTRL_AUTOTXTEN_DEFAULT        (_USART_TRIGCTRL_AUTOTXTEN_DEFAULT << 6) /**< Shifted mode DEFAULT for USART_TRIGCTRL */
-#define USART_TRIGCTRL_TXARX0EN                 (0x1UL << 7)                             /**< Enable Transmit Trigger after RX End of Frame plus TCMP0VAL */
+#define USART_TRIGCTRL_TXARX0EN                 (0x1UL << 7)                             /**< Enable Transmit Trigger After RX End of Frame Plus TCMP0VAL */
 #define _USART_TRIGCTRL_TXARX0EN_SHIFT          7                                        /**< Shift value for USART_TXARX0EN */
 #define _USART_TRIGCTRL_TXARX0EN_MASK           0x80UL                                   /**< Bit mask for USART_TXARX0EN */
 #define _USART_TRIGCTRL_TXARX0EN_DEFAULT        0x00000000UL                             /**< Mode DEFAULT for USART_TRIGCTRL */
 #define USART_TRIGCTRL_TXARX0EN_DEFAULT         (_USART_TRIGCTRL_TXARX0EN_DEFAULT << 7)  /**< Shifted mode DEFAULT for USART_TRIGCTRL */
-#define USART_TRIGCTRL_TXARX1EN                 (0x1UL << 8)                             /**< Enable Transmit Trigger after RX End of Frame plus TCMP1VAL */
+#define USART_TRIGCTRL_TXARX1EN                 (0x1UL << 8)                             /**< Enable Transmit Trigger After RX End of Frame Plus TCMP1VAL */
 #define _USART_TRIGCTRL_TXARX1EN_SHIFT          8                                        /**< Shift value for USART_TXARX1EN */
 #define _USART_TRIGCTRL_TXARX1EN_MASK           0x100UL                                  /**< Bit mask for USART_TXARX1EN */
 #define _USART_TRIGCTRL_TXARX1EN_DEFAULT        0x00000000UL                             /**< Mode DEFAULT for USART_TRIGCTRL */
 #define USART_TRIGCTRL_TXARX1EN_DEFAULT         (_USART_TRIGCTRL_TXARX1EN_DEFAULT << 8)  /**< Shifted mode DEFAULT for USART_TRIGCTRL */
-#define USART_TRIGCTRL_TXARX2EN                 (0x1UL << 9)                             /**< Enable Transmit Trigger after RX End of Frame plus TCMP2VAL */
+#define USART_TRIGCTRL_TXARX2EN                 (0x1UL << 9)                             /**< Enable Transmit Trigger After RX End of Frame Plus TCMP2VAL */
 #define _USART_TRIGCTRL_TXARX2EN_SHIFT          9                                        /**< Shift value for USART_TXARX2EN */
 #define _USART_TRIGCTRL_TXARX2EN_MASK           0x200UL                                  /**< Bit mask for USART_TXARX2EN */
 #define _USART_TRIGCTRL_TXARX2EN_DEFAULT        0x00000000UL                             /**< Mode DEFAULT for USART_TRIGCTRL */
 #define USART_TRIGCTRL_TXARX2EN_DEFAULT         (_USART_TRIGCTRL_TXARX2EN_DEFAULT << 9)  /**< Shifted mode DEFAULT for USART_TRIGCTRL */
-#define USART_TRIGCTRL_RXATX0EN                 (0x1UL << 10)                            /**< Enable Receive Trigger after TX end of frame plus TCMPVAL0 baud-times */
+#define USART_TRIGCTRL_RXATX0EN                 (0x1UL << 10)                            /**< Enable Receive Trigger After TX End of Frame Plus TCMPVAL0 Baud-times */
 #define _USART_TRIGCTRL_RXATX0EN_SHIFT          10                                       /**< Shift value for USART_RXATX0EN */
 #define _USART_TRIGCTRL_RXATX0EN_MASK           0x400UL                                  /**< Bit mask for USART_RXATX0EN */
 #define _USART_TRIGCTRL_RXATX0EN_DEFAULT        0x00000000UL                             /**< Mode DEFAULT for USART_TRIGCTRL */
 #define USART_TRIGCTRL_RXATX0EN_DEFAULT         (_USART_TRIGCTRL_RXATX0EN_DEFAULT << 10) /**< Shifted mode DEFAULT for USART_TRIGCTRL */
-#define USART_TRIGCTRL_RXATX1EN                 (0x1UL << 11)                            /**< Enable Receive Trigger after TX end of frame plus TCMPVAL1 baud-times */
+#define USART_TRIGCTRL_RXATX1EN                 (0x1UL << 11)                            /**< Enable Receive Trigger After TX End of Frame Plus TCMPVAL1 Baud-times */
 #define _USART_TRIGCTRL_RXATX1EN_SHIFT          11                                       /**< Shift value for USART_RXATX1EN */
 #define _USART_TRIGCTRL_RXATX1EN_MASK           0x800UL                                  /**< Bit mask for USART_RXATX1EN */
 #define _USART_TRIGCTRL_RXATX1EN_DEFAULT        0x00000000UL                             /**< Mode DEFAULT for USART_TRIGCTRL */
 #define USART_TRIGCTRL_RXATX1EN_DEFAULT         (_USART_TRIGCTRL_RXATX1EN_DEFAULT << 11) /**< Shifted mode DEFAULT for USART_TRIGCTRL */
-#define USART_TRIGCTRL_RXATX2EN                 (0x1UL << 12)                            /**< Enable Receive Trigger after TX end of frame plus TCMPVAL2 baud-times */
+#define USART_TRIGCTRL_RXATX2EN                 (0x1UL << 12)                            /**< Enable Receive Trigger After TX End of Frame Plus TCMPVAL2 Baud-times */
 #define _USART_TRIGCTRL_RXATX2EN_SHIFT          12                                       /**< Shift value for USART_RXATX2EN */
 #define _USART_TRIGCTRL_RXATX2EN_MASK           0x1000UL                                 /**< Bit mask for USART_RXATX2EN */
 #define _USART_TRIGCTRL_RXATX2EN_DEFAULT        0x00000000UL                             /**< Mode DEFAULT for USART_TRIGCTRL */
@@ -530,7 +530,7 @@ typedef struct {
 #define _USART_STATUS_TXIDLE_MASK               0x2000UL                                     /**< Bit mask for USART_TXIDLE */
 #define _USART_STATUS_TXIDLE_DEFAULT            0x00000001UL                                 /**< Mode DEFAULT for USART_STATUS */
 #define USART_STATUS_TXIDLE_DEFAULT             (_USART_STATUS_TXIDLE_DEFAULT << 13)         /**< Shifted mode DEFAULT for USART_STATUS */
-#define USART_STATUS_TIMERRESTARTED             (0x1UL << 14)                                /**< The USART Timer restarted itself */
+#define USART_STATUS_TIMERRESTARTED             (0x1UL << 14)                                /**< The USART Timer Restarted Itself */
 #define _USART_STATUS_TIMERRESTARTED_SHIFT      14                                           /**< Shift value for USART_TIMERRESTARTED */
 #define _USART_STATUS_TIMERRESTARTED_MASK       0x4000UL                                     /**< Bit mask for USART_TIMERRESTARTED */
 #define _USART_STATUS_TIMERRESTARTED_DEFAULT    0x00000000UL                                 /**< Mode DEFAULT for USART_STATUS */
@@ -547,7 +547,7 @@ typedef struct {
 #define _USART_CLKDIV_DIV_MASK                  0x7FFFF8UL                               /**< Bit mask for USART_DIV */
 #define _USART_CLKDIV_DIV_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for USART_CLKDIV */
 #define USART_CLKDIV_DIV_DEFAULT                (_USART_CLKDIV_DIV_DEFAULT << 3)         /**< Shifted mode DEFAULT for USART_CLKDIV */
-#define USART_CLKDIV_AUTOBAUDEN                 (0x1UL << 31)                            /**< AUTOBAUD detection enable */
+#define USART_CLKDIV_AUTOBAUDEN                 (0x1UL << 31)                            /**< AUTOBAUD Detection Enable */
 #define _USART_CLKDIV_AUTOBAUDEN_SHIFT          31                                       /**< Shift value for USART_AUTOBAUDEN */
 #define _USART_CLKDIV_AUTOBAUDEN_MASK           0x80000000UL                             /**< Bit mask for USART_AUTOBAUDEN */
 #define _USART_CLKDIV_AUTOBAUDEN_DEFAULT        0x00000000UL                             /**< Mode DEFAULT for USART_CLKDIV */
@@ -690,7 +690,7 @@ typedef struct {
 #define _USART_TXDATAX_TXTRIAT_MASK             0x1000UL                               /**< Bit mask for USART_TXTRIAT */
 #define _USART_TXDATAX_TXTRIAT_DEFAULT          0x00000000UL                           /**< Mode DEFAULT for USART_TXDATAX */
 #define USART_TXDATAX_TXTRIAT_DEFAULT           (_USART_TXDATAX_TXTRIAT_DEFAULT << 12) /**< Shifted mode DEFAULT for USART_TXDATAX */
-#define USART_TXDATAX_TXBREAK                   (0x1UL << 13)                          /**< Transmit Data As Break */
+#define USART_TXDATAX_TXBREAK                   (0x1UL << 13)                          /**< Transmit Data as Break */
 #define _USART_TXDATAX_TXBREAK_SHIFT            13                                     /**< Shift value for USART_TXBREAK */
 #define _USART_TXDATAX_TXBREAK_MASK             0x2000UL                               /**< Bit mask for USART_TXBREAK */
 #define _USART_TXDATAX_TXBREAK_DEFAULT          0x00000000UL                           /**< Mode DEFAULT for USART_TXDATAX */
@@ -731,7 +731,7 @@ typedef struct {
 #define _USART_TXDOUBLEX_TXTRIAT0_MASK          0x1000UL                                  /**< Bit mask for USART_TXTRIAT0 */
 #define _USART_TXDOUBLEX_TXTRIAT0_DEFAULT       0x00000000UL                              /**< Mode DEFAULT for USART_TXDOUBLEX */
 #define USART_TXDOUBLEX_TXTRIAT0_DEFAULT        (_USART_TXDOUBLEX_TXTRIAT0_DEFAULT << 12) /**< Shifted mode DEFAULT for USART_TXDOUBLEX */
-#define USART_TXDOUBLEX_TXBREAK0                (0x1UL << 13)                             /**< Transmit Data As Break */
+#define USART_TXDOUBLEX_TXBREAK0                (0x1UL << 13)                             /**< Transmit Data as Break */
 #define _USART_TXDOUBLEX_TXBREAK0_SHIFT         13                                        /**< Shift value for USART_TXBREAK0 */
 #define _USART_TXDOUBLEX_TXBREAK0_MASK          0x2000UL                                  /**< Bit mask for USART_TXBREAK0 */
 #define _USART_TXDOUBLEX_TXBREAK0_DEFAULT       0x00000000UL                              /**< Mode DEFAULT for USART_TXDOUBLEX */
@@ -760,7 +760,7 @@ typedef struct {
 #define _USART_TXDOUBLEX_TXTRIAT1_MASK          0x10000000UL                              /**< Bit mask for USART_TXTRIAT1 */
 #define _USART_TXDOUBLEX_TXTRIAT1_DEFAULT       0x00000000UL                              /**< Mode DEFAULT for USART_TXDOUBLEX */
 #define USART_TXDOUBLEX_TXTRIAT1_DEFAULT        (_USART_TXDOUBLEX_TXTRIAT1_DEFAULT << 28) /**< Shifted mode DEFAULT for USART_TXDOUBLEX */
-#define USART_TXDOUBLEX_TXBREAK1                (0x1UL << 29)                             /**< Transmit Data As Break */
+#define USART_TXDOUBLEX_TXBREAK1                (0x1UL << 29)                             /**< Transmit Data as Break */
 #define _USART_TXDOUBLEX_TXBREAK1_SHIFT         29                                        /**< Shift value for USART_TXBREAK1 */
 #define _USART_TXDOUBLEX_TXBREAK1_MASK          0x20000000UL                              /**< Bit mask for USART_TXBREAK1 */
 #define _USART_TXDOUBLEX_TXBREAK1_DEFAULT       0x00000000UL                              /**< Mode DEFAULT for USART_TXDOUBLEX */
@@ -846,7 +846,7 @@ typedef struct {
 #define _USART_IF_MPAF_MASK                     0x400UL                          /**< Bit mask for USART_MPAF */
 #define _USART_IF_MPAF_DEFAULT                  0x00000000UL                     /**< Mode DEFAULT for USART_IF */
 #define USART_IF_MPAF_DEFAULT                   (_USART_IF_MPAF_DEFAULT << 10)   /**< Shifted mode DEFAULT for USART_IF */
-#define USART_IF_SSM                            (0x1UL << 11)                    /**< Slave-Select In Master Mode Interrupt Flag */
+#define USART_IF_SSM                            (0x1UL << 11)                    /**< Slave-Select in Master Mode Interrupt Flag */
 #define _USART_IF_SSM_SHIFT                     11                               /**< Shift value for USART_SSM */
 #define _USART_IF_SSM_MASK                      0x800UL                          /**< Bit mask for USART_SSM */
 #define _USART_IF_SSM_DEFAULT                   0x00000000UL                     /**< Mode DEFAULT for USART_IF */
@@ -861,17 +861,17 @@ typedef struct {
 #define _USART_IF_TXIDLE_MASK                   0x2000UL                         /**< Bit mask for USART_TXIDLE */
 #define _USART_IF_TXIDLE_DEFAULT                0x00000000UL                     /**< Mode DEFAULT for USART_IF */
 #define USART_IF_TXIDLE_DEFAULT                 (_USART_IF_TXIDLE_DEFAULT << 13) /**< Shifted mode DEFAULT for USART_IF */
-#define USART_IF_TCMP0                          (0x1UL << 14)                    /**< Timer comparator 0 Interrupt Flag */
+#define USART_IF_TCMP0                          (0x1UL << 14)                    /**< Timer Comparator 0 Interrupt Flag */
 #define _USART_IF_TCMP0_SHIFT                   14                               /**< Shift value for USART_TCMP0 */
 #define _USART_IF_TCMP0_MASK                    0x4000UL                         /**< Bit mask for USART_TCMP0 */
 #define _USART_IF_TCMP0_DEFAULT                 0x00000000UL                     /**< Mode DEFAULT for USART_IF */
 #define USART_IF_TCMP0_DEFAULT                  (_USART_IF_TCMP0_DEFAULT << 14)  /**< Shifted mode DEFAULT for USART_IF */
-#define USART_IF_TCMP1                          (0x1UL << 15)                    /**< Timer comparator 1 Interrupt Flag */
+#define USART_IF_TCMP1                          (0x1UL << 15)                    /**< Timer Comparator 1 Interrupt Flag */
 #define _USART_IF_TCMP1_SHIFT                   15                               /**< Shift value for USART_TCMP1 */
 #define _USART_IF_TCMP1_MASK                    0x8000UL                         /**< Bit mask for USART_TCMP1 */
 #define _USART_IF_TCMP1_DEFAULT                 0x00000000UL                     /**< Mode DEFAULT for USART_IF */
 #define USART_IF_TCMP1_DEFAULT                  (_USART_IF_TCMP1_DEFAULT << 15)  /**< Shifted mode DEFAULT for USART_IF */
-#define USART_IF_TCMP2                          (0x1UL << 16)                    /**< Timer comparator 2 Interrupt Flag */
+#define USART_IF_TCMP2                          (0x1UL << 16)                    /**< Timer Comparator 2 Interrupt Flag */
 #define _USART_IF_TCMP2_SHIFT                   16                               /**< Shift value for USART_TCMP2 */
 #define _USART_IF_TCMP2_MASK                    0x10000UL                        /**< Bit mask for USART_TCMP2 */
 #define _USART_IF_TCMP2_DEFAULT                 0x00000000UL                     /**< Mode DEFAULT for USART_IF */
@@ -1275,12 +1275,12 @@ typedef struct {
 #define USART_I2SCTRL_JUSTIFY_DEFAULT           (_USART_I2SCTRL_JUSTIFY_DEFAULT << 2)  /**< Shifted mode DEFAULT for USART_I2SCTRL */
 #define USART_I2SCTRL_JUSTIFY_LEFT              (_USART_I2SCTRL_JUSTIFY_LEFT << 2)     /**< Shifted mode LEFT for USART_I2SCTRL */
 #define USART_I2SCTRL_JUSTIFY_RIGHT             (_USART_I2SCTRL_JUSTIFY_RIGHT << 2)    /**< Shifted mode RIGHT for USART_I2SCTRL */
-#define USART_I2SCTRL_DMASPLIT                  (0x1UL << 3)                           /**< Separate DMA Request For Left/Right Data */
+#define USART_I2SCTRL_DMASPLIT                  (0x1UL << 3)                           /**< Separate DMA Request for Left/Right Data */
 #define _USART_I2SCTRL_DMASPLIT_SHIFT           3                                      /**< Shift value for USART_DMASPLIT */
 #define _USART_I2SCTRL_DMASPLIT_MASK            0x8UL                                  /**< Bit mask for USART_DMASPLIT */
 #define _USART_I2SCTRL_DMASPLIT_DEFAULT         0x00000000UL                           /**< Mode DEFAULT for USART_I2SCTRL */
 #define USART_I2SCTRL_DMASPLIT_DEFAULT          (_USART_I2SCTRL_DMASPLIT_DEFAULT << 3) /**< Shifted mode DEFAULT for USART_I2SCTRL */
-#define USART_I2SCTRL_DELAY                     (0x1UL << 4)                           /**< Delay on I2S data */
+#define USART_I2SCTRL_DELAY                     (0x1UL << 4)                           /**< Delay on I2S Data */
 #define _USART_I2SCTRL_DELAY_SHIFT              4                                      /**< Shift value for USART_DELAY */
 #define _USART_I2SCTRL_DELAY_MASK               0x10UL                                 /**< Bit mask for USART_DELAY */
 #define _USART_I2SCTRL_DELAY_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for USART_I2SCTRL */
@@ -1393,7 +1393,7 @@ typedef struct {
 /* Bit fields for USART CTRLX */
 #define _USART_CTRLX_RESETVALUE                 0x00000000UL                        /**< Default value for USART_CTRLX */
 #define _USART_CTRLX_MASK                       0x0000000FUL                        /**< Mask for USART_CTRLX */
-#define USART_CTRLX_DBGHALT                     (0x1UL << 0)                        /**< Debug halt */
+#define USART_CTRLX_DBGHALT                     (0x1UL << 0)                        /**< Debug Halt */
 #define _USART_CTRLX_DBGHALT_SHIFT              0                                   /**< Shift value for USART_DBGHALT */
 #define _USART_CTRLX_DBGHALT_MASK               0x1UL                               /**< Bit mask for USART_DBGHALT */
 #define _USART_CTRLX_DBGHALT_DEFAULT            0x00000000UL                        /**< Mode DEFAULT for USART_CTRLX */
@@ -1403,7 +1403,7 @@ typedef struct {
 #define _USART_CTRLX_CTSINV_MASK                0x2UL                               /**< Bit mask for USART_CTSINV */
 #define _USART_CTRLX_CTSINV_DEFAULT             0x00000000UL                        /**< Mode DEFAULT for USART_CTRLX */
 #define USART_CTRLX_CTSINV_DEFAULT              (_USART_CTRLX_CTSINV_DEFAULT << 1)  /**< Shifted mode DEFAULT for USART_CTRLX */
-#define USART_CTRLX_CTSEN                       (0x1UL << 2)                        /**< CTS Function enabled */
+#define USART_CTRLX_CTSEN                       (0x1UL << 2)                        /**< CTS Function Enabled */
 #define _USART_CTRLX_CTSEN_SHIFT                2                                   /**< Shift value for USART_CTSEN */
 #define _USART_CTRLX_CTSEN_MASK                 0x4UL                               /**< Bit mask for USART_CTSEN */
 #define _USART_CTRLX_CTSEN_DEFAULT              0x00000000UL                        /**< Mode DEFAULT for USART_CTRLX */

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_wdog.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_wdog.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32pg1b_wdog.h
  * @brief EFM32PG1B_WDOG register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,
@@ -96,7 +96,7 @@ typedef struct {
 #define _WDOG_CTRL_EM3RUN_MASK                    0x8UL                                 /**< Bit mask for WDOG_EM3RUN */
 #define _WDOG_CTRL_EM3RUN_DEFAULT                 0x00000000UL                          /**< Mode DEFAULT for WDOG_CTRL */
 #define WDOG_CTRL_EM3RUN_DEFAULT                  (_WDOG_CTRL_EM3RUN_DEFAULT << 3)      /**< Shifted mode DEFAULT for WDOG_CTRL */
-#define WDOG_CTRL_LOCK                            (0x1UL << 4)                          /**< Configuration lock */
+#define WDOG_CTRL_LOCK                            (0x1UL << 4)                          /**< Configuration Lock */
 #define _WDOG_CTRL_LOCK_SHIFT                     4                                     /**< Shift value for WDOG_LOCK */
 #define _WDOG_CTRL_LOCK_MASK                      0x10UL                                /**< Bit mask for WDOG_LOCK */
 #define _WDOG_CTRL_LOCK_DEFAULT                   0x00000000UL                          /**< Mode DEFAULT for WDOG_CTRL */
@@ -220,7 +220,7 @@ typedef struct {
 #define WDOG_PCH_PRSCTRL_PRSSEL_PRSCH9            (_WDOG_PCH_PRSCTRL_PRSSEL_PRSCH9 << 0)        /**< Shifted mode PRSCH9 for WDOG_PCH_PRSCTRL */
 #define WDOG_PCH_PRSCTRL_PRSSEL_PRSCH10           (_WDOG_PCH_PRSCTRL_PRSSEL_PRSCH10 << 0)       /**< Shifted mode PRSCH10 for WDOG_PCH_PRSCTRL */
 #define WDOG_PCH_PRSCTRL_PRSSEL_PRSCH11           (_WDOG_PCH_PRSCTRL_PRSSEL_PRSCH11 << 0)       /**< Shifted mode PRSCH11 for WDOG_PCH_PRSCTRL */
-#define WDOG_PCH_PRSCTRL_PRSMISSRSTEN             (0x1UL << 8)                                  /**< PRS missing event will trigger a watchdog reset */
+#define WDOG_PCH_PRSCTRL_PRSMISSRSTEN             (0x1UL << 8)                                  /**< PRS Missing Event Will Trigger a Watchdog Reset */
 #define _WDOG_PCH_PRSCTRL_PRSMISSRSTEN_SHIFT      8                                             /**< Shift value for WDOG_PRSMISSRSTEN */
 #define _WDOG_PCH_PRSCTRL_PRSMISSRSTEN_MASK       0x100UL                                       /**< Bit mask for WDOG_PRSMISSRSTEN */
 #define _WDOG_PCH_PRSCTRL_PRSMISSRSTEN_DEFAULT    0x00000000UL                                  /**< Mode DEFAULT for WDOG_PCH_PRSCTRL */

--- a/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_wdog_pch.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/efm32pg1b_wdog_pch.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efm32pg1b_wdog_pch.h
  * @brief EFM32PG1B_WDOG_PCH register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32pg1b/include/vendor/em_device.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/em_device.h
@@ -12,10 +12,10 @@
 
  *
  * @endverbatim
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efm32pg1b/include/vendor/system_efm32pg1b.h
+++ b/cpu/efm32/families/efm32pg1b/include/vendor/system_efm32pg1b.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file system_efm32pg1b.h
  * @brief CMSIS Cortex-M3/M4 System Layer for EFM32 devices.
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,
@@ -116,7 +116,7 @@ uint32_t SystemCoreClockGet(void);
  *****************************************************************************/
 static __INLINE void SystemCoreClockUpdate(void)
 {
-  SystemCoreClockGet();
+  (void)SystemCoreClockGet();
 }
 
 uint32_t SystemMaxCoreClockGet(void);

--- a/cpu/efm32/families/efm32pg1b/system.c
+++ b/cpu/efm32/families/efm32pg1b/system.c
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file system_efm32pg1b.c
  * @brief CMSIS Cortex-M3/M4 System Layer for EFM32 devices.
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,
@@ -143,7 +143,7 @@ uint32_t SystemCoreClockGet(void)
   ret   = SystemHFClockGet();
   presc = (CMU->HFCOREPRESC & _CMU_HFCOREPRESC_PRESC_MASK)
           >> _CMU_HFCOREPRESC_PRESC_SHIFT;
-  ret  /= (presc + 1);
+  ret  /= presc + 1U;
 
   /* Keep CMSIS system clock variable up-to-date */
   SystemCoreClock = ret;
@@ -163,8 +163,11 @@ uint32_t SystemCoreClockGet(void)
  ******************************************************************************/
 uint32_t SystemMaxCoreClockGet(void)
 {
-  return (EFM32_HFRCO_MAX_FREQ > EFM32_HFXO_FREQ \
-          ? EFM32_HFRCO_MAX_FREQ : EFM32_HFXO_FREQ);
+#if (EFM32_HFRCO_MAX_FREQ > EFM32_HFXO_FREQ)
+  return EFM32_HFRCO_MAX_FREQ;
+#else
+  return EFM32_HFXO_FREQ;
+#endif
 }
 
 /***************************************************************************//**
@@ -257,9 +260,10 @@ void SystemHFXOClockSet(uint32_t freq)
   SystemHFXOClock = freq;
 
   /* Update core clock frequency if HFXO is used to clock core */
-  if ((CMU->HFCLKSTATUS & _CMU_HFCLKSTATUS_SELECTED_MASK) == CMU_HFCLKSTATUS_SELECTED_HFXO) {
+  if ((CMU->HFCLKSTATUS & _CMU_HFCLKSTATUS_SELECTED_MASK)
+      == CMU_HFCLKSTATUS_SELECTED_HFXO) {
     /* The function will update the global variable */
-    SystemCoreClockGet();
+    (void)SystemCoreClockGet();
   }
 #else
   (void)freq; /* Unused parameter */
@@ -283,7 +287,7 @@ void SystemInit(void)
 #if (__FPU_PRESENT == 1) && (__FPU_USED == 1)
   /* Set floating point coprosessor access mode. */
   SCB->CPACR |= ((3UL << 10 * 2)                      /* set CP10 Full Access */
-                 | (3UL << 11 * 2)  );              /* set CP11 Full Access */
+                 | (3UL << 11 * 2));                  /* set CP11 Full Access */
 #endif
 }
 
@@ -363,9 +367,10 @@ void SystemLFXOClockSet(uint32_t freq)
   SystemLFXOClock = freq;
 
   /* Update core clock frequency if LFXO is used to clock core */
-  if ((CMU->HFCLKSTATUS & _CMU_HFCLKSTATUS_SELECTED_MASK) == CMU_HFCLKSTATUS_SELECTED_LFXO) {
+  if ((CMU->HFCLKSTATUS & _CMU_HFCLKSTATUS_SELECTED_MASK)
+      == CMU_HFCLKSTATUS_SELECTED_LFXO) {
     /* The function will update the global variable */
-    SystemCoreClockGet();
+    (void)SystemCoreClockGet();
   }
 #else
   (void)freq; /* Unused parameter */

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p132f256gm32.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p132f256gm32.h
@@ -2,10 +2,10 @@
  * @file efr32mg1p132f256gm32.h
  * @brief CMSIS Cortex-M Peripheral Access Layer Header File
  *        for EFR32MG1P132F256GM32
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,
@@ -193,11 +193,11 @@ typedef enum IRQn{
 #define EXT_IRQ_COUNT             34             /**< Number of External (NVIC) interrupts */
 
 /** AF channels connect the different on-chip peripherals with the af-mux */
-#define AFCHAN_MAX                72
+#define AFCHAN_MAX                72U
 /** AF channel maximum location number */
-#define AFCHANLOC_MAX             32
+#define AFCHANLOC_MAX             32U
 /** Analog AF channels */
-#define AFACHAN_MAX               61
+#define AFACHAN_MAX               61U
 
 /* Part number capabilities */
 

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p132f256gm48.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p132f256gm48.h
@@ -2,10 +2,10 @@
  * @file efr32mg1p132f256gm48.h
  * @brief CMSIS Cortex-M Peripheral Access Layer Header File
  *        for EFR32MG1P132F256GM48
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,
@@ -193,11 +193,11 @@ typedef enum IRQn{
 #define EXT_IRQ_COUNT             34             /**< Number of External (NVIC) interrupts */
 
 /** AF channels connect the different on-chip peripherals with the af-mux */
-#define AFCHAN_MAX                72
+#define AFCHAN_MAX                72U
 /** AF channel maximum location number */
-#define AFCHANLOC_MAX             32
+#define AFCHANLOC_MAX             32U
 /** Analog AF channels */
-#define AFACHAN_MAX               61
+#define AFACHAN_MAX               61U
 
 /* Part number capabilities */
 

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_acmp.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_acmp.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efr32mg1p_acmp.h
  * @brief EFR32MG1P_ACMP register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,
@@ -113,7 +113,7 @@ typedef struct {
 #define _ACMP_CTRL_APORTYMASTERDIS_MASK                0x200UL                                    /**< Bit mask for ACMP_APORTYMASTERDIS */
 #define _ACMP_CTRL_APORTYMASTERDIS_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for ACMP_CTRL */
 #define ACMP_CTRL_APORTYMASTERDIS_DEFAULT              (_ACMP_CTRL_APORTYMASTERDIS_DEFAULT << 9)  /**< Shifted mode DEFAULT for ACMP_CTRL */
-#define ACMP_CTRL_APORTVMASTERDIS                      (0x1UL << 10)                              /**< APORT Bus Master Disable for Bus selected by VASEL */
+#define ACMP_CTRL_APORTVMASTERDIS                      (0x1UL << 10)                              /**< APORT Bus Master Disable for Bus Selected By VASEL */
 #define _ACMP_CTRL_APORTVMASTERDIS_SHIFT               10                                         /**< Shift value for ACMP_APORTVMASTERDIS */
 #define _ACMP_CTRL_APORTVMASTERDIS_MASK                0x400UL                                    /**< Bit mask for ACMP_APORTVMASTERDIS */
 #define _ACMP_CTRL_APORTVMASTERDIS_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for ACMP_CTRL */
@@ -122,15 +122,15 @@ typedef struct {
 #define _ACMP_CTRL_PWRSEL_MASK                         0x7000UL                                   /**< Bit mask for ACMP_PWRSEL */
 #define _ACMP_CTRL_PWRSEL_DEFAULT                      0x00000000UL                               /**< Mode DEFAULT for ACMP_CTRL */
 #define _ACMP_CTRL_PWRSEL_AVDD                         0x00000000UL                               /**< Mode AVDD for ACMP_CTRL */
-#define _ACMP_CTRL_PWRSEL_VREGVDD                      0x00000001UL                               /**< Mode VREGVDD for ACMP_CTRL */
+#define _ACMP_CTRL_PWRSEL_DVDD                         0x00000001UL                               /**< Mode DVDD for ACMP_CTRL */
 #define _ACMP_CTRL_PWRSEL_IOVDD0                       0x00000002UL                               /**< Mode IOVDD0 for ACMP_CTRL */
 #define _ACMP_CTRL_PWRSEL_IOVDD1                       0x00000004UL                               /**< Mode IOVDD1 for ACMP_CTRL */
 #define ACMP_CTRL_PWRSEL_DEFAULT                       (_ACMP_CTRL_PWRSEL_DEFAULT << 12)          /**< Shifted mode DEFAULT for ACMP_CTRL */
 #define ACMP_CTRL_PWRSEL_AVDD                          (_ACMP_CTRL_PWRSEL_AVDD << 12)             /**< Shifted mode AVDD for ACMP_CTRL */
-#define ACMP_CTRL_PWRSEL_VREGVDD                       (_ACMP_CTRL_PWRSEL_VREGVDD << 12)          /**< Shifted mode VREGVDD for ACMP_CTRL */
+#define ACMP_CTRL_PWRSEL_DVDD                          (_ACMP_CTRL_PWRSEL_DVDD << 12)             /**< Shifted mode DVDD for ACMP_CTRL */
 #define ACMP_CTRL_PWRSEL_IOVDD0                        (_ACMP_CTRL_PWRSEL_IOVDD0 << 12)           /**< Shifted mode IOVDD0 for ACMP_CTRL */
 #define ACMP_CTRL_PWRSEL_IOVDD1                        (_ACMP_CTRL_PWRSEL_IOVDD1 << 12)           /**< Shifted mode IOVDD1 for ACMP_CTRL */
-#define ACMP_CTRL_ACCURACY                             (0x1UL << 15)                              /**< ACMP accuracy mode */
+#define ACMP_CTRL_ACCURACY                             (0x1UL << 15)                              /**< ACMP Accuracy Mode */
 #define _ACMP_CTRL_ACCURACY_SHIFT                      15                                         /**< Shift value for ACMP_ACCURACY */
 #define _ACMP_CTRL_ACCURACY_MASK                       0x8000UL                                   /**< Bit mask for ACMP_ACCURACY */
 #define _ACMP_CTRL_ACCURACY_DEFAULT                    0x00000000UL                               /**< Mode DEFAULT for ACMP_CTRL */
@@ -1092,52 +1092,52 @@ typedef struct {
 /* Bit fields for ACMP APORTREQ */
 #define _ACMP_APORTREQ_RESETVALUE                      0x00000000UL                             /**< Default value for ACMP_APORTREQ */
 #define _ACMP_APORTREQ_MASK                            0x000003FFUL                             /**< Mask for ACMP_APORTREQ */
-#define ACMP_APORTREQ_APORT0XREQ                       (0x1UL << 0)                             /**< 1 if the bus connected to APORT0X is requested */
+#define ACMP_APORTREQ_APORT0XREQ                       (0x1UL << 0)                             /**< 1 If the Bus Connected to APORT0X is Requested */
 #define _ACMP_APORTREQ_APORT0XREQ_SHIFT                0                                        /**< Shift value for ACMP_APORT0XREQ */
 #define _ACMP_APORTREQ_APORT0XREQ_MASK                 0x1UL                                    /**< Bit mask for ACMP_APORT0XREQ */
 #define _ACMP_APORTREQ_APORT0XREQ_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for ACMP_APORTREQ */
 #define ACMP_APORTREQ_APORT0XREQ_DEFAULT               (_ACMP_APORTREQ_APORT0XREQ_DEFAULT << 0) /**< Shifted mode DEFAULT for ACMP_APORTREQ */
-#define ACMP_APORTREQ_APORT0YREQ                       (0x1UL << 1)                             /**< 1 if the bus connected to APORT0Y is requested */
+#define ACMP_APORTREQ_APORT0YREQ                       (0x1UL << 1)                             /**< 1 If the Bus Connected to APORT0Y is Requested */
 #define _ACMP_APORTREQ_APORT0YREQ_SHIFT                1                                        /**< Shift value for ACMP_APORT0YREQ */
 #define _ACMP_APORTREQ_APORT0YREQ_MASK                 0x2UL                                    /**< Bit mask for ACMP_APORT0YREQ */
 #define _ACMP_APORTREQ_APORT0YREQ_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for ACMP_APORTREQ */
 #define ACMP_APORTREQ_APORT0YREQ_DEFAULT               (_ACMP_APORTREQ_APORT0YREQ_DEFAULT << 1) /**< Shifted mode DEFAULT for ACMP_APORTREQ */
-#define ACMP_APORTREQ_APORT1XREQ                       (0x1UL << 2)                             /**< 1 if the bus connected to APORT2X is requested */
+#define ACMP_APORTREQ_APORT1XREQ                       (0x1UL << 2)                             /**< 1 If the Bus Connected to APORT2X is Requested */
 #define _ACMP_APORTREQ_APORT1XREQ_SHIFT                2                                        /**< Shift value for ACMP_APORT1XREQ */
 #define _ACMP_APORTREQ_APORT1XREQ_MASK                 0x4UL                                    /**< Bit mask for ACMP_APORT1XREQ */
 #define _ACMP_APORTREQ_APORT1XREQ_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for ACMP_APORTREQ */
 #define ACMP_APORTREQ_APORT1XREQ_DEFAULT               (_ACMP_APORTREQ_APORT1XREQ_DEFAULT << 2) /**< Shifted mode DEFAULT for ACMP_APORTREQ */
-#define ACMP_APORTREQ_APORT1YREQ                       (0x1UL << 3)                             /**< 1 if the bus connected to APORT1X is requested */
+#define ACMP_APORTREQ_APORT1YREQ                       (0x1UL << 3)                             /**< 1 If the Bus Connected to APORT1X is Requested */
 #define _ACMP_APORTREQ_APORT1YREQ_SHIFT                3                                        /**< Shift value for ACMP_APORT1YREQ */
 #define _ACMP_APORTREQ_APORT1YREQ_MASK                 0x8UL                                    /**< Bit mask for ACMP_APORT1YREQ */
 #define _ACMP_APORTREQ_APORT1YREQ_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for ACMP_APORTREQ */
 #define ACMP_APORTREQ_APORT1YREQ_DEFAULT               (_ACMP_APORTREQ_APORT1YREQ_DEFAULT << 3) /**< Shifted mode DEFAULT for ACMP_APORTREQ */
-#define ACMP_APORTREQ_APORT2XREQ                       (0x1UL << 4)                             /**< 1 if the bus connected to APORT2X is requested */
+#define ACMP_APORTREQ_APORT2XREQ                       (0x1UL << 4)                             /**< 1 If the Bus Connected to APORT2X is Requested */
 #define _ACMP_APORTREQ_APORT2XREQ_SHIFT                4                                        /**< Shift value for ACMP_APORT2XREQ */
 #define _ACMP_APORTREQ_APORT2XREQ_MASK                 0x10UL                                   /**< Bit mask for ACMP_APORT2XREQ */
 #define _ACMP_APORTREQ_APORT2XREQ_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for ACMP_APORTREQ */
 #define ACMP_APORTREQ_APORT2XREQ_DEFAULT               (_ACMP_APORTREQ_APORT2XREQ_DEFAULT << 4) /**< Shifted mode DEFAULT for ACMP_APORTREQ */
-#define ACMP_APORTREQ_APORT2YREQ                       (0x1UL << 5)                             /**< 1 if the bus connected to APORT2Y is requested */
+#define ACMP_APORTREQ_APORT2YREQ                       (0x1UL << 5)                             /**< 1 If the Bus Connected to APORT2Y is Requested */
 #define _ACMP_APORTREQ_APORT2YREQ_SHIFT                5                                        /**< Shift value for ACMP_APORT2YREQ */
 #define _ACMP_APORTREQ_APORT2YREQ_MASK                 0x20UL                                   /**< Bit mask for ACMP_APORT2YREQ */
 #define _ACMP_APORTREQ_APORT2YREQ_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for ACMP_APORTREQ */
 #define ACMP_APORTREQ_APORT2YREQ_DEFAULT               (_ACMP_APORTREQ_APORT2YREQ_DEFAULT << 5) /**< Shifted mode DEFAULT for ACMP_APORTREQ */
-#define ACMP_APORTREQ_APORT3XREQ                       (0x1UL << 6)                             /**< 1 if the bus connected to APORT3X is requested */
+#define ACMP_APORTREQ_APORT3XREQ                       (0x1UL << 6)                             /**< 1 If the Bus Connected to APORT3X is Requested */
 #define _ACMP_APORTREQ_APORT3XREQ_SHIFT                6                                        /**< Shift value for ACMP_APORT3XREQ */
 #define _ACMP_APORTREQ_APORT3XREQ_MASK                 0x40UL                                   /**< Bit mask for ACMP_APORT3XREQ */
 #define _ACMP_APORTREQ_APORT3XREQ_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for ACMP_APORTREQ */
 #define ACMP_APORTREQ_APORT3XREQ_DEFAULT               (_ACMP_APORTREQ_APORT3XREQ_DEFAULT << 6) /**< Shifted mode DEFAULT for ACMP_APORTREQ */
-#define ACMP_APORTREQ_APORT3YREQ                       (0x1UL << 7)                             /**< 1 if the bus connected to APORT3Y is requested */
+#define ACMP_APORTREQ_APORT3YREQ                       (0x1UL << 7)                             /**< 1 If the Bus Connected to APORT3Y is Requested */
 #define _ACMP_APORTREQ_APORT3YREQ_SHIFT                7                                        /**< Shift value for ACMP_APORT3YREQ */
 #define _ACMP_APORTREQ_APORT3YREQ_MASK                 0x80UL                                   /**< Bit mask for ACMP_APORT3YREQ */
 #define _ACMP_APORTREQ_APORT3YREQ_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for ACMP_APORTREQ */
 #define ACMP_APORTREQ_APORT3YREQ_DEFAULT               (_ACMP_APORTREQ_APORT3YREQ_DEFAULT << 7) /**< Shifted mode DEFAULT for ACMP_APORTREQ */
-#define ACMP_APORTREQ_APORT4XREQ                       (0x1UL << 8)                             /**< 1 if the bus connected to APORT4X is requested */
+#define ACMP_APORTREQ_APORT4XREQ                       (0x1UL << 8)                             /**< 1 If the Bus Connected to APORT4X is Requested */
 #define _ACMP_APORTREQ_APORT4XREQ_SHIFT                8                                        /**< Shift value for ACMP_APORT4XREQ */
 #define _ACMP_APORTREQ_APORT4XREQ_MASK                 0x100UL                                  /**< Bit mask for ACMP_APORT4XREQ */
 #define _ACMP_APORTREQ_APORT4XREQ_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for ACMP_APORTREQ */
 #define ACMP_APORTREQ_APORT4XREQ_DEFAULT               (_ACMP_APORTREQ_APORT4XREQ_DEFAULT << 8) /**< Shifted mode DEFAULT for ACMP_APORTREQ */
-#define ACMP_APORTREQ_APORT4YREQ                       (0x1UL << 9)                             /**< 1 if the bus connected to APORT4Y is requested */
+#define ACMP_APORTREQ_APORT4YREQ                       (0x1UL << 9)                             /**< 1 If the Bus Connected to APORT4Y is Requested */
 #define _ACMP_APORTREQ_APORT4YREQ_SHIFT                9                                        /**< Shift value for ACMP_APORT4YREQ */
 #define _ACMP_APORTREQ_APORT4YREQ_MASK                 0x200UL                                  /**< Bit mask for ACMP_APORT4YREQ */
 #define _ACMP_APORTREQ_APORT4YREQ_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for ACMP_APORTREQ */
@@ -1146,52 +1146,52 @@ typedef struct {
 /* Bit fields for ACMP APORTCONFLICT */
 #define _ACMP_APORTCONFLICT_RESETVALUE                 0x00000000UL                                       /**< Default value for ACMP_APORTCONFLICT */
 #define _ACMP_APORTCONFLICT_MASK                       0x000003FFUL                                       /**< Mask for ACMP_APORTCONFLICT */
-#define ACMP_APORTCONFLICT_APORT0XCONFLICT             (0x1UL << 0)                                       /**< 1 if the bus connected to APORT0X is in conflict with another peripheral */
+#define ACMP_APORTCONFLICT_APORT0XCONFLICT             (0x1UL << 0)                                       /**< 1 If the Bus Connected to APORT0X is in Conflict With Another Peripheral */
 #define _ACMP_APORTCONFLICT_APORT0XCONFLICT_SHIFT      0                                                  /**< Shift value for ACMP_APORT0XCONFLICT */
 #define _ACMP_APORTCONFLICT_APORT0XCONFLICT_MASK       0x1UL                                              /**< Bit mask for ACMP_APORT0XCONFLICT */
 #define _ACMP_APORTCONFLICT_APORT0XCONFLICT_DEFAULT    0x00000000UL                                       /**< Mode DEFAULT for ACMP_APORTCONFLICT */
 #define ACMP_APORTCONFLICT_APORT0XCONFLICT_DEFAULT     (_ACMP_APORTCONFLICT_APORT0XCONFLICT_DEFAULT << 0) /**< Shifted mode DEFAULT for ACMP_APORTCONFLICT */
-#define ACMP_APORTCONFLICT_APORT0YCONFLICT             (0x1UL << 1)                                       /**< 1 if the bus connected to APORT0Y is in conflict with another peripheral */
+#define ACMP_APORTCONFLICT_APORT0YCONFLICT             (0x1UL << 1)                                       /**< 1 If the Bus Connected to APORT0Y is in Conflict With Another Peripheral */
 #define _ACMP_APORTCONFLICT_APORT0YCONFLICT_SHIFT      1                                                  /**< Shift value for ACMP_APORT0YCONFLICT */
 #define _ACMP_APORTCONFLICT_APORT0YCONFLICT_MASK       0x2UL                                              /**< Bit mask for ACMP_APORT0YCONFLICT */
 #define _ACMP_APORTCONFLICT_APORT0YCONFLICT_DEFAULT    0x00000000UL                                       /**< Mode DEFAULT for ACMP_APORTCONFLICT */
 #define ACMP_APORTCONFLICT_APORT0YCONFLICT_DEFAULT     (_ACMP_APORTCONFLICT_APORT0YCONFLICT_DEFAULT << 1) /**< Shifted mode DEFAULT for ACMP_APORTCONFLICT */
-#define ACMP_APORTCONFLICT_APORT1XCONFLICT             (0x1UL << 2)                                       /**< 1 if the bus connected to APORT1X is in conflict with another peripheral */
+#define ACMP_APORTCONFLICT_APORT1XCONFLICT             (0x1UL << 2)                                       /**< 1 If the Bus Connected to APORT1X is in Conflict With Another Peripheral */
 #define _ACMP_APORTCONFLICT_APORT1XCONFLICT_SHIFT      2                                                  /**< Shift value for ACMP_APORT1XCONFLICT */
 #define _ACMP_APORTCONFLICT_APORT1XCONFLICT_MASK       0x4UL                                              /**< Bit mask for ACMP_APORT1XCONFLICT */
 #define _ACMP_APORTCONFLICT_APORT1XCONFLICT_DEFAULT    0x00000000UL                                       /**< Mode DEFAULT for ACMP_APORTCONFLICT */
 #define ACMP_APORTCONFLICT_APORT1XCONFLICT_DEFAULT     (_ACMP_APORTCONFLICT_APORT1XCONFLICT_DEFAULT << 2) /**< Shifted mode DEFAULT for ACMP_APORTCONFLICT */
-#define ACMP_APORTCONFLICT_APORT1YCONFLICT             (0x1UL << 3)                                       /**< 1 if the bus connected to APORT1X is in conflict with another peripheral */
+#define ACMP_APORTCONFLICT_APORT1YCONFLICT             (0x1UL << 3)                                       /**< 1 If the Bus Connected to APORT1X is in Conflict With Another Peripheral */
 #define _ACMP_APORTCONFLICT_APORT1YCONFLICT_SHIFT      3                                                  /**< Shift value for ACMP_APORT1YCONFLICT */
 #define _ACMP_APORTCONFLICT_APORT1YCONFLICT_MASK       0x8UL                                              /**< Bit mask for ACMP_APORT1YCONFLICT */
 #define _ACMP_APORTCONFLICT_APORT1YCONFLICT_DEFAULT    0x00000000UL                                       /**< Mode DEFAULT for ACMP_APORTCONFLICT */
 #define ACMP_APORTCONFLICT_APORT1YCONFLICT_DEFAULT     (_ACMP_APORTCONFLICT_APORT1YCONFLICT_DEFAULT << 3) /**< Shifted mode DEFAULT for ACMP_APORTCONFLICT */
-#define ACMP_APORTCONFLICT_APORT2XCONFLICT             (0x1UL << 4)                                       /**< 1 if the bus connected to APORT2X is in conflict with another peripheral */
+#define ACMP_APORTCONFLICT_APORT2XCONFLICT             (0x1UL << 4)                                       /**< 1 If the Bus Connected to APORT2X is in Conflict With Another Peripheral */
 #define _ACMP_APORTCONFLICT_APORT2XCONFLICT_SHIFT      4                                                  /**< Shift value for ACMP_APORT2XCONFLICT */
 #define _ACMP_APORTCONFLICT_APORT2XCONFLICT_MASK       0x10UL                                             /**< Bit mask for ACMP_APORT2XCONFLICT */
 #define _ACMP_APORTCONFLICT_APORT2XCONFLICT_DEFAULT    0x00000000UL                                       /**< Mode DEFAULT for ACMP_APORTCONFLICT */
 #define ACMP_APORTCONFLICT_APORT2XCONFLICT_DEFAULT     (_ACMP_APORTCONFLICT_APORT2XCONFLICT_DEFAULT << 4) /**< Shifted mode DEFAULT for ACMP_APORTCONFLICT */
-#define ACMP_APORTCONFLICT_APORT2YCONFLICT             (0x1UL << 5)                                       /**< 1 if the bus connected to APORT2Y is in conflict with another peripheral */
+#define ACMP_APORTCONFLICT_APORT2YCONFLICT             (0x1UL << 5)                                       /**< 1 If the Bus Connected to APORT2Y is in Conflict With Another Peripheral */
 #define _ACMP_APORTCONFLICT_APORT2YCONFLICT_SHIFT      5                                                  /**< Shift value for ACMP_APORT2YCONFLICT */
 #define _ACMP_APORTCONFLICT_APORT2YCONFLICT_MASK       0x20UL                                             /**< Bit mask for ACMP_APORT2YCONFLICT */
 #define _ACMP_APORTCONFLICT_APORT2YCONFLICT_DEFAULT    0x00000000UL                                       /**< Mode DEFAULT for ACMP_APORTCONFLICT */
 #define ACMP_APORTCONFLICT_APORT2YCONFLICT_DEFAULT     (_ACMP_APORTCONFLICT_APORT2YCONFLICT_DEFAULT << 5) /**< Shifted mode DEFAULT for ACMP_APORTCONFLICT */
-#define ACMP_APORTCONFLICT_APORT3XCONFLICT             (0x1UL << 6)                                       /**< 1 if the bus connected to APORT3X is in conflict with another peripheral */
+#define ACMP_APORTCONFLICT_APORT3XCONFLICT             (0x1UL << 6)                                       /**< 1 If the Bus Connected to APORT3X is in Conflict With Another Peripheral */
 #define _ACMP_APORTCONFLICT_APORT3XCONFLICT_SHIFT      6                                                  /**< Shift value for ACMP_APORT3XCONFLICT */
 #define _ACMP_APORTCONFLICT_APORT3XCONFLICT_MASK       0x40UL                                             /**< Bit mask for ACMP_APORT3XCONFLICT */
 #define _ACMP_APORTCONFLICT_APORT3XCONFLICT_DEFAULT    0x00000000UL                                       /**< Mode DEFAULT for ACMP_APORTCONFLICT */
 #define ACMP_APORTCONFLICT_APORT3XCONFLICT_DEFAULT     (_ACMP_APORTCONFLICT_APORT3XCONFLICT_DEFAULT << 6) /**< Shifted mode DEFAULT for ACMP_APORTCONFLICT */
-#define ACMP_APORTCONFLICT_APORT3YCONFLICT             (0x1UL << 7)                                       /**< 1 if the bus connected to APORT3Y is in conflict with another peripheral */
+#define ACMP_APORTCONFLICT_APORT3YCONFLICT             (0x1UL << 7)                                       /**< 1 If the Bus Connected to APORT3Y is in Conflict With Another Peripheral */
 #define _ACMP_APORTCONFLICT_APORT3YCONFLICT_SHIFT      7                                                  /**< Shift value for ACMP_APORT3YCONFLICT */
 #define _ACMP_APORTCONFLICT_APORT3YCONFLICT_MASK       0x80UL                                             /**< Bit mask for ACMP_APORT3YCONFLICT */
 #define _ACMP_APORTCONFLICT_APORT3YCONFLICT_DEFAULT    0x00000000UL                                       /**< Mode DEFAULT for ACMP_APORTCONFLICT */
 #define ACMP_APORTCONFLICT_APORT3YCONFLICT_DEFAULT     (_ACMP_APORTCONFLICT_APORT3YCONFLICT_DEFAULT << 7) /**< Shifted mode DEFAULT for ACMP_APORTCONFLICT */
-#define ACMP_APORTCONFLICT_APORT4XCONFLICT             (0x1UL << 8)                                       /**< 1 if the bus connected to APORT4X is in conflict with another peripheral */
+#define ACMP_APORTCONFLICT_APORT4XCONFLICT             (0x1UL << 8)                                       /**< 1 If the Bus Connected to APORT4X is in Conflict With Another Peripheral */
 #define _ACMP_APORTCONFLICT_APORT4XCONFLICT_SHIFT      8                                                  /**< Shift value for ACMP_APORT4XCONFLICT */
 #define _ACMP_APORTCONFLICT_APORT4XCONFLICT_MASK       0x100UL                                            /**< Bit mask for ACMP_APORT4XCONFLICT */
 #define _ACMP_APORTCONFLICT_APORT4XCONFLICT_DEFAULT    0x00000000UL                                       /**< Mode DEFAULT for ACMP_APORTCONFLICT */
 #define ACMP_APORTCONFLICT_APORT4XCONFLICT_DEFAULT     (_ACMP_APORTCONFLICT_APORT4XCONFLICT_DEFAULT << 8) /**< Shifted mode DEFAULT for ACMP_APORTCONFLICT */
-#define ACMP_APORTCONFLICT_APORT4YCONFLICT             (0x1UL << 9)                                       /**< 1 if the bus connected to APORT4Y is in conflict with another peripheral */
+#define ACMP_APORTCONFLICT_APORT4YCONFLICT             (0x1UL << 9)                                       /**< 1 If the Bus Connected to APORT4Y is in Conflict With Another Peripheral */
 #define _ACMP_APORTCONFLICT_APORT4YCONFLICT_SHIFT      9                                                  /**< Shift value for ACMP_APORT4YCONFLICT */
 #define _ACMP_APORTCONFLICT_APORT4YCONFLICT_MASK       0x200UL                                            /**< Bit mask for ACMP_APORT4YCONFLICT */
 #define _ACMP_APORTCONFLICT_APORT4YCONFLICT_DEFAULT    0x00000000UL                                       /**< Mode DEFAULT for ACMP_APORTCONFLICT */

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_adc.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_adc.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efr32mg1p_adc.h
  * @brief EFR32MG1P_ADC register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,
@@ -57,14 +57,14 @@ typedef struct {
   __IOM uint32_t CMD;             /**< Command Register  */
   __IM uint32_t  STATUS;          /**< Status Register  */
   __IOM uint32_t SINGLECTRL;      /**< Single Channel Control Register  */
-  __IOM uint32_t SINGLECTRLX;     /**< Single Channel Control Register continued  */
+  __IOM uint32_t SINGLECTRLX;     /**< Single Channel Control Register Continued  */
   __IOM uint32_t SCANCTRL;        /**< Scan Control Register  */
-  __IOM uint32_t SCANCTRLX;       /**< Scan Control Register continued  */
+  __IOM uint32_t SCANCTRLX;       /**< Scan Control Register Continued  */
   __IOM uint32_t SCANMASK;        /**< Scan Sequence Input Mask Register  */
-  __IOM uint32_t SCANINPUTSEL;    /**< Input Selection register for Scan mode  */
-  __IOM uint32_t SCANNEGSEL;      /**< Negative Input select register for Scan  */
+  __IOM uint32_t SCANINPUTSEL;    /**< Input Selection Register for Scan Mode  */
+  __IOM uint32_t SCANNEGSEL;      /**< Negative Input Select Register for Scan  */
   __IOM uint32_t CMPTHR;          /**< Compare Threshold Register  */
-  __IOM uint32_t BIASPROG;        /**< Bias Programming Register for various analog blocks used in ADC operation.  */
+  __IOM uint32_t BIASPROG;        /**< Bias Programming Register for Various Analog Blocks Used in ADC Operation  */
   __IOM uint32_t CAL;             /**< Calibration Register  */
   __IM uint32_t  IF;              /**< Interrupt Flag Register  */
   __IOM uint32_t IFS;             /**< Interrupt Flag Set Register  */
@@ -125,7 +125,7 @@ typedef struct {
 #define _ADC_CTRL_TAILGATE_MASK                            0x10UL                                    /**< Bit mask for ADC_TAILGATE */
 #define _ADC_CTRL_TAILGATE_DEFAULT                         0x00000000UL                              /**< Mode DEFAULT for ADC_CTRL */
 #define ADC_CTRL_TAILGATE_DEFAULT                          (_ADC_CTRL_TAILGATE_DEFAULT << 4)         /**< Shifted mode DEFAULT for ADC_CTRL */
-#define ADC_CTRL_ASYNCCLKEN                                (0x1UL << 6)                              /**< Selects ASYNC CLK enable mode when ADCCLKMODE=1 */
+#define ADC_CTRL_ASYNCCLKEN                                (0x1UL << 6)                              /**< Selects ASYNC CLK Enable Mode When ADCCLKMODE=1 */
 #define _ADC_CTRL_ASYNCCLKEN_SHIFT                         6                                         /**< Shift value for ADC_ASYNCCLKEN */
 #define _ADC_CTRL_ASYNCCLKEN_MASK                          0x40UL                                    /**< Bit mask for ADC_ASYNCCLKEN */
 #define _ADC_CTRL_ASYNCCLKEN_DEFAULT                       0x00000000UL                              /**< Mode DEFAULT for ADC_CTRL */
@@ -1062,7 +1062,7 @@ typedef struct {
 #define ADC_SINGLECTRLX_VREFSEL_VREFPNWATT                 (_ADC_SINGLECTRLX_VREFSEL_VREFPNWATT << 0)        /**< Shifted mode VREFPNWATT for ADC_SINGLECTRLX */
 #define ADC_SINGLECTRLX_VREFSEL_VREFPN                     (_ADC_SINGLECTRLX_VREFSEL_VREFPN << 0)            /**< Shifted mode VREFPN for ADC_SINGLECTRLX */
 #define ADC_SINGLECTRLX_VREFSEL_VBGRLOW                    (_ADC_SINGLECTRLX_VREFSEL_VBGRLOW << 0)           /**< Shifted mode VBGRLOW for ADC_SINGLECTRLX */
-#define ADC_SINGLECTRLX_VREFATTFIX                         (0x1UL << 3)                                      /**< Enable fixed scaling on VREF */
+#define ADC_SINGLECTRLX_VREFATTFIX                         (0x1UL << 3)                                      /**< Enable Fixed Scaling on VREF */
 #define _ADC_SINGLECTRLX_VREFATTFIX_SHIFT                  3                                                 /**< Shift value for ADC_VREFATTFIX */
 #define _ADC_SINGLECTRLX_VREFATTFIX_MASK                   0x8UL                                             /**< Bit mask for ADC_VREFATTFIX */
 #define _ADC_SINGLECTRLX_VREFATTFIX_DEFAULT                0x00000000UL                                      /**< Mode DEFAULT for ADC_SINGLECTRLX */
@@ -1129,7 +1129,7 @@ typedef struct {
 #define _ADC_SINGLECTRLX_CONVSTARTDELAY_MASK               0x7000000UL                                       /**< Bit mask for ADC_CONVSTARTDELAY */
 #define _ADC_SINGLECTRLX_CONVSTARTDELAY_DEFAULT            0x00000000UL                                      /**< Mode DEFAULT for ADC_SINGLECTRLX */
 #define ADC_SINGLECTRLX_CONVSTARTDELAY_DEFAULT             (_ADC_SINGLECTRLX_CONVSTARTDELAY_DEFAULT << 24)   /**< Shifted mode DEFAULT for ADC_SINGLECTRLX */
-#define ADC_SINGLECTRLX_CONVSTARTDELAYEN                   (0x1UL << 27)                                     /**< Enable delaying next conversion start */
+#define ADC_SINGLECTRLX_CONVSTARTDELAYEN                   (0x1UL << 27)                                     /**< Enable Delaying Next Conversion Start */
 #define _ADC_SINGLECTRLX_CONVSTARTDELAYEN_SHIFT            27                                                /**< Shift value for ADC_CONVSTARTDELAYEN */
 #define _ADC_SINGLECTRLX_CONVSTARTDELAYEN_MASK             0x8000000UL                                       /**< Bit mask for ADC_CONVSTARTDELAYEN */
 #define _ADC_SINGLECTRLX_CONVSTARTDELAYEN_DEFAULT          0x00000000UL                                      /**< Mode DEFAULT for ADC_SINGLECTRLX */
@@ -1245,7 +1245,7 @@ typedef struct {
 #define ADC_SCANCTRLX_VREFSEL_VREFPNWATT                   (_ADC_SCANCTRLX_VREFSEL_VREFPNWATT << 0)        /**< Shifted mode VREFPNWATT for ADC_SCANCTRLX */
 #define ADC_SCANCTRLX_VREFSEL_VREFPN                       (_ADC_SCANCTRLX_VREFSEL_VREFPN << 0)            /**< Shifted mode VREFPN for ADC_SCANCTRLX */
 #define ADC_SCANCTRLX_VREFSEL_VBGRLOW                      (_ADC_SCANCTRLX_VREFSEL_VBGRLOW << 0)           /**< Shifted mode VBGRLOW for ADC_SCANCTRLX */
-#define ADC_SCANCTRLX_VREFATTFIX                           (0x1UL << 3)                                    /**< Enable fixed scaling on VREF */
+#define ADC_SCANCTRLX_VREFATTFIX                           (0x1UL << 3)                                    /**< Enable Fixed Scaling on VREF */
 #define _ADC_SCANCTRLX_VREFATTFIX_SHIFT                    3                                               /**< Shift value for ADC_VREFATTFIX */
 #define _ADC_SCANCTRLX_VREFATTFIX_MASK                     0x8UL                                           /**< Bit mask for ADC_VREFATTFIX */
 #define _ADC_SCANCTRLX_VREFATTFIX_DEFAULT                  0x00000000UL                                    /**< Mode DEFAULT for ADC_SCANCTRLX */
@@ -1312,7 +1312,7 @@ typedef struct {
 #define _ADC_SCANCTRLX_CONVSTARTDELAY_MASK                 0x7000000UL                                     /**< Bit mask for ADC_CONVSTARTDELAY */
 #define _ADC_SCANCTRLX_CONVSTARTDELAY_DEFAULT              0x00000000UL                                    /**< Mode DEFAULT for ADC_SCANCTRLX */
 #define ADC_SCANCTRLX_CONVSTARTDELAY_DEFAULT               (_ADC_SCANCTRLX_CONVSTARTDELAY_DEFAULT << 24)   /**< Shifted mode DEFAULT for ADC_SCANCTRLX */
-#define ADC_SCANCTRLX_CONVSTARTDELAYEN                     (0x1UL << 27)                                   /**< Enable delaying next conversion start */
+#define ADC_SCANCTRLX_CONVSTARTDELAYEN                     (0x1UL << 27)                                   /**< Enable Delaying Next Conversion Start */
 #define _ADC_SCANCTRLX_CONVSTARTDELAYEN_SHIFT              27                                              /**< Shift value for ADC_CONVSTARTDELAYEN */
 #define _ADC_SCANCTRLX_CONVSTARTDELAYEN_MASK               0x8000000UL                                     /**< Bit mask for ADC_CONVSTARTDELAYEN */
 #define _ADC_SCANCTRLX_CONVSTARTDELAYEN_DEFAULT            0x00000000UL                                    /**< Mode DEFAULT for ADC_SCANCTRLX */
@@ -1749,12 +1749,12 @@ typedef struct {
 #define ADC_BIASPROG_ADCBIASPROG_SCALE8                    (_ADC_BIASPROG_ADCBIASPROG_SCALE8 << 0)  /**< Shifted mode SCALE8 for ADC_BIASPROG */
 #define ADC_BIASPROG_ADCBIASPROG_SCALE16                   (_ADC_BIASPROG_ADCBIASPROG_SCALE16 << 0) /**< Shifted mode SCALE16 for ADC_BIASPROG */
 #define ADC_BIASPROG_ADCBIASPROG_SCALE32                   (_ADC_BIASPROG_ADCBIASPROG_SCALE32 << 0) /**< Shifted mode SCALE32 for ADC_BIASPROG */
-#define ADC_BIASPROG_VFAULTCLR                             (0x1UL << 12)                            /**< Clear VREFOF flag */
+#define ADC_BIASPROG_VFAULTCLR                             (0x1UL << 12)                            /**< Clear VREFOF Flag */
 #define _ADC_BIASPROG_VFAULTCLR_SHIFT                      12                                       /**< Shift value for ADC_VFAULTCLR */
 #define _ADC_BIASPROG_VFAULTCLR_MASK                       0x1000UL                                 /**< Bit mask for ADC_VFAULTCLR */
 #define _ADC_BIASPROG_VFAULTCLR_DEFAULT                    0x00000000UL                             /**< Mode DEFAULT for ADC_BIASPROG */
 #define ADC_BIASPROG_VFAULTCLR_DEFAULT                     (_ADC_BIASPROG_VFAULTCLR_DEFAULT << 12)  /**< Shifted mode DEFAULT for ADC_BIASPROG */
-#define ADC_BIASPROG_GPBIASACC                             (0x1UL << 16)                            /**< Accuracy setting for the system bias during ADC operation */
+#define ADC_BIASPROG_GPBIASACC                             (0x1UL << 16)                            /**< Accuracy Setting for the System Bias During ADC Operation */
 #define _ADC_BIASPROG_GPBIASACC_SHIFT                      16                                       /**< Shift value for ADC_GPBIASACC */
 #define _ADC_BIASPROG_GPBIASACC_MASK                       0x10000UL                                /**< Bit mask for ADC_GPBIASACC */
 #define _ADC_BIASPROG_GPBIASACC_DEFAULT                    0x00000000UL                             /**< Mode DEFAULT for ADC_BIASPROG */
@@ -1779,7 +1779,7 @@ typedef struct {
 #define _ADC_CAL_SINGLEGAIN_MASK                           0x7F00UL                                /**< Bit mask for ADC_SINGLEGAIN */
 #define _ADC_CAL_SINGLEGAIN_DEFAULT                        0x00000040UL                            /**< Mode DEFAULT for ADC_CAL */
 #define ADC_CAL_SINGLEGAIN_DEFAULT                         (_ADC_CAL_SINGLEGAIN_DEFAULT << 8)      /**< Shifted mode DEFAULT for ADC_CAL */
-#define ADC_CAL_OFFSETINVMODE                              (0x1UL << 15)                           /**< Negative single-ended offset calibration is enabled */
+#define ADC_CAL_OFFSETINVMODE                              (0x1UL << 15)                           /**< Negative Single-ended Offset Calibration is Enabled */
 #define _ADC_CAL_OFFSETINVMODE_SHIFT                       15                                      /**< Shift value for ADC_OFFSETINVMODE */
 #define _ADC_CAL_OFFSETINVMODE_MASK                        0x8000UL                                /**< Bit mask for ADC_OFFSETINVMODE */
 #define _ADC_CAL_OFFSETINVMODE_DEFAULT                     0x00000000UL                            /**< Mode DEFAULT for ADC_CAL */
@@ -1796,7 +1796,7 @@ typedef struct {
 #define _ADC_CAL_SCANGAIN_MASK                             0x7F000000UL                            /**< Bit mask for ADC_SCANGAIN */
 #define _ADC_CAL_SCANGAIN_DEFAULT                          0x00000040UL                            /**< Mode DEFAULT for ADC_CAL */
 #define ADC_CAL_SCANGAIN_DEFAULT                           (_ADC_CAL_SCANGAIN_DEFAULT << 24)       /**< Shifted mode DEFAULT for ADC_CAL */
-#define ADC_CAL_CALEN                                      (0x1UL << 31)                           /**< Calibration mode is enabled */
+#define ADC_CAL_CALEN                                      (0x1UL << 31)                           /**< Calibration Mode is Enabled */
 #define _ADC_CAL_CALEN_SHIFT                               31                                      /**< Shift value for ADC_CALEN */
 #define _ADC_CAL_CALEN_MASK                                0x80000000UL                            /**< Bit mask for ADC_CALEN */
 #define _ADC_CAL_CALEN_DEFAULT                             0x00000000UL                            /**< Mode DEFAULT for ADC_CAL */
@@ -2057,52 +2057,52 @@ typedef struct {
 /* Bit fields for ADC APORTREQ */
 #define _ADC_APORTREQ_RESETVALUE                           0x00000000UL                            /**< Default value for ADC_APORTREQ */
 #define _ADC_APORTREQ_MASK                                 0x000003FFUL                            /**< Mask for ADC_APORTREQ */
-#define ADC_APORTREQ_APORT0XREQ                            (0x1UL << 0)                            /**< 1 if the bus connected to APORT0X is requested */
+#define ADC_APORTREQ_APORT0XREQ                            (0x1UL << 0)                            /**< 1 If the Bus Connected to APORT0X is Requested */
 #define _ADC_APORTREQ_APORT0XREQ_SHIFT                     0                                       /**< Shift value for ADC_APORT0XREQ */
 #define _ADC_APORTREQ_APORT0XREQ_MASK                      0x1UL                                   /**< Bit mask for ADC_APORT0XREQ */
 #define _ADC_APORTREQ_APORT0XREQ_DEFAULT                   0x00000000UL                            /**< Mode DEFAULT for ADC_APORTREQ */
 #define ADC_APORTREQ_APORT0XREQ_DEFAULT                    (_ADC_APORTREQ_APORT0XREQ_DEFAULT << 0) /**< Shifted mode DEFAULT for ADC_APORTREQ */
-#define ADC_APORTREQ_APORT0YREQ                            (0x1UL << 1)                            /**< 1 if the bus connected to APORT0Y is requested */
+#define ADC_APORTREQ_APORT0YREQ                            (0x1UL << 1)                            /**< 1 If the Bus Connected to APORT0Y is Requested */
 #define _ADC_APORTREQ_APORT0YREQ_SHIFT                     1                                       /**< Shift value for ADC_APORT0YREQ */
 #define _ADC_APORTREQ_APORT0YREQ_MASK                      0x2UL                                   /**< Bit mask for ADC_APORT0YREQ */
 #define _ADC_APORTREQ_APORT0YREQ_DEFAULT                   0x00000000UL                            /**< Mode DEFAULT for ADC_APORTREQ */
 #define ADC_APORTREQ_APORT0YREQ_DEFAULT                    (_ADC_APORTREQ_APORT0YREQ_DEFAULT << 1) /**< Shifted mode DEFAULT for ADC_APORTREQ */
-#define ADC_APORTREQ_APORT1XREQ                            (0x1UL << 2)                            /**< 1 if the bus connected to APORT1X is requested */
+#define ADC_APORTREQ_APORT1XREQ                            (0x1UL << 2)                            /**< 1 If the Bus Connected to APORT1X is Requested */
 #define _ADC_APORTREQ_APORT1XREQ_SHIFT                     2                                       /**< Shift value for ADC_APORT1XREQ */
 #define _ADC_APORTREQ_APORT1XREQ_MASK                      0x4UL                                   /**< Bit mask for ADC_APORT1XREQ */
 #define _ADC_APORTREQ_APORT1XREQ_DEFAULT                   0x00000000UL                            /**< Mode DEFAULT for ADC_APORTREQ */
 #define ADC_APORTREQ_APORT1XREQ_DEFAULT                    (_ADC_APORTREQ_APORT1XREQ_DEFAULT << 2) /**< Shifted mode DEFAULT for ADC_APORTREQ */
-#define ADC_APORTREQ_APORT1YREQ                            (0x1UL << 3)                            /**< 1 if the bus connected to APORT1Y is requested */
+#define ADC_APORTREQ_APORT1YREQ                            (0x1UL << 3)                            /**< 1 If the Bus Connected to APORT1Y is Requested */
 #define _ADC_APORTREQ_APORT1YREQ_SHIFT                     3                                       /**< Shift value for ADC_APORT1YREQ */
 #define _ADC_APORTREQ_APORT1YREQ_MASK                      0x8UL                                   /**< Bit mask for ADC_APORT1YREQ */
 #define _ADC_APORTREQ_APORT1YREQ_DEFAULT                   0x00000000UL                            /**< Mode DEFAULT for ADC_APORTREQ */
 #define ADC_APORTREQ_APORT1YREQ_DEFAULT                    (_ADC_APORTREQ_APORT1YREQ_DEFAULT << 3) /**< Shifted mode DEFAULT for ADC_APORTREQ */
-#define ADC_APORTREQ_APORT2XREQ                            (0x1UL << 4)                            /**< 1 if the bus connected to APORT2X is requested */
+#define ADC_APORTREQ_APORT2XREQ                            (0x1UL << 4)                            /**< 1 If the Bus Connected to APORT2X is Requested */
 #define _ADC_APORTREQ_APORT2XREQ_SHIFT                     4                                       /**< Shift value for ADC_APORT2XREQ */
 #define _ADC_APORTREQ_APORT2XREQ_MASK                      0x10UL                                  /**< Bit mask for ADC_APORT2XREQ */
 #define _ADC_APORTREQ_APORT2XREQ_DEFAULT                   0x00000000UL                            /**< Mode DEFAULT for ADC_APORTREQ */
 #define ADC_APORTREQ_APORT2XREQ_DEFAULT                    (_ADC_APORTREQ_APORT2XREQ_DEFAULT << 4) /**< Shifted mode DEFAULT for ADC_APORTREQ */
-#define ADC_APORTREQ_APORT2YREQ                            (0x1UL << 5)                            /**< 1 if the bus connected to APORT2Y is requested */
+#define ADC_APORTREQ_APORT2YREQ                            (0x1UL << 5)                            /**< 1 If the Bus Connected to APORT2Y is Requested */
 #define _ADC_APORTREQ_APORT2YREQ_SHIFT                     5                                       /**< Shift value for ADC_APORT2YREQ */
 #define _ADC_APORTREQ_APORT2YREQ_MASK                      0x20UL                                  /**< Bit mask for ADC_APORT2YREQ */
 #define _ADC_APORTREQ_APORT2YREQ_DEFAULT                   0x00000000UL                            /**< Mode DEFAULT for ADC_APORTREQ */
 #define ADC_APORTREQ_APORT2YREQ_DEFAULT                    (_ADC_APORTREQ_APORT2YREQ_DEFAULT << 5) /**< Shifted mode DEFAULT for ADC_APORTREQ */
-#define ADC_APORTREQ_APORT3XREQ                            (0x1UL << 6)                            /**< 1 if the bus connected to APORT3X is requested */
+#define ADC_APORTREQ_APORT3XREQ                            (0x1UL << 6)                            /**< 1 If the Bus Connected to APORT3X is Requested */
 #define _ADC_APORTREQ_APORT3XREQ_SHIFT                     6                                       /**< Shift value for ADC_APORT3XREQ */
 #define _ADC_APORTREQ_APORT3XREQ_MASK                      0x40UL                                  /**< Bit mask for ADC_APORT3XREQ */
 #define _ADC_APORTREQ_APORT3XREQ_DEFAULT                   0x00000000UL                            /**< Mode DEFAULT for ADC_APORTREQ */
 #define ADC_APORTREQ_APORT3XREQ_DEFAULT                    (_ADC_APORTREQ_APORT3XREQ_DEFAULT << 6) /**< Shifted mode DEFAULT for ADC_APORTREQ */
-#define ADC_APORTREQ_APORT3YREQ                            (0x1UL << 7)                            /**< 1 if the bus connected to APORT3Y is requested */
+#define ADC_APORTREQ_APORT3YREQ                            (0x1UL << 7)                            /**< 1 If the Bus Connected to APORT3Y is Requested */
 #define _ADC_APORTREQ_APORT3YREQ_SHIFT                     7                                       /**< Shift value for ADC_APORT3YREQ */
 #define _ADC_APORTREQ_APORT3YREQ_MASK                      0x80UL                                  /**< Bit mask for ADC_APORT3YREQ */
 #define _ADC_APORTREQ_APORT3YREQ_DEFAULT                   0x00000000UL                            /**< Mode DEFAULT for ADC_APORTREQ */
 #define ADC_APORTREQ_APORT3YREQ_DEFAULT                    (_ADC_APORTREQ_APORT3YREQ_DEFAULT << 7) /**< Shifted mode DEFAULT for ADC_APORTREQ */
-#define ADC_APORTREQ_APORT4XREQ                            (0x1UL << 8)                            /**< 1 if the bus connected to APORT4X is requested */
+#define ADC_APORTREQ_APORT4XREQ                            (0x1UL << 8)                            /**< 1 If the Bus Connected to APORT4X is Requested */
 #define _ADC_APORTREQ_APORT4XREQ_SHIFT                     8                                       /**< Shift value for ADC_APORT4XREQ */
 #define _ADC_APORTREQ_APORT4XREQ_MASK                      0x100UL                                 /**< Bit mask for ADC_APORT4XREQ */
 #define _ADC_APORTREQ_APORT4XREQ_DEFAULT                   0x00000000UL                            /**< Mode DEFAULT for ADC_APORTREQ */
 #define ADC_APORTREQ_APORT4XREQ_DEFAULT                    (_ADC_APORTREQ_APORT4XREQ_DEFAULT << 8) /**< Shifted mode DEFAULT for ADC_APORTREQ */
-#define ADC_APORTREQ_APORT4YREQ                            (0x1UL << 9)                            /**< 1 if the bus connected to APORT4Y is requested */
+#define ADC_APORTREQ_APORT4YREQ                            (0x1UL << 9)                            /**< 1 If the Bus Connected to APORT4Y is Requested */
 #define _ADC_APORTREQ_APORT4YREQ_SHIFT                     9                                       /**< Shift value for ADC_APORT4YREQ */
 #define _ADC_APORTREQ_APORT4YREQ_MASK                      0x200UL                                 /**< Bit mask for ADC_APORT4YREQ */
 #define _ADC_APORTREQ_APORT4YREQ_DEFAULT                   0x00000000UL                            /**< Mode DEFAULT for ADC_APORTREQ */
@@ -2111,52 +2111,52 @@ typedef struct {
 /* Bit fields for ADC APORTCONFLICT */
 #define _ADC_APORTCONFLICT_RESETVALUE                      0x00000000UL                                      /**< Default value for ADC_APORTCONFLICT */
 #define _ADC_APORTCONFLICT_MASK                            0x000003FFUL                                      /**< Mask for ADC_APORTCONFLICT */
-#define ADC_APORTCONFLICT_APORT0XCONFLICT                  (0x1UL << 0)                                      /**< 1 if the bus connected to APORT0X is in conflict with another peripheral */
+#define ADC_APORTCONFLICT_APORT0XCONFLICT                  (0x1UL << 0)                                      /**< 1 If the Bus Connected to APORT0X is in Conflict With Another Peripheral */
 #define _ADC_APORTCONFLICT_APORT0XCONFLICT_SHIFT           0                                                 /**< Shift value for ADC_APORT0XCONFLICT */
 #define _ADC_APORTCONFLICT_APORT0XCONFLICT_MASK            0x1UL                                             /**< Bit mask for ADC_APORT0XCONFLICT */
 #define _ADC_APORTCONFLICT_APORT0XCONFLICT_DEFAULT         0x00000000UL                                      /**< Mode DEFAULT for ADC_APORTCONFLICT */
 #define ADC_APORTCONFLICT_APORT0XCONFLICT_DEFAULT          (_ADC_APORTCONFLICT_APORT0XCONFLICT_DEFAULT << 0) /**< Shifted mode DEFAULT for ADC_APORTCONFLICT */
-#define ADC_APORTCONFLICT_APORT0YCONFLICT                  (0x1UL << 1)                                      /**< 1 if the bus connected to APORT0Y is in conflict with another peripheral */
+#define ADC_APORTCONFLICT_APORT0YCONFLICT                  (0x1UL << 1)                                      /**< 1 If the Bus Connected to APORT0Y is in Conflict With Another Peripheral */
 #define _ADC_APORTCONFLICT_APORT0YCONFLICT_SHIFT           1                                                 /**< Shift value for ADC_APORT0YCONFLICT */
 #define _ADC_APORTCONFLICT_APORT0YCONFLICT_MASK            0x2UL                                             /**< Bit mask for ADC_APORT0YCONFLICT */
 #define _ADC_APORTCONFLICT_APORT0YCONFLICT_DEFAULT         0x00000000UL                                      /**< Mode DEFAULT for ADC_APORTCONFLICT */
 #define ADC_APORTCONFLICT_APORT0YCONFLICT_DEFAULT          (_ADC_APORTCONFLICT_APORT0YCONFLICT_DEFAULT << 1) /**< Shifted mode DEFAULT for ADC_APORTCONFLICT */
-#define ADC_APORTCONFLICT_APORT1XCONFLICT                  (0x1UL << 2)                                      /**< 1 if the bus connected to APORT1X is in conflict with another peripheral */
+#define ADC_APORTCONFLICT_APORT1XCONFLICT                  (0x1UL << 2)                                      /**< 1 If the Bus Connected to APORT1X is in Conflict With Another Peripheral */
 #define _ADC_APORTCONFLICT_APORT1XCONFLICT_SHIFT           2                                                 /**< Shift value for ADC_APORT1XCONFLICT */
 #define _ADC_APORTCONFLICT_APORT1XCONFLICT_MASK            0x4UL                                             /**< Bit mask for ADC_APORT1XCONFLICT */
 #define _ADC_APORTCONFLICT_APORT1XCONFLICT_DEFAULT         0x00000000UL                                      /**< Mode DEFAULT for ADC_APORTCONFLICT */
 #define ADC_APORTCONFLICT_APORT1XCONFLICT_DEFAULT          (_ADC_APORTCONFLICT_APORT1XCONFLICT_DEFAULT << 2) /**< Shifted mode DEFAULT for ADC_APORTCONFLICT */
-#define ADC_APORTCONFLICT_APORT1YCONFLICT                  (0x1UL << 3)                                      /**< 1 if the bus connected to APORT1Y is in conflict with another peripheral */
+#define ADC_APORTCONFLICT_APORT1YCONFLICT                  (0x1UL << 3)                                      /**< 1 If the Bus Connected to APORT1Y is in Conflict With Another Peripheral */
 #define _ADC_APORTCONFLICT_APORT1YCONFLICT_SHIFT           3                                                 /**< Shift value for ADC_APORT1YCONFLICT */
 #define _ADC_APORTCONFLICT_APORT1YCONFLICT_MASK            0x8UL                                             /**< Bit mask for ADC_APORT1YCONFLICT */
 #define _ADC_APORTCONFLICT_APORT1YCONFLICT_DEFAULT         0x00000000UL                                      /**< Mode DEFAULT for ADC_APORTCONFLICT */
 #define ADC_APORTCONFLICT_APORT1YCONFLICT_DEFAULT          (_ADC_APORTCONFLICT_APORT1YCONFLICT_DEFAULT << 3) /**< Shifted mode DEFAULT for ADC_APORTCONFLICT */
-#define ADC_APORTCONFLICT_APORT2XCONFLICT                  (0x1UL << 4)                                      /**< 1 if the bus connected to APORT2X is in conflict with another peripheral */
+#define ADC_APORTCONFLICT_APORT2XCONFLICT                  (0x1UL << 4)                                      /**< 1 If the Bus Connected to APORT2X is in Conflict With Another Peripheral */
 #define _ADC_APORTCONFLICT_APORT2XCONFLICT_SHIFT           4                                                 /**< Shift value for ADC_APORT2XCONFLICT */
 #define _ADC_APORTCONFLICT_APORT2XCONFLICT_MASK            0x10UL                                            /**< Bit mask for ADC_APORT2XCONFLICT */
 #define _ADC_APORTCONFLICT_APORT2XCONFLICT_DEFAULT         0x00000000UL                                      /**< Mode DEFAULT for ADC_APORTCONFLICT */
 #define ADC_APORTCONFLICT_APORT2XCONFLICT_DEFAULT          (_ADC_APORTCONFLICT_APORT2XCONFLICT_DEFAULT << 4) /**< Shifted mode DEFAULT for ADC_APORTCONFLICT */
-#define ADC_APORTCONFLICT_APORT2YCONFLICT                  (0x1UL << 5)                                      /**< 1 if the bus connected to APORT2Y is in conflict with another peripheral */
+#define ADC_APORTCONFLICT_APORT2YCONFLICT                  (0x1UL << 5)                                      /**< 1 If the Bus Connected to APORT2Y is in Conflict With Another Peripheral */
 #define _ADC_APORTCONFLICT_APORT2YCONFLICT_SHIFT           5                                                 /**< Shift value for ADC_APORT2YCONFLICT */
 #define _ADC_APORTCONFLICT_APORT2YCONFLICT_MASK            0x20UL                                            /**< Bit mask for ADC_APORT2YCONFLICT */
 #define _ADC_APORTCONFLICT_APORT2YCONFLICT_DEFAULT         0x00000000UL                                      /**< Mode DEFAULT for ADC_APORTCONFLICT */
 #define ADC_APORTCONFLICT_APORT2YCONFLICT_DEFAULT          (_ADC_APORTCONFLICT_APORT2YCONFLICT_DEFAULT << 5) /**< Shifted mode DEFAULT for ADC_APORTCONFLICT */
-#define ADC_APORTCONFLICT_APORT3XCONFLICT                  (0x1UL << 6)                                      /**< 1 if the bus connected to APORT3X is in conflict with another peripheral */
+#define ADC_APORTCONFLICT_APORT3XCONFLICT                  (0x1UL << 6)                                      /**< 1 If the Bus Connected to APORT3X is in Conflict With Another Peripheral */
 #define _ADC_APORTCONFLICT_APORT3XCONFLICT_SHIFT           6                                                 /**< Shift value for ADC_APORT3XCONFLICT */
 #define _ADC_APORTCONFLICT_APORT3XCONFLICT_MASK            0x40UL                                            /**< Bit mask for ADC_APORT3XCONFLICT */
 #define _ADC_APORTCONFLICT_APORT3XCONFLICT_DEFAULT         0x00000000UL                                      /**< Mode DEFAULT for ADC_APORTCONFLICT */
 #define ADC_APORTCONFLICT_APORT3XCONFLICT_DEFAULT          (_ADC_APORTCONFLICT_APORT3XCONFLICT_DEFAULT << 6) /**< Shifted mode DEFAULT for ADC_APORTCONFLICT */
-#define ADC_APORTCONFLICT_APORT3YCONFLICT                  (0x1UL << 7)                                      /**< 1 if the bus connected to APORT3Y is in conflict with another peripheral */
+#define ADC_APORTCONFLICT_APORT3YCONFLICT                  (0x1UL << 7)                                      /**< 1 If the Bus Connected to APORT3Y is in Conflict With Another Peripheral */
 #define _ADC_APORTCONFLICT_APORT3YCONFLICT_SHIFT           7                                                 /**< Shift value for ADC_APORT3YCONFLICT */
 #define _ADC_APORTCONFLICT_APORT3YCONFLICT_MASK            0x80UL                                            /**< Bit mask for ADC_APORT3YCONFLICT */
 #define _ADC_APORTCONFLICT_APORT3YCONFLICT_DEFAULT         0x00000000UL                                      /**< Mode DEFAULT for ADC_APORTCONFLICT */
 #define ADC_APORTCONFLICT_APORT3YCONFLICT_DEFAULT          (_ADC_APORTCONFLICT_APORT3YCONFLICT_DEFAULT << 7) /**< Shifted mode DEFAULT for ADC_APORTCONFLICT */
-#define ADC_APORTCONFLICT_APORT4XCONFLICT                  (0x1UL << 8)                                      /**< 1 if the bus connected to APORT4X is in conflict with another peripheral */
+#define ADC_APORTCONFLICT_APORT4XCONFLICT                  (0x1UL << 8)                                      /**< 1 If the Bus Connected to APORT4X is in Conflict With Another Peripheral */
 #define _ADC_APORTCONFLICT_APORT4XCONFLICT_SHIFT           8                                                 /**< Shift value for ADC_APORT4XCONFLICT */
 #define _ADC_APORTCONFLICT_APORT4XCONFLICT_MASK            0x100UL                                           /**< Bit mask for ADC_APORT4XCONFLICT */
 #define _ADC_APORTCONFLICT_APORT4XCONFLICT_DEFAULT         0x00000000UL                                      /**< Mode DEFAULT for ADC_APORTCONFLICT */
 #define ADC_APORTCONFLICT_APORT4XCONFLICT_DEFAULT          (_ADC_APORTCONFLICT_APORT4XCONFLICT_DEFAULT << 8) /**< Shifted mode DEFAULT for ADC_APORTCONFLICT */
-#define ADC_APORTCONFLICT_APORT4YCONFLICT                  (0x1UL << 9)                                      /**< 1 if the bus connected to APORT4Y is in conflict with another peripheral */
+#define ADC_APORTCONFLICT_APORT4YCONFLICT                  (0x1UL << 9)                                      /**< 1 If the Bus Connected to APORT4Y is in Conflict With Another Peripheral */
 #define _ADC_APORTCONFLICT_APORT4YCONFLICT_SHIFT           9                                                 /**< Shift value for ADC_APORT4YCONFLICT */
 #define _ADC_APORTCONFLICT_APORT4YCONFLICT_MASK            0x200UL                                           /**< Bit mask for ADC_APORT4YCONFLICT */
 #define _ADC_APORTCONFLICT_APORT4YCONFLICT_DEFAULT         0x00000000UL                                      /**< Mode DEFAULT for ADC_APORTCONFLICT */
@@ -2181,7 +2181,7 @@ typedef struct {
 /* Bit fields for ADC SINGLEFIFOCLEAR */
 #define _ADC_SINGLEFIFOCLEAR_RESETVALUE                    0x00000000UL                                        /**< Default value for ADC_SINGLEFIFOCLEAR */
 #define _ADC_SINGLEFIFOCLEAR_MASK                          0x00000001UL                                        /**< Mask for ADC_SINGLEFIFOCLEAR */
-#define ADC_SINGLEFIFOCLEAR_SINGLEFIFOCLEAR                (0x1UL << 0)                                        /**< Clear Single FIFO content */
+#define ADC_SINGLEFIFOCLEAR_SINGLEFIFOCLEAR                (0x1UL << 0)                                        /**< Clear Single FIFO Content */
 #define _ADC_SINGLEFIFOCLEAR_SINGLEFIFOCLEAR_SHIFT         0                                                   /**< Shift value for ADC_SINGLEFIFOCLEAR */
 #define _ADC_SINGLEFIFOCLEAR_SINGLEFIFOCLEAR_MASK          0x1UL                                               /**< Bit mask for ADC_SINGLEFIFOCLEAR */
 #define _ADC_SINGLEFIFOCLEAR_SINGLEFIFOCLEAR_DEFAULT       0x00000000UL                                        /**< Mode DEFAULT for ADC_SINGLEFIFOCLEAR */
@@ -2190,7 +2190,7 @@ typedef struct {
 /* Bit fields for ADC SCANFIFOCLEAR */
 #define _ADC_SCANFIFOCLEAR_RESETVALUE                      0x00000000UL                                    /**< Default value for ADC_SCANFIFOCLEAR */
 #define _ADC_SCANFIFOCLEAR_MASK                            0x00000001UL                                    /**< Mask for ADC_SCANFIFOCLEAR */
-#define ADC_SCANFIFOCLEAR_SCANFIFOCLEAR                    (0x1UL << 0)                                    /**< Clear Scan FIFO content */
+#define ADC_SCANFIFOCLEAR_SCANFIFOCLEAR                    (0x1UL << 0)                                    /**< Clear Scan FIFO Content */
 #define _ADC_SCANFIFOCLEAR_SCANFIFOCLEAR_SHIFT             0                                               /**< Shift value for ADC_SCANFIFOCLEAR */
 #define _ADC_SCANFIFOCLEAR_SCANFIFOCLEAR_MASK              0x1UL                                           /**< Bit mask for ADC_SCANFIFOCLEAR */
 #define _ADC_SCANFIFOCLEAR_SCANFIFOCLEAR_DEFAULT           0x00000000UL                                    /**< Mode DEFAULT for ADC_SCANFIFOCLEAR */

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_af_pins.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_af_pins.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efr32mg1p_af_pins.h
  * @brief EFR32MG1P_AF_PINS register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_af_ports.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_af_ports.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efr32mg1p_af_ports.h
  * @brief EFR32MG1P_AF_PORTS register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_cmu.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_cmu.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efr32mg1p_cmu.h
  * @brief EFR32MG1P_CMU register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,
@@ -65,7 +65,7 @@ typedef struct {
   __IOM uint32_t HFXOCTRL;            /**< HFXO Control Register  */
   __IOM uint32_t HFXOCTRL1;           /**< HFXO Control 1  */
   __IOM uint32_t HFXOSTARTUPCTRL;     /**< HFXO Startup Control  */
-  __IOM uint32_t HFXOSTEADYSTATECTRL; /**< HFXO Steady State control  */
+  __IOM uint32_t HFXOSTEADYSTATECTRL; /**< HFXO Steady State Control  */
   __IOM uint32_t HFXOTIMEOUTCTRL;     /**< HFXO Timeout Control  */
   __IOM uint32_t LFXOCTRL;            /**< LFXO Control Register  */
   __IOM uint32_t ULFRCOCTRL;          /**< ULFRCO Control Register  */
@@ -99,7 +99,7 @@ typedef struct {
   __IOM uint32_t HFPERCLKEN0;         /**< High Frequency Peripheral Clock Enable Register 0  */
 
   uint32_t       RESERVED10[7];       /**< Reserved for future use **/
-  __IOM uint32_t LFACLKEN0;           /**< Low Frequency A Clock Enable Register 0  (Async Reg)  */
+  __IOM uint32_t LFACLKEN0;           /**< Low Frequency a Clock Enable Register 0  (Async Reg)  */
   uint32_t       RESERVED11[1];       /**< Reserved for future use **/
   __IOM uint32_t LFBCLKEN0;           /**< Low Frequency B Clock Enable Register 0 (Async Reg)  */
 
@@ -116,7 +116,7 @@ typedef struct {
   __IOM uint32_t HFEXPPRESC;          /**< High Frequency Export Clock Prescaler Register  */
 
   uint32_t       RESERVED16[2];       /**< Reserved for future use **/
-  __IOM uint32_t LFAPRESC0;           /**< Low Frequency A Prescaler Register 0 (Async Reg)  */
+  __IOM uint32_t LFAPRESC0;           /**< Low Frequency a Prescaler Register 0 (Async Reg)  */
   uint32_t       RESERVED17[1];       /**< Reserved for future use **/
   __IOM uint32_t LFBPRESC0;           /**< Low Frequency B Prescaler Register 0  (Async Reg)  */
   uint32_t       RESERVED18[1];       /**< Reserved for future use **/
@@ -254,7 +254,7 @@ typedef struct {
 #define CMU_HFRCOCTRL_CLKDIV_DIV1                         (_CMU_HFRCOCTRL_CLKDIV_DIV1 << 25)          /**< Shifted mode DIV1 for CMU_HFRCOCTRL */
 #define CMU_HFRCOCTRL_CLKDIV_DIV2                         (_CMU_HFRCOCTRL_CLKDIV_DIV2 << 25)          /**< Shifted mode DIV2 for CMU_HFRCOCTRL */
 #define CMU_HFRCOCTRL_CLKDIV_DIV4                         (_CMU_HFRCOCTRL_CLKDIV_DIV4 << 25)          /**< Shifted mode DIV4 for CMU_HFRCOCTRL */
-#define CMU_HFRCOCTRL_FINETUNINGEN                        (0x1UL << 27)                               /**< Enable reference for fine tuning */
+#define CMU_HFRCOCTRL_FINETUNINGEN                        (0x1UL << 27)                               /**< Enable Reference for Fine Tuning */
 #define _CMU_HFRCOCTRL_FINETUNINGEN_SHIFT                 27                                          /**< Shift value for CMU_FINETUNINGEN */
 #define _CMU_HFRCOCTRL_FINETUNINGEN_MASK                  0x8000000UL                                 /**< Bit mask for CMU_FINETUNINGEN */
 #define _CMU_HFRCOCTRL_FINETUNINGEN_DEFAULT               0x00000000UL                                /**< Mode DEFAULT for CMU_HFRCOCTRL */
@@ -298,7 +298,7 @@ typedef struct {
 #define CMU_AUXHFRCOCTRL_CLKDIV_DIV1                      (_CMU_AUXHFRCOCTRL_CLKDIV_DIV1 << 25)          /**< Shifted mode DIV1 for CMU_AUXHFRCOCTRL */
 #define CMU_AUXHFRCOCTRL_CLKDIV_DIV2                      (_CMU_AUXHFRCOCTRL_CLKDIV_DIV2 << 25)          /**< Shifted mode DIV2 for CMU_AUXHFRCOCTRL */
 #define CMU_AUXHFRCOCTRL_CLKDIV_DIV4                      (_CMU_AUXHFRCOCTRL_CLKDIV_DIV4 << 25)          /**< Shifted mode DIV4 for CMU_AUXHFRCOCTRL */
-#define CMU_AUXHFRCOCTRL_FINETUNINGEN                     (0x1UL << 27)                                  /**< Enable reference for fine tuning */
+#define CMU_AUXHFRCOCTRL_FINETUNINGEN                     (0x1UL << 27)                                  /**< Enable Reference for Fine Tuning */
 #define _CMU_AUXHFRCOCTRL_FINETUNINGEN_SHIFT              27                                             /**< Shift value for CMU_FINETUNINGEN */
 #define _CMU_AUXHFRCOCTRL_FINETUNINGEN_MASK               0x8000000UL                                    /**< Bit mask for CMU_FINETUNINGEN */
 #define _CMU_AUXHFRCOCTRL_FINETUNINGEN_DEFAULT            0x00000000UL                                   /**< Mode DEFAULT for CMU_AUXHFRCOCTRL */
@@ -315,17 +315,17 @@ typedef struct {
 #define _CMU_LFRCOCTRL_TUNING_MASK                        0x1FFUL                                   /**< Bit mask for CMU_TUNING */
 #define _CMU_LFRCOCTRL_TUNING_DEFAULT                     0x00000100UL                              /**< Mode DEFAULT for CMU_LFRCOCTRL */
 #define CMU_LFRCOCTRL_TUNING_DEFAULT                      (_CMU_LFRCOCTRL_TUNING_DEFAULT << 0)      /**< Shifted mode DEFAULT for CMU_LFRCOCTRL */
-#define CMU_LFRCOCTRL_ENVREF                              (0x1UL << 16)                             /**< Enable duty cycling of vref */
+#define CMU_LFRCOCTRL_ENVREF                              (0x1UL << 16)                             /**< Enable Duty Cycling of Vref */
 #define _CMU_LFRCOCTRL_ENVREF_SHIFT                       16                                        /**< Shift value for CMU_ENVREF */
 #define _CMU_LFRCOCTRL_ENVREF_MASK                        0x10000UL                                 /**< Bit mask for CMU_ENVREF */
 #define _CMU_LFRCOCTRL_ENVREF_DEFAULT                     0x00000000UL                              /**< Mode DEFAULT for CMU_LFRCOCTRL */
 #define CMU_LFRCOCTRL_ENVREF_DEFAULT                      (_CMU_LFRCOCTRL_ENVREF_DEFAULT << 16)     /**< Shifted mode DEFAULT for CMU_LFRCOCTRL */
-#define CMU_LFRCOCTRL_ENCHOP                              (0x1UL << 17)                             /**< Enable comparator chopping */
+#define CMU_LFRCOCTRL_ENCHOP                              (0x1UL << 17)                             /**< Enable Comparator Chopping */
 #define _CMU_LFRCOCTRL_ENCHOP_SHIFT                       17                                        /**< Shift value for CMU_ENCHOP */
 #define _CMU_LFRCOCTRL_ENCHOP_MASK                        0x20000UL                                 /**< Bit mask for CMU_ENCHOP */
 #define _CMU_LFRCOCTRL_ENCHOP_DEFAULT                     0x00000001UL                              /**< Mode DEFAULT for CMU_LFRCOCTRL */
 #define CMU_LFRCOCTRL_ENCHOP_DEFAULT                      (_CMU_LFRCOCTRL_ENCHOP_DEFAULT << 17)     /**< Shifted mode DEFAULT for CMU_LFRCOCTRL */
-#define CMU_LFRCOCTRL_ENDEM                               (0x1UL << 18)                             /**< Enable dynamic element matching */
+#define CMU_LFRCOCTRL_ENDEM                               (0x1UL << 18)                             /**< Enable Dynamic Element Matching */
 #define _CMU_LFRCOCTRL_ENDEM_SHIFT                        18                                        /**< Shift value for CMU_ENDEM */
 #define _CMU_LFRCOCTRL_ENDEM_MASK                         0x40000UL                                 /**< Bit mask for CMU_ENDEM */
 #define _CMU_LFRCOCTRL_ENDEM_DEFAULT                      0x00000001UL                              /**< Mode DEFAULT for CMU_LFRCOCTRL */
@@ -367,17 +367,17 @@ typedef struct {
 #define CMU_HFXOCTRL_PEAKDETSHUNTOPTMODE_AUTOCMD          (_CMU_HFXOCTRL_PEAKDETSHUNTOPTMODE_AUTOCMD << 4) /**< Shifted mode AUTOCMD for CMU_HFXOCTRL */
 #define CMU_HFXOCTRL_PEAKDETSHUNTOPTMODE_CMD              (_CMU_HFXOCTRL_PEAKDETSHUNTOPTMODE_CMD << 4)     /**< Shifted mode CMD for CMU_HFXOCTRL */
 #define CMU_HFXOCTRL_PEAKDETSHUNTOPTMODE_MANUAL           (_CMU_HFXOCTRL_PEAKDETSHUNTOPTMODE_MANUAL << 4)  /**< Shifted mode MANUAL for CMU_HFXOCTRL */
-#define CMU_HFXOCTRL_LOWPOWER                             (0x1UL << 8)                                     /**< Low power mode control. PSR performance is reduced to enable low current consumption. */
+#define CMU_HFXOCTRL_LOWPOWER                             (0x1UL << 8)                                     /**< Low Power Mode Control */
 #define _CMU_HFXOCTRL_LOWPOWER_SHIFT                      8                                                /**< Shift value for CMU_LOWPOWER */
 #define _CMU_HFXOCTRL_LOWPOWER_MASK                       0x100UL                                          /**< Bit mask for CMU_LOWPOWER */
 #define _CMU_HFXOCTRL_LOWPOWER_DEFAULT                    0x00000000UL                                     /**< Mode DEFAULT for CMU_HFXOCTRL */
 #define CMU_HFXOCTRL_LOWPOWER_DEFAULT                     (_CMU_HFXOCTRL_LOWPOWER_DEFAULT << 8)            /**< Shifted mode DEFAULT for CMU_HFXOCTRL */
-#define CMU_HFXOCTRL_XTI2GND                              (0x1UL << 9)                                     /**< Clamp HFXTAL_N pin to ground when HFXO oscillator is off. */
+#define CMU_HFXOCTRL_XTI2GND                              (0x1UL << 9)                                     /**< Clamp HFXTAL_N Pin to Ground When HFXO Oscillator is Off */
 #define _CMU_HFXOCTRL_XTI2GND_SHIFT                       9                                                /**< Shift value for CMU_XTI2GND */
 #define _CMU_HFXOCTRL_XTI2GND_MASK                        0x200UL                                          /**< Bit mask for CMU_XTI2GND */
 #define _CMU_HFXOCTRL_XTI2GND_DEFAULT                     0x00000000UL                                     /**< Mode DEFAULT for CMU_HFXOCTRL */
 #define CMU_HFXOCTRL_XTI2GND_DEFAULT                      (_CMU_HFXOCTRL_XTI2GND_DEFAULT << 9)             /**< Shifted mode DEFAULT for CMU_HFXOCTRL */
-#define CMU_HFXOCTRL_XTO2GND                              (0x1UL << 10)                                    /**< Clamp HFXTAL_P pin to ground when HFXO oscillator is off. */
+#define CMU_HFXOCTRL_XTO2GND                              (0x1UL << 10)                                    /**< Clamp HFXTAL_P Pin to Ground When HFXO Oscillator is Off */
 #define _CMU_HFXOCTRL_XTO2GND_SHIFT                       10                                               /**< Shift value for CMU_XTO2GND */
 #define _CMU_HFXOCTRL_XTO2GND_MASK                        0x400UL                                          /**< Bit mask for CMU_XTO2GND */
 #define _CMU_HFXOCTRL_XTO2GND_DEFAULT                     0x00000000UL                                     /**< Mode DEFAULT for CMU_HFXOCTRL */
@@ -402,12 +402,12 @@ typedef struct {
 #define CMU_HFXOCTRL_LFTIMEOUT_64CYCLES                   (_CMU_HFXOCTRL_LFTIMEOUT_64CYCLES << 24)         /**< Shifted mode 64CYCLES for CMU_HFXOCTRL */
 #define CMU_HFXOCTRL_LFTIMEOUT_1KCYCLES                   (_CMU_HFXOCTRL_LFTIMEOUT_1KCYCLES << 24)         /**< Shifted mode 1KCYCLES for CMU_HFXOCTRL */
 #define CMU_HFXOCTRL_LFTIMEOUT_4KCYCLES                   (_CMU_HFXOCTRL_LFTIMEOUT_4KCYCLES << 24)         /**< Shifted mode 4KCYCLES for CMU_HFXOCTRL */
-#define CMU_HFXOCTRL_AUTOSTARTEM0EM1                      (0x1UL << 28)                                    /**< Automatically start of HFXO upon EM0/EM1 entry from EM2/EM3 */
+#define CMU_HFXOCTRL_AUTOSTARTEM0EM1                      (0x1UL << 28)                                    /**< Automatically Start of HFXO Upon EM0/EM1 Entry From EM2/EM3 */
 #define _CMU_HFXOCTRL_AUTOSTARTEM0EM1_SHIFT               28                                               /**< Shift value for CMU_AUTOSTARTEM0EM1 */
 #define _CMU_HFXOCTRL_AUTOSTARTEM0EM1_MASK                0x10000000UL                                     /**< Bit mask for CMU_AUTOSTARTEM0EM1 */
 #define _CMU_HFXOCTRL_AUTOSTARTEM0EM1_DEFAULT             0x00000000UL                                     /**< Mode DEFAULT for CMU_HFXOCTRL */
 #define CMU_HFXOCTRL_AUTOSTARTEM0EM1_DEFAULT              (_CMU_HFXOCTRL_AUTOSTARTEM0EM1_DEFAULT << 28)    /**< Shifted mode DEFAULT for CMU_HFXOCTRL */
-#define CMU_HFXOCTRL_AUTOSTARTSELEM0EM1                   (0x1UL << 29)                                    /**< Automatically start and select of HFXO upon EM0/EM1 entry from EM2/EM3 */
+#define CMU_HFXOCTRL_AUTOSTARTSELEM0EM1                   (0x1UL << 29)                                    /**< Automatically Start and Select of HFXO Upon EM0/EM1 Entry From EM2/EM3 */
 #define _CMU_HFXOCTRL_AUTOSTARTSELEM0EM1_SHIFT            29                                               /**< Shift value for CMU_AUTOSTARTSELEM0EM1 */
 #define _CMU_HFXOCTRL_AUTOSTARTSELEM0EM1_MASK             0x20000000UL                                     /**< Bit mask for CMU_AUTOSTARTSELEM0EM1 */
 #define _CMU_HFXOCTRL_AUTOSTARTSELEM0EM1_DEFAULT          0x00000000UL                                     /**< Mode DEFAULT for CMU_HFXOCTRL */
@@ -469,7 +469,7 @@ typedef struct {
 #define _CMU_HFXOSTEADYSTATECTRL_REGSELILOW_MASK          0x3000000UL                                          /**< Bit mask for CMU_REGSELILOW */
 #define _CMU_HFXOSTEADYSTATECTRL_REGSELILOW_DEFAULT       0x00000003UL                                         /**< Mode DEFAULT for CMU_HFXOSTEADYSTATECTRL */
 #define CMU_HFXOSTEADYSTATECTRL_REGSELILOW_DEFAULT        (_CMU_HFXOSTEADYSTATECTRL_REGSELILOW_DEFAULT << 24)  /**< Shifted mode DEFAULT for CMU_HFXOSTEADYSTATECTRL */
-#define CMU_HFXOSTEADYSTATECTRL_PEAKDETEN                 (0x1UL << 26)                                        /**< Enables oscillator peak detectors */
+#define CMU_HFXOSTEADYSTATECTRL_PEAKDETEN                 (0x1UL << 26)                                        /**< Enables Oscillator Peak Detectors */
 #define _CMU_HFXOSTEADYSTATECTRL_PEAKDETEN_SHIFT          26                                                   /**< Shift value for CMU_PEAKDETEN */
 #define _CMU_HFXOSTEADYSTATECTRL_PEAKDETEN_MASK           0x4000000UL                                          /**< Bit mask for CMU_PEAKDETEN */
 #define _CMU_HFXOSTEADYSTATECTRL_PEAKDETEN_DEFAULT        0x00000000UL                                         /**< Mode DEFAULT for CMU_HFXOSTEADYSTATECTRL */
@@ -997,7 +997,7 @@ typedef struct {
 #define _CMU_STATUS_CALRDY_MASK                           0x10000UL                                   /**< Bit mask for CMU_CALRDY */
 #define _CMU_STATUS_CALRDY_DEFAULT                        0x00000001UL                                /**< Mode DEFAULT for CMU_STATUS */
 #define CMU_STATUS_CALRDY_DEFAULT                         (_CMU_STATUS_CALRDY_DEFAULT << 16)          /**< Shifted mode DEFAULT for CMU_STATUS */
-#define CMU_STATUS_HFXOREQ                                (0x1UL << 21)                               /**< HFXO is Required by Hardware */
+#define CMU_STATUS_HFXOREQ                                (0x1UL << 21)                               /**< HFXO is Required By Hardware */
 #define _CMU_STATUS_HFXOREQ_SHIFT                         21                                          /**< Shift value for CMU_HFXOREQ */
 #define _CMU_STATUS_HFXOREQ_MASK                          0x200000UL                                  /**< Bit mask for CMU_HFXOREQ */
 #define _CMU_STATUS_HFXOREQ_DEFAULT                       0x00000000UL                                /**< Mode DEFAULT for CMU_STATUS */
@@ -1007,22 +1007,22 @@ typedef struct {
 #define _CMU_STATUS_HFXOPEAKDETRDY_MASK                   0x400000UL                                  /**< Bit mask for CMU_HFXOPEAKDETRDY */
 #define _CMU_STATUS_HFXOPEAKDETRDY_DEFAULT                0x00000000UL                                /**< Mode DEFAULT for CMU_STATUS */
 #define CMU_STATUS_HFXOPEAKDETRDY_DEFAULT                 (_CMU_STATUS_HFXOPEAKDETRDY_DEFAULT << 22)  /**< Shifted mode DEFAULT for CMU_STATUS */
-#define CMU_STATUS_HFXOSHUNTOPTRDY                        (0x1UL << 23)                               /**< HFXO Shunt Current Optimization ready */
+#define CMU_STATUS_HFXOSHUNTOPTRDY                        (0x1UL << 23)                               /**< HFXO Shunt Current Optimization Ready */
 #define _CMU_STATUS_HFXOSHUNTOPTRDY_SHIFT                 23                                          /**< Shift value for CMU_HFXOSHUNTOPTRDY */
 #define _CMU_STATUS_HFXOSHUNTOPTRDY_MASK                  0x800000UL                                  /**< Bit mask for CMU_HFXOSHUNTOPTRDY */
 #define _CMU_STATUS_HFXOSHUNTOPTRDY_DEFAULT               0x00000000UL                                /**< Mode DEFAULT for CMU_STATUS */
 #define CMU_STATUS_HFXOSHUNTOPTRDY_DEFAULT                (_CMU_STATUS_HFXOSHUNTOPTRDY_DEFAULT << 23) /**< Shifted mode DEFAULT for CMU_STATUS */
-#define CMU_STATUS_HFXOAMPHIGH                            (0x1UL << 24)                               /**< HFXO oscillation amplitude is too high */
+#define CMU_STATUS_HFXOAMPHIGH                            (0x1UL << 24)                               /**< HFXO Oscillation Amplitude is Too High */
 #define _CMU_STATUS_HFXOAMPHIGH_SHIFT                     24                                          /**< Shift value for CMU_HFXOAMPHIGH */
 #define _CMU_STATUS_HFXOAMPHIGH_MASK                      0x1000000UL                                 /**< Bit mask for CMU_HFXOAMPHIGH */
 #define _CMU_STATUS_HFXOAMPHIGH_DEFAULT                   0x00000000UL                                /**< Mode DEFAULT for CMU_STATUS */
 #define CMU_STATUS_HFXOAMPHIGH_DEFAULT                    (_CMU_STATUS_HFXOAMPHIGH_DEFAULT << 24)     /**< Shifted mode DEFAULT for CMU_STATUS */
-#define CMU_STATUS_HFXOAMPLOW                             (0x1UL << 25)                               /**< HFXO amplitude tuning value too low */
+#define CMU_STATUS_HFXOAMPLOW                             (0x1UL << 25)                               /**< HFXO Amplitude Tuning Value Too Low */
 #define _CMU_STATUS_HFXOAMPLOW_SHIFT                      25                                          /**< Shift value for CMU_HFXOAMPLOW */
 #define _CMU_STATUS_HFXOAMPLOW_MASK                       0x2000000UL                                 /**< Bit mask for CMU_HFXOAMPLOW */
 #define _CMU_STATUS_HFXOAMPLOW_DEFAULT                    0x00000000UL                                /**< Mode DEFAULT for CMU_STATUS */
 #define CMU_STATUS_HFXOAMPLOW_DEFAULT                     (_CMU_STATUS_HFXOAMPLOW_DEFAULT << 25)      /**< Shifted mode DEFAULT for CMU_STATUS */
-#define CMU_STATUS_HFXOREGILOW                            (0x1UL << 26)                               /**< HFXO regulator shunt current too low */
+#define CMU_STATUS_HFXOREGILOW                            (0x1UL << 26)                               /**< HFXO Regulator Shunt Current Too Low */
 #define _CMU_STATUS_HFXOREGILOW_SHIFT                     26                                          /**< Shift value for CMU_HFXOREGILOW */
 #define _CMU_STATUS_HFXOREGILOW_MASK                      0x4000000UL                                 /**< Bit mask for CMU_HFXOREGILOW */
 #define _CMU_STATUS_HFXOREGILOW_DEFAULT                   0x00000000UL                                /**< Mode DEFAULT for CMU_STATUS */
@@ -1598,12 +1598,12 @@ typedef struct {
 /* Bit fields for CMU SYNCBUSY */
 #define _CMU_SYNCBUSY_RESETVALUE                          0x00000000UL                               /**< Default value for CMU_SYNCBUSY */
 #define _CMU_SYNCBUSY_MASK                                0x3F050055UL                               /**< Mask for CMU_SYNCBUSY */
-#define CMU_SYNCBUSY_LFACLKEN0                            (0x1UL << 0)                               /**< Low Frequency A Clock Enable 0 Busy */
+#define CMU_SYNCBUSY_LFACLKEN0                            (0x1UL << 0)                               /**< Low Frequency a Clock Enable 0 Busy */
 #define _CMU_SYNCBUSY_LFACLKEN0_SHIFT                     0                                          /**< Shift value for CMU_LFACLKEN0 */
 #define _CMU_SYNCBUSY_LFACLKEN0_MASK                      0x1UL                                      /**< Bit mask for CMU_LFACLKEN0 */
 #define _CMU_SYNCBUSY_LFACLKEN0_DEFAULT                   0x00000000UL                               /**< Mode DEFAULT for CMU_SYNCBUSY */
 #define CMU_SYNCBUSY_LFACLKEN0_DEFAULT                    (_CMU_SYNCBUSY_LFACLKEN0_DEFAULT << 0)     /**< Shifted mode DEFAULT for CMU_SYNCBUSY */
-#define CMU_SYNCBUSY_LFAPRESC0                            (0x1UL << 2)                               /**< Low Frequency A Prescaler 0 Busy */
+#define CMU_SYNCBUSY_LFAPRESC0                            (0x1UL << 2)                               /**< Low Frequency a Prescaler 0 Busy */
 #define _CMU_SYNCBUSY_LFAPRESC0_SHIFT                     2                                          /**< Shift value for CMU_LFAPRESC0 */
 #define _CMU_SYNCBUSY_LFAPRESC0_MASK                      0x4UL                                      /**< Bit mask for CMU_LFAPRESC0 */
 #define _CMU_SYNCBUSY_LFAPRESC0_DEFAULT                   0x00000000UL                               /**< Mode DEFAULT for CMU_SYNCBUSY */
@@ -1705,7 +1705,7 @@ typedef struct {
 #define CMU_ADCCTRL_ADC0CLKSEL_AUXHFRCO                   (_CMU_ADCCTRL_ADC0CLKSEL_AUXHFRCO << 4) /**< Shifted mode AUXHFRCO for CMU_ADCCTRL */
 #define CMU_ADCCTRL_ADC0CLKSEL_HFXO                       (_CMU_ADCCTRL_ADC0CLKSEL_HFXO << 4)     /**< Shifted mode HFXO for CMU_ADCCTRL */
 #define CMU_ADCCTRL_ADC0CLKSEL_HFSRCCLK                   (_CMU_ADCCTRL_ADC0CLKSEL_HFSRCCLK << 4) /**< Shifted mode HFSRCCLK for CMU_ADCCTRL */
-#define CMU_ADCCTRL_ADC0CLKINV                            (0x1UL << 8)                            /**< Invert clock selected by ADC0CLKSEL */
+#define CMU_ADCCTRL_ADC0CLKINV                            (0x1UL << 8)                            /**< Invert Clock Selected By ADC0CLKSEL */
 #define _CMU_ADCCTRL_ADC0CLKINV_SHIFT                     8                                       /**< Shift value for CMU_ADC0CLKINV */
 #define _CMU_ADCCTRL_ADC0CLKINV_MASK                      0x100UL                                 /**< Bit mask for CMU_ADC0CLKINV */
 #define _CMU_ADCCTRL_ADC0CLKINV_DEFAULT                   0x00000000UL                            /**< Mode DEFAULT for CMU_ADCCTRL */

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_cryotimer.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_cryotimer.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efr32mg1p_cryotimer.h
  * @brief EFR32MG1P_CRYOTIMER register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,
@@ -132,7 +132,7 @@ typedef struct {
 /* Bit fields for CRYOTIMER EM4WUEN */
 #define _CRYOTIMER_EM4WUEN_RESETVALUE             0x00000000UL                            /**< Default value for CRYOTIMER_EM4WUEN */
 #define _CRYOTIMER_EM4WUEN_MASK                   0x00000001UL                            /**< Mask for CRYOTIMER_EM4WUEN */
-#define CRYOTIMER_EM4WUEN_EM4WU                   (0x1UL << 0)                            /**< EM4 Wake-up enable */
+#define CRYOTIMER_EM4WUEN_EM4WU                   (0x1UL << 0)                            /**< EM4 Wake-up Enable */
 #define _CRYOTIMER_EM4WUEN_EM4WU_SHIFT            0                                       /**< Shift value for CRYOTIMER_EM4WU */
 #define _CRYOTIMER_EM4WUEN_EM4WU_MASK             0x1UL                                   /**< Bit mask for CRYOTIMER_EM4WU */
 #define _CRYOTIMER_EM4WUEN_EM4WU_DEFAULT          0x00000000UL                            /**< Mode DEFAULT for CRYOTIMER_EM4WUEN */
@@ -141,7 +141,7 @@ typedef struct {
 /* Bit fields for CRYOTIMER IF */
 #define _CRYOTIMER_IF_RESETVALUE                  0x00000000UL                        /**< Default value for CRYOTIMER_IF */
 #define _CRYOTIMER_IF_MASK                        0x00000001UL                        /**< Mask for CRYOTIMER_IF */
-#define CRYOTIMER_IF_PERIOD                       (0x1UL << 0)                        /**< Wakeup event/Interrupt */
+#define CRYOTIMER_IF_PERIOD                       (0x1UL << 0)                        /**< Wakeup Event/Interrupt */
 #define _CRYOTIMER_IF_PERIOD_SHIFT                0                                   /**< Shift value for CRYOTIMER_PERIOD */
 #define _CRYOTIMER_IF_PERIOD_MASK                 0x1UL                               /**< Bit mask for CRYOTIMER_PERIOD */
 #define _CRYOTIMER_IF_PERIOD_DEFAULT              0x00000000UL                        /**< Mode DEFAULT for CRYOTIMER_IF */

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_crypto.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_crypto.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efr32mg1p_crypto.h
  * @brief EFR32MG1P_CRYPTO register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,
@@ -70,7 +70,7 @@ typedef struct {
   __IOM uint32_t IFS;            /**< Interrupt Flag Set Register  */
   __IOM uint32_t IFC;            /**< Interrupt Flag Clear Register  */
   __IOM uint32_t IEN;            /**< Interrupt Enable Register  */
-  __IOM uint32_t SEQ0;           /**< Sequence register 0  */
+  __IOM uint32_t SEQ0;           /**< Sequence Register 0  */
   __IOM uint32_t SEQ1;           /**< Sequence Register 1  */
   __IOM uint32_t SEQ2;           /**< Sequence Register 2  */
   __IOM uint32_t SEQ3;           /**< Sequence Register 3  */
@@ -102,7 +102,7 @@ typedef struct {
   uint32_t       RESERVED10[3];  /**< Reserved for future use **/
   __IOM uint32_t DDATA0BYTE;     /**< DDATA0 Register Byte Access  */
   __IOM uint32_t DDATA1BYTE;     /**< DDATA1 Register Byte Access  */
-  __IOM uint32_t DDATA0BYTE32;   /**< DDATA0 Register Byte 32 access.  */
+  __IOM uint32_t DDATA0BYTE32;   /**< DDATA0 Register Byte 32 Access  */
   uint32_t       RESERVED11[13]; /**< Reserved for future use **/
   __IOM uint32_t QDATA0;         /**< QDATA0 Register Access  */
   __IOM uint32_t QDATA1;         /**< QDATA1 Register Access  */
@@ -659,12 +659,12 @@ typedef struct {
 #define _CRYPTO_STATUS_SEQRUNNING_MASK               0x1UL                                      /**< Bit mask for CRYPTO_SEQRUNNING */
 #define _CRYPTO_STATUS_SEQRUNNING_DEFAULT            0x00000000UL                               /**< Mode DEFAULT for CRYPTO_STATUS */
 #define CRYPTO_STATUS_SEQRUNNING_DEFAULT             (_CRYPTO_STATUS_SEQRUNNING_DEFAULT << 0)   /**< Shifted mode DEFAULT for CRYPTO_STATUS */
-#define CRYPTO_STATUS_INSTRRUNNING                   (0x1UL << 1)                               /**< Action is active */
+#define CRYPTO_STATUS_INSTRRUNNING                   (0x1UL << 1)                               /**< Action is Active */
 #define _CRYPTO_STATUS_INSTRRUNNING_SHIFT            1                                          /**< Shift value for CRYPTO_INSTRRUNNING */
 #define _CRYPTO_STATUS_INSTRRUNNING_MASK             0x2UL                                      /**< Bit mask for CRYPTO_INSTRRUNNING */
 #define _CRYPTO_STATUS_INSTRRUNNING_DEFAULT          0x00000000UL                               /**< Mode DEFAULT for CRYPTO_STATUS */
 #define CRYPTO_STATUS_INSTRRUNNING_DEFAULT           (_CRYPTO_STATUS_INSTRRUNNING_DEFAULT << 1) /**< Shifted mode DEFAULT for CRYPTO_STATUS */
-#define CRYPTO_STATUS_DMAACTIVE                      (0x1UL << 2)                               /**< DMA Action is active */
+#define CRYPTO_STATUS_DMAACTIVE                      (0x1UL << 2)                               /**< DMA Action is Active */
 #define _CRYPTO_STATUS_DMAACTIVE_SHIFT               2                                          /**< Shift value for CRYPTO_DMAACTIVE */
 #define _CRYPTO_STATUS_DMAACTIVE_MASK                0x4UL                                      /**< Bit mask for CRYPTO_DMAACTIVE */
 #define _CRYPTO_STATUS_DMAACTIVE_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for CRYPTO_STATUS */
@@ -807,12 +807,12 @@ typedef struct {
 #define _CRYPTO_SEQCTRL_DMA1SKIP_MASK                0xC000000UL                               /**< Bit mask for CRYPTO_DMA1SKIP */
 #define _CRYPTO_SEQCTRL_DMA1SKIP_DEFAULT             0x00000000UL                              /**< Mode DEFAULT for CRYPTO_SEQCTRL */
 #define CRYPTO_SEQCTRL_DMA1SKIP_DEFAULT              (_CRYPTO_SEQCTRL_DMA1SKIP_DEFAULT << 26)  /**< Shifted mode DEFAULT for CRYPTO_SEQCTRL */
-#define CRYPTO_SEQCTRL_DMA0PRESA                     (0x1UL << 28)                             /**< DMA0 Preserve A */
+#define CRYPTO_SEQCTRL_DMA0PRESA                     (0x1UL << 28)                             /**< DMA0 Preserve a */
 #define _CRYPTO_SEQCTRL_DMA0PRESA_SHIFT              28                                        /**< Shift value for CRYPTO_DMA0PRESA */
 #define _CRYPTO_SEQCTRL_DMA0PRESA_MASK               0x10000000UL                              /**< Bit mask for CRYPTO_DMA0PRESA */
 #define _CRYPTO_SEQCTRL_DMA0PRESA_DEFAULT            0x00000000UL                              /**< Mode DEFAULT for CRYPTO_SEQCTRL */
 #define CRYPTO_SEQCTRL_DMA0PRESA_DEFAULT             (_CRYPTO_SEQCTRL_DMA0PRESA_DEFAULT << 28) /**< Shifted mode DEFAULT for CRYPTO_SEQCTRL */
-#define CRYPTO_SEQCTRL_DMA1PRESA                     (0x1UL << 29)                             /**< DMA1 Preserve A */
+#define CRYPTO_SEQCTRL_DMA1PRESA                     (0x1UL << 29)                             /**< DMA1 Preserve a */
 #define _CRYPTO_SEQCTRL_DMA1PRESA_SHIFT              29                                        /**< Shift value for CRYPTO_DMA1PRESA */
 #define _CRYPTO_SEQCTRL_DMA1PRESA_MASK               0x20000000UL                              /**< Bit mask for CRYPTO_DMA1PRESA */
 #define _CRYPTO_SEQCTRL_DMA1PRESA_DEFAULT            0x00000000UL                              /**< Mode DEFAULT for CRYPTO_SEQCTRL */
@@ -844,7 +844,7 @@ typedef struct {
 /* Bit fields for CRYPTO IF */
 #define _CRYPTO_IF_RESETVALUE                        0x00000000UL                        /**< Default value for CRYPTO_IF */
 #define _CRYPTO_IF_MASK                              0x00000003UL                        /**< Mask for CRYPTO_IF */
-#define CRYPTO_IF_INSTRDONE                          (0x1UL << 0)                        /**< Instruction done */
+#define CRYPTO_IF_INSTRDONE                          (0x1UL << 0)                        /**< Instruction Done */
 #define _CRYPTO_IF_INSTRDONE_SHIFT                   0                                   /**< Shift value for CRYPTO_INSTRDONE */
 #define _CRYPTO_IF_INSTRDONE_MASK                    0x1UL                               /**< Bit mask for CRYPTO_INSTRDONE */
 #define _CRYPTO_IF_INSTRDONE_DEFAULT                 0x00000000UL                        /**< Mode DEFAULT for CRYPTO_IF */

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_devinfo.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_devinfo.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efr32mg1p_devinfo.h
  * @brief EFR32MG1P_DEVINFO register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,
@@ -271,8 +271,6 @@ typedef struct {
 #define _DEVINFO_PART_DEVICE_FAMILY_EFM32JG1B                    0x00000053UL                                   /**< Mode EFM32JG1B for DEVINFO_PART */
 #define _DEVINFO_PART_DEVICE_FAMILY_EFM32PG12B                   0x00000055UL                                   /**< Mode EFM32PG12B for DEVINFO_PART */
 #define _DEVINFO_PART_DEVICE_FAMILY_EFM32JG12B                   0x00000057UL                                   /**< Mode EFM32JG12B for DEVINFO_PART */
-#define _DEVINFO_PART_DEVICE_FAMILY_EFM32PG13B                   0x00000059UL                                   /**< Mode EFM32PG13B for DEVINFO_PART */
-#define _DEVINFO_PART_DEVICE_FAMILY_EFM32JG13B                   0x0000005BUL                                   /**< Mode EFM32JG13B for DEVINFO_PART */
 #define _DEVINFO_PART_DEVICE_FAMILY_EFM32GG11B                   0x00000064UL                                   /**< Mode EFM32GG11B for DEVINFO_PART */
 #define _DEVINFO_PART_DEVICE_FAMILY_EFM32TG11B                   0x00000067UL                                   /**< Mode EFM32TG11B for DEVINFO_PART */
 #define _DEVINFO_PART_DEVICE_FAMILY_EZR32LG                      0x00000078UL                                   /**< Mode EZR32LG for DEVINFO_PART */
@@ -332,8 +330,6 @@ typedef struct {
 #define DEVINFO_PART_DEVICE_FAMILY_EFM32JG1B                     (_DEVINFO_PART_DEVICE_FAMILY_EFM32JG1B << 16)  /**< Shifted mode EFM32JG1B for DEVINFO_PART */
 #define DEVINFO_PART_DEVICE_FAMILY_EFM32PG12B                    (_DEVINFO_PART_DEVICE_FAMILY_EFM32PG12B << 16) /**< Shifted mode EFM32PG12B for DEVINFO_PART */
 #define DEVINFO_PART_DEVICE_FAMILY_EFM32JG12B                    (_DEVINFO_PART_DEVICE_FAMILY_EFM32JG12B << 16) /**< Shifted mode EFM32JG12B for DEVINFO_PART */
-#define DEVINFO_PART_DEVICE_FAMILY_EFM32PG13B                    (_DEVINFO_PART_DEVICE_FAMILY_EFM32PG13B << 16) /**< Shifted mode EFM32PG13B for DEVINFO_PART */
-#define DEVINFO_PART_DEVICE_FAMILY_EFM32JG13B                    (_DEVINFO_PART_DEVICE_FAMILY_EFM32JG13B << 16) /**< Shifted mode EFM32JG13B for DEVINFO_PART */
 #define DEVINFO_PART_DEVICE_FAMILY_EFM32GG11B                    (_DEVINFO_PART_DEVICE_FAMILY_EFM32GG11B << 16) /**< Shifted mode EFM32GG11B for DEVINFO_PART */
 #define DEVINFO_PART_DEVICE_FAMILY_EFM32TG11B                    (_DEVINFO_PART_DEVICE_FAMILY_EFM32TG11B << 16) /**< Shifted mode EFM32TG11B for DEVINFO_PART */
 #define DEVINFO_PART_DEVICE_FAMILY_EZR32LG                       (_DEVINFO_PART_DEVICE_FAMILY_EZR32LG << 16)    /**< Shifted mode EZR32LG for DEVINFO_PART */

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_dma_descriptor.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_dma_descriptor.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efr32mg1p_dma_descriptor.h
  * @brief EFR32MG1P_DMA_DESCRIPTOR register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_dmareq.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_dmareq.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efr32mg1p_dmareq.h
  * @brief EFR32MG1P_DMAREQ register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_emu.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_emu.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efr32mg1p_emu.h
  * @brief EFR32MG1P_EMU register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,
@@ -60,15 +60,15 @@ typedef struct {
 
   uint32_t       RESERVED0[1];    /**< Reserved for future use **/
   __IOM uint32_t EM4CTRL;         /**< EM4 Control Register  */
-  __IOM uint32_t TEMPLIMITS;      /**< Temperature limits for interrupt generation  */
-  __IM uint32_t  TEMP;            /**< Value of last temperature measurement  */
+  __IOM uint32_t TEMPLIMITS;      /**< Temperature Limits for Interrupt Generation  */
+  __IM uint32_t  TEMP;            /**< Value of Last Temperature Measurement  */
   __IM uint32_t  IF;              /**< Interrupt Flag Register  */
   __IOM uint32_t IFS;             /**< Interrupt Flag Set Register  */
   __IOM uint32_t IFC;             /**< Interrupt Flag Clear Register  */
   __IOM uint32_t IEN;             /**< Interrupt Enable Register  */
   __IOM uint32_t PWRLOCK;         /**< Regulator and Supply Lock Register  */
   __IOM uint32_t PWRCFG;          /**< Power Configuration Register  */
-  __IOM uint32_t PWRCTRL;         /**< Power Control Register.  */
+  __IOM uint32_t PWRCTRL;         /**< Power Control Register  */
   __IOM uint32_t DCDCCTRL;        /**< DCDC Control  */
 
   uint32_t       RESERVED1[2];    /**< Reserved for future use **/
@@ -100,7 +100,7 @@ typedef struct {
   __IOM uint32_t TESTLOCK;        /**< Test Lock Register  */
 
   uint32_t       RESERVED7[2];    /**< Reserved for future use **/
-  __IOM uint32_t BIASTESTCTRL;    /**< Test Control Register for regulator and BIAS  */
+  __IOM uint32_t BIASTESTCTRL;    /**< Test Control Register for Regulator and BIAS  */
 } EMU_TypeDef;                    /** @} */
 
 /**************************************************************************//**
@@ -122,32 +122,32 @@ typedef struct {
 /* Bit fields for EMU STATUS */
 #define _EMU_STATUS_RESETVALUE                       0x00000000UL                           /**< Default value for EMU_STATUS */
 #define _EMU_STATUS_MASK                             0x0010011FUL                           /**< Mask for EMU_STATUS */
-#define EMU_STATUS_VMONRDY                           (0x1UL << 0)                           /**< VMON ready */
+#define EMU_STATUS_VMONRDY                           (0x1UL << 0)                           /**< VMON Ready */
 #define _EMU_STATUS_VMONRDY_SHIFT                    0                                      /**< Shift value for EMU_VMONRDY */
 #define _EMU_STATUS_VMONRDY_MASK                     0x1UL                                  /**< Bit mask for EMU_VMONRDY */
 #define _EMU_STATUS_VMONRDY_DEFAULT                  0x00000000UL                           /**< Mode DEFAULT for EMU_STATUS */
 #define EMU_STATUS_VMONRDY_DEFAULT                   (_EMU_STATUS_VMONRDY_DEFAULT << 0)     /**< Shifted mode DEFAULT for EMU_STATUS */
-#define EMU_STATUS_VMONAVDD                          (0x1UL << 1)                           /**< VMON AVDD Channel. */
+#define EMU_STATUS_VMONAVDD                          (0x1UL << 1)                           /**< VMON AVDD Channel */
 #define _EMU_STATUS_VMONAVDD_SHIFT                   1                                      /**< Shift value for EMU_VMONAVDD */
 #define _EMU_STATUS_VMONAVDD_MASK                    0x2UL                                  /**< Bit mask for EMU_VMONAVDD */
 #define _EMU_STATUS_VMONAVDD_DEFAULT                 0x00000000UL                           /**< Mode DEFAULT for EMU_STATUS */
 #define EMU_STATUS_VMONAVDD_DEFAULT                  (_EMU_STATUS_VMONAVDD_DEFAULT << 1)    /**< Shifted mode DEFAULT for EMU_STATUS */
-#define EMU_STATUS_VMONALTAVDD                       (0x1UL << 2)                           /**< Alternate VMON AVDD Channel. */
+#define EMU_STATUS_VMONALTAVDD                       (0x1UL << 2)                           /**< Alternate VMON AVDD Channel */
 #define _EMU_STATUS_VMONALTAVDD_SHIFT                2                                      /**< Shift value for EMU_VMONALTAVDD */
 #define _EMU_STATUS_VMONALTAVDD_MASK                 0x4UL                                  /**< Bit mask for EMU_VMONALTAVDD */
 #define _EMU_STATUS_VMONALTAVDD_DEFAULT              0x00000000UL                           /**< Mode DEFAULT for EMU_STATUS */
 #define EMU_STATUS_VMONALTAVDD_DEFAULT               (_EMU_STATUS_VMONALTAVDD_DEFAULT << 2) /**< Shifted mode DEFAULT for EMU_STATUS */
-#define EMU_STATUS_VMONDVDD                          (0x1UL << 3)                           /**< VMON DVDD Channel. */
+#define EMU_STATUS_VMONDVDD                          (0x1UL << 3)                           /**< VMON DVDD Channel */
 #define _EMU_STATUS_VMONDVDD_SHIFT                   3                                      /**< Shift value for EMU_VMONDVDD */
 #define _EMU_STATUS_VMONDVDD_MASK                    0x8UL                                  /**< Bit mask for EMU_VMONDVDD */
 #define _EMU_STATUS_VMONDVDD_DEFAULT                 0x00000000UL                           /**< Mode DEFAULT for EMU_STATUS */
 #define EMU_STATUS_VMONDVDD_DEFAULT                  (_EMU_STATUS_VMONDVDD_DEFAULT << 3)    /**< Shifted mode DEFAULT for EMU_STATUS */
-#define EMU_STATUS_VMONIO0                           (0x1UL << 4)                           /**< VMON IOVDD0 Channel. */
+#define EMU_STATUS_VMONIO0                           (0x1UL << 4)                           /**< VMON IOVDD0 Channel */
 #define _EMU_STATUS_VMONIO0_SHIFT                    4                                      /**< Shift value for EMU_VMONIO0 */
 #define _EMU_STATUS_VMONIO0_MASK                     0x10UL                                 /**< Bit mask for EMU_VMONIO0 */
 #define _EMU_STATUS_VMONIO0_DEFAULT                  0x00000000UL                           /**< Mode DEFAULT for EMU_STATUS */
 #define EMU_STATUS_VMONIO0_DEFAULT                   (_EMU_STATUS_VMONIO0_DEFAULT << 4)     /**< Shifted mode DEFAULT for EMU_STATUS */
-#define EMU_STATUS_VMONFVDD                          (0x1UL << 8)                           /**< VMON VDDFLASH Channel. */
+#define EMU_STATUS_VMONFVDD                          (0x1UL << 8)                           /**< VMON VDDFLASH Channel */
 #define _EMU_STATUS_VMONFVDD_SHIFT                   8                                      /**< Shift value for EMU_VMONFVDD */
 #define _EMU_STATUS_VMONFVDD_MASK                    0x100UL                                /**< Bit mask for EMU_VMONFVDD */
 #define _EMU_STATUS_VMONFVDD_DEFAULT                 0x00000000UL                           /**< Mode DEFAULT for EMU_STATUS */
@@ -217,17 +217,17 @@ typedef struct {
 #define EMU_EM4CTRL_EM4STATE_DEFAULT                 (_EMU_EM4CTRL_EM4STATE_DEFAULT << 0)       /**< Shifted mode DEFAULT for EMU_EM4CTRL */
 #define EMU_EM4CTRL_EM4STATE_EM4S                    (_EMU_EM4CTRL_EM4STATE_EM4S << 0)          /**< Shifted mode EM4S for EMU_EM4CTRL */
 #define EMU_EM4CTRL_EM4STATE_EM4H                    (_EMU_EM4CTRL_EM4STATE_EM4H << 0)          /**< Shifted mode EM4H for EMU_EM4CTRL */
-#define EMU_EM4CTRL_RETAINLFRCO                      (0x1UL << 1)                               /**< LFRCO Retain during EM4 */
+#define EMU_EM4CTRL_RETAINLFRCO                      (0x1UL << 1)                               /**< LFRCO Retain During EM4 */
 #define _EMU_EM4CTRL_RETAINLFRCO_SHIFT               1                                          /**< Shift value for EMU_RETAINLFRCO */
 #define _EMU_EM4CTRL_RETAINLFRCO_MASK                0x2UL                                      /**< Bit mask for EMU_RETAINLFRCO */
 #define _EMU_EM4CTRL_RETAINLFRCO_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for EMU_EM4CTRL */
 #define EMU_EM4CTRL_RETAINLFRCO_DEFAULT              (_EMU_EM4CTRL_RETAINLFRCO_DEFAULT << 1)    /**< Shifted mode DEFAULT for EMU_EM4CTRL */
-#define EMU_EM4CTRL_RETAINLFXO                       (0x1UL << 2)                               /**< LFXO Retain during EM4 */
+#define EMU_EM4CTRL_RETAINLFXO                       (0x1UL << 2)                               /**< LFXO Retain During EM4 */
 #define _EMU_EM4CTRL_RETAINLFXO_SHIFT                2                                          /**< Shift value for EMU_RETAINLFXO */
 #define _EMU_EM4CTRL_RETAINLFXO_MASK                 0x4UL                                      /**< Bit mask for EMU_RETAINLFXO */
 #define _EMU_EM4CTRL_RETAINLFXO_DEFAULT              0x00000000UL                               /**< Mode DEFAULT for EMU_EM4CTRL */
 #define EMU_EM4CTRL_RETAINLFXO_DEFAULT               (_EMU_EM4CTRL_RETAINLFXO_DEFAULT << 2)     /**< Shifted mode DEFAULT for EMU_EM4CTRL */
-#define EMU_EM4CTRL_RETAINULFRCO                     (0x1UL << 3)                               /**< ULFRCO Retain during EM4S */
+#define EMU_EM4CTRL_RETAINULFRCO                     (0x1UL << 3)                               /**< ULFRCO Retain During EM4S */
 #define _EMU_EM4CTRL_RETAINULFRCO_SHIFT              3                                          /**< Shift value for EMU_RETAINULFRCO */
 #define _EMU_EM4CTRL_RETAINULFRCO_MASK               0x8UL                                      /**< Bit mask for EMU_RETAINULFRCO */
 #define _EMU_EM4CTRL_RETAINULFRCO_DEFAULT            0x00000000UL                               /**< Mode DEFAULT for EMU_EM4CTRL */
@@ -258,7 +258,7 @@ typedef struct {
 #define _EMU_TEMPLIMITS_TEMPHIGH_MASK                0xFF00UL                                /**< Bit mask for EMU_TEMPHIGH */
 #define _EMU_TEMPLIMITS_TEMPHIGH_DEFAULT             0x000000FFUL                            /**< Mode DEFAULT for EMU_TEMPLIMITS */
 #define EMU_TEMPLIMITS_TEMPHIGH_DEFAULT              (_EMU_TEMPLIMITS_TEMPHIGH_DEFAULT << 8) /**< Shifted mode DEFAULT for EMU_TEMPLIMITS */
-#define EMU_TEMPLIMITS_EM4WUEN                       (0x1UL << 16)                           /**< Enable EM4 Wakeup due to low/high temperature */
+#define EMU_TEMPLIMITS_EM4WUEN                       (0x1UL << 16)                           /**< Enable EM4 Wakeup Due to Low/high Temperature */
 #define _EMU_TEMPLIMITS_EM4WUEN_SHIFT                16                                      /**< Shift value for EMU_EM4WUEN */
 #define _EMU_TEMPLIMITS_EM4WUEN_MASK                 0x10000UL                               /**< Bit mask for EMU_EM4WUEN */
 #define _EMU_TEMPLIMITS_EM4WUEN_DEFAULT              0x00000000UL                            /**< Mode DEFAULT for EMU_TEMPLIMITS */
@@ -325,32 +325,32 @@ typedef struct {
 #define _EMU_IF_VMONFVDDRISE_MASK                    0x8000UL                                     /**< Bit mask for EMU_VMONFVDDRISE */
 #define _EMU_IF_VMONFVDDRISE_DEFAULT                 0x00000000UL                                 /**< Mode DEFAULT for EMU_IF */
 #define EMU_IF_VMONFVDDRISE_DEFAULT                  (_EMU_IF_VMONFVDDRISE_DEFAULT << 15)         /**< Shifted mode DEFAULT for EMU_IF */
-#define EMU_IF_PFETOVERCURRENTLIMIT                  (0x1UL << 16)                                /**< PFET current limit hit */
+#define EMU_IF_PFETOVERCURRENTLIMIT                  (0x1UL << 16)                                /**< PFET Current Limit Hit */
 #define _EMU_IF_PFETOVERCURRENTLIMIT_SHIFT           16                                           /**< Shift value for EMU_PFETOVERCURRENTLIMIT */
 #define _EMU_IF_PFETOVERCURRENTLIMIT_MASK            0x10000UL                                    /**< Bit mask for EMU_PFETOVERCURRENTLIMIT */
 #define _EMU_IF_PFETOVERCURRENTLIMIT_DEFAULT         0x00000000UL                                 /**< Mode DEFAULT for EMU_IF */
 #define EMU_IF_PFETOVERCURRENTLIMIT_DEFAULT          (_EMU_IF_PFETOVERCURRENTLIMIT_DEFAULT << 16) /**< Shifted mode DEFAULT for EMU_IF */
-#define EMU_IF_NFETOVERCURRENTLIMIT                  (0x1UL << 17)                                /**< NFET current limit hit */
+#define EMU_IF_NFETOVERCURRENTLIMIT                  (0x1UL << 17)                                /**< NFET Current Limit Hit */
 #define _EMU_IF_NFETOVERCURRENTLIMIT_SHIFT           17                                           /**< Shift value for EMU_NFETOVERCURRENTLIMIT */
 #define _EMU_IF_NFETOVERCURRENTLIMIT_MASK            0x20000UL                                    /**< Bit mask for EMU_NFETOVERCURRENTLIMIT */
 #define _EMU_IF_NFETOVERCURRENTLIMIT_DEFAULT         0x00000000UL                                 /**< Mode DEFAULT for EMU_IF */
 #define EMU_IF_NFETOVERCURRENTLIMIT_DEFAULT          (_EMU_IF_NFETOVERCURRENTLIMIT_DEFAULT << 17) /**< Shifted mode DEFAULT for EMU_IF */
-#define EMU_IF_DCDCLPRUNNING                         (0x1UL << 18)                                /**< LP mode is running */
+#define EMU_IF_DCDCLPRUNNING                         (0x1UL << 18)                                /**< LP Mode is Running */
 #define _EMU_IF_DCDCLPRUNNING_SHIFT                  18                                           /**< Shift value for EMU_DCDCLPRUNNING */
 #define _EMU_IF_DCDCLPRUNNING_MASK                   0x40000UL                                    /**< Bit mask for EMU_DCDCLPRUNNING */
 #define _EMU_IF_DCDCLPRUNNING_DEFAULT                0x00000000UL                                 /**< Mode DEFAULT for EMU_IF */
 #define EMU_IF_DCDCLPRUNNING_DEFAULT                 (_EMU_IF_DCDCLPRUNNING_DEFAULT << 18)        /**< Shifted mode DEFAULT for EMU_IF */
-#define EMU_IF_DCDCLNRUNNING                         (0x1UL << 19)                                /**< LN mode is running */
+#define EMU_IF_DCDCLNRUNNING                         (0x1UL << 19)                                /**< LN Mode is Running */
 #define _EMU_IF_DCDCLNRUNNING_SHIFT                  19                                           /**< Shift value for EMU_DCDCLNRUNNING */
 #define _EMU_IF_DCDCLNRUNNING_MASK                   0x80000UL                                    /**< Bit mask for EMU_DCDCLNRUNNING */
 #define _EMU_IF_DCDCLNRUNNING_DEFAULT                0x00000000UL                                 /**< Mode DEFAULT for EMU_IF */
 #define EMU_IF_DCDCLNRUNNING_DEFAULT                 (_EMU_IF_DCDCLNRUNNING_DEFAULT << 19)        /**< Shifted mode DEFAULT for EMU_IF */
-#define EMU_IF_DCDCINBYPASS                          (0x1UL << 20)                                /**< DCDC is in bypass */
+#define EMU_IF_DCDCINBYPASS                          (0x1UL << 20)                                /**< DCDC is in Bypass */
 #define _EMU_IF_DCDCINBYPASS_SHIFT                   20                                           /**< Shift value for EMU_DCDCINBYPASS */
 #define _EMU_IF_DCDCINBYPASS_MASK                    0x100000UL                                   /**< Bit mask for EMU_DCDCINBYPASS */
 #define _EMU_IF_DCDCINBYPASS_DEFAULT                 0x00000000UL                                 /**< Mode DEFAULT for EMU_IF */
 #define EMU_IF_DCDCINBYPASS_DEFAULT                  (_EMU_IF_DCDCINBYPASS_DEFAULT << 20)         /**< Shifted mode DEFAULT for EMU_IF */
-#define EMU_IF_EM23WAKEUP                            (0x1UL << 24)                                /**< Wakeup IRQ from EM2 and EM3 */
+#define EMU_IF_EM23WAKEUP                            (0x1UL << 24)                                /**< Wakeup IRQ From EM2 and EM3 */
 #define _EMU_IF_EM23WAKEUP_SHIFT                     24                                           /**< Shift value for EMU_EM23WAKEUP */
 #define _EMU_IF_EM23WAKEUP_MASK                      0x1000000UL                                  /**< Bit mask for EMU_EM23WAKEUP */
 #define _EMU_IF_EM23WAKEUP_DEFAULT                   0x00000000UL                                 /**< Mode DEFAULT for EMU_IF */
@@ -746,7 +746,7 @@ typedef struct {
 /* Bit fields for EMU DCDCMISCCTRL */
 #define _EMU_DCDCMISCCTRL_RESETVALUE                 0x33307700UL                                    /**< Default value for EMU_DCDCMISCCTRL */
 #define _EMU_DCDCMISCCTRL_MASK                       0x377FFF01UL                                    /**< Mask for EMU_DCDCMISCCTRL */
-#define EMU_DCDCMISCCTRL_LNFORCECCM                  (0x1UL << 0)                                    /**< Force DCDC into CCM mode in low noise operation */
+#define EMU_DCDCMISCCTRL_LNFORCECCM                  (0x1UL << 0)                                    /**< Force DCDC Into CCM Mode in Low Noise Operation */
 #define _EMU_DCDCMISCCTRL_LNFORCECCM_SHIFT           0                                               /**< Shift value for EMU_LNFORCECCM */
 #define _EMU_DCDCMISCCTRL_LNFORCECCM_MASK            0x1UL                                           /**< Bit mask for EMU_LNFORCECCM */
 #define _EMU_DCDCMISCCTRL_LNFORCECCM_DEFAULT         0x00000000UL                                    /**< Mode DEFAULT for EMU_DCDCMISCCTRL */
@@ -861,7 +861,7 @@ typedef struct {
 #define _EMU_DCDCTIMING_LPINITWAIT_MASK              0xFFUL                                        /**< Bit mask for EMU_LPINITWAIT */
 #define _EMU_DCDCTIMING_LPINITWAIT_DEFAULT           0x000000FFUL                                  /**< Mode DEFAULT for EMU_DCDCTIMING */
 #define EMU_DCDCTIMING_LPINITWAIT_DEFAULT            (_EMU_DCDCTIMING_LPINITWAIT_DEFAULT << 0)     /**< Shifted mode DEFAULT for EMU_DCDCTIMING */
-#define EMU_DCDCTIMING_COMPENPRCHGEN                 (0x1UL << 11)                                 /**< LN mode precharge enable */
+#define EMU_DCDCTIMING_COMPENPRCHGEN                 (0x1UL << 11)                                 /**< LN Mode Precharge Enable */
 #define _EMU_DCDCTIMING_COMPENPRCHGEN_SHIFT          11                                            /**< Shift value for EMU_COMPENPRCHGEN */
 #define _EMU_DCDCTIMING_COMPENPRCHGEN_MASK           0x800UL                                       /**< Bit mask for EMU_COMPENPRCHGEN */
 #define _EMU_DCDCTIMING_COMPENPRCHGEN_DEFAULT        0x00000001UL                                  /**< Mode DEFAULT for EMU_DCDCTIMING */
@@ -882,7 +882,7 @@ typedef struct {
 /* Bit fields for EMU DCDCLPVCTRL */
 #define _EMU_DCDCLPVCTRL_RESETVALUE                  0x00000168UL                           /**< Default value for EMU_DCDCLPVCTRL */
 #define _EMU_DCDCLPVCTRL_MASK                        0x000001FFUL                           /**< Mask for EMU_DCDCLPVCTRL */
-#define EMU_DCDCLPVCTRL_LPATT                        (0x1UL << 0)                           /**< Low power feedback attenuation */
+#define EMU_DCDCLPVCTRL_LPATT                        (0x1UL << 0)                           /**< Low Power Feedback Attenuation */
 #define _EMU_DCDCLPVCTRL_LPATT_SHIFT                 0                                      /**< Shift value for EMU_LPATT */
 #define _EMU_DCDCLPVCTRL_LPATT_MASK                  0x1UL                                  /**< Bit mask for EMU_LPATT */
 #define _EMU_DCDCLPVCTRL_LPATT_DEFAULT               0x00000000UL                           /**< Mode DEFAULT for EMU_DCDCLPVCTRL */
@@ -903,7 +903,7 @@ typedef struct {
 #define _EMU_DCDCLPCTRL_LPCMPHYSSEL_MASK             0xF000UL                                     /**< Bit mask for EMU_LPCMPHYSSEL */
 #define _EMU_DCDCLPCTRL_LPCMPHYSSEL_DEFAULT          0x00000007UL                                 /**< Mode DEFAULT for EMU_DCDCLPCTRL */
 #define EMU_DCDCLPCTRL_LPCMPHYSSEL_DEFAULT           (_EMU_DCDCLPCTRL_LPCMPHYSSEL_DEFAULT << 12)  /**< Shifted mode DEFAULT for EMU_DCDCLPCTRL */
-#define EMU_DCDCLPCTRL_LPVREFDUTYEN                  (0x1UL << 24)                                /**< LP mode duty cycling enable */
+#define EMU_DCDCLPCTRL_LPVREFDUTYEN                  (0x1UL << 24)                                /**< LP Mode Duty Cycling Enable */
 #define _EMU_DCDCLPCTRL_LPVREFDUTYEN_SHIFT           24                                           /**< Shift value for EMU_LPVREFDUTYEN */
 #define _EMU_DCDCLPCTRL_LPVREFDUTYEN_MASK            0x1000000UL                                  /**< Bit mask for EMU_LPVREFDUTYEN */
 #define _EMU_DCDCLPCTRL_LPVREFDUTYEN_DEFAULT         0x00000000UL                                 /**< Mode DEFAULT for EMU_DCDCLPCTRL */
@@ -928,7 +928,7 @@ typedef struct {
 /* Bit fields for EMU DCDCSYNC */
 #define _EMU_DCDCSYNC_RESETVALUE                     0x00000000UL                              /**< Default value for EMU_DCDCSYNC */
 #define _EMU_DCDCSYNC_MASK                           0x00000001UL                              /**< Mask for EMU_DCDCSYNC */
-#define EMU_DCDCSYNC_DCDCCTRLBUSY                    (0x1UL << 0)                              /**< DCDC CTRL Register Transfer Busy. */
+#define EMU_DCDCSYNC_DCDCCTRLBUSY                    (0x1UL << 0)                              /**< DCDC CTRL Register Transfer Busy */
 #define _EMU_DCDCSYNC_DCDCCTRLBUSY_SHIFT             0                                         /**< Shift value for EMU_DCDCCTRLBUSY */
 #define _EMU_DCDCSYNC_DCDCCTRLBUSY_MASK              0x1UL                                     /**< Bit mask for EMU_DCDCCTRLBUSY */
 #define _EMU_DCDCSYNC_DCDCCTRLBUSY_DEFAULT           0x00000000UL                              /**< Mode DEFAULT for EMU_DCDCSYNC */
@@ -1041,7 +1041,7 @@ typedef struct {
 #define _EMU_VMONIO0CTRL_FALLWU_MASK                 0x8UL                                        /**< Bit mask for EMU_FALLWU */
 #define _EMU_VMONIO0CTRL_FALLWU_DEFAULT              0x00000000UL                                 /**< Mode DEFAULT for EMU_VMONIO0CTRL */
 #define EMU_VMONIO0CTRL_FALLWU_DEFAULT               (_EMU_VMONIO0CTRL_FALLWU_DEFAULT << 3)       /**< Shifted mode DEFAULT for EMU_VMONIO0CTRL */
-#define EMU_VMONIO0CTRL_RETDIS                       (0x1UL << 4)                                 /**< EM4 IO0 Retention disable */
+#define EMU_VMONIO0CTRL_RETDIS                       (0x1UL << 4)                                 /**< EM4 IO0 Retention Disable */
 #define _EMU_VMONIO0CTRL_RETDIS_SHIFT                4                                            /**< Shift value for EMU_RETDIS */
 #define _EMU_VMONIO0CTRL_RETDIS_MASK                 0x10UL                                       /**< Bit mask for EMU_RETDIS */
 #define _EMU_VMONIO0CTRL_RETDIS_DEFAULT              0x00000000UL                                 /**< Mode DEFAULT for EMU_VMONIO0CTRL */

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_fpueh.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_fpueh.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efr32mg1p_fpueh.h
  * @brief EFR32MG1P_FPUEH register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_gpcrc.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_gpcrc.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efr32mg1p_gpcrc.h
  * @brief EFR32MG1P_GPCRC register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_gpio.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_gpio.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efr32mg1p_gpio.h
  * @brief EFR32MG1P_GPIO register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,
@@ -66,7 +66,7 @@ typedef struct {
   __IOM uint32_t IFS;            /**< Interrupt Flag Set Register  */
   __IOM uint32_t IFC;            /**< Interrupt Flag Clear Register  */
   __IOM uint32_t IEN;            /**< Interrupt Enable Register  */
-  __IOM uint32_t EM4WUEN;        /**< EM4 wake up Enable Register  */
+  __IOM uint32_t EM4WUEN;        /**< EM4 Wake Up Enable Register  */
 
   uint32_t       RESERVED1[4];   /**< Reserved for future use **/
   __IOM uint32_t ROUTEPEN;       /**< I/O Routing Pin Enable Register  */
@@ -87,7 +87,7 @@ typedef struct {
 /* Bit fields for GPIO P_CTRL */
 #define _GPIO_P_CTRL_RESETVALUE                         0x00500050UL                                  /**< Default value for GPIO_P_CTRL */
 #define _GPIO_P_CTRL_MASK                               0x10711071UL                                  /**< Mask for GPIO_P_CTRL */
-#define GPIO_P_CTRL_DRIVESTRENGTH                       (0x1UL << 0)                                  /**< Drive strength for port */
+#define GPIO_P_CTRL_DRIVESTRENGTH                       (0x1UL << 0)                                  /**< Drive Strength for Port */
 #define _GPIO_P_CTRL_DRIVESTRENGTH_SHIFT                0                                             /**< Shift value for GPIO_DRIVESTRENGTH */
 #define _GPIO_P_CTRL_DRIVESTRENGTH_MASK                 0x1UL                                         /**< Bit mask for GPIO_DRIVESTRENGTH */
 #define _GPIO_P_CTRL_DRIVESTRENGTH_DEFAULT              0x00000000UL                                  /**< Mode DEFAULT for GPIO_P_CTRL */
@@ -100,12 +100,12 @@ typedef struct {
 #define _GPIO_P_CTRL_SLEWRATE_MASK                      0x70UL                                        /**< Bit mask for GPIO_SLEWRATE */
 #define _GPIO_P_CTRL_SLEWRATE_DEFAULT                   0x00000005UL                                  /**< Mode DEFAULT for GPIO_P_CTRL */
 #define GPIO_P_CTRL_SLEWRATE_DEFAULT                    (_GPIO_P_CTRL_SLEWRATE_DEFAULT << 4)          /**< Shifted mode DEFAULT for GPIO_P_CTRL */
-#define GPIO_P_CTRL_DINDIS                              (0x1UL << 12)                                 /**< Data In Disable */
+#define GPIO_P_CTRL_DINDIS                              (0x1UL << 12)                                 /**< Data in Disable */
 #define _GPIO_P_CTRL_DINDIS_SHIFT                       12                                            /**< Shift value for GPIO_DINDIS */
 #define _GPIO_P_CTRL_DINDIS_MASK                        0x1000UL                                      /**< Bit mask for GPIO_DINDIS */
 #define _GPIO_P_CTRL_DINDIS_DEFAULT                     0x00000000UL                                  /**< Mode DEFAULT for GPIO_P_CTRL */
 #define GPIO_P_CTRL_DINDIS_DEFAULT                      (_GPIO_P_CTRL_DINDIS_DEFAULT << 12)           /**< Shifted mode DEFAULT for GPIO_P_CTRL */
-#define GPIO_P_CTRL_DRIVESTRENGTHALT                    (0x1UL << 16)                                 /**< Alternate drive strength for port */
+#define GPIO_P_CTRL_DRIVESTRENGTHALT                    (0x1UL << 16)                                 /**< Alternate Drive Strength for Port */
 #define _GPIO_P_CTRL_DRIVESTRENGTHALT_SHIFT             16                                            /**< Shift value for GPIO_DRIVESTRENGTHALT */
 #define _GPIO_P_CTRL_DRIVESTRENGTHALT_MASK              0x10000UL                                     /**< Bit mask for GPIO_DRIVESTRENGTHALT */
 #define _GPIO_P_CTRL_DRIVESTRENGTHALT_DEFAULT           0x00000000UL                                  /**< Mode DEFAULT for GPIO_P_CTRL */
@@ -118,7 +118,7 @@ typedef struct {
 #define _GPIO_P_CTRL_SLEWRATEALT_MASK                   0x700000UL                                    /**< Bit mask for GPIO_SLEWRATEALT */
 #define _GPIO_P_CTRL_SLEWRATEALT_DEFAULT                0x00000005UL                                  /**< Mode DEFAULT for GPIO_P_CTRL */
 #define GPIO_P_CTRL_SLEWRATEALT_DEFAULT                 (_GPIO_P_CTRL_SLEWRATEALT_DEFAULT << 20)      /**< Shifted mode DEFAULT for GPIO_P_CTRL */
-#define GPIO_P_CTRL_DINDISALT                           (0x1UL << 28)                                 /**< Alternate Data In Disable */
+#define GPIO_P_CTRL_DINDISALT                           (0x1UL << 28)                                 /**< Alternate Data in Disable */
 #define _GPIO_P_CTRL_DINDISALT_SHIFT                    28                                            /**< Shift value for GPIO_DINDISALT */
 #define _GPIO_P_CTRL_DINDISALT_MASK                     0x10000000UL                                  /**< Bit mask for GPIO_DINDISALT */
 #define _GPIO_P_CTRL_DINDISALT_DEFAULT                  0x00000000UL                                  /**< Mode DEFAULT for GPIO_P_CTRL */

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_gpio_p.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_gpio_p.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efr32mg1p_gpio_p.h
  * @brief EFR32MG1P_GPIO_P register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,
@@ -56,10 +56,10 @@ typedef struct {
   __IOM uint32_t DOUT;         /**< Port Data Out Register  */
   uint32_t       RESERVED0[2]; /**< Reserved for future use **/
   __IOM uint32_t DOUTTGL;      /**< Port Data Out Toggle Register  */
-  __IM uint32_t  DIN;          /**< Port Data In Register  */
+  __IM uint32_t  DIN;          /**< Port Data in Register  */
   __IOM uint32_t PINLOCKN;     /**< Port Unlocked Pins Register  */
   uint32_t       RESERVED1[1]; /**< Reserved for future use **/
-  __IOM uint32_t OVTDIS;       /**< Over Voltage Disable for all modes  */
+  __IOM uint32_t OVTDIS;       /**< Over Voltage Disable for All Modes  */
   uint32_t       RESERVED2[1]; /**< Reserved future */
 } GPIO_P_TypeDef;
 

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_i2c.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_i2c.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efr32mg1p_i2c.h
  * @brief EFR32MG1P_I2C register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,
@@ -98,7 +98,7 @@ typedef struct {
 #define _I2C_CTRL_AUTOACK_MASK             0x4UL                            /**< Bit mask for I2C_AUTOACK */
 #define _I2C_CTRL_AUTOACK_DEFAULT          0x00000000UL                     /**< Mode DEFAULT for I2C_CTRL */
 #define I2C_CTRL_AUTOACK_DEFAULT           (_I2C_CTRL_AUTOACK_DEFAULT << 2) /**< Shifted mode DEFAULT for I2C_CTRL */
-#define I2C_CTRL_AUTOSE                    (0x1UL << 3)                     /**< Automatic STOP when Empty */
+#define I2C_CTRL_AUTOSE                    (0x1UL << 3)                     /**< Automatic STOP When Empty */
 #define _I2C_CTRL_AUTOSE_SHIFT             3                                /**< Shift value for I2C_AUTOSE */
 #define _I2C_CTRL_AUTOSE_MASK              0x8UL                            /**< Bit mask for I2C_AUTOSE */
 #define _I2C_CTRL_AUTOSE_DEFAULT           0x00000000UL                     /**< Mode DEFAULT for I2C_CTRL */
@@ -149,7 +149,7 @@ typedef struct {
 #define I2C_CTRL_BITO_40PCC                (_I2C_CTRL_BITO_40PCC << 12)     /**< Shifted mode 40PCC for I2C_CTRL */
 #define I2C_CTRL_BITO_80PCC                (_I2C_CTRL_BITO_80PCC << 12)     /**< Shifted mode 80PCC for I2C_CTRL */
 #define I2C_CTRL_BITO_160PCC               (_I2C_CTRL_BITO_160PCC << 12)    /**< Shifted mode 160PCC for I2C_CTRL */
-#define I2C_CTRL_GIBITO                    (0x1UL << 15)                    /**< Go Idle on Bus Idle Timeout  */
+#define I2C_CTRL_GIBITO                    (0x1UL << 15)                    /**< Go Idle on Bus Idle Timeout */
 #define _I2C_CTRL_GIBITO_SHIFT             15                               /**< Shift value for I2C_GIBITO */
 #define _I2C_CTRL_GIBITO_MASK              0x8000UL                         /**< Bit mask for I2C_GIBITO */
 #define _I2C_CTRL_GIBITO_DEFAULT           0x00000000UL                     /**< Mode DEFAULT for I2C_CTRL */
@@ -174,12 +174,12 @@ typedef struct {
 /* Bit fields for I2C CMD */
 #define _I2C_CMD_RESETVALUE                0x00000000UL                    /**< Default value for I2C_CMD */
 #define _I2C_CMD_MASK                      0x000000FFUL                    /**< Mask for I2C_CMD */
-#define I2C_CMD_START                      (0x1UL << 0)                    /**< Send start condition */
+#define I2C_CMD_START                      (0x1UL << 0)                    /**< Send Start Condition */
 #define _I2C_CMD_START_SHIFT               0                               /**< Shift value for I2C_START */
 #define _I2C_CMD_START_MASK                0x1UL                           /**< Bit mask for I2C_START */
 #define _I2C_CMD_START_DEFAULT             0x00000000UL                    /**< Mode DEFAULT for I2C_CMD */
 #define I2C_CMD_START_DEFAULT              (_I2C_CMD_START_DEFAULT << 0)   /**< Shifted mode DEFAULT for I2C_CMD */
-#define I2C_CMD_STOP                       (0x1UL << 1)                    /**< Send stop condition */
+#define I2C_CMD_STOP                       (0x1UL << 1)                    /**< Send Stop Condition */
 #define _I2C_CMD_STOP_SHIFT                1                               /**< Shift value for I2C_STOP */
 #define _I2C_CMD_STOP_MASK                 0x2UL                           /**< Bit mask for I2C_STOP */
 #define _I2C_CMD_STOP_DEFAULT              0x00000000UL                    /**< Mode DEFAULT for I2C_CMD */
@@ -194,12 +194,12 @@ typedef struct {
 #define _I2C_CMD_NACK_MASK                 0x8UL                           /**< Bit mask for I2C_NACK */
 #define _I2C_CMD_NACK_DEFAULT              0x00000000UL                    /**< Mode DEFAULT for I2C_CMD */
 #define I2C_CMD_NACK_DEFAULT               (_I2C_CMD_NACK_DEFAULT << 3)    /**< Shifted mode DEFAULT for I2C_CMD */
-#define I2C_CMD_CONT                       (0x1UL << 4)                    /**< Continue transmission */
+#define I2C_CMD_CONT                       (0x1UL << 4)                    /**< Continue Transmission */
 #define _I2C_CMD_CONT_SHIFT                4                               /**< Shift value for I2C_CONT */
 #define _I2C_CMD_CONT_MASK                 0x10UL                          /**< Bit mask for I2C_CONT */
 #define _I2C_CMD_CONT_DEFAULT              0x00000000UL                    /**< Mode DEFAULT for I2C_CMD */
 #define I2C_CMD_CONT_DEFAULT               (_I2C_CMD_CONT_DEFAULT << 4)    /**< Shifted mode DEFAULT for I2C_CMD */
-#define I2C_CMD_ABORT                      (0x1UL << 5)                    /**< Abort transmission */
+#define I2C_CMD_ABORT                      (0x1UL << 5)                    /**< Abort Transmission */
 #define _I2C_CMD_ABORT_SHIFT               5                               /**< Shift value for I2C_ABORT */
 #define _I2C_CMD_ABORT_MASK                0x20UL                          /**< Bit mask for I2C_ABORT */
 #define _I2C_CMD_ABORT_DEFAULT             0x00000000UL                    /**< Mode DEFAULT for I2C_CMD */
@@ -285,12 +285,12 @@ typedef struct {
 #define _I2C_STATUS_PNACK_MASK             0x8UL                              /**< Bit mask for I2C_PNACK */
 #define _I2C_STATUS_PNACK_DEFAULT          0x00000000UL                       /**< Mode DEFAULT for I2C_STATUS */
 #define I2C_STATUS_PNACK_DEFAULT           (_I2C_STATUS_PNACK_DEFAULT << 3)   /**< Shifted mode DEFAULT for I2C_STATUS */
-#define I2C_STATUS_PCONT                   (0x1UL << 4)                       /**< Pending continue */
+#define I2C_STATUS_PCONT                   (0x1UL << 4)                       /**< Pending Continue */
 #define _I2C_STATUS_PCONT_SHIFT            4                                  /**< Shift value for I2C_PCONT */
 #define _I2C_STATUS_PCONT_MASK             0x10UL                             /**< Bit mask for I2C_PCONT */
 #define _I2C_STATUS_PCONT_DEFAULT          0x00000000UL                       /**< Mode DEFAULT for I2C_STATUS */
 #define I2C_STATUS_PCONT_DEFAULT           (_I2C_STATUS_PCONT_DEFAULT << 4)   /**< Shifted mode DEFAULT for I2C_STATUS */
-#define I2C_STATUS_PABORT                  (0x1UL << 5)                       /**< Pending abort */
+#define I2C_STATUS_PABORT                  (0x1UL << 5)                       /**< Pending Abort */
 #define _I2C_STATUS_PABORT_SHIFT           5                                  /**< Shift value for I2C_PABORT */
 #define _I2C_STATUS_PABORT_MASK            0x20UL                             /**< Bit mask for I2C_PABORT */
 #define _I2C_STATUS_PABORT_DEFAULT         0x00000000UL                       /**< Mode DEFAULT for I2C_STATUS */
@@ -403,12 +403,12 @@ typedef struct {
 /* Bit fields for I2C IF */
 #define _I2C_IF_RESETVALUE                 0x00000010UL                    /**< Default value for I2C_IF */
 #define _I2C_IF_MASK                       0x0007FFFFUL                    /**< Mask for I2C_IF */
-#define I2C_IF_START                       (0x1UL << 0)                    /**< START condition Interrupt Flag */
+#define I2C_IF_START                       (0x1UL << 0)                    /**< START Condition Interrupt Flag */
 #define _I2C_IF_START_SHIFT                0                               /**< Shift value for I2C_START */
 #define _I2C_IF_START_MASK                 0x1UL                           /**< Bit mask for I2C_START */
 #define _I2C_IF_START_DEFAULT              0x00000000UL                    /**< Mode DEFAULT for I2C_IF */
 #define I2C_IF_START_DEFAULT               (_I2C_IF_START_DEFAULT << 0)    /**< Shifted mode DEFAULT for I2C_IF */
-#define I2C_IF_RSTART                      (0x1UL << 1)                    /**< Repeated START condition Interrupt Flag */
+#define I2C_IF_RSTART                      (0x1UL << 1)                    /**< Repeated START Condition Interrupt Flag */
 #define _I2C_IF_RSTART_SHIFT               1                               /**< Shift value for I2C_RSTART */
 #define _I2C_IF_RSTART_MASK                0x2UL                           /**< Bit mask for I2C_RSTART */
 #define _I2C_IF_RSTART_DEFAULT             0x00000000UL                    /**< Mode DEFAULT for I2C_IF */
@@ -483,7 +483,7 @@ typedef struct {
 #define _I2C_IF_CLTO_MASK                  0x8000UL                        /**< Bit mask for I2C_CLTO */
 #define _I2C_IF_CLTO_DEFAULT               0x00000000UL                    /**< Mode DEFAULT for I2C_IF */
 #define I2C_IF_CLTO_DEFAULT                (_I2C_IF_CLTO_DEFAULT << 15)    /**< Shifted mode DEFAULT for I2C_IF */
-#define I2C_IF_SSTOP                       (0x1UL << 16)                   /**< Slave STOP condition Interrupt Flag */
+#define I2C_IF_SSTOP                       (0x1UL << 16)                   /**< Slave STOP Condition Interrupt Flag */
 #define _I2C_IF_SSTOP_SHIFT                16                              /**< Shift value for I2C_SSTOP */
 #define _I2C_IF_SSTOP_MASK                 0x10000UL                       /**< Bit mask for I2C_SSTOP */
 #define _I2C_IF_SSTOP_DEFAULT              0x00000000UL                    /**< Mode DEFAULT for I2C_IF */

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_idac.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_idac.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efr32mg1p_idac.h
  * @brief EFR32MG1P_IDAC register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,
@@ -247,7 +247,7 @@ typedef struct {
 /* Bit fields for IDAC DUTYCONFIG */
 #define _IDAC_DUTYCONFIG_RESETVALUE                    0x00000000UL                                    /**< Default value for IDAC_DUTYCONFIG */
 #define _IDAC_DUTYCONFIG_MASK                          0x00000002UL                                    /**< Mask for IDAC_DUTYCONFIG */
-#define IDAC_DUTYCONFIG_EM2DUTYCYCLEDIS                (0x1UL << 1)                                    /**< Duty Cycle Enable. */
+#define IDAC_DUTYCONFIG_EM2DUTYCYCLEDIS                (0x1UL << 1)                                    /**< Duty Cycle Enable */
 #define _IDAC_DUTYCONFIG_EM2DUTYCYCLEDIS_SHIFT         1                                               /**< Shift value for IDAC_EM2DUTYCYCLEDIS */
 #define _IDAC_DUTYCONFIG_EM2DUTYCYCLEDIS_MASK          0x2UL                                           /**< Bit mask for IDAC_EM2DUTYCYCLEDIS */
 #define _IDAC_DUTYCONFIG_EM2DUTYCYCLEDIS_DEFAULT       0x00000000UL                                    /**< Mode DEFAULT for IDAC_DUTYCONFIG */
@@ -301,12 +301,12 @@ typedef struct {
 /* Bit fields for IDAC APORTREQ */
 #define _IDAC_APORTREQ_RESETVALUE                      0x00000000UL                             /**< Default value for IDAC_APORTREQ */
 #define _IDAC_APORTREQ_MASK                            0x0000000CUL                             /**< Mask for IDAC_APORTREQ */
-#define IDAC_APORTREQ_APORT1XREQ                       (0x1UL << 2)                             /**< 1 if the APORT bus connected to APORT1X is requested */
+#define IDAC_APORTREQ_APORT1XREQ                       (0x1UL << 2)                             /**< 1 If the APORT Bus Connected to APORT1X is Requested */
 #define _IDAC_APORTREQ_APORT1XREQ_SHIFT                2                                        /**< Shift value for IDAC_APORT1XREQ */
 #define _IDAC_APORTREQ_APORT1XREQ_MASK                 0x4UL                                    /**< Bit mask for IDAC_APORT1XREQ */
 #define _IDAC_APORTREQ_APORT1XREQ_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for IDAC_APORTREQ */
 #define IDAC_APORTREQ_APORT1XREQ_DEFAULT               (_IDAC_APORTREQ_APORT1XREQ_DEFAULT << 2) /**< Shifted mode DEFAULT for IDAC_APORTREQ */
-#define IDAC_APORTREQ_APORT1YREQ                       (0x1UL << 3)                             /**< 1 if the bus connected to APORT1Y is requested */
+#define IDAC_APORTREQ_APORT1YREQ                       (0x1UL << 3)                             /**< 1 If the Bus Connected to APORT1Y is Requested */
 #define _IDAC_APORTREQ_APORT1YREQ_SHIFT                3                                        /**< Shift value for IDAC_APORT1YREQ */
 #define _IDAC_APORTREQ_APORT1YREQ_MASK                 0x8UL                                    /**< Bit mask for IDAC_APORT1YREQ */
 #define _IDAC_APORTREQ_APORT1YREQ_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for IDAC_APORTREQ */
@@ -315,12 +315,12 @@ typedef struct {
 /* Bit fields for IDAC APORTCONFLICT */
 #define _IDAC_APORTCONFLICT_RESETVALUE                 0x00000000UL                                       /**< Default value for IDAC_APORTCONFLICT */
 #define _IDAC_APORTCONFLICT_MASK                       0x0000000CUL                                       /**< Mask for IDAC_APORTCONFLICT */
-#define IDAC_APORTCONFLICT_APORT1XCONFLICT             (0x1UL << 2)                                       /**< 1 if the bus connected to APORT1X is in conflict with another peripheral */
+#define IDAC_APORTCONFLICT_APORT1XCONFLICT             (0x1UL << 2)                                       /**< 1 If the Bus Connected to APORT1X is in Conflict With Another Peripheral */
 #define _IDAC_APORTCONFLICT_APORT1XCONFLICT_SHIFT      2                                                  /**< Shift value for IDAC_APORT1XCONFLICT */
 #define _IDAC_APORTCONFLICT_APORT1XCONFLICT_MASK       0x4UL                                              /**< Bit mask for IDAC_APORT1XCONFLICT */
 #define _IDAC_APORTCONFLICT_APORT1XCONFLICT_DEFAULT    0x00000000UL                                       /**< Mode DEFAULT for IDAC_APORTCONFLICT */
 #define IDAC_APORTCONFLICT_APORT1XCONFLICT_DEFAULT     (_IDAC_APORTCONFLICT_APORT1XCONFLICT_DEFAULT << 2) /**< Shifted mode DEFAULT for IDAC_APORTCONFLICT */
-#define IDAC_APORTCONFLICT_APORT1YCONFLICT             (0x1UL << 3)                                       /**< 1 if the bus connected to APORT1Y is in conflict with another peripheral */
+#define IDAC_APORTCONFLICT_APORT1YCONFLICT             (0x1UL << 3)                                       /**< 1 If the Bus Connected to APORT1Y is in Conflict With Another Peripheral */
 #define _IDAC_APORTCONFLICT_APORT1YCONFLICT_SHIFT      3                                                  /**< Shift value for IDAC_APORT1YCONFLICT */
 #define _IDAC_APORTCONFLICT_APORT1YCONFLICT_MASK       0x8UL                                              /**< Bit mask for IDAC_APORT1YCONFLICT */
 #define _IDAC_APORTCONFLICT_APORT1YCONFLICT_DEFAULT    0x00000000UL                                       /**< Mode DEFAULT for IDAC_APORTCONFLICT */

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_ldma.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_ldma.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efr32mg1p_ldma.h
  * @brief EFR32MG1P_LDMA register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,
@@ -69,7 +69,7 @@ typedef struct {
   __IM uint32_t   IF;           /**< Interrupt Flag Register  */
   __IOM uint32_t  IFS;          /**< Interrupt Flag Set Register  */
   __IOM uint32_t  IFC;          /**< Interrupt Flag Clear Register  */
-  __IOM uint32_t  IEN;          /**< Interrupt Enable register  */
+  __IOM uint32_t  IEN;          /**< Interrupt Enable Register  */
 
   uint32_t        RESERVED2[4]; /**< Reserved registers */
   LDMA_CH_TypeDef CH[8];        /**< DMA Channel Registers */

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_ldma_ch.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_ldma_ch.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efr32mg1p_ldma_ch.h
  * @brief EFR32MG1P_LDMA_CH register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_letimer.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_letimer.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efr32mg1p_letimer.h
  * @brief EFR32MG1P_LETIMER register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,
@@ -137,7 +137,7 @@ typedef struct {
 #define _LETIMER_CTRL_BUFTOP_MASK               0x100UL                                /**< Bit mask for LETIMER_BUFTOP */
 #define _LETIMER_CTRL_BUFTOP_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for LETIMER_CTRL */
 #define LETIMER_CTRL_BUFTOP_DEFAULT             (_LETIMER_CTRL_BUFTOP_DEFAULT << 8)    /**< Shifted mode DEFAULT for LETIMER_CTRL */
-#define LETIMER_CTRL_COMP0TOP                   (0x1UL << 9)                           /**< Compare Value 0 Is Top Value */
+#define LETIMER_CTRL_COMP0TOP                   (0x1UL << 9)                           /**< Compare Value 0 is Top Value */
 #define _LETIMER_CTRL_COMP0TOP_SHIFT            9                                      /**< Shift value for LETIMER_COMP0TOP */
 #define _LETIMER_CTRL_COMP0TOP_MASK             0x200UL                                /**< Bit mask for LETIMER_COMP0TOP */
 #define _LETIMER_CTRL_COMP0TOP_DEFAULT          0x00000000UL                           /**< Mode DEFAULT for LETIMER_CTRL */

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_leuart.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_leuart.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efr32mg1p_leuart.h
  * @brief EFR32MG1P_LEUART register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,
@@ -122,12 +122,12 @@ typedef struct {
 #define LEUART_CTRL_STOPBITS_DEFAULT             (_LEUART_CTRL_STOPBITS_DEFAULT << 4) /**< Shifted mode DEFAULT for LEUART_CTRL */
 #define LEUART_CTRL_STOPBITS_ONE                 (_LEUART_CTRL_STOPBITS_ONE << 4)     /**< Shifted mode ONE for LEUART_CTRL */
 #define LEUART_CTRL_STOPBITS_TWO                 (_LEUART_CTRL_STOPBITS_TWO << 4)     /**< Shifted mode TWO for LEUART_CTRL */
-#define LEUART_CTRL_INV                          (0x1UL << 5)                         /**< Invert Input And Output */
+#define LEUART_CTRL_INV                          (0x1UL << 5)                         /**< Invert Input and Output */
 #define _LEUART_CTRL_INV_SHIFT                   5                                    /**< Shift value for LEUART_INV */
 #define _LEUART_CTRL_INV_MASK                    0x20UL                               /**< Bit mask for LEUART_INV */
 #define _LEUART_CTRL_INV_DEFAULT                 0x00000000UL                         /**< Mode DEFAULT for LEUART_CTRL */
 #define LEUART_CTRL_INV_DEFAULT                  (_LEUART_CTRL_INV_DEFAULT << 5)      /**< Shifted mode DEFAULT for LEUART_CTRL */
-#define LEUART_CTRL_ERRSDMA                      (0x1UL << 6)                         /**< Clear RX DMA On Error */
+#define LEUART_CTRL_ERRSDMA                      (0x1UL << 6)                         /**< Clear RX DMA on Error */
 #define _LEUART_CTRL_ERRSDMA_SHIFT               6                                    /**< Shift value for LEUART_ERRSDMA */
 #define _LEUART_CTRL_ERRSDMA_MASK                0x40UL                               /**< Bit mask for LEUART_ERRSDMA */
 #define _LEUART_CTRL_ERRSDMA_DEFAULT             0x00000000UL                         /**< Mode DEFAULT for LEUART_CTRL */
@@ -338,7 +338,7 @@ typedef struct {
 #define _LEUART_TXDATAX_TXDATA_MASK              0x1FFUL                                 /**< Bit mask for LEUART_TXDATA */
 #define _LEUART_TXDATAX_TXDATA_DEFAULT           0x00000000UL                            /**< Mode DEFAULT for LEUART_TXDATAX */
 #define LEUART_TXDATAX_TXDATA_DEFAULT            (_LEUART_TXDATAX_TXDATA_DEFAULT << 0)   /**< Shifted mode DEFAULT for LEUART_TXDATAX */
-#define LEUART_TXDATAX_TXBREAK                   (0x1UL << 13)                           /**< Transmit Data As Break */
+#define LEUART_TXDATAX_TXBREAK                   (0x1UL << 13)                           /**< Transmit Data as Break */
 #define _LEUART_TXDATAX_TXBREAK_SHIFT            13                                      /**< Shift value for LEUART_TXBREAK */
 #define _LEUART_TXDATAX_TXBREAK_MASK             0x2000UL                                /**< Bit mask for LEUART_TXBREAK */
 #define _LEUART_TXDATAX_TXBREAK_DEFAULT          0x00000000UL                            /**< Mode DEFAULT for LEUART_TXDATAX */

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_msc.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_msc.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efr32mg1p_msc.h
  * @brief EFR32MG1P_MSC register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,
@@ -101,7 +101,7 @@ typedef struct {
 #define _MSC_CTRL_CLKDISFAULTEN_MASK            0x2UL                                  /**< Bit mask for MSC_CLKDISFAULTEN */
 #define _MSC_CTRL_CLKDISFAULTEN_DEFAULT         0x00000000UL                           /**< Mode DEFAULT for MSC_CTRL */
 #define MSC_CTRL_CLKDISFAULTEN_DEFAULT          (_MSC_CTRL_CLKDISFAULTEN_DEFAULT << 1) /**< Shifted mode DEFAULT for MSC_CTRL */
-#define MSC_CTRL_PWRUPONDEMAND                  (0x1UL << 2)                           /**< Power Up On Demand During Wake Up */
+#define MSC_CTRL_PWRUPONDEMAND                  (0x1UL << 2)                           /**< Power Up on Demand During Wake Up */
 #define _MSC_CTRL_PWRUPONDEMAND_SHIFT           2                                      /**< Shift value for MSC_PWRUPONDEMAND */
 #define _MSC_CTRL_PWRUPONDEMAND_MASK            0x4UL                                  /**< Bit mask for MSC_PWRUPONDEMAND */
 #define _MSC_CTRL_PWRUPONDEMAND_DEFAULT         0x00000000UL                           /**< Mode DEFAULT for MSC_CTRL */
@@ -157,7 +157,7 @@ typedef struct {
 /* Bit fields for MSC WRITECTRL */
 #define _MSC_WRITECTRL_RESETVALUE               0x00000000UL                                /**< Default value for MSC_WRITECTRL */
 #define _MSC_WRITECTRL_MASK                     0x00000003UL                                /**< Mask for MSC_WRITECTRL */
-#define MSC_WRITECTRL_WREN                      (0x1UL << 0)                                /**< Enable Write/Erase Controller  */
+#define MSC_WRITECTRL_WREN                      (0x1UL << 0)                                /**< Enable Write/Erase Controller */
 #define _MSC_WRITECTRL_WREN_SHIFT               0                                           /**< Shift value for MSC_WREN */
 #define _MSC_WRITECTRL_WREN_MASK                0x1UL                                       /**< Bit mask for MSC_WREN */
 #define _MSC_WRITECTRL_WREN_DEFAULT             0x00000000UL                                /**< Mode DEFAULT for MSC_WRITECTRL */
@@ -171,7 +171,7 @@ typedef struct {
 /* Bit fields for MSC WRITECMD */
 #define _MSC_WRITECMD_RESETVALUE                0x00000000UL                             /**< Default value for MSC_WRITECMD */
 #define _MSC_WRITECMD_MASK                      0x0000113FUL                             /**< Mask for MSC_WRITECMD */
-#define MSC_WRITECMD_LADDRIM                    (0x1UL << 0)                             /**< Load MSC_ADDRB into ADDR */
+#define MSC_WRITECMD_LADDRIM                    (0x1UL << 0)                             /**< Load MSC_ADDRB Into ADDR */
 #define _MSC_WRITECMD_LADDRIM_SHIFT             0                                        /**< Shift value for MSC_LADDRIM */
 #define _MSC_WRITECMD_LADDRIM_MASK              0x1UL                                    /**< Bit mask for MSC_LADDRIM */
 #define _MSC_WRITECMD_LADDRIM_DEFAULT           0x00000000UL                             /**< Mode DEFAULT for MSC_WRITECMD */
@@ -196,17 +196,17 @@ typedef struct {
 #define _MSC_WRITECMD_WRITETRIG_MASK            0x10UL                                   /**< Bit mask for MSC_WRITETRIG */
 #define _MSC_WRITECMD_WRITETRIG_DEFAULT         0x00000000UL                             /**< Mode DEFAULT for MSC_WRITECMD */
 #define MSC_WRITECMD_WRITETRIG_DEFAULT          (_MSC_WRITECMD_WRITETRIG_DEFAULT << 4)   /**< Shifted mode DEFAULT for MSC_WRITECMD */
-#define MSC_WRITECMD_ERASEABORT                 (0x1UL << 5)                             /**< Abort erase sequence */
+#define MSC_WRITECMD_ERASEABORT                 (0x1UL << 5)                             /**< Abort Erase Sequence */
 #define _MSC_WRITECMD_ERASEABORT_SHIFT          5                                        /**< Shift value for MSC_ERASEABORT */
 #define _MSC_WRITECMD_ERASEABORT_MASK           0x20UL                                   /**< Bit mask for MSC_ERASEABORT */
 #define _MSC_WRITECMD_ERASEABORT_DEFAULT        0x00000000UL                             /**< Mode DEFAULT for MSC_WRITECMD */
 #define MSC_WRITECMD_ERASEABORT_DEFAULT         (_MSC_WRITECMD_ERASEABORT_DEFAULT << 5)  /**< Shifted mode DEFAULT for MSC_WRITECMD */
-#define MSC_WRITECMD_ERASEMAIN0                 (0x1UL << 8)                             /**< Mass erase region 0 */
+#define MSC_WRITECMD_ERASEMAIN0                 (0x1UL << 8)                             /**< Mass Erase Region 0 */
 #define _MSC_WRITECMD_ERASEMAIN0_SHIFT          8                                        /**< Shift value for MSC_ERASEMAIN0 */
 #define _MSC_WRITECMD_ERASEMAIN0_MASK           0x100UL                                  /**< Bit mask for MSC_ERASEMAIN0 */
 #define _MSC_WRITECMD_ERASEMAIN0_DEFAULT        0x00000000UL                             /**< Mode DEFAULT for MSC_WRITECMD */
 #define MSC_WRITECMD_ERASEMAIN0_DEFAULT         (_MSC_WRITECMD_ERASEMAIN0_DEFAULT << 8)  /**< Shifted mode DEFAULT for MSC_WRITECMD */
-#define MSC_WRITECMD_CLEARWDATA                 (0x1UL << 12)                            /**< Clear WDATA state */
+#define MSC_WRITECMD_CLEARWDATA                 (0x1UL << 12)                            /**< Clear WDATA State */
 #define _MSC_WRITECMD_CLEARWDATA_SHIFT          12                                       /**< Shift value for MSC_CLEARWDATA */
 #define _MSC_WRITECMD_CLEARWDATA_MASK           0x1000UL                                 /**< Bit mask for MSC_CLEARWDATA */
 #define _MSC_WRITECMD_CLEARWDATA_DEFAULT        0x00000000UL                             /**< Mode DEFAULT for MSC_WRITECMD */
@@ -295,7 +295,7 @@ typedef struct {
 #define _MSC_IF_PWRUPF_MASK                     0x10UL                          /**< Bit mask for MSC_PWRUPF */
 #define _MSC_IF_PWRUPF_DEFAULT                  0x00000000UL                    /**< Mode DEFAULT for MSC_IF */
 #define MSC_IF_PWRUPF_DEFAULT                   (_MSC_IF_PWRUPF_DEFAULT << 4)   /**< Shifted mode DEFAULT for MSC_IF */
-#define MSC_IF_ICACHERR                         (0x1UL << 5)                    /**< iCache RAM Parity Error Flag */
+#define MSC_IF_ICACHERR                         (0x1UL << 5)                    /**< ICache RAM Parity Error Flag */
 #define _MSC_IF_ICACHERR_SHIFT                  5                               /**< Shift value for MSC_ICACHERR */
 #define _MSC_IF_ICACHERR_MASK                   0x20UL                          /**< Bit mask for MSC_ICACHERR */
 #define _MSC_IF_ICACHERR_DEFAULT                0x00000000UL                    /**< Mode DEFAULT for MSC_IF */

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_pcnt.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_pcnt.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efr32mg1p_pcnt.h
  * @brief EFR32MG1P_PCNT register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,
@@ -133,7 +133,7 @@ typedef struct {
 #define _PCNT_CTRL_HYST_MASK               0x100UL                               /**< Bit mask for PCNT_HYST */
 #define _PCNT_CTRL_HYST_DEFAULT            0x00000000UL                          /**< Mode DEFAULT for PCNT_CTRL */
 #define PCNT_CTRL_HYST_DEFAULT             (_PCNT_CTRL_HYST_DEFAULT << 8)        /**< Shifted mode DEFAULT for PCNT_CTRL */
-#define PCNT_CTRL_S1CDIR                   (0x1UL << 9)                          /**< Count direction determined by S1 */
+#define PCNT_CTRL_S1CDIR                   (0x1UL << 9)                          /**< Count Direction Determined By S1 */
 #define _PCNT_CTRL_S1CDIR_SHIFT            9                                     /**< Shift value for PCNT_S1CDIR */
 #define _PCNT_CTRL_S1CDIR_MASK             0x200UL                               /**< Bit mask for PCNT_S1CDIR */
 #define _PCNT_CTRL_S1CDIR_DEFAULT          0x00000000UL                          /**< Mode DEFAULT for PCNT_CTRL */
@@ -212,12 +212,12 @@ typedef struct {
 #define PCNT_CTRL_TCCCOMP_LTOE             (_PCNT_CTRL_TCCCOMP_LTOE << 22)       /**< Shifted mode LTOE for PCNT_CTRL */
 #define PCNT_CTRL_TCCCOMP_GTOE             (_PCNT_CTRL_TCCCOMP_GTOE << 22)       /**< Shifted mode GTOE for PCNT_CTRL */
 #define PCNT_CTRL_TCCCOMP_RANGE            (_PCNT_CTRL_TCCCOMP_RANGE << 22)      /**< Shifted mode RANGE for PCNT_CTRL */
-#define PCNT_CTRL_PRSGATEEN                (0x1UL << 24)                         /**< PRS gate enable */
+#define PCNT_CTRL_PRSGATEEN                (0x1UL << 24)                         /**< PRS Gate Enable */
 #define _PCNT_CTRL_PRSGATEEN_SHIFT         24                                    /**< Shift value for PCNT_PRSGATEEN */
 #define _PCNT_CTRL_PRSGATEEN_MASK          0x1000000UL                           /**< Bit mask for PCNT_PRSGATEEN */
 #define _PCNT_CTRL_PRSGATEEN_DEFAULT       0x00000000UL                          /**< Mode DEFAULT for PCNT_CTRL */
 #define PCNT_CTRL_PRSGATEEN_DEFAULT        (_PCNT_CTRL_PRSGATEEN_DEFAULT << 24)  /**< Shifted mode DEFAULT for PCNT_CTRL */
-#define PCNT_CTRL_TCCPRSPOL                (0x1UL << 25)                         /**< TCC PRS polarity select */
+#define PCNT_CTRL_TCCPRSPOL                (0x1UL << 25)                         /**< TCC PRS Polarity Select */
 #define _PCNT_CTRL_TCCPRSPOL_SHIFT         25                                    /**< Shift value for PCNT_TCCPRSPOL */
 #define _PCNT_CTRL_TCCPRSPOL_MASK          0x2000000UL                           /**< Bit mask for PCNT_TCCPRSPOL */
 #define _PCNT_CTRL_TCCPRSPOL_DEFAULT       0x00000000UL                          /**< Mode DEFAULT for PCNT_CTRL */
@@ -254,7 +254,7 @@ typedef struct {
 #define PCNT_CTRL_TCCPRSSEL_PRSCH9         (_PCNT_CTRL_TCCPRSSEL_PRSCH9 << 26)   /**< Shifted mode PRSCH9 for PCNT_CTRL */
 #define PCNT_CTRL_TCCPRSSEL_PRSCH10        (_PCNT_CTRL_TCCPRSSEL_PRSCH10 << 26)  /**< Shifted mode PRSCH10 for PCNT_CTRL */
 #define PCNT_CTRL_TCCPRSSEL_PRSCH11        (_PCNT_CTRL_TCCPRSSEL_PRSCH11 << 26)  /**< Shifted mode PRSCH11 for PCNT_CTRL */
-#define PCNT_CTRL_TOPBHFSEL                (0x1UL << 31)                         /**< TOPB High frequency value select */
+#define PCNT_CTRL_TOPBHFSEL                (0x1UL << 31)                         /**< TOPB High Frequency Value Select */
 #define _PCNT_CTRL_TOPBHFSEL_SHIFT         31                                    /**< Shift value for PCNT_TOPBHFSEL */
 #define _PCNT_CTRL_TOPBHFSEL_MASK          0x80000000UL                          /**< Bit mask for PCNT_TOPBHFSEL */
 #define _PCNT_CTRL_TOPBHFSEL_DEFAULT       0x00000000UL                          /**< Mode DEFAULT for PCNT_CTRL */
@@ -334,7 +334,7 @@ typedef struct {
 #define _PCNT_IF_AUXOF_MASK                0x8UL                           /**< Bit mask for PCNT_AUXOF */
 #define _PCNT_IF_AUXOF_DEFAULT             0x00000000UL                    /**< Mode DEFAULT for PCNT_IF */
 #define PCNT_IF_AUXOF_DEFAULT              (_PCNT_IF_AUXOF_DEFAULT << 3)   /**< Shifted mode DEFAULT for PCNT_IF */
-#define PCNT_IF_TCC                        (0x1UL << 4)                    /**< Triggered compare Interrupt Read Flag */
+#define PCNT_IF_TCC                        (0x1UL << 4)                    /**< Triggered Compare Interrupt Read Flag */
 #define _PCNT_IF_TCC_SHIFT                 4                               /**< Shift value for PCNT_TCC */
 #define _PCNT_IF_TCC_MASK                  0x10UL                          /**< Bit mask for PCNT_TCC */
 #define _PCNT_IF_TCC_DEFAULT               0x00000000UL                    /**< Mode DEFAULT for PCNT_IF */

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_prs.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_prs.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efr32mg1p_prs.h
  * @brief EFR32MG1P_PRS register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,
@@ -958,7 +958,7 @@ typedef struct {
 #define _PRS_CH_CTRL_ANDNEXT_MASK              0x10000000UL                               /**< Bit mask for PRS_ANDNEXT */
 #define _PRS_CH_CTRL_ANDNEXT_DEFAULT           0x00000000UL                               /**< Mode DEFAULT for PRS_CH_CTRL */
 #define PRS_CH_CTRL_ANDNEXT_DEFAULT            (_PRS_CH_CTRL_ANDNEXT_DEFAULT << 28)       /**< Shifted mode DEFAULT for PRS_CH_CTRL */
-#define PRS_CH_CTRL_ASYNC                      (0x1UL << 30)                              /**< Asynchronous reflex */
+#define PRS_CH_CTRL_ASYNC                      (0x1UL << 30)                              /**< Asynchronous Reflex */
 #define _PRS_CH_CTRL_ASYNC_SHIFT               30                                         /**< Shift value for PRS_ASYNC */
 #define _PRS_CH_CTRL_ASYNC_MASK                0x40000000UL                               /**< Bit mask for PRS_ASYNC */
 #define _PRS_CH_CTRL_ASYNC_DEFAULT             0x00000000UL                               /**< Mode DEFAULT for PRS_CH_CTRL */

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_prs_ch.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_prs_ch.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efr32mg1p_prs_ch.h
  * @brief EFR32MG1P_PRS_CH register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_prs_signals.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_prs_signals.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efr32mg1p_prs_signals.h
  * @brief EFR32MG1P_PRS_SIGNALS register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_rmu.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_rmu.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efr32mg1p_rmu.h
  * @brief EFR32MG1P_RMU register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,
@@ -125,7 +125,7 @@ typedef struct {
 /* Bit fields for RMU RSTCAUSE */
 #define _RMU_RSTCAUSE_RESETVALUE           0x00000000UL                            /**< Default value for RMU_RSTCAUSE */
 #define _RMU_RSTCAUSE_MASK                 0x00010F1DUL                            /**< Mask for RMU_RSTCAUSE */
-#define RMU_RSTCAUSE_PORST                 (0x1UL << 0)                            /**< Power On Reset */
+#define RMU_RSTCAUSE_PORST                 (0x1UL << 0)                            /**< Power on Reset */
 #define _RMU_RSTCAUSE_PORST_SHIFT          0                                       /**< Shift value for RMU_PORST */
 #define _RMU_RSTCAUSE_PORST_MASK           0x1UL                                   /**< Bit mask for RMU_PORST */
 #define _RMU_RSTCAUSE_PORST_DEFAULT        0x00000000UL                            /**< Mode DEFAULT for RMU_RSTCAUSE */

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_romtable.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_romtable.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efr32mg1p_romtable.h
  * @brief EFR32MG1P_ROMTABLE register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_rtcc.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_rtcc.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efr32mg1p_rtcc.h
  * @brief EFR32MG1P_RTCC register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,
@@ -56,16 +56,16 @@ typedef struct {
   __IOM uint32_t   PRECNT;        /**< Pre-Counter Value Register  */
   __IOM uint32_t   CNT;           /**< Counter Value Register  */
   __IM uint32_t    COMBCNT;       /**< Combined Pre-Counter and Counter Value Register  */
-  __IOM uint32_t   TIME;          /**< Time of day register  */
-  __IOM uint32_t   DATE;          /**< Date register  */
+  __IOM uint32_t   TIME;          /**< Time of Day Register  */
+  __IOM uint32_t   DATE;          /**< Date Register  */
   __IM uint32_t    IF;            /**< RTCC Interrupt Flags  */
   __IOM uint32_t   IFS;           /**< Interrupt Flag Set Register  */
   __IOM uint32_t   IFC;           /**< Interrupt Flag Clear Register  */
   __IOM uint32_t   IEN;           /**< Interrupt Enable Register  */
-  __IM uint32_t    STATUS;        /**< Status register  */
+  __IM uint32_t    STATUS;        /**< Status Register  */
   __IOM uint32_t   CMD;           /**< Command Register  */
   __IM uint32_t    SYNCBUSY;      /**< Synchronization Busy Register  */
-  __IOM uint32_t   POWERDOWN;     /**< Retention RAM power-down register  */
+  __IOM uint32_t   POWERDOWN;     /**< Retention RAM Power-down Register  */
   __IOM uint32_t   LOCK;          /**< Configuration Lock Register  */
   __IOM uint32_t   EM4WUEN;       /**< Wake Up Enable  */
 
@@ -95,12 +95,12 @@ typedef struct {
 #define _RTCC_CTRL_DEBUGRUN_MASK            0x4UL                                   /**< Bit mask for RTCC_DEBUGRUN */
 #define _RTCC_CTRL_DEBUGRUN_DEFAULT         0x00000000UL                            /**< Mode DEFAULT for RTCC_CTRL */
 #define RTCC_CTRL_DEBUGRUN_DEFAULT          (_RTCC_CTRL_DEBUGRUN_DEFAULT << 2)      /**< Shifted mode DEFAULT for RTCC_CTRL */
-#define RTCC_CTRL_PRECCV0TOP                (0x1UL << 4)                            /**< Pre-counter CCV0 top value enable. */
+#define RTCC_CTRL_PRECCV0TOP                (0x1UL << 4)                            /**< Pre-counter CCV0 Top Value Enable */
 #define _RTCC_CTRL_PRECCV0TOP_SHIFT         4                                       /**< Shift value for RTCC_PRECCV0TOP */
 #define _RTCC_CTRL_PRECCV0TOP_MASK          0x10UL                                  /**< Bit mask for RTCC_PRECCV0TOP */
 #define _RTCC_CTRL_PRECCV0TOP_DEFAULT       0x00000000UL                            /**< Mode DEFAULT for RTCC_CTRL */
 #define RTCC_CTRL_PRECCV0TOP_DEFAULT        (_RTCC_CTRL_PRECCV0TOP_DEFAULT << 4)    /**< Shifted mode DEFAULT for RTCC_CTRL */
-#define RTCC_CTRL_CCV1TOP                   (0x1UL << 5)                            /**< CCV1 top value enable */
+#define RTCC_CTRL_CCV1TOP                   (0x1UL << 5)                            /**< CCV1 Top Value Enable */
 #define _RTCC_CTRL_CCV1TOP_SHIFT            5                                       /**< Shift value for RTCC_CCV1TOP */
 #define _RTCC_CTRL_CCV1TOP_MASK             0x20UL                                  /**< Bit mask for RTCC_CCV1TOP */
 #define _RTCC_CTRL_CCV1TOP_DEFAULT          0x00000000UL                            /**< Mode DEFAULT for RTCC_CTRL */
@@ -141,7 +141,7 @@ typedef struct {
 #define RTCC_CTRL_CNTPRESC_DIV8192          (_RTCC_CTRL_CNTPRESC_DIV8192 << 8)      /**< Shifted mode DIV8192 for RTCC_CTRL */
 #define RTCC_CTRL_CNTPRESC_DIV16384         (_RTCC_CTRL_CNTPRESC_DIV16384 << 8)     /**< Shifted mode DIV16384 for RTCC_CTRL */
 #define RTCC_CTRL_CNTPRESC_DIV32768         (_RTCC_CTRL_CNTPRESC_DIV32768 << 8)     /**< Shifted mode DIV32768 for RTCC_CTRL */
-#define RTCC_CTRL_CNTTICK                   (0x1UL << 12)                           /**< Counter prescaler mode. */
+#define RTCC_CTRL_CNTTICK                   (0x1UL << 12)                           /**< Counter Prescaler Mode */
 #define _RTCC_CTRL_CNTTICK_SHIFT            12                                      /**< Shift value for RTCC_CNTTICK */
 #define _RTCC_CTRL_CNTTICK_MASK             0x1000UL                                /**< Bit mask for RTCC_CNTTICK */
 #define _RTCC_CTRL_CNTTICK_DEFAULT          0x00000000UL                            /**< Mode DEFAULT for RTCC_CTRL */
@@ -150,12 +150,12 @@ typedef struct {
 #define RTCC_CTRL_CNTTICK_DEFAULT           (_RTCC_CTRL_CNTTICK_DEFAULT << 12)      /**< Shifted mode DEFAULT for RTCC_CTRL */
 #define RTCC_CTRL_CNTTICK_PRESC             (_RTCC_CTRL_CNTTICK_PRESC << 12)        /**< Shifted mode PRESC for RTCC_CTRL */
 #define RTCC_CTRL_CNTTICK_CCV0MATCH         (_RTCC_CTRL_CNTTICK_CCV0MATCH << 12)    /**< Shifted mode CCV0MATCH for RTCC_CTRL */
-#define RTCC_CTRL_OSCFDETEN                 (0x1UL << 15)                           /**< Oscillator failure detection enable */
+#define RTCC_CTRL_OSCFDETEN                 (0x1UL << 15)                           /**< Oscillator Failure Detection Enable */
 #define _RTCC_CTRL_OSCFDETEN_SHIFT          15                                      /**< Shift value for RTCC_OSCFDETEN */
 #define _RTCC_CTRL_OSCFDETEN_MASK           0x8000UL                                /**< Bit mask for RTCC_OSCFDETEN */
 #define _RTCC_CTRL_OSCFDETEN_DEFAULT        0x00000000UL                            /**< Mode DEFAULT for RTCC_CTRL */
 #define RTCC_CTRL_OSCFDETEN_DEFAULT         (_RTCC_CTRL_OSCFDETEN_DEFAULT << 15)    /**< Shifted mode DEFAULT for RTCC_CTRL */
-#define RTCC_CTRL_CNTMODE                   (0x1UL << 16)                           /**< Main counter mode */
+#define RTCC_CTRL_CNTMODE                   (0x1UL << 16)                           /**< Main Counter Mode */
 #define _RTCC_CTRL_CNTMODE_SHIFT            16                                      /**< Shift value for RTCC_CNTMODE */
 #define _RTCC_CTRL_CNTMODE_MASK             0x10000UL                               /**< Bit mask for RTCC_CNTMODE */
 #define _RTCC_CTRL_CNTMODE_DEFAULT          0x00000000UL                            /**< Mode DEFAULT for RTCC_CTRL */
@@ -164,7 +164,7 @@ typedef struct {
 #define RTCC_CTRL_CNTMODE_DEFAULT           (_RTCC_CTRL_CNTMODE_DEFAULT << 16)      /**< Shifted mode DEFAULT for RTCC_CTRL */
 #define RTCC_CTRL_CNTMODE_NORMAL            (_RTCC_CTRL_CNTMODE_NORMAL << 16)       /**< Shifted mode NORMAL for RTCC_CTRL */
 #define RTCC_CTRL_CNTMODE_CALENDAR          (_RTCC_CTRL_CNTMODE_CALENDAR << 16)     /**< Shifted mode CALENDAR for RTCC_CTRL */
-#define RTCC_CTRL_LYEARCORRDIS              (0x1UL << 17)                           /**< Leap year correction disabled. */
+#define RTCC_CTRL_LYEARCORRDIS              (0x1UL << 17)                           /**< Leap Year Correction Disabled */
 #define _RTCC_CTRL_LYEARCORRDIS_SHIFT       17                                      /**< Shift value for RTCC_LYEARCORRDIS */
 #define _RTCC_CTRL_LYEARCORRDIS_MASK        0x20000UL                               /**< Bit mask for RTCC_LYEARCORRDIS */
 #define _RTCC_CTRL_LYEARCORRDIS_DEFAULT     0x00000000UL                            /**< Mode DEFAULT for RTCC_CTRL */
@@ -241,7 +241,7 @@ typedef struct {
 #define _RTCC_DATE_MONTHU_MASK              0xF00UL                           /**< Bit mask for RTCC_MONTHU */
 #define _RTCC_DATE_MONTHU_DEFAULT           0x00000000UL                      /**< Mode DEFAULT for RTCC_DATE */
 #define RTCC_DATE_MONTHU_DEFAULT            (_RTCC_DATE_MONTHU_DEFAULT << 8)  /**< Shifted mode DEFAULT for RTCC_DATE */
-#define RTCC_DATE_MONTHT                    (0x1UL << 12)                     /**< Month, tens. */
+#define RTCC_DATE_MONTHT                    (0x1UL << 12)                     /**< Month, Tens */
 #define _RTCC_DATE_MONTHT_SHIFT             12                                /**< Shift value for RTCC_MONTHT */
 #define _RTCC_DATE_MONTHT_MASK              0x1000UL                          /**< Bit mask for RTCC_MONTHT */
 #define _RTCC_DATE_MONTHT_DEFAULT           0x00000000UL                      /**< Mode DEFAULT for RTCC_DATE */
@@ -282,37 +282,37 @@ typedef struct {
 #define _RTCC_IF_CC2_MASK                   0x8UL                              /**< Bit mask for RTCC_CC2 */
 #define _RTCC_IF_CC2_DEFAULT                0x00000000UL                       /**< Mode DEFAULT for RTCC_IF */
 #define RTCC_IF_CC2_DEFAULT                 (_RTCC_IF_CC2_DEFAULT << 3)        /**< Shifted mode DEFAULT for RTCC_IF */
-#define RTCC_IF_OSCFAIL                     (0x1UL << 4)                       /**< Oscillator failure Interrupt Flag */
+#define RTCC_IF_OSCFAIL                     (0x1UL << 4)                       /**< Oscillator Failure Interrupt Flag */
 #define _RTCC_IF_OSCFAIL_SHIFT              4                                  /**< Shift value for RTCC_OSCFAIL */
 #define _RTCC_IF_OSCFAIL_MASK               0x10UL                             /**< Bit mask for RTCC_OSCFAIL */
 #define _RTCC_IF_OSCFAIL_DEFAULT            0x00000000UL                       /**< Mode DEFAULT for RTCC_IF */
 #define RTCC_IF_OSCFAIL_DEFAULT             (_RTCC_IF_OSCFAIL_DEFAULT << 4)    /**< Shifted mode DEFAULT for RTCC_IF */
-#define RTCC_IF_CNTTICK                     (0x1UL << 5)                       /**< Main counter tick */
+#define RTCC_IF_CNTTICK                     (0x1UL << 5)                       /**< Main Counter Tick */
 #define _RTCC_IF_CNTTICK_SHIFT              5                                  /**< Shift value for RTCC_CNTTICK */
 #define _RTCC_IF_CNTTICK_MASK               0x20UL                             /**< Bit mask for RTCC_CNTTICK */
 #define _RTCC_IF_CNTTICK_DEFAULT            0x00000000UL                       /**< Mode DEFAULT for RTCC_IF */
 #define RTCC_IF_CNTTICK_DEFAULT             (_RTCC_IF_CNTTICK_DEFAULT << 5)    /**< Shifted mode DEFAULT for RTCC_IF */
-#define RTCC_IF_MINTICK                     (0x1UL << 6)                       /**< Minute tick */
+#define RTCC_IF_MINTICK                     (0x1UL << 6)                       /**< Minute Tick */
 #define _RTCC_IF_MINTICK_SHIFT              6                                  /**< Shift value for RTCC_MINTICK */
 #define _RTCC_IF_MINTICK_MASK               0x40UL                             /**< Bit mask for RTCC_MINTICK */
 #define _RTCC_IF_MINTICK_DEFAULT            0x00000000UL                       /**< Mode DEFAULT for RTCC_IF */
 #define RTCC_IF_MINTICK_DEFAULT             (_RTCC_IF_MINTICK_DEFAULT << 6)    /**< Shifted mode DEFAULT for RTCC_IF */
-#define RTCC_IF_HOURTICK                    (0x1UL << 7)                       /**< Hour tick */
+#define RTCC_IF_HOURTICK                    (0x1UL << 7)                       /**< Hour Tick */
 #define _RTCC_IF_HOURTICK_SHIFT             7                                  /**< Shift value for RTCC_HOURTICK */
 #define _RTCC_IF_HOURTICK_MASK              0x80UL                             /**< Bit mask for RTCC_HOURTICK */
 #define _RTCC_IF_HOURTICK_DEFAULT           0x00000000UL                       /**< Mode DEFAULT for RTCC_IF */
 #define RTCC_IF_HOURTICK_DEFAULT            (_RTCC_IF_HOURTICK_DEFAULT << 7)   /**< Shifted mode DEFAULT for RTCC_IF */
-#define RTCC_IF_DAYTICK                     (0x1UL << 8)                       /**< Day tick */
+#define RTCC_IF_DAYTICK                     (0x1UL << 8)                       /**< Day Tick */
 #define _RTCC_IF_DAYTICK_SHIFT              8                                  /**< Shift value for RTCC_DAYTICK */
 #define _RTCC_IF_DAYTICK_MASK               0x100UL                            /**< Bit mask for RTCC_DAYTICK */
 #define _RTCC_IF_DAYTICK_DEFAULT            0x00000000UL                       /**< Mode DEFAULT for RTCC_IF */
 #define RTCC_IF_DAYTICK_DEFAULT             (_RTCC_IF_DAYTICK_DEFAULT << 8)    /**< Shifted mode DEFAULT for RTCC_IF */
-#define RTCC_IF_DAYOWOF                     (0x1UL << 9)                       /**< Day of week overflow */
+#define RTCC_IF_DAYOWOF                     (0x1UL << 9)                       /**< Day of Week Overflow */
 #define _RTCC_IF_DAYOWOF_SHIFT              9                                  /**< Shift value for RTCC_DAYOWOF */
 #define _RTCC_IF_DAYOWOF_MASK               0x200UL                            /**< Bit mask for RTCC_DAYOWOF */
 #define _RTCC_IF_DAYOWOF_DEFAULT            0x00000000UL                       /**< Mode DEFAULT for RTCC_IF */
 #define RTCC_IF_DAYOWOF_DEFAULT             (_RTCC_IF_DAYOWOF_DEFAULT << 9)    /**< Shifted mode DEFAULT for RTCC_IF */
-#define RTCC_IF_MONTHTICK                   (0x1UL << 10)                      /**< Month tick */
+#define RTCC_IF_MONTHTICK                   (0x1UL << 10)                      /**< Month Tick */
 #define _RTCC_IF_MONTHTICK_SHIFT            10                                 /**< Shift value for RTCC_MONTHTICK */
 #define _RTCC_IF_MONTHTICK_MASK             0x400UL                            /**< Bit mask for RTCC_MONTHTICK */
 #define _RTCC_IF_MONTHTICK_DEFAULT          0x00000000UL                       /**< Mode DEFAULT for RTCC_IF */
@@ -502,7 +502,7 @@ typedef struct {
 /* Bit fields for RTCC CMD */
 #define _RTCC_CMD_RESETVALUE                0x00000000UL                       /**< Default value for RTCC_CMD */
 #define _RTCC_CMD_MASK                      0x00000001UL                       /**< Mask for RTCC_CMD */
-#define RTCC_CMD_CLRSTATUS                  (0x1UL << 0)                       /**< Clear RTCC_STATUS register. */
+#define RTCC_CMD_CLRSTATUS                  (0x1UL << 0)                       /**< Clear RTCC_STATUS Register */
 #define _RTCC_CMD_CLRSTATUS_SHIFT           0                                  /**< Shift value for RTCC_CLRSTATUS */
 #define _RTCC_CMD_CLRSTATUS_MASK            0x1UL                              /**< Bit mask for RTCC_CLRSTATUS */
 #define _RTCC_CMD_CLRSTATUS_DEFAULT         0x00000000UL                       /**< Mode DEFAULT for RTCC_CMD */
@@ -520,7 +520,7 @@ typedef struct {
 /* Bit fields for RTCC POWERDOWN */
 #define _RTCC_POWERDOWN_RESETVALUE          0x00000000UL                       /**< Default value for RTCC_POWERDOWN */
 #define _RTCC_POWERDOWN_MASK                0x00000001UL                       /**< Mask for RTCC_POWERDOWN */
-#define RTCC_POWERDOWN_RAM                  (0x1UL << 0)                       /**< Retention RAM power-down */
+#define RTCC_POWERDOWN_RAM                  (0x1UL << 0)                       /**< Retention RAM Power-down */
 #define _RTCC_POWERDOWN_RAM_SHIFT           0                                  /**< Shift value for RTCC_RAM */
 #define _RTCC_POWERDOWN_RAM_MASK            0x1UL                              /**< Bit mask for RTCC_RAM */
 #define _RTCC_POWERDOWN_RAM_DEFAULT         0x00000000UL                       /**< Mode DEFAULT for RTCC_POWERDOWN */
@@ -545,7 +545,7 @@ typedef struct {
 /* Bit fields for RTCC EM4WUEN */
 #define _RTCC_EM4WUEN_RESETVALUE            0x00000000UL                       /**< Default value for RTCC_EM4WUEN */
 #define _RTCC_EM4WUEN_MASK                  0x00000001UL                       /**< Mask for RTCC_EM4WUEN */
-#define RTCC_EM4WUEN_EM4WU                  (0x1UL << 0)                       /**< EM4 Wake-up enable */
+#define RTCC_EM4WUEN_EM4WU                  (0x1UL << 0)                       /**< EM4 Wake-up Enable */
 #define _RTCC_EM4WUEN_EM4WU_SHIFT           0                                  /**< Shift value for RTCC_EM4WU */
 #define _RTCC_EM4WUEN_EM4WU_MASK            0x1UL                              /**< Bit mask for RTCC_EM4WU */
 #define _RTCC_EM4WUEN_EM4WU_DEFAULT         0x00000000UL                       /**< Mode DEFAULT for RTCC_EM4WUEN */
@@ -616,7 +616,7 @@ typedef struct {
 #define RTCC_CC_CTRL_PRSSEL_PRSCH9          (_RTCC_CC_CTRL_PRSSEL_PRSCH9 << 6)      /**< Shifted mode PRSCH9 for RTCC_CC_CTRL */
 #define RTCC_CC_CTRL_PRSSEL_PRSCH10         (_RTCC_CC_CTRL_PRSSEL_PRSCH10 << 6)     /**< Shifted mode PRSCH10 for RTCC_CC_CTRL */
 #define RTCC_CC_CTRL_PRSSEL_PRSCH11         (_RTCC_CC_CTRL_PRSSEL_PRSCH11 << 6)     /**< Shifted mode PRSCH11 for RTCC_CC_CTRL */
-#define RTCC_CC_CTRL_COMPBASE               (0x1UL << 11)                           /**< Capture compare channel comparison base. */
+#define RTCC_CC_CTRL_COMPBASE               (0x1UL << 11)                           /**< Capture Compare Channel Comparison Base */
 #define _RTCC_CC_CTRL_COMPBASE_SHIFT        11                                      /**< Shift value for CC_COMPBASE */
 #define _RTCC_CC_CTRL_COMPBASE_MASK         0x800UL                                 /**< Bit mask for CC_COMPBASE */
 #define _RTCC_CC_CTRL_COMPBASE_DEFAULT      0x00000000UL                            /**< Mode DEFAULT for RTCC_CC_CTRL */
@@ -629,7 +629,7 @@ typedef struct {
 #define _RTCC_CC_CTRL_COMPMASK_MASK         0x1F000UL                               /**< Bit mask for CC_COMPMASK */
 #define _RTCC_CC_CTRL_COMPMASK_DEFAULT      0x00000000UL                            /**< Mode DEFAULT for RTCC_CC_CTRL */
 #define RTCC_CC_CTRL_COMPMASK_DEFAULT       (_RTCC_CC_CTRL_COMPMASK_DEFAULT << 12)  /**< Shifted mode DEFAULT for RTCC_CC_CTRL */
-#define RTCC_CC_CTRL_DAYCC                  (0x1UL << 17)                           /**< Day Capture/Compare selection */
+#define RTCC_CC_CTRL_DAYCC                  (0x1UL << 17)                           /**< Day Capture/Compare Selection */
 #define _RTCC_CC_CTRL_DAYCC_SHIFT           17                                      /**< Shift value for CC_DAYCC */
 #define _RTCC_CC_CTRL_DAYCC_MASK            0x20000UL                               /**< Bit mask for CC_DAYCC */
 #define _RTCC_CC_CTRL_DAYCC_DEFAULT         0x00000000UL                            /**< Mode DEFAULT for RTCC_CC_CTRL */
@@ -690,7 +690,7 @@ typedef struct {
 #define _RTCC_CC_DATE_MONTHU_MASK           0xF00UL                              /**< Bit mask for CC_MONTHU */
 #define _RTCC_CC_DATE_MONTHU_DEFAULT        0x00000000UL                         /**< Mode DEFAULT for RTCC_CC_DATE */
 #define RTCC_CC_DATE_MONTHU_DEFAULT         (_RTCC_CC_DATE_MONTHU_DEFAULT << 8)  /**< Shifted mode DEFAULT for RTCC_CC_DATE */
-#define RTCC_CC_DATE_MONTHT                 (0x1UL << 12)                        /**< Month, tens. */
+#define RTCC_CC_DATE_MONTHT                 (0x1UL << 12)                        /**< Month, Tens */
 #define _RTCC_CC_DATE_MONTHT_SHIFT          12                                   /**< Shift value for CC_MONTHT */
 #define _RTCC_CC_DATE_MONTHT_MASK           0x1000UL                             /**< Bit mask for CC_MONTHT */
 #define _RTCC_CC_DATE_MONTHT_DEFAULT        0x00000000UL                         /**< Mode DEFAULT for RTCC_CC_DATE */

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_rtcc_cc.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_rtcc_cc.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efr32mg1p_rtcc_cc.h
  * @brief EFR32MG1P_RTCC_CC register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_rtcc_ret.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_rtcc_ret.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efr32mg1p_rtcc_ret.h
  * @brief EFR32MG1P_RTCC_RET register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,
@@ -50,7 +50,7 @@ extern "C" {
  * @ingroup EFR32MG1P_RTCC
  *****************************************************************************/
 typedef struct {
-  __IOM uint32_t REG; /**< Retention register  */
+  __IOM uint32_t REG; /**< Retention Register  */
 } RTCC_RET_TypeDef;
 
 /** @} End of group Parts */

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_timer.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_timer.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efr32mg1p_timer.h
  * @brief EFR32MG1P_TIMER register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,
@@ -202,7 +202,7 @@ typedef struct {
 #define _TIMER_CTRL_ATI_MASK                       0x10000000UL                             /**< Bit mask for TIMER_ATI */
 #define _TIMER_CTRL_ATI_DEFAULT                    0x00000000UL                             /**< Mode DEFAULT for TIMER_CTRL */
 #define TIMER_CTRL_ATI_DEFAULT                     (_TIMER_CTRL_ATI_DEFAULT << 28)          /**< Shifted mode DEFAULT for TIMER_CTRL */
-#define TIMER_CTRL_RSSCOIST                        (0x1UL << 29)                            /**< Reload-Start Sets Compare Output initial State */
+#define TIMER_CTRL_RSSCOIST                        (0x1UL << 29)                            /**< Reload-Start Sets Compare Output Initial State */
 #define _TIMER_CTRL_RSSCOIST_SHIFT                 29                                       /**< Shift value for TIMER_RSSCOIST */
 #define _TIMER_CTRL_RSSCOIST_MASK                  0x20000000UL                             /**< Bit mask for TIMER_RSSCOIST */
 #define _TIMER_CTRL_RSSCOIST_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for TIMER_CTRL */
@@ -1307,7 +1307,7 @@ typedef struct {
 #define _TIMER_DTCTRL_DTIPOL_MASK                  0x4UL                                 /**< Bit mask for TIMER_DTIPOL */
 #define _TIMER_DTCTRL_DTIPOL_DEFAULT               0x00000000UL                          /**< Mode DEFAULT for TIMER_DTCTRL */
 #define TIMER_DTCTRL_DTIPOL_DEFAULT                (_TIMER_DTCTRL_DTIPOL_DEFAULT << 2)   /**< Shifted mode DEFAULT for TIMER_DTCTRL */
-#define TIMER_DTCTRL_DTCINV                        (0x1UL << 3)                          /**< DTI Complementary Output Invert. */
+#define TIMER_DTCTRL_DTCINV                        (0x1UL << 3)                          /**< DTI Complementary Output Invert */
 #define _TIMER_DTCTRL_DTCINV_SHIFT                 3                                     /**< Shift value for TIMER_DTCINV */
 #define _TIMER_DTCTRL_DTCINV_MASK                  0x8UL                                 /**< Bit mask for TIMER_DTCINV */
 #define _TIMER_DTCTRL_DTCINV_DEFAULT               0x00000000UL                          /**< Mode DEFAULT for TIMER_DTCTRL */

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_timer_cc.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_timer_cc.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efr32mg1p_timer_cc.h
  * @brief EFR32MG1P_TIMER_CC register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_usart.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_usart.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efr32mg1p_usart.h
  * @brief EFR32MG1P_USART register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,
@@ -54,7 +54,7 @@ extern "C" {
 typedef struct {
   __IOM uint32_t CTRL;         /**< Control Register  */
   __IOM uint32_t FRAME;        /**< USART Frame Format Register  */
-  __IOM uint32_t TRIGCTRL;     /**< USART Trigger Control register  */
+  __IOM uint32_t TRIGCTRL;     /**< USART Trigger Control Register  */
   __IOM uint32_t CMD;          /**< Command Register  */
   __IM uint32_t  STATUS;       /**< USART Status Register  */
   __IOM uint32_t CLKDIV;       /**< Clock Control Register  */
@@ -78,9 +78,9 @@ typedef struct {
   __IOM uint32_t I2SCTRL;      /**< I2S Control Register  */
   __IOM uint32_t TIMING;       /**< Timing Register  */
   __IOM uint32_t CTRLX;        /**< Control Register Extended  */
-  __IOM uint32_t TIMECMP0;     /**< Used to generate interrupts and various delays  */
-  __IOM uint32_t TIMECMP1;     /**< Used to generate interrupts and various delays  */
-  __IOM uint32_t TIMECMP2;     /**< Used to generate interrupts and various delays  */
+  __IOM uint32_t TIMECMP0;     /**< Used to Generate Interrupts and Various Delays  */
+  __IOM uint32_t TIMECMP1;     /**< Used to Generate Interrupts and Various Delays  */
+  __IOM uint32_t TIMECMP2;     /**< Used to Generate Interrupts and Various Delays  */
   __IOM uint32_t ROUTEPEN;     /**< I/O Routing Pin Enable Register  */
   __IOM uint32_t ROUTELOC0;    /**< I/O Routing Location Register  */
   __IOM uint32_t ROUTELOC1;    /**< I/O Routing Location Register  */
@@ -142,7 +142,7 @@ typedef struct {
 #define USART_CTRL_CLKPOL_DEFAULT               (_USART_CTRL_CLKPOL_DEFAULT << 8)        /**< Shifted mode DEFAULT for USART_CTRL */
 #define USART_CTRL_CLKPOL_IDLELOW               (_USART_CTRL_CLKPOL_IDLELOW << 8)        /**< Shifted mode IDLELOW for USART_CTRL */
 #define USART_CTRL_CLKPOL_IDLEHIGH              (_USART_CTRL_CLKPOL_IDLEHIGH << 8)       /**< Shifted mode IDLEHIGH for USART_CTRL */
-#define USART_CTRL_CLKPHA                       (0x1UL << 9)                             /**< Clock Edge For Setup/Sample */
+#define USART_CTRL_CLKPHA                       (0x1UL << 9)                             /**< Clock Edge for Setup/Sample */
 #define _USART_CTRL_CLKPHA_SHIFT                9                                        /**< Shift value for USART_CLKPHA */
 #define _USART_CTRL_CLKPHA_MASK                 0x200UL                                  /**< Bit mask for USART_CLKPHA */
 #define _USART_CTRL_CLKPHA_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for USART_CTRL */
@@ -156,7 +156,7 @@ typedef struct {
 #define _USART_CTRL_MSBF_MASK                   0x400UL                                  /**< Bit mask for USART_MSBF */
 #define _USART_CTRL_MSBF_DEFAULT                0x00000000UL                             /**< Mode DEFAULT for USART_CTRL */
 #define USART_CTRL_MSBF_DEFAULT                 (_USART_CTRL_MSBF_DEFAULT << 10)         /**< Shifted mode DEFAULT for USART_CTRL */
-#define USART_CTRL_CSMA                         (0x1UL << 11)                            /**< Action On Slave-Select In Master Mode */
+#define USART_CTRL_CSMA                         (0x1UL << 11)                            /**< Action on Slave-Select in Master Mode */
 #define _USART_CTRL_CSMA_SHIFT                  11                                       /**< Shift value for USART_CSMA */
 #define _USART_CTRL_CSMA_MASK                   0x800UL                                  /**< Bit mask for USART_CSMA */
 #define _USART_CTRL_CSMA_DEFAULT                0x00000000UL                             /**< Mode DEFAULT for USART_CTRL */
@@ -179,7 +179,7 @@ typedef struct {
 #define _USART_CTRL_RXINV_MASK                  0x2000UL                                 /**< Bit mask for USART_RXINV */
 #define _USART_CTRL_RXINV_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for USART_CTRL */
 #define USART_CTRL_RXINV_DEFAULT                (_USART_CTRL_RXINV_DEFAULT << 13)        /**< Shifted mode DEFAULT for USART_CTRL */
-#define USART_CTRL_TXINV                        (0x1UL << 14)                            /**< Transmitter output Invert */
+#define USART_CTRL_TXINV                        (0x1UL << 14)                            /**< Transmitter Output Invert */
 #define _USART_CTRL_TXINV_SHIFT                 14                                       /**< Shift value for USART_TXINV */
 #define _USART_CTRL_TXINV_MASK                  0x4000UL                                 /**< Bit mask for USART_TXINV */
 #define _USART_CTRL_TXINV_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for USART_CTRL */
@@ -219,17 +219,17 @@ typedef struct {
 #define _USART_CTRL_BIT8DV_MASK                 0x200000UL                               /**< Bit mask for USART_BIT8DV */
 #define _USART_CTRL_BIT8DV_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for USART_CTRL */
 #define USART_CTRL_BIT8DV_DEFAULT               (_USART_CTRL_BIT8DV_DEFAULT << 21)       /**< Shifted mode DEFAULT for USART_CTRL */
-#define USART_CTRL_ERRSDMA                      (0x1UL << 22)                            /**< Halt DMA On Error */
+#define USART_CTRL_ERRSDMA                      (0x1UL << 22)                            /**< Halt DMA on Error */
 #define _USART_CTRL_ERRSDMA_SHIFT               22                                       /**< Shift value for USART_ERRSDMA */
 #define _USART_CTRL_ERRSDMA_MASK                0x400000UL                               /**< Bit mask for USART_ERRSDMA */
 #define _USART_CTRL_ERRSDMA_DEFAULT             0x00000000UL                             /**< Mode DEFAULT for USART_CTRL */
 #define USART_CTRL_ERRSDMA_DEFAULT              (_USART_CTRL_ERRSDMA_DEFAULT << 22)      /**< Shifted mode DEFAULT for USART_CTRL */
-#define USART_CTRL_ERRSRX                       (0x1UL << 23)                            /**< Disable RX On Error */
+#define USART_CTRL_ERRSRX                       (0x1UL << 23)                            /**< Disable RX on Error */
 #define _USART_CTRL_ERRSRX_SHIFT                23                                       /**< Shift value for USART_ERRSRX */
 #define _USART_CTRL_ERRSRX_MASK                 0x800000UL                               /**< Bit mask for USART_ERRSRX */
 #define _USART_CTRL_ERRSRX_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for USART_CTRL */
 #define USART_CTRL_ERRSRX_DEFAULT               (_USART_CTRL_ERRSRX_DEFAULT << 23)       /**< Shifted mode DEFAULT for USART_CTRL */
-#define USART_CTRL_ERRSTX                       (0x1UL << 24)                            /**< Disable TX On Error */
+#define USART_CTRL_ERRSTX                       (0x1UL << 24)                            /**< Disable TX on Error */
 #define _USART_CTRL_ERRSTX_SHIFT                24                                       /**< Shift value for USART_ERRSTX */
 #define _USART_CTRL_ERRSTX_MASK                 0x1000000UL                              /**< Bit mask for USART_ERRSTX */
 #define _USART_CTRL_ERRSTX_DEFAULT              0x00000000UL                             /**< Mode DEFAULT for USART_CTRL */
@@ -239,7 +239,7 @@ typedef struct {
 #define _USART_CTRL_SSSEARLY_MASK               0x2000000UL                              /**< Bit mask for USART_SSSEARLY */
 #define _USART_CTRL_SSSEARLY_DEFAULT            0x00000000UL                             /**< Mode DEFAULT for USART_CTRL */
 #define USART_CTRL_SSSEARLY_DEFAULT             (_USART_CTRL_SSSEARLY_DEFAULT << 25)     /**< Shifted mode DEFAULT for USART_CTRL */
-#define USART_CTRL_BYTESWAP                     (0x1UL << 28)                            /**< Byteswap In Double Accesses */
+#define USART_CTRL_BYTESWAP                     (0x1UL << 28)                            /**< Byteswap in Double Accesses */
 #define _USART_CTRL_BYTESWAP_SHIFT              28                                       /**< Shift value for USART_BYTESWAP */
 #define _USART_CTRL_BYTESWAP_MASK               0x10000000UL                             /**< Bit mask for USART_BYTESWAP */
 #define _USART_CTRL_BYTESWAP_DEFAULT            0x00000000UL                             /**< Mode DEFAULT for USART_CTRL */
@@ -334,32 +334,32 @@ typedef struct {
 #define _USART_TRIGCTRL_AUTOTXTEN_MASK          0x40UL                                   /**< Bit mask for USART_AUTOTXTEN */
 #define _USART_TRIGCTRL_AUTOTXTEN_DEFAULT       0x00000000UL                             /**< Mode DEFAULT for USART_TRIGCTRL */
 #define USART_TRIGCTRL_AUTOTXTEN_DEFAULT        (_USART_TRIGCTRL_AUTOTXTEN_DEFAULT << 6) /**< Shifted mode DEFAULT for USART_TRIGCTRL */
-#define USART_TRIGCTRL_TXARX0EN                 (0x1UL << 7)                             /**< Enable Transmit Trigger after RX End of Frame plus TCMP0VAL */
+#define USART_TRIGCTRL_TXARX0EN                 (0x1UL << 7)                             /**< Enable Transmit Trigger After RX End of Frame Plus TCMP0VAL */
 #define _USART_TRIGCTRL_TXARX0EN_SHIFT          7                                        /**< Shift value for USART_TXARX0EN */
 #define _USART_TRIGCTRL_TXARX0EN_MASK           0x80UL                                   /**< Bit mask for USART_TXARX0EN */
 #define _USART_TRIGCTRL_TXARX0EN_DEFAULT        0x00000000UL                             /**< Mode DEFAULT for USART_TRIGCTRL */
 #define USART_TRIGCTRL_TXARX0EN_DEFAULT         (_USART_TRIGCTRL_TXARX0EN_DEFAULT << 7)  /**< Shifted mode DEFAULT for USART_TRIGCTRL */
-#define USART_TRIGCTRL_TXARX1EN                 (0x1UL << 8)                             /**< Enable Transmit Trigger after RX End of Frame plus TCMP1VAL */
+#define USART_TRIGCTRL_TXARX1EN                 (0x1UL << 8)                             /**< Enable Transmit Trigger After RX End of Frame Plus TCMP1VAL */
 #define _USART_TRIGCTRL_TXARX1EN_SHIFT          8                                        /**< Shift value for USART_TXARX1EN */
 #define _USART_TRIGCTRL_TXARX1EN_MASK           0x100UL                                  /**< Bit mask for USART_TXARX1EN */
 #define _USART_TRIGCTRL_TXARX1EN_DEFAULT        0x00000000UL                             /**< Mode DEFAULT for USART_TRIGCTRL */
 #define USART_TRIGCTRL_TXARX1EN_DEFAULT         (_USART_TRIGCTRL_TXARX1EN_DEFAULT << 8)  /**< Shifted mode DEFAULT for USART_TRIGCTRL */
-#define USART_TRIGCTRL_TXARX2EN                 (0x1UL << 9)                             /**< Enable Transmit Trigger after RX End of Frame plus TCMP2VAL */
+#define USART_TRIGCTRL_TXARX2EN                 (0x1UL << 9)                             /**< Enable Transmit Trigger After RX End of Frame Plus TCMP2VAL */
 #define _USART_TRIGCTRL_TXARX2EN_SHIFT          9                                        /**< Shift value for USART_TXARX2EN */
 #define _USART_TRIGCTRL_TXARX2EN_MASK           0x200UL                                  /**< Bit mask for USART_TXARX2EN */
 #define _USART_TRIGCTRL_TXARX2EN_DEFAULT        0x00000000UL                             /**< Mode DEFAULT for USART_TRIGCTRL */
 #define USART_TRIGCTRL_TXARX2EN_DEFAULT         (_USART_TRIGCTRL_TXARX2EN_DEFAULT << 9)  /**< Shifted mode DEFAULT for USART_TRIGCTRL */
-#define USART_TRIGCTRL_RXATX0EN                 (0x1UL << 10)                            /**< Enable Receive Trigger after TX end of frame plus TCMPVAL0 baud-times */
+#define USART_TRIGCTRL_RXATX0EN                 (0x1UL << 10)                            /**< Enable Receive Trigger After TX End of Frame Plus TCMPVAL0 Baud-times */
 #define _USART_TRIGCTRL_RXATX0EN_SHIFT          10                                       /**< Shift value for USART_RXATX0EN */
 #define _USART_TRIGCTRL_RXATX0EN_MASK           0x400UL                                  /**< Bit mask for USART_RXATX0EN */
 #define _USART_TRIGCTRL_RXATX0EN_DEFAULT        0x00000000UL                             /**< Mode DEFAULT for USART_TRIGCTRL */
 #define USART_TRIGCTRL_RXATX0EN_DEFAULT         (_USART_TRIGCTRL_RXATX0EN_DEFAULT << 10) /**< Shifted mode DEFAULT for USART_TRIGCTRL */
-#define USART_TRIGCTRL_RXATX1EN                 (0x1UL << 11)                            /**< Enable Receive Trigger after TX end of frame plus TCMPVAL1 baud-times */
+#define USART_TRIGCTRL_RXATX1EN                 (0x1UL << 11)                            /**< Enable Receive Trigger After TX End of Frame Plus TCMPVAL1 Baud-times */
 #define _USART_TRIGCTRL_RXATX1EN_SHIFT          11                                       /**< Shift value for USART_RXATX1EN */
 #define _USART_TRIGCTRL_RXATX1EN_MASK           0x800UL                                  /**< Bit mask for USART_RXATX1EN */
 #define _USART_TRIGCTRL_RXATX1EN_DEFAULT        0x00000000UL                             /**< Mode DEFAULT for USART_TRIGCTRL */
 #define USART_TRIGCTRL_RXATX1EN_DEFAULT         (_USART_TRIGCTRL_RXATX1EN_DEFAULT << 11) /**< Shifted mode DEFAULT for USART_TRIGCTRL */
-#define USART_TRIGCTRL_RXATX2EN                 (0x1UL << 12)                            /**< Enable Receive Trigger after TX end of frame plus TCMPVAL2 baud-times */
+#define USART_TRIGCTRL_RXATX2EN                 (0x1UL << 12)                            /**< Enable Receive Trigger After TX End of Frame Plus TCMPVAL2 Baud-times */
 #define _USART_TRIGCTRL_RXATX2EN_SHIFT          12                                       /**< Shift value for USART_RXATX2EN */
 #define _USART_TRIGCTRL_RXATX2EN_MASK           0x1000UL                                 /**< Bit mask for USART_RXATX2EN */
 #define _USART_TRIGCTRL_RXATX2EN_DEFAULT        0x00000000UL                             /**< Mode DEFAULT for USART_TRIGCTRL */
@@ -530,7 +530,7 @@ typedef struct {
 #define _USART_STATUS_TXIDLE_MASK               0x2000UL                                     /**< Bit mask for USART_TXIDLE */
 #define _USART_STATUS_TXIDLE_DEFAULT            0x00000001UL                                 /**< Mode DEFAULT for USART_STATUS */
 #define USART_STATUS_TXIDLE_DEFAULT             (_USART_STATUS_TXIDLE_DEFAULT << 13)         /**< Shifted mode DEFAULT for USART_STATUS */
-#define USART_STATUS_TIMERRESTARTED             (0x1UL << 14)                                /**< The USART Timer restarted itself */
+#define USART_STATUS_TIMERRESTARTED             (0x1UL << 14)                                /**< The USART Timer Restarted Itself */
 #define _USART_STATUS_TIMERRESTARTED_SHIFT      14                                           /**< Shift value for USART_TIMERRESTARTED */
 #define _USART_STATUS_TIMERRESTARTED_MASK       0x4000UL                                     /**< Bit mask for USART_TIMERRESTARTED */
 #define _USART_STATUS_TIMERRESTARTED_DEFAULT    0x00000000UL                                 /**< Mode DEFAULT for USART_STATUS */
@@ -547,7 +547,7 @@ typedef struct {
 #define _USART_CLKDIV_DIV_MASK                  0x7FFFF8UL                               /**< Bit mask for USART_DIV */
 #define _USART_CLKDIV_DIV_DEFAULT               0x00000000UL                             /**< Mode DEFAULT for USART_CLKDIV */
 #define USART_CLKDIV_DIV_DEFAULT                (_USART_CLKDIV_DIV_DEFAULT << 3)         /**< Shifted mode DEFAULT for USART_CLKDIV */
-#define USART_CLKDIV_AUTOBAUDEN                 (0x1UL << 31)                            /**< AUTOBAUD detection enable */
+#define USART_CLKDIV_AUTOBAUDEN                 (0x1UL << 31)                            /**< AUTOBAUD Detection Enable */
 #define _USART_CLKDIV_AUTOBAUDEN_SHIFT          31                                       /**< Shift value for USART_AUTOBAUDEN */
 #define _USART_CLKDIV_AUTOBAUDEN_MASK           0x80000000UL                             /**< Bit mask for USART_AUTOBAUDEN */
 #define _USART_CLKDIV_AUTOBAUDEN_DEFAULT        0x00000000UL                             /**< Mode DEFAULT for USART_CLKDIV */
@@ -690,7 +690,7 @@ typedef struct {
 #define _USART_TXDATAX_TXTRIAT_MASK             0x1000UL                               /**< Bit mask for USART_TXTRIAT */
 #define _USART_TXDATAX_TXTRIAT_DEFAULT          0x00000000UL                           /**< Mode DEFAULT for USART_TXDATAX */
 #define USART_TXDATAX_TXTRIAT_DEFAULT           (_USART_TXDATAX_TXTRIAT_DEFAULT << 12) /**< Shifted mode DEFAULT for USART_TXDATAX */
-#define USART_TXDATAX_TXBREAK                   (0x1UL << 13)                          /**< Transmit Data As Break */
+#define USART_TXDATAX_TXBREAK                   (0x1UL << 13)                          /**< Transmit Data as Break */
 #define _USART_TXDATAX_TXBREAK_SHIFT            13                                     /**< Shift value for USART_TXBREAK */
 #define _USART_TXDATAX_TXBREAK_MASK             0x2000UL                               /**< Bit mask for USART_TXBREAK */
 #define _USART_TXDATAX_TXBREAK_DEFAULT          0x00000000UL                           /**< Mode DEFAULT for USART_TXDATAX */
@@ -731,7 +731,7 @@ typedef struct {
 #define _USART_TXDOUBLEX_TXTRIAT0_MASK          0x1000UL                                  /**< Bit mask for USART_TXTRIAT0 */
 #define _USART_TXDOUBLEX_TXTRIAT0_DEFAULT       0x00000000UL                              /**< Mode DEFAULT for USART_TXDOUBLEX */
 #define USART_TXDOUBLEX_TXTRIAT0_DEFAULT        (_USART_TXDOUBLEX_TXTRIAT0_DEFAULT << 12) /**< Shifted mode DEFAULT for USART_TXDOUBLEX */
-#define USART_TXDOUBLEX_TXBREAK0                (0x1UL << 13)                             /**< Transmit Data As Break */
+#define USART_TXDOUBLEX_TXBREAK0                (0x1UL << 13)                             /**< Transmit Data as Break */
 #define _USART_TXDOUBLEX_TXBREAK0_SHIFT         13                                        /**< Shift value for USART_TXBREAK0 */
 #define _USART_TXDOUBLEX_TXBREAK0_MASK          0x2000UL                                  /**< Bit mask for USART_TXBREAK0 */
 #define _USART_TXDOUBLEX_TXBREAK0_DEFAULT       0x00000000UL                              /**< Mode DEFAULT for USART_TXDOUBLEX */
@@ -760,7 +760,7 @@ typedef struct {
 #define _USART_TXDOUBLEX_TXTRIAT1_MASK          0x10000000UL                              /**< Bit mask for USART_TXTRIAT1 */
 #define _USART_TXDOUBLEX_TXTRIAT1_DEFAULT       0x00000000UL                              /**< Mode DEFAULT for USART_TXDOUBLEX */
 #define USART_TXDOUBLEX_TXTRIAT1_DEFAULT        (_USART_TXDOUBLEX_TXTRIAT1_DEFAULT << 28) /**< Shifted mode DEFAULT for USART_TXDOUBLEX */
-#define USART_TXDOUBLEX_TXBREAK1                (0x1UL << 29)                             /**< Transmit Data As Break */
+#define USART_TXDOUBLEX_TXBREAK1                (0x1UL << 29)                             /**< Transmit Data as Break */
 #define _USART_TXDOUBLEX_TXBREAK1_SHIFT         29                                        /**< Shift value for USART_TXBREAK1 */
 #define _USART_TXDOUBLEX_TXBREAK1_MASK          0x20000000UL                              /**< Bit mask for USART_TXBREAK1 */
 #define _USART_TXDOUBLEX_TXBREAK1_DEFAULT       0x00000000UL                              /**< Mode DEFAULT for USART_TXDOUBLEX */
@@ -846,7 +846,7 @@ typedef struct {
 #define _USART_IF_MPAF_MASK                     0x400UL                          /**< Bit mask for USART_MPAF */
 #define _USART_IF_MPAF_DEFAULT                  0x00000000UL                     /**< Mode DEFAULT for USART_IF */
 #define USART_IF_MPAF_DEFAULT                   (_USART_IF_MPAF_DEFAULT << 10)   /**< Shifted mode DEFAULT for USART_IF */
-#define USART_IF_SSM                            (0x1UL << 11)                    /**< Slave-Select In Master Mode Interrupt Flag */
+#define USART_IF_SSM                            (0x1UL << 11)                    /**< Slave-Select in Master Mode Interrupt Flag */
 #define _USART_IF_SSM_SHIFT                     11                               /**< Shift value for USART_SSM */
 #define _USART_IF_SSM_MASK                      0x800UL                          /**< Bit mask for USART_SSM */
 #define _USART_IF_SSM_DEFAULT                   0x00000000UL                     /**< Mode DEFAULT for USART_IF */
@@ -861,17 +861,17 @@ typedef struct {
 #define _USART_IF_TXIDLE_MASK                   0x2000UL                         /**< Bit mask for USART_TXIDLE */
 #define _USART_IF_TXIDLE_DEFAULT                0x00000000UL                     /**< Mode DEFAULT for USART_IF */
 #define USART_IF_TXIDLE_DEFAULT                 (_USART_IF_TXIDLE_DEFAULT << 13) /**< Shifted mode DEFAULT for USART_IF */
-#define USART_IF_TCMP0                          (0x1UL << 14)                    /**< Timer comparator 0 Interrupt Flag */
+#define USART_IF_TCMP0                          (0x1UL << 14)                    /**< Timer Comparator 0 Interrupt Flag */
 #define _USART_IF_TCMP0_SHIFT                   14                               /**< Shift value for USART_TCMP0 */
 #define _USART_IF_TCMP0_MASK                    0x4000UL                         /**< Bit mask for USART_TCMP0 */
 #define _USART_IF_TCMP0_DEFAULT                 0x00000000UL                     /**< Mode DEFAULT for USART_IF */
 #define USART_IF_TCMP0_DEFAULT                  (_USART_IF_TCMP0_DEFAULT << 14)  /**< Shifted mode DEFAULT for USART_IF */
-#define USART_IF_TCMP1                          (0x1UL << 15)                    /**< Timer comparator 1 Interrupt Flag */
+#define USART_IF_TCMP1                          (0x1UL << 15)                    /**< Timer Comparator 1 Interrupt Flag */
 #define _USART_IF_TCMP1_SHIFT                   15                               /**< Shift value for USART_TCMP1 */
 #define _USART_IF_TCMP1_MASK                    0x8000UL                         /**< Bit mask for USART_TCMP1 */
 #define _USART_IF_TCMP1_DEFAULT                 0x00000000UL                     /**< Mode DEFAULT for USART_IF */
 #define USART_IF_TCMP1_DEFAULT                  (_USART_IF_TCMP1_DEFAULT << 15)  /**< Shifted mode DEFAULT for USART_IF */
-#define USART_IF_TCMP2                          (0x1UL << 16)                    /**< Timer comparator 2 Interrupt Flag */
+#define USART_IF_TCMP2                          (0x1UL << 16)                    /**< Timer Comparator 2 Interrupt Flag */
 #define _USART_IF_TCMP2_SHIFT                   16                               /**< Shift value for USART_TCMP2 */
 #define _USART_IF_TCMP2_MASK                    0x10000UL                        /**< Bit mask for USART_TCMP2 */
 #define _USART_IF_TCMP2_DEFAULT                 0x00000000UL                     /**< Mode DEFAULT for USART_IF */
@@ -1275,12 +1275,12 @@ typedef struct {
 #define USART_I2SCTRL_JUSTIFY_DEFAULT           (_USART_I2SCTRL_JUSTIFY_DEFAULT << 2)  /**< Shifted mode DEFAULT for USART_I2SCTRL */
 #define USART_I2SCTRL_JUSTIFY_LEFT              (_USART_I2SCTRL_JUSTIFY_LEFT << 2)     /**< Shifted mode LEFT for USART_I2SCTRL */
 #define USART_I2SCTRL_JUSTIFY_RIGHT             (_USART_I2SCTRL_JUSTIFY_RIGHT << 2)    /**< Shifted mode RIGHT for USART_I2SCTRL */
-#define USART_I2SCTRL_DMASPLIT                  (0x1UL << 3)                           /**< Separate DMA Request For Left/Right Data */
+#define USART_I2SCTRL_DMASPLIT                  (0x1UL << 3)                           /**< Separate DMA Request for Left/Right Data */
 #define _USART_I2SCTRL_DMASPLIT_SHIFT           3                                      /**< Shift value for USART_DMASPLIT */
 #define _USART_I2SCTRL_DMASPLIT_MASK            0x8UL                                  /**< Bit mask for USART_DMASPLIT */
 #define _USART_I2SCTRL_DMASPLIT_DEFAULT         0x00000000UL                           /**< Mode DEFAULT for USART_I2SCTRL */
 #define USART_I2SCTRL_DMASPLIT_DEFAULT          (_USART_I2SCTRL_DMASPLIT_DEFAULT << 3) /**< Shifted mode DEFAULT for USART_I2SCTRL */
-#define USART_I2SCTRL_DELAY                     (0x1UL << 4)                           /**< Delay on I2S data */
+#define USART_I2SCTRL_DELAY                     (0x1UL << 4)                           /**< Delay on I2S Data */
 #define _USART_I2SCTRL_DELAY_SHIFT              4                                      /**< Shift value for USART_DELAY */
 #define _USART_I2SCTRL_DELAY_MASK               0x10UL                                 /**< Bit mask for USART_DELAY */
 #define _USART_I2SCTRL_DELAY_DEFAULT            0x00000000UL                           /**< Mode DEFAULT for USART_I2SCTRL */
@@ -1393,7 +1393,7 @@ typedef struct {
 /* Bit fields for USART CTRLX */
 #define _USART_CTRLX_RESETVALUE                 0x00000000UL                        /**< Default value for USART_CTRLX */
 #define _USART_CTRLX_MASK                       0x0000000FUL                        /**< Mask for USART_CTRLX */
-#define USART_CTRLX_DBGHALT                     (0x1UL << 0)                        /**< Debug halt */
+#define USART_CTRLX_DBGHALT                     (0x1UL << 0)                        /**< Debug Halt */
 #define _USART_CTRLX_DBGHALT_SHIFT              0                                   /**< Shift value for USART_DBGHALT */
 #define _USART_CTRLX_DBGHALT_MASK               0x1UL                               /**< Bit mask for USART_DBGHALT */
 #define _USART_CTRLX_DBGHALT_DEFAULT            0x00000000UL                        /**< Mode DEFAULT for USART_CTRLX */
@@ -1403,7 +1403,7 @@ typedef struct {
 #define _USART_CTRLX_CTSINV_MASK                0x2UL                               /**< Bit mask for USART_CTSINV */
 #define _USART_CTRLX_CTSINV_DEFAULT             0x00000000UL                        /**< Mode DEFAULT for USART_CTRLX */
 #define USART_CTRLX_CTSINV_DEFAULT              (_USART_CTRLX_CTSINV_DEFAULT << 1)  /**< Shifted mode DEFAULT for USART_CTRLX */
-#define USART_CTRLX_CTSEN                       (0x1UL << 2)                        /**< CTS Function enabled */
+#define USART_CTRLX_CTSEN                       (0x1UL << 2)                        /**< CTS Function Enabled */
 #define _USART_CTRLX_CTSEN_SHIFT                2                                   /**< Shift value for USART_CTSEN */
 #define _USART_CTRLX_CTSEN_MASK                 0x4UL                               /**< Bit mask for USART_CTSEN */
 #define _USART_CTRLX_CTSEN_DEFAULT              0x00000000UL                        /**< Mode DEFAULT for USART_CTRLX */

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_wdog.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_wdog.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efr32mg1p_wdog.h
  * @brief EFR32MG1P_WDOG register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,
@@ -96,7 +96,7 @@ typedef struct {
 #define _WDOG_CTRL_EM3RUN_MASK                    0x8UL                                 /**< Bit mask for WDOG_EM3RUN */
 #define _WDOG_CTRL_EM3RUN_DEFAULT                 0x00000000UL                          /**< Mode DEFAULT for WDOG_CTRL */
 #define WDOG_CTRL_EM3RUN_DEFAULT                  (_WDOG_CTRL_EM3RUN_DEFAULT << 3)      /**< Shifted mode DEFAULT for WDOG_CTRL */
-#define WDOG_CTRL_LOCK                            (0x1UL << 4)                          /**< Configuration lock */
+#define WDOG_CTRL_LOCK                            (0x1UL << 4)                          /**< Configuration Lock */
 #define _WDOG_CTRL_LOCK_SHIFT                     4                                     /**< Shift value for WDOG_LOCK */
 #define _WDOG_CTRL_LOCK_MASK                      0x10UL                                /**< Bit mask for WDOG_LOCK */
 #define _WDOG_CTRL_LOCK_DEFAULT                   0x00000000UL                          /**< Mode DEFAULT for WDOG_CTRL */
@@ -220,7 +220,7 @@ typedef struct {
 #define WDOG_PCH_PRSCTRL_PRSSEL_PRSCH9            (_WDOG_PCH_PRSCTRL_PRSSEL_PRSCH9 << 0)        /**< Shifted mode PRSCH9 for WDOG_PCH_PRSCTRL */
 #define WDOG_PCH_PRSCTRL_PRSSEL_PRSCH10           (_WDOG_PCH_PRSCTRL_PRSSEL_PRSCH10 << 0)       /**< Shifted mode PRSCH10 for WDOG_PCH_PRSCTRL */
 #define WDOG_PCH_PRSCTRL_PRSSEL_PRSCH11           (_WDOG_PCH_PRSCTRL_PRSSEL_PRSCH11 << 0)       /**< Shifted mode PRSCH11 for WDOG_PCH_PRSCTRL */
-#define WDOG_PCH_PRSCTRL_PRSMISSRSTEN             (0x1UL << 8)                                  /**< PRS missing event will trigger a watchdog reset */
+#define WDOG_PCH_PRSCTRL_PRSMISSRSTEN             (0x1UL << 8)                                  /**< PRS Missing Event Will Trigger a Watchdog Reset */
 #define _WDOG_PCH_PRSCTRL_PRSMISSRSTEN_SHIFT      8                                             /**< Shift value for WDOG_PRSMISSRSTEN */
 #define _WDOG_PCH_PRSCTRL_PRSMISSRSTEN_MASK       0x100UL                                       /**< Bit mask for WDOG_PRSMISSRSTEN */
 #define _WDOG_PCH_PRSCTRL_PRSMISSRSTEN_DEFAULT    0x00000000UL                                  /**< Mode DEFAULT for WDOG_PCH_PRSCTRL */

--- a/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_wdog_pch.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/efr32mg1p_wdog_pch.h
@@ -1,10 +1,10 @@
 /**************************************************************************//**
  * @file efr32mg1p_wdog_pch.h
  * @brief EFR32MG1P_WDOG_PCH register and bit field definitions
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efr32mg1p/include/vendor/em_device.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/em_device.h
@@ -12,10 +12,10 @@
 
  *
  * @endverbatim
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,

--- a/cpu/efm32/families/efr32mg1p/include/vendor/system_efr32mg1p.h
+++ b/cpu/efm32/families/efr32mg1p/include/vendor/system_efr32mg1p.h
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file system_efr32mg1p.h
  * @brief CMSIS Cortex-M3/M4 System Layer for EFR32 devices.
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,
@@ -126,7 +126,7 @@ uint32_t SystemCoreClockGet(void);
  *****************************************************************************/
 static __INLINE void SystemCoreClockUpdate(void)
 {
-  SystemCoreClockGet();
+  (void)SystemCoreClockGet();
 }
 
 uint32_t SystemMaxCoreClockGet(void);

--- a/cpu/efm32/families/efr32mg1p/system.c
+++ b/cpu/efm32/families/efr32mg1p/system.c
@@ -1,10 +1,10 @@
 /***************************************************************************//**
  * @file system_efr32mg1p.c
  * @brief CMSIS Cortex-M3/M4 System Layer for EFR32 devices.
- * @version 5.3.3
+ * @version 5.4.0
  ******************************************************************************
  * # License
- * <b>Copyright 2017 Silicon Laboratories, Inc. http://www.silabs.com</b>
+ * <b>Copyright 2017 Silicon Laboratories, Inc. www.silabs.com</b>
  ******************************************************************************
  *
  * Permission is granted to anyone to use this software for any purpose,
@@ -143,7 +143,7 @@ uint32_t SystemCoreClockGet(void)
   ret   = SystemHFClockGet();
   presc = (CMU->HFCOREPRESC & _CMU_HFCOREPRESC_PRESC_MASK)
           >> _CMU_HFCOREPRESC_PRESC_SHIFT;
-  ret  /= (presc + 1);
+  ret  /= presc + 1U;
 
   /* Keep CMSIS system clock variable up-to-date */
   SystemCoreClock = ret;
@@ -163,8 +163,11 @@ uint32_t SystemCoreClockGet(void)
  ******************************************************************************/
 uint32_t SystemMaxCoreClockGet(void)
 {
-  return (EFR32_HFRCO_MAX_FREQ > EFR32_HFXO_FREQ \
-          ? EFR32_HFRCO_MAX_FREQ : EFR32_HFXO_FREQ);
+#if (EFR32_HFRCO_MAX_FREQ > EFR32_HFXO_FREQ)
+  return EFR32_HFRCO_MAX_FREQ;
+#else
+  return EFR32_HFXO_FREQ;
+#endif
 }
 
 /***************************************************************************//**
@@ -257,9 +260,10 @@ void SystemHFXOClockSet(uint32_t freq)
   SystemHFXOClock = freq;
 
   /* Update core clock frequency if HFXO is used to clock core */
-  if ((CMU->HFCLKSTATUS & _CMU_HFCLKSTATUS_SELECTED_MASK) == CMU_HFCLKSTATUS_SELECTED_HFXO) {
+  if ((CMU->HFCLKSTATUS & _CMU_HFCLKSTATUS_SELECTED_MASK)
+      == CMU_HFCLKSTATUS_SELECTED_HFXO) {
     /* The function will update the global variable */
-    SystemCoreClockGet();
+    (void)SystemCoreClockGet();
   }
 #else
   (void)freq; /* Unused parameter */
@@ -283,7 +287,7 @@ void SystemInit(void)
 #if (__FPU_PRESENT == 1) && (__FPU_USED == 1)
   /* Set floating point coprosessor access mode. */
   SCB->CPACR |= ((3UL << 10 * 2)                      /* set CP10 Full Access */
-                 | (3UL << 11 * 2)  );              /* set CP11 Full Access */
+                 | (3UL << 11 * 2));                  /* set CP11 Full Access */
 #endif
 
   /****************************
@@ -291,7 +295,7 @@ void SystemInit(void)
    * Enable bypass switch as errata workaround. The bypass current limit will be
    * disabled again in CHIP_Init() to avoid added current consumption. */
 
-  EMU->DCDCCLIMCTRL |= 1 << _EMU_DCDCCLIMCTRL_BYPLIMEN_SHIFT;
+  EMU->DCDCCLIMCTRL |= 1U << _EMU_DCDCCLIMCTRL_BYPLIMEN_SHIFT;
   EMU->DCDCCTRL = (EMU->DCDCCTRL & ~_EMU_DCDCCTRL_DCDCMODE_MASK)
                   | EMU_DCDCCTRL_DCDCMODE_BYPASS;
   *(volatile uint32_t *)(0x400E3074) &= ~(0x1UL << 0);
@@ -374,9 +378,10 @@ void SystemLFXOClockSet(uint32_t freq)
   SystemLFXOClock = freq;
 
   /* Update core clock frequency if LFXO is used to clock core */
-  if ((CMU->HFCLKSTATUS & _CMU_HFCLKSTATUS_SELECTED_MASK) == CMU_HFCLKSTATUS_SELECTED_LFXO) {
+  if ((CMU->HFCLKSTATUS & _CMU_HFCLKSTATUS_SELECTED_MASK)
+      == CMU_HFCLKSTATUS_SELECTED_LFXO) {
     /* The function will update the global variable */
-    SystemCoreClockGet();
+    (void)SystemCoreClockGet();
   }
 #else
   (void)freq; /* Unused parameter */

--- a/cpu/efm32/families/efr32mg1p/vectors.c
+++ b/cpu/efm32/families/efr32mg1p/vectors.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2015-2017 Freie Universität Berlin
+ * Copyright (C) 2015-2018 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level

--- a/pkg/gecko_sdk/Makefile
+++ b/pkg/gecko_sdk/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME=gecko_sdk
 PKG_URL=https://github.com/basilfx/RIOT-gecko-sdk
-PKG_VERSION=d6a90efb97f175101821304e6e5a1ba20eef02aa
+PKG_VERSION=d381e526d68a2d0c951f37040c1c2e168ac66cd6
 PKG_LICENSE=Zlib
 
 ifneq ($(CPU),efm32)


### PR DESCRIPTION
### Contribution description

This PR updates `gecko-sdk` to vendor version 2.2 (which includes emlib 5.4.0, [changelog](https://github.com/basilfx/RIOT-gecko-sdk/blob/master/dist/emlib/Changes_emlib.txt)). Most notable are the changes towards being MISRAC 2012 compatible and GCC 7.x fixes.

Unfortunately, this package updates requires updated EFM32 vendor headers. which is 99% of this PR.  Yes, most changes are version numbers, but they have renamed a few crucial defines. I therefore suggest to focus on a8e57ff only.

I cannot split this PR since the vendor headers need the updated `gecko-sdk`, and vice versa.

Tested `examples/default` on the stk3600, sltb001a and slstk3401a and they all work.

### Issues/PRs references

#8832, #8824 and #8802 need their vendor headers updated as well.