### PR TITLE
cpu: lpc1768: correct number of power modes

### DIFF
--- a/cpu/lpc1768/include/periph_cpu.h
+++ b/cpu/lpc1768/include/periph_cpu.h
@@ -71,7 +71,7 @@ typedef enum {
 /**
  * @brief   Power management configuration
  */
-#define PM_NUM_MODES    (3U)
+#define PM_NUM_MODES    (2U)
 
 #ifdef __cplusplus
 }

--- a/cpu/lpc1768/periph/pm.c
+++ b/cpu/lpc1768/periph/pm.c
@@ -33,11 +33,10 @@ void pm_set(unsigned mode)
             LPC_SC->PCON = 0x00;
             cortexm_sleep(1);
             break;
-        case 2:
+        default:
             /* enter sleep mode */
             LPC_SC->PCON = 0x00;
             cortexm_sleep(0);
-            break;
     }
 }
 


### PR DESCRIPTION
### Contribution description

Fixes the number of power modes, as discussed [here](https://github.com/RIOT-OS/RIOT/pull/8861#discussion_r179063129). I incorrectly interpreted `pm_layered.h`.

### Issues/PRs references

[Discussion](https://github.com/RIOT-OS/RIOT/pull/8861#discussion_r179063129).