### PR TITLE
tests/pthread_barrier: Convert UTF-8 to ASCII in printf statement

### DIFF
--- a/tests/pthread_barrier/main.c
+++ b/tests/pthread_barrier/main.c
@@ -44,7 +44,7 @@ static void *run(void *id_)
         pthread_barrier_wait(&barrier);
 
         uint32_t timeout_us = random_uint32() % 2500000;
-        printf("Child %i sleeps for %8" PRIu32 " µs.\n", id, timeout_us);
+        printf("Child %i sleeps for %8" PRIu32 " us.\n", id, timeout_us);
         xtimer_usleep(timeout_us);
     }
 


### PR DESCRIPTION
### Contribution description

This fixes an issue with pexpect on python3 being unable to write UTF-8 strings to its logfile.

### Issues/PRs references

None