### PR TITLE
pkg/ccn-lite:enable CS dump in shell command

### DIFF
--- a/examples/ccn-lite-relay/README.md
+++ b/examples/ccn-lite-relay/README.md
@@ -15,12 +15,13 @@ RIOT provides three shell to interact with the CCN-Lite stack:
                 If the second parameter is omitted, the Interest will be
                 broadcasted. You may call it like this:
                 `ccnl_int /riot/peter/schmerzl b6:e5:94:26:ab:da`
-* `ccnl_cont` - generates and populates content. The command expects one
-                mandatory and one optional parameter. The first parameter
-                specifies the name of the content to be created, the second
-                parameter specifies the content itself. The second parameter
-                may include spaces, e.g. you can call:
-                `ccnl_cont /riot/peter/schmerzl Hello World! Hello RIOT!`
+* `ccnl_cs`   - dumps CS or generates and populates content. If the command is
+                called without parameters, it will print all content items in
+                the cache. Otherwise, the command expects two parameters. The
+                first parameter specifies the name of the content to be created,
+                the second parameter specifies the content itself. The second
+                parameter may include spaces, e.g. you can call:
+               `ccnl_cont /riot/peter/schmerzl Hello World! Hello RIOT!`
 * `ccnl_fib`  - modifies the FIB or shows its current state. If the command is
                 called without parameters, it will print the current state of
                 the FIB. It can also be called with the action parameters `add`

--- a/sys/shell/commands/shell_commands.c
+++ b/sys/shell/commands/shell_commands.c
@@ -213,7 +213,7 @@ const shell_command_t _shell_command_list[] = {
 #ifdef MODULE_CCN_LITE_UTILS
     { "ccnl_open", "opens an interface or socket", _ccnl_open },
     { "ccnl_int", "sends an interest", _ccnl_interest },
-    { "ccnl_cont", "create content and populated it", _ccnl_content },
+    { "ccnl_cs", "shows CS or creates content and populates it", _ccnl_content },
     { "ccnl_fib", "shows or modifies the CCN-Lite FIB", _ccnl_fib },
 #endif
 #ifdef MODULE_SNTP


### PR DESCRIPTION
### Contribution description

This PR adds a new feature to the CCN-lite shell command `ccnl_cont` which dumps all content items in the cache. Please note that without a version bump to the below referenced PR, this will result in some formating errors. A version bump will be PRed soon.

### Issues/PRs references

[https://github.com/cn-uofbasel/ccn-lite/pull/224](https://github.com/cn-uofbasel/ccn-lite/pull/224)