### PR TITLE
tests: enable ps_schedstatistics and struct_tm_utility on-hardware CI tests

### DIFF
--- a/tests/ps_schedstatistics/Makefile
+++ b/tests/ps_schedstatistics/Makefile
@@ -11,6 +11,8 @@ USEMODULE += ps
 USEMODULE += schedstatistics
 USEMODULE += printf_float
 
+TEST_ON_CI_WHITELIST += all
+
 include $(RIOTBASE)/Makefile.include
 
 test:

--- a/tests/ps_schedstatistics/tests/01-run.py
+++ b/tests/ps_schedstatistics/tests/01-run.py
@@ -39,6 +39,8 @@ def _check_startup(child):
 
 
 def _check_help(child):
+    child.sendline('')
+    child.expect('>')
     child.sendline('help')
     child.expect_exact('Command              Description')
     child.expect_exact('---------------------------------------')

--- a/tests/struct_tm_utility/Makefile
+++ b/tests/struct_tm_utility/Makefile
@@ -8,6 +8,8 @@ USEMODULE += timex
 # The MSP-430 toolchain lacks sscanf:
 BOARD_BLACKLIST := chronos msb-430 msb-430h telosb wsn430-v1_3b wsn430-v1_4 z1
 
+TEST_ON_CI_WHITELIST += all
+
 include $(RIOTBASE)/Makefile.include
 
 test:

--- a/tests/struct_tm_utility/tests/01-run.py
+++ b/tests/struct_tm_utility/tests/01-run.py
@@ -105,7 +105,13 @@ def _check_day(child):
                        'but no error should occur.')
 
 
+def _wait_prompt(child):
+    child.sendline('')
+    child.expect('>')
+
+
 def testfunc(child):
+    _wait_prompt(child)
     _check_help(child)
     _check_days_in(child)
     _check_leap_year(child)


### PR DESCRIPTION
### Contribution description

fixes & CI-enables ps_schedstatistics, struct_tm_utility

### Issues/PRs references

#8869 