### PR TITLE
cpu: efm32: correct power modes

### DIFF
--- a/cpu/efm32/include/periph_cpu.h
+++ b/cpu/efm32/include/periph_cpu.h
@@ -372,9 +372,14 @@ typedef struct {
 } uart_conf_t;
 
 /**
+ * @brief   CPU provides own pm_off() function
+ */
+#define PROVIDES_PM_LAYERED_OFF
+
+/**
  * @brief   Number of usable power modes.
  */
-#define PM_NUM_MODES    (3U)
+#define PM_NUM_MODES    (2U)
 
 #ifdef __cplusplus
 }

--- a/cpu/efm32/periph/pm.c
+++ b/cpu/efm32/periph/pm.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Bas Stottelaar <basstottelaar@gmail.com>
+ * Copyright (C) 2017-2018 Bas Stottelaar <basstottelaar@gmail.com>
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -33,9 +33,13 @@ void pm_set(unsigned mode)
             /* after exiting EM2, clocks are restored */
             EMU_EnterEM2(true);
             break;
-        case 2:
+        default:
             /* wait for next event or interrupt */
             EMU_EnterEM1();
-            break;
     }
+}
+
+void pm_off(void)
+{
+    EMU_EnterEM4();
 }


### PR DESCRIPTION
### Contribution description

This PR corrects the number of power modes and provides `pm_off`. Like the LPC1768, I've made the same mistake on the EFM32 platform (which was fixed by #8874).

For more information on the different EFM32 energy modes, see [here](https://www.silabs.com/products/mcu/32-bit/efm32-energy-modes).

Tested this on the STK3600 and SLSTK3401a.

### Issues/PRs references

#8874