### PR TITLE
examples/ccn-lite-relay: use xorshift PRNG

### DIFF
--- a/examples/ccn-lite-relay/Makefile
+++ b/examples/ccn-lite-relay/Makefile
@@ -36,7 +36,7 @@ USEMODULE += gnrc_pktdump
 USEMODULE += timex
 USEMODULE += xtimer
 USEMODULE += random
-USEMODULE += prng_minstd
+USEMODULE += prng_xorshift
 
 USEPKG += tlsf
 


### PR DESCRIPTION
### Contribution description

This PR changes the PRNG to use in examples/ccn-lite-relay. As pointed out in #7545 the xorshift is an efficient one.


### Issues/PRs references

Relates to #7545, ~~waits for #8883~~