### PR TITLE
xtimer: Add XTIMER_SHIFT = 6 automatic option

### DIFF
--- a/sys/include/xtimer.h
+++ b/sys/include/xtimer.h
@@ -610,6 +610,8 @@ void xtimer_set_timeout_flag(xtimer_t *t, uint32_t timeout);
 #define XTIMER_SHIFT (4)
 #elif (XTIMER_HZ >> 5 == XTIMER_HZ_BASE) || (XTIMER_HZ << 5 == XTIMER_HZ_BASE)
 #define XTIMER_SHIFT (5)
+#elif (XTIMER_HZ >> 6 == XTIMER_HZ_BASE) || (XTIMER_HZ << 6 == XTIMER_HZ_BASE)
+#define XTIMER_SHIFT (6)
 #else
 #error "XTIMER_SHIFT cannot be derived for given XTIMER_HZ, verify settings!"
 #endif


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Just adding another step in the conditionals for XTIMER_SHIFT 6. Discovered that it was missing when trying to use a 15625 Hz xtimer instead of 1 MHz as an experiment.

### Issues/PRs references

