### PR TITLE
murdock: make job collection use subjobs

### DIFF
--- a/.murdock
+++ b/.murdock
@@ -87,7 +87,7 @@ get_app_board_pairs() {
 # use dwqc to create full "appdir board" compile job list
 get_compile_jobs() {
     get_apps | \
-        dwqc -E BOARDS -E APPS -s \
+        dwqc --subjob -E BOARDS -E APPS -s \
         "$0 get_app_board_pairs \${1}" \
         | xargs '-d\n' -n 1 echo $0 compile
 }


### PR DESCRIPTION
### Contribution description

Currently, before starting with actual compilation, Murdock collects *all* jobs.
This PR tries to use DWQ's subjob feature to get jobs starting as soon as they're available.