### PR TITLE
doc: remove sys_util references

### DIFF
--- a/sys/bitfield/bitfield.c
+++ b/sys/bitfield/bitfield.c
@@ -7,7 +7,6 @@
  */
 
 /**
- * @ingroup     sys_util
  * @{
  *
  * @file

--- a/sys/include/div.h
+++ b/sys/include/div.h
@@ -8,13 +8,14 @@
  */
 
 /**
- * @brief     Integer division functions
+ * @defgroup  sys_div   Integer division functions
+ * @ingroup   sys
  *
  * This header provides some integer division functions that can be used
  * to prevent linking in compiler-generated ones, which are often larger.
  *
  * @file
- * @ingroup   sys_util
+ * @ingroup   sys
  * @author    Kaspar Schleiser <kaspar@schleiser.de>
  * @author    Joakim Nohlgård <joakim.nohlgard@eistec.se>
  * @{

--- a/sys/include/iolist.h
+++ b/sys/include/iolist.h
@@ -7,8 +7,8 @@
  */
 
 /**
- * @defgroup    sys_util_iolist iolist scatter / gather IO
- * @ingroup     sys_util
+ * @defgroup    sys_iolist iolist scatter / gather IO
+ * @ingroup     sys
  * @brief       Provides linked-list scatter / gather IO
  *
  * @{

--- a/sys/iolist/iolist.c
+++ b/sys/iolist/iolist.c
@@ -7,7 +7,6 @@
  */
 
 /**
- * @ingroup     sys_util
  * @{
  *
  * @file


### PR DESCRIPTION
### Contribution description
This removes all references of the `sys_util` documentation group which does not exist. Due to it being referenced by some module documentations there were some cases where the rendered doc was broken:

* `div` did not appear in the list of modules
* `iolist` appeared on top level of the module tree

### Issues/PRs references
None