### PR TITLE
cpu: efm32: throw error on including rtc and rtt together.

### DIFF
--- a/cpu/efm32/Makefile.features
+++ b/cpu/efm32/Makefile.features
@@ -2,6 +2,9 @@ FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_flashpage
 FEATURES_PROVIDED += periph_pm
 
+FEATURES_CONFLICT += periph_rtc:periph_rtt
+FEATURES_CONFLICT_MSG += "On the EFM32, the RTC and RTT map to the same hardware peripheral."
+
 ifeq (1,$(EFM32_TNRG))
   FEATURES_PROVIDED += periph_hwrng
 endif


### PR DESCRIPTION
### Contribution description

On the EFM32, RTT and RTC use the same hardware peripheral. It doesn't make sense to include both of them, especially if #8543 gets merged.

This PR will throw an error if you include both the RTT and RTC driver.

To test, create/modify an application which includes both, then verify that it will not build.

### Issues/PRs references

#8543