### PR TITLE
netopt: move NETOPT_BLE_CTX to new netopt doc style

### DIFF
--- a/sys/include/net/netopt.h
+++ b/sys/include/net/netopt.h
@@ -532,7 +532,12 @@ typedef enum {
      */
     NETOPT_TX_RETRIES_NEEDED,
 
-    NETOPT_BLE_CTX,             /**< set radio context (channel, CRC, AA) */
+    /**
+     * @brief   (netdev_ble_ctx_t) set BLE radio context (channel, CRC, AA)
+     *
+     * @warning As @ref drivers_netdev_ble is still experimental, use with care!
+     */
+    NETOPT_BLE_CTX,
 
     /* add more options if needed */
 


### PR DESCRIPTION
### Contribution description
Documentation of the option types was clarified in #8655. I only noticed
after merging #8884, that `NETOPT_BLE_CTX` was not documented using
that new style. So I deliver the change myself to make it quicker.

### Issues/PRs references
Fixes an oversight in #8884, related to #8655.