### PR TITLE
gnrc: fix build of gnrc_ipv6_blacklist when ENABLE_DEBUG is disabled

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/blacklist/gnrc_ipv6_blacklist.c
+++ b/sys/net/gnrc/network_layer/ipv6/blacklist/gnrc_ipv6_blacklist.c
@@ -25,9 +25,7 @@
 ipv6_addr_t gnrc_ipv6_blacklist[GNRC_IPV6_BLACKLIST_SIZE];
 BITFIELD(gnrc_ipv6_blacklist_set, GNRC_IPV6_BLACKLIST_SIZE);
 
-#if ENABLE_DEBUG
 static char addr_str[IPV6_ADDR_MAX_STR_LEN];
-#endif
 
 int gnrc_ipv6_blacklist_add(const ipv6_addr_t *addr)
 {


### PR DESCRIPTION
### Contribution description

Without this commit it doesn't build because `addr_str` isn't defined when
`ENABLE_DEBUG` is not set. With `gcc 7.3.0` this causes the following compiler error:

```
/home/soeren/sys/net/gnrc/network_layer/ipv6/blacklist/gnrc_ipv6_blacklist.c: In function ‘gnrc_ipv6_blacklist_add’:                                                       
/home/soeren/sys/net/gnrc/network_layer/ipv6/blacklist/gnrc_ipv6_blacklist.c:39:36: error: ‘addr_str’ undeclared (first use in this function); did you mean ‘addr’?        
                   ipv6_addr_to_str(addr_str, addr, sizeof(addr_str)));                                                                                                  
                                    ^                                                                                                                                    
/home/soeren/core/include/debug.h:63:33: note: in definition of macro ‘DEBUG_PRINT’                                                                                        
 #define DEBUG_PRINT(...) printf(__VA_ARGS__)                                                                                                                            
                                 ^~~~~~~~~~~                                                                                                                             
/home/soeren/sys/net/gnrc/network_layer/ipv6/blacklist/gnrc_ipv6_blacklist.c:38:13: note: in expansion of macro ‘DEBUG’                                                    
             DEBUG("IPv6 blacklist: blacklisted %s\n",                                                                                                                   
             ^~~~~                                                                                                                                                       
/home/soeren/sys/net/gnrc/network_layer/ipv6/blacklist/gnrc_ipv6_blacklist.c:39:36: note: each undeclared identifier is reported only once for each function it appears in 
                   ipv6_addr_to_str(addr_str, addr, sizeof(addr_str)));                                                                                                  
                                    ^                                                                                                                                    
/home/soeren/core/include/debug.h:63:33: note: in definition of macro ‘DEBUG_PRINT’                                                                                        
 #define DEBUG_PRINT(...) printf(__VA_ARGS__)                                                                                                                            
                                 ^~~~~~~~~~~                                                                                                                             
/home/soeren/sys/net/gnrc/network_layer/ipv6/blacklist/gnrc_ipv6_blacklist.c:38:13: note: in expansion of macro ‘DEBUG’                                                    
             DEBUG("IPv6 blacklist: blacklisted %s\n",                                                                                                                   
             ^~~~~                                                                                                                                                       
/home/soeren/sys/net/gnrc/network_layer/ipv6/blacklist/gnrc_ipv6_blacklist.c: In function ‘gnrc_ipv6_blacklist_del’:                                                       
/home/soeren/sys/net/gnrc/network_layer/ipv6/blacklist/gnrc_ipv6_blacklist.c:52:36: error: ‘addr_str’ undeclared (first use in this function); did you mean ‘addr’?        
                   ipv6_addr_to_str(addr_str, addr, sizeof(addr_str)));                                                                                                  
                                    ^                                                                                                                                    
/home/soeren/core/include/debug.h:63:33: note: in definition of macro ‘DEBUG_PRINT’                                                                                        
 #define DEBUG_PRINT(...) printf(__VA_ARGS__)                                                                                                                            
                                 ^~~~~~~~~~~                                                                                                                             
/home/soeren/sys/net/gnrc/network_layer/ipv6/blacklist/gnrc_ipv6_blacklist.c:51:13: note: in expansion of macro ‘DEBUG’                                                    
             DEBUG("IPv6 blacklist: unblacklisted %s\n",                                                                                                                 
             ^~~~~                                                                                                                                                       
```



This issue was introduced in: c001e14f9deeb8f64618289d4448d2ef2cb9186d