### PR TITLE
tests/periph_flashpage: fix typo in doxygen header

### DIFF
--- a/tests/periph_flashpage/main.c
+++ b/tests/periph_flashpage/main.c
@@ -11,7 +11,7 @@
  * @{
  *
  * @file
- * @brief       Manual test application for UART peripheral drivers
+ * @brief       Manual test application for flashpage peripheral drivers
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  *


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR fixes a small typo (UART instead of flashpage) in the periph_flashpage test application.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->