### PR TITLE
cpu/atmega_common: return to non-interrupt context swaps

### DIFF
--- a/boards/common/arduino-atmega/include/board_common.h
+++ b/boards/common/arduino-atmega/include/board_common.h
@@ -60,32 +60,6 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   Context swap defines
- *
- * Setup to use PC5 which is pin change interrupt 13 (PCINT13)
- * This emulates a software triggered interrupt
- */
-#ifdef CPU_ATMEGA328P
-#define AVR_CONTEXT_SWAP_INIT do { \
-            DDRD |= (1 << PD7); \
-            PCICR |= (1 << PCIE2); \
-            PCMSK2 |= (1 << PCINT23); \
-} while (0)
-#define AVR_CONTEXT_SWAP_INTERRUPT_VECT  PCINT2_vect
-#define AVR_CONTEXT_SWAP_TRIGGER   PORTD ^= (1 << PD7)
-#endif
-
-#ifdef CPU_ATMEGA2560
-#define AVR_CONTEXT_SWAP_INIT do { \
-    DDRJ |= (1 << PJ6); \
-    PCICR |= (1 << PCIE1); \
-    PCMSK1 |= (1 << PCINT15); \
-} while (0)
-#define AVR_CONTEXT_SWAP_INTERRUPT_VECT  PCINT1_vect
-#define AVR_CONTEXT_SWAP_TRIGGER   PORTJ ^= (1 << PJ6)
-#endif
-
-/**
  * @name    xtimer configuration values
  * @{
  */

--- a/boards/jiminy-mega256rfr2/include/board.h
+++ b/boards/jiminy-mega256rfr2/include/board.h
@@ -76,21 +76,6 @@ extern "C" {
 /** @} */
 
 /**
- * @name Context swap defines
- * This emulates a software triggered interrupt
- * @{
- */
-#define AVR_CONTEXT_SWAP_INIT do { \
-        DDRE |= (1 << PE7); \
-        EICRB |= (1 << ISC70); \
-        EIMSK |= (1 << INT7); \
-        sei(); \
-} while (0)
-#define AVR_CONTEXT_SWAP_INTERRUPT_VECT  INT7_vect
-#define AVR_CONTEXT_SWAP_TRIGGER   PORTE ^= (1 << PE7)
-/** @} */
-
-/**
  * @name xtimer configuration values
  * @{
  */

--- a/boards/mega-xplained/include/board.h
+++ b/boards/mega-xplained/include/board.h
@@ -50,22 +50,6 @@ extern "C" {
 #define UART_STDIO_DEV       (UART_DEV(1))
 
 /**
- * @name    Context swap defines
- *
- * Setup to use PD7 which is pin change interrupt 31 (PCINT31)
- * This emulates a software triggered interrupt
- * @{
- */
-#define AVR_CONTEXT_SWAP_INIT do { \
-            DDRD |= (1 << PD7); \
-            PCICR |= (1 << PCIE3); \
-            PCMSK3 |= (1 << PCINT31); \
-} while (0)
-#define AVR_CONTEXT_SWAP_INTERRUPT_VECT  PCINT3_vect
-#define AVR_CONTEXT_SWAP_TRIGGER   PORTD ^= (1 << PD7)
-/** @} */
-
-/**
  * @name    xtimer configuration values
  *
  * Xtimer runs at 8MHz / 64 = 125kHz

--- a/boards/waspmote-pro/include/board.h
+++ b/boards/waspmote-pro/include/board.h
@@ -146,21 +146,6 @@ extern "C" {
 /** @} */
 
 /**
- * @brief Context swap defines
- * Setup to use PB5 which is pin change interrupt 5
- * This emulates a software triggered interrupt
- **/
-#define AVR_CONTEXT_SWAP_INIT do { \
-    DDRB |= (1 << PB5); \
-    PCICR |= (1 << PCIE0); \
-    PCMSK0 |= (1 << PCINT5); \
-} while (0)
-/** @cond INTERNAL */
-#define AVR_CONTEXT_SWAP_INTERRUPT_VECT  PCINT0_vect
-#define AVR_CONTEXT_SWAP_TRIGGER   PORTB ^= (1 << PB5)
-/** @endcond */
-
-/**
  * @name    xtimer configuration values
  * @{
  */

--- a/cpu/atmega_common/include/cpu.h
+++ b/cpu/atmega_common/include/cpu.h
@@ -97,6 +97,13 @@ __attribute__((always_inline)) static inline void cpu_print_last_instruction(voi
  */
 void atmega_stdio_init(void);
 
+/**
+ * @brief   Exit ISR mode and yield with a return from interrupt. Use at the
+ * end of ISRs in place of thread_yield_higher. If thread_yield is needed, use
+ * thread_yield followed by thread_yield_isr instead of thread_yield alone.
+ */
+void thread_yield_isr(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/atmega_common/periph/gpio.c
+++ b/cpu/atmega_common/periph/gpio.c
@@ -313,10 +313,9 @@ ISR(INT6_vect, ISR_BLOCK)
 }
 #endif
 
-#if defined(INT7_vect) && !defined(BOARD_JIMINY_MEGA256RFR2)
-/**< INT7 is context swap pin for the Jiminy board */
+#if defined(INT7_vect)
 ISR(INT7_vect, ISR_BLOCK)
 {
     irq_handler(7); /**< predefined interrupt pin */
 }
-#endif  /* INT7_vect && END BOARD_JIMINY_MEGA256RFR2 */
+#endif

--- a/cpu/atmega_common/periph/timer.c
+++ b/cpu/atmega_common/periph/timer.c
@@ -176,6 +176,7 @@ static inline void _isr(tim_t tim, int chan)
 
     if (sched_context_switch_request) {
         thread_yield();
+        thread_yield_isr();
     }
 
     __exit_isr();

--- a/cpu/atmega_common/periph/uart.c
+++ b/cpu/atmega_common/periph/uart.c
@@ -170,6 +170,7 @@ static inline void isr_handler(int num)
 
     if (sched_context_switch_request) {
         thread_yield();
+        thread_yield_isr();
     }
 }
 


### PR DESCRIPTION
Second attempt. See also, first attempt: #8898

This removes the ISR based context swaps on the ATmegas. They were originally introduced in #5745. ISR swaps were introduced to handle the problems with context swaps while inside an ISR. However, there aren't really any differences in the execution environment within an ISR on the ATmega, which means that there are simpler ways to handle this problem.

The behavior is as follows:
- If thread_yield_higher is called outside of an ISR, it changes context and then changes the program counter using the 'ret' (subroutine return) instruction. This is the same behavior as prior to #5745.
- If thread_yield_higher is called within an ISR, it sets sched_context_switch_request and does nothing else.
- The function thread_yield_isr is introduced, which is meant to be called within ISRs to yield. It changes the context, tells RIOT it is no longer within an ISR (using __exit_isr) and then changes the program counter using the 'reti' (interrupt return) instruction.

tests/thread_* on mega-xplained all passed (including tests/thread_race added by #8897). Also tested with xtimer_* on mega-xplained and all passed except for xtimer_longterm (did not run this test) and xtimer_now64_continuity which showed some inaccuracy. This may be due to the low xtimer accuracy on mega-xplained however.

References:
- Fixes #8896
- Race conditions tested for by #8897
- First attempt at solving race conditions #8898
- ISR context swaps introduced by #5745