### PR TITLE
net/rdcli_common: improve doc for SUFFIX_LEN option

### DIFF
--- a/sys/include/net/rdcli_config.h
+++ b/sys/include/net/rdcli_config.h
@@ -63,6 +63,8 @@ extern "C" {
 #ifndef RDCLI_EP
 /**
  * @brief   Number of generated hexadecimal characters added to the ep
+ *
+ * @note    Must be an even number
  */
 #define RDCLI_EP_SUFFIX_LEN     (16)
 


### PR DESCRIPTION
### Contribution description
@bergzand just notice correctly, that the code for `rdcli_common` does only support even numbers for the number of hex digits in the generated part of the endpoint name. So this PR adds this constraint to the documentation

### Issues/PRs references
pointed out in #8905