### PR TITLE
netdev_tap: fix return value of set option function

### DIFF
--- a/cpu/native/netdev_tap/netdev_tap.c
+++ b/cpu/native/netdev_tap/netdev_tap.c
@@ -141,9 +141,11 @@ static int _set(netdev_t *dev, netopt_t opt, const void *value, size_t value_len
         case NETOPT_ADDRESS:
             assert(value_len >= ETHERNET_ADDR_LEN);
             _set_mac_addr(dev, (const uint8_t*)value);
+            res = ETHERNET_ADDR_LEN;
             break;
         case NETOPT_PROMISCUOUSMODE:
             _set_promiscous(dev, ((const bool *)value)[0]);
+            res = sizeof(netopt_enable_t);
             break;
         default:
             res = netdev_eth_set(dev, opt, value, value_len);


### PR DESCRIPTION
### Contribution description
Found this while testing #8823. The set option function does not return the actual length set, resulting in the network interface layer of GNRC to think that the value wasn't actually set (or an error occured, however you want to interpret a result of 0 with set ;-)), resulting in the reconfiguration of the hardware and IPv6 addresses with DAD, not actually going through, since GNRC is not notified about the change.

### Issues/PRs references
Found in #8823, but independent of that (as long as you don't test #8823 on native, then you need this one).