### PR TITLE
doc: update IPv6 RFC references

### DIFF
--- a/sys/include/net/gnrc/ipv6/ext.h
+++ b/sys/include/net/gnrc/ipv6/ext.h
@@ -10,9 +10,7 @@
  * @defgroup    net_gnrc_ipv6_ext IPv6 extension headers.
  * @ingroup     net_gnrc_ipv6
  * @brief       Implementation of IPv6 extension headers
- * @see <a href="https://tools.ietf.org/html/rfc2460#section-4">
- *          RFC 2460, section 4
- *      </a>
+ * @see [RFC 8200, section 4](https://tools.ietf.org/html/rfc8200#section-4)
  * @{
  *
  * @file

--- a/sys/include/net/ipv6.h
+++ b/sys/include/net/ipv6.h
@@ -11,9 +11,7 @@
  * @ingroup     net
  * @brief       Provides types and helper functions related to Internet Protocol
  *              version 6 (IPv6)
- * @see <a href="http://tools.ietf.org/html/rfc2460">
- *          RFC 2460
- *      </a> et al.
+ * @see [RFC 8200](http://tools.ietf.org/html/rfc8200) et al.
  * @{
  *
  * @file
@@ -35,9 +33,7 @@ extern "C" {
 /**
  * @brief   minimum **M**aximum **T**ransition **U**nit
  *
- * @see <a href="https://tools.ietf.org/html/rfc4944#section-5.3">
- *          RFC 2460, section 5.3
- *      </a>
+ * @see [RFC 8200, section 5](https://tools.ietf.org/html/rfc8200#section-5)
  */
 #define IPV6_MIN_MTU    (1280)
 

--- a/sys/include/net/ipv6/ext.h
+++ b/sys/include/net/ipv6/ext.h
@@ -34,9 +34,7 @@ extern "C" {
 /**
  * @brief   IPv6 extension headers.
  *
- * @see <a href="https://tools.ietf.org/html/rfc2460#section-4">
- *          RFC 2460, section 4.1
- *      </a>
+ * @see [RFC 8200, section 4](https://tools.ietf.org/html/rfc8200#section-4)
  */
 typedef struct __attribute__((packed)) {
     uint8_t nh;     /**< next header */

--- a/sys/include/net/ipv6/ext/rh.h
+++ b/sys/include/net/ipv6/ext/rh.h
@@ -44,9 +44,7 @@ extern "C" {
 /**
  * @brief   IPv6 routing extension header.
  *
- * @see <a href="https://tools.ietf.org/html/rfc2460#section-4.4">
- *          RFC 2460, section 4.4
- *      </a>
+ * @see [RFC 8200](https://tools.ietf.org/html/rfc8200#section-4.4)
  *
  * @extends ipv6_ext_t
  */

--- a/sys/include/net/ipv6/hdr.h
+++ b/sys/include/net/ipv6/hdr.h
@@ -61,9 +61,7 @@ extern "C" {
  * +-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+-+
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  *
- * @see <a href="http://tools.ietf.org/html/rfc2460#section-3">
- *          RFC 2460, section 3
- *      </a>
+ * @see [RFC 8200, section 3](http://tools.ietf.org/html/rfc8200#section-3)
  */
 typedef struct __attribute__((packed)) {
     /**
@@ -268,9 +266,7 @@ static inline uint32_t ipv6_hdr_get_fl(const ipv6_hdr_t *hdr)
 /**
  * @brief   Calculates the Internet Checksum for the IPv6 Pseudo Header.
  *
- * @see <a href="https://tools.ietf.org/html/rfc2460#section-8.1">
- *          RFC 2460, section 8.1
- *      </a>
+ * @see [RFC 8200, section 8.1](https://tools.ietf.org/html/rfc8200#section-8.1)
  *
  * @param[in] sum       Preinialized value of the sum.
  * @param[in] prot_num  The @ref net_protnum you want to calculate the

--- a/sys/net/gnrc/transport_layer/udp/gnrc_udp.c
+++ b/sys/net/gnrc/transport_layer/udp/gnrc_udp.c
@@ -87,7 +87,7 @@ static uint16_t _calc_csum(gnrc_pktsnip_t *hdr, gnrc_pktsnip_t *pseudo_hdr,
     }
     /* return inverted results */
     if (csum == 0xFFFF) {
-        /* https://tools.ietf.org/html/rfc2460#section-8.1
+        /* https://tools.ietf.org/html/rfc8200#section-8.1
          * bullet 4
          * "if that computation yields a result of zero, it must be changed
          * to hex FFFF for placement in the UDP header."
@@ -137,7 +137,7 @@ static void _receive(gnrc_pktsnip_t *pkt)
 
     /* validate checksum */
     if (byteorder_ntohs(hdr->checksum) == 0) {
-        /* RFC 2460 Section 8.1
+        /* RFC 8200 Section 8.1
          * "IPv6 receivers must discard UDP packets containing a zero checksum,
          * and should log the error."
          */

--- a/tests/unittests/tests-gnrc_udp/tests-gnrc_udp.c
+++ b/tests/unittests/tests-gnrc_udp/tests-gnrc_udp.c
@@ -204,7 +204,7 @@ static void test_gnrc_udp__csum_zero(void)
     int status = _compute_checksum(payload_data, sizeof(payload_data), &checksum);
 
     TEST_ASSERT_EQUAL_INT(0, status);
-    /* https://tools.ietf.org/html/rfc2460#section-8.1
+    /* https://tools.ietf.org/html/rfc8200#section-8.1
      * bullet 4
      * "if that computation yields a result of zero, it must be changed
      * to hex FFFF for placement in the UDP header."
@@ -228,7 +228,7 @@ static void test_gnrc_udp__csum_all(void)
 
         TEST_ASSERT_EQUAL_INT(0, status);
         if (i == 0xFFFF) {
-            /* https://tools.ietf.org/html/rfc2460#section-8.1
+            /* https://tools.ietf.org/html/rfc8200#section-8.1
              * bullet 4
              * "if that computation yields a result of zero, it must be changed
              * to hex FFFF for placement in the UDP header."


### PR DESCRIPTION
### Contribution description
[RFC 2460](https://tools.ietf.org/html/rfc2460) was obsoleted by [RFC 8200](https://tools.ietf.org/html/rfc8200). This PR changes the references around, so we don't reference an obsoleted RFC ;-).

Also I'm moving these references from the old-style HTML-like format to the newer-style Markdown-like format.

### Issues/PRs references
None