### PR TITLE
Makefile.include: fix missing target for libraries

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -352,10 +352,13 @@ endif # RIOTNOLINK
 $(ELFFILE): $(BASELIBS)
 	$(Q)$(_LINK) -o $@
 
-# All modules are built by application.inc.mk makefile
 $(BINDIR)/$(APPLICATION_MODULE).a: $(RIOTBUILD_CONFIG_HEADER_C) $(USEPKG:%=$(BINDIR)/%.a) $(APPDEPS)
 	$(Q)DIRS="$(DIRS)" "$(MAKE)" -C $(APPDIR) -f $(RIOTMAKE)/application.inc.mk
 $(BINDIR)/$(APPLICATION_MODULE).a: FORCE
+
+# Other modules are built by application.inc.mk and packages building
+_SUBMAKE_LIBS = $(filter-out $(BINDIR)/$(APPLICATION_MODULE).a $(USEPKG:%=$(BINDIR)/%.a) $(APPDEPS), $(BASELIBS))
+$(_SUBMAKE_LIBS): $(BINDIR)/$(APPLICATION_MODULE).a $(USEPKG:%=$(BINDIR)/%.a)
 
 # 'print-size' triggers a rebuild. Use 'info-buildsize' if you do not need to rebuild.
 print-size: $(ELFFILE)


### PR DESCRIPTION
Unittests add libraries in 'BASELIBS' which do not have any rules to be built as
they are built by 'application.inc.mk' and the DIRS variable.
So make complains about missing target for the unittests archives.

The fix tells these files are generated when building '$(APPLICATION_MODULE).a'.

The bug was introduced by #8844

Fixes #8910