### PR TITLE
Test murdock failed to detect bug in Makefile

### DIFF
--- a/.murdock
+++ b/.murdock
@@ -120,7 +120,9 @@ compile() {
 
     # compile
     CCACHE_BASEDIR="$(pwd)" BOARD=$board RIOT_CI_BUILD=1 \
-        make -C${appdir} clean all -j${JOBS:-4}
+        make -C${appdir} clean -j${JOBS:-4}
+    CCACHE_BASEDIR="$(pwd)" BOARD=$board RIOT_CI_BUILD=1 \
+        make -C${appdir} all -j${JOBS:-4}
     RES=$?
 
     # run tests

--- a/makefiles/buildtests.inc.mk
+++ b/makefiles/buildtests.inc.mk
@@ -10,7 +10,7 @@ buildtest:
 		$(COLOR_ECHO) -n "Building for $$board ... " ; \
 		BOARD=$${board} RIOT_CI_BUILD=1 RIOT_VERSION_OVERRIDE=buildtest \
 			$(MAKE) clean >/dev/null 2>&1; \
-			$(MAKE) clean all -j $(NPROC) >/dev/null 2>&1; \
+			$(MAKE) all -j $(NPROC) >/dev/null 2>&1; \
 		RES=$$? ; \
 		if [ $$RES -eq 0 ]; then \
 			$(COLOR_ECHO) "$(COLOR_GREEN)success.$(COLOR_RESET)" ; \

--- a/makefiles/buildtests.inc.mk
+++ b/makefiles/buildtests.inc.mk
@@ -9,6 +9,7 @@ buildtest:
 	for board in $(BOARDS); do \
 		$(COLOR_ECHO) -n "Building for $$board ... " ; \
 		BOARD=$${board} RIOT_CI_BUILD=1 RIOT_VERSION_OVERRIDE=buildtest \
+			$(MAKE) clean >/dev/null 2>&1; \
 			$(MAKE) clean all -j $(NPROC) >/dev/null 2>&1; \
 		RES=$$? ; \
 		if [ $$RES -eq 0 ]; then \

--- a/makefiles/buildtests.inc.mk
+++ b/makefiles/buildtests.inc.mk
@@ -9,8 +9,7 @@ buildtest:
 	for board in $(BOARDS); do \
 		$(COLOR_ECHO) -n "Building for $$board ... " ; \
 		BOARD=$${board} RIOT_CI_BUILD=1 RIOT_VERSION_OVERRIDE=buildtest \
-			$(MAKE) clean >/dev/null 2>&1; \
-			$(MAKE) all -j $(NPROC) >/dev/null 2>&1; \
+			$(MAKE) clean all -j $(NPROC) >/dev/null 2>&1; \
 		RES=$$? ; \
 		if [ $$RES -eq 0 ]; then \
 			$(COLOR_ECHO) "$(COLOR_GREEN)success.$(COLOR_RESET)" ; \


### PR DESCRIPTION
### Contribution description

Murdock was not finding the problem described in https://github.com/RIOT-OS/RIOT/issues/8910

~~Reason is that archives files are kept between build, and so when running `make clean all` the files exist and make did not complain.~~ (I mixed with buildtest command)

As murdock is run with `clean all`, there is a rule that say `$(BASELIBS) (other_stuff): clean` so make was not complaining.

The goal of this PR is just to show that it fails in murdock without fix in https://github.com/RIOT-OS/RIOT/pull/8911

### Issues/PRs references

Issue https://github.com/RIOT-OS/RIOT/issues/8910
