### PR TITLE
doc: Add nightly build status of master to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+[![Nightly CI status master](https://ci.riot-os.org/RIOT-OS/RIOT/master/latest/badge.svg)](https://ci.riot-os.org/RIOT-OS/RIOT/master/latest/output.html)
+
                           ZZZZZZ
                         ZZZZZZZZZZZZ
                       ZZZZZZZZZZZZZZZZ


### PR DESCRIPTION
### Contribution description
This adds a small badge to the README that shows the current build status of the nightly builds.

### Issues/PRs references
There is still an issue with the alignment within the graphic, that should be fixed with https://github.com/RIOT-OS/murdock-scripts/pull/15 (and once @kaspar030/@smlng worked in that change into the running instance of Murdock)