### PR TITLE
net/nanocoap: add generic handling for string-based options

### DIFF
--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2016-17 Kaspar Schleiser <kaspar@schleiser.de>
+ *               2018 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -18,6 +19,7 @@
  *
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  * @author      Ken Bannister <kb2ma@runbox.com>
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
 #ifndef NET_NANOCOAP_H
@@ -63,9 +65,11 @@ extern "C" {
  */
 #define COAP_OPT_URI_HOST       (3)
 #define COAP_OPT_OBSERVE        (6)
+#define COAP_OPT_LOCATION_PATH  (8)
 #define COAP_OPT_URI_PATH       (11)
 #define COAP_OPT_CONTENT_FORMAT (12)
 #define COAP_OPT_URI_QUERY      (15)
+#define COAP_OPT_LOCATION_QUERY (20)
 #define COAP_OPT_BLOCK2         (23)
 #define COAP_OPT_BLOCK1         (27)
 /** @} */
@@ -450,17 +454,87 @@ size_t coap_put_option(uint8_t *buf, uint16_t lastonum, uint16_t onum, uint8_t *
 size_t coap_put_option_ct(uint8_t *buf, uint16_t lastonum, uint16_t content_type);
 
 /**
- * @brief   Insert URI encoded option into buffer
+ * @brief   Encode the given string as multi-part option into buffer
+ *
+ * @param[out]  buf         buffer to write to
+ * @param[in]   lastonum    number of previous option (for delta calculation),
+ *                          or 0 if first option
+ * @param[in]   optnum      option number to use
+ * @param[in]   string      string to encode as option
+ * @param[in]   separator   character used in @p string to separate parts
+ *
+ * @return      number of bytes written to @p buf
+ */
+size_t coap_opt_put_string(uint8_t *buf, uint16_t lastonum, uint16_t optnum,
+                           const char *string, char separator);
+
+/**
+ * @brief   Convenience function for inserting URI_PATH option into buffer
  *
  * @param[out]  buf         buffer to write to
  * @param[in]   lastonum    number of previous option (for delta calculation),
  *                          or 0 if first option
  * @param[in]   uri         ptr to source URI
- * @param[in]   optnum      option number to use (e.g., COAP_OPT_URI_PATH)
  *
  * @returns     amount of bytes written to @p buf
  */
-size_t coap_put_option_uri(uint8_t *buf, uint16_t lastonum, const char *uri, uint16_t optnum);
+static inline size_t coap_opt_put_uri_path(uint8_t *buf, uint16_t lastonum,
+                                           const char *uri)
+{
+    return coap_opt_put_string(buf, lastonum, COAP_OPT_URI_PATH, uri, '/');
+}
+
+/**
+ * @brief   Convenience function for inserting URI_QUERY option into buffer
+ *
+ * @param[out]  buf         buffer to write to
+ * @param[in]   lastonum    number of previous option (for delta calculation),
+ *                          or 0 if first option
+ * @param[in]   uri         ptr to source URI
+ *
+ * @returns     amount of bytes written to @p buf
+ */
+static inline size_t coap_opt_put_uri_query(uint8_t *buf, uint16_t lastonum,
+                                            const char *uri)
+{
+    return coap_opt_put_string(buf, lastonum, COAP_OPT_URI_QUERY, uri, '&');
+}
+
+/**
+ * @brief   Convenience function for inserting LOCATION_PATH option into buffer
+ *
+ * @param[out]  buf         buffer to write to
+ * @param[in]   lastonum    number of previous option (for delta calculation),
+ *                          or 0 if first option
+ * @param[in]   location    ptr to string holding the location
+ *
+ * @returns     amount of bytes written to @p buf
+ */
+static inline size_t coap_opt_put_location_path(uint8_t *buf,
+                                                uint16_t lastonum,
+                                                const char *location)
+{
+    return coap_opt_put_string(buf, lastonum, COAP_OPT_LOCATION_PATH,
+                               location, '/');
+}
+
+/**
+ * @brief   Convenience function for inserting LOCATION_QUERY option into buffer
+ *
+ * @param[out]  buf         buffer to write to
+ * @param[in]   lastonum    number of previous option (for delta calculation),
+ *                          or 0 if first option
+ * @param[in]   location    ptr to string holding the location
+ *
+ * @returns     amount of bytes written to @p buf
+ */
+static inline size_t coap_opt_put_location_query(uint8_t *buf,
+                                                 uint16_t lastonum,
+                                                 const char *location)
+{
+    return coap_opt_put_string(buf, lastonum, COAP_OPT_LOCATION_QUERY,
+                               location, '&');
+}
 
 /**
  * @brief    Generic block option getter
@@ -585,10 +659,30 @@ ssize_t coap_opt_finish(coap_pkt_t *pkt, uint16_t flags);
 unsigned coap_get_content_type(coap_pkt_t *pkt);
 
 /**
- * @brief   Get the packet's request URI
+ * @brief   Read a full option as null terminated string into the target buffer
  *
- * This function decodes the pkt's URI option into a "/"-seperated and
- * NULL-terminated string.
+ * This function is for reading and concatenating string based, multi-part CoAP
+ * options like COAP_OPT_URI_PATH or COAP_OPT_LOCATION_PATH. It will write all
+ * parts of the given option into the target buffer, separating the parts using
+ * the given @p separator. The resulting string is `\0` terminated.
+ *
+ * @param[in]   pkt         packet to read from
+ * @param[in]   optnum      absolute option number
+ * @param[out]  target      target buffer
+ * @param[in]   max_len     size of @p target
+ * @param[in]   separator   character used for separating the option parts
+ *
+ * @return      -ENOSPC if the complete option does not fit into @p target
+ * @return      nr of bytes written to @p target (including '\0')
+ */
+ssize_t coap_opt_get_string(const coap_pkt_t *pkt, uint16_t optnum,
+                            uint8_t *target, size_t max_len, char separator);
+
+/**
+ * @brief   Convenience function for getting the packet's URI_PATH
+ *
+ * This function decodes the pkt's URI option into a "/"-separated and
+ * '\0'-terminated string.
  *
  * Caller must ensure @p target can hold at least NANOCOAP_URI_MAX bytes!
  *
@@ -598,10 +692,78 @@ unsigned coap_get_content_type(coap_pkt_t *pkt);
  * @returns     -ENOSPC     if URI option is larger than NANOCOAP_URI_MAX
  * @returns     nr of bytes written to @p target (including '\0')
  */
-int coap_get_uri(coap_pkt_t *pkt, uint8_t *target);
+static inline ssize_t coap_get_uri_path(const coap_pkt_t *pkt, uint8_t *target)
+{
+    return coap_opt_get_string(pkt, COAP_OPT_URI_PATH, target,
+                               NANOCOAP_URI_MAX, '/');
+}
 
 /**
- * @brief    Helper to decode SZX value to size in bytes
+ * @brief   Convenience function for getting the packet's URI_QUERY option
+ *
+ * This function decodes the pkt's URI_QUERY option into a "&"-separated and
+ * '\0'-terminated string.
+ *
+ * Caller must ensure @p target can hold at least NANOCOAP_URI_MAX bytes!
+ *
+ * @param[in]   pkt     pkt to work on
+ * @param[out]  target  buffer for target URI
+ *
+ * @returns     -ENOSPC     if URI option is larger than NANOCOAP_URI_MAX
+ * @returns     nr of bytes written to @p target (including '\0')
+ */
+static inline ssize_t coap_get_uri_query(const coap_pkt_t *pkt, uint8_t *target)
+{
+    return coap_opt_get_string(pkt, COAP_OPT_URI_QUERY, target,
+                               NANOCOAP_URI_MAX, '&');
+}
+
+/**
+ * @brief   Convenience function for getting the packet's LOCATION_PATH option
+ *
+ * This function decodes the pkt's LOCATION_PATH option into a '/'-separated and
+ * '\0'-terminated string.
+ *
+ * Caller must ensure @p target can hold at least 2 bytes!
+ *
+ * @param[in]   pkt     pkt to work on
+ * @param[out]  target  buffer for location path
+ * @param[in]   max_len size of @p target in bytes
+ *
+ * @returns     -ENOSPC     if URI option is larger than @p max_len
+ * @returns     nr of bytes written to @p target (including '\0')
+ */
+static inline ssize_t coap_get_location_path(const coap_pkt_t *pkt,
+                                             uint8_t *target, size_t max_len)
+{
+    return coap_opt_get_string(pkt, COAP_OPT_LOCATION_PATH,
+                               target, max_len, '/');
+}
+
+/**
+ * @brief   Convenience function for getting the packet's LOCATION_QUERY option
+ *
+ * This function decodes the pkt's LOCATION_PATH option into a '&'-separated and
+ * '\0'-terminated string.
+ *
+ * Caller must ensure @p target can hold at least 2 bytes!
+ *
+ * @param[in]   pkt     pkt to work on
+ * @param[out]  target  buffer for location path
+ * @param[in]   max_len size of @p target in bytes
+ *
+ * @returns     -ENOSPC     if URI option is larger than @p max_len
+ * @returns     nr of bytes written to @p target (including '\0')
+ */
+static inline ssize_t coap_get_location_query(const coap_pkt_t *pkt,
+                                              uint8_t *target, size_t max_len)
+{
+    return coap_opt_get_string(pkt, COAP_OPT_LOCATION_QUERY,
+                               target, max_len, '&');
+}
+
+/**
+ * @brief   Helper to decode SZX value to size in bytes
  *
  * @param[in]   szx     SZX value to decode
  *

--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -564,8 +564,8 @@ static ssize_t _write_options(coap_pkt_t *pdu, uint8_t *buf, size_t len)
                 DEBUG("gcoap: _write_options: path does not start with '/'\n");
                 return -EINVAL;
             }
-            bufpos += coap_put_option_uri(bufpos, last_optnum, (char *)pdu->url,
-                                          COAP_OPT_URI_PATH);
+            bufpos += coap_opt_put_uri_path(bufpos, last_optnum,
+                                            (char *)pdu->url);
             last_optnum = COAP_OPT_URI_PATH;
         }
     }
@@ -578,8 +578,8 @@ static ssize_t _write_options(coap_pkt_t *pdu, uint8_t *buf, size_t len)
 
     /* Uri-query for requests */
     if (coap_get_code_class(pdu) == COAP_CLASS_REQ) {
-        bufpos += coap_put_option_uri(bufpos, last_optnum, (char *)pdu->qs,
-                                      COAP_OPT_URI_QUERY);
+        bufpos += coap_opt_put_uri_query(bufpos, last_optnum,
+                                         (char *)pdu->qs);
         /* uncomment when further options are added below ... */
         /* last_optnum = COAP_OPT_URI_QUERY; */
     }

--- a/sys/net/application_layer/nanocoap/sock.c
+++ b/sys/net/application_layer/nanocoap/sock.c
@@ -95,7 +95,7 @@ ssize_t nanocoap_get(sock_udp_ep_t *remote, const char *path, uint8_t *buf, size
 
     pkt.hdr = (coap_hdr_t*)buf;
     pktpos += coap_build_hdr(pkt.hdr, COAP_REQ, NULL, 0, COAP_METHOD_GET, 1);
-    pktpos += coap_put_option_uri(pktpos, 0, path, COAP_OPT_URI_PATH);
+    pktpos += coap_opt_put_uri_path(pktpos, 0, path);
     pkt.payload = pktpos;
     pkt.payload_len = 0;
 

--- a/tests/unittests/tests-nanocoap/tests-nanocoap.c
+++ b/tests/unittests/tests-nanocoap/tests-nanocoap.c
@@ -30,20 +30,27 @@ static void test_nanocoap__hdr(void)
     uint8_t buf[128];
     uint16_t msgid = 0xABCD;
     char path[] = "/test/abcd/efgh";
+    char loc_path[] = "/foo/bar";
     unsigned char path_tmp[64] = {0};
 
     uint8_t *pktpos = &buf[0];
-    pktpos += coap_build_hdr((coap_hdr_t *)pktpos, COAP_REQ, NULL, 0, COAP_METHOD_GET, msgid);
-    pktpos += coap_put_option_uri(pktpos, 0, path, COAP_OPT_URI_PATH);
+    pktpos += coap_build_hdr((coap_hdr_t *)pktpos, COAP_REQ, NULL, 0,
+                             COAP_METHOD_GET, msgid);
+    pktpos += coap_opt_put_location_path(pktpos, 0, loc_path);
+    pktpos += coap_opt_put_uri_path(pktpos, COAP_OPT_LOCATION_PATH, path);
 
     coap_pkt_t pkt;
     coap_parse(&pkt, &buf[0], pktpos - &buf[0]);
 
     TEST_ASSERT_EQUAL_INT(msgid, coap_get_id(&pkt));
 
-    int res = coap_get_uri(&pkt, path_tmp);
+    int res = coap_get_uri_path(&pkt, path_tmp);
     TEST_ASSERT_EQUAL_INT(sizeof(path), res);
     TEST_ASSERT_EQUAL_STRING((char *)path, (char *)path_tmp);
+
+    res = coap_get_location_path(&pkt, path_tmp, 64);
+    TEST_ASSERT_EQUAL_INT(sizeof(loc_path), res);
+    TEST_ASSERT_EQUAL_STRING((char *)loc_path, (char *)path_tmp);
 }
 
 /*
@@ -76,7 +83,7 @@ static void test_nanocoap__get_req(void)
     TEST_ASSERT_EQUAL_INT(total_opt_len, len);
 
     char uri[10] = {0};
-    coap_get_uri(&pkt, (uint8_t *)&uri[0]);
+    coap_get_uri_path(&pkt, (uint8_t *)&uri[0]);
     TEST_ASSERT_EQUAL_STRING((char *)path, (char *)uri);
 
     len = coap_opt_finish(&pkt, COAP_OPT_FINISH_NONE);
@@ -140,7 +147,7 @@ static void test_nanocoap__get_multi_path(void)
     TEST_ASSERT_EQUAL_INT(uri_opt_len, len);
 
     char uri[10] = {0};
-    coap_get_uri(&pkt, (uint8_t *)&uri[0]);
+    coap_get_uri_path(&pkt, (uint8_t *)&uri[0]);
     TEST_ASSERT_EQUAL_STRING((char *)path, (char *)uri);
 }
 
@@ -162,7 +169,7 @@ static void test_nanocoap__get_root_path(void)
     coap_pkt_init(&pkt, &buf[0], sizeof(buf), len);
 
     char uri[10] = {0};
-    coap_get_uri(&pkt, (uint8_t *)&uri[0]);
+    coap_get_uri_path(&pkt, (uint8_t *)&uri[0]);
     TEST_ASSERT_EQUAL_STRING((char *)path, (char *)uri);
 }
 
@@ -188,13 +195,13 @@ static void test_nanocoap__get_max_path(void)
     TEST_ASSERT_EQUAL_INT(uri_opt_len, len);
 
     char uri[NANOCOAP_URI_MAX] = {0};
-    coap_get_uri(&pkt, (uint8_t *)&uri[0]);
+    coap_get_uri_path(&pkt, (uint8_t *)&uri[0]);
     TEST_ASSERT_EQUAL_STRING((char *)path, (char *)uri);
 }
 
 /*
  * Builds on get_req test, to test path longer than NANOCOAP_URI_MAX. We
- * expect coap_get_uri() to return -ENOSPC.
+ * expect coap_get_uri_path() to return -ENOSPC.
  */
 static void test_nanocoap__get_path_too_long(void)
 {
@@ -215,7 +222,7 @@ static void test_nanocoap__get_path_too_long(void)
     TEST_ASSERT_EQUAL_INT(uri_opt_len, len);
 
     char uri[NANOCOAP_URI_MAX] = {0};
-    int get_len = coap_get_uri(&pkt, (uint8_t *)&uri[0]);
+    int get_len = coap_get_uri_path(&pkt, (uint8_t *)&uri[0]);
     TEST_ASSERT_EQUAL_INT(-ENOSPC, get_len);
 }
 


### PR DESCRIPTION
### Contribution description
Many string-based options (e.g. `COAP_OPT_URI`, `COAP_OPT_LOCATION_PATH`) share a similar structure: they consist of string 'snippets', that are split using some kind of separation character, typically `/`. This PR adds a more generic function for setting and reading these kind of options to `nanocoap`.

Please let me know what you think of this approach - once consensus is reached I will spend the time to add the missing doxygen...

### Issues/PRs references
Follow-up on #8772