### PR TITLE
evtimer: rename variables append ms

### DIFF
--- a/sys/include/evtimer.h
+++ b/sys/include/evtimer.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2016-17 Kaspar Schleiser <kaspar@schleiser.de>
  *               2017 Freie Universität Berlin
+ *               2018 Josua Arndt
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -38,6 +39,7 @@
  *
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  * @author      Martine Lenders <m.lenders@fu-berlin.de>
+ * @author      Josua Arndt <jarndt@ias.rwth-aachen.de>
  */
 
 #ifndef EVTIMER_H
@@ -56,7 +58,7 @@ extern "C" {
  */
 typedef struct evtimer_event {
     struct evtimer_event *next; /**< the next event in the queue */
-    uint32_t offset;            /**< offset in milliseconds from previous event */
+    uint32_t offset_ms;            /**< offset in milliseconds from previous event */
 } evtimer_event_t;
 
 /**

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.c
@@ -816,7 +816,7 @@ uint32_t _evtimer_lookup(const void *ctx, uint16_t type)
 
     DEBUG("nib: lookup ctx = %p, type = %04x\n", (void *)ctx, type);
     while (event != NULL) {
-        offset += event->event.offset;
+        offset += event->event.offset_ms;
         if ((event->msg.type == type) &&
             ((ctx == NULL) || (event->msg.content.ptr == ctx))) {
             return offset;

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.h
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.h
@@ -802,10 +802,10 @@ uint32_t _evtimer_lookup(const void *ctx, uint16_t type);
  * @param[in] ctx       The context of the event
  * @param[in] type      [Type of the event](@ref net_gnrc_ipv6_nib_msg).
  * @param[in,out] event Representation of the event.
- * @param[in] offset    Offset in milliseconds to the event.
+ * @param[in] offset_ms Offset in milliseconds to the event.
  */
 static inline void _evtimer_add(void *ctx, int16_t type,
-                                evtimer_msg_event_t *event, uint32_t offset)
+                                evtimer_msg_event_t *event, uint32_t offset_ms)
 {
 #ifdef MODULE_GNRC_IPV6
     kernel_pid_t target_pid = gnrc_ipv6_pid;
@@ -814,7 +814,7 @@ static inline void _evtimer_add(void *ctx, int16_t type,
 #endif
     evtimer_del((evtimer_t *)(&_nib_evtimer), (evtimer_event_t *)event);
     event->event.next = NULL;
-    event->event.offset = offset;
+    event->event.offset_ms = offset_ms;
     event->msg.type = type;
     event->msg.content.ptr = ctx;
     evtimer_add_msg(&_nib_evtimer, event, target_pid);

--- a/tests/evtimer_msg/main.c
+++ b/tests/evtimer_msg/main.c
@@ -28,10 +28,10 @@
 static char worker_stack[THREAD_STACKSIZE_MAIN];
 static evtimer_t evtimer;
 static evtimer_msg_event_t events[] = {
-    { .event = { .offset = 1000 }, .msg = { .content = { .ptr = "supposed to be 1000" } } },
-    { .event = { .offset = 1500 }, .msg = { .content = { .ptr = "supposed to be 1500" } } },
-    { .event = { .offset = 659 }, .msg = { .content = { .ptr = "supposed to be 659" } } },
-    { .event = { .offset = 3954 }, .msg = { .content = { .ptr = "supposed to be 3954" } } },
+    { .event = { .offset_ms = 1000 }, .msg = { .content = { .ptr = "supposed to be 1000" } } },
+    { .event = { .offset_ms = 1500 }, .msg = { .content = { .ptr = "supposed to be 1500" } } },
+    { .event = { .offset_ms = 659 }, .msg = { .content = { .ptr = "supposed to be 659" } } },
+    { .event = { .offset_ms = 3954 }, .msg = { .content = { .ptr = "supposed to be 3954" } } },
 };
 
 #define NEVENTS ((unsigned)(sizeof(events) / sizeof(evtimer_msg_event_t)))

--- a/tests/evtimer_underflow/main.c
+++ b/tests/evtimer_underflow/main.c
@@ -30,14 +30,14 @@ msg_t worker_msg_queue[WORKER_MSG_QUEUE_SIZE];
 static char worker_stack[THREAD_STACKSIZE_MAIN];
 static evtimer_t evtimer;
 static evtimer_msg_event_t events[] = {
-    { .event = { .offset = 0 }, .msg = { .content = { .ptr = "1" } } },
-    { .event = { .offset = 0 }, .msg = { .content = { .ptr = "2" } } },
-    { .event = { .offset = 0 }, .msg = { .content = { .ptr = "3" } } },
-    { .event = { .offset = 0 }, .msg = { .content = { .ptr = "4" } } },
-    { .event = { .offset = 0 }, .msg = { .content = { .ptr = "5" } } },
-    { .event = { .offset = 0 }, .msg = { .content = { .ptr = "6" } } },
-    { .event = { .offset = 0 }, .msg = { .content = { .ptr = "7" } } },
-    { .event = { .offset = 0 }, .msg = { .content = { .ptr = "8" } } },
+    { .event = { .offset_ms = 0 }, .msg = { .content = { .ptr = "1" } } },
+    { .event = { .offset_ms = 0 }, .msg = { .content = { .ptr = "2" } } },
+    { .event = { .offset_ms = 0 }, .msg = { .content = { .ptr = "3" } } },
+    { .event = { .offset_ms = 0 }, .msg = { .content = { .ptr = "4" } } },
+    { .event = { .offset_ms = 0 }, .msg = { .content = { .ptr = "5" } } },
+    { .event = { .offset_ms = 0 }, .msg = { .content = { .ptr = "6" } } },
+    { .event = { .offset_ms = 0 }, .msg = { .content = { .ptr = "7" } } },
+    { .event = { .offset_ms = 0 }, .msg = { .content = { .ptr = "8" } } },
 };
 
 #define NEVENTS (sizeof(events) / sizeof(evtimer_msg_event_t))


### PR DESCRIPTION
the suffix `ms` was added to variable names and to debug messages.

As the `event.offset` was change to `event.offset_ms` also `gnrc_ipv6_nib: event.offset_ms` had to be adapted.