### PR TITLE
pkg/spiffs: remove c11 dependency and clean-up makefile

### DIFF
--- a/pkg/spiffs/Makefile
+++ b/pkg/spiffs/Makefile
@@ -3,8 +3,6 @@ PKG_URL=https://github.com/pellepl/spiffs.git
 PKG_VERSION=287148c46587089c4543a21eef2d6e9e14b88364
 PKG_LICENSE=MIT
 
-CFLAGS += -std=c11
-
 .PHONY: all
 
 all: git-download

--- a/pkg/spiffs/Makefile
+++ b/pkg/spiffs/Makefile
@@ -1,19 +1,13 @@
 PKG_NAME=spiffs
 PKG_URL=https://github.com/pellepl/spiffs.git
 PKG_VERSION=287148c46587089c4543a21eef2d6e9e14b88364
-PKG_BUILDDIR ?= $(PKGDIRBASE)/$(PKG_NAME)
+PKG_LICENSE=MIT
 
 CFLAGS += -std=c11
 
 .PHONY: all
 
 all: git-download
-	@mkdir -p "$(PKG_BUILDDIR)/riotbuild"
-	@cp $(PKG_BUILDDIR)/src/*.c $(PKG_BUILDDIR)/src/*.h $(PKG_BUILDDIR)/riotbuild
-
-	@echo 'MODULE:=spiffs' > $(PKG_BUILDDIR)/riotbuild/Makefile
-	@echo 'include $$(RIOTBASE)/Makefile.base' >> $(PKG_BUILDDIR)/riotbuild/Makefile
-
-	"$(MAKE)" -C $(PKG_BUILDDIR)/riotbuild
+	"$(MAKE)" -C $(PKG_BUILDDIR)/src -f $(CURDIR)/Makefile.spiffs
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/spiffs/Makefile.include
+++ b/pkg/spiffs/Makefile.include
@@ -1,5 +1,5 @@
 INCLUDES += -I$(RIOTPKG)/spiffs/include
-INCLUDES += -I$(PKGDIRBASE)/spiffs/riotbuild/
+INCLUDES += -I$(PKGDIRBASE)/spiffs/src/
 
 ifneq (,$(filter spiffs_fs,$(USEMODULE)))
   DIRS += $(RIOTBASE)/pkg/spiffs/fs

--- a/pkg/spiffs/Makefile.spiffs
+++ b/pkg/spiffs/Makefile.spiffs
@@ -1,3 +1,6 @@
 MODULE := spiffs
 
+# Disable 'ISO C99 doesn’t support unnamed structs/unions [-Werror=pedantic]'
+CFLAGS += -Wno-pedantic
+
 include $(RIOTBASE)/Makefile.base

--- a/pkg/spiffs/Makefile.spiffs
+++ b/pkg/spiffs/Makefile.spiffs
@@ -1,0 +1,3 @@
+MODULE := spiffs
+
+include $(RIOTBASE)/Makefile.base


### PR DESCRIPTION
### Contribution description

A C11 dependency was added to mask a warning about unnamed struct/union.
It can be solved by disabling `-Wpedantic` for the package, to avoid pulling c11 for compiler which do not support it.
I also cleaned up the makefiles.

### Issues/PRs references

Should fix #8876