### PR TITLE
Makefile.include: check FEATURES_CONFLICT against FEATURES_USED

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -515,11 +515,11 @@ ifneq (, $(filter all, $(if $(MAKECMDGOALS), $(MAKECMDGOALS), all)))
     EXPECT_ERRORS := 1
   endif
 
-  # Test if any required feature conflict with another one.
-  CONFLICT := $(foreach var,$(FEATURES_CONFLICT),$(if $(filter $(words $(subst :, ,$(var))),$(words $(filter $(FEATURES_REQUIRED),$(subst :, ,$(var))))),$(subst :, ,$(var))))
+  # Test if any used feature conflict with another one.
+  CONFLICT := $(foreach var,$(FEATURES_CONFLICT),$(if $(filter $(words $(subst :, ,$(var))),$(words $(filter $(FEATURES_USED),$(subst :, ,$(var))))),$(subst :, ,$(var))))
   ifneq (, $(strip $(CONFLICT)))
     $(shell $(COLOR_ECHO) "$(COLOR_YELLOW)The following features may conflict:$(COLOR_RESET)"\
-                          "$(COLOR_GREEN)$(sort $(filter $(FEATURES_REQUIRED), $(CONFLICT)))$(COLOR_RESET)" 1>&2)
+                          "$(COLOR_GREEN)$(sort $(filter $(FEATURES_USED), $(CONFLICT)))$(COLOR_RESET)" 1>&2)
     ifneq (, $(FEATURES_CONFLICT_MSG))
         $(shell $(COLOR_ECHO) "$(COLOR_YELLOW)Rationale: $(COLOR_RESET)$(FEATURES_CONFLICT_MSG)" 1>&2)
     endif


### PR DESCRIPTION
The FEATURES_CONFLICT check should be done on used features to also
test for included optional features.

### Contribution description

This make the FEATURES_CONFLICT test detect conflict with optional features included.

It can be tested with: `FEATURES_OPTIONAL="periph_dac periph_spi" make -C examples/hello-world/`
```
$ FEATURES_OPTIONAL="periph_dac periph_spi" make -C examples/hello-world/ 
BOARD=stm32f4discovery
make: Entering directory '/home/cladmi/git/work/RIOT/examples/hello-world'
The following features may conflict: periph_dac periph_spi
Rationale: On stm32f4discovery boards there are the same pins for the DAC and/or SPI_0.

EXPECT undesired behaviour!
Building application "hello-world" for "stm32f4discovery" with MCU "stm32f4".
...
```

### Issues/PRs references

It will allow using FEATURES_CONFLICT for https://github.com/RIOT-OS/RIOT/pull/8890
