### PR TITLE
drivers/sx127x: various improvements

### DIFF
--- a/drivers/include/sx127x.h
+++ b/drivers/include/sx127x.h
@@ -100,8 +100,8 @@ extern "C" {
 enum {
     SX127X_INIT_OK = 0,                /**< Initialization was successful */
     SX127X_ERR_SPI,                    /**< Failed to initialize SPI bus or CS line */
-    SX127X_ERR_TEST_FAILED,            /**< SX127X testing failed during initialization (check chip) */
-    SX127X_ERR_THREAD                  /**< Unable to create DIO handling thread (check amount of free memory) */
+    SX127X_ERR_GPIOS,                  /**< Failed to initialize GPIOs */
+    SX127X_ERR_NODEV                   /**< No valid device version found */
 };
 
 /**

--- a/drivers/sx127x/include/sx127x_internal.h
+++ b/drivers/sx127x/include/sx127x_internal.h
@@ -42,12 +42,14 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   Tests the transceiver version type.
+ * @brief   Check the transceiver version
  *
  * @param[in] dev                      The sx127x device descriptor
- * @return true if test passed, false otherwise
+ *
+ * @return 0 when a valid device version is found
+ * @return -1 when no valid device version is found
  */
-bool sx127x_test(const sx127x_t *dev);
+int sx127x_check_version(const sx127x_t *dev);
 
 /**
  * @brief   Writes the radio register at specified address.

--- a/drivers/sx127x/include/sx127x_internal.h
+++ b/drivers/sx127x/include/sx127x_internal.h
@@ -109,16 +109,6 @@ void sx127x_write_fifo(const sx127x_t *dev, uint8_t *buffer, uint8_t size);
 void sx127x_read_fifo(const sx127x_t *dev, uint8_t *buffer, uint8_t size);
 
 /**
- * @brief   Performs the Rx chain calibration for LF and HF bands
- *
- *          Must be called just after the reset so all registers are at their
- *          default values
- *
- * @param[in] dev                      The sx127x device structure pointer
- */
-void sx127x_rx_chain_calibration(sx127x_t *dev);
-
-/**
  * @brief   Reads the current RSSI value.
  *
  * @param[in] dev                      The sx127x device descriptor
@@ -126,6 +116,18 @@ void sx127x_rx_chain_calibration(sx127x_t *dev);
  * @return current value of RSSI in [dBm]
  */
 int16_t sx127x_read_rssi(const sx127x_t *dev);
+
+#if defined(MODULE_SX1276)
+/**
+ * @brief   Performs the Rx chain calibration for LF and HF bands
+ *
+ *          Must be called just after the reset so all registers are at their
+ *          default values
+ *
+ * @param[in] dev                      The sx127x device structure pointer
+ */
+void sx1276_rx_chain_calibration(sx127x_t *dev);
+#endif
 
 #ifdef __cplusplus
 }

--- a/drivers/sx127x/sx127x.c
+++ b/drivers/sx127x/sx127x.c
@@ -115,23 +115,22 @@ int sx127x_init(sx127x_t *dev)
 
 void sx127x_init_radio_settings(sx127x_t *dev)
 {
-    sx127x_set_freq_hop(dev, LORA_FREQUENCY_HOPPING_DEFAULT);
-    sx127x_set_iq_invert(dev, LORA_IQ_INVERTED_DEFAULT);
+    sx127x_set_modem(dev, SX127X_MODEM_DEFAULT);
+    sx127x_set_channel(dev, SX127X_CHANNEL_DEFAULT);
     sx127x_set_bandwidth(dev, LORA_BW_DEFAULT);
     sx127x_set_spreading_factor(dev, LORA_SF_DEFAULT);
     sx127x_set_coding_rate(dev, LORA_CR_DEFAULT);
-    sx127x_set_fixed_header_len_mode(dev, LORA_FIXED_HEADER_LEN_MODE_DEFAULT);
     sx127x_set_crc(dev, LORA_PAYLOAD_CRC_ON_DEFAULT);
-    sx127x_set_symbol_timeout(dev, LORA_SYMBOL_TIMEOUT_DEFAULT);
-    sx127x_set_preamble_length(dev, LORA_PREAMBLE_LENGTH_DEFAULT);
-    sx127x_set_payload_length(dev, LORA_PAYLOAD_LENGTH_DEFAULT);
+    sx127x_set_freq_hop(dev, LORA_FREQUENCY_HOPPING_DEFAULT);
     sx127x_set_hop_period(dev, LORA_FREQUENCY_HOPPING_PERIOD_DEFAULT);
-
+    sx127x_set_fixed_header_len_mode(dev, LORA_FIXED_HEADER_LEN_MODE_DEFAULT);
+    sx127x_set_iq_invert(dev, LORA_IQ_INVERTED_DEFAULT);
+    sx127x_set_payload_length(dev, LORA_PAYLOAD_LENGTH_DEFAULT);
+    sx127x_set_tx_power(dev, SX127X_RADIO_TX_POWER);
+    sx127x_set_preamble_length(dev, LORA_PREAMBLE_LENGTH_DEFAULT);
+    sx127x_set_symbol_timeout(dev, LORA_SYMBOL_TIMEOUT_DEFAULT);
     sx127x_set_rx_single(dev, SX127X_RX_SINGLE);
     sx127x_set_tx_timeout(dev, SX127X_TX_TIMEOUT_DEFAULT);
-    sx127x_set_modem(dev, SX127X_MODEM_DEFAULT);
-    sx127x_set_channel(dev, SX127X_CHANNEL_DEFAULT);
-    sx127x_set_tx_power(dev, SX127X_RADIO_TX_POWER);
 }
 
 uint32_t sx127x_random(sx127x_t *dev)

--- a/drivers/sx127x/sx127x.c
+++ b/drivers/sx127x/sx127x.c
@@ -117,8 +117,10 @@ int sx127x_init(sx127x_t *dev)
 
 void sx127x_init_radio_settings(sx127x_t *dev)
 {
-    sx127x_set_modem(dev, SX127X_MODEM_DEFAULT);
+    DEBUG("[sx127x] initialize radio settings\n");
     sx127x_set_channel(dev, SX127X_CHANNEL_DEFAULT);
+    sx127x_set_modem(dev, SX127X_MODEM_DEFAULT);
+    sx127x_set_tx_power(dev, SX127X_RADIO_TX_POWER);
     sx127x_set_bandwidth(dev, LORA_BW_DEFAULT);
     sx127x_set_spreading_factor(dev, LORA_SF_DEFAULT);
     sx127x_set_coding_rate(dev, LORA_CR_DEFAULT);
@@ -128,7 +130,6 @@ void sx127x_init_radio_settings(sx127x_t *dev)
     sx127x_set_fixed_header_len_mode(dev, LORA_FIXED_HEADER_LEN_MODE_DEFAULT);
     sx127x_set_iq_invert(dev, LORA_IQ_INVERTED_DEFAULT);
     sx127x_set_payload_length(dev, LORA_PAYLOAD_LENGTH_DEFAULT);
-    sx127x_set_tx_power(dev, SX127X_RADIO_TX_POWER);
     sx127x_set_preamble_length(dev, LORA_PREAMBLE_LENGTH_DEFAULT);
     sx127x_set_symbol_timeout(dev, LORA_SYMBOL_TIMEOUT_DEFAULT);
     sx127x_set_rx_single(dev, SX127X_RX_SINGLE);

--- a/drivers/sx127x/sx127x.c
+++ b/drivers/sx127x/sx127x.c
@@ -41,9 +41,9 @@
 #include "debug.h"
 
 /* Internal functions */
-static void _init_isrs(sx127x_t *dev);
+static int _init_spi(sx127x_t *dev);
+static int _init_gpios(sx127x_t *dev);
 static void _init_timers(sx127x_t *dev);
-static int _init_peripherals(sx127x_t *dev);
 static void _on_tx_timeout(void *arg);
 static void _on_rx_timeout(void *arg);
 
@@ -90,14 +90,15 @@ void sx127x_reset(const sx127x_t *dev)
 int sx127x_init(sx127x_t *dev)
 {
     /* Do internal initialization routines */
-    if (!_init_peripherals(dev)) {
+    if (_init_spi(dev) < 0) {
+        DEBUG("[sx127x] error: failed to initialize SPI\n");
         return -SX127X_ERR_SPI;
     }
 
     /* Check presence of SX127X */
-    if (!sx127x_test(dev)) {
-        DEBUG("[sx127x] init: sx127x test failed\n");
-        return -SX127X_ERR_TEST_FAILED;
+    if (sx127x_check_version(dev) < 0) {
+        DEBUG("[sx127x] error: no valid device found\n");
+        return -SX127X_ERR_NODEV;
     }
 
     _init_timers(dev);
@@ -110,14 +111,17 @@ int sx127x_init(sx127x_t *dev)
 #endif
     sx127x_set_op_mode(dev, SX127X_RF_OPMODE_SLEEP);
 
-    _init_isrs(dev);
+    if (_init_gpios(dev) < 0) {
+        DEBUG("[sx127x] error: failed to initialize GPIOs\n");
+        return -SX127X_ERR_GPIOS;
+    }
 
     return SX127X_INIT_OK;
 }
 
 void sx127x_init_radio_settings(sx127x_t *dev)
 {
-    DEBUG("[sx127x] initialize radio settings\n");
+    DEBUG("[sx127x] initializing radio settings\n");
     sx127x_set_channel(dev, SX127X_CHANNEL_DEFAULT);
     sx127x_set_modem(dev, SX127X_MODEM_DEFAULT);
     sx127x_set_tx_power(dev, SX127X_RADIO_TX_POWER);
@@ -204,27 +208,37 @@ static void sx127x_on_dio3_isr(void *arg)
 }
 
 /* Internal event handlers */
-static void _init_isrs(sx127x_t *dev)
+static int _init_gpios(sx127x_t *dev)
 {
-    if (gpio_init_int(dev->params.dio0_pin, GPIO_IN, GPIO_RISING,
-                      sx127x_on_dio0_isr, dev) < 0) {
-        DEBUG("[sx127x] error: cannot initialize DIO0 pin\n");
+    int res = gpio_init_int(dev->params.dio0_pin, GPIO_IN, GPIO_RISING,
+                            sx127x_on_dio0_isr, dev);
+    if (res < 0) {
+        DEBUG("[sx127x] error: failed to initialize DIO0 pin\n");
+        return res;
     }
 
-    if (gpio_init_int(dev->params.dio1_pin, GPIO_IN, GPIO_RISING,
-                      sx127x_on_dio1_isr, dev) < 0) {
-        DEBUG("[sx127x] error: cannot initialize DIO1 pin\n");
+    res = gpio_init_int(dev->params.dio1_pin, GPIO_IN, GPIO_RISING,
+                         sx127x_on_dio1_isr, dev);
+    if (res < 0) {
+        DEBUG("[sx127x] error: failed to initialize DIO1 pin\n");
+        return res;
     }
 
-    if (gpio_init_int(dev->params.dio2_pin, GPIO_IN, GPIO_RISING,
-                      sx127x_on_dio2_isr, dev) < 0) {
-        DEBUG("[sx127x] error: cannot initialize DIO2 pin\n");
+    res = gpio_init_int(dev->params.dio2_pin, GPIO_IN, GPIO_RISING,
+                        sx127x_on_dio2_isr, dev);
+    if (res < 0) {
+        DEBUG("[sx127x] error: failed to initialize DIO2 pin\n");
+        return res;
     }
 
-    if (gpio_init_int(dev->params.dio3_pin, GPIO_IN, GPIO_RISING,
-                      sx127x_on_dio3_isr, dev) < 0) {
-        DEBUG("[sx127x] error: cannot initialize DIO3 pin\n");
+    res = gpio_init_int(dev->params.dio3_pin, GPIO_IN, GPIO_RISING,
+                        sx127x_on_dio3_isr, dev);
+    if (res < 0) {
+        DEBUG("[sx127x] error: failed to initialize DIO3 pin\n");
+        return res;
     }
+
+    return res;
 }
 
 static void _on_tx_timeout(void *arg)
@@ -250,7 +264,7 @@ static void _init_timers(sx127x_t *dev)
     dev->_internal.rx_timeout_timer.callback = _on_rx_timeout;
 }
 
-static int _init_peripherals(sx127x_t *dev)
+static int _init_spi(sx127x_t *dev)
 {
     int res;
 
@@ -258,11 +272,11 @@ static int _init_peripherals(sx127x_t *dev)
     res = spi_init_cs(dev->params.spi, dev->params.nss_pin);
 
     if (res != SPI_OK) {
-        DEBUG("[sx127x] error initializing SPI_%i device (code %i)\n",
-                  dev->params.spi, res);
-        return 0;
+        DEBUG("[sx127x] error: failed to initialize SPI_%i device (code %i)\n",
+              dev->params.spi, res);
+        return -1;
     }
 
-    DEBUG("[sx127x] peripherals initialized with success\n");
-    return 1;
+    DEBUG("[sx127x] SPI_%i initialized with success\n", dev->params.spi);
+    return 0;
 }

--- a/drivers/sx127x/sx127x.c
+++ b/drivers/sx127x/sx127x.c
@@ -105,7 +105,9 @@ int sx127x_init(sx127x_t *dev)
 
     sx127x_reset(dev);
 
-    sx127x_rx_chain_calibration(dev);
+#if defined(MODULE_SX1276)
+    sx1276_rx_chain_calibration(dev);
+#endif
     sx127x_set_op_mode(dev, SX127X_RF_OPMODE_SLEEP);
 
     _init_isrs(dev);

--- a/drivers/sx127x/sx127x.c
+++ b/drivers/sx127x/sx127x.c
@@ -96,7 +96,7 @@ int sx127x_init(sx127x_t *dev)
 
     /* Check presence of SX127X */
     if (!sx127x_test(dev)) {
-        DEBUG("[Error] init : sx127x test failed\n");
+        DEBUG("[sx127x] init: sx127x test failed\n");
         return -SX127X_ERR_TEST_FAILED;
     }
 
@@ -205,20 +205,24 @@ static void sx127x_on_dio3_isr(void *arg)
 /* Internal event handlers */
 static void _init_isrs(sx127x_t *dev)
 {
-    if (gpio_init_int(dev->params.dio0_pin, GPIO_IN, GPIO_RISING, sx127x_on_dio0_isr, dev) < 0) {
-        DEBUG("Error: cannot initialize DIO0 pin\n");
+    if (gpio_init_int(dev->params.dio0_pin, GPIO_IN, GPIO_RISING,
+                      sx127x_on_dio0_isr, dev) < 0) {
+        DEBUG("[sx127x] error: cannot initialize DIO0 pin\n");
     }
 
-    if (gpio_init_int(dev->params.dio1_pin, GPIO_IN, GPIO_RISING, sx127x_on_dio1_isr, dev) < 0) {
-        DEBUG("Error: cannot initialize DIO1 pin\n");
+    if (gpio_init_int(dev->params.dio1_pin, GPIO_IN, GPIO_RISING,
+                      sx127x_on_dio1_isr, dev) < 0) {
+        DEBUG("[sx127x] error: cannot initialize DIO1 pin\n");
     }
 
-    if (gpio_init_int(dev->params.dio2_pin, GPIO_IN, GPIO_RISING, sx127x_on_dio2_isr, dev) < 0) {
-        DEBUG("Error: cannot initialize DIO2 pin\n");
+    if (gpio_init_int(dev->params.dio2_pin, GPIO_IN, GPIO_RISING,
+                      sx127x_on_dio2_isr, dev) < 0) {
+        DEBUG("[sx127x] error: cannot initialize DIO2 pin\n");
     }
 
-    if (gpio_init_int(dev->params.dio3_pin, GPIO_IN, GPIO_RISING, sx127x_on_dio3_isr, dev) < 0) {
-        DEBUG("Error: cannot initialize DIO3 pin\n");
+    if (gpio_init_int(dev->params.dio3_pin, GPIO_IN, GPIO_RISING,
+                      sx127x_on_dio3_isr, dev) < 0) {
+        DEBUG("[sx127x] error: cannot initialize DIO3 pin\n");
     }
 }
 
@@ -253,11 +257,11 @@ static int _init_peripherals(sx127x_t *dev)
     res = spi_init_cs(dev->params.spi, dev->params.nss_pin);
 
     if (res != SPI_OK) {
-        DEBUG("sx127x: error initializing SPI_%i device (code %i)\n",
+        DEBUG("[sx127x] error initializing SPI_%i device (code %i)\n",
                   dev->params.spi, res);
         return 0;
     }
 
-    DEBUG("sx127x: peripherals initialized with success\n");
+    DEBUG("[sx127x] peripherals initialized with success\n");
     return 1;
 }

--- a/drivers/sx127x/sx127x_getset.c
+++ b/drivers/sx127x/sx127x_getset.c
@@ -46,16 +46,16 @@ void sx127x_set_state(sx127x_t *dev, uint8_t state)
 #if ENABLE_DEBUG
     switch (state) {
     case SX127X_RF_IDLE:
-        DEBUG("[DEBUG] Change state: IDLE\n");
+        DEBUG("[sx127x] Change state: IDLE\n");
         break;
     case SX127X_RF_RX_RUNNING:
-        DEBUG("[DEBUG] Change state: RX\n");
+        DEBUG("[sx127x] Change state: RX\n");
         break;
     case SX127X_RF_TX_RUNNING:
-        DEBUG("[DEBUG] Change state: TX\n");
+        DEBUG("[sx127x] Change state: TX\n");
         break;
     default:
-        DEBUG("[DEBUG] Change state: UNKNOWN\n");
+        DEBUG("[sx127x] Change state: UNKNOWN\n");
         break;
     }
 #endif
@@ -65,6 +65,8 @@ void sx127x_set_state(sx127x_t *dev, uint8_t state)
 
 void sx127x_set_modem(sx127x_t *dev, uint8_t modem)
 {
+    DEBUG("[sx127x] set modem: %d\n", modem);
+
     if ((sx127x_reg_read(dev, SX127X_REG_OPMODE) & SX127X_RF_LORA_OPMODE_LONGRANGEMODE_ON) != 0) {
         dev->settings.modem = SX127X_MODEM_LORA;
     }
@@ -75,11 +77,9 @@ void sx127x_set_modem(sx127x_t *dev, uint8_t modem)
     /* Skip if unchanged to avoid resetting the transceiver below (may end up
      * in crashes) */
     if (dev->settings.modem == modem) {
-        DEBUG("[DEBUG] already using modem: %d\n", modem);
+        DEBUG("[sx127x] already using modem: %d\n", modem);
         return;
     }
-
-    DEBUG("[DEBUG] set modem: %d\n", modem);
 
     dev->settings.modem = modem;
 
@@ -109,7 +109,7 @@ uint8_t sx127x_get_syncword(const sx127x_t *dev)
 
 void sx127x_set_syncword(sx127x_t *dev, uint8_t syncword)
 {
-    DEBUG("[DEBUG] Set syncword: %02x\n", syncword);
+    DEBUG("[sx127x] Set syncword: %02x\n", syncword);
 
     sx127x_reg_write(dev, SX127X_REG_LR_SYNCWORD, syncword);
 }
@@ -123,7 +123,7 @@ uint32_t sx127x_get_channel(const sx127x_t *dev)
 
 void sx127x_set_channel(sx127x_t *dev, uint32_t channel)
 {
-    DEBUG("[DEBUG] Set channel: %lu\n", channel);
+    DEBUG("[sx127x] Set channel: %lu\n", channel);
 
     /* Save current operating mode */
     dev->settings.channel = channel;
@@ -198,7 +198,7 @@ uint32_t sx127x_get_time_on_air(const sx127x_t *dev, uint8_t pkt_len)
 
 void sx127x_set_sleep(sx127x_t *dev)
 {
-    DEBUG("[DEBUG] Set sleep\n");
+    DEBUG("[sx127x] Set sleep\n");
 
     /* Disable running timers */
     xtimer_remove(&dev->_internal.tx_timeout_timer);
@@ -211,7 +211,7 @@ void sx127x_set_sleep(sx127x_t *dev)
 
 void sx127x_set_standby(sx127x_t *dev)
 {
-    DEBUG("[DEBUG] Set standby\n");
+    DEBUG("[sx127x] Set standby\n");
 
     /* Disable running timers */
     xtimer_remove(&dev->_internal.tx_timeout_timer);
@@ -223,7 +223,7 @@ void sx127x_set_standby(sx127x_t *dev)
 
 void sx127x_set_rx(sx127x_t *dev)
 {
-    DEBUG("[DEBUG] Set RX\n");
+    DEBUG("[sx127x] Set RX\n");
 
     switch (dev->settings.modem) {
         case SX127X_MODEM_FSK:
@@ -393,7 +393,7 @@ uint8_t sx127x_get_max_payload_len(const sx127x_t *dev)
 
 void sx127x_set_max_payload_len(const sx127x_t *dev, uint8_t maxlen)
 {
-    DEBUG("[DEBUG] Set max payload len: %d\n", maxlen);
+    DEBUG("[sx127x] Set max payload len: %d\n", maxlen);
 
     switch (dev->settings.modem) {
         case SX127X_MODEM_FSK:
@@ -416,22 +416,22 @@ void sx127x_set_op_mode(const sx127x_t *dev, uint8_t op_mode)
 #if ENABLE_DEBUG
     switch(op_mode) {
     case SX127X_RF_OPMODE_SLEEP:
-        DEBUG("[DEBUG] Set op mode: SLEEP\n");
+        DEBUG("[sx127x] Set op mode: SLEEP\n");
         break;
     case SX127X_RF_OPMODE_STANDBY:
-        DEBUG("[DEBUG] Set op mode: STANDBY\n");
+        DEBUG("[sx127x] Set op mode: STANDBY\n");
         break;
     case SX127X_RF_OPMODE_RECEIVER_SINGLE:
-        DEBUG("[DEBUG] Set op mode: RECEIVER SINGLE\n");
+        DEBUG("[sx127x] Set op mode: RECEIVER SINGLE\n");
         break;
     case SX127X_RF_OPMODE_RECEIVER:
-        DEBUG("[DEBUG] Set op mode: RECEIVER\n");
+        DEBUG("[sx127x] Set op mode: RECEIVER\n");
         break;
     case SX127X_RF_OPMODE_TRANSMITTER:
-        DEBUG("[DEBUG] Set op mode: TRANSMITTER\n");
+        DEBUG("[sx127x] Set op mode: TRANSMITTER\n");
         break;
     default:
-        DEBUG("[DEBUG] Set op mode: UNKNOWN (%d)\n", op_mode);
+        DEBUG("[sx127x] Set op mode: UNKNOWN (%d)\n", op_mode);
         break;
     }
 #endif
@@ -503,7 +503,8 @@ static void _update_bandwidth(const sx127x_t *dev)
         config1_reg |=  SX1276_RF_LORA_MODEMCONFIG1_BW_500_KHZ;
         break;
     default:
-        DEBUG("Unsupported bandwidth, %d", dev->settings.lora.bandwidth);
+        DEBUG("[sx127x] Unsupported bandwidth, %d\n",
+              dev->settings.lora.bandwidth);
         break;
     }
 #endif
@@ -512,7 +513,7 @@ static void _update_bandwidth(const sx127x_t *dev)
 
 void sx127x_set_bandwidth(sx127x_t *dev, uint8_t bandwidth)
 {
-    DEBUG("[DEBUG] Set bandwidth: %d\n", bandwidth);
+    DEBUG("[sx127x] Set bandwidth: %d\n", bandwidth);
 
     dev->settings.lora.bandwidth = bandwidth;
 
@@ -545,7 +546,7 @@ uint8_t sx127x_get_spreading_factor(const sx127x_t *dev)
 
 void sx127x_set_spreading_factor(sx127x_t *dev, uint8_t datarate)
 {
-    DEBUG("[DEBUG] Set spreading factor: %d\n", datarate);
+    DEBUG("[sx127x] Set spreading factor: %d\n", datarate);
 
     if (datarate == LORA_SF6 &&
         !(dev->settings.lora.flags & SX127X_ENABLE_FIXED_HEADER_LENGTH_FLAG)) {
@@ -588,7 +589,7 @@ uint8_t sx127x_get_coding_rate(const sx127x_t *dev)
 
 void sx127x_set_coding_rate(sx127x_t *dev, uint8_t coderate)
 {
-    DEBUG("[DEBUG] Set coding rate: %d\n", coderate);
+    DEBUG("[sx127x] Set coding rate: %d\n", coderate);
 
     dev->settings.lora.coderate = coderate;
     uint8_t config1_reg = sx127x_reg_read(dev, SX127X_REG_LR_MODEMCONFIG1);
@@ -621,7 +622,7 @@ bool sx127x_get_rx_single(const sx127x_t *dev)
 
 void sx127x_set_rx_single(sx127x_t *dev, bool single)
 {
-    DEBUG("[DEBUG] Set RX single: %d\n", single);
+    DEBUG("[sx127x] Set RX single: %d\n", single);
     _set_flag(dev, SX127X_RX_CONTINUOUS_FLAG, !single);
 }
 
@@ -638,7 +639,7 @@ bool sx127x_get_crc(const sx127x_t *dev)
 
 void sx127x_set_crc(sx127x_t *dev, bool crc)
 {
-    DEBUG("[DEBUG] Set CRC: %d\n", crc);
+    DEBUG("[sx127x] Set CRC: %d\n", crc);
     _set_flag(dev, SX127X_ENABLE_CRC_FLAG, crc);
 
 #if defined(MODULE_SX1272)
@@ -661,7 +662,7 @@ uint8_t sx127x_get_hop_period(const sx127x_t *dev)
 
 void sx127x_set_hop_period(sx127x_t *dev, uint8_t hop_period)
 {
-    DEBUG("[DEBUG] Set Hop period: %d\n", hop_period);
+    DEBUG("[sx127x] Set Hop period: %d\n", hop_period);
 
     dev->settings.lora.freq_hop_period = hop_period;
 
@@ -680,7 +681,7 @@ bool  sx127x_get_fixed_header_len_mode(const sx127x_t *dev)
 
 void sx127x_set_fixed_header_len_mode(sx127x_t *dev, bool fixed_len)
 {
-    DEBUG("[DEBUG] Set fixed header length: %d\n", fixed_len);
+    DEBUG("[sx127x] Set fixed header length: %d\n", fixed_len);
 
     _set_flag(dev, SX127X_ENABLE_FIXED_HEADER_LENGTH_FLAG, fixed_len);
 
@@ -702,7 +703,7 @@ uint8_t sx127x_get_payload_length(const sx127x_t *dev)
 
 void sx127x_set_payload_length(sx127x_t *dev, uint8_t len)
 {
-    DEBUG("[DEBUG] Set payload len: %d\n", len);
+    DEBUG("[sx127x] Set payload len: %d\n", len);
 
     sx127x_reg_write(dev, SX127X_REG_LR_PAYLOADLENGTH, len);
 }
@@ -723,7 +724,7 @@ uint8_t sx127x_get_tx_power(const sx127x_t *dev)
 
 void sx127x_set_tx_power(sx127x_t *dev, int8_t power)
 {
-    DEBUG("[DEBUG] Set power: %d\n", power);
+    DEBUG("[sx127x] Set power: %d\n", power);
 
     dev->settings.lora.power = power;
 
@@ -801,7 +802,7 @@ uint16_t sx127x_get_preamble_length(const sx127x_t *dev)
 
 void sx127x_set_preamble_length(sx127x_t *dev, uint16_t preamble)
 {
-    DEBUG("[DEBUG] Set preamble length: %d\n", preamble);
+    DEBUG("[sx127x] Set preamble length: %d\n", preamble);
 
     dev->settings.lora.preamble_len = preamble;
 
@@ -813,21 +814,21 @@ void sx127x_set_preamble_length(sx127x_t *dev, uint16_t preamble)
 
 void sx127x_set_rx_timeout(sx127x_t *dev, uint32_t timeout)
 {
-    DEBUG("[DEBUG] Set RX timeout: %lu\n", timeout);
+    DEBUG("[sx127x] Set RX timeout: %lu\n", timeout);
 
     dev->settings.lora.rx_timeout = timeout;
 }
 
 void sx127x_set_tx_timeout(sx127x_t *dev, uint32_t timeout)
 {
-    DEBUG("[DEBUG] Set TX timeout: %lu\n", timeout);
+    DEBUG("[sx127x] Set TX timeout: %lu\n", timeout);
 
     dev->settings.lora.tx_timeout = timeout;
 }
 
 void sx127x_set_symbol_timeout(sx127x_t *dev, uint16_t timeout)
 {
-    DEBUG("[DEBUG] Set symbol timeout: %d\n", timeout);
+    DEBUG("[sx127x] Set symbol timeout: %d\n", timeout);
 
     dev->settings.lora.rx_timeout = timeout;
 
@@ -845,7 +846,7 @@ bool sx127x_get_iq_invert(const sx127x_t *dev)
 
 void sx127x_set_iq_invert(sx127x_t *dev, bool iq_invert)
 {
-    DEBUG("[DEBUG] Set IQ invert: %d\n", iq_invert);
+    DEBUG("[sx127x] Set IQ invert: %d\n", iq_invert);
 
     _set_flag(dev, SX127X_IQ_INVERTED_FLAG, iq_invert);
 
@@ -862,7 +863,7 @@ void sx127x_set_iq_invert(sx127x_t *dev, bool iq_invert)
 
 void sx127x_set_freq_hop(sx127x_t *dev, bool freq_hop_on)
 {
-    DEBUG("[DEBUG] Set freq hop: %d\n", freq_hop_on);
+    DEBUG("[sx127x] Set freq hop: %d\n", freq_hop_on);
 
      _set_flag(dev, SX127X_CHANNEL_HOPPING_FLAG, freq_hop_on);
 }

--- a/drivers/sx127x/sx127x_internal.c
+++ b/drivers/sx127x/sx127x_internal.c
@@ -124,7 +124,8 @@ void sx127x_read_fifo(const sx127x_t *dev, uint8_t *buffer, uint8_t size)
     sx127x_reg_read_burst(dev, 0, buffer, size);
 }
 
-void sx127x_rx_chain_calibration(sx127x_t *dev)
+#if defined(MODULE_SX1276)
+void sx1276_rx_chain_calibration(sx127x_t *dev)
 {
     uint8_t reg_pa_config_init_val;
     uint32_t initial_freq;
@@ -164,6 +165,7 @@ void sx127x_rx_chain_calibration(sx127x_t *dev)
     sx127x_reg_write(dev, SX127X_REG_PACONFIG, reg_pa_config_init_val);
     sx127x_set_channel(dev, initial_freq);
 }
+#endif
 
 int16_t sx127x_read_rssi(const sx127x_t *dev)
 {

--- a/drivers/sx127x/sx127x_internal.c
+++ b/drivers/sx127x/sx127x_internal.c
@@ -49,18 +49,18 @@ bool sx127x_test(const sx127x_t *dev)
 
 #if defined(MODULE_SX1272)
     if (version != VERSION_SX1272) {
-        DEBUG("[Error] sx1272 test failed, invalid version number: %d\n",
+        DEBUG("[sx127x] sx1272 test failed, invalid version number: %d\n",
               version);
         return false;
     }
-    DEBUG("SX1272 transceiver detected.\n");
+    DEBUG("[sx127x] SX1272 transceiver detected.\n");
 #else /* MODULE_SX1276) */
     if (version != VERSION_SX1276) {
-        DEBUG("[Error] sx1276 test failed, invalid version number: %d\n",
+        DEBUG("[sx127x] sx1276 test failed, invalid version number: %d\n",
               version);
         return false;
     }
-    DEBUG("SX1276 transceiver detected.\n");
+    DEBUG("[sx127x] SX1276 transceiver detected.\n");
 #endif
 
     return true;

--- a/drivers/sx127x/sx127x_internal.c
+++ b/drivers/sx127x/sx127x_internal.c
@@ -42,7 +42,7 @@
 #define SX127X_SPI_MODE     (SPI_MODE_0)
 
 
-bool sx127x_test(const sx127x_t *dev)
+int sx127x_check_version(const sx127x_t *dev)
 {
     /* Read version number and compare with sx127x assigned revision */
     uint8_t version = sx127x_reg_read(dev, SX127X_REG_VERSION);
@@ -51,19 +51,19 @@ bool sx127x_test(const sx127x_t *dev)
     if (version != VERSION_SX1272) {
         DEBUG("[sx127x] sx1272 test failed, invalid version number: %d\n",
               version);
-        return false;
+        return -1;
     }
-    DEBUG("[sx127x] SX1272 transceiver detected.\n");
+    DEBUG("[sx127x] SX1272 transceiver detected\n");
 #else /* MODULE_SX1276) */
     if (version != VERSION_SX1276) {
         DEBUG("[sx127x] sx1276 test failed, invalid version number: %d\n",
               version);
-        return false;
+        return -1;
     }
-    DEBUG("[sx127x] SX1276 transceiver detected.\n");
+    DEBUG("[sx127x] SX1276 transceiver detected\n");
 #endif
 
-    return true;
+    return 0;
 }
 
 void sx127x_reg_write(const sx127x_t *dev, uint8_t addr, uint8_t data)

--- a/drivers/sx127x/sx127x_netdev.c
+++ b/drivers/sx127x/sx127x_netdev.c
@@ -46,7 +46,7 @@ static int _send(netdev_t *netdev, const iolist_t *iolist)
     sx127x_t *dev = (sx127x_t*) netdev;
 
     if (sx127x_get_state(dev) == SX127X_RF_TX_RUNNING) {
-        DEBUG("[WARNING] Cannot send packet: radio already in transmitting "
+        DEBUG("[sx127x] Cannot send packet: radio already in transmitting "
               "state.\n");
         return -ENOTSUP;
     }
@@ -220,14 +220,17 @@ static int _init(netdev_t *netdev)
     sx127x->settings = settings;
 
     /* Launch initialization of driver and device */
-    DEBUG("init_radio: initializing driver...\n");
-    sx127x_init(sx127x);
+    DEBUG("[sx127x] netdev: initializing driver...\n");
+    if (sx127x_init(sx127x) != SX127X_INIT_OK) {
+        DEBUG("[sx127x] netdev: initialization failed\n");
+        return -1;
+    }
 
     sx127x_init_radio_settings(sx127x);
     /* Put chip into sleep */
     sx127x_set_sleep(sx127x);
 
-    DEBUG("init_radio: sx127x initialization done\n");
+    DEBUG("[sx127x] netdev: initialization done\n");
 
     return 0;
 }
@@ -561,10 +564,11 @@ void _on_dio0_irq(void *arg)
             }
             break;
         case SX127X_RF_IDLE:
-            printf("sx127x_on_dio0: IDLE state\n");
+            DEBUG("[sx127x] netdev: sx127x_on_dio0: IDLE state\n");
             break;
         default:
-            printf("sx127x_on_dio0: Unknown state [%d]\n", dev->settings.state);
+            DEBUG("[sx127x] netdev: sx127x_on_dio0: unknown state [%d]\n",
+                  dev->settings.state);
             break;
     }
 }
@@ -604,7 +608,7 @@ void _on_dio1_irq(void *arg)
             }
             break;
         default:
-            puts("sx127x_on_dio1: Unknown state");
+            puts("[sx127x] netdev: sx127x_on_dio1: unknown state");
             break;
     }
 }
@@ -657,7 +661,7 @@ void _on_dio2_irq(void *arg)
             }
             break;
         default:
-            puts("sx127x_on_dio2: Unknown state");
+            puts("[sx127x] netdev: sx127x_on_dio2: unknown state");
             break;
     }
 }
@@ -684,7 +688,7 @@ void _on_dio3_irq(void *arg)
             netdev->event_callback(netdev, NETDEV_EVENT_CAD_DONE);
             break;
         default:
-            puts("sx127x_on_dio3: Unknown modem");
+            puts("[sx127x] netdev: sx127x_on_dio3: unknown modem");
             break;
     }
 }

--- a/pkg/semtech-loramac/contrib/semtech_loramac_radio.c
+++ b/pkg/semtech-loramac/contrib/semtech_loramac_radio.c
@@ -44,7 +44,11 @@ extern sx127x_t sx127x;
 void SX127XInit(RadioEvents_t *events)
 {
     (void) events;
-    sx127x_init(&sx127x);
+    if (sx127x_init(&sx127x) < 0) {
+        DEBUG("[semtech-loramac] radio: failed to initialize radio\n");
+    }
+
+    DEBUG("[semtech-loramac] radio: initialization successful\n");
 }
 
 RadioState_t SX127XGetStatus(void)

--- a/tests/driver_sx127x/main.c
+++ b/tests/driver_sx127x/main.c
@@ -49,7 +49,6 @@ static kernel_pid_t _recv_pid;
 
 static char message[32];
 static sx127x_t sx127x;
-static netdev_t *netdev;
 
 int lora_setup_cmd(int argc, char **argv) {
 
@@ -120,6 +119,7 @@ int random_cmd(int argc, char **argv)
     (void)argc;
     (void)argv;
 
+    netdev_t *netdev = (netdev_t*) &sx127x;
     printf("random: number from sx127x: %u\n",
            (unsigned int) sx127x_random((sx127x_t*) netdev));
 
@@ -141,6 +141,7 @@ int register_cmd(int argc, char **argv)
             puts("usage: register get <all | allinline | regnum>");
             return -1;
         }
+
         if (strcmp(argv[2], "all") == 0) {
             puts("- listing all registers -");
             uint8_t reg = 0, data = 0;
@@ -157,7 +158,8 @@ int register_cmd(int argc, char **argv)
             }
             puts("-done-");
             return 0;
-        } else if (strcmp(argv[2], "allinline") == 0) {
+        }
+        else if (strcmp(argv[2], "allinline") == 0) {
             puts("- listing all registers in one line -");
             /* Listing registers map */
             for (uint16_t reg = 0; reg < 256; reg++) {
@@ -165,24 +167,29 @@ int register_cmd(int argc, char **argv)
             }
             puts("- done -");
             return 0;
-        } else {
+        }
+        else {
             long int num = 0;
             /* Register number in hex */
             if (strstr(argv[2], "0x") != NULL) {
                 num = strtol(argv[2], NULL, 16);
-            } else {
+            }
+            else {
                 num = atoi(argv[2]);
             }
+
             if (num >= 0 && num <= 255) {
                 printf("[regs] 0x%02X = 0x%02X\n",
                        (uint8_t) num,
                        sx127x_reg_read(&sx127x, (uint8_t) num));
-            } else {
+            }
+            else {
                 puts("regs: invalid register number specified");
                 return -1;
             }
         }
-    } else if (strstr(argv[1], "set") != NULL) {
+    }
+    else if (strstr(argv[1], "set") != NULL) {
         if (argc < 4) {
             puts("usage: register set <regnum> <value>");
             return -1;
@@ -193,14 +200,16 @@ int register_cmd(int argc, char **argv)
         /* Register number in hex */
         if (strstr(argv[2], "0x") != NULL) {
             num = strtol(argv[2], NULL, 16);
-        } else {
+        }
+        else {
             num = atoi(argv[2]);
         }
 
         /* Register value in hex */
         if (strstr(argv[3], "0x") != NULL) {
             val = strtol(argv[3], NULL, 16);
-        } else {
+        }
+        else {
             val = atoi(argv[3]);
         }
 
@@ -229,6 +238,7 @@ int send_cmd(int argc, char **argv)
         .iol_len = (strlen(argv[1]) + 1)
     };
 
+    netdev_t *netdev = (netdev_t*) &sx127x;
     if (netdev->driver->send(netdev, &iolist) == -ENOTSUP) {
         puts("Cannot send: radio is still transmitting");
     }
@@ -241,6 +251,7 @@ int listen_cmd(int argc, char **argv)
     (void)argc;
     (void)argv;
 
+    netdev_t *netdev = (netdev_t*) &sx127x;
     /* Switch to continuous listen mode */
     const netopt_enable_t single = false;
     netdev->driver->set(netdev, NETOPT_SINGLE_RECEIVE, &single, sizeof(single));
@@ -263,6 +274,7 @@ int channel_cmd(int argc, char **argv)
         return -1;
     }
 
+    netdev_t *netdev = (netdev_t*) &sx127x;
     uint32_t chan;
     if (strstr(argv[1], "get") != NULL) {
         netdev->driver->get(netdev, NETOPT_CHANNEL_FREQUENCY, &chan, sizeof(chan));
@@ -321,15 +333,19 @@ static void _event_cb(netdev_t *dev, netdev_event_t event)
                        packet_info.rssi, (int)packet_info.snr,
                        sx127x_get_time_on_air((const sx127x_t*)dev, len));
                 break;
+
             case NETDEV_EVENT_TX_COMPLETE:
                 sx127x_set_sleep(&sx127x);
                 puts("Transmission completed");
                 break;
+
             case NETDEV_EVENT_CAD_DONE:
                 break;
+
             case NETDEV_EVENT_TX_TIMEOUT:
                 sx127x_set_sleep(&sx127x);
                 break;
+
             default:
                 printf("Unexpected netdev event received: %d\n", event);
                 break;
@@ -360,7 +376,7 @@ void *_recv_thread(void *arg)
 int main(void)
 {
     memcpy(&sx127x.params, sx127x_params, sizeof(sx127x_params));
-    netdev = (netdev_t*) &sx127x;
+    netdev_t *netdev = (netdev_t*) &sx127x;
     netdev->driver = &sx127x_driver;
     netdev->driver->init(netdev);
     netdev->event_callback = _event_cb;

--- a/tests/driver_sx127x/main.c
+++ b/tests/driver_sx127x/main.c
@@ -378,7 +378,12 @@ int main(void)
     memcpy(&sx127x.params, sx127x_params, sizeof(sx127x_params));
     netdev_t *netdev = (netdev_t*) &sx127x;
     netdev->driver = &sx127x_driver;
-    netdev->driver->init(netdev);
+
+    if (netdev->driver->init(netdev) < 0) {
+        puts("Failed to initialize SX127x device, exiting");
+        return 1;
+    }
+
     netdev->event_callback = _event_cb;
 
     _recv_pid = thread_create(stack, sizeof(stack), THREAD_PRIORITY_MAIN - 1,


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR provides several enhancements/fixes to the sx127x driver and in particular to the sx1272 variant:
- improve the debug messages output by making them consistent. It uses a `[sx127x] <message>`  pattern everywhere, this improves the readability of debug messages
- remove the `sx127x_rx_chain_calibration` from the sx1272 variant as it is not used in the original semtech code and I think this is causing troubles with the driver
- slightly reorder initialization sequence (similar to the semtech device driver)

I started to work on that because I had problem when using the sx1272 with the loramac package ~, it's currently broken in fact (but I'm sure it worked before)~.
During my tests I realized that the driver test application was also broken with sx1272 (unless one explicit uses the `setup` command once). At least this PR fixes that ~but there's still broken things (using SF7 doesn't work actually, and I think this explains why loramac doesn't work with sx1272)~.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

fixes #8935 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->