### PR TITLE
kinetis: Refactor clock initialization code

### DIFF
--- a/boards/frdm-k22f/include/periph_conf.h
+++ b/boards/frdm-k22f/include/periph_conf.h
@@ -41,20 +41,24 @@ static const clock_config_t clock_config = {
      */
     .clkdiv1 = SIM_CLKDIV1_OUTDIV1(0) | SIM_CLKDIV1_OUTDIV2(1) |
                SIM_CLKDIV1_OUTDIV3(2) | SIM_CLKDIV1_OUTDIV4(2),
+    .rtc_clc = 0, /* External load caps on the FRDM-K22F board */
+    .osc32ksel = SIM_SOPT1_OSC32KSEL(2),
+    .clock_flags =
+        KINETIS_CLOCK_OSC0_EN |
+        KINETIS_CLOCK_RTCOSC_EN |
+        KINETIS_CLOCK_USE_FAST_IRC |
+        0,
     .default_mode = KINETIS_MCG_MODE_FEE,
     /* The crystal connected to OSC0 is 8 MHz */
     .erc_range = KINETIS_MCG_ERC_RANGE_HIGH,
-    .fcrdiv = 0, /* Fast IRC divide by 1 => 4 MHz */
-    .oscsel = 0, /* Use OSC0 for external clock */
-    .clc = 0, /* External load caps on the FRDM-K22F board */
-    .fll_frdiv = 0b011, /* Divide by 256 */
+    .osc_clc = 0, /* External load caps on the FRDM-K22F board */
+    .oscsel = MCG_C7_OSCSEL(0), /* Use OSC0 for external clock */
+    .fcrdiv = MCG_SC_FCRDIV(0), /* Fast IRC divide by 1 => 4 MHz */
+    .fll_frdiv = MCG_C1_FRDIV(0b011), /* Divide by 256 */
     .fll_factor_fei = KINETIS_MCG_FLL_FACTOR_1464, /* FLL freq = 48 MHz */
     .fll_factor_fee = KINETIS_MCG_FLL_FACTOR_1920, /* FLL freq = 60 MHz */
-    .pll_prdiv = 0b00011, /* Divide by 4 */
-    .pll_vdiv = 0b00110, /* Multiply by 30 => PLL freq = 60 MHz */
-    .enable_oscillator = true,
-    .select_fast_irc = true,
-    .enable_mcgirclk = false,
+    .pll_prdiv = MCG_C5_PRDIV0(0b00011), /* Divide by 4 */
+    .pll_vdiv  = MCG_C6_VDIV0(0b00110), /* Multiply by 30 => PLL freq = 60 MHz */
 };
 #define CLOCK_CORECLOCK              (60000000ul)
 #define CLOCK_BUSCLOCK               (CLOCK_CORECLOCK / 2)

--- a/boards/frdm-k64f/include/periph_conf.h
+++ b/boards/frdm-k64f/include/periph_conf.h
@@ -42,20 +42,24 @@ static const clock_config_t clock_config = {
      */
     .clkdiv1 = SIM_CLKDIV1_OUTDIV1(0) | SIM_CLKDIV1_OUTDIV2(0) |
                SIM_CLKDIV1_OUTDIV3(2) | SIM_CLKDIV1_OUTDIV4(2),
+    .rtc_clc = 0, /* External load caps on board */
+    .osc32ksel = SIM_SOPT1_OSC32KSEL(2),
+    .clock_flags =
+        /* No OSC0_EN, use EXTAL directly without OSC0 */
+        KINETIS_CLOCK_RTCOSC_EN |
+        KINETIS_CLOCK_USE_FAST_IRC |
+        0,
     .default_mode = KINETIS_MCG_MODE_PEE,
     /* The board has an external RMII (Ethernet) clock which drives the ERC at 50 MHz */
     .erc_range = KINETIS_MCG_ERC_RANGE_VERY_HIGH,
-    .fcrdiv = 0, /* Fast IRC divide by 1 => 4 MHz */
-    .oscsel = 0, /* Use EXTAL for external clock */
-    .clc = 0, /* External load caps on board */
-    .fll_frdiv = 0b111, /* Divide by 1536 => FLL input 32252 Hz */
+    .osc_clc = 0, /* External load caps on board */
+    .oscsel = MCG_C7_OSCSEL(0), /* Use EXTAL for external clock */
+    .fcrdiv = MCG_SC_FCRDIV(0), /* Fast IRC divide by 1 => 4 MHz */
+    .fll_frdiv = MCG_C1_FRDIV(0b111), /* Divide by 1536 => FLL input 32252 Hz */
     .fll_factor_fei = KINETIS_MCG_FLL_FACTOR_1464, /* FLL freq = 48 MHz  */
     .fll_factor_fee = KINETIS_MCG_FLL_FACTOR_1920, /* FLL freq = 62.5 MHz */
-    .pll_prdiv = 0b10011, /* Divide by 20 */
-    .pll_vdiv = 0b00000, /* Multiply by 24 => PLL freq = 60 MHz */
-    .enable_oscillator = false, /* Use EXTAL directly without OSC0 */
-    .select_fast_irc = true,
-    .enable_mcgirclk = false,
+    .pll_prdiv = MCG_C5_PRDIV0(0b10011), /* Divide by 20 */
+    .pll_vdiv  = MCG_C6_VDIV0(0b00000), /* Multiply by 24 => PLL freq = 60 MHz */
 };
 #define CLOCK_CORECLOCK              (60000000ul)
 #define CLOCK_BUSCLOCK               (CLOCK_CORECLOCK / 1)

--- a/boards/frdm-kw41z/board.c
+++ b/boards/frdm-kw41z/board.c
@@ -20,17 +20,11 @@
 
 #include "board.h"
 #include "periph/gpio.h"
-#include "periph/rtt.h"
 
 void board_init(void)
 {
     /* initialize the CPU core */
     cpu_init();
-
-#if MODULE_XTIMER && !(KINETIS_XTIMER_SOURCE_PIT)
-    /* Start the RTT, used as time base for xtimer when using LPTMR backend */
-    rtt_init();
-#endif
 
     /* initialize and turn off LEDs */
     gpio_init(LED0_PIN, GPIO_OUT);

--- a/boards/frdm-kw41z/include/periph_conf.h
+++ b/boards/frdm-kw41z/include/periph_conf.h
@@ -39,20 +39,30 @@ static const clock_config_t clock_config = {
      * Flash: 24 MHz
      */
     .clkdiv1            = SIM_CLKDIV1_OUTDIV1(0) | SIM_CLKDIV1_OUTDIV4(1),
+    /* unsure if this RTC load cap configuration is correct, but it matches the
+     * settings used by the example code in the NXP provided SDK */
+    .rtc_clc            = 0,
+    /* Use the 32 kHz oscillator as ERCLK32K. Note that the values here have a
+     * different mapping for the KW41Z than the values used in the Kinetis K series */
+    .osc32ksel          = SIM_SOPT1_OSC32KSEL(0),
+    .clock_flags =
+        KINETIS_CLOCK_OSC0_EN | /* Enable RSIM oscillator */
+        KINETIS_CLOCK_RTCOSC_EN |
+        KINETIS_CLOCK_USE_FAST_IRC |
+        KINETIS_CLOCK_MCGIRCLK_EN | /* Used for LPUART clocking */
+        KINETIS_CLOCK_MCGIRCLK_STOP_EN |
+        0,
     /* Using FEI mode by default, the external crystal settings below are only
      * used if mode is changed to an external mode (PEE, FBE, or FEE) */
     .default_mode       = KINETIS_MCG_MODE_FEI,
     /* The crystal connected to RSIM OSC is 32 MHz */
     .erc_range          = KINETIS_MCG_ERC_RANGE_VERY_HIGH,
-    .fcrdiv             = 0, /* Fast IRC divide by 1 => 4 MHz */
-    .oscsel             = 0, /* Use RSIM for external clock */
-    .clc                = 0, /* no load cap configuration */
-    .fll_frdiv          = 0b101, /* Divide by 1024 */
+    .osc_clc            = 0, /* no load cap configuration */
+    .oscsel             = MCG_C7_OSCSEL(0), /* Use RSIM for external clock */
+    .fcrdiv             = MCG_SC_FCRDIV(0), /* Fast IRC divide by 1 => 4 MHz */
+    .fll_frdiv          = MCG_C1_FRDIV(0b101), /* Divide by 1024 */
     .fll_factor_fei     = KINETIS_MCG_FLL_FACTOR_1464, /* FEI FLL freq = 48 MHz */
     .fll_factor_fee     = KINETIS_MCG_FLL_FACTOR_1280, /* FEE FLL freq = 40 MHz */
-    .enable_oscillator  = true, /* Use RF module oscillator */
-    .select_fast_irc    = true,
-    .enable_mcgirclk    = true, /* Used for LPUART clocking */
 };
 /* Radio xtal frequency, either 32 MHz or 26 MHz */
 #define CLOCK_RADIOXTAL              (32000000ul)

--- a/boards/mulle/board.c
+++ b/boards/mulle/board.c
@@ -103,28 +103,6 @@ void board_init(void)
     /* Turn on AVDD for reading voltages */
     gpio_set(MULLE_POWER_AVDD);
 
-    /* Initialize RTC oscillator as early as possible since we are using it as a
-     * base clock for the FLL.
-     * It takes a while to stabilize the oscillator, therefore we do this as
-     * soon as possible during boot in order to let it stabilize while other
-     * stuff is initializing. */
-    /* If the clock is not stable then the UART will have the wrong baud rate
-     * for debug prints as well */
-    rtt_init();
-
-    /* Set 32 kHz clock source */
-    SIM->SOPT1 = (SIM->SOPT1 & ~(SIM_SOPT1_OSC32KSEL_MASK)) | SIM_SOPT1_OSC32KSEL(2);
-
-    /* At this point we need to wait for 1 ms until the clock is stable.
-     * Since the clock is not yet stable we can only guess how long we must
-     * wait. I have tried to make this as short as possible but still being able
-     * to read the initialization messages written on the UART.
-     * (If the clock is not stable all UART output is garbled until it has
-     * stabilized) */
-    for (int i = 0; i < 100000; ++i) {
-        __asm__ volatile("nop\n");
-    }
-
     /* initialize the CPU */
     cpu_init();
 

--- a/boards/pba-d-01-kw2x/include/periph_conf.h
+++ b/boards/pba-d-01-kw2x/include/periph_conf.h
@@ -43,20 +43,24 @@ static const clock_config_t clock_config = {
      */
     .clkdiv1 = SIM_CLKDIV1_OUTDIV1(0) | SIM_CLKDIV1_OUTDIV2(0) |
                SIM_CLKDIV1_OUTDIV4(1),
+    .rtc_clc = 0, /* External load caps on the FRDM-K22F board */
+    .osc32ksel = SIM_SOPT1_OSC32KSEL(2),
+    .clock_flags =
+        /* No OSC0_EN, use modem clock from EXTAL0 */
+        KINETIS_CLOCK_RTCOSC_EN |
+        KINETIS_CLOCK_USE_FAST_IRC |
+        0,
     .default_mode = KINETIS_MCG_MODE_PEE,
     /* The modem generates a 4 MHz clock signal */
     .erc_range = KINETIS_MCG_ERC_RANGE_HIGH,
-    .fcrdiv = 0, /* Fast IRC divide by 1 => 4 MHz */
-    .oscsel = 0, /* Use EXTAL0 for external clock */
-    .clc = 0, /* OSC0 is unused*/
-    .fll_frdiv = 0b010, /* Divide by 128 */
+    .osc_clc = 0, /* OSC0 is unused*/
+    .oscsel = MCG_C7_OSCSEL(0), /* Use EXTAL0 for external clock */
+    .fcrdiv = MCG_SC_FCRDIV(0), /* Fast IRC divide by 1 => 4 MHz */
+    .fll_frdiv = MCG_C1_FRDIV(0b010), /* Divide by 128 */
     .fll_factor_fei = KINETIS_MCG_FLL_FACTOR_1464, /* FLL freq = 48 MHz */
     .fll_factor_fee = KINETIS_MCG_FLL_FACTOR_1280, /* FLL freq = 40 MHz */
-    .pll_prdiv = 0b00001, /* Divide by 2 */
-    .pll_vdiv = 0b00000, /* Multiply by 24 => PLL freq = 48 MHz */
-    .enable_oscillator = false, /* Use modem clock from EXTAL0 */
-    .select_fast_irc = true,
-    .enable_mcgirclk = false,
+    .pll_prdiv = MCG_C5_PRDIV0(0b00001), /* Divide by 2 */
+    .pll_vdiv = MCG_C6_VDIV0(0b00000), /* Multiply by 24 => PLL freq = 48 MHz */
 };
 #define CLOCK_CORECLOCK              (48000000ul)
 #define CLOCK_BUSCLOCK               (CLOCK_CORECLOCK / 1)

--- a/boards/teensy31/include/periph_conf.h
+++ b/boards/teensy31/include/periph_conf.h
@@ -45,24 +45,28 @@ static const clock_config_t clock_config = {
      * consumption than using the 16 MHz crystal and the OSC0 module */
     .clkdiv1 = SIM_CLKDIV1_OUTDIV1(0) | SIM_CLKDIV1_OUTDIV2(0) |
                SIM_CLKDIV1_OUTDIV3(1) | SIM_CLKDIV1_OUTDIV4(1),
+    /* RTC crystal has to be soldered by the user, we can't know the load cap requirements */
+    .rtc_clc = 0,
+    .osc32ksel = SIM_SOPT1_OSC32KSEL(2),
+    .clock_flags =
+        KINETIS_CLOCK_RTCOSC_EN |
+        KINETIS_CLOCK_USE_FAST_IRC |
+        0,
     .default_mode = KINETIS_MCG_MODE_FEE,
     .erc_range = KINETIS_MCG_ERC_RANGE_LOW, /* Input clock is 32768 Hz */
-    .fcrdiv = 0, /* Fast IRC divide by 1 => 4 MHz */
-    .oscsel = 1, /* Use RTC for external clock */
     /* 16 pF capacitors yield ca 10 pF load capacitance as required by the
      * onboard xtal, not used when OSC0 is disabled */
-    .clc = 0b0001,
-    .fll_frdiv = 0b000, /* Divide by 1 => FLL input 32768 Hz */
+    .osc_clc = OSC_CR_SC16P_MASK,
+    .oscsel = MCG_C7_OSCSEL(1), /* Use RTC oscillator as external clock */
+    .fcrdiv = MCG_SC_FCRDIV(0), /* Fast IRC divide by 1 => 4 MHz */
+    .fll_frdiv = MCG_C1_FRDIV(0b000), /* Divide by 1 => FLL input 32768 Hz */
     .fll_factor_fei = KINETIS_MCG_FLL_FACTOR_1464, /* FLL freq = 48 MHz */
     .fll_factor_fee = KINETIS_MCG_FLL_FACTOR_1464, /* FLL freq = 48 MHz */
     /* PLL is unavailable when using a 32768 Hz source clock, so the
      * configuration below can only be used if the above config is modified to
      * use the 16 MHz crystal instead of the RTC. */
-    .pll_prdiv = 0b00111, /* Divide by 8 */
-    .pll_vdiv = 0b01100, /* Multiply by 36 => PLL freq = 72 MHz */
-    .enable_oscillator = false, /* the RTC module provides the clock input signal */
-    .select_fast_irc = true, /* Only used for FBI mode */
-    .enable_mcgirclk = false,
+    .pll_prdiv = MCG_C5_PRDIV0(0b00111), /* Divide by 8 */
+    .pll_vdiv  = MCG_C6_VDIV0(0b01100), /* Multiply by 36 => PLL freq = 72 MHz */
 };
 #define CLOCK_CORECLOCK              (48000000ul)
 #define CLOCK_BUSCLOCK               (CLOCK_CORECLOCK / 1)

--- a/cpu/kinetis/include/cpu_conf_kinetis.h
+++ b/cpu/kinetis/include/cpu_conf_kinetis.h
@@ -124,6 +124,10 @@ extern "C"
 /** Enable PIT clock gate */
 #define PIT_CLKEN()    (bit_set32(&SIM->SCGC6, SIM_SCGC6_PIT_SHIFT))
 #endif
+#ifdef SIM_SCGC6_RTC_SHIFT
+/** Enable RTC clock gate */
+#define RTC_CLKEN()    (bit_set32(&SIM->SCGC6, SIM_SCGC6_RTC_SHIFT))
+#endif
 /** @} */
 
 /**


### PR DESCRIPTION
### Contribution description

- Move RTC oscillator configuration to the clock_config struct and handle it from kinetis_mcg_init
- Modularize kinetis_mcg_init to improve readability
- Merge boolean settings in clock_config_t into a single clock_flags field

### Issues/PRs references

Used by #8814, #8930, #8933 