### PR TITLE
kinetis: Refactor RTT driver

### DIFF
--- a/boards/frdm-k22f/include/periph_conf.h
+++ b/boards/frdm-k22f/include/periph_conf.h
@@ -265,21 +265,6 @@ static const spi_conf_t spi_config[] = {
 #define I2C_0_PORT_CFG               (PORT_PCR_MUX(I2C_0_PIN_AF) | PORT_PCR_ODE_MASK)
 /** @} */
 
-/**
-* @name RTT and RTC configuration
-* @{
-*/
-#define RTT_NUMOF                    (1U)
-#define RTC_NUMOF                    (1U)
-#define RTT_DEV                      RTC
-#define RTT_IRQ                      RTC_IRQn
-#define RTT_IRQ_PRIO                 10
-#define RTT_UNLOCK()                 (SIM->SCGC6 |= (SIM_SCGC6_RTC_MASK))
-#define RTT_ISR                      isr_rtc
-#define RTT_FREQUENCY                (1)
-#define RTT_MAX_VALUE                (0xffffffff)
-/** @} */
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/frdm-k64f/include/periph_conf.h
+++ b/boards/frdm-k64f/include/periph_conf.h
@@ -259,21 +259,6 @@ static const spi_conf_t spi_config[] = {
 #define I2C_0_PORT_CFG               (PORT_PCR_MUX(I2C_0_PIN_AF) | PORT_PCR_ODE_MASK)
 /** @} */
 
-/**
-* @name RTT and RTC configuration
-* @{
-*/
-#define RTT_NUMOF                    (1U)
-#define RTC_NUMOF                    (1U)
-#define RTT_DEV                      RTC
-#define RTT_IRQ                      RTC_IRQn
-#define RTT_IRQ_PRIO                 10
-#define RTT_UNLOCK()                 (SIM->SCGC6 |= (SIM_SCGC6_RTC_MASK))
-#define RTT_ISR                      isr_rtc
-#define RTT_FREQUENCY                (1)
-#define RTT_MAX_VALUE                (0xffffffff)
-/** @} */
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/frdm-kw41z/include/periph_conf.h
+++ b/boards/frdm-kw41z/include/periph_conf.h
@@ -287,21 +287,6 @@ static const spi_conf_t spi_config[] = {
 /** @} */
 
 /**
-* @name RTT and RTC configuration
-* @{
-*/
-#define RTT_NUMOF                    (1U)
-#define RTC_NUMOF                    (1U)
-#define RTT_DEV                      RTC
-#define RTT_IRQ                      RTC_IRQn
-#define RTT_IRQ_PRIO                 10
-#define RTT_UNLOCK()                 (bit_set32(&SIM->SCGC6, SIM_SCGC6_RTC_SHIFT))
-#define RTT_ISR                      isr_rtc
-#define RTT_FREQUENCY                (1)
-#define RTT_MAX_VALUE                (0xffffffff)
-/** @} */
-
-/**
  * @name Random Number Generator configuration
  * @{
  */

--- a/boards/mulle/include/periph_conf.h
+++ b/boards/mulle/include/periph_conf.h
@@ -115,6 +115,7 @@ static const clock_config_t clock_config = {
 #define PIT_ISR_0               isr_pit1
 #define PIT_ISR_1               isr_pit3
 #define LPTMR_ISR_0             isr_lptmr0
+
 /** @} */
 
 /**
@@ -372,28 +373,6 @@ static const spi_conf_t spi_config[] = {
 /* Fast plus (1000 kHz): MUL = 1, SCL divider = 48, total: 48 */
 #define KINETIS_I2C_F_ICR_FAST_PLUS  (0x10)
 #define KINETIS_I2C_F_MULT_FAST_PLUS (0)
-/** @} */
-
-/**
- * @name RTC configuration
- * @{
- */
-/* RIOT RTC implementation uses RTT for underlying timekeeper */
-#define RTC_NUMOF           (1U)
-/** @} */
-
-/**
- * @name RTT configuration
- * @{
- */
-#define RTT_NUMOF           (1U)
-#define RTT_IRQ             RTC_IRQn
-#define RTT_IRQ_PRIO        10
-#define RTT_ISR             isr_rtc
-#define RTT_DEV             RTC
-#define RTT_UNLOCK()        (BITBAND_REG32(SIM->SCGC6, SIM_SCGC6_RTC_SHIFT) = 1)
-#define RTT_MAX_VALUE       (0xffffffff)
-#define RTT_FREQUENCY       (1)             /* in Hz */
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/pba-d-01-kw2x/include/periph_conf.h
+++ b/boards/pba-d-01-kw2x/include/periph_conf.h
@@ -289,21 +289,6 @@ static const spi_conf_t spi_config[] = {
 
 /** @} */
 
-/**
-* @name RTT and RTC configuration
-* @{
-*/
-#define RTT_NUMOF            (1U)
-#define RTC_NUMOF            (1U)
-#define RTT_DEV              RTC
-#define RTT_IRQ              RTC_IRQn
-#define RTT_IRQ_PRIO         10
-#define RTT_UNLOCK()         (SIM->SCGC6 |= (SIM_SCGC6_RTC_MASK))
-#define RTT_ISR              isr_rtc
-#define RTT_FREQUENCY        (1)
-#define RTT_MAX_VALUE        (0xffffffff)
-/** @} */
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/teensy31/Makefile.features
+++ b/boards/teensy31/Makefile.features
@@ -1,11 +1,13 @@
 # Put defined MCU peripherals here (in alphabetical order)
-FEATURES_PROVIDED += periph_cpuid
-FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_pwm
+FEATURES_PROVIDED += periph_rtc
+FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m4_2
 
-include $(RIOTCPU)/cortexm_common/Makefile.features
+include $(RIOTCPU)/kinetis/Makefile.features
+# No HWRNG in MK20D7 devices
+FEATURES_PROVIDED := $(filter-out periph_hwrng,$(FEATURES_PROVIDED))

--- a/cpu/kinetis/include/periph_cpu.h
+++ b/cpu/kinetis/include/periph_cpu.h
@@ -114,6 +114,20 @@ typedef uint16_t gpio_t;
  */
 #define PM_NUM_MODES    (1U)
 
+#ifdef RTC
+/* All Kinetis CPUs have exactly one RTC hardware module, except for the KL02
+ * family which don't have an RTC at all */
+/**
+ * @name RTT and RTC configuration
+ * @{
+ */
+#define RTT_NUMOF                    (1U)
+#define RTC_NUMOF                    (1U)
+#define RTT_FREQUENCY                (1)
+#define RTT_MAX_VALUE                (0xffffffff)
+/** @} */
+#endif
+
 #ifndef DOXYGEN
 /**
  * @name    GPIO pin modes


### PR DESCRIPTION

### Contribution description

- Keep counter value between resets
- Let kinetis_mcg_init manage the RTC oscillator, to avoid disrupting the core clock in certain configurations
- Remove some unnecessary macros for hardware abstraction; all Kinetis CPUs which have an RTC only have a single RTC instance, and the ISRs and hardware registers are named the same way in all Kinetis CPU headers.

### Issues/PRs references

Depends on #8928 