### PR TITLE
testrunner: spawnu 'make term' with 'codec_errors="replace"'

### DIFF
--- a/dist/tools/testrunner/testrunner.py
+++ b/dist/tools/testrunner/testrunner.py
@@ -37,7 +37,7 @@ def find_exc_origin(exc_info):
 
 def run(testfunc, timeout=10, echo=True, traceback=False):
     env = os.environ.copy()
-    child = pexpect.spawnu("make term", env=env, timeout=timeout)
+    child = pexpect.spawnu("make term", env=env, timeout=timeout, codec_errors='replace')
 
     # on many platforms, the termprog needs a short while to be ready...
     time.sleep(MAKE_TERM_STARTED_DELAY)


### PR DESCRIPTION
### Contribution description

testrunner currently calls ```make term``` with unicode input encoding. That fails on non-unicode characters, which, on flaky serials, happen all the time.
This PR configures pexpect to replace offending characters.

### Issues/PRs references

#8869