### PR TITLE
pkg/littlefs: disable error prints

### DIFF
--- a/pkg/littlefs/Makefile.littlefs
+++ b/pkg/littlefs/Makefile.littlefs
@@ -5,4 +5,9 @@ CFLAGS += -Wno-unused-parameter -Wno-format
 # used by MIPS
 CFLAGS += -Wno-missing-field-initializers
 
+# Disable debug printing
+ifneq ($(DEVELHELP),1)
+  CFLAGS += -DLFS_NO_DEBUG -DLFS_NO_WARN -DLFS_NO_ERROR
+endif
+
 include $(RIOTBASE)/Makefile.base


### PR DESCRIPTION
### Contribution description

There have been complaints about the error prints from littlefs, especially in unit tests, this should fix this.
Print are enabled only when `DEVELHELP` is set.

Before:
```
main(): This is RIOT! (Version: 2018.04-devel-939-ga1050-vincent-XPS-13-pr/lfs_no_print)
.lfs error:479: Corrupted dir pair at 0 1
lfs error:2212: Invalid superblock at 0 1
.......
OK (8 tests)
```

After:
```
main(): This is RIOT! (Version: 2018.04-devel-939-ga1050-vincent-XPS-13-pr/lfs_no_print)
........
OK (8 tests)
```

### Issues/PRs references
