### PR TITLE
net/rdcli_simple: specify RD address as string

### DIFF
--- a/examples/rdcli_simple/Makefile
+++ b/examples/rdcli_simple/Makefile
@@ -35,9 +35,11 @@ CFLAGS += -DDEVELHELP
 RD_LT ?= 60
 # Override this variable to set the RD server address (default is the all nodes
 # multicast address)
-RD_SERVER ?= IPV6_ADDR_ALL_NODES_LINK_LOCAL
+RD_ADDR ?= \"ff02::1\"
+RD_PORT ?= 5683
 
 CFLAGS += -DRDCLI_LT=$(RD_LT)
-CFLAGS += -DRDCLI_SERVER_ADDR=$(RD_SERVER)
+CFLAGS += -DRDCLI_SERVER_ADDR=$(RD_ADDR)
+CFLAGS += -DRDCLI_SERVER_PORT=$(RD_PORT)
 
 include $(RIOTBASE)/Makefile.include

--- a/examples/rdcli_simple/README.md
+++ b/examples/rdcli_simple/README.md
@@ -14,7 +14,11 @@ CFLAGS="-DRDCLI_LT=\"7200\" -DRDCLI_EP=\"MyNode\"" make all
 
 Per default, the node is looking for the CoRE RD at the all nodes link-local
 multicast address [FF02::1]:5683. To change the target address or port, simply
-redefine `RDCLI_SERVER_ADDR` and `RDCLI_SERVER_PORT`, e.g.:
+override the `RD_ADDR` and `RD_PORT` variables, e.g.:
 ```
-CFLAGS="-DRDCLI_SERVER_ADDR=IPV6_ADDR_ALL_ROUTERS_LINK_LOCAL" make all
+RD_ADDR=\\\"::1\\\" RD_PORT=12345 make all
+```
+or
+```
+RD_ADDR=\\\"abc:0815::123\\\" make all
 ```

--- a/examples/rdcli_simple/main.c
+++ b/examples/rdcli_simple/main.c
@@ -75,8 +75,10 @@ int main(void)
 
     /* print RD client information */
     puts("RD client information:");
-    printf("  ep: %s\n", rdcli_common_get_ep());
-    printf("  lt: %is\n", (int)RDCLI_LT);
+    printf(" RD addr: %s\n", RDCLI_SERVER_ADDR);
+    printf(" RD port: %u\n", (unsigned)RDCLI_SERVER_PORT);
+    printf("      ep: %s\n", rdcli_common_get_ep());
+    printf("      lt: %is\n", (int)RDCLI_LT);
 
     /* run the shell */
     char line_buf[SHELL_DEFAULT_BUFSIZE];

--- a/sys/include/net/rdcli_config.h
+++ b/sys/include/net/rdcli_config.h
@@ -76,10 +76,11 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   Default IPv6 address to use when looking for RDs
+ * @brief   Use ALL_NODES multicast address as default address when looking for
+ *          a RD server
  */
 #ifndef RDCLI_SERVER_ADDR
-#define RDCLI_SERVER_ADDR       IPV6_ADDR_ALL_NODES_LINK_LOCAL
+#define RDCLI_SERVER_ADDR       "ff02::1"
 #endif
 
 /**

--- a/sys/include/net/rdcli_simple.h
+++ b/sys/include/net/rdcli_simple.h
@@ -30,8 +30,9 @@ extern "C" {
  * @brief   Error codes used by the rdcli_simple implementation
  */
 enum {
-    RDCLI_SIMPLE_OK  = 0,       /**< all ok */
-    RDCLI_SIMPLE_ERR = -1,      /**< return for formatting and network errors */
+    RDCLI_SIMPLE_OK     =  0,   /**< all good */
+    RDCLI_SIMPLE_NOADDR = -1,   /**< on address conversion errors */
+    RDCLI_SIMPLE_ERROR  = -2,   /**< on other errors */
 };
 
 /**
@@ -39,7 +40,8 @@ enum {
  *          to the RD server's /.well-known/core resource
  *
  * @return  RDCLI_SIMPLE_OK on success
- * @return  RDCLI_ERROR if something goes wrong preparing or sending the
+ * @return  RDCLI_SIMPLE_NOADDR if conversion of RD address fails
+ * @return  RDCLI_SIMPLE_ERROR if something goes wrong preparing or sending the
  *          initial request
  */
 int rdcli_simple_register(void);

--- a/sys/include/net/rdcli_simple.h
+++ b/sys/include/net/rdcli_simple.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Freie Universität Berlin
+ * Copyright (C) 2017-2018 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -27,8 +27,20 @@ extern "C" {
 #endif
 
 /**
+ * @brief   Error codes used by the rdcli_simple implementation
+ */
+enum {
+    RDCLI_SIMPLE_OK  = 0,       /**< all ok */
+    RDCLI_SIMPLE_ERR = -1,      /**< return for formatting and network errors */
+};
+
+/**
  * @brief   Initiate the node registration by sending an empty CoAP POST message
  *          to the RD server's /.well-known/core resource
+ *
+ * @return  RDCLI_SIMPLE_OK on success
+ * @return  RDCLI_ERROR if something goes wrong preparing or sending the
+ *          initial request
  */
 int rdcli_simple_register(void);
 

--- a/sys/net/application_layer/rdcli_simple/rdcli_simple.c
+++ b/sys/net/application_layer/rdcli_simple/rdcli_simple.c
@@ -42,19 +42,21 @@ static const sock_udp_ep_t remote = {
 int rdcli_simple_register(void)
 {
     /* build the initial CON packet */
-    int res = gcoap_req_init(&pkt, buf, sizeof(buf), COAP_METHOD_POST,
-                             "/.well-known/core");
-    if (res < 0) {
-        return res;
+    if (gcoap_req_init(&pkt, buf, sizeof(buf), COAP_METHOD_POST,
+                             "/.well-known/core") < 0) {
+        return RDCLI_SIMPLE_ERR;
     }
     /* make packet confirmable */
     coap_hdr_set_type(pkt.hdr, COAP_TYPE_CON);
     /* add Uri-Query options */
-    res = rdcli_common_add_qstring(&pkt);
-    if (res < 0) {
-        return res;
+    if (rdcli_common_add_qstring(&pkt) < 0) {
+        return RDCLI_SIMPLE_ERR;
     }
     /* finish, we don't have any payload */
     ssize_t len = gcoap_finish(&pkt, 0, COAP_FORMAT_LINK);
-    return (int)gcoap_req_send2(buf, len, &remote, NULL);
+    if (gcoap_req_send2(buf, len, &remote, NULL) == 0) {
+        return RDCLI_SIMPLE_ERR;
+    }
+
+    return RDCLI_SIMPLE_OK;
 }

--- a/sys/net/application_layer/rdcli_simple/rdcli_simple.c
+++ b/sys/net/application_layer/rdcli_simple/rdcli_simple.c
@@ -25,37 +25,44 @@
 #include "net/rdcli_config.h"
 #include "net/rdcli_common.h"
 #include "net/rdcli_simple.h"
+#include "net/ipv6/addr.h"
 
 #define BUFSIZE             (128U)
 
+/* we don't want to allocate the CoAP packet and scratch buffer on the stack,
+ * as they are too large for that. */
 static coap_pkt_t pkt;
 static uint8_t buf[BUFSIZE];
 
-/* allocate an UDP endpoint to the RD server */
-static const sock_udp_ep_t remote = {
-    .family    = AF_INET6,
-    .netif     = SOCK_ADDR_ANY_NETIF,
-    .addr      = RDCLI_SERVER_ADDR ,
-    .port      = RDCLI_SERVER_PORT
-};
-
 int rdcli_simple_register(void)
 {
+    sock_udp_ep_t remote = {
+        .family    = AF_INET6,
+        .netif     = SOCK_ADDR_ANY_NETIF,
+        .port      = RDCLI_SERVER_PORT,
+    };
+
+    /* parse RD server address */
+    if (ipv6_addr_from_str((ipv6_addr_t *)&remote.addr.ipv6,
+                           RDCLI_SERVER_ADDR) == NULL) {
+        return RDCLI_SIMPLE_NOADDR;
+    }
+
     /* build the initial CON packet */
     if (gcoap_req_init(&pkt, buf, sizeof(buf), COAP_METHOD_POST,
                              "/.well-known/core") < 0) {
-        return RDCLI_SIMPLE_ERR;
+        return RDCLI_SIMPLE_ERROR;
     }
     /* make packet confirmable */
     coap_hdr_set_type(pkt.hdr, COAP_TYPE_CON);
     /* add Uri-Query options */
     if (rdcli_common_add_qstring(&pkt) < 0) {
-        return RDCLI_SIMPLE_ERR;
+        return RDCLI_SIMPLE_ERROR;
     }
     /* finish, we don't have any payload */
     ssize_t len = gcoap_finish(&pkt, 0, COAP_FORMAT_LINK);
     if (gcoap_req_send2(buf, len, &remote, NULL) == 0) {
-        return RDCLI_SIMPLE_ERR;
+        return RDCLI_SIMPLE_ERROR;
     }
 
     return RDCLI_SIMPLE_OK;

--- a/sys/net/application_layer/rdcli_simple/rdcli_simple_standalone.c
+++ b/sys/net/application_layer/rdcli_simple/rdcli_simple_standalone.c
@@ -38,8 +38,7 @@ static void *reg_runner(void *arg)
     xtimer_sleep(RDCLI_STARTUP_DELAY);
 
     while (1) {
-        int res = rdcli_simple_register();
-        if (res < 0) {
+        if (rdcli_simple_register() != RDCLI_SIMPLE_OK) {
             LOG_ERROR("[rdcli_simple] error: unable to trigger registration\n");
         }
         xtimer_sleep(RDCLI_UPDATE_INTERVAL);

--- a/sys/net/application_layer/rdcli_simple/rdcli_simple_standalone.c
+++ b/sys/net/application_layer/rdcli_simple/rdcli_simple_standalone.c
@@ -39,12 +39,15 @@ static void *reg_runner(void *arg)
 
     while (1) {
         if (rdcli_simple_register() != RDCLI_SIMPLE_OK) {
-            LOG_ERROR("[rdcli_simple] error: unable to trigger registration\n");
+            /* if this fails once, it will always fail, so we might as well
+             * quit now */
+            LOG_ERROR("[rdcli_simple] error: unable to send registration\n");
+            break;
         }
         xtimer_sleep(RDCLI_UPDATE_INTERVAL);
     }
 
-    return NULL;    /* should never be reached */
+    return NULL;
 }
 
 void rdcli_simple_run(void)


### PR DESCRIPTION
### Contribution description
One of the findings of a CoRE RD plugtest this week was, that it is quite cumbersome in practice, to specify the RD server address in binary format as required by the current `rdcli_simple` implementation. With this PR the RD server address is now specified as string and parsed at run-time, making it much easier to specify the RD server address.

The downside is some run-timer overhead (1 call to `ipv6_addr_from_string()`), and a memory overhead of ~120 bytes ROM (`rdcli_simple` example @ `samr21-xpro`). But I would say this is worth it.

### Issues/PRs references
none