### PR TITLE
mulle: Fix off-by-1 error in clock dividers

### DIFF
--- a/boards/mulle/include/periph_conf.h
+++ b/boards/mulle/include/periph_conf.h
@@ -47,7 +47,7 @@ static const clock_config_t clock_config = {
      * should have better accuracy than the internal slow clock, and lower power
      * consumption than using the 16 MHz crystal and the OSC0 module */
     .clkdiv1 = SIM_CLKDIV1_OUTDIV1(0) | SIM_CLKDIV1_OUTDIV2(0) |
-               SIM_CLKDIV1_OUTDIV3(2) | SIM_CLKDIV1_OUTDIV4(2),
+               SIM_CLKDIV1_OUTDIV3(1) | SIM_CLKDIV1_OUTDIV4(1),
     .default_mode = KINETIS_MCG_MODE_FEE,
     .erc_range = KINETIS_MCG_ERC_RANGE_LOW, /* Input clock is 32768 Hz */
     .fcrdiv = 0, /* Fast IRC divide by 1 => 4 MHz */


### PR DESCRIPTION
### Contribution description

The comment says the config should yield 24 MHz flash clock, but the
settings were configured to divide-by-3. (48 MHz / 3 = 16 MHz)

### Issues/PRs references

noticed in the discussion of #8929 