### PR TITLE
gnrc_lwmac: enable radio duty-cycle printing.

### DIFF
--- a/sys/include/net/gnrc/lwmac/types.h
+++ b/sys/include/net/gnrc/lwmac/types.h
@@ -91,14 +91,6 @@ extern "C" {
 #define GNRC_LWMAC_RADIO_IS_ON               (0x04)
 
 /**
- * @brief   Enable/disable duty-cycle record and print out.
- *          Set "1" to enable, set "0" to disable.
- */
-#ifndef GNRC_LWMAC_ENABLE_DUTYCYLE_RECORD
-#define GNRC_LWMAC_ENABLE_DUTYCYLE_RECORD    (0U)
-#endif
-
-/**
  * @brief The default largest number of parallel timeouts in LWMAC
  */
 #ifndef GNRC_LWMAC_TIMEOUT_COUNT
@@ -204,7 +196,7 @@ typedef struct lwmac {
     uint8_t lwmac_info;                                         /**< LWMAC's internal informations (flags) */
     gnrc_lwmac_timeout_t timeouts[GNRC_LWMAC_TIMEOUT_COUNT];    /**< Store timeouts used for protocol */
 
-#if (GNRC_LWMAC_ENABLE_DUTYCYLE_RECORD == 1)
+#if (GNRC_MAC_ENABLE_DUTYCYCLE_RECORD == 1)
     /* Parameters for recording duty-cycle */
     uint32_t last_radio_on_time_ticks;                          /**< The last time in ticks when radio is on */
     uint32_t radio_off_time_ticks;                              /**< The time in ticks when radio is off */

--- a/sys/net/gnrc/link_layer/lwmac/lwmac.c
+++ b/sys/net/gnrc/link_layer/lwmac/lwmac.c
@@ -266,14 +266,6 @@ void lwmac_set_state(gnrc_netif_t *netif, gnrc_lwmac_state_t newstate)
         case GNRC_LWMAC_TRANSMITTING: {
             /* Enable duty cycling again */
             rtt_handler(GNRC_LWMAC_EVENT_RTT_RESUME, netif);
-#if (GNRC_LWMAC_ENABLE_DUTYCYLE_RECORD == 1)
-            /* Output duty-cycle ratio */
-            uint64_t duty;
-            duty = (uint64_t) rtt_get_counter();
-            duty = ((uint64_t) netif->mac.prot.lwmac.awake_duration_sum_ticks) * 100 /
-                   (duty - (uint64_t)netif->mac.prot.lwmac.system_start_time_ticks);
-            printf("[LWMAC]: achieved duty-cycle: %lu %% \n", (uint32_t)duty);
-#endif
             break;
         }
         case GNRC_LWMAC_SLEEPING: {
@@ -880,7 +872,16 @@ static void _lwmac_msg_handler(gnrc_netif_t *netif, msg_t *msg)
             lwmac_schedule_update(netif);
             break;
         }
-
+#if (GNRC_MAC_ENABLE_DUTYCYCLE_RECORD == 1)
+        case GNRC_MAC_TYPE_GET_DUTYCYCLE: {
+            /* Output LWMAC's radio duty-cycle ratio */
+            uint64_t duty = (uint64_t) rtt_get_counter();
+            duty = ((uint64_t) netif->mac.prot.lwmac.awake_duration_sum_ticks) * 100 /
+                   (duty - (uint64_t)netif->mac.prot.lwmac.system_start_time_ticks);
+            printf("[LWMAC]: achieved radio duty-cycle: %u %% \n", (unsigned) duty);
+            break;
+        }
+#endif
         default: {
 #if ENABLE_DEBUG
             DEBUG("[LWMAC]: unknown message type 0x%04x"
@@ -933,7 +934,7 @@ static void _lwmac_init(gnrc_netif_t *netif)
     /* Start duty cycling */
     lwmac_set_state(netif, GNRC_LWMAC_START);
 
-#if (GNRC_LWMAC_ENABLE_DUTYCYLE_RECORD == 1)
+#if (GNRC_MAC_ENABLE_DUTYCYCLE_RECORD == 1)
     /* Start duty cycle recording */
     netif->mac.prot.lwmac.system_start_time_ticks = rtt_get_counter();
     netif->mac.prot.lwmac.last_radio_on_time_ticks = netif->mac.prot.lwmac.system_start_time_ticks;

--- a/sys/net/gnrc/link_layer/lwmac/lwmac_internal.c
+++ b/sys/net/gnrc/link_layer/lwmac/lwmac_internal.c
@@ -191,7 +191,7 @@ void _gnrc_lwmac_set_netdev_state(gnrc_netif_t *netif, netopt_state_t devstate)
                             &devstate,
                             sizeof(devstate));
 
-#if (GNRC_LWMAC_ENABLE_DUTYCYLE_RECORD == 1)
+#if (GNRC_MAC_ENABLE_DUTYCYCLE_RECORD == 1)
     if (devstate == NETOPT_STATE_IDLE) {
         if (!(netif->mac.prot.lwmac.lwmac_info & GNRC_LWMAC_RADIO_IS_ON)) {
             netif->mac.prot.lwmac.last_radio_on_time_ticks = rtt_get_counter();


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Enable LWMAC protocol to display its current, achieved radio duty-cycle, by using the MAC shell command.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references
See also #8178.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->