### PR TITLE
examples/filesystem: fix typos and cleanup

### DIFF
--- a/examples/filesystem/README.md
+++ b/examples/filesystem/README.md
@@ -1,31 +1,78 @@
 # File system usage example
 
-This is a basic example how to use a file system with RIOT in your embedded application.
+## Description
 
-This example shows:
- - how to mount/format/unmount a filesystem, with spiffs, littlefs and constfs examples
- - how to open/read/write/close a file with and without newlib
+This basic example shows how to use a file system with RIOT in your embedded
+application.
 
-In RIOT, most filesystems use `mtd` as flash interface. So to use this example
-you must define `MTD_0`. `MTD_0` is a pointer to a `mtd_dev_t` instance.
-This example use `littlefs` as default filesystem on the whole `mtd` device.
-A `constfs` filesystem is also demonstrated with two files.
+In particular, this example shows:
 
-All the RIOT filesystems are used through the `vfs` interface, and on most platform
-they can be accessed transparently with `open/close/read/write/...` functions.
+- how to mount/format/unmount a file system, either with spiffs, littlefs or
+  constfs
+- how to open/read/write/close a file with and without newlib
+
+In RIOT, most file systems use a `mtd` as flash interface. So to use this
+example one must define `MTD_0`. `MTD_0` is a pointer to a `mtd_dev_t`
+instance.
+
+This example uses `littlefs` as default file system on the whole `mtd`.
+A `constfs` file system is also demonstrated with two files.
+
+All the RIOT file systems are used through the `vfs` interface, and on most
+platforms files can be accessed transparently with `open/close/read/write/...`
+functions.
 With newlib, `fopen/fclose/fread/fwrite/...` can also be used transparently.
 
-The following commands are available:
- - `format`: should be called the first time only, it will format the `mtd` device
-with the comfigured filesystem
- - `mount`: mount the filesystem on the configured mount point (default is `/sda`
-but it can be configured with `FLASH_MOUNT_POINT` define). The `constfs` filesystem
-is mounted automatically when the application starts
- - `umount`: unmount `/sda`
- - `cat <file>`: similarly to unix `cat` unix command, it prints the given `<file>` on
-stdout
- - `tee <file> <str>`: similarly to `tee` unix command, it writes `<str>` in `<file>`
+## Shell commands
 
-Apart from these commands, the default `vfs` commands can be used, for instance:
- - `vfs df`: shows all mountpoints and used/available memory
- - `vfs ls <path>`: list files
+The following commands are available:
+
+- `format`: should be called the first time only, it will format the `mtd`
+  with the configured file system
+- `mount`: mount the file system on the configured mount point (default is
+  `/sda` but it can be configured with `FLASH_MOUNT_POINT` define). The
+  `constfs` file system is mounted automatically on `/const` when the
+   application starts
+- `umount`: unmount `/sda`
+- `cat <file>`: similarly to unix `cat` unix command, it prints the given
+  `<file>` on stdout
+- `tee <file> <str>`: similarly to `tee` unix command, it writes `<str>` in
+  `<file>`
+
+Besides of these commands, the default `vfs` commands can be used, for
+instance:
+
+- `vfs df`: shows all mountpoints and used/available file system space
+- `vfs ls <path>`: list files
+
+## Example on `native` with `constfs`
+
+- Build and run the `filesystem` example application on the `native` target:
+
+```
+make -C examples/filesystem all term
+[...]
+main(): This is RIOT! (Version: 2018.04-devel-/examples/filesystem)
+constfs mounted successfully
+```
+
+- List the available files in the `constfs` predefined partition:
+
+```
+> ls /const
+ls /const
+/hello-world
+/hello-riot
+total 2 files
+```
+
+- Print the content of the files:
+
+```
+> cat /const/hello-world
+cat /const/hello-world
+Hello World!
+> cat /const/hello-riot
+cat /const/hello-riot
+Hello RIOT!
+```

--- a/examples/filesystem/main.c
+++ b/examples/filesystem/main.c
@@ -103,7 +103,7 @@ static constfs_t constfs_desc = {
 };
 
 /* constfs mount point, as for previous example, it needs a file system driver,
- * a mount poinr and private_data is a pointer to the constfs descriptor */
+ * a mount point and private_data as a pointer to the constfs descriptor */
 static vfs_mount_t const_mount = {
     .fs = &constfs_file_system,
     .mount_point = "/const",


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is a follow-up of #8559 that cleans up a bit the filesystem example README:
- ensure all lines are less than 80 characters length
- a few typos are fixed
- some rewording
- reformatting of markdown bullet points (add extra line before the first bullet + no space before `-`)

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

#8559 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->