### PR TITLE
drivers/my9221: make local functions "static"

### DIFF
--- a/drivers/my9221/my9221.c
+++ b/drivers/my9221/my9221.c
@@ -38,7 +38,7 @@
 /**
  * @brief Write a single data to the LED controller
  */
-void _write(my9221_t *dev, uint16_t data)
+static void _write(my9221_t *dev, uint16_t data)
 {
     assert(dev);
 
@@ -52,7 +52,7 @@ void _write(my9221_t *dev, uint16_t data)
 /**
  * @brief Load data into the latch register of the LED controller
  */
-void _latch(my9221_t *dev)
+static void _latch(my9221_t *dev)
 {
     assert(dev);
 
@@ -68,7 +68,7 @@ void _latch(my9221_t *dev)
 /**
  * @brief Write state data of all LEDs to the controller
  */
-void _set_state(my9221_t *dev)
+static void _set_state(my9221_t *dev)
 {
     assert(dev);
 


### PR DESCRIPTION
### Contribution description

my9221 had some only locally used functions declared non-static.
```_write``` broke riscv.

This PR marks those functions "static".


### Issues/PRs references

https://ci.riot-os.org/RIOT-OS/RIOT/8275/79fec931b6b1198cc3373f635bb09b76188e9784/output/compile/tests/driver_grove_ledbar/hifive1.txt
