### PR TITLE
pkg/cn-cbor: compile with context pointer support

### DIFF
--- a/pkg/cn-cbor/Makefile.include
+++ b/pkg/cn-cbor/Makefile.include
@@ -1,1 +1,4 @@
 INCLUDES += -I$(PKGDIRBASE)/cn-cbor/include
+
+#enable context pointer
+CFLAGS += -DUSE_CBOR_CONTEXT

--- a/tests/unittests/tests-cn_cbor/Makefile.include
+++ b/tests/unittests/tests-cn_cbor/Makefile.include
@@ -1,2 +1,3 @@
 ﻿USEPKG += cn-cbor
 USEMODULE += fmt
+USEMODULE += memarray

--- a/tests/unittests/tests-cn_cbor/tests-cn_cbor.c
+++ b/tests/unittests/tests-cn_cbor/tests-cn_cbor.c
@@ -18,14 +18,17 @@
   */
 
 #define EBUF_SIZE 32
+#define NUM_BLOCKS  7
 
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
 
+#include "assert.h"
 #include "cn-cbor/cn-cbor.h"
 #include "embUnit.h"
 #include "fmt.h"
+#include "memarray.h"
 
 typedef struct {
     char *hex;
@@ -36,19 +39,44 @@ static size_t test, offs;
 static unsigned char ebuf[EBUF_SIZE];
 static cn_cbor_errback errb;
 
-/* Dummy context struct to force fallback to POSIX calloc/free */
+/* Block allocator */
+static cn_cbor block_storage_data[NUM_BLOCKS];
+static memarray_t storage;
+
+/* calloc/free functions */
+static void *cbor_calloc(size_t count, size_t size, void *memblock);
+static void cbor_free(void *ptr, void *memblock);
+
+/* CN_CBOR block allocator context struct*/
 static cn_cbor_context ct =
 {
-    NULL,
-    NULL,
-    NULL,
+    .calloc_func = cbor_calloc,
+    .free_func = cbor_free,
+    .context = &storage,
 };
+
+static void *cbor_calloc(size_t count, size_t size, void *memblock)
+{
+    (void)count;
+    assert(count == 1); /* Count is always 1 with cn-cbor */
+    void *block = memarray_alloc(memblock);
+    if (block) {
+        memset(block, 0, size);
+    }
+    return block;
+}
+
+static void cbor_free(void *ptr, void *memblock)
+{
+    memarray_free(memblock, ptr);
+}
 
 static void setup_cn_cbor(void)
 {
     test = 0;
     offs = 0;
     memset(ebuf, '\0', EBUF_SIZE);
+    memarray_init(&storage, block_storage_data, sizeof(cn_cbor), NUM_BLOCKS);
 }
 
 static void test_parse(void)
@@ -123,7 +151,7 @@ static void test_parse(void)
         for (offs = 0; offs < len; offs++) {
             TEST_ASSERT_EQUAL_INT(buf[offs], ebuf[offs]);
         }
-        cn_cbor_free(cbor);
+        cn_cbor_free(cbor, &ct);
     }
 }
 
@@ -154,7 +182,7 @@ static void test_errors(void)
         cn_cbor *cbor = cn_cbor_decode(buf, len, &ct, &errb);
         TEST_ASSERT_NULL(cbor);
         TEST_ASSERT_EQUAL_INT(errb.err, tests[offs].err);
-        cn_cbor_free(cbor);
+        cn_cbor_free(cbor, &ct);
     }
 }
 

--- a/tests/unittests/tests-cn_cbor/tests-cn_cbor.c
+++ b/tests/unittests/tests-cn_cbor/tests-cn_cbor.c
@@ -36,6 +36,14 @@ static size_t test, offs;
 static unsigned char ebuf[EBUF_SIZE];
 static cn_cbor_errback errb;
 
+/* Dummy context struct to force fallback to POSIX calloc/free */
+static cn_cbor_context ct =
+{
+    NULL,
+    NULL,
+    NULL,
+};
+
 static void setup_cn_cbor(void)
 {
     test = 0;
@@ -107,7 +115,7 @@ static void test_parse(void)
 
         errb.err = CN_CBOR_NO_ERROR;
 
-        cn_cbor *cbor = cn_cbor_decode(buf, len, &errb);
+        cn_cbor *cbor = cn_cbor_decode(buf, len, &ct, &errb);
         TEST_ASSERT_EQUAL_INT(errb.err, CN_CBOR_NO_ERROR);
         TEST_ASSERT_NOT_NULL(cbor);
 
@@ -143,7 +151,7 @@ static void test_errors(void)
         size_t len = fmt_hex_bytes(buf, tests[offs].hex);
         TEST_ASSERT(len);
 
-        cn_cbor *cbor = cn_cbor_decode(buf, len, &errb);
+        cn_cbor *cbor = cn_cbor_decode(buf, len, &ct, &errb);
         TEST_ASSERT_NULL(cbor);
         TEST_ASSERT_EQUAL_INT(errb.err, tests[offs].err);
         cn_cbor_free(cbor);


### PR DESCRIPTION
### Contribution description

This enables `USE_CONTEXT` when compiling cn-cbor. With this a cn_cbor_context struct with application specific calloc/free calls is used for the allocation of `cn_cbor` structs. Now that there is a memarray module in RIOT, enabling this allows us to use the memarray for `cn_cbor` struct allocation instead of having to use POSIX calloc and free calls.

The test is adapted to use a struct with `NULL` values, this causes cn-cbor to fall back to calloc/free.

### Issues/PRs references

Also required for building the libcose unittest from #8895 together with the cn-cbor test