### PR TITLE
doc: doxygen: add command

### DIFF
--- a/doc/doxygen/riot.doxyfile
+++ b/doc/doxygen/riot.doxyfile
@@ -228,7 +228,7 @@ TAB_SIZE               = 4
 # "Side Effects:". You can put \n's in the value part of an alias to insert
 # newlines.
 
-ALIASES                =
+ALIASES                = experimental="@warning <strong class=\"text-danger\">This feature is experimental!</strong>\n"
 
 # This tag can be used to specify a number of word-keyword mappings (TCL only).
 # A mapping has the form "name=value". For example adding "class=itcl::class"


### PR DESCRIPTION
### Contribution description
This introduces the `@experimental` command to Doxygen via Doxygen's alias feature (credits goes to [Sebastian Pipping](http://doxygen.10944.n7.nabble.com/experimental-command-td2869.html) for the idea, though I used a slightly different approach and utilized our inclusion of bootstrap into the generated doc). Also, I provided an example by marking Skald as experimental.

### Issues/PRs references
None