### PR TITLE
cpu/cc2538: remove obsolete periph file guard

### DIFF
--- a/cpu/cc2538/periph/i2c.c
+++ b/cpu/cc2538/periph/i2c.c
@@ -36,9 +36,6 @@
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
-/* guard this file in case no I2C device is defined */
-#if I2C_NUMOF
-
 #ifndef I2C_0_SCL_PIN
 #define I2C_0_SCL_PIN i2c_config[I2C_0].scl_pin
 #endif
@@ -666,5 +663,3 @@ void i2c_poweroff(i2c_t dev)
         SYS_CTRL_DCGCI2C &= ~1; /**< Disable the I2C0 clock. */
     }
 }
-
-#endif /* I2C_NUMOF */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR partially addresses #7981 with cc2538 cpus

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

#7981

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->