### PR TITLE
cpu/lpc1768: remove useless timer periph file guard

### DIFF
--- a/cpu/lpc1768/periph/timer.c
+++ b/cpu/lpc1768/periph/timer.c
@@ -24,9 +24,6 @@
 #include "periph_conf.h"
 #include "periph/timer.h"
 
-/* guard file in case no timers are defined */
-#if TIMER_0_EN
-
 /**
  * @name Timer channel interrupt flags
  * @{
@@ -148,5 +145,3 @@ void TIMER_0_ISR(void)
     cortexm_isr_end();
 }
 #endif
-
-#endif /* TIMER_0_EN */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR partially addresses #7981 with lpc1768 cpu

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

#7981

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->