### PR TITLE
cpu/lpc2387: remove useless periph file guard

### DIFF
--- a/cpu/lpc2387/periph/pwm.c
+++ b/cpu/lpc2387/periph/pwm.c
@@ -27,9 +27,6 @@
 #include "bitarithm.h"
 #include "periph/pwm.h"
 
-/* guard file in case no PWM device is defined */
-#ifdef PWM_NUMOF
-
 /**
  * @note The PWM is always initialized with left-aligned mode.
  *
@@ -126,5 +123,3 @@ void pwm_poweroff(pwm_t dev)
     PWM1TCR &= ~(BIT0);
     PCONP &= ~(PCPWM1);
 }
-
-#endif /* PWM_NUMOF */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR partially addresses #7981 with lpc2387 cpu

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

#7981

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->