### PR TITLE
cpu/lm4f120: remove useless periph file guard

### DIFF
--- a/cpu/lm4f120/periph/spi.c
+++ b/cpu/lm4f120/periph/spi.c
@@ -27,8 +27,6 @@
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
-#ifdef SPI_NUMOF
-
 /**
  * @brief Array holding one pre-initialized mutex for each SPI device
  */
@@ -137,5 +135,3 @@ void spi_transfer_bytes(spi_t bus, spi_cs_t cs, bool cont,
         gpio_set((gpio_t)cs);
     }
 }
-
-#endif /* SPI_NUMOF */

--- a/cpu/lm4f120/periph/timer.c
+++ b/cpu/lm4f120/periph/timer.c
@@ -17,6 +17,7 @@
  *
  * @author      Rakendra Thapa <rakendrathapa@gmail.com>
  *              Marc Poulhiès <dkm@kataplop.net>
+ * @}
  */
 
 #include <stdint.h>
@@ -29,12 +30,8 @@
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
-/* guard file in case no timers are defined */
-#if TIMER_NUMOF
-
 /**
  * @brief Struct holding the configuration data
- * @{
  */
 typedef struct {
     timer_cb_t cb;          /**< timeout callback */
@@ -43,7 +40,6 @@ typedef struct {
 } timer_conf_t;
 
 static timer_conf_t config[TIMER_NUMOF];
-/**@}*/
 
 #include "hw_timer.h"
 
@@ -344,6 +340,3 @@ void isr_wtimer1a(void)
     cortexm_isr_end();
 }
 #endif /* TIMER_1_EN */
-
-#endif /* TIMER_NUMOF */
-/** @} */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR partially addresses #7981 with lm4f120 cpu

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

#7981

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->