### PR TITLE
cpu/atmega_common: remove useless periph file guard

### DIFF
--- a/cpu/atmega_common/periph/i2c.c
+++ b/cpu/atmega_common/periph/i2c.c
@@ -32,9 +32,6 @@
 #include "debug.h"
 #define ENABLE_DEBUG      (0)
 
-/* guard file in case no I2C device is defined */
-#if I2C_NUMOF
-
 #define MT_START            0x08
 #define MT_START_REPEATED   0x10
 #define MT_ADDRESS_ACK      0x18
@@ -369,5 +366,3 @@ static void _stop(void)
     DEBUG("STOP condition transmitted\n");
     TWCR = 0;
 }
-
-#endif /* I2C_NUMOF */

--- a/cpu/atmega_common/periph/timer.c
+++ b/cpu/atmega_common/periph/timer.c
@@ -62,9 +62,7 @@ typedef struct {
 
 /**
  * @brief   Allocate memory for saving the device states
- * @{
  */
-#ifdef TIMER_NUMOF
 static ctx_t ctx[] = {
 #ifdef TIMER_0
     { TIMER_0, TIMER_0_MASK, TIMER_0_FLAG, NULL, NULL, 0, 0 },
@@ -79,11 +77,6 @@ static ctx_t ctx[] = {
     { TIMER_3, TIMER_3_MASK, TIMER_3_FLAG, NULL, NULL, 0, 0 },
 #endif
 };
-#else
-/* fallback if no timer is configured */
-static ctx_t *ctx[] = {{ NULL }};
-#endif
-/** @} */
 
 /**
  * @brief Setup the given timer

--- a/cpu/atmega_common/periph/uart.c
+++ b/cpu/atmega_common/periph/uart.c
@@ -58,9 +58,7 @@
 
 /**
  * @brief   Configured device map
- * @{
  */
-#if UART_NUMOF
 static mega_uart_t *dev[] = {
 #ifdef UART_0
     UART_0,
@@ -75,10 +73,6 @@ static mega_uart_t *dev[] = {
     UART_3
 #endif
 };
-#else
-/* fallback if no UART is defined */
-static const mega_uart_t *dev[] = { NULL };
-#endif
 
 /**
  * @brief   Allocate memory to store the callback functions.


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR partially addresses #7981 with atmega cpus family

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

#7981

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->