### PR TITLE
drivers/io1_xplained: fix gpios devices initialization

### DIFF
--- a/drivers/io1_xplained/include/io1_xplained_params.h
+++ b/drivers/io1_xplained/include/io1_xplained_params.h
@@ -68,11 +68,21 @@ saul_reg_info_t io1_xplained_saul_info[][4] =
 /**
  * @brief   Allocate and configure the extension LED gpios
  */
-gpio_t io1_xplained_saul_gpios[3] =
+saul_gpio_params_t io1_xplained_saul_gpios[3] =
 {
-    IO1_LED_PIN,
-    IO1_GPIO1_PIN,
-    IO1_GPIO2_PIN,
+    {
+        .pin = IO1_LED_PIN,
+        .mode = GPIO_OUT,
+        .flags = SAUL_GPIO_INVERTED,
+    },
+    {
+        .pin = IO1_GPIO1_PIN,
+        .mode = GPIO_OUT,
+    },
+    {
+        .pin = IO1_GPIO2_PIN,
+        .mode = GPIO_OUT
+    }
 };
 
 

--- a/sys/auto_init/saul/auto_init_io1_xplained.c
+++ b/sys/auto_init/saul/auto_init_io1_xplained.c
@@ -73,8 +73,8 @@ void auto_init_io1_xplained(void)
 
         /* GPIOs */
         for (unsigned j = 1; j < 4; j++) {
-            saul_entries[i * 4 + j].dev = &(io1_xplained_saul_gpios[j]);
-            saul_entries[i * 4 + j].name = io1_xplained_saul_info[i][j].name;
+            saul_entries[i * 4 + j].dev = &(io1_xplained_saul_gpios[j - 1]);
+            saul_entries[i * 4 + j].name = io1_xplained_saul_info[i][j - 1].name;
             saul_entries[i * 4 + j].driver = &gpio_out_saul_driver;
             saul_reg_add(&(saul_entries[i * 4 + j]));
         }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR fixes the GPIOs auto initalizers for the IO1 Xplained pro extension.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

Fixes #8766

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->