### PR TITLE
boards*: cleanup doxygen

### DIFF
--- a/boards/arduino-mkr1000/include/board.h
+++ b/boards/arduino-mkr1000/include/board.h
@@ -37,7 +37,7 @@ extern "C" {
 #define ARDUINO_LED         (6U)
 
 /**
- * @brief   LED pin definitions and handlers
+ * @name    LED pin definitions and handlers
  * @{
  */
 #define LED0_PIN            GPIO_PIN(PA, 20)

--- a/boards/chronos/include/board.h
+++ b/boards/chronos/include/board.h
@@ -28,7 +28,7 @@ extern "C" {
 #endif
 
 /**
- * @name    Define the CPU model for the <msp430.h>
+ * @brief   Define the CPU model for the <msp430.h>
  */
 #ifndef __CC430F6137__
 #define __CC430F6137__

--- a/boards/common/arduino-atmega/include/arduino_pinmap.h
+++ b/boards/common/arduino-atmega/include/arduino_pinmap.h
@@ -33,9 +33,10 @@ extern "C" {
 #endif
 
 /**
- * @brief   Mapping of MCU pins to Arduino pins
+ * @name    Mapping of MCU pins to Arduino pins
  *
  * @note    ISCP pins are not mapped.
+ * @{
  */
 
 /* Digital pins */
@@ -158,7 +159,6 @@ extern "C" {
 #define ARDUINO_PIN_A14         ARDUINO_PIN_68
 #define ARDUINO_PIN_A15         ARDUINO_PIN_69
 #endif
-/** @ */
 
 #define ARDUINO_A0              ADC_LINE(0)
 #define ARDUINO_A1              ADC_LINE(1)
@@ -178,6 +178,7 @@ extern "C" {
 #define ARDUINO_A14             ADC_LINE(14)
 #define ARDUINO_A15             ADC_LINE(15)
 #endif
+/** @} */
 
 #ifdef __cplusplus
 }

--- a/boards/common/arduino-due/include/arduino_pinmap.h
+++ b/boards/common/arduino-due/include/arduino_pinmap.h
@@ -112,7 +112,7 @@ extern "C" {
 #define ARDUINO_PIN_76          GPIO_PIN(PA, 27)
 #define ARDUINO_PIN_77          GPIO_PIN(PA, 28)
 #define ARDUINO_PIN_78          GPIO_PIN(PB, 23)
-/** @ */
+/** @} */
 
 /**
  * @name    Mapping of Arduino analog pins to RIOT ADC lines

--- a/boards/common/nucleo144/include/board.h
+++ b/boards/common/nucleo144/include/board.h
@@ -60,7 +60,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   User button
+ * @name    User button
  * @{
  */
 #define BTN0_PIN            GPIO_PIN(PORT_C, 13)

--- a/boards/common/nucleo32/include/arduino_pinmap.h
+++ b/boards/common/nucleo32/include/arduino_pinmap.h
@@ -61,7 +61,7 @@ extern "C" {
 #define ARDUINO_PIN_A5          GPIO_PIN(PORT_A, 6)
 #define ARDUINO_PIN_A6          GPIO_PIN(PORT_A, 7)
 #define ARDUINO_PIN_A7          GPIO_PIN(PORT_A, 2)
-/** @ */
+/** @} */
 
 /**
  * @name    Mapping of Arduino analog pins to RIOT ADC lines

--- a/boards/common/nucleo64/include/board.h
+++ b/boards/common/nucleo64/include/board.h
@@ -49,7 +49,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   User button
+ * @name    User button
  * @{
  */
 #define BTN0_PIN            GPIO_PIN(PORT_C, 13)

--- a/boards/frdm-k64f/include/periph_conf.h
+++ b/boards/frdm-k64f/include/periph_conf.h
@@ -88,7 +88,6 @@ static const clock_config_t clock_config = {
 #define PIT_ISR_0               isr_pit1
 #define PIT_ISR_1               isr_pit3
 #define LPTMR_ISR_0             isr_lptmr0
-
 /** @} */
 
 /**

--- a/boards/ikea-tradfri/include/periph_conf.h
+++ b/boards/ikea-tradfri/include/periph_conf.h
@@ -54,9 +54,11 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   RTC configuration
+ * @name    RTC configuration
+ * @{
  */
 #define RTC_NUMOF           (1U)
+/** @} */
 
 /**
  * @name    RTT configuration

--- a/boards/maple-mini/include/board.h
+++ b/boards/maple-mini/include/board.h
@@ -49,7 +49,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   User button
+ * @name    User button
  * @{
  */
 #define BTN0_PIN            GPIO_PIN(PORT_B, 8)

--- a/boards/mega-xplained/include/board.h
+++ b/boards/mega-xplained/include/board.h
@@ -50,10 +50,11 @@ extern "C" {
 #define UART_STDIO_DEV       (UART_DEV(1))
 
 /**
- * @brief   Context swap defines
+ * @name    Context swap defines
  *
  * Setup to use PD7 which is pin change interrupt 31 (PCINT31)
  * This emulates a software triggered interrupt
+ * @{
  */
 #define AVR_CONTEXT_SWAP_INIT do { \
             DDRD |= (1 << PD7); \
@@ -62,6 +63,7 @@ extern "C" {
 } while (0)
 #define AVR_CONTEXT_SWAP_INTERRUPT_VECT  PCINT3_vect
 #define AVR_CONTEXT_SWAP_TRIGGER   PORTD ^= (1 << PD7)
+/** @} */
 
 /**
  * @name    xtimer configuration values

--- a/boards/mulle/include/mulle-nvram.h
+++ b/boards/mulle/include/mulle-nvram.h
@@ -6,15 +6,6 @@
  * details.
  */
 
-#ifndef MULLE_NVRAM_H
-#define MULLE_NVRAM_H
-
-#include "nvram.h"
-
-#ifdef __cplusplus
-extern "C" {
-#endif
-
 /**
  * @ingroup     boards_mulle
  * @{
@@ -24,6 +15,15 @@ extern "C" {
  *
  * @author      Joakim Gebart <joakim.gebart@eistec.se>
  */
+
+#ifndef MULLE_NVRAM_H
+#define MULLE_NVRAM_H
+
+#include "nvram.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 typedef enum mulle_nvram_address {
     /** @brief NVRAM magic number, used to identify an initialized FRAM device. */
@@ -36,10 +36,9 @@ typedef enum mulle_nvram_address {
 
 extern nvram_t *mulle_nvram;
 
-/** @} */
-
 #ifdef __cplusplus
 }
 #endif
 
 #endif /* MULLE_NVRAM_H */
+/** @} */

--- a/boards/mulle/include/periph_conf.h
+++ b/boards/mulle/include/periph_conf.h
@@ -115,7 +115,6 @@ static const clock_config_t clock_config = {
 #define PIT_ISR_0               isr_pit1
 #define PIT_ISR_1               isr_pit3
 #define LPTMR_ISR_0             isr_lptmr0
-
 /** @} */
 
 /**
@@ -334,8 +333,6 @@ static const spi_conf_t spi_config[] = {
 #define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
 /** @} */
 
-/** @} */
-
 /**
  * @name I2C configuration
  * @{
@@ -397,7 +394,6 @@ static const spi_conf_t spi_config[] = {
 #define RTT_UNLOCK()        (BITBAND_REG32(SIM->SCGC6, SIM_SCGC6_RTC_SHIFT) = 1)
 #define RTT_MAX_VALUE       (0xffffffff)
 #define RTT_FREQUENCY       (1)             /* in Hz */
-
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/nrf51dongle/include/board.h
+++ b/boards/nrf51dongle/include/board.h
@@ -29,7 +29,7 @@ extern "C" {
 #endif
 
 /**
- * @brief   Xtimer configuration
+ * @name    Xtimer configuration
  * @{
  */
 #define XTIMER_WIDTH                (24)
@@ -37,7 +37,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   LED pin definitions and handlers
+ * @name    LED pin definitions and handlers
  * @{
  */
 #define LED0_PIN            GPIO_PIN(0, 21)

--- a/boards/opencm904/include/board.h
+++ b/boards/opencm904/include/board.h
@@ -49,7 +49,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief User button
+ * @name User button
  * @{
  */
 #define BTN0_PIN            GPIO_PIN(PORT_C, 15)

--- a/boards/openmote-cc2538/include/periph_conf.h
+++ b/boards/openmote-cc2538/include/periph_conf.h
@@ -101,7 +101,6 @@ static const uart_conf_t uart_config[] = {
 
 /* macros common across all UARTs */
 #define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
-
 /** @} */
 
 /**

--- a/boards/pba-d-01-kw2x/include/periph_conf.h
+++ b/boards/pba-d-01-kw2x/include/periph_conf.h
@@ -89,7 +89,6 @@ static const clock_config_t clock_config = {
 #define PIT_ISR_0               isr_pit1
 #define PIT_ISR_1               isr_pit3
 #define LPTMR_ISR_0             isr_lptmr0
-
 /** @} */
 
 /**

--- a/boards/pic32-clicker/include/board.h
+++ b/boards/pic32-clicker/include/board.h
@@ -48,7 +48,7 @@ extern "C" {
 #define EIC_IRQ (1)
 
 /**
- * @brief   LED pin configuration
+ * @name    LED pin configuration
  * @{
  */
 #define LED1_PIN            GPIO_PIN(PORT_B, 1)

--- a/boards/pic32-wifire/include/board.h
+++ b/boards/pic32-wifire/include/board.h
@@ -48,7 +48,7 @@ extern "C" {
 #define EIC_IRQ      (1)
 
 /**
- * @brief   LED pin configuration
+ * @name    LED pin configuration
  * @{
  */
 #define LED1_PIN            GPIO_PIN(PORT_G, 6)

--- a/boards/remote-reva/include/periph_conf.h
+++ b/boards/remote-reva/include/periph_conf.h
@@ -52,6 +52,10 @@ static const i2c_conf_t i2c_config[I2C_NUMOF] = {
 /** @} */
 
 /**
+ * @name SPI configuration
+ * @{
+ */
+/**
  * @brief   Pre-calculated clock divider values based on a CLOCK_CORECLOCK (32MHz)
  *
  * Calculated with (CPSR * (SCR + 1)) = (CLOCK_CORECLOCK / bus_freq), where
@@ -66,10 +70,6 @@ static const spi_clk_conf_t spi_clk_config[] = {
     { .cpsr =  2, .scr =  1 }   /* ~10.7MHz */
 };
 
-/**
- * @name SPI configuration
- * @{
- */
 static const spi_conf_t spi_config[] = {
     {
         .dev      = SSI0,

--- a/boards/remote-revb/include/periph_conf.h
+++ b/boards/remote-revb/include/periph_conf.h
@@ -55,6 +55,10 @@ static const i2c_conf_t i2c_config[I2C_NUMOF] = {
 /** @} */
 
 /**
+ * @name SPI configuration
+ * @{
+ */
+/**
  * @brief   Pre-calculated clock divider values based on a CLOCK_CORECLOCK (32MHz)
  *
  * Calculated with (CPSR * (SCR + 1)) = (CLOCK_CORECLOCK / bus_freq), where
@@ -69,10 +73,6 @@ static const spi_clk_conf_t spi_clk_config[] = {
     { .cpsr =  2, .scr =  1 }   /* ~10.7MHz */
 };
 
-/**
- * @name SPI configuration
- * @{
- */
 static const spi_conf_t spi_config[] = {
     {
         .dev      = SSI0,

--- a/boards/spark-core/include/board.h
+++ b/boards/spark-core/include/board.h
@@ -36,7 +36,7 @@
 #define XTIMER_WIDTH        (16)
 
 /**
- * @brief   Macros for controlling the on-board LEDs
+ * @name    Macros for controlling the on-board LEDs
  * @{
  */
 #define LED0_PIN            GPIO_PIN(PORT_A, 9)
@@ -69,8 +69,10 @@
 
 /**
  * @name User button configuration
+ * @{
  */
 #define BUTTON1             GPIO_PIN(PORT_B,2)
+/** @} */
 
 /**
  * @name CC3000 pin configuration

--- a/boards/spark-core/include/periph_conf.h
+++ b/boards/spark-core/include/periph_conf.h
@@ -22,7 +22,7 @@
 #include "periph_cpu.h"
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
 
 /**

--- a/boards/stk3600/include/periph_conf.h
+++ b/boards/stk3600/include/periph_conf.h
@@ -159,9 +159,11 @@ static const pwm_conf_t pwm_config[] = {
 /** @} */
 
 /**
- * @brief   RTC configuration
+ * @name    RTC configuration
+ * @{
  */
 #define RTC_NUMOF           (1U)
+/** @} */
 
 /**
  * @name    RTT configuration

--- a/boards/stk3700/include/periph_conf.h
+++ b/boards/stk3700/include/periph_conf.h
@@ -159,9 +159,11 @@ static const pwm_conf_t pwm_config[] = {
 /** @} */
 
 /**
- * @brief   RTC configuration
+ * @name    RTC configuration
+ * @{
  */
 #define RTC_NUMOF           (1U)
+/** @} */
 
 /**
  * @name    RTT configuration

--- a/boards/stm32f0discovery/include/board.h
+++ b/boards/stm32f0discovery/include/board.h
@@ -49,7 +49,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief User button
+ * @name User button
  * @{
  */
 #define BTN0_PIN            GPIO_PIN(PORT_A, 0)

--- a/boards/stm32f3discovery/include/board.h
+++ b/boards/stm32f3discovery/include/board.h
@@ -85,7 +85,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief User button
+ * @name User button
  * @{
  */
 #define BTN0_PIN            GPIO_PIN(PORT_A, 0)

--- a/boards/stm32f4discovery/include/board.h
+++ b/boards/stm32f4discovery/include/board.h
@@ -76,7 +76,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief User button
+ * @name User button
  * @{
  */
 #define BTN0_PIN            GPIO_PIN(PORT_A, 0)

--- a/boards/stm32f7discovery/include/board.h
+++ b/boards/stm32f7discovery/include/board.h
@@ -65,7 +65,7 @@ extern "C" {
 /** @} */
 
 /**
- * @brief User button
+ * @name User button
  * @{
  */
 #define BTN0_PIN            GPIO_PIN(PORT_A, 0)

--- a/boards/teensy31/include/board.h
+++ b/boards/teensy31/include/board.h
@@ -23,6 +23,10 @@
 #include "periph_conf.h"
 #include "mtd.h"
 
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /* Use the on board RTC 32kHz clock for LPTMR clocking. */
 #undef LPTIMER_CLKSRC
 /** @brief Clock source for the LPTMR module */
@@ -55,10 +59,6 @@
 #define LED0_OFF            (LED_PORT->PCOR = (1 << LED0_BIT))
 #define LED0_TOGGLE         (LED_PORT->PTOR = (1 << LED0_BIT))
 /** @} */
-
-#ifdef __cplusplus
-extern "C" {
-#endif
 
 /**
  * @brief Initialize board specific hardware, including clock, LEDs and std-IO

--- a/boards/teensy31/include/periph_conf.h
+++ b/boards/teensy31/include/periph_conf.h
@@ -22,8 +22,7 @@
 #include "periph_cpu.h"
 
 #ifdef __cplusplus
-extern "C"
-{
+extern "C" {
 #endif
 
 /**

--- a/boards/waspmote-pro/include/waspmote_pinmap.h
+++ b/boards/waspmote-pro/include/waspmote_pinmap.h
@@ -27,8 +27,8 @@ extern "C" {
 #endif
 
 /**
- * @brief   Mapping of MCU pins to Waspomte board pins
- *
+ * @name   Mapping of MCU pins to Waspomte board pins
+ * @{
  */
 /*
  * DESCRIPTION WASP API PIN               PORT   PIN
@@ -84,7 +84,7 @@ extern "C" {
 #define RTC_PW                  GPIO_PIN(PORT_G, 2)
 #define	RTC_SLEEP               GPIO_PIN(PORT_G, 1)
 #define	LOW_BAT_MON             GPIO_PIN(PORT_G, 0)
-/** @ */
+/** @} */
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
- replace brief with name where required
- remove some unwanted empty lines
- fix missing closing doxygen name block

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

I found #6466 was still opened and went through the board doxygen documentation. There remaining occurence of `@brief` where `@name` should be used.

This PR fixes the ones I found + a few other minor things.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

Partially addresses #6466

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->