### PR TITLE
drivers/io1_xplained: improve driver and add support for the sdcard and light sensor

### DIFF
--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -152,6 +152,7 @@ endif
 
 ifneq (,$(filter io1_xplained,$(USEMODULE)))
   FEATURES_REQUIRED += periph_gpio
+  FEATURES_REQUIRED += periph_adc
   USEMODULE += at30tse75x
   USEMODULE += sdcard_spi
 endif

--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -153,6 +153,7 @@ endif
 ifneq (,$(filter io1_xplained,$(USEMODULE)))
   FEATURES_REQUIRED += periph_gpio
   USEMODULE += at30tse75x
+  USEMODULE += sdcard_spi
 endif
 
 ifneq (,$(filter jc42,$(USEMODULE)))

--- a/drivers/include/io1_xplained.h
+++ b/drivers/include/io1_xplained.h
@@ -53,11 +53,12 @@ enum {
     IO1_XPLAINED_OK = 0,           /**< Initialization successful */
     IO1_XPLAINED_NOTEMP,           /**< Error during temperature sensor initialization */
     IO1_XPLAINED_NOSDCARD,         /**< Error during sdcard initialization */
+    IO1_XPLAINED_NOLIGHT,          /**< Error during light sensor (ADC) initialization */
     IO1_XPLAINED_NOLED,            /**< Error during extension LED initialization */
     IO1_XPLAINED_NOGPIO1,          /**< Error during extension GPIO1 initialization */
     IO1_XPLAINED_NOGPIO2,          /**< Error during extension GPIO2 initialization */
-    IO1_XPLAINED_READ_OK,          /**< Temperature read successful */
-    IO1_XPLAINED_READ_ERR          /**< Error when reading temperature sensor */
+    IO1_XPLAINED_READ_OK,          /**< Light sensor read successful */
+    IO1_XPLAINED_READ_ERR          /**< Error when reading light sensor */
 };
 
 /**
@@ -90,6 +91,16 @@ typedef struct {
  * @return                  -IO1_XPLAINED_NOGPIO2 if GPIO2 initialization failed
  */
 int io1_xplained_init(io1_xplained_t *dev, const io1_xplained_params_t *params);
+
+/**
+ * @brief   Read light sensor level on the IO1 Xplained extension
+ *
+ * @param[out] light        Light level value (between 0 and 1023)
+ *
+ * @return                  IO1_XPLAINED_READ_OK on success
+ * @return                  -IO1_XPLAINED_READ_ERR when the value cannot be read
+ */
+int io1_xplained_read_light_level(uint16_t *light);
 
 #ifdef __cplusplus
 }

--- a/drivers/include/io1_xplained.h
+++ b/drivers/include/io1_xplained.h
@@ -81,37 +81,12 @@ typedef struct {
  *
  * @return                  IO1_XPLAINED_OK on success
  * @return                  -IO1_XPLAINED_NOTEMP if temperature sensor initialization failed
+ * @return                  -IO1_XPLAINED_NOSDCARD if sdcard initialization failed
  * @return                  -IO1_XPLAINED_NOLED if LED initialization failed
  * @return                  -IO1_XPLAINED_NOGPIO1 if GPIO1 initialization failed
  * @return                  -IO1_XPLAINED_NOGPIO2 if GPIO2 initialization failed
  */
 int io1_xplained_init(io1_xplained_t *dev, const io1_xplained_params_t *params);
-
-/**
- * @brief   Read temperature value from the given IO1 Xplained extension, returned in °C
- *
- * @param[in] dev           Device descriptor of IO1 Xplained to read from
- * @param[out] temperature  Temperature in °C
- *
- * @return                  IO1_XPLAINED_READ_OK on success
- * @return                  -IO1_XPLAINED_READ_ERR if temperature sensor read failed
- */
-int io1_xplained_read_temperature(const io1_xplained_t *dev, float *temperature);
-
-/**
- * @brief   Set the on-board led of the IO1 Xplained extension
- */
-void io1_xplained_set_led(void);
-
-/**
- * @brief   Clear the on-board led of the IO1 Xplained extension
- */
-void io1_xplained_clear_led(void);
-
-/**
- * @brief   Toggle the on-board led of the IO1 Xplained extension
- */
-void io1_xplained_toggle_led(void);
 
 #ifdef __cplusplus
 }

--- a/drivers/include/io1_xplained.h
+++ b/drivers/include/io1_xplained.h
@@ -40,6 +40,7 @@
 
 #include "saul.h"
 #include "at30tse75x.h"
+#include "sdcard_spi.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -51,6 +52,7 @@ extern "C" {
 enum {
     IO1_XPLAINED_OK = 0,           /**< Initialization successful */
     IO1_XPLAINED_NOTEMP,           /**< Error during temperature sensor initialization */
+    IO1_XPLAINED_NOSDCARD,         /**< Error during sdcard initialization */
     IO1_XPLAINED_NOLED,            /**< Error during extension LED initialization */
     IO1_XPLAINED_NOGPIO1,          /**< Error during extension GPIO1 initialization */
     IO1_XPLAINED_NOGPIO2,          /**< Error during extension GPIO2 initialization */
@@ -71,6 +73,7 @@ typedef struct {
 typedef struct {
     io1_xplained_params_t params;  /**< Initialization parameters */
     at30tse75x_t temp;             /**< On-board temperature sensor */
+    sdcard_spi_t sdcard;           /**< On-board SD card */
 } io1_xplained_t;
 
 /**

--- a/drivers/io1_xplained/include/io1_xplained_internals.h
+++ b/drivers/io1_xplained/include/io1_xplained_internals.h
@@ -22,7 +22,9 @@
 
 #include "cpu.h"
 #include "periph_cpu.h"
-
+#include "periph/adc.h"
+#include "periph/gpio.h"
+#include "periph/spi.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -48,6 +50,14 @@ extern "C" {
 #define IO1_SDCARD_SPI_PARAM_POWER         (GPIO_UNDEF)
 #define IO1_SDCARD_SPI_PARAM_POWER_AH      (true)
 #define IO1_SDCARD_SPI_PARAM_DETECT        GPIO_PIN(0,23)
+/** @} */
+
+/**
+ * @name    IO1 Xplained Light sensor ADC configuration
+ * @{
+ */
+#define IO1_LIGHT_ADC_LINE                 ADC_LINE(0)
+#define IO1_LIGHT_ADC_RES                  ADC_RES_10BIT
 /** @} */
 
 /**

--- a/drivers/io1_xplained/include/io1_xplained_internals.h
+++ b/drivers/io1_xplained/include/io1_xplained_internals.h
@@ -32,8 +32,22 @@ extern "C" {
  * @name    IO1 Xplained I2C addresses
  * @{
  */
-#define TEMPERATURE_BASE_ADDR          (0x48)
-#define TEMPERATURE_DEFAULT_ADDR       (0x07)
+#define IO1_TEMPERATURE_BASE_ADDR          (0x48)
+#define IO1_TEMPERATURE_DEFAULT_ADDR       (0x07)
+/** @} */
+
+/**
+ * @name    IO1 Xplained SD Card configuration
+ * @{
+ */
+#define IO1_SDCARD_SPI_PARAM_SPI           SPI_DEV(1)
+#define IO1_SDCARD_SPI_PARAM_CS            GPIO_PIN(1,3)
+#define IO1_SDCARD_SPI_PARAM_CLK           GPIO_PIN(1,23)
+#define IO1_SDCARD_SPI_PARAM_MOSI          GPIO_PIN(1,22)
+#define IO1_SDCARD_SPI_PARAM_MISO          GPIO_PIN(1,2)
+#define IO1_SDCARD_SPI_PARAM_POWER         (GPIO_UNDEF)
+#define IO1_SDCARD_SPI_PARAM_POWER_AH      (true)
+#define IO1_SDCARD_SPI_PARAM_DETECT        GPIO_PIN(0,23)
 /** @} */
 
 /**

--- a/drivers/io1_xplained/io1_xplained.c
+++ b/drivers/io1_xplained/io1_xplained.c
@@ -18,12 +18,14 @@
  * @}
  */
 
-#include "log.h"
 #include "io1_xplained.h"
 #include "io1_xplained_internals.h"
 #include "at30tse75x.h"
 #include "periph/i2c.h"
 #include "periph/gpio.h"
+
+#define ENABLE_DEBUG (0)
+#include "debug.h"
 
 /*---------------------------------------------------------------------------*
  *                          IO1 Xplained Core API                            *
@@ -36,8 +38,9 @@ int io1_xplained_init(io1_xplained_t *dev, const io1_xplained_params_t *params)
     /* Initialize I2C interface */
     if (at30tse75x_init(&dev->temp,
                         I2C_DEV(0),
-                        I2C_SPEED_NORMAL, (TEMPERATURE_BASE_ADDR | dev->params.addr)) < 0) {
-        LOG_ERROR("Cannot initialize temperature sensor.\n");
+                        I2C_SPEED_NORMAL,
+                        (TEMPERATURE_BASE_ADDR | dev->params.addr)) < 0) {
+        DEBUG("[io1_xplained] Cannot initialize temperature sensor.\n");
         return -IO1_XPLAINED_NOTEMP;
     }
 
@@ -45,45 +48,21 @@ int io1_xplained_init(io1_xplained_t *dev, const io1_xplained_params_t *params)
     at30tse75x_set_resolution(&dev->temp, AT30TSE75X_RESOLUTION_12BIT);
 
     if (gpio_init(IO1_LED_PIN, GPIO_OUT) < 0) {
-        LOG_ERROR("GPIO LED not enabled\n");
+        DEBUG("[io1_xplained] LED initialization failed\n");
         return -IO1_XPLAINED_NOLED;
     }
 
     if (gpio_init(IO1_GPIO1_PIN, GPIO_OUT) < 0) {
-        LOG_ERROR("GPIO1 not enabled\n");
+        DEBUG("[io1_xplained] GPIO1 initialization failed\n");
         return -IO1_XPLAINED_NOGPIO1;
     }
 
     if (gpio_init(IO1_GPIO2_PIN, GPIO_OUT) < 0) {
-        LOG_ERROR("GPIO2 not enabled\n");
+        DEBUG("[io1_xplained] GPIO2 initialization failed\n");
         return -IO1_XPLAINED_NOGPIO2;
     }
 
-    LOG_DEBUG("IO1 Xplained extension initialized!\n");
+    DEBUG("IO1 Xplained extension initialized with success!\n");
 
     return IO1_XPLAINED_OK;
-}
-
-int io1_xplained_read_temperature(const io1_xplained_t *dev, float *temperature)
-{
-    if (at30tse75x_get_temperature(&dev->temp, temperature) < 0) {
-        LOG_ERROR("Cannot read temperature sensor.\n");
-        return -IO1_XPLAINED_READ_ERR;
-    }
-    return IO1_XPLAINED_READ_OK;
-}
-
-void io1_xplained_set_led(void)
-{
-    gpio_set(IO1_LED_PIN);
-}
-
-void io1_xplained_clear_led(void)
-{
-    gpio_clear(IO1_LED_PIN);
-}
-
-void io1_xplained_toggle_led(void)
-{
-    gpio_toggle(IO1_LED_PIN);
 }

--- a/drivers/io1_xplained/io1_xplained.c
+++ b/drivers/io1_xplained/io1_xplained.c
@@ -24,7 +24,7 @@
 #include "at30tse75x.h"
 #include "sdcard_spi.h"
 
-#include "periph/adc.h"
+#include "periph/i2c.h"
 #include "periph/gpio.h"
 
 #define ENABLE_DEBUG (0)
@@ -73,6 +73,11 @@ int io1_xplained_init(io1_xplained_t *dev, const io1_xplained_params_t *params)
         }
     }
 
+    if (adc_init(IO1_LIGHT_ADC_LINE) < 0) {
+        DEBUG("[io1_xplained] Light sensor (ADC) initialization failed\n");
+        return -IO1_XPLAINED_NOLIGHT;
+    }
+
     if (gpio_init(IO1_LED_PIN, GPIO_OUT) < 0) {
         DEBUG("[io1_xplained] LED initialization failed\n");
         return -IO1_XPLAINED_NOLED;
@@ -91,4 +96,18 @@ int io1_xplained_init(io1_xplained_t *dev, const io1_xplained_params_t *params)
     DEBUG("IO1 Xplained extension initialized with success!\n");
 
     return IO1_XPLAINED_OK;
+}
+
+int io1_xplained_read_light_level(uint16_t *light)
+{
+    int sample = adc_sample(IO1_LIGHT_ADC_LINE, IO1_LIGHT_ADC_RES);
+
+    if (sample < 0) {
+        DEBUG("[io1_xplained] Light sensor read failed\n");
+        return -IO1_XPLAINED_READ_ERR;
+    }
+
+    *light = (1023 - sample);
+
+    return IO1_XPLAINED_READ_OK;
 }

--- a/drivers/io1_xplained/io1_xplained.c
+++ b/drivers/io1_xplained/io1_xplained.c
@@ -20,8 +20,11 @@
 
 #include "io1_xplained.h"
 #include "io1_xplained_internals.h"
+
 #include "at30tse75x.h"
-#include "periph/i2c.h"
+#include "sdcard_spi.h"
+
+#include "periph/adc.h"
 #include "periph/gpio.h"
 
 #define ENABLE_DEBUG (0)
@@ -39,13 +42,36 @@ int io1_xplained_init(io1_xplained_t *dev, const io1_xplained_params_t *params)
     if (at30tse75x_init(&dev->temp,
                         I2C_DEV(0),
                         I2C_SPEED_NORMAL,
-                        (TEMPERATURE_BASE_ADDR | dev->params.addr)) < 0) {
+                        (IO1_TEMPERATURE_BASE_ADDR | dev->params.addr)) < 0) {
         DEBUG("[io1_xplained] Cannot initialize temperature sensor.\n");
         return -IO1_XPLAINED_NOTEMP;
     }
 
     /* Use maximum resolution */
     at30tse75x_set_resolution(&dev->temp, AT30TSE75X_RESOLUTION_12BIT);
+
+    if (gpio_init(IO1_SDCARD_SPI_PARAM_DETECT, GPIO_IN) < 0) {
+        DEBUG("[io1_xplained] SD Card detect initialization failed\n");
+        return -IO1_XPLAINED_NOSDCARD;
+    }
+
+    /* Card detect pin is inverted */
+    if (!gpio_read(IO1_SDCARD_SPI_PARAM_DETECT)) {
+        /* Initialize the SD Card */
+        sdcard_spi_params_t sdcard_params = {
+            .spi_dev        = IO1_SDCARD_SPI_PARAM_SPI,
+            .cs             = IO1_SDCARD_SPI_PARAM_CS,
+            .clk            = IO1_SDCARD_SPI_PARAM_CLK,
+            .mosi           = IO1_SDCARD_SPI_PARAM_MOSI,
+            .miso           = IO1_SDCARD_SPI_PARAM_MISO,
+            .power          = IO1_SDCARD_SPI_PARAM_POWER,
+            .power_act_high = IO1_SDCARD_SPI_PARAM_POWER_AH
+        };
+        if (sdcard_spi_init(&dev->sdcard, &sdcard_params) != 0) {
+            DEBUG("[io1_xplained] SD Card initialization failed\n");
+            return -IO1_XPLAINED_NOSDCARD;
+        }
+    }
 
     if (gpio_init(IO1_LED_PIN, GPIO_OUT) < 0) {
         DEBUG("[io1_xplained] LED initialization failed\n");

--- a/drivers/io1_xplained/io1_xplained_saul.c
+++ b/drivers/io1_xplained/io1_xplained_saul.c
@@ -22,12 +22,14 @@
 
 #include "saul.h"
 #include "io1_xplained.h"
+#include "at30tse75x.h"
 
 static float temperature;
 
 static int read_temperature(const void *dev, phydat_t *res)
 {
-    io1_xplained_read_temperature((const io1_xplained_t *)dev, &temperature);
+    const io1_xplained_t *io1 = (const io1_xplained_t *)dev;
+    at30tse75x_get_temperature(&io1->temp, &temperature);
     res->val[0] = (int)(temperature * 100.0);
     res->unit = UNIT_TEMP_C;
     res->scale = -2;

--- a/tests/driver_io1_xplained/main.c
+++ b/tests/driver_io1_xplained/main.c
@@ -27,14 +27,31 @@
 #include "periph/gpio.h"
 
 #include "at30tse75x.h"
+#include "sdcard_spi.h"
 #include "io1_xplained.h"
 #include "io1_xplained_params.h"
 
 #define DELAY_1S   (1U) /* 1 seconds delay between each test */
 
+static io1_xplained_t dev;
+
+static void _sd_card_cid(void)
+{
+    puts("SD Card CID info:");
+    printf("MID: %d\n", dev.sdcard.cid.MID);
+    printf("OID: %c%c\n", dev.sdcard.cid.OID[0], dev.sdcard.cid.OID[1]);
+    printf("PNM: %c%c%c%c%c\n",
+           dev.sdcard.cid.PNM[0], dev.sdcard.cid.PNM[1], dev.sdcard.cid.PNM[2],
+           dev.sdcard.cid.PNM[3], dev.sdcard.cid.PNM[4]);
+    printf("PRV: %d\n", dev.sdcard.cid.PRV);
+    printf("PSN: %lu\n", dev.sdcard.cid.PSN);
+    printf("MDT: %d\n", dev.sdcard.cid.MDT);
+    printf("CRC: %d\n", dev.sdcard.cid.CID_CRC);
+    puts("+----------------------------------------+\n");
+}
+
 int main(void)
 {
-    io1_xplained_t dev;
     float temperature;
 
     puts("IO1 Xplained extention test application\n");
@@ -54,6 +71,12 @@ int main(void)
                "+-------------------------------------+\n",
                temperature);
         xtimer_sleep(DELAY_1S);
+
+        /* Card detect pin is inverted */
+        if (!gpio_read(IO1_SDCARD_SPI_PARAM_DETECT)) {
+            _sd_card_cid();
+            xtimer_sleep(DELAY_1S);
+        }
 
         /* set led */
         gpio_set(IO1_LED_PIN);

--- a/tests/driver_io1_xplained/main.c
+++ b/tests/driver_io1_xplained/main.c
@@ -21,12 +21,16 @@
 #include <stdio.h>
 #include <inttypes.h>
 
-#include "io1_xplained.h"
-#include "io1_xplained_params.h"
 #include "xtimer.h"
 #include "board.h"
 
-#define SLEEP_1S   (1 * 1000 * 1000u) /* 1 seconds delay between each test */
+#include "periph/gpio.h"
+
+#include "at30tse75x.h"
+#include "io1_xplained.h"
+#include "io1_xplained_params.h"
+
+#define DELAY_1S   (1U) /* 1 seconds delay between each test */
 
 int main(void)
 {
@@ -45,27 +49,27 @@ int main(void)
     puts("\n+--------Starting tests --------+");
     while (1) {
         /* Get temperature in degrees celsius */
-        io1_xplained_read_temperature(&dev, &temperature);
+        at30tse75x_get_temperature(&dev.temp, &temperature);
         printf("Temperature [°C]: %.2f\n"
-               "\n+-------------------------------------+\n",
+               "+-------------------------------------+\n",
                temperature);
-        xtimer_usleep(SLEEP_1S);
+        xtimer_sleep(DELAY_1S);
 
         /* set led */
-        io1_xplained_set_led();
-        xtimer_usleep(SLEEP_1S);
+        gpio_set(IO1_LED_PIN);
+        xtimer_sleep(DELAY_1S);
 
         /* clear led */
-        io1_xplained_clear_led();
-        xtimer_usleep(SLEEP_1S);
+        gpio_clear(IO1_LED_PIN);
+        xtimer_sleep(DELAY_1S);
 
         /* toggle led */
-        io1_xplained_toggle_led();
-        xtimer_usleep(SLEEP_1S);
+        gpio_toggle(IO1_LED_PIN);
+        xtimer_sleep(DELAY_1S);
 
         /* toggle led again */
-        io1_xplained_toggle_led();
-        xtimer_usleep(SLEEP_1S);
+        gpio_toggle(IO1_LED_PIN);
+        xtimer_sleep(DELAY_1S);
     }
 
     return 0;

--- a/tests/driver_io1_xplained/main.c
+++ b/tests/driver_io1_xplained/main.c
@@ -78,6 +78,13 @@ int main(void)
             xtimer_sleep(DELAY_1S);
         }
 
+        uint16_t light;
+        io1_xplained_read_light_level(&light);
+        printf("Light level: %i\n"
+               "+-------------------------------------+\n",
+               light);
+        xtimer_sleep(DELAY_1S);
+
         /* set led */
         gpio_set(IO1_LED_PIN);
         xtimer_sleep(DELAY_1S);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

After working on #8960, I realized that some things could be improved in the driver:
- instead of wrapping the on-board device API, one could directly access the device via their driver API (this is the case for the temperature sensor which uses at30tse75x)
- use finer DEBUG instead of global LOG_ functions
- add support for sdcard
- add support for light sensor

This PR does that.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->