### PR TITLE
sys/net/uhcpc: add missing stdio.h include

### DIFF
--- a/sys/net/application_layer/uhcp/uhcpc.c
+++ b/sys/net/application_layer/uhcp/uhcpc.c
@@ -7,6 +7,7 @@
  */
 
 #include <arpa/inet.h>
+#include <stdio.h>
 
 #include "net/af.h"
 #include "net/sock/udp.h"


### PR DESCRIPTION
### Contribution description

uhcpc uses ```puts()``` without proper stdio.h include.

### Issues/PRs references

See [this](https://ci.riot-os.org/RIOT-OS/RIOT/8966/adab587db3e95b01d520c38f90cb49b584265054/output/compile/examples/gnrc_border_router/hifive1.txt)