### PR TITLE
dist/tools/pyterm: handle ctrl+d nicely

### DIFF
--- a/dist/tools/pyterm/pyterm
+++ b/dist/tools/pyterm/pyterm
@@ -288,6 +288,12 @@ class SerCmd(cmd.Cmd):
         """
         self.ser.write("help\n".encode("utf-8"))
 
+    def do_EOF(self, line):
+        """Handle EOF (Ctrl+D) nicely."""
+        self.logger.debug("Received EOF")
+        self.do_PYTERM_exit("")
+        sys.exit(0)
+
     def complete_date(self, text, line, begidx, endidm):
         """Auto completion for date string.
         """


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR fixes the EOF being sent to the RIOT shell when one hits Ctrl+D in Pyterm.

The idea is to catch the 'EOF' string before it is sent to the shell and prompt the user if he wants to quit or not (there's the same behaviour in IPython).

If the user answers 'y' or 'Y', pyterm exits smoothly, if he answers 'n' or 'N', nothing happens, if he just hits 'Enter', this is considered as 'y' and pyterm exits and if he hits Ctrl+D a second time pyterm exits.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

Fixes #7058

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->