### PR TITLE
sys/binsearch: Add binary search module.

### DIFF
--- a/sys/binsearch/Makefile
+++ b/sys/binsearch/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/sys/binsearch/binsearch.c
+++ b/sys/binsearch/binsearch.c
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2017 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
 /**
  * @file
  *

--- a/sys/binsearch/binsearch.c
+++ b/sys/binsearch/binsearch.c
@@ -1,0 +1,40 @@
+/**
+ * @file
+ *
+ * @brief   Generic binary search for tables containing strings.
+ * @author  Juan Carrano <j.carrano@fu-berlin.de>
+ *
+ */
+
+#include <string.h>
+
+#include "binsearch.h"
+
+int binsearch_str(const void *start, size_t offset, size_t stride, size_t nmemb,
+                  const char *str, size_t n)
+{
+    const uint8_t *cstart = (((const uint8_t *)start) + offset);
+    size_t lo = 0, hi = nmemb;
+
+    while (lo < hi) {
+        size_t mid = (lo + hi) / 2;
+        const char *target = *((const char * const *)(cstart + mid * stride));
+        int cmp = strncmp(str, target, n);
+
+        if (cmp == 0)
+            return mid;
+        else if (cmp < 0)
+            hi = mid;
+        else /* (cmp > 0) */
+            lo = mid + 1;
+    }
+    return BINSEARCH_NOTFOUND;
+}
+
+const void * binsearch_str_p(const void *start, size_t offset, size_t stride,
+                            size_t nmemb, const char *str, size_t n)
+{
+    int ix = binsearch_str(start, offset, stride, nmemb, str, n);
+
+    return (ix == BINSEARCH_NOTFOUND)? NULL : (const uint8_t *)start + ix*stride;
+}

--- a/sys/include/binsearch.h
+++ b/sys/include/binsearch.h
@@ -1,5 +1,18 @@
+/*
+ * Copyright (C) 2017 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
 /**
+ *
+ * @defgroup    sys_binsearch Binary Search
+ * @ingroup     sys
+ * @brief   Generic binary search for tables containing strings.
  * @file
+ * @{
  *
  * @brief   Generic binary search for tables containing strings.
  * @author  Juan Carrano <j.carrano@fu-berlin.de>
@@ -35,6 +48,10 @@
 #define BINSEARCH_H
 
 #include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 #define BINSEARCH_NOTFOUND (-1)
 
@@ -115,5 +132,11 @@ int binsearch_str(const void *start, size_t offset, size_t stride, size_t nmemb,
 const void * binsearch_str_p(const void *start, size_t offset, size_t stride,
                              size_t nmemb, const char *str, size_t n);
 
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */
 
 #endif /* BINSEARCH_H */

--- a/sys/include/binsearch.h
+++ b/sys/include/binsearch.h
@@ -40,7 +40,7 @@
  * "name" field of the first elements will be 4 bytes more than the address of
  * "my_table". With this two numbers we can compute the address of the i-th
  * "name" field as:
- *      <address of my_table> + offset + i*stride
+ *      [address of my_table] + offset + i*stride
  * Where stride=12 bytes and offset = 4 bytes.
  */
 

--- a/sys/include/binsearch.h
+++ b/sys/include/binsearch.h
@@ -1,0 +1,119 @@
+/**
+ * @file
+ *
+ * @brief   Generic binary search for tables containing strings.
+ * @author  Juan Carrano <j.carrano@fu-berlin.de>
+ *
+ * It is often the case that one has an array of structs, where one of the
+ * members of the struct is a string pointer containing a key that must be
+ * searched. If the array is sorted by this key and of known length, a binary
+ * search can be performed.
+ *
+ * To make the code generic we must reinterpret the structure array
+ * as an array of pointers to string with a stride (separation in bytes between
+ * elements) and offset (position of the first element relative to the start of
+ * the array) given by the struct definition.
+ *
+ * For example, given the following struct and array definitions and assuming
+ * a 32 bit platform with strict aligment:
+ *  struct s1 {
+ *      int a;      // Takes up 4 bytes
+ *      char *name; // Takes up 4 bytes
+ *      char m;     // Takes up 1 byte
+ *  };
+ *  struct s1 my_table[] = {......};
+ *
+ * Then each element of my_table will be aligned to 12 bytes. The address of the
+ * "name" field of the first elements will be 4 bytes more than the address of
+ * "my_table". With this two numbers we can compute the address of the i-th
+ * "name" field as:
+ *      <address of my_table> + offset + i*stride
+ * Where stride=12 bytes and offset = 4 bytes.
+ */
+
+#ifndef BINSEARCH_H
+#define BINSEARCH_H
+
+#include <stdint.h>
+
+#define BINSEARCH_NOTFOUND (-1)
+
+/**
+ * Produce a compiler error if x is not an lvalue.
+ */
+#define _ENSURE_LVALUE(x) ((void)sizeof(&(x)))
+
+/**
+ * UNSAFE MACRO: Difference in bytes between the addresses of two consecutive
+ * array elements.
+ */
+#define _ARRAY_STRIDE(arr) ((size_t)((uint8_t *)((arr) + 1) - (uint8_t *)(arr)))
+
+/**
+ * UNSAFE MACRO: Offset in bytes from the start of the array to member "member"
+ * of the first element.
+ */
+#define _ARRAY_MEMBER_OFFS(arr, member) \
+    ((size_t)((uint8_t *)(&((arr)->member)) - (uint8_t *)(arr)))
+
+/**
+ * Find the index of the array element that contains "str" in
+ *     member "member".
+ *
+ * An error will be raised if arr is not an lvalue. This ensures the macro is
+ * safe
+ *
+ * @return  Index of the array element containing the string, or
+ *              BINSEARCH_NOTFOUND if it is not found.
+ */
+#define BINSEARCH_STR(arr, nmemb, member, str, n) \
+    (_ENSURE_LVALUE(arr), \
+    (binsearch_str((arr), _ARRAY_MEMBER_OFFS(arr, member), _ARRAY_STRIDE(arr), \
+        (nmemb), (str), (n))) \
+    )
+
+/**
+ * Find a pointer of the array element that contains "str" in
+ *     member "member".
+ *
+ * @return      Address of the element containing the string (as a void pointer),
+ *      or null if it is not found.
+ */
+#define BINSEARCH_STR_P(arr, nmemb, member, str, n) \
+    (_ENSURE_LVALUE(arr), \
+    (binsearch_str_p((arr), _ARRAY_MEMBER_OFFS(arr, member), _ARRAY_STRIDE(arr),\
+        (nmemb), (str), (n))) \
+    )
+
+/**
+ * Search for an array element containing a string.
+ *
+ * This does NOT check for NULL pointers.
+ *
+ * @param   start   Pointer to start of array. The array must be ordered
+ *                  according to the search string.
+ * @param   offset  Offset of member containing string within structure. This
+ *                  can be determined using offsetof.
+ * @param   stride  Difference in bytes between the addresses of two consecutive
+ *                  array elements.
+ * @param   nmemb   Number of elements in the array.
+ * @param   str     String that will be compared against.
+ * @param   n       Compare up to n characters (see strncmp())
+ *
+ * @return      Index of the array element containing the string, or
+ *              BINSEARCH_NOTFOUND if it is not found.
+ */
+int binsearch_str(const void *start, size_t offset, size_t stride, size_t nmemb,
+                  const char *str, size_t n);
+
+/**
+ * Like binsearch_str but returns the pointer to the element.
+ *
+ * @return      Address of the element containing the string, or null if it is
+ *              not found.
+ */
+const void * binsearch_str_p(const void *start, size_t offset, size_t stride,
+                             size_t nmemb, const char *str, size_t n);
+
+
+#endif /* BINSEARCH_H */

--- a/tests/unittests/tests-binsearch/Makefile
+++ b/tests/unittests/tests-binsearch/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/tests/unittests/tests-binsearch/Makefile.include
+++ b/tests/unittests/tests-binsearch/Makefile.include
@@ -1,0 +1,1 @@
+USEMODULE += binsearch

--- a/tests/unittests/tests-binsearch/tests-binsearch.c
+++ b/tests/unittests/tests-binsearch/tests-binsearch.c
@@ -1,0 +1,99 @@
+/**
+ * @ingroup tests
+ * @{
+ * @file
+ *
+ * @brief   Test binary search.
+ * @author  Juan Carrano <j.carrano@fu-berlin.de>
+ *
+ * @}
+ */
+
+#include <stddef.h>
+
+#include "embUnit.h"
+
+#include "binsearch.h"
+
+struct my_record {
+    int b;
+    char z;
+    const char *the_key;
+    float dummy;
+};
+
+struct my_record my_table[] = {
+    {45688,     'b', "antonio", 89.5},
+    {25432,     'g', "carl",    2342389.3},
+    {42356,     '3', "hans",    189.4},
+    {1212,      'g', "jenny",   23489.5},
+    {75,        '8', "lisandro",89.7},
+    {224,       'o', "luke",    289.8},
+    {6733,      '1', "massimo", 2342389.2},
+    {23,       '\0', "mike",    389.6},
+    {7535,      '1', "peter",   2489.7},
+    {3452,      '9', "piotr",   489.9},
+    {4342,      ' ', "raoult",  2389.2},
+    {45424,(char)0xFF, "richard", 4289.5},
+    {2234,      'b', "vittorio",989.2}
+};
+
+#define TABLE_LEN (sizeof(my_table)/sizeof(my_table[0]))
+#define COMPARE_LEN 255
+
+/**
+ * Truncate the table to n elements and perform various tests.
+ */
+static void _test_n_elements(int n)
+{
+    int i;
+
+    /* first test the smallest string (nonexistant) */
+    int ix = BINSEARCH_STR(my_table, n, the_key, "", COMPARE_LEN);
+    const struct my_record *norecord;
+
+    TEST_ASSERT_EQUAL_INT(BINSEARCH_NOTFOUND, ix);
+
+    /* test existing strings */
+    for (i=0; i<n; i++) {
+        const char *k = my_table[i].the_key;
+        const struct my_record *r = BINSEARCH_STR_P(my_table, n, the_key, k, COMPARE_LEN);
+
+        TEST_ASSERT(r != NULL);
+        TEST_ASSERT_EQUAL_STRING(k, r->the_key); /* We should find it */
+    }
+
+    /* test a big string (nonexistant) */
+    ix = BINSEARCH_STR(my_table, n, the_key, "zzzzzzzzzzz", COMPARE_LEN);
+    TEST_ASSERT_EQUAL_INT(BINSEARCH_NOTFOUND, ix);
+
+    norecord = BINSEARCH_STR_P(my_table, n, the_key, "invalidname", COMPARE_LEN);
+    TEST_ASSERT_NULL(norecord);
+}
+
+static void test_n_elements(void)
+{
+    size_t n;
+
+    for (n = 0; n <= TABLE_LEN; n++) {
+        _test_n_elements(n);
+    }
+}
+
+
+Test *tests_binsearch_tests(void)
+{
+    EMB_UNIT_TESTFIXTURES(fixtures) {
+        new_TestFixture(test_n_elements),
+    };
+
+    EMB_UNIT_TESTCALLER(binsearch_tests, NULL, NULL, fixtures);
+
+    return (Test *)&binsearch_tests;
+}
+
+
+void tests_binsearch(void)
+{
+    TESTS_RUN(tests_binsearch_tests());
+}

--- a/tests/unittests/tests-binsearch/tests-binsearch.c
+++ b/tests/unittests/tests-binsearch/tests-binsearch.c
@@ -1,3 +1,11 @@
+/*
+ * Copyright (C) 2017 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
 /**
  * @ingroup tests
  * @{


### PR DESCRIPTION
### Description

There are places (for example, the shell and the Lua interpreter I'm working on) where one has to search an array of structs (a table), which is generally ordered.

This code allows to do this in a generic way. Also, it uses binary search so it should be faster than iteration for bigger arrays.

There are two functions and two macros. The macros are a convenience to avoid having to use `sizeof` and `offsetof` all the time.