### PR TITLE
dist/tools/openocd: use reset halt command for board using stlink

### DIFF
--- a/boards/b-l072z-lrwan1/Makefile.include
+++ b/boards/b-l072z-lrwan1/Makefile.include
@@ -12,8 +12,5 @@ include $(RIOTMAKE)/tools/serial.inc.mk
 # this board has an on-board ST-link adapter
 export DEBUG_ADAPTER ?= stlink
 
-# call a 'reset halt' command before starting the debugger
-export OPENOCD_DBG_START_CMD = -c 'reset halt'
-
 # this board uses openocd
 include $(RIOTMAKE)/tools/openocd.inc.mk

--- a/makefiles/tools/openocd-adapters/stlink.inc.mk
+++ b/makefiles/tools/openocd-adapters/stlink.inc.mk
@@ -12,6 +12,9 @@ ifneq (,$(DEBUG_ADAPTER_ID))
 endif
 export OPENOCD_ADAPTER_INIT
 
+# call a 'reset halt' command before starting the debugger
+export OPENOCD_DBG_START_CMD = -c 'reset halt'
+
 # if no openocd specific configuration file, check for default locations:
 # 1. Using the default dist/openocd.cfg (automatically set by openocd.sh)
 # 2. Using the common cpu specific config file

--- a/makefiles/tools/openocd-adapters/stlink.inc.mk
+++ b/makefiles/tools/openocd-adapters/stlink.inc.mk
@@ -13,7 +13,7 @@ endif
 export OPENOCD_ADAPTER_INIT
 
 # call a 'reset halt' command before starting the debugger
-export OPENOCD_DBG_START_CMD = -c 'reset halt'
+export OPENOCD_DBG_START_CMD ?= -c reset halt
 
 # if no openocd specific configuration file, check for default locations:
 # 1. Using the default dist/openocd.cfg (automatically set by openocd.sh)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Based on ~#8856~ and ~#8475~, this PR uses the `reset halt` command of openocd for all board using an stlink adapter.

It might not be the best solution and has side effects: after starting the debug session the program is always halted in the entry point (for ARM) otherwise it can be at any position which might be something expected (but doesn't work after).

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

Fixes #8975, based on ~#8856~ and ~#8475~

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->