### PR TITLE
boards/iotlab-m3|a8: fix openocd configuration

### DIFF
--- a/boards/common/iotlab/Makefile.include
+++ b/boards/common/iotlab/Makefile.include
@@ -10,6 +10,10 @@ PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*B)))
 export BAUD = 500000
 include $(RIOTMAKE)/tools/serial.inc.mk
 
+# call a 'reset halt' command before starting the debugger
+# it is required as `connect_assert_srst` is set
+export OPENOCD_DBG_START_CMD = -c 'reset halt'
+
 # this board uses openocd
 include $(RIOTMAKE)/tools/openocd.inc.mk
 

--- a/boards/iotlab-a8-m3/dist/openocd.cfg
+++ b/boards/iotlab-a8-m3/dist/openocd.cfg
@@ -1,9 +1,8 @@
-interface ftdi
-ftdi_vid_pid 0x0403 0x6010
-
-ftdi_layout_init 0x0c08 0x0c2b
-ftdi_layout_signal nTRST -data 0x0800
-ftdi_layout_signal nSRST -data 0x0400
-
+source [find interface/ftdi/iotlab-usb.cfg]
 source [find target/stm32f1x.cfg]
+
+# use combined on interfaces or targets that can't set TRST/SRST separately
+# Using connect_assert_srst removes errors on first flash
+reset_config trst_and_srst connect_assert_srst
+
 $_TARGETNAME configure -rtos auto

--- a/boards/iotlab-m3/dist/openocd.cfg
+++ b/boards/iotlab-m3/dist/openocd.cfg
@@ -1,9 +1,8 @@
-interface ftdi
-ftdi_vid_pid 0x0403 0x6010
-
-ftdi_layout_init 0x0c08 0x0c2b
-ftdi_layout_signal nTRST -data 0x0800
-ftdi_layout_signal nSRST -data 0x0400
-
+source [find interface/ftdi/iotlab-usb.cfg]
 source [find target/stm32f1x.cfg]
+
+# use combined on interfaces or targets that can't set TRST/SRST separately
+# Using connect_assert_srst removes errors on first flash
+reset_config trst_and_srst connect_assert_srst
+
 $_TARGETNAME configure -rtos auto


### PR DESCRIPTION
`iotlab-m3` boards always ended up not being able to flash after time.
This changes managed to fix and flash boards that where able to be flashed with
the old `ftdi2232` driver and not `RIOT`

It combines configuration from openocd, iot-lab and RIOT config

 * http://repo.or.cz/openocd.git/blob/HEAD:/tcl/interface/ftdi/iotlab-usb.cfg
   * ftdi configuration
 * https://github.com/iot-lab/iot-lab-gateway/blob/2.4.1/gateway_code/static/iot-lab-m3.cfg
   * `trst_and_srst` config
 * RIOT
   * Kee the `configure -rtos` auto

I do not understand the configuration, just adapted and tested.

### Contribution description

At IoT-LAB, we kept using the old `ftdi2232` driver because the unreliability of the riot flashing using `ftdi` but never looked into how it was done.

However, it will not fix issues where there are real hardware issues, just "unstuck" some of the non flashable nodes.

When trying, sometime we flashed two times to make it work I think.

### Issues/PRs references

Anyone that got M3 nodes stuck that could not be flashed with RIOT but still flashed by using the IoT-LAB scripts.