### PR TITLE
examples/gnrc_minimal: remove obsolete reference to XBee from README

### DIFF
--- a/examples/gnrc_minimal/README.md
+++ b/examples/gnrc_minimal/README.md
@@ -29,7 +29,3 @@ is achieved by:
  * Reducing the maximum neighbor cache size from 8 to 1.
 
 Please take a look at the Makefile to see how the configuration is done.
-
-## Support for XBee
-Please uncomment the lines in the Makefile in order to support the XBee into
-this example.


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

There is a reference to a Makefile comment related to XBee support in the README but the comment was removed from the application Makefile some time ago.

This PR removes this reference from the README.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->