### PR TITLE
pkg/semtech_loramac: handle non OK mcps confirm messages

### DIFF
--- a/pkg/semtech-loramac/include/semtech_loramac.h
+++ b/pkg/semtech-loramac/include/semtech_loramac.h
@@ -45,6 +45,7 @@ extern "C" {
 #define MSG_TYPE_LORAMAC_TX_DONE       (0x3462)  /**< MAC TX completes */
 #define MSG_TYPE_LORAMAC_RX            (0x3463)  /**< Some data received */
 #define MSG_TYPE_LORAMAC_LINK_CHECK    (0x3464)  /**< Link check info received */
+#define MSG_TYPE_LORAMAC_TX_CNF_FAILED (0x3465)  /**< MAC TX confirmed failed */
 /** @} */
 
 /**
@@ -61,6 +62,7 @@ enum {
     SEMTECH_LORAMAC_NOT_JOINED,                  /**< MAC is not joined */
     SEMTECH_LORAMAC_TX_SCHEDULED,                /**< TX data scheduled */
     SEMTECH_LORAMAC_TX_DONE,                     /**< Transmission completed */
+    SEMTECH_LORAMAC_TX_CNF_FAILED,               /**< Confirmable transmission failed */
     SEMTECH_LORAMAC_DATA_RECEIVED,               /**< Data received */
     SEMTECH_LORAMAC_BUSY                         /**< Internal MAC is busy */
 };

--- a/tests/pkg_semtech-loramac/main.c
+++ b/tests/pkg_semtech-loramac/main.c
@@ -411,6 +411,10 @@ static int _cmd_loramac(int argc, char **argv)
                        (char *)loramac.rx_data.payload, loramac.rx_data.port);
                 break;
 
+            case SEMTECH_LORAMAC_TX_CNF_FAILED:
+                puts("Confirmable TX failed");
+                break;
+
             case SEMTECH_LORAMAC_TX_DONE:
                 puts("TX complete, no data received");
                 break;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is built on top of #8798 and #8639 and provides a fallback when no OK MCPS confirm message is received from the network after a TX.

It doesn't solve the fact that no message can be received when using ABP activation but at least it prevents the mac thread from being stuck forever.

For simplicity, non OK status are all treated as error (so we don't distinguish all the cases). See [here](https://github.com/Lora-net/LoRaMac-node/blob/v4.4.0/src/mac/LoRaMac.h#L575) for more information.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

Based on ~#8798~ and ~#8639~ 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->