### PR TITLE
doc: fix 'EXTERNAL_MODULES_DIRS' name

### DIFF
--- a/doc/doxygen/src/creating-modules.md
+++ b/doc/doxygen/src/creating-modules.md
@@ -67,8 +67,8 @@ their dependencies.
 Modules outside of RIOTBASE                      {#modules-outside-of-riotbase}
 ===========================
 Modules can be defined outside `RIOTBASE`. In addition to add it to `USEMODULE`
-the user needs to add the path to the module to `EXTERNAL_MODULES` and add the
-include path to the API definitions to `INCLUDES`.
+the user needs to add the path to the module to `EXTERNAL_MODULE_DIRS` and add
+the include path to the API definitions to `INCLUDES`.
 
 Pseudomodules                                                  {#pseudomodules}
 =============


### PR DESCRIPTION
Name in the documentation did not match the one in Makefile.include.

https://github.com/RIOT-OS/RIOT/blob/94214cdcae1f11d6ed9f1c7f91bbd53595f8d8ed/Makefile.include#L333