### PR TITLE
net/rdcli: fix doxygen groups for RD client code

### DIFF
--- a/sys/include/net/rdcli_common.h
+++ b/sys/include/net/rdcli_common.h
@@ -7,8 +7,9 @@
  */
 
 /**
- * @defgroup    net_rdcli_common Shared Functions for CoRE RD Clients
- * @ingroup     net_rdcli
+ * @defgroup    net_rdcli_common CoRE RD Client Common
+ * @ingroup     net
+ * @brief       Shared functionality for CoRE Resource Directory clients
  * @{
  *
  * @file

--- a/sys/include/net/rdcli_config.h
+++ b/sys/include/net/rdcli_config.h
@@ -7,8 +7,9 @@
  */
 
 /**
- * @defgroup    net_rdcli_config CoAP Resource Directory Client Configuration
- * @ingroup     net_rdcli
+ * @defgroup    net_rdcli_config CoRE RD Client Configuration
+ * @ingroup     net
+ * @brief       Shared CoRE Resource Directory Client Configuration
  * @{
  *
  * @file

--- a/sys/include/net/rdcli_simple.h
+++ b/sys/include/net/rdcli_simple.h
@@ -7,8 +7,8 @@
  */
 
 /**
- * @defgroup    net_rdcli_simple Simple CoRE Resource Directory Registration
- * @ingroup     net_rdcli
+ * @defgroup    net_rdcli_simple CoRE RD Simple Client
+ * @ingroup     net
  * @brief       CoAP-based CoRE Resource Directory client supporting the simple
  *              registration only
  * @{


### PR DESCRIPTION
### Contribution description
When merging the CoRE RD client code (#7406) it seems that I introduced some inconsistencies regarding doxygen  group names and group dependencies. This PR should fix that.

### Issues/PRs references
broken doxygen introduced with #7406