### PR TITLE
sys/event: allow calling event_post multiple times

### DIFF
--- a/sys/event/event.c
+++ b/sys/event/event.c
@@ -23,11 +23,12 @@ void event_queue_init(event_queue_t *queue)
 
 void event_post(event_queue_t *queue, event_t *event)
 {
-    assert(!event->list_node.next);
-    assert(queue->waiter);
+    assert(queue && queue->waiter && event);
 
     unsigned state = irq_disable();
-    clist_rpush(&queue->event_list, &event->list_node);
+    if (!event->list_node.next) {
+        clist_rpush(&queue->event_list, &event->list_node);
+    }
     irq_restore(state);
 
     thread_flags_set(queue->waiter, THREAD_FLAG_EVENT);

--- a/sys/include/event.h
+++ b/sys/include/event.h
@@ -149,6 +149,11 @@ void event_queue_init(event_queue_t *queue);
 /**
  * @brief   Queue an event
  *
+ * The given event will be posted on the given @p queue. If the event is already
+ * queued when calling this function, the event will not be touched and remain
+ * in the previous position on the queue. So reposting an event while it is
+ * already on the queue will have no effect.
+ *
  * @param[in]   queue   event queue to queue event in
  * @param[in]   event   event to queue in event queue
  */


### PR DESCRIPTION
### Contribution description
Currently, `event_post()` triggers a failed assertion when called for an event, that is already queued (somewhere). In some use-cases, it is however useful, to be able to call `event_post()` more than once for the same event, for example when using events similar to `thread_flags`.

This PR modifies the `event_post()` function slightly, so that it can be call multiple times for the same event, simply leaving the event untouched in case it is already queued.

### Issues/PRs references
none