### PR TITLE
drivers: add driver for APDS9007 illuminance sensor

### DIFF
--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -29,6 +29,11 @@ ifneq (,$(filter apa102,$(USEMODULE)))
   FEATURES_REQUIRED += periph_gpio
 endif
 
+ifneq (,$(filter apds9007,$(USEMODULE)))
+  USEMODULE += xtimer
+  FEATURES_REQUIRED += periph_adc
+endif
+
 ifneq (,$(filter at,$(USEMODULE)))
   FEATURES_REQUIRED += periph_uart
   USEMODULE += fmt

--- a/drivers/Makefile.include
+++ b/drivers/Makefile.include
@@ -18,6 +18,10 @@ ifneq (,$(filter apa102,$(USEMODULE)))
   USEMODULE_INCLUDES += $(RIOTBASE)/drivers/apa102/include
 endif
 
+ifneq (,$(filter apds9007,$(USEMODULE)))
+  USEMODULE_INCLUDES += $(RIOTBASE)/drivers/apds9007/include
+endif
+
 ifneq (,$(filter at86rf2xx,$(USEMODULE)))
   USEMODULE_INCLUDES += $(RIOTBASE)/drivers/at86rf2xx/include
 endif

--- a/drivers/apds9007/Makefile
+++ b/drivers/apds9007/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/drivers/apds9007/apds9007.c
+++ b/drivers/apds9007/apds9007.c
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2018 UC Berkeley
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ *
+ */
+
+/**
+ * @ingroup     drivers_apds9007
+ * @{
+ *
+ * @file
+ * @brief       Driver for the APDS9007 Light Sensor.
+ *
+ * @author      Hyung-Sin Kim <hs.kim@cs.berkeley.edu>
+ *
+ * @}
+ */
+
+#include <string.h>
+
+#include "apds9007.h"
+#include "xtimer.h"
+
+#define ENABLE_DEBUG    (0)
+#include "debug.h"
+
+
+void apds9007_set_active(const apds9007_t *dev)
+{
+    gpio_write(dev->p.gpio, 0);
+}
+
+void apds9007_set_idle(const apds9007_t *dev)
+{
+    gpio_write(dev->p.gpio, 1);
+}
+
+void apds9007_init(apds9007_t *dev, const apds9007_params_t *params)
+{
+    dev->p.gpio = params->gpio;
+    dev->p.adcline = params->adcline;
+    dev->p.adcres  = params->adcres;
+
+    gpio_init(params->gpio, GPIO_OUT);
+    adc_init(params->adcline);
+    apds9007_set_idle(dev);
+}
+
+int apds9007_read(const apds9007_t *dev, int16_t *light)
+{
+    apds9007_set_active(dev);
+    xtimer_usleep(APDS9007_STABILIZATION_TIME);
+
+    /* This is raw voltage value, which needs to be converted to lux
+     * considering passive components */
+    *light = (int16_t) adc_sample(dev->p.adcline, dev->p.adcres);
+    apds9007_set_idle(dev);
+    if (*light == -1) {
+        return APDS9007_ADCERR;
+    }
+    return APDS9007_OK;
+}

--- a/drivers/apds9007/apds9007_saul.c
+++ b/drivers/apds9007/apds9007_saul.c
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2018 UC Berkeley
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_apds9007
+ * @{
+ *
+ * @file
+ * @brief       APDS9007 adaption to the RIOT actuator/sensor interface
+ *
+ * @author      Hyung-Sin Kim <hs.kim@cs.berkeley.edu>
+ *
+ * @}
+ */
+
+#include <string.h>
+
+#include "saul.h"
+#include "apds9007.h"
+
+static int read(const void *dev, phydat_t *res)
+{
+    if (apds9007_read((const apds9007_t *)dev, &(res->val[0])) != APDS9007_OK) {
+        /* Read failure */
+        return -ECANCELED;
+    }
+    memset(&(res->val[1]), 0, 2 * sizeof(int16_t));
+    res->unit = UNIT_NONE;
+    res->scale = 0;
+    return 1;
+}
+
+const saul_driver_t apds9007_saul_light_driver = {
+    .read = read,
+    .write = saul_notsup,
+    .type = SAUL_SENSE_LIGHT,
+};

--- a/drivers/apds9007/include/apds9007_params.h
+++ b/drivers/apds9007/include/apds9007_params.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2018 UC Berkeley
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_apds9007
+ *
+ * @{
+ * @file
+ * @brief       Default configuration for APDS9007 devices
+ *
+ * @author      Hyung-Sin Kim <hs.kim@cs.berkeley.edu>
+ */
+
+#ifndef APDS9007_PARAMS_H
+#define APDS9007_PARAMS_H
+
+#include "board.h"
+#include "apds9007.h"
+#include "saul_reg.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Set default configuration parameters for the APDS9007 driver
+ * @{
+ */
+#ifndef APDS9007_PARAM_GPIO
+#define APDS9007_PARAM_GPIO     GPIO_PIN(PA,6)
+#endif
+#ifndef APDS9007_PARAM_ADCLINE
+#define APDS9007_PARAM_ADCLINE  0
+#endif
+#ifndef APDS9007_PARAM_ADCRES
+#define APDS9007_PARAM_ADCRES   ADC_RES_12BIT
+#endif
+
+#ifndef APDS9007_PARAMS
+#define APDS9007_PARAMS         { .gpio = APDS9007_PARAM_GPIO, \
+                                  .adcline = APDS9007_PARAM_ADCLINE, \
+                                  .adcres = APDS9007_PARAM_ADCRES }
+#endif
+#ifndef APDS9007_SAUL_INFO
+#define APDS9007_SAUL_INFO      { .name = "apds9007" }
+#endif
+/**@}*/
+
+/**
+ * @brief   APDS9007 configuration
+ */
+static const apds9007_params_t apds9007_params[] =
+{
+    APDS9007_PARAMS
+};
+
+/**
+ * @brief   Additional meta information to keep in the SAUL registry
+ */
+static const saul_reg_info_t apds9007_saul_info[] =
+{
+    APDS9007_SAUL_INFO
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* APDS9007_PARAMS_H */
+/** @} */

--- a/drivers/include/apds9007.h
+++ b/drivers/include/apds9007.h
@@ -1,0 +1,106 @@
+/*
+ * Copyright (C) 2018 UC Berkeley
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    drivers_apds9007 APDS9007 light sensor
+ * @ingroup     drivers_sensors
+ * @brief       Driver for the APDS9007 light sensor
+ *
+ * The connection between the MCU and the APDS9007 is based on the
+ * GPIO-interface.
+ *
+ * @{
+ *
+ * @file
+ * @brief       Driver for the APDS9007 light sensor
+ *
+ * @author      Hyung-Sin Kim <hs.kim@cs.berkeley.edu>
+ */
+
+#ifndef APDS9007_H
+#define APDS9007_H
+
+#include <stdint.h>
+#include "periph/gpio.h"
+#include "periph/adc.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Stabilization time for APDS9007 output
+ */
+#ifndef APDS9007_STABILIZATION_TIME
+#define APDS9007_STABILIZATION_TIME 20000UL
+#endif
+
+/**
+ * @brief   APDS9007 specific return values
+ */
+enum {
+    APDS9007_OK      = 0,    /**< everything went as expected */
+    APDS9007_ADCERR = -1,    /**< ADC reading error */
+};
+
+/**
+ * @brief   Parameters needed for device initialization
+ */
+typedef struct {
+    gpio_t    gpio;            /**< GPIO pin that sensor is connected to */
+    adc_t     adcline;         /**< ADC channel that sensor is connected to */
+    adc_res_t adcres;          /**< ADC resolution that sensor uses */
+} apds9007_params_t;
+
+/**
+  * @brief   Device descriptor for a APDS9007 device
+  * @{
+  */
+typedef struct {
+    apds9007_params_t p;   /**< device driver configuration */
+} apds9007_t;
+/** @} */
+
+/**
+ * @brief   Initialize an APDS9007 device
+ *
+ * @param[out] dev          device descriptor
+ * @param[in] params        parameters for device
+ */
+void apds9007_init(apds9007_t* dev, const apds9007_params_t* params);
+
+/**
+ * @brief   Activate APDS9007 device
+ *
+ * @param[in] dev          device descriptor
+ */
+void apds9007_set_active(const apds9007_t* dev);
+
+/**
+ * @brief   Turn off APDS9007 device
+ *
+ * @param[in] dev          device descriptor
+ */
+void apds9007_set_idle(const apds9007_t* dev);
+
+/**
+ * @brief   Read illuminance value
+ *
+ * @param[in]  dev          device descriptor
+ * @param[out] light        Illuminance in raw voltage
+ *
+ * @return                  APDS9007_OK on success
+ * @return                  APDS9007_ADCERR on ADC error
+ */
+int apds9007_read(const apds9007_t* dev, int16_t *light);
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */
+#endif /* APDS9007_H */

--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -386,6 +386,10 @@ void auto_init(void)
     extern void auto_init_adxl345(void);
     auto_init_adxl345();
 #endif
+#ifdef MODULE_APDS9007
+    extern void auto_init_apds9007(void);
+    auto_init_apds9007();
+#endif
 #ifdef MODULE_BMP180
     extern void auto_init_bmp180(void);
     auto_init_bmp180();

--- a/tests/driver_apds9007/Makefile
+++ b/tests/driver_apds9007/Makefile
@@ -1,0 +1,7 @@
+include ../Makefile.tests_common
+
+BOARD_BLACKLIST := msb-430 msb-430h telosb wsn430-v1_3b wsn430-v1_4 z1
+
+USEMODULE += apds9007
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/driver_apds9007/README.md
+++ b/tests/driver_apds9007/README.md
@@ -1,0 +1,12 @@
+# About
+This is a manual test application for the APDS9007 driver.
+
+# Usage
+This test application will initialize the APDS9007 sensor with the configuration
+as specified in the default `apds9007_params.h` file.
+
+If you want to use this test application with different parameters, you can
+simply override the default APDS9007_PARAMS.
+
+After initialization, the sensor reads the pulse counter values every second and
+prints them to STDOUT.

--- a/tests/driver_apds9007/main.c
+++ b/tests/driver_apds9007/main.c
@@ -1,0 +1,50 @@
+/*
+ * Copyright (C) 2018 UC Berkeley
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Test application for the APDS9007 driver
+ *
+ * @author      Hyung-Sin Kim <hs.kim@cs.berkeley.edu>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+
+#include "xtimer.h"
+#include "apds9007_params.h"
+#include "apds9007.h"
+
+#define SLEEP       US_PER_SEC
+
+int main(void)
+{
+    apds9007_t dev;
+
+    printf("APDS9007 driver test application\n");
+
+    /* Initialization */
+    apds9007_init(&dev, &apds9007_params[0]);
+
+    while (1) {
+        /* Pulse counter reading */
+        int16_t light;
+        if (apds9007_read(&dev, &light) != APDS9007_OK) {
+            printf("Read failure\n");
+        } else {
+            printf("illuminance in raw voltage value: %d\n", light);
+        }
+        xtimer_usleep(SLEEP);
+    }
+
+    return 0;
+}


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

This PR provides a driver implementation for APDS9007 illuminance sensor.
APDS9007 gives raw voltage value which is proportional to "lux".
This driver reads this voltage value through ADC, which needs to be converted to "lux" according to passive components. The voltage->lux conversion is out of the scope of this PR.

Note: 
APDS9007's illuminance output is 3 to 70,000 lux, which cannot be captured by a 16 bit variable.
But raw voltage output is 0 to 3000 mV, which is durable.

### Dependencies

https://github.com/RIOT-OS/RIOT/pull/9013

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->




<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->