### PR TITLE
sys/auto_init: fix syntax error on auto_init_pulse_counter.c

### DIFF
--- a/sys/auto_init/saul/auto_init_pulse_counter.c
+++ b/sys/auto_init/saul/auto_init_pulse_counter.c
@@ -52,7 +52,7 @@ extern saul_driver_t pulse_counter_saul_driver;
 
 void auto_init_pulse_counter(void)
 {
-    assert(PULSE_COUNTER_NUM == PULSE_COUNTER_INFO_NUM)
+    assert(PULSE_COUNTER_NUM == PULSE_COUNTER_INFO_NUM);
     for (unsigned i = 0; i < PULSE_COUNTER_NUM; i++) {
         LOG_DEBUG("[auto_init_saul] initializing pulse_counter #%u\n", i);
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

Very simple syntax error fix

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->



<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->