### PR TITLE
pkg/tlsf: add documentation.

### DIFF
--- a/pkg/tlsf/doc.txt
+++ b/pkg/tlsf/doc.txt
@@ -1,0 +1,17 @@
+/**
+ * @defgroup pkg_tlsf	Two-Level Segregated Fit memory allocator
+ * @ingroup  pkg
+ * @brief    TLSF is a general purpose dynamic memory allocator specifically
+ *            designed to meet real-time requirements:
+ * @see      http://www.gii.upv.es/tlsf/
+ * @see      https://github.com/mattconte/tlsf
+ *
+ * TLSF provides an implementation of malloc/realloc/free/etc with the following
+ * characteristics:
+ *
+ *  - O(1) Performance
+ *  - Works on a user supplied block of memory instead of a global heap.
+ *  - Efficient both in terms of memory overhead and processor time.
+ *  - Low fragmentation.
+ *
+ */

--- a/sys/oneway-malloc/include/malloc.h
+++ b/sys/oneway-malloc/include/malloc.h
@@ -20,6 +20,8 @@
  *
  * @note        You should prefer statically allocated memory whenever possible.
  *
+ * @see         pkg_tlsf
+ *
  * @{
  * @file
  *


### PR DESCRIPTION
The doc.txt for TLSF was empty, so it wouldn't show up in Doxygen. I wrote a brief description and also cross linked it from the "Oneway Malloc" docs, so that people looking for memory allocation can find it.