### PR TITLE
make: don't create BINDIR for flash-only

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -275,12 +275,6 @@ CFLAGS += -DBOARD_$(BOARDDEF)=\"$(BOARD)\" -DRIOT_BOARD=BOARD_$(BOARDDEF)
 CFLAGS += -DCPU_$(CPUDEF)=\"$(CPU)\" -DRIOT_CPU=CPU_$(CPUDEF)
 CFLAGS += -DMCU_$(MCUDEF)=\"$(MCU)\" -DRIOT_MCU=MCU_$(MCUDEF)
 
-# OSX fails to create empty archives. Provide a wrapper to catch that error.
-ifneq (0, $(shell mkdir -p $(BINDIR); $(AR) rc $(BINDIR)/empty-archive.a 2> /dev/null; \
-            echo $$?; rm -f $(BINDIR)/empty-archive.a 2>&1 > /dev/null))
-	AR := $(RIOTBASE)/dist/ar-wrapper $(AR)
-endif
-
 # Feature test default CFLAGS and LINKFLAGS for the set compiled.
 include $(RIOTMAKE)/cflags.inc.mk
 
@@ -438,6 +432,11 @@ distclean:
 # if make target != 'flash-only', add target 'all' to ensure build before flash
 ifeq (,$(filter flash-only, $(MAKECMDGOALS)))
   BUILD_BEFORE_FLASH = all
+  # OSX fails to create empty archives. Provide a wrapper to catch that error.
+  ifneq (0, $(shell mkdir -p $(BINDIR); $(AR) rc $(BINDIR)/empty-archive.a 2> /dev/null; \
+              echo $$?; rm -f $(BINDIR)/empty-archive.a 2>&1 > /dev/null))
+    AR := $(RIOTBASE)/dist/ar-wrapper $(AR)
+  endif
 endif
 
 flash: $(BUILD_BEFORE_FLASH) $(FLASHDEPS)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR omits the creation of `BINDIR` for `make flash-only` (as used by murdock when running tests on boards), otherwise (i.e. currently) an empty directory is created which isn't used or needed. 


### Issues/PRs references

None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->