### PR TITLE
sys/arduino: drop cpp feature dependency [BACKPORT]

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -534,7 +534,6 @@ endif
 
 ifneq (,$(filter arduino,$(USEMODULE)))
   FEATURES_REQUIRED += arduino
-  FEATURES_REQUIRED += cpp
   USEMODULE += xtimer
 endif
 

--- a/boards/common/arduino-atmega/Makefile.features
+++ b/boards/common/arduino-atmega/Makefile.features
@@ -7,7 +7,9 @@ FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
 # Various other features (if any)
-FEATURES_PROVIDED += arduino
+ifeq (,$(filter jiminy-mega256rfr2,$(BOARD)))
+  FEATURES_PROVIDED += arduino
+endif
 
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = avr8


### PR DESCRIPTION
### Contribution description

Backport of #8995.

Copy&pase description:

---

Contribution description

Currently, the arduino module depends on the "cpp" feature. As AVR's don't have libstdc++, they don't provide that feature, as otherwise all cpp examples would break.
But the AVR does provide a cpp compiler and thus the arduino module compiles just fine.

This PR removes the cpp dependency from arduino module.
Issues/PRs references

Fixes #8548.