### PR TITLE
net/gcoap: increase stack size by sizeof(coap_pkt_t)

### DIFF
--- a/sys/include/net/gcoap.h
+++ b/sys/include/net/gcoap.h
@@ -410,7 +410,8 @@ extern "C" {
  * @brief Stack size for module thread
  */
 #ifndef GCOAP_STACK_SIZE
-#define GCOAP_STACK_SIZE (THREAD_STACKSIZE_DEFAULT + DEBUG_EXTRA_STACKSIZE)
+#define GCOAP_STACK_SIZE (THREAD_STACKSIZE_DEFAULT + DEBUG_EXTRA_STACKSIZE \
+                          + sizeof(coap_pkt_t))
 #endif
 
 /**


### PR DESCRIPTION
### Contribution description

Apparently the latest nanocoap rework had side effects on gcoap's stack usage, and not of the good kind.

This PR adds ```sizeof(coap_pkt_t)``` to the gcoap stacksize. Meant as quickfix for the release, better solution is on its way.

### Issues/PRs references

Fixes #8981.