### PR TITLE
make: Add 'BUILDDEPS' variable

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -364,6 +364,9 @@ LINKFLAGPREFIX ?= -Wl,
 
 DIRS += $(EXTERNAL_MODULE_DIRS)
 
+# Define dependencies required for building (headers, downloading source files,)
+BUILDDEPS += $(RIOTBUILD_CONFIG_HEADER_C)
+
 # Save value to verify it is not modified later
 _BASELIBS_VALUE_BEFORE_USAGE := $(BASELIBS)
 
@@ -387,7 +390,7 @@ endif # RIOTNOLINK
 $(ELFFILE): $(BASELIBS)
 	$(Q)$(_LINK) -o $@
 
-$(BINDIR)/$(APPLICATION_MODULE).a: $(RIOTBUILD_CONFIG_HEADER_C) $(USEPKG:%=$(BINDIR)/%.a) $(APPDEPS) $(BUILDDEPS)
+$(BINDIR)/$(APPLICATION_MODULE).a: $(USEPKG:%=$(BINDIR)/%.a) $(APPDEPS) $(BUILDDEPS)
 	$(Q)DIRS="$(DIRS)" "$(MAKE)" -C $(APPDIR) -f $(RIOTMAKE)/application.inc.mk
 $(BINDIR)/$(APPLICATION_MODULE).a: FORCE
 
@@ -425,14 +428,14 @@ endef
 
 # The `clean` needs to be serialized before everything else.
 ifneq (, $(filter clean, $(MAKECMDGOALS)))
-    all $(BASELIBS) $(USEPKG:%=$(RIOTPKG)/%/Makefile.include) $(RIOTBUILD_CONFIG_HEADER_C) pkg-prepare $(BUILDDEPS): clean
+    all $(BASELIBS) $(USEPKG:%=$(RIOTPKG)/%/Makefile.include) pkg-prepare $(BUILDDEPS): clean
 endif
 
 .PHONY: pkg-prepare $(USEPKG:%=$(BINDIR)/%.a)
 pkg-prepare:
 	-@for i in $(USEPKG) ; do "$(MAKE)" -C $(RIOTPKG)/$$i prepare ; done
 
-$(USEPKG:%=$(BINDIR)/%.a): $(RIOTBUILD_CONFIG_HEADER_C) pkg-prepare $(BUILDDEPS)
+$(USEPKG:%=$(BINDIR)/%.a): pkg-prepare $(BUILDDEPS)
 	@mkdir -p $(BINDIR)
 	$(QQ)"$(MAKE)" -C $(RIOTPKG)/$(patsubst $(BINDIR)/%.a,%,$@)
 

--- a/Makefile.include
+++ b/Makefile.include
@@ -366,6 +366,7 @@ DIRS += $(EXTERNAL_MODULE_DIRS)
 
 # Define dependencies required for building (headers, downloading source files,)
 BUILDDEPS += $(RIOTBUILD_CONFIG_HEADER_C)
+BUILDDEPS += pkg-prepare
 BUILDDEPS += $(APPDEPS)
 
 # Save value to verify it is not modified later
@@ -429,14 +430,14 @@ endef
 
 # The `clean` needs to be serialized before everything else.
 ifneq (, $(filter clean, $(MAKECMDGOALS)))
-    all $(BASELIBS) $(USEPKG:%=$(RIOTPKG)/%/Makefile.include) pkg-prepare $(BUILDDEPS): clean
+    all $(BASELIBS) $(USEPKG:%=$(RIOTPKG)/%/Makefile.include) $(BUILDDEPS): clean
 endif
 
 .PHONY: pkg-prepare $(USEPKG:%=$(BINDIR)/%.a)
 pkg-prepare:
 	-@for i in $(USEPKG) ; do "$(MAKE)" -C $(RIOTPKG)/$$i prepare ; done
 
-$(USEPKG:%=$(BINDIR)/%.a): pkg-prepare $(BUILDDEPS)
+$(USEPKG:%=$(BINDIR)/%.a): $(BUILDDEPS)
 	@mkdir -p $(BINDIR)
 	$(QQ)"$(MAKE)" -C $(RIOTPKG)/$(patsubst $(BINDIR)/%.a,%,$@)
 

--- a/Makefile.include
+++ b/Makefile.include
@@ -366,6 +366,7 @@ DIRS += $(EXTERNAL_MODULE_DIRS)
 
 # Define dependencies required for building (headers, downloading source files,)
 BUILDDEPS += $(RIOTBUILD_CONFIG_HEADER_C)
+BUILDDEPS += $(APPDEPS)
 
 # Save value to verify it is not modified later
 _BASELIBS_VALUE_BEFORE_USAGE := $(BASELIBS)
@@ -390,7 +391,7 @@ endif # RIOTNOLINK
 $(ELFFILE): $(BASELIBS)
 	$(Q)$(_LINK) -o $@
 
-$(BINDIR)/$(APPLICATION_MODULE).a: $(USEPKG:%=$(BINDIR)/%.a) $(APPDEPS) $(BUILDDEPS)
+$(BINDIR)/$(APPLICATION_MODULE).a: $(USEPKG:%=$(BINDIR)/%.a) $(BUILDDEPS)
 	$(Q)DIRS="$(DIRS)" "$(MAKE)" -C $(APPDIR) -f $(RIOTMAKE)/application.inc.mk
 $(BINDIR)/$(APPLICATION_MODULE).a: FORCE
 

--- a/Makefile.include
+++ b/Makefile.include
@@ -387,7 +387,7 @@ endif # RIOTNOLINK
 $(ELFFILE): $(BASELIBS)
 	$(Q)$(_LINK) -o $@
 
-$(BINDIR)/$(APPLICATION_MODULE).a: $(RIOTBUILD_CONFIG_HEADER_C) $(USEPKG:%=$(BINDIR)/%.a) $(APPDEPS)
+$(BINDIR)/$(APPLICATION_MODULE).a: $(RIOTBUILD_CONFIG_HEADER_C) $(USEPKG:%=$(BINDIR)/%.a) $(APPDEPS) $(BUILDDEPS)
 	$(Q)DIRS="$(DIRS)" "$(MAKE)" -C $(APPDIR) -f $(RIOTMAKE)/application.inc.mk
 $(BINDIR)/$(APPLICATION_MODULE).a: FORCE
 
@@ -425,14 +425,14 @@ endef
 
 # The `clean` needs to be serialized before everything else.
 ifneq (, $(filter clean, $(MAKECMDGOALS)))
-    all $(BASELIBS) $(USEPKG:%=$(RIOTPKG)/%/Makefile.include) $(RIOTBUILD_CONFIG_HEADER_C) pkg-prepare: clean
+    all $(BASELIBS) $(USEPKG:%=$(RIOTPKG)/%/Makefile.include) $(RIOTBUILD_CONFIG_HEADER_C) pkg-prepare $(BUILDDEPS): clean
 endif
 
 .PHONY: pkg-prepare $(USEPKG:%=$(BINDIR)/%.a)
 pkg-prepare:
 	-@for i in $(USEPKG) ; do "$(MAKE)" -C $(RIOTPKG)/$$i prepare ; done
 
-$(USEPKG:%=$(BINDIR)/%.a): $(RIOTBUILD_CONFIG_HEADER_C) pkg-prepare
+$(USEPKG:%=$(BINDIR)/%.a): $(RIOTBUILD_CONFIG_HEADER_C) pkg-prepare $(BUILDDEPS)
 	@mkdir -p $(BINDIR)
 	$(QQ)"$(MAKE)" -C $(RIOTPKG)/$(patsubst $(BINDIR)/%.a,%,$@)
 

--- a/makefiles/vars.inc.mk
+++ b/makefiles/vars.inc.mk
@@ -17,6 +17,7 @@ export USEMODULE             # Sys Module dependencies of the application. Set i
 export USEPKG                # Pkg dependencies (third party modules) of the application. Set in the application's Makefile.
 export DISABLE_MODULE        # Used in the application's Makefile to suppress DEFAULT_MODULEs.
 export APPDEPS               # Files / Makefile targets that need to be created before the application can be build. Set in the application's Makefile.
+# BUILDDEPS                  # Files / Makefile targets that need to be created before starting to build.
 
 export RIOTBASE              # The root folder of RIOT. The folder where this very file lives in.
 export RIOTCPU               # For third party CPUs this folder is the base of the CPUs.


### PR DESCRIPTION
Extend/fix `APPDEPS` as a new variable to declare general build dependencies.

This PR proposes to add a new `BUILDDEPS` variable instead of fixing `APPDEPS`.
It is only a proposal and is here to show how it could be used.
Fixing `APPDEPS` and making it evolve is also a possibility, with other sub-prs, I just want to start talking about it and justify the pull requests that would change `APPDEPS`.

### Contribution description

`BUILDDEPS` are files / make targets that should be build before compiling.
It can include packages source download, generating headers, modules.
    
It is the equivalent of `APPDEPS` but not limited to the application (as documented).
It cannot be done right now with `APPDEPS` as it is used in `BASELIBS` and fixing it requires changing mips using it for source files.

#### Other solution

Another solution is to fix `APPDEPS` now:
* Replace:
    * https://github.com/RIOT-OS/RIOT/blob/af70c0844c5622aef2fd89b75f5ed96adfda47d0/boards/pic32-clicker/Makefile.include#L4
    * https://github.com/RIOT-OS/RIOT/blob/af70c0844c5622aef2fd89b75f5ed96adfda47d0/boards/pic32-wifire/Makefile.include#L4
* Revert https://github.com/RIOT-OS/RIOT/pull/4906 that puts is in `BASELIBS` and so in the linker command
* Extend `APPDEPS` documentation.
* Maybe rename it to something like `BUILDDEPS`.

### Issues/PRs references

This would be necessary to do https://github.com/RIOT-OS/RIOT/pull/7654 properly.
With https://github.com/RIOT-OS/RIOT/pull/8987 it would allow defining external packages by setting a dependency that downloads the source files.