### PR TITLE
pseudomodules: allow defining them in pkg/PKG/Makefile.include

### DIFF
--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -131,3 +131,5 @@ NO_PSEUDOMODULES += periph_common
 PSEUDOMODULES += auto_init_skald
 PSEUDOMODULES += skald_ibeacon
 PSEUDOMODULES += skald_eddystone
+
+# Packages may also add modules to PSEUDOMODULES in their `Makefile.include`.


### PR DESCRIPTION
### Contribution description

Officially allow packages to define pseudomodules in their Makefile.include as
done in the libcose package.

https://github.com/RIOT-OS/RIOT/blob/6c39d2d621d15cd6f252545c791bbc381b1b48bf/pkg/libcose/Makefile.include#L11-L12

### Issues/PRs references

Proposed implementation of this RFC https://github.com/RIOT-OS/RIOT/issues/8984