### PR TITLE
pkg: cleanup old GIT_APPLY_PATCHES variable

### DIFF
--- a/pkg/pkg.mk
+++ b/pkg/pkg.mk
@@ -30,7 +30,6 @@ $(PKG_BUILDDIR)/.git-downloaded:
 	rm -Rf $(PKG_BUILDDIR)
 	mkdir -p $(PKG_BUILDDIR)
 	$(GITCACHE) clone "$(PKG_URL)" "$(PKG_VERSION)" "$(PKG_BUILDDIR)"
-	$(GIT_APPLY_PATCHES)
 	touch $@
 
 clean::


### PR DESCRIPTION
Cleanup old variable usage that was removed in 0fb50ebeda07eeca4a83c2f8ca517e9aa3e8f6a9

### Issues/PRs references

Ending cleanup done by https://github.com/RIOT-OS/RIOT/pull/5400