### PR TITLE
pkg/pkg.mk: Do not sign when applying patches

### DIFF
--- a/pkg/pkg.mk
+++ b/pkg/pkg.mk
@@ -19,7 +19,7 @@ else
 git-download: $(PKG_BUILDDIR)/.git-downloaded
 endif
 
-GITAMFLAGS = --ignore-whitespace
+GITAMFLAGS = --no-gpg-sign --ignore-whitespace
 
 ifneq (,$(wildcard $(PKG_DIR)/patches))
 $(PKG_BUILDDIR)/.git-patched: $(PKG_BUILDDIR)/.git-downloaded $(PKG_DIR)/Makefile $(PKG_DIR)/patches/*.patch

--- a/pkg/pkg.mk
+++ b/pkg/pkg.mk
@@ -19,10 +19,12 @@ else
 git-download: $(PKG_BUILDDIR)/.git-downloaded
 endif
 
+GITAMFLAGS = --ignore-whitespace
+
 ifneq (,$(wildcard $(PKG_DIR)/patches))
 $(PKG_BUILDDIR)/.git-patched: $(PKG_BUILDDIR)/.git-downloaded $(PKG_DIR)/Makefile $(PKG_DIR)/patches/*.patch
 	git -C $(PKG_BUILDDIR) checkout -f $(PKG_VERSION)
-	git -C $(PKG_BUILDDIR) am --ignore-whitespace "$(PKG_DIR)"/patches/*.patch
+	git -C $(PKG_BUILDDIR) am $(GITAMFLAGS) "$(PKG_DIR)"/patches/*.patch
 	touch $@
 endif
 


### PR DESCRIPTION
Disable signing every applied patches for user that have gpgsign by default.

### Issues/PRs references

Build system asking for gpg key passphrase when you have in your configuration
```
[commit]
    gpgsign = True
```