### PR TITLE
frdm-k22f: Fix typos and remove unused includes

### DIFF
--- a/boards/frdm-k22f/board.c
+++ b/boards/frdm-k22f/board.c
@@ -9,7 +9,7 @@
  */
 
 /**
- * @ingroup     boards_frdm-k64f
+ * @ingroup     boards_frdm-k22f
  * @{
  *
  * @file
@@ -20,9 +20,7 @@
  * @}
  */
 
-#include <stdint.h>
 #include "board.h"
-#include "mcg.h"
 #include "periph/gpio.h"
 
 void board_init(void)
@@ -32,9 +30,9 @@ void board_init(void)
 
     /* initialize and turn off the on-board RGB-LED */
     gpio_init(LED0_PIN, GPIO_OUT);
-    gpio_init(LED1_PIN, GPIO_OUT);
-    gpio_init(LED2_PIN, GPIO_OUT);
     gpio_set(LED0_PIN);
+    gpio_init(LED1_PIN, GPIO_OUT);
     gpio_set(LED1_PIN);
+    gpio_init(LED2_PIN, GPIO_OUT);
     gpio_set(LED2_PIN);
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Fixes some minor mistakes in boards/frdm-k22f/board.c
 - Remove unused includes
 - Change copy paste reference to K64F
 - set GPIOs immediately after initialization


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->