### PR TITLE
dist/testbed-support: use new cli-tools command names

### DIFF
--- a/dist/testbed-support/Makefile.iotlab
+++ b/dist/testbed-support/Makefile.iotlab
@@ -1,14 +1,14 @@
-.PHONY: iotlab-auth iotlab-exp iotlab-flash iotlab-reset iotlab-term iotlab-check-exp
+.PHONY: iotlab-exp iotlab-flash iotlab-reset iotlab-term iotlab-check-exp
 
 IOTLAB_NODES        ?= 5
 IOTLAB_DURATION     ?= 30
 IOTLAB_TYPE         ?= m3:at86rf231
 IOTLAB_AUTH         ?= $(HOME)/.iotlabrc
 IOTLAB_USER         ?= $(shell cut -f1 -d: $(IOTLAB_AUTH))
-IOTLAB_EXP_ID       ?= $(shell experiment-cli get -l --state Running | grep -m 1 '"id"' | grep -Eo '[[:digit:]]+')
+IOTLAB_EXP_ID       ?= $(shell iotlab-experiment get -l --state Running | grep -m 1 '"id"' | grep -Eo '[[:digit:]]+')
 IOTLAB_EXP_NAME     ?= RIOT_EXP
 IOTLAB_DEBUG_PORT   ?= 3333
-IOTLAB_DEBUG_NODE   ?= $(shell experiment-cli get -i $(IOTLAB_EXP_ID) --resources | \
+IOTLAB_DEBUG_NODE   ?= $(shell iotlab-experiment get -i $(IOTLAB_EXP_ID) --resources | \
                          grep -m 1 "network_address" | sed 's/.*-\([0-9]*\)\..*/\1/')
 
 IOTLAB_AUTHORITY    = "$(IOTLAB_USER)@$(IOTLAB_SITE).iot-lab.info"
@@ -29,7 +29,7 @@ ifdef IOTLAB_EXCLUDE_NODES
 endif
 
 $(IOTLAB_AUTH):
-	auth-cli -u $(IOTLAB_USER)
+	iotlab-auth -u $(IOTLAB_USER)
 
 iotlab-exp: $(IOTLAB_AUTH) all
 	$(eval IOTLAB_SITE ?= grenoble)
@@ -43,10 +43,10 @@ iotlab-exp: $(IOTLAB_AUTH) all
     endif
 
     ifeq (,$(Q))
-	  @echo "experiment-cli submit -d $(IOTLAB_DURATION) $(NODES_PARAM) -n $(IOTLAB_EXP_NAME)"
+	  @echo "iotlab-experiment submit -d $(IOTLAB_DURATION) $(NODES_PARAM) -n $(IOTLAB_EXP_NAME)"
     endif
-	$(eval NEW_ID := $(shell experiment-cli submit -d $(IOTLAB_DURATION) $(NODES_PARAM) -n $(IOTLAB_EXP_NAME) | grep -Eo '[[:digit:]]+'))
-	$(Q)experiment-cli wait -i $(NEW_ID)
+	$(eval NEW_ID := $(shell iotlab-experiment submit -d $(IOTLAB_DURATION) $(NODES_PARAM) -n $(IOTLAB_EXP_NAME) | grep -Eo '[[:digit:]]+'))
+	$(Q)iotlab-experiment wait -i $(NEW_ID)
 
     ifdef IOTLAB_LOGGING
 	  $(Q)ssh -t $(IOTLAB_AUTHORITY) "tmux new -d -s riot-$(NEW_ID)\
@@ -55,24 +55,24 @@ iotlab-exp: $(IOTLAB_AUTH) all
     endif
 
 iotlab-flash: $(IOTLAB_AUTH) iotlab-check-exp all
-	$(Q)node-cli --update $(BINARY) -i $(IOTLAB_EXP_ID) $(NODES_PARAM_BASE) $(EXCLUDE_PARAM)
+	$(Q)iotlab-node --update $(BINARY) -i $(IOTLAB_EXP_ID) $(NODES_PARAM_BASE) $(EXCLUDE_PARAM)
 
 iotlab-reset: $(IOTLAB_AUTH) iotlab-check-exp
-	$(Q)node-cli --reset -i $(IOTLAB_EXP_ID) $(NODES_PARAM_BASE) $(EXCLUDE_PARAM)
+	$(Q)iotlab-node --reset -i $(IOTLAB_EXP_ID) $(NODES_PARAM_BASE) $(EXCLUDE_PARAM)
 
 iotlab-debug-server: $(IOTLAB_AUTH) iotlab-check-exp
 	$(eval DEBUG_TYPE := $(shell echo $(IOTLAB_TYPE) | cut -d: -f1))
 	$(eval DEBUG_NODE := $(shell echo $(IOTLAB_DEBUG_NODE) | sed 's/$(DEBUG_TYPE)-\([0-9]*\)/\1/'))
 
-	$(Q)node-cli --debug-start -i $(IOTLAB_EXP_ID) -l $(IOTLAB_SITE),$(DEBUG_TYPE),$(DEBUG_NODE)
+	$(Q)iotlab-node --debug-start -i $(IOTLAB_EXP_ID) -l $(IOTLAB_SITE),$(DEBUG_TYPE),$(DEBUG_NODE)
 	@echo "Debug on node $(IOTLAB_DEBUG_NODE)"
 	$(Q)ssh -N -L $(IOTLAB_DEBUG_PORT):$(IOTLAB_DEBUG_NODE):3333 $(IOTLAB_AUTHORITY)
 
 iotlab-stop: $(IOTLAB_AUTH) iotlab-check-exp
-	$(Q)experiment-cli stop -i $(IOTLAB_EXP_ID)
+	$(Q)iotlab-experiment stop -i $(IOTLAB_EXP_ID)
 
 iotlab-term: iotlab-check-exp
-	$(Q)ssh -t $(IOTLAB_AUTHORITY) "test -f ~/.iotlabrc || auth-cli -u $(IOTLAB_USER)"
+	$(Q)ssh -t $(IOTLAB_AUTHORITY) "test -f ~/.iotlabrc || iotlab-auth -u $(IOTLAB_USER)"
 
 	$(Q)ssh -t $(IOTLAB_AUTHORITY) \
 	"tmux attach -t riot-$(IOTLAB_EXP_ID) || tmux new -s riot-$(IOTLAB_EXP_ID) \
@@ -81,4 +81,4 @@ iotlab-term: iotlab-check-exp
 	RIOT_LOG-$(IOTLAB_EXP_NAME)-$(IOTLAB_EXP_ID), \
 	serial_aggregator -i $(IOTLAB_EXP_ID) $(NODES_PARAM_BASE))'"
 
-iotlab-check-exp: IOTLAB_SITE ?= $(shell experiment-cli get -ri -i $(IOTLAB_EXP_ID) | sed -n 4p | cut -d\" -f2)
+iotlab-check-exp: IOTLAB_SITE ?= $(shell iotlab-experiment get -ri -i $(IOTLAB_EXP_ID) | sed -n 4p | cut -d\" -f2)

--- a/dist/testbed-support/README.iotlab.md
+++ b/dist/testbed-support/README.iotlab.md
@@ -39,7 +39,7 @@ brackets):
 
 ### Format of a Resource ID
 Both variables `IOTLAB_PHY_NODES` and `IOTLAB_EXCLUDE_NODES` use the resource id
-string format as specified in the output of `experiment-cli submit --help`.
+string format as specified in the output of `iotlab-experiment submit --help`.
 An example would be: 1-3+7+10-13
 
 ### Targets


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

While looking at #9011, I realized that `Makefile.iotlab` in `dist/testbed-support` was still using the old iotlabcli command names. The new tools are now called `iotlab-xx` and are deployed on all ssh frontends of iotlab.

By the way, if someone is still using them locally from his machine, they should be updated using pip:
```
pip install iotlabcli --upgrade
```

This PR is just replacing the old `xx-cli` command names with the new `iotlab-xx` (and avoids the deprecation warning displayed when using the old names)

This PR also removes `iotlab-auth` from the .PHONY list, since it seems useless.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->