### PR TITLE
tests/pkg_cayenne_lpp: fix inconsistent buffer values across architectures (native, boards)

### DIFF
--- a/tests/pkg_cayenne-lpp/main.c
+++ b/tests/pkg_cayenne-lpp/main.c
@@ -19,41 +19,90 @@
  */
 
 #include <stdio.h>
+#include <string.h>
 
 #include "cayenne_lpp.h"
 
+#define TEST_BUFFER1 { 0x03, 0x67, 0x01, 0x10, 0x05, 0x67, 0x00, 0xff }
+#ifdef BOARD_NATIVE
+#define TEST_BUFFER2 { 0x01, 0x67, 0xFF, 0xD8, \
+                       0x06, 0x71, 0x04, 0xD1, 0xFB, 0x2F, 0x00, 0x00 }
+#else
+#define TEST_BUFFER2 { 0x01, 0x67, 0xFF, 0xD7, \
+                       0x06, 0x71, 0x04, 0xD2, 0xFB, 0x2E, 0x00, 0x00 }
+#endif
+#define TEST_BUFFER3 { 0x01, 0x88, 0x06, 0x76, \
+                       0x5E, 0xF2, 0x96, 0x0A, 0x00, 0x03, 0xE8 }
+
 static cayenne_lpp_t lpp;
 
-static void _print_buffer(cayenne_lpp_t *lpp)
+static const uint8_t test_buffer1[] = TEST_BUFFER1;
+static const uint8_t test_buffer2[] = TEST_BUFFER2;
+static const uint8_t test_buffer3[] = TEST_BUFFER3;
+
+static void _print_buffer(const uint8_t *buffer, size_t len, const char *msg)
 {
-    for (uint8_t i = 0; i < lpp->cursor; ++i) {
-        printf("%02X", lpp->buffer[i]);
+    printf("%s: ", msg);
+    for (uint8_t i = 0; i < len; i++) {
+        printf("%02X", buffer[i]);
     }
-    puts("");
 }
 
 int main(void)
 {
-    puts("Cayenne LPP test application");
+    puts("Cayenne LPP test application\n");
 
     /* generate payload like the one given as example at
      * https://mydevices.com/cayenne/docs_stage/lora/#lora-cayenne-low-power-payload
      */
     /* Device with 2 temperature sensors */
+    puts("Test 1:");
+    puts("-------");
     cayenne_lpp_add_temperature(&lpp, 3, 27.2);
     cayenne_lpp_add_temperature(&lpp, 5, 25.5);
-    _print_buffer(&lpp);
+    _print_buffer(lpp.buffer, lpp.cursor, "Result");
+    /* check buffer */
+    if (memcmp(lpp.buffer, test_buffer1, lpp.cursor) != 0) {
+        puts("");
+        _print_buffer(test_buffer1, 2 * CAYENNE_LPP_TEMPERATURE_SIZE,
+                      "Expected");
+        puts(" FAILED");
+        return 1;
+    }
+    puts(" SUCCESS\n");
 
     /* Device with temperature and acceleration sensors */
+    puts("Test 2:");
+    puts("-------");
     cayenne_lpp_reset(&lpp);
     cayenne_lpp_add_temperature(&lpp, 1, -4.1);
     cayenne_lpp_add_accelerometer(&lpp, 6, 1.234, -1.234, 0);
-    _print_buffer(&lpp);
+    _print_buffer(lpp.buffer, lpp.cursor, "Result");
+    /* check buffer */
+    if (memcmp(lpp.buffer, test_buffer2, lpp.cursor) != 0) {
+        puts("");
+        _print_buffer(test_buffer2,
+                      CAYENNE_LPP_TEMPERATURE_SIZE + CAYENNE_LPP_ACCELEROMETER_SIZE,
+                      "Expected");
+        puts(" FAILED");
+        return 1;
+    }
+    puts(" SUCCESS\n");
 
     /* Device with GPS */
+    puts("Test 3:");
+    puts("-------");
     cayenne_lpp_reset(&lpp);
     cayenne_lpp_add_gps(&lpp, 1, 42.3519, -87.9094, 10);
-    _print_buffer(&lpp);
+    _print_buffer(lpp.buffer, lpp.cursor, "Result");
+    /* check buffer */
+    if (memcmp(lpp.buffer, test_buffer3, lpp.cursor) != 0) {
+        puts("");
+        _print_buffer(test_buffer3, CAYENNE_LPP_GPS_SIZE, "Expected");
+        puts(" FAILED");
+        return 1;
+    }
+    puts(" SUCCESS");
 
     return 0;
 }

--- a/tests/pkg_cayenne-lpp/tests/01-run.py
+++ b/tests/pkg_cayenne-lpp/tests/01-run.py
@@ -3,11 +3,13 @@
 import os
 import sys
 
+NB_TESTS = 3
+
 
 def testfunc(child):
-    child.expect_exact('03670110056700FF')
-    child.expect_exact('0167FFD8067104D1FB2F0000')
-    child.expect_exact('018806765EF2960A0003E8')
+    for test in range(NB_TESTS):
+        child.expect_exact('Test {}:'.format(test + 1))
+        child.expect('Result: [0-9A-Z]+ SUCCESS')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is an attempt to have a more robust output check with the pkg_cayenne-lpp test application.
I also don't think it's the goal of the test target to verify that the generated payload is valid.
But PRs on the [upstream project](https://github.com/aabadie/cayenne-lpp) are very welcome ;)

It should be useful with #9007.

I tested it on native and nucleo-l073, the ouput are sligthly different but the test target passes.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

#9007

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->