### PR TITLE
make/javascript: fix RIOTBASE

### DIFF
--- a/examples/javascript/Makefile
+++ b/examples/javascript/Makefile
@@ -4,6 +4,9 @@ APPLICATION = riot_javascript
 # default BOARD environment
 BOARD ?= native
 
+# This has to be the absolute path to the RIOT base directory:
+RIOTBASE ?= $(CURDIR)/../..
+
 BOARD_INSUFFICIENT_MEMORY := airfy-beacon b-l072z-lrwan1 bluepill calliope-mini \
                              cc2650-launchpad cc2650stk maple-mini \
                              microbit nrf51dongle nrf6310 nucleo-f030 nucleo-f070 \
@@ -30,7 +33,7 @@ endif
 # Add the package for Jerryscript
 USEPKG += jerryscript
 
-include $(CURDIR)/../../Makefile.include
+include $(RIOTBASE)/Makefile.include
 
 JS_PATH := $(BINDIR)/js/$(MODULE)
 # add directory of generated *.js.h files to include path


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
While running some experiments for the Rapstore I noticed the JS example doesn't receive the RIOTBASE param, so it's not possible to compile it from other locations. This PR adds RIOTBASE support, pointint by default to $(CURDIR)/../..

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references
None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->