### PR TITLE
sys/xtimer: tick conversion

### DIFF
--- a/sys/include/xtimer/tick_conversion.h
+++ b/sys/include/xtimer/tick_conversion.h
@@ -24,11 +24,8 @@
 #error "Do not include this file directly! Use xtimer.h instead"
 #endif
 
-#include <stdio.h>
-#include <string.h>
-
-#include "fmt.h"
 #include "div.h"
+#include "fmt.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/sys/include/xtimer/tick_conversion.h
+++ b/sys/include/xtimer/tick_conversion.h
@@ -205,11 +205,15 @@ static inline uint64_t _xtimer_usec_from_ticks64(uint64_t ticks) {
 #else
 /* No matching implementation found, try to give meaningful error messages */
 #if ((XTIMER_HZ % 15625) == 0)
-#error "Unsupported hardware timer frequency (XTIMER_HZ), missing XTIMER_SHIFT \
-in board.h? See xtimer.h documentation for more info"
+#error Unsupported hardware timer frequency (XTIMER_HZ).
+/* Xtimer is not correctly configured maybe missing XTIMER_SHIFT in board.h?
+ * See xtimer.h documentation for more information!
+ */
 #else
-#error "Unknown hardware timer frequency (XTIMER_HZ), check board.h and/or add \
-an implementation in sys/include/xtimer/tick_conversion.h"
+#error Unknown hardware timer frequency (XTIMER_HZ).
+/* Check board.h and/or add an implementation in
+ * sys/include/xtimer/tick_conversion.h to convert the hardware ticks
+ */
 #endif
 #endif
 

--- a/sys/include/xtimer/tick_conversion.h
+++ b/sys/include/xtimer/tick_conversion.h
@@ -13,8 +13,55 @@
  * @{
  * @file
  * @brief   xtimer tick <-> seconds conversions for different values of XTIMER_HZ
+ *
  * @author  Joakim Nohlgård <joakim.nohlgard@eistec.se>
+ * @author  Josua Arndt <jarndt@ias.rwth-aachen.de>
  */
+
+/*
+ * As tick_conversion.h is included in multiple files ENABLE_DEBUG can not be
+ * used as it gets redefined "[-Werror]"
+ * To use  the debug print enable module fmt in the project makefile
+ *
+ * USEMODULE += fmt
+ * CFLAGS += -DENABLE_DEBUG_TICKS=1
+ * */
+#ifndef ENABLE_DEBUG_TICKS
+#define ENABLE_DEBUG_TICKS   (0)
+#endif
+#if ENABLE_DEBUG_TICKS
+#ifndef MODULE_FMT
+#error "Module fmt is necessary to ENABLE_DEBUG_TICKS set 'USEMODULE += fmt' \
+in the makefile."
+#endif
+#include <stdio.h>
+#include <string.h>
+#include "fmt.h"
+#define DEBUG_PRINT_TICKS_32( CLOCK_HZ, EQUAL, VALUE1, VALUE2, BASE2) ({\
+char buf_1[21];                                                         \
+char buf_2[21];                                                         \
+size_t size = fmt_u32_dec(buf_1, VALUE1);                               \
+buf_1[size] = '\0';                                                     \
+size = fmt_u32_dec(buf_2, VALUE2);                                      \
+buf_2[size] = '\0';                                                     \
+printf("32bit %" PRIu32 " "EQUAL" 1MHz : %s "#VALUE1" = %s "BASE2"\n",  \
+       (uint32_t)CLOCK_HZ , buf_1, buf_2);                              \
+})
+
+#define DEBUG_PRINT_TICKS_64( CLOCK_HZ, EQUAL, VALUE1, VALUE2, BASE2) ({\
+char buf_1[21];                                                         \
+char buf_2[21];                                                         \
+size_t size = fmt_u64_dec(buf_1, VALUE1);                               \
+buf_1[size] = '\0';                                                     \
+size = fmt_u64_dec(buf_2, VALUE2);                                      \
+buf_2[size] = '\0';                                                     \
+printf("64bit %" PRIu32 " "EQUAL" 1MHz : %s "#VALUE1" = %s "BASE2"\n",  \
+       (uint32_t)CLOCK_HZ , buf_1, buf_2);                              \
+})
+#else
+#define DEBUG_PRINT_TICKS_32(CLOCK_HZ, EQUAL, VALUE1, VALUE2, BASE2) {}
+#define DEBUG_PRINT_TICKS_64(CLOCK_HZ, EQUAL, VALUE1, VALUE2, BASE2) {}
+#endif
 
 #ifndef XTIMER_TICK_CONVERSION_H
 #define XTIMER_TICK_CONVERSION_H
@@ -38,21 +85,25 @@ extern "C" {
 #if (XTIMER_HZ != (1000000ul << XTIMER_SHIFT))
 #error XTIMER_HZ != (1000000ul << XTIMER_SHIFT)
 #endif
-/* XTIMER_HZ is a power-of-two multiple of 1 MHz */
+/* XTIMER_HZ is a power-of-two multiple of 1 MHz and is bigger than 1000MHz */
 /* e.g. cc2538 uses a 16 MHz timer */
-static inline uint32_t _xtimer_ticks_from_usec(uint32_t usec) {
-    return (usec << XTIMER_SHIFT); /* multiply by power of two */
+static inline uint32_t _xtimer_ticks_from_usec(uint32_t us) {
+    DEBUG_PRINT_TICKS_32(XTIMER_HZ, ">", us, us << XTIMER_SHIFT, "ticks");
+    return (us << XTIMER_SHIFT); /* multiply by power of two */
 }
 
-static inline uint64_t _xtimer_ticks_from_usec64(uint64_t usec) {
-    return (usec << XTIMER_SHIFT); /* multiply by power of two */
+static inline uint64_t _xtimer_ticks_from_usec64(uint64_t us) {
+    DEBUG_PRINT_TICKS_64(XTIMER_HZ, ">", us, us << XTIMER_SHIFT, "ticks");
+    return (us << XTIMER_SHIFT); /* multiply by power of two */
 }
 
 static inline uint32_t _xtimer_usec_from_ticks(uint32_t ticks) {
+    DEBUG_PRINT_TICKS_32(XTIMER_HZ, ">", ticks, ticks >> XTIMER_SHIFT, "us");
     return (ticks >> XTIMER_SHIFT); /* divide by power of two */
 }
 
 static inline uint64_t _xtimer_usec_from_ticks64(uint64_t ticks) {
+    DEBUG_PRINT_TICKS_64(XTIMER_HZ, ">", ticks, ticks >> XTIMER_SHIFT, "us");
     return (ticks >> XTIMER_SHIFT); /* divide by power of two */
 }
 
@@ -60,67 +111,80 @@ static inline uint64_t _xtimer_usec_from_ticks64(uint64_t ticks) {
 #if ((XTIMER_HZ << XTIMER_SHIFT) != 1000000ul)
 #error (XTIMER_HZ << XTIMER_SHIFT) != 1000000ul
 #endif
-/* 1 MHz is a power-of-two multiple of XTIMER_HZ */
+/* 1 MHz is a power-of-two multiple of XTIMER_HZ and is smaller than 1000MHz */
 /* e.g. ATmega2560 uses a 250 kHz timer */
-static inline uint32_t _xtimer_ticks_from_usec(uint32_t usec) {
-    return (usec >> XTIMER_SHIFT); /* divide by power of two */
+static inline uint32_t _xtimer_ticks_from_usec(uint32_t us) {
+    DEBUG_PRINT_TICKS_32(XTIMER_HZ, "<", us, us >> XTIMER_SHIFT, "ticks");
+    return (us >> XTIMER_SHIFT); /* divide by power of two */
 }
 
-static inline uint64_t _xtimer_ticks_from_usec64(uint64_t usec) {
-    return (usec >> XTIMER_SHIFT); /* divide by power of two */
+static inline uint64_t _xtimer_ticks_from_usec64(uint64_t us) {
+    DEBUG_PRINT_TICKS_64(XTIMER_HZ, "<", us, us >> XTIMER_SHIFT, "ticks");
+    return (us >> XTIMER_SHIFT); /* divide by power of two */
 }
 
 static inline uint32_t _xtimer_usec_from_ticks(uint32_t ticks) {
+    DEBUG_PRINT_TICKS_32(XTIMER_HZ, "<", ticks, ticks << XTIMER_SHIFT, "us");
     return (ticks << XTIMER_SHIFT); /* multiply by power of two */
 }
 
 static inline uint64_t _xtimer_usec_from_ticks64(uint64_t ticks) {
+    DEBUG_PRINT_TICKS_64(XTIMER_HZ, "<", ticks, ticks << XTIMER_SHIFT, "us");
     return (ticks << XTIMER_SHIFT); /* multiply by power of two */
 }
 #endif /* defined(XTIMER_SHIFT) && (XTIMER_SHIFT != 0) */
 #elif XTIMER_HZ == (1000000ul)
 /* This is the most straightforward as the xtimer API is based around
  * microseconds for representing time values. */
+static inline uint32_t _xtimer_ticks_from_usec(uint32_t us) {
+    DEBUG_PRINT_TICKS_32(XTIMER_HZ, "=", us, us, "ticks");
+    return us; /* no-op */
+}
+
+static inline uint64_t _xtimer_ticks_from_usec64(uint64_t us) {
+    DEBUG_PRINT_TICKS_64(XTIMER_HZ, "=", us, us, "ticks");
+    return us; /* no-op */
+}
+
 static inline uint32_t _xtimer_usec_from_ticks(uint32_t ticks) {
+    DEBUG_PRINT_TICKS_32(XTIMER_HZ, "=", ticks, ticks, "us");
     return ticks; /* no-op */
 }
 
 static inline uint64_t _xtimer_usec_from_ticks64(uint64_t ticks) {
+    DEBUG_PRINT_TICKS_64(XTIMER_HZ, "=", ticks, ticks , "us");
     return ticks; /* no-op */
 }
-
-static inline uint32_t _xtimer_ticks_from_usec(uint32_t usec) {
-    return usec; /* no-op */
-}
-
-static inline uint64_t _xtimer_ticks_from_usec64(uint64_t usec) {
-    return usec; /* no-op */
-}
-
 #elif XTIMER_HZ == (32768ul)
 /* This is a common frequency for RTC crystals. We use the fact that the
  * greatest common divisor between 32768 and 1000000 is 64, so instead of
  * multiplying by the fraction (32768 / 1000000), we will instead use
  * (512 / 15625), which reduces the truncation caused by the integer widths */
-static inline uint32_t _xtimer_ticks_from_usec(uint32_t usec) {
-    return div_u32_by_15625div512(usec);
+static inline uint32_t _xtimer_ticks_from_usec(uint32_t us) {
+    DEBUG_PRINT_TICKS_32(XTIMER_HZ, "<", us, div_u64_by_15625div512(us),
+            "ticks");
+    return div_u32_by_15625div512(us);
 }
 
-static inline uint64_t _xtimer_ticks_from_usec64(uint64_t usec) {
-    return div_u64_by_15625div512(usec);
+static inline uint64_t _xtimer_ticks_from_usec64(uint64_t us) {
+    DEBUG_PRINT_TICKS_64(XTIMER_HZ, "<", us, div_u64_by_15625div512(us),
+            "ticks");
+    return div_u64_by_15625div512(us);
 }
 
 static inline uint32_t _xtimer_usec_from_ticks(uint32_t ticks) {
-    /* return (usec * 15625) / 512; */
+    /* return (us * 15625) / 512; */
     /* Using 64 bit multiplication to avoid truncating the top 9 bits */
-    uint64_t usec = (uint64_t)ticks * 15625ul;
-    return (usec >> 9); /* equivalent to (usec / 512) */
+    uint64_t us = (uint64_t)ticks * 15625ul;
+    DEBUG_PRINT_TICKS_32XTIMER_HZ, "<", ticks, (us >> 9) , "us");
+    return (us >> 9); /* equivalent to (us / 512) */
 }
 
 static inline uint64_t _xtimer_usec_from_ticks64(uint64_t ticks) {
-    /* return (usec * 15625) / 512; */
-    uint64_t usec = (uint64_t)ticks * 15625ul;
-    return (usec >> 9); /* equivalent to (usec / 512) */
+    /* return (us * 15625) / 512; */
+    uint64_t us = (uint64_t)ticks * 15625ul;
+    DEBUG_PRINT_TICKS_64(XTIMER_HZ, "<", ticks, (us >> 9) , "us");
+    return (us >> 9); /* equivalent to (us / 512) */
 }
 
 #else

--- a/sys/include/xtimer/tick_conversion.h
+++ b/sys/include/xtimer/tick_conversion.h
@@ -26,6 +26,7 @@
 
 #include <stdio.h>
 #include <string.h>
+
 #include "fmt.h"
 #include "div.h"
 
@@ -40,7 +41,7 @@ extern "C" {
  *
  * USEMODULE += fmt
  * CFLAGS += -DENABLE_DEBUG_PRINT_TICK_CONVERSION=1
- * */
+ */
 #ifndef ENABLE_DEBUG_PRINT_TICK_CONVERSION
 #define ENABLE_DEBUG_PRINT_TICK_CONVERSION   (0)
 #endif
@@ -48,15 +49,13 @@ extern "C" {
 #if ENABLE_DEBUG_PRINT_TICK_CONVERSION
 #ifndef MODULE_FMT
 #error Module fmt is necessary to ENABLE_DEBUG_TICKS
-/* Add module fmt to the makefile.
- * USEMODULE += fmt
- */
 #endif
 #endif
 
 inline void debug_print_ticks32(uint32_t clock_hz, char *sign, uint32_t from,
-                         char *base_from, uint32_t to,char *base_to) {
-    if(ENABLE_DEBUG_PRINT_TICK_CONVERSION){
+                                char *base_from, uint32_t to, char *base_to)
+{
+    if (ENABLE_DEBUG_PRINT_TICK_CONVERSION) {
         print_str("32bit ");
         print_u32_dec(clock_hz);
         print_str(" ");
@@ -74,8 +73,9 @@ inline void debug_print_ticks32(uint32_t clock_hz, char *sign, uint32_t from,
 }
 
 inline void debug_print_ticks64(uint32_t clock_hz, char *sign, uint64_t from,
-                         char *base_from, uint64_t to,char *base_to) {
-    if(ENABLE_DEBUG_PRINT_TICK_CONVERSION){
+                                char *base_from, uint64_t to, char *base_to)
+{
+    if (ENABLE_DEBUG_PRINT_TICK_CONVERSION) {
         print_str("64bit ");
         print_u32_dec(clock_hz);
         print_str(" ");
@@ -163,7 +163,6 @@ static inline uint64_t _xtimer_ticks_from_usec64(uint64_t us) {
 }
 
 static inline uint32_t _xtimer_usec_from_ticks(uint32_t ticks) {
-    DEBUG_PRINT_TICKS_32(XTIMER_HZ, "=", ticks, ticks, "us");
     debug_print_ticks32(XTIMER_HZ, "=", ticks, "ticks", ticks, "us");
     return ticks; /* no-op */
 }

--- a/sys/include/xtimer/tick_conversion.h
+++ b/sys/include/xtimer/tick_conversion.h
@@ -49,8 +49,8 @@ extern "C" {
 #endif
 #endif
 
-inline void debug_print_ticks(uint32_t clock_hz, char *sign, uint64_t from,
-                              char *base_from, uint64_t to, char *base_to)
+__attribute__((always_inline)) inline void debug_print_ticks(uint32_t clock_hz,
+        char *sign, uint64_t from, char *base_from, uint64_t to, char *base_to)
 {
     if (ENABLE_DEBUG_PRINT_TICK_CONVERSION) {
         print_str("64bit ");

--- a/sys/include/xtimer/tick_conversion.h
+++ b/sys/include/xtimer/tick_conversion.h
@@ -103,22 +103,26 @@ inline void debug_print_ticks64(uint32_t clock_hz, char *sign, uint64_t from,
 #endif
 /* XTIMER_HZ is a power-of-two multiple of 1 MHz and is bigger than 1MHz */
 /* e.g. cc2538 uses a 16 MHz timer */
-static inline uint32_t _xtimer_ticks_from_usec(uint32_t us) {
+static inline uint32_t _xtimer_ticks_from_usec(uint32_t us)
+{
     debug_print_ticks32(XTIMER_HZ, ">", us, "us", us >> XTIMER_SHIFT, "ticks");
     return (us << XTIMER_SHIFT); /* multiply by power of two */
 }
 
-static inline uint64_t _xtimer_ticks_from_usec64(uint64_t us) {
+static inline uint64_t _xtimer_ticks_from_usec64(uint64_t us)
+{
     debug_print_ticks64(XTIMER_HZ, ">", us, "us", us >> XTIMER_SHIFT, "ticks");
     return (us << XTIMER_SHIFT); /* multiply by power of two */
 }
 
-static inline uint32_t _xtimer_usec_from_ticks(uint32_t ticks) {
+static inline uint32_t _xtimer_usec_from_ticks(uint32_t ticks)
+{
     debug_print_ticks64(XTIMER_HZ, ">", ticks, "ticks", ticks >> XTIMER_SHIFT, "us");
     return (ticks >> XTIMER_SHIFT); /* divide by power of two */
 }
 
-static inline uint64_t _xtimer_usec_from_ticks64(uint64_t ticks) {
+static inline uint64_t _xtimer_usec_from_ticks64(uint64_t ticks)
+{
     debug_print_ticks64(XTIMER_HZ, ">", ticks, "ticks", ticks >> XTIMER_SHIFT, "us");
     return (ticks >> XTIMER_SHIFT); /* divide by power of two */
 }
@@ -129,22 +133,26 @@ static inline uint64_t _xtimer_usec_from_ticks64(uint64_t ticks) {
 #endif
 /* 1 MHz is a power-of-two multiple of XTIMER_HZ and is smaller than 1MHz */
 /* e.g. ATmega2560 uses a 250 kHz timer */
-static inline uint32_t _xtimer_ticks_from_usec(uint32_t us) {
+static inline uint32_t _xtimer_ticks_from_usec(uint32_t us)
+{
     debug_print_ticks32(XTIMER_HZ, "<", us, "us", us >> XTIMER_SHIFT, "ticks");
     return (us >> XTIMER_SHIFT); /* divide by power of two */
 }
 
-static inline uint64_t _xtimer_ticks_from_usec64(uint64_t us) {
+static inline uint64_t _xtimer_ticks_from_usec64(uint64_t us)
+{
     debug_print_ticks64(XTIMER_HZ, "<", us, "us", us >> XTIMER_SHIFT, "ticks");
     return (us >> XTIMER_SHIFT); /* divide by power of two */
 }
 
-static inline uint32_t _xtimer_usec_from_ticks(uint32_t ticks) {
+static inline uint32_t _xtimer_usec_from_ticks(uint32_t ticks)
+{
     debug_print_ticks32(XTIMER_HZ, "<", ticks, "ticks", ticks << XTIMER_SHIFT, "us");
     return (ticks << XTIMER_SHIFT); /* multiply by power of two */
 }
 
-static inline uint64_t _xtimer_usec_from_ticks64(uint64_t ticks) {
+static inline uint64_t _xtimer_usec_from_ticks64(uint64_t ticks)
+{
     debug_print_ticks64(XTIMER_HZ, "<", ticks, "ticks", ticks << XTIMER_SHIFT, "us");
     return (ticks << XTIMER_SHIFT); /* multiply by power of two */
 }
@@ -152,22 +160,26 @@ static inline uint64_t _xtimer_usec_from_ticks64(uint64_t ticks) {
 #elif XTIMER_HZ == (1000000ul)
 /* This is the most straightforward as the xtimer API is based around
  * microseconds for representing time values. */
-static inline uint32_t _xtimer_ticks_from_usec(uint32_t us) {
+static inline uint32_t _xtimer_ticks_from_usec(uint32_t us)
+{
     debug_print_ticks32(XTIMER_HZ, "=", us, "us", us, "ticks");
     return us; /* no-op */
 }
 
-static inline uint64_t _xtimer_ticks_from_usec64(uint64_t us) {
+static inline uint64_t _xtimer_ticks_from_usec64(uint64_t us)
+{
     debug_print_ticks64(XTIMER_HZ, "=", us, "us", us, "ticks");
     return us; /* no-op */
 }
 
-static inline uint32_t _xtimer_usec_from_ticks(uint32_t ticks) {
+static inline uint32_t _xtimer_usec_from_ticks(uint32_t ticks)
+{
     debug_print_ticks32(XTIMER_HZ, "=", ticks, "ticks", ticks, "us");
     return ticks; /* no-op */
 }
 
-static inline uint64_t _xtimer_usec_from_ticks64(uint64_t ticks) {
+static inline uint64_t _xtimer_usec_from_ticks64(uint64_t ticks)
+{
     debug_print_ticks32(XTIMER_HZ, "=", ticks, "ticks", ticks, "us");
     return ticks; /* no-op */
 }
@@ -176,27 +188,33 @@ static inline uint64_t _xtimer_usec_from_ticks64(uint64_t ticks) {
  * greatest common divisor between 32768 and 1000000 is 64, so instead of
  * multiplying by the fraction (32768 / 1000000), we will instead use
  * (512 / 15625), which reduces the truncation caused by the integer widths */
-static inline uint32_t _xtimer_ticks_from_usec(uint32_t us) {
+static inline uint32_t _xtimer_ticks_from_usec(uint32_t us)
+{
     debug_print_ticks32(XTIMER_HZ, "<", us, "us", div_u64_by_15625div512(us), "ticks");
     return div_u32_by_15625div512(us);
 }
 
-static inline uint64_t _xtimer_ticks_from_usec64(uint64_t us) {
+static inline uint64_t _xtimer_ticks_from_usec64(uint64_t us)
+{
     debug_print_ticks64(XTIMER_HZ, "<", us, "us", div_u64_by_15625div512(us), "ticks");
     return div_u64_by_15625div512(us);
 }
 
-static inline uint32_t _xtimer_usec_from_ticks(uint32_t ticks) {
+static inline uint32_t _xtimer_usec_from_ticks(uint32_t ticks)
+{
     /* return (us * 15625) / 512; */
     /* Using 64 bit multiplication to avoid truncating the top 9 bits */
     uint64_t us = (uint64_t)ticks * 15625ul;
+
     debug_print_ticks32(XTIMER_HZ, "<", ticks, "ticks", (us >> 9), "us");
     return (us >> 9); /* equivalent to (us / 512) */
 }
 
-static inline uint64_t _xtimer_usec_from_ticks64(uint64_t ticks) {
+static inline uint64_t _xtimer_usec_from_ticks64(uint64_t ticks)
+{
     /* return (us * 15625) / 512; */
     uint64_t us = (uint64_t)ticks * 15625ul;
+
     debug_print_ticks32(XTIMER_HZ, "<", ticks, "ticks", (us >> 9), "us");
     return (us >> 9); /* equivalent to (us / 512) */
 }

--- a/sys/include/xtimer/tick_conversion.h
+++ b/sys/include/xtimer/tick_conversion.h
@@ -55,23 +55,52 @@ in the makefile."
 inline void debug_print_ticks32(uint32_t clock_hz, char *sign, uint32_t from,
                          char *base_from, uint32_t to,char *base_to) {
     if(ENABLE_DEBUG_PRINT_TICK_CONVERSION){
-        printf("32bit %" PRIu32 " %s 1MHz : %" PRIu32 " %s = %" PRIu32 " %s\n",
-        clock_hz , sign, from, base_from, to, base_to);
+        // printf("32bit %" PRIu32 " %s 1MHz : %" PRIu32 " %s = %" PRIu32 " %s\n",
+        // clock_hz , sign, from, base_from, to, base_to);
+        
+        print_str("32bit ");
+        print_u32_dec(clock_hz);
+        print_str(" ");
+        print_str(sign);
+        print_str(" 1MHz : ");
+        print_u32_dec(from);
+        print_str(" ");
+        print_str(base_from);
+        print_str(" = ");
+        print_u32_dec(to);
+        print_str(" ");
+        print_str(base_to);
+        print_str("\n");
     }
 }
 
-inline void debug_print_ticks64(uint32_t clock_hz, char *sign, uint32_t from,
-                         char *base_from, uint32_t to,char *base_to) {
+inline void debug_print_ticks64(uint32_t clock_hz, char *sign, uint64_t from,
+                         char *base_from, uint64_t to,char *base_to) {
     if(ENABLE_DEBUG_PRINT_TICK_CONVERSION){
-        char buf_from[21];
-        char buf_to[21];
-        size_t size = fmt_u64_dec(buf_from, from);
-        buf_from[size] = '\0';
-        size = fmt_u64_dec(buf_to, to);
-        buf_to[size] = '\0';
+        // char buf[21];
+        // size_t size = fmt_u64_dec(buf, from);
+        // buf[size] = '\0';
 
-        printf("64bit %" PRIu32 " %s 1MHz : %s %s = %s %s\n",
-            clock_hz , sign, buf_from, base_from, buf_to, base_to);
+        // printf("64bit %" PRIu32 " %s 1MHz : %s %s",
+        //     clock_hz , sign, buf, base_from);
+
+        // size = fmt_u64_dec(buf, to);
+        // buf[size] = '\0';
+        // printf(" = %s %s\n",buf, base_to);
+
+        print_str("64bit ");
+        print_u32_dec(clock_hz);
+        print_str(" ");
+        print_str(sign);
+        print_str(" 1MHz : ");
+        print_u64_dec(from);
+        print_str(" ");
+        print_str(base_from);
+        print_str(" = ");
+        print_u64_dec(to);
+        print_str(" ");
+        print_str(base_to);
+        print_str("\n");
     }
 }
 

--- a/sys/include/xtimer/tick_conversion.h
+++ b/sys/include/xtimer/tick_conversion.h
@@ -52,28 +52,8 @@ extern "C" {
 #endif
 #endif
 
-inline void debug_print_ticks32(uint32_t clock_hz, char *sign, uint32_t from,
-                                char *base_from, uint32_t to, char *base_to)
-{
-    if (ENABLE_DEBUG_PRINT_TICK_CONVERSION) {
-        print_str("32bit ");
-        print_u32_dec(clock_hz);
-        print_str(" ");
-        print_str(sign);
-        print_str(" 1MHz : ");
-        print_u32_dec(from);
-        print_str(" ");
-        print_str(base_from);
-        print_str(" = ");
-        print_u32_dec(to);
-        print_str(" ");
-        print_str(base_to);
-        print_str("\n");
-    }
-}
-
-inline void debug_print_ticks64(uint32_t clock_hz, char *sign, uint64_t from,
-                                char *base_from, uint64_t to, char *base_to)
+inline void debug_print_ticks(uint32_t clock_hz, char *sign, uint64_t from,
+                              char *base_from, uint64_t to, char *base_to)
 {
     if (ENABLE_DEBUG_PRINT_TICK_CONVERSION) {
         print_str("64bit ");
@@ -105,25 +85,27 @@ inline void debug_print_ticks64(uint32_t clock_hz, char *sign, uint64_t from,
 /* e.g. cc2538 uses a 16 MHz timer */
 static inline uint32_t _xtimer_ticks_from_usec(uint32_t us)
 {
-    debug_print_ticks32(XTIMER_HZ, ">", us, "us", us >> XTIMER_SHIFT, "ticks");
+    debug_print_ticks(XTIMER_HZ, ">", (uint64_t)us, "us",
+                      (uint64_t)(us >> XTIMER_SHIFT), "ticks");
     return (us << XTIMER_SHIFT); /* multiply by power of two */
 }
 
 static inline uint64_t _xtimer_ticks_from_usec64(uint64_t us)
 {
-    debug_print_ticks64(XTIMER_HZ, ">", us, "us", us >> XTIMER_SHIFT, "ticks");
+    debug_print_ticks(XTIMER_HZ, ">", us, "us", us >> XTIMER_SHIFT, "ticks");
     return (us << XTIMER_SHIFT); /* multiply by power of two */
 }
 
 static inline uint32_t _xtimer_usec_from_ticks(uint32_t ticks)
 {
-    debug_print_ticks64(XTIMER_HZ, ">", ticks, "ticks", ticks >> XTIMER_SHIFT, "us");
+    debug_print_ticks(XTIMER_HZ, ">", (uint64_t)ticks, "ticks",
+                      (uint64_t)(ticks >> XTIMER_SHIFT), "us");
     return (ticks >> XTIMER_SHIFT); /* divide by power of two */
 }
 
 static inline uint64_t _xtimer_usec_from_ticks64(uint64_t ticks)
 {
-    debug_print_ticks64(XTIMER_HZ, ">", ticks, "ticks", ticks >> XTIMER_SHIFT, "us");
+    debug_print_ticks(XTIMER_HZ, ">", ticks, "ticks", ticks >> XTIMER_SHIFT, "us");
     return (ticks >> XTIMER_SHIFT); /* divide by power of two */
 }
 
@@ -135,25 +117,27 @@ static inline uint64_t _xtimer_usec_from_ticks64(uint64_t ticks)
 /* e.g. ATmega2560 uses a 250 kHz timer */
 static inline uint32_t _xtimer_ticks_from_usec(uint32_t us)
 {
-    debug_print_ticks32(XTIMER_HZ, "<", us, "us", us >> XTIMER_SHIFT, "ticks");
+    debug_print_ticks(XTIMER_HZ, "<", (uint64_t)us, "us",
+                      (uint64_t)(us >> XTIMER_SHIFT), "ticks");
     return (us >> XTIMER_SHIFT); /* divide by power of two */
 }
 
 static inline uint64_t _xtimer_ticks_from_usec64(uint64_t us)
 {
-    debug_print_ticks64(XTIMER_HZ, "<", us, "us", us >> XTIMER_SHIFT, "ticks");
+    debug_print_ticks(XTIMER_HZ, "<", us, "us", us >> XTIMER_SHIFT, "ticks");
     return (us >> XTIMER_SHIFT); /* divide by power of two */
 }
 
 static inline uint32_t _xtimer_usec_from_ticks(uint32_t ticks)
 {
-    debug_print_ticks32(XTIMER_HZ, "<", ticks, "ticks", ticks << XTIMER_SHIFT, "us");
+    debug_print_ticks(XTIMER_HZ, "<", (uint64_t)ticks, "ticks",
+                      (uint64_t)(ticks << XTIMER_SHIFT), "us");
     return (ticks << XTIMER_SHIFT); /* multiply by power of two */
 }
 
 static inline uint64_t _xtimer_usec_from_ticks64(uint64_t ticks)
 {
-    debug_print_ticks64(XTIMER_HZ, "<", ticks, "ticks", ticks << XTIMER_SHIFT, "us");
+    debug_print_ticks(XTIMER_HZ, "<", ticks, "ticks", ticks << XTIMER_SHIFT, "us");
     return (ticks << XTIMER_SHIFT); /* multiply by power of two */
 }
 #endif /* defined(XTIMER_SHIFT) && (XTIMER_SHIFT != 0) */
@@ -162,25 +146,25 @@ static inline uint64_t _xtimer_usec_from_ticks64(uint64_t ticks)
  * microseconds for representing time values. */
 static inline uint32_t _xtimer_ticks_from_usec(uint32_t us)
 {
-    debug_print_ticks32(XTIMER_HZ, "=", us, "us", us, "ticks");
+    debug_print_ticks(XTIMER_HZ, "=", (uint64_t)us, "us", (uint64_t)us, "ticks");
     return us; /* no-op */
 }
 
 static inline uint64_t _xtimer_ticks_from_usec64(uint64_t us)
 {
-    debug_print_ticks64(XTIMER_HZ, "=", us, "us", us, "ticks");
+    debug_print_ticks(XTIMER_HZ, "=", us, "us", us, "ticks");
     return us; /* no-op */
 }
 
 static inline uint32_t _xtimer_usec_from_ticks(uint32_t ticks)
 {
-    debug_print_ticks32(XTIMER_HZ, "=", ticks, "ticks", ticks, "us");
+    debug_print_ticks(XTIMER_HZ, "=", (uint64_t)ticks, "ticks", (uint64_t)ticks, "us");
     return ticks; /* no-op */
 }
 
 static inline uint64_t _xtimer_usec_from_ticks64(uint64_t ticks)
 {
-    debug_print_ticks32(XTIMER_HZ, "=", ticks, "ticks", ticks, "us");
+    debug_print_ticks(XTIMER_HZ, "=", ticks, "ticks", ticks, "us");
     return ticks; /* no-op */
 }
 #elif XTIMER_HZ == (32768ul)
@@ -190,13 +174,14 @@ static inline uint64_t _xtimer_usec_from_ticks64(uint64_t ticks)
  * (512 / 15625), which reduces the truncation caused by the integer widths */
 static inline uint32_t _xtimer_ticks_from_usec(uint32_t us)
 {
-    debug_print_ticks32(XTIMER_HZ, "<", us, "us", div_u64_by_15625div512(us), "ticks");
+    debug_print_ticks(XTIMER_HZ, "<", (uint64_t)us, "us",
+                      (uint64_t)div_u64_by_15625div512(us), "ticks");
     return div_u32_by_15625div512(us);
 }
 
 static inline uint64_t _xtimer_ticks_from_usec64(uint64_t us)
 {
-    debug_print_ticks64(XTIMER_HZ, "<", us, "us", div_u64_by_15625div512(us), "ticks");
+    debug_print_ticks(XTIMER_HZ, "<", us, "us", div_u64_by_15625div512(us), "ticks");
     return div_u64_by_15625div512(us);
 }
 
@@ -206,7 +191,8 @@ static inline uint32_t _xtimer_usec_from_ticks(uint32_t ticks)
     /* Using 64 bit multiplication to avoid truncating the top 9 bits */
     uint64_t us = (uint64_t)ticks * 15625ul;
 
-    debug_print_ticks32(XTIMER_HZ, "<", ticks, "ticks", (us >> 9), "us");
+    debug_print_ticks(XTIMER_HZ, "<", (uint64_t)ticks, "ticks",
+                      (uint64_t)(us >> 9), "us");
     return (us >> 9); /* equivalent to (us / 512) */
 }
 
@@ -215,7 +201,7 @@ static inline uint64_t _xtimer_usec_from_ticks64(uint64_t ticks)
     /* return (us * 15625) / 512; */
     uint64_t us = (uint64_t)ticks * 15625ul;
 
-    debug_print_ticks32(XTIMER_HZ, "<", ticks, "ticks", (us >> 9), "us");
+    debug_print_ticks(XTIMER_HZ, "<", ticks, "ticks", (us >> 9), "us");
     return (us >> 9); /* equivalent to (us / 512) */
 }
 

--- a/sys/include/xtimer/tick_conversion.h
+++ b/sys/include/xtimer/tick_conversion.h
@@ -47,17 +47,16 @@ extern "C" {
 
 #if ENABLE_DEBUG_PRINT_TICK_CONVERSION
 #ifndef MODULE_FMT
-#error "Module fmt is necessary to ENABLE_DEBUG_TICKS set 'USEMODULE += fmt' \
-in the makefile."
+#error Module fmt is necessary to ENABLE_DEBUG_TICKS
+/* Add module fmt to the makefile.
+ * USEMODULE += fmt
+ */
 #endif
 #endif
 
 inline void debug_print_ticks32(uint32_t clock_hz, char *sign, uint32_t from,
                          char *base_from, uint32_t to,char *base_to) {
     if(ENABLE_DEBUG_PRINT_TICK_CONVERSION){
-        // printf("32bit %" PRIu32 " %s 1MHz : %" PRIu32 " %s = %" PRIu32 " %s\n",
-        // clock_hz , sign, from, base_from, to, base_to);
-        
         print_str("32bit ");
         print_u32_dec(clock_hz);
         print_str(" ");
@@ -77,17 +76,6 @@ inline void debug_print_ticks32(uint32_t clock_hz, char *sign, uint32_t from,
 inline void debug_print_ticks64(uint32_t clock_hz, char *sign, uint64_t from,
                          char *base_from, uint64_t to,char *base_to) {
     if(ENABLE_DEBUG_PRINT_TICK_CONVERSION){
-        // char buf[21];
-        // size_t size = fmt_u64_dec(buf, from);
-        // buf[size] = '\0';
-
-        // printf("64bit %" PRIu32 " %s 1MHz : %s %s",
-        //     clock_hz , sign, buf, base_from);
-
-        // size = fmt_u64_dec(buf, to);
-        // buf[size] = '\0';
-        // printf(" = %s %s\n",buf, base_to);
-
         print_str("64bit ");
         print_u32_dec(clock_hz);
         print_str(" ");

--- a/sys/include/xtimer/tick_conversion.h
+++ b/sys/include/xtimer/tick_conversion.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2016 Eistec AB
+ *               2018 Josua Arndt
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -125,9 +126,11 @@ static inline uint64_t _xtimer_usec_from_ticks64(uint64_t ticks) {
 #else
 /* No matching implementation found, try to give meaningful error messages */
 #if ((XTIMER_HZ % 15625) == 0)
-#error Unsupported hardware timer frequency (XTIMER_HZ), missing XTIMER_SHIFT in board.h? See xtimer.h documentation for more info
+#error "Unsupported hardware timer frequency (XTIMER_HZ), missing XTIMER_SHIFT \
+in board.h? See xtimer.h documentation for more info"
 #else
-#error Unknown hardware timer frequency (XTIMER_HZ), check board.h and/or add an implementation in sys/include/xtimer/tick_conversion.h
+#error "Unknown hardware timer frequency (XTIMER_HZ), check board.h and/or add \
+an implementation in sys/include/xtimer/tick_conversion.h"
 #endif
 #endif
 


### PR DESCRIPTION
This PR adds a debug print to the xtimer conversion, this enables a better debuging of time conversion related problems.

The messages are as follows.
```
32bit 125000 < 1MHz : 239307 ticks = 1914456 us
32bit 125000 < 1MHz : 10000 us = 1250 ticks
```` 