### PR TITLE
make: add (optional) SIZEFLAGS variable

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -362,7 +362,7 @@ $(_SUBMAKE_LIBS): $(BINDIR)/$(APPLICATION_MODULE).a $(USEPKG:%=$(BINDIR)/%.a)
 
 # 'print-size' triggers a rebuild. Use 'info-buildsize' if you do not need to rebuild.
 print-size: $(ELFFILE)
-	$(Q)$(SIZE) $<
+	$(Q)$(SIZE) $(SIZEFLAGS) $<
 
 %.hex: %.elf
 	$(Q)$(OBJCOPY) $(OFLAGS) -Oihex $< $@

--- a/makefiles/vars.inc.mk
+++ b/makefiles/vars.inc.mk
@@ -55,6 +55,7 @@ export OFLAGS                # The parameter for OBJCOPY, e.g. to strip the debu
 export OBJDUMP               # The command used to create the assembly listing.
 export OBJDUMPFLAGS          # The parameter for OBJDUMP.
 export SIZE                  # The command to read to size of the ELF sections.
+export SIZEFLAGS             # The optional size flags.
 export UNDEF                 # Object files that the linker must include in the ELFFILE even if no call to the functions or symbols (ex: interrupt vectors).
 export WERROR                # Treat all compiler warnings as errors if set to 1 (see -Werror flag in GCC manual)
 


### PR DESCRIPTION
This PR adds the possibility to use sizeflags.

this can be used to produce formated output like 

```
AVR Memory Usage
----------------
Device: atmega256rfr2

Program:   10302 bytes (3.9% Full)
(.text + .data + .bootloader)

Data:       1496 bytes (4.6% Full)
(.data + .bss + .noinit)
```

```
/tests_xtimer_usleep.elf  :
section                      size      addr
.data                         518   8389120
.text                        9784         0
.bss                          976   8389638
.noinit                         2   8390614
.comment                       92         0
.note.gnu.avr.deviceinfo       64         0
.debug_aranges               1472         0
.debug_info                 35340         0
.debug_abbrev               15895         0
.debug_line                 33168         0
.debug_frame                 5152         0
.debug_str                  79889         0
.debug_loc                  22320         0
.debug_ranges                1392         0
.debug_macro                94936         0
Total                      301000
```

```
  text	   data	    bss	    dec	    hex	filename
   9784	    518	    978	  11280	   2c10	/tests_xtimer_usleep.elf
```
