### PR TITLE
tests/bloom_bytes: increase timeout for wsn430

### DIFF
--- a/tests/bloom_bytes/tests/01-run.py
+++ b/tests/bloom_bytes/tests/01-run.py
@@ -10,11 +10,15 @@ import os
 import sys
 
 
+# Biggest step takes 135 seconds on wn430
+TIMEOUT = 150
+
+
 def testfunc(child):
     child.expect_exact("Testing Bloom filter.")
     child.expect_exact("m: 4096 k: 8")
-    child.expect("adding 512 elements took \d+ms")
-    child.expect("checking 10000 elements took \d+ms")
+    child.expect("adding 512 elements took \d+ms", timeout=TIMEOUT)
+    child.expect("checking 10000 elements took \d+ms", timeout=TIMEOUT)
     child.expect("\d+ elements probably in the filter.")
     child.expect("\d+ elements not in the filter.")
     child.expect(".+ false positive rate.")


### PR DESCRIPTION
### Contribution description

Fix bloom_bytes test on wsn430 failing because of timeout too small.

Test output:

    adding 512 elements took 10243ms
    checking 10000 elements took 134720ms

I also re-run tests on arduino-uno and arduino-mega2560 to verify the timeout is ok.

### Issues/PRs references

Tests for the release.