### PR TITLE
tests/mutex_unlock_and_sleep: increase timeout

### DIFF
--- a/tests/mutex_unlock_and_sleep/main.c
+++ b/tests/mutex_unlock_and_sleep/main.c
@@ -27,7 +27,11 @@ static volatile int indicator;
 static kernel_pid_t main_pid;
 static char stack[THREAD_STACKSIZE_DEFAULT];
 
+#ifdef BOARD_NATIVE
 static const unsigned KITERATIONS = 100;
+#else
+static const unsigned KITERATIONS = 10;
+#endif
 
 static void *second_thread(void *arg)
 {

--- a/tests/mutex_unlock_and_sleep/main.c
+++ b/tests/mutex_unlock_and_sleep/main.c
@@ -27,6 +27,8 @@ static volatile int indicator;
 static kernel_pid_t main_pid;
 static char stack[THREAD_STACKSIZE_DEFAULT];
 
+static const unsigned KITERATIONS = 100;
+
 static void *second_thread(void *arg)
 {
     (void) arg;
@@ -42,6 +44,7 @@ static void *second_thread(void *arg)
 int main(void)
 {
     uint32_t count = 0;
+    uint32_t kcount = 0;
 
     indicator = 0;
     main_pid = thread_getpid();
@@ -64,8 +67,10 @@ int main(void)
             printf("[ERROR] threads did not sleep properly (%d).\n", indicator);
             return 1;
         }
-        if ((count % 100000) == 0) {
-            printf("[ALIVE] alternated %"PRIu32"k times.\n", (count / 1000));
+        if (count == (KITERATIONS * 1000)) {
+            count = 0;
+            kcount += KITERATIONS;
+            printf("[ALIVE] alternated %"PRIu32"k times.\n", kcount);
         }
         mutex_unlock_and_sleep(&mutex);
     }

--- a/tests/mutex_unlock_and_sleep/tests/01-run.py
+++ b/tests/mutex_unlock_and_sleep/tests/01-run.py
@@ -11,7 +11,7 @@ import sys
 
 
 def testfunc(child):
-    for i in range(20):
+    for i in range(10):
         child.expect(r"\[ALIVE\] alternated \d+k times.")
 
 


### PR DESCRIPTION
### Contribution description

Fix test on wsn430 failing because of timeout too small.
In total, the test takes **10 minutes** on wsn430-v1_4.

I also re-run the beginning of the tests on arduino-uno and arduino-mega2560 to verify the timeout is ok (it take ~20seconds on them).

### Alternative

Another solution, could be to not do 100k iterations but only 10k.
I do not know if there is a reason for such a high number ?

I could remove the increased timeout if 10k is enough.

### Issues/PRs references

Tests for the release.