### PR TITLE
tests/pkg_tiny-asn1: blacklist wsn430 boards

### DIFF
--- a/tests/pkg_tiny-asn1/Makefile
+++ b/tests/pkg_tiny-asn1/Makefile
@@ -1,5 +1,7 @@
 include ../Makefile.tests_common
 
+BOARD_BLACKLIST := wsn430-v1_3b wsn430-v1_4
+
 USEPKG += tiny-asn1
 
 TEST_ON_CI_WHITELIST += all


### PR DESCRIPTION
### Contribution description

Boards do not have enough memory to `malloc` for the test

    ERROR: Could not allocate the memory for the ASN.1 objects

### Issues/PRs references

Release testing.