### PR TITLE
tests/pkg_micro-ecc: blacklist wsn430 boards

### DIFF
--- a/tests/pkg_micro-ecc/Makefile
+++ b/tests/pkg_micro-ecc/Makefile
@@ -2,6 +2,9 @@ include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno
 
+# micro-ecc is not 16 bit compatible
+BOARD_BLACKLIST = chronos msb-430 msb-430h telosb wsn430-v1_3b wsn430-v1_4 z1
+
 USEMODULE += hashes
 USEPKG += micro-ecc
 


### PR DESCRIPTION
### Contribution description

Test breaks on wsn430 boards with the node rebooting.

I suspect because `micro-ecc` does not have 16b support.
If that is the reason other 16bit boards may also be added there.

 * https://github.com/kmackay/micro-ecc/issues/96

### Issues/PRs references

Release testing.