### PR TITLE
tests/xtimer_usleep_short: add expected runtime

### DIFF
--- a/tests/xtimer_usleep_short/main.c
+++ b/tests/xtimer_usleep_short/main.c
@@ -22,16 +22,24 @@
 #define TEST_USLEEP_MIN (0)
 #define TEST_USLEEP_MAX (500)
 
+#define TEST_TIME (125250)
+
 int main(void)
 {
     xtimer_sleep(3);
     printf("This test will call xtimer_usleep for values from %d down to %d\n",
             TEST_USLEEP_MAX, TEST_USLEEP_MIN);
 
+    uint32_t start, sleeping_time=0;
+
     for (int i = TEST_USLEEP_MAX; i >= TEST_USLEEP_MIN; i--) {
         printf("going to sleep %d usecs...\n", i);
+        start = xtimer_now_usec();
         xtimer_usleep(i);
+        sleeping_time += xtimer_now_usec() - start;
     }
+
+    printf("Slept for %" PRIu32 " expected %" PRIu32"\n", sleeping_time, TEST_TIME);
 
     puts("[SUCCESS]");
 

--- a/tests/xtimer_usleep_short/main.c
+++ b/tests/xtimer_usleep_short/main.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2017 HAW-Hamburg
+ *               2018 Josua Arndt
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -14,6 +15,7 @@
  * @brief       xtimer_usleep_short test application
  *
  * @author      Michel Rottleuthner <michel.rottleuthner@haw-hamburg.de>
+ * @author      Josua Arndt <jarndt@ias.rwth-aachen.de>
  * @}
  */
 #include <stdio.h>
@@ -32,39 +34,41 @@
 int main(void)
 {
     xtimer_sleep(3);
-    printf("This test will call xtimer_usleep for values from %d down to %d\n",
+    printf("This test will call xtimer_usleep for values from %d us down to %d us.\n",
            TEST_USLEEP_MAX, TEST_USLEEP_MIN);
 
-    printf("Expected delay margin is %d us\n",
+    printf("Expected delay margin is %d us.\n",
            TEST_XTIMER_USLEEP_SHORT_SLEEP_MARGIN_US);
 
     uint32_t test_time = 0, sleeping_time = 0, margin_fault = 0;
 
     for (int i = TEST_USLEEP_MAX; i >= TEST_USLEEP_MIN; i--) {
-        printf("going to sleep %d us\n", i);
+
         uint32_t start = xtimer_now_usec();
         xtimer_usleep(i);
         uint32_t slept = xtimer_now_usec() - start;
-        printf("Slept for      %" PRIu32 " us\n", slept);
 
-        if (slept < (unsigned int)i) {
-            puts("Timeout to short");
+        if (slept < (unsigned int)i || 
+            slept > (unsigned int)i + TEST_XTIMER_USLEEP_SHORT_SLEEP_MARGIN_US) {
+            printf("ERROR: Slept for %" PRIu32 " us not in range [%d, %d] us.\n",
+                   slept, i, i + TEST_XTIMER_USLEEP_SHORT_SLEEP_MARGIN_US);
             ++margin_fault;
         }
-        else if (slept > (unsigned int)i + TEST_XTIMER_USLEEP_SHORT_SLEEP_MARGIN_US) {
-            puts("Timeout longer than expected margin.");
-            ++margin_fault;
+        else {
+            printf("OK: Slept for %" PRIu32 " us not in range [%d, %d] us.\n",
+                   slept, i, i + TEST_XTIMER_USLEEP_SHORT_SLEEP_MARGIN_US);
         }
 
         sleeping_time += slept;
         test_time += i;
     }
 
-    printf("Slept for %" PRIu32 " us expected %" PRIu32 " us\n",
+    printf("Slept for %" PRIu32 " us expected %" PRIu32 " us.\n",
            sleeping_time, test_time);
 
     if (margin_fault != 0) {
-        printf("Sleep delay margin was not kept for %" PRIu32 " times\n", margin_fault);
+        printf("Sleep delay margin was not kept for %" PRIu32 " times.\n",
+                margin_fault);
         puts("[FAILED]");
         return 1;
     }

--- a/tests/xtimer_usleep_short/main.c
+++ b/tests/xtimer_usleep_short/main.c
@@ -28,9 +28,9 @@ int main(void)
 {
     xtimer_sleep(3);
     printf("This test will call xtimer_usleep for values from %d down to %d\n",
-            TEST_USLEEP_MAX, TEST_USLEEP_MIN);
+           TEST_USLEEP_MAX, TEST_USLEEP_MIN);
 
-    uint32_t start, sleeping_time=0;
+    uint32_t start, sleeping_time = 0;
 
     for (int i = TEST_USLEEP_MAX; i >= TEST_USLEEP_MIN; i--) {
         printf("going to sleep %d usecs...\n", i);
@@ -39,9 +39,18 @@ int main(void)
         sleeping_time += xtimer_now_usec() - start;
     }
 
-    printf("Slept for %" PRIu32 " expected %" PRIu32"\n", sleeping_time, TEST_TIME);
+    printf("Slept for %" PRIu32 " expected %" PRIu32 "\n",
+           sleeping_time, (uint32_t)TEST_TIME);
 
-    puts("[SUCCESS]");
+    if ((sleeping_time < ((uint32_t)TEST_TIME)*9/10)
+        || (sleeping_time > ((uint32_t)TEST_TIME) * 11/10)) {
+        printf("Sleep time is not in 10%% range %" PRIu32 " < %" PRIu32 " < %" PRIu32 "\n",
+               ((uint32_t)(TEST_TIME)*9/10), ((uint32_t)TEST_TIME), ((uint32_t)(TEST_TIME)*11/10) );
+        puts("[FAILED]");
+    }
+    else {
+        puts("[SUCCESS]");
+    }
 
     return 0;
 }

--- a/tests/xtimer_usleep_short/main.c
+++ b/tests/xtimer_usleep_short/main.c
@@ -28,13 +28,13 @@ int main(void)
     printf("This test will call xtimer_usleep for values from %d down to %d\n",
            TEST_USLEEP_MAX, TEST_USLEEP_MIN);
 
-    uint32_t start, slept, test_time = 0, sleeping_time = 0;
+    uint32_t test_time = 0, sleeping_time = 0;
 
     for (int i = TEST_USLEEP_MAX; i >= TEST_USLEEP_MIN; i--) {
         printf("going to sleep %d us\n", i);
-        start = xtimer_now_usec();
+        uint32_t start = xtimer_now_usec();
         xtimer_usleep(i);
-        slept = xtimer_now_usec() - start;
+        uint32_t slept = xtimer_now_usec() - start;
         printf("Slept for      %" PRIu32 " us\n", slept);
         sleeping_time += slept;
         test_time += i;

--- a/tests/xtimer_usleep_short/main.c
+++ b/tests/xtimer_usleep_short/main.c
@@ -22,30 +22,29 @@
 #define TEST_USLEEP_MIN (0)
 #define TEST_USLEEP_MAX (500)
 
-#define TEST_TIME (125250)
-
 int main(void)
 {
     xtimer_sleep(3);
     printf("This test will call xtimer_usleep for values from %d down to %d\n",
            TEST_USLEEP_MAX, TEST_USLEEP_MIN);
 
-    uint32_t start, sleeping_time = 0;
+    uint32_t start, test_time = 0, sleeping_time = 0;
 
     for (int i = TEST_USLEEP_MAX; i >= TEST_USLEEP_MIN; i--) {
         printf("going to sleep %d usecs...\n", i);
         start = xtimer_now_usec();
         xtimer_usleep(i);
         sleeping_time += xtimer_now_usec() - start;
+        test_time += i;
     }
 
     printf("Slept for %" PRIu32 " expected %" PRIu32 "\n",
-           sleeping_time, (uint32_t)TEST_TIME);
+           sleeping_time, test_time);
 
-    if ((sleeping_time < ((uint32_t)TEST_TIME)*9/10)
-        || (sleeping_time > ((uint32_t)TEST_TIME) * 11/10)) {
+    if (sleeping_time < (test_time * 9 / 10)
+        || sleeping_time > (test_time * 11 / 10)) {
         printf("Sleep time is not in 10%% range %" PRIu32 " < %" PRIu32 " < %" PRIu32 "\n",
-               ((uint32_t)(TEST_TIME)*9/10), ((uint32_t)TEST_TIME), ((uint32_t)(TEST_TIME)*11/10) );
+               (test_time * 9 / 10), test_time, (test_time * 11 / 10));
         puts("[FAILED]");
     }
     else {

--- a/tests/xtimer_usleep_short/main.c
+++ b/tests/xtimer_usleep_short/main.c
@@ -28,28 +28,22 @@ int main(void)
     printf("This test will call xtimer_usleep for values from %d down to %d\n",
            TEST_USLEEP_MAX, TEST_USLEEP_MIN);
 
-    uint32_t start, test_time = 0, sleeping_time = 0;
+    uint32_t start, slept, test_time = 0, sleeping_time = 0;
 
     for (int i = TEST_USLEEP_MAX; i >= TEST_USLEEP_MIN; i--) {
-        printf("going to sleep %d usecs...\n", i);
+        printf("going to sleep %d us\n", i);
         start = xtimer_now_usec();
         xtimer_usleep(i);
-        sleeping_time += xtimer_now_usec() - start;
+        slept = xtimer_now_usec() - start;
+        printf("Slept for      %" PRIu32 " us\n", slept);
+        sleeping_time += slept;
         test_time += i;
     }
 
     printf("Slept for %" PRIu32 " expected %" PRIu32 "\n",
            sleeping_time, test_time);
 
-    if (sleeping_time < (test_time * 9 / 10)
-        || sleeping_time > (test_time * 11 / 10)) {
-        printf("Sleep time is not in 10%% range %" PRIu32 " < %" PRIu32 " < %" PRIu32 "\n",
-               (test_time * 9 / 10), test_time, (test_time * 11 / 10));
-        puts("[FAILED]");
-    }
-    else {
-        puts("[SUCCESS]");
-    }
+    puts("[SUCCESS]");
 
     return 0;
 }

--- a/tests/xtimer_usleep_short/tests/01-run.py
+++ b/tests/xtimer_usleep_short/tests/01-run.py
@@ -12,29 +12,30 @@ import pexpect
 
 
 def testfunc(child):
-    child.expect(u"This test will call xtimer_usleep for values from (\d+) down to (\d+)")
+    child.expect("This test will call xtimer_usleep for values from (\d+) us down to (\d+) us.")
     sleep_max = int(child.match.group(1))
     sleep_min = int(child.match.group(2))
+    delay = sleep_max - sleep_min
 
-    i = sleep_max - sleep_min
+    child.expect("Expected delay margin is (\d+) us.")
+    sleep_margin = int(child.match.group(1))
 
-    while (i >= 0):
+    for delay in range(sleep_max, sleep_min, -1):
         try:
-            child.expect(u"going to sleep (\d+) us", timeout=3)
-            sleep_exp = int(child.match.group(1))
-
-            child.expect(u"Slept for      (\d+) us", timeout=3)
+            child.expect("\w+: Slept for \d+ us not in range \[\d+, \d+\] us.",
+                         timeout=20)
 
         except pexpect.TIMEOUT:
-            print("xtimer stuck when trying to sleep %d us" % (sleep_exp))
+            print("xtimer stuck when trying to sleep %d us or failed.".format(delay))
             print("[FAILED]")
-            break
-        i = i - 1
+            exit(1)
 
-    child.expect(u"Slept for (\d+) us expected (\d+) us")
-
-    child.expect(u"[SUCCESS]", timeout=3)
-
+    child.expect("Slept for \d+ us expected \d+ us.")
+    child.expect("((Sleep delay margin was not kept for \d+ times.)|(\[SUCCESS\]))")
+    msg = child.match.group(1)
+    if msg != "[SUCCESS]" :
+        child.expect("[FAILED]")
+        exit(1)
 
 if __name__ == "__main__":
     sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))

--- a/tests/xtimer_usleep_short/tests/01-run.py
+++ b/tests/xtimer_usleep_short/tests/01-run.py
@@ -25,15 +25,7 @@ def testfunc(child):
             break
         i = i - 1
 
-    child.expect(u"Slept for (\\d+) expected (\\d+)", timeout=3)
-    runtime = int(child.match.group(1))
-    expected = int(child.match.group(2))
-
-    if runtime < expected*0.9 or runtime > expected*1.1:
-            print("xtimer slept to long")
-            print("[FAILED]")
-            return
-
+    child.expect(u"Slept for \\d+ expected \\d+")
     child.expect(u"[SUCCESS]", timeout=3)
 
 

--- a/tests/xtimer_usleep_short/tests/01-run.py
+++ b/tests/xtimer_usleep_short/tests/01-run.py
@@ -25,6 +25,15 @@ def testfunc(child):
             break
         i = i - 1
 
+    child.expect(u"Slept for (\\d+) expected (\\d+)", timeout=3)
+    runtime = int(child.match.group(1))
+    expected = int(child.match.group(2))
+
+    if runtime < expected*0.9 or runtime > expected*1.1:
+            print("xtimer slept to long")
+            print("[FAILED]")
+            return
+
     child.expect(u"[SUCCESS]", timeout=3)
 
 

--- a/tests/xtimer_usleep_short/tests/01-run.py
+++ b/tests/xtimer_usleep_short/tests/01-run.py
@@ -10,8 +10,6 @@ import os
 import sys
 import pexpect
 
-DEVIATION = .1
-
 
 def testfunc(child):
     child.expect(u"This test will call xtimer_usleep for values from (\d+) down to (\d+)")

--- a/tests/xtimer_usleep_short/tests/01-run.py
+++ b/tests/xtimer_usleep_short/tests/01-run.py
@@ -26,9 +26,6 @@ def testfunc(child):
             sleep_exp = int(child.match.group(1))
 
             child.expect(u"Slept for      (\d+) us", timeout=3)
-            slept = int(child.match.group(1))
-            if slept < sleep_exp*(1-DEVIATION) or slept > sleep_exp*(1+DEVIATION):
-                print("More than %2.0f%% deviation." % (DEVIATION*100))
 
         except pexpect.TIMEOUT:
             print("xtimer stuck when trying to sleep %d us" % (sleep_exp))
@@ -36,14 +33,7 @@ def testfunc(child):
             break
         i = i - 1
 
-    child.expect(u"Slept for (\d+) expected (\d+)")
-    sleep_exp = int(child.match.group(1))
-    slept = int(child.match.group(2))
-
-    if slept < sleep_exp*(1-DEVIATION) or slept > sleep_exp*(1+DEVIATION):
-        print("All test together had more than %2.0f%% deviation." % (DEVIATION*100))
-        print("[FAILED]")
-        return
+    child.expect(u"Slept for (\d+) us expected (\d+) us")
 
     child.expect(u"[SUCCESS]", timeout=3)
 

--- a/tests/xtimer_usleep_short/tests/01-run.py
+++ b/tests/xtimer_usleep_short/tests/01-run.py
@@ -12,6 +12,7 @@ import pexpect
 
 DEVIATION = .1
 
+
 def testfunc(child):
     child.expect(u"This test will call xtimer_usleep for values from (\d+) down to (\d+)")
     sleep_max = int(child.match.group(1))


### PR DESCRIPTION
In some cases the sleep time is very long compared to the expected sleep time.
This pr adds a functionality to test against the expected sleep time.
If the sleep time is far of the expected sleep time an error is thrown.