### PR TITLE
tests/float: increase timeout for wsn430 [backport 2018.04]

### DIFF
--- a/tests/float/tests/01-run.py
+++ b/tests/float/tests/01-run.py
@@ -9,10 +9,13 @@
 import os
 import sys
 
+# It takes 35 seconds on wsn430, so add some margin
+TIMEOUT = 45
+
 
 def testfunc(child):
     child.expect_exact("Testing floating point arithmetics...")
-    child.expect_exact("[SUCCESS]")
+    child.expect_exact("[SUCCESS]", timeout=TIMEOUT)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Backport of #9030

### Contribution description

Fix test on wsn430 failing because of timeout too small.
It takes 35 seconds to run.

I also re-run tests on arduino-uno and arduino-mega2560 to verify the timeout is ok.

### Issues/PRs references

Tests for the release.