### PR TITLE
tests:sizeof_tcb: fix for wsn430 and arduino [backport 2018.04]

### DIFF
--- a/tests/sizeof_tcb/main.c
+++ b/tests/sizeof_tcb/main.c
@@ -23,7 +23,7 @@
 
 #include "thread.h"
 
-#define P(NAME) printf("\t%-*s%4u%4u\n", 11, #NAME, \
+#define P(NAME) printf("\t%-11s%4u%4u\n", #NAME, \
                        (unsigned)sizeof(((thread_t *) 0)->NAME), \
                        (unsigned)offsetof(thread_t, NAME));
 

--- a/tests/sizeof_tcb/tests/01-run.py
+++ b/tests/sizeof_tcb/tests/01-run.py
@@ -12,16 +12,29 @@ import sys
 
 def testfunc(child):
     child.expect_exact('\tmember, sizeof, offsetof')
-    child.expect(r'sizeof\(thread_t\): [36, 48]')
-    child.expect_exact('\tsp            4   0')
-    child.expect_exact('\tstatus        1   4')
-    child.expect_exact('\tpriority      1   5')
-    child.expect_exact('\tpid           2   6')
-    child.expect_exact('\trq_entry      4   8')
-    child.expect_exact('\twait_data     4  12')
-    child.expect_exact('\tmsg_waiters   4  16')
-    child.expect_exact('\tmsg_queue    12  20')
-    child.expect_exact('\tmsg_array     4  32')
+    ret = child.expect([r'sizeof\(thread_t\): [36, 48]',
+                        r'sizeof\(thread_t\): [20, 26]'])
+    if ret == 0:
+        child.expect_exact('\tsp            4   0')
+        child.expect_exact('\tstatus        1   4')
+        child.expect_exact('\tpriority      1   5')
+        child.expect_exact('\tpid           2   6')
+        child.expect_exact('\trq_entry      4   8')
+        child.expect_exact('\twait_data     4  12')
+        child.expect_exact('\tmsg_waiters   4  16')
+        child.expect_exact('\tmsg_queue    12  20')
+        child.expect_exact('\tmsg_array     4  32')
+    else:
+        # 16 bit platform (wsn430)
+        child.expect_exact('\tsp            2   0')
+        child.expect_exact('\tstatus        1   2')
+        child.expect_exact('\tpriority      1   3')
+        child.expect_exact('\tpid           2   4')
+        child.expect_exact('\trq_entry      2   6')
+        child.expect_exact('\twait_data     2   8')
+        child.expect_exact('\tmsg_waiters   2  10')
+        child.expect_exact('\tmsg_queue     6  12')
+        child.expect_exact('\tmsg_array     2  18')
     child.expect_exact('SUCCESS')
 
 


### PR DESCRIPTION
# Backport of #9031

### Contribution description

Fix sizeof_tcb for 16 bit platform (wsn430) and fix printf format for arduino.

* The test was only written for 32bit platform, add a test for 16bit.
* printf `%-*s` format is not supported on arduino


I run the tests on `wsn430-v1_4`, `arduino-uno` and `arduino-mega2560`.

### Issues/PRs references

Tests for the release.