### PR TITLE
doc: fix flake8 issues in generate changelog script

### DIFF
--- a/doc/doxygen/generate-changelog.py
+++ b/doc/doxygen/generate-changelog.py
@@ -10,6 +10,7 @@ from __future__ import print_function
 import re
 import sys
 
+
 def generate_changelog(template_filename, changelog_filename, output_filename):
     with open(template_filename) as template, \
          open(changelog_filename) as changelog, \
@@ -17,7 +18,6 @@ def generate_changelog(template_filename, changelog_filename, output_filename):
         changelog_lines = []
         release_title = re.compile(r"((RIOT-\d{4}\.\d{2} - Release Notes)|(Release 2013\.08))")
         notes_template = re.compile(r"\[Notes\]")
-        first_title = True
         title = 0
         prev_newline = False
         # Traverse changelog file line-wise
@@ -36,15 +36,14 @@ def generate_changelog(template_filename, changelog_filename, output_filename):
             elif release_title.match(line):
                 # if line contains a release title
                 release_match = re.search(r"(\d{4}\.\d{2})", line)
-                assert(release_match != None)
+                assert(release_match is not None)
                 # parse out release number
                 release = release_match.group(1)
                 title = "Release %s" % release
                 tag = "release-%s" % release.replace('.', '-')
                 # append as level 1 title with reference anchor tag
-                changelog_lines.append("# %s {#%s}\n" % (title ,tag))
+                changelog_lines.append("# %s {#%s}\n" % (title, tag))
                 title = True
-                first_title = False
             else:
                 # append non-title log lines as verbatim (so notation is kept)
                 changelog_lines.append("    %s" % line)
@@ -58,9 +57,9 @@ def generate_changelog(template_filename, changelog_filename, output_filename):
                 # just print the template line
                 print(line, file=output, end="")
 
+
 if __name__ == "__main__":
     if len(sys.argv) < 4:
         print("usage %s <md template> <changelog> <output md>" % sys.argv[0], file=sys.stderr)
         sys.exit(1)
     generate_changelog(sys.argv[1], sys.argv[2], sys.argv[3])
-


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

While verifying if the flake8 check script is correctly working, I noticed that there were remaining flake8 issues.
This PR fixes the ones found in the generate-changelog.py script.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->