### PR TITLE
tests/thread_flags: fix printf on 16bit platform

### DIFF
--- a/tests/thread_flags/main.c
+++ b/tests/thread_flags/main.c
@@ -96,7 +96,7 @@ int main(void)
     xtimer_set_timeout_flag(&t, TIMEOUT);
     thread_flags_wait_any(THREAD_FLAG_TIMEOUT);
     uint32_t diff = xtimer_now_usec() - before;
-    printf("main: timeout triggered. time passed: %uus\n", (unsigned)diff);
+    printf("main: timeout triggered. time passed: %"PRIu32"us\n", diff);
 
     if (diff < (TIMEOUT + THRESHOLD)) {
         puts("SUCCESS");


### PR DESCRIPTION
### Contribution description

Diff output was truncated to a 16b unsigned on wsn430 which made tests fail

    main: timeout triggered. time passed: 34581us

Instead of

    main: timeout triggered. time passed: 100117us

### Issues/PRs references

Release testing