### PR TITLE
make: add and export RIOTTOOLS directory

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -11,6 +11,7 @@ RIOTCPU        ?= $(RIOTBASE)/cpu
 RIOTBOARD      ?= $(RIOTBASE)/boards
 RIOTMAKE       ?= $(RIOTBASE)/makefiles
 RIOTPKG        ?= $(RIOTBASE)/pkg
+RIOTTOOLS      ?= $(RIOTBASE)/dist/tools
 RIOTPROJECT    ?= $(shell git rev-parse --show-toplevel 2>/dev/null || pwd)
 GITCACHE       ?= $(RIOTBASE)/dist/tools/git/git-cache
 APPDIR         ?= $(CURDIR)
@@ -26,6 +27,7 @@ __DIRECTORY_VARIABLES := \
   RIOTBOARD \
   RIOTMAKE \
   RIOTPKG \
+  RIOTTOOLS \
   RIOTPROJECT \
   APPDIR \
   BINDIRBASE \
@@ -43,6 +45,7 @@ override RIOTCPU        := $(abspath $(RIOTCPU))
 override RIOTBOARD      := $(abspath $(RIOTBOARD))
 override RIOTMAKE       := $(abspath $(RIOTMAKE))
 override RIOTPKG        := $(abspath $(RIOTPKG))
+override RIOTTOOLS      := $(abspath $(RIOTTOOLS))
 override RIOTPROJECT    := $(abspath $(RIOTPROJECT))
 override GITCACHE       := $(abspath $(GITCACHE))
 override APPDIR         := $(abspath $(APPDIR))

--- a/makefiles/vars.inc.mk
+++ b/makefiles/vars.inc.mk
@@ -22,6 +22,7 @@ export RIOTBASE              # The root folder of RIOT. The folder where this ve
 export RIOTCPU               # For third party CPUs this folder is the base of the CPUs.
 export RIOTBOARD             # For third party BOARDs this folder is the base of the BOARDs.
 export RIOTPKG               # For overriding RIOT's pkg directory
+export RIOTTOOLS             # Location of host machine tools
 export RIOTPROJECT           # Top level git root of the project being built, or PWD if not a git repository
 export RIOTMAKE              # Location of all supplemental Makefiles (such as this file)
 export BINDIRBASE            # This is the folder where the application should be built in. For each BOARD a different subfolder is used.


### PR DESCRIPTION
### Contribution description

Add a RIOTTOOLS variable to cleanup build scripts.

Replacing usage will come in further commits/PRs.

### Issues/PRs references

First step of https://github.com/RIOT-OS/RIOT/pull/8821