### PR TITLE
cpu/stm32-common: slightly rework flashpage driver and fix iotlab-m3

### DIFF
--- a/cpu/stm32_common/periph/flash_common.c
+++ b/cpu/stm32_common/periph/flash_common.c
@@ -38,8 +38,8 @@
 
 void _unlock(void)
 {
-    DEBUG("[flash-common] unlocking the flash module\n");
     if (CNTRL_REG & CNTRL_REG_LOCK) {
+        DEBUG("[flash-common] unlocking the flash module\n");
         KEY_REG = FLASH_KEY1;
         KEY_REG = FLASH_KEY2;
     }
@@ -47,6 +47,8 @@ void _unlock(void)
 
 void _lock(void)
 {
-    DEBUG("[flash-common] locking the flash module\n");
-    CNTRL_REG |= CNTRL_REG_LOCK;
+    if (!(CNTRL_REG & CNTRL_REG_LOCK)) {
+        DEBUG("[flash-common] locking the flash module\n");
+        CNTRL_REG |= CNTRL_REG_LOCK;
+    }
 }

--- a/cpu/stm32_common/periph/flashpage.c
+++ b/cpu/stm32_common/periph/flashpage.c
@@ -69,6 +69,11 @@ static void _wait_for_pending_operations(void)
 {
     DEBUG("[flashpage] waiting for any pending operation to finish\n");
     while (FLASH->SR & FLASH_SR_BSY) {}
+
+    /* Clear 'end of operation' bit in status register */
+    if (FLASH->SR & FLASH_SR_EOP) {
+        FLASH->SR &= ~(FLASH_SR_EOP);
+    }
 }
 
 static void _erase_page(void *page_addr)

--- a/cpu/stm32_common/periph/flashpage.c
+++ b/cpu/stm32_common/periph/flashpage.c
@@ -77,7 +77,7 @@ static void _erase_page(void *page_addr)
     stmclk_enable_hsi();
 #endif
 
-   /* unlock the flash module */
+    /* unlock the flash module */
     _unlock_flash();
 
     /* make sure no flash operation is ongoing */
@@ -140,10 +140,10 @@ void flashpage_write_raw(void *target_addr, const void *data, size_t len)
     stmclk_enable_hsi();
 #endif
 
-    DEBUG("[flashpage_raw] unlocking the flash module\n");
+    /* unlock the flash module */
     _unlock_flash();
 
-    DEBUG("[flashpage] write: now writing the data\n");
+    DEBUG("[flashpage_raw] write: now writing the data\n");
 #if !(defined(CPU_FAM_STM32L0) || defined(CPU_FAM_STM32L1))
     /* set PG bit and program page to flash */
     CNTRL_REG |= FLASH_CR_PG;
@@ -156,9 +156,9 @@ void flashpage_write_raw(void *target_addr, const void *data, size_t len)
 
     /* clear program bit again */
     CNTRL_REG &= ~(FLASH_CR_PG);
-    DEBUG("[flashpage] write: done writing data\n");
+    DEBUG("[flashpage_raw] write: done writing data\n");
 
-    DEBUG("flashpage_raw] now locking the flash module again\n");
+    /* lock the flash module again */
     _lock();
 
 #if !(defined(CPU_FAM_STM32L0) || defined(CPU_FAM_STM32L1))


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is an attempt to fix the #9065 issue that was introduced by #8768. Regarding the differences, the calls to lock/unlock functions were moved in different places in #8768, wrapping each calls to erase and write_raw internal functions.
This change seems to have introduced timing issues on iotlab-m3 but not on the other boards I tested (nucleo-l073, l152 and f070).

Reverting this change and adding extra checks fixes the issue. One last thing it still not working (but it was already the case before #8768): `flashpage_raw`. I tested different things but none worked on iotlab-m3. I can disable this feature for STM32F1 family if requested.

Other CPUs (l0, l1, f0) are still working for both write and write_raw functions.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

Fixes #9065 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->