### PR TITLE
sys/arduino: use RIOTTOOLS variable

### DIFF
--- a/sys/arduino/Makefile.include
+++ b/sys/arduino/Makefile.include
@@ -3,7 +3,7 @@ SKETCHES = $(wildcard $(APPDIR)/*.sketch)
 SRCDIR = $(RIOTBASE)/sys/arduino
 
 # run the Arduino pre-build script
-$(shell $(RIOTBASE)/dist/tools/arduino/pre_build.sh $(SRCDIR) $(APPDIR) $(SKETCHES))
+$(shell $(RIOTTOOLS)/arduino/pre_build.sh $(SRCDIR) $(APPDIR) $(SKETCHES))
 
 # include the Arduino headers
 INCLUDES += -I$(RIOTBASE)/sys/arduino/include


### PR DESCRIPTION
### Contribution description

Use RIOTTOOLS variable for sys/arduino

Follow up to #9067 and part of #8821

### Testing

Compiling for arduino works:

    make -C examples/arduino_hello-world/ BOARD=arduino-zero
    # check content of _sketches
    cat examples/arduino_hello-world/_sketches.cpp

### Issues/PRs references

Follow up to #9067 and part of #8821