### PR TITLE
pkg: use RIOTTOOLS variable

### DIFF
--- a/pkg/ccn-lite/Makefile
+++ b/pkg/ccn-lite/Makefile
@@ -19,6 +19,6 @@ $(PKG_BUILDDIR)/src/Makefile: $(TOOLCHAIN_FILE)
 		  -DCCNL_RIOT=1 -DRIOT_CFLAGS="$(RIOT_CFLAGS)" -DBUILD_TESTING=OFF .
 
 $(TOOLCHAIN_FILE): git-download
-	$(RIOTBASE)/dist/tools/cmake/generate-xcompile-toolchain.sh > $(TOOLCHAIN_FILE)
+	$(RIOTTOOLS)/cmake/generate-xcompile-toolchain.sh > $(TOOLCHAIN_FILE)
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/relic/Makefile
+++ b/pkg/relic/Makefile
@@ -20,7 +20,7 @@ $(PKG_BUILDDIR)/Makefile: $(TOOLCHAIN_FILE)
 		  -DCHECK=off -DTESTS=0 -DBENCH=0 -DSHLIB=off -Wno-dev $(RELIC_CONFIG_FLAGS) .
 
 $(TOOLCHAIN_FILE): fix_source
-	$(RIOTBASE)/dist/tools/cmake/generate-xcompile-toolchain.sh > $(TOOLCHAIN_FILE)
+	$(RIOTTOOLS)/cmake/generate-xcompile-toolchain.sh > $(TOOLCHAIN_FILE)
 
 fix_source: git-download
 	./fix-util_print_wo_args.sh $(PKG_BUILDDIR)


### PR DESCRIPTION
### Contribution description

Use RIOTTOOLS variable in packages

Follow up to #9067 and part of #8821

### Testing

Murdock working compilation should be enough.

Manual testing anyway on my computer

    make -C examples/ccn-lite-relay/ all    # ccn-lite
    make -C tests/unittests all             # relic

### Issues/PRs references

Follow up to #9067 and part of #8821