### PR TITLE
 cpu/nrf5x: define nrfmin feature in nrf5x_common

### DIFF
--- a/boards/airfy-beacon/Makefile.features
+++ b/boards/airfy-beacon/Makefile.features
@@ -8,7 +8,6 @@ FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
 # Various other features (if any)
-FEATURES_PROVIDED += radio_nrfmin
 
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m0_2

--- a/boards/airfy-beacon/include/periph_conf.h
+++ b/boards/airfy-beacon/include/periph_conf.h
@@ -124,16 +124,6 @@ static const i2c_conf_t i2c_config[] = {
 #define ADC_NUMOF           (4)
 /** @} */
 
-/**
- * @name    Radio device configuration
- *
- * The radio is not guarded by a NUMOF define, as the radio is selected by its
- * own module in the build system.
- * @{
- */
-#define RADIO_IRQ_PRIO      1
-/** @} */
-
 #ifdef __cplusplus
 } /* end extern "C" */
 #endif

--- a/boards/calliope-mini/Makefile.features
+++ b/boards/calliope-mini/Makefile.features
@@ -7,7 +7,6 @@ FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_pwm
 
 # Various other features (if any)
-FEATURES_PROVIDED += radio_nrfmin
 
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m0_1

--- a/boards/calliope-mini/include/periph_conf.h
+++ b/boards/calliope-mini/include/periph_conf.h
@@ -113,16 +113,6 @@ static const i2c_conf_t i2c_config[] = {
 /** @} */
 
 /**
- * @name    Radio device configuration
- *
- * The radio is not guarded by a NUMOF define, as the radio is selected by its
- * own module in the build system.
- * @{
- */
-#define RADIO_IRQ_PRIO      1
-/** @} */
-
-/**
  * @name    PWM configuration
  * @{
  */

--- a/boards/common/nrf52xxxdk/Makefile.features
+++ b/boards/common/nrf52xxxdk/Makefile.features
@@ -9,7 +9,6 @@ FEATURES_PROVIDED += periph_uart
 # Various other features (if any)
 FEATURES_PROVIDED += radio_ble
 FEATURES_PROVIDED += radio_nrfble
-FEATURES_PROVIDED += radio_nrfmin
 
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m4_3

--- a/boards/microbit/Makefile.features
+++ b/boards/microbit/Makefile.features
@@ -6,7 +6,6 @@ FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
 # Various other features (if any)
-FEATURES_PROVIDED += radio_nrfmin
 
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m0_1

--- a/boards/microbit/include/periph_conf.h
+++ b/boards/microbit/include/periph_conf.h
@@ -118,16 +118,6 @@ static const i2c_conf_t i2c_config[] = {
 #define ADC_NUMOF          (0)
 /** @} */
 
-/**
- * @name   Radio device configuration
- *
- * The radio is not guarded by a NUMOF define, as the radio is selected by its
- * own module in the build system.
- * @{
- */
-#define RADIO_IRQ_PRIO      1
-/** @} */
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/nrf51dongle/Makefile.features
+++ b/boards/nrf51dongle/Makefile.features
@@ -5,7 +5,6 @@ FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
 # Various other features (if any)
-FEATURES_PROVIDED += radio_nrfmin
 
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m0_1

--- a/boards/nrf51dongle/include/periph_conf.h
+++ b/boards/nrf51dongle/include/periph_conf.h
@@ -86,16 +86,6 @@ static const timer_conf_t timer_config[] = {
 #define ADC_NUMOF          (0)
 /** @} */
 
-/**
- * @name Radio device configuration
- *
- * The radio is not guarded by a NUMOF define, as the radio is selected by its
- * own module in the build system.
- * @{
- */
-#define RADIO_IRQ_PRIO      1
-/** @} */
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/nrf6310/Makefile.features
+++ b/boards/nrf6310/Makefile.features
@@ -6,7 +6,6 @@ FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
 # Various other features (if any)
-FEATURES_PROVIDED += radio_nrfmin
 
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m0_2

--- a/boards/nrf6310/include/periph_conf.h
+++ b/boards/nrf6310/include/periph_conf.h
@@ -84,16 +84,6 @@ static const timer_conf_t timer_config[] = {
 /** @} */
 
 /**
- * @name    Radio device configuration
- *
- * The radio is not guarded by a NUMOF define, as the radio is selected by its
- * own module in the build system.
- * @{
- */
-#define RADIO_IRQ_PRIO      1
-/** @} */
-
-/**
  * @name    SPI configuration
  * @{
  */

--- a/boards/ruuvitag/Makefile.features
+++ b/boards/ruuvitag/Makefile.features
@@ -6,7 +6,6 @@ FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
 # Various other features (if any)
-FEATURES_PROVIDED += radio_nrfmin
 
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m4_3

--- a/boards/thingy52/Makefile.features
+++ b/boards/thingy52/Makefile.features
@@ -5,7 +5,6 @@ FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
 # Various other features (if any)
-FEATURES_PROVIDED += radio_nrfmin
 
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m4_3

--- a/boards/yunjia-nrf51822/Makefile.features
+++ b/boards/yunjia-nrf51822/Makefile.features
@@ -8,7 +8,6 @@ FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
 # Various other features (if any)
-FEATURES_PROVIDED += radio_nrfmin
 
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m0_2

--- a/boards/yunjia-nrf51822/include/periph_conf.h
+++ b/boards/yunjia-nrf51822/include/periph_conf.h
@@ -122,16 +122,6 @@ static const i2c_conf_t i2c_config[] = {
 #define ADC_NUMOF           (4)
 /** @} */
 
-/**
- * @name Radio device configuration
- *
- * The radio is not guarded by a NUMOF define, as the radio is selected by its
- * own module in the build system.
- * @{
- */
-#define RADIO_IRQ_PRIO      1
-/** @} */
-
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/nrf5x_common/Makefile.features
+++ b/cpu/nrf5x_common/Makefile.features
@@ -1,5 +1,9 @@
+# Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_flashpage
 FEATURES_PROVIDED += periph_hwrng
+
+# Various other features (if any)
+FEATURES_PROVIDED += radio_nrfmin
 
 -include $(RIOTCPU)/cortexm_common/Makefile.features


### PR DESCRIPTION
### Contribution description
The `nrfmin` radio is part of all `nrf51` and `nrf52` CPUs and does not depend on any board specific configuration. Its feature should hence be defined by the (shared) CPU's `Makefile.features`.

This PR also removes the unsued `RADIO_IRQ_PRIO` define from some nrf51-based board's periph_conf.h files.

### Issues/PRs references
none