### PR TITLE
boards/iotlab: fix saul gpio configuration

### DIFF
--- a/boards/common/iotlab/include/gpio_params.h
+++ b/boards/common/iotlab/include/gpio_params.h
@@ -34,17 +34,20 @@ static const  saul_gpio_params_t saul_gpio_params[] =
     {
         .name = "LED(red)",
         .pin = LED0_PIN,
-        .mode = GPIO_OUT
+        .mode = GPIO_OUT,
+        .flags = SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR,
     },
     {
         .name = "LED(green)",
         .pin = LED1_PIN,
-        .mode = GPIO_OUT
+        .mode = GPIO_OUT,
+        .flags = SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR,
     },
     {
         .name = "LED(orange)",
         .pin = LED2_PIN,
-        .mode = GPIO_OUT
+        .mode = GPIO_OUT,
+        .flags = SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR,
     },
 };
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR fixes the GPIO default params used with the iotlab boards: the on-boards LEDs are inverted via saul and are initialized set.
With this PR, controlling the LEDs via saul has now the expected behaviour: writing 1 turns the LED on, writing 0 turns the LED off. After boot, all LEDs are turned off.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->