### PR TITLE
kinetis: Memory segment attribute fixes

### DIFF
--- a/cpu/kinetis/ldscripts/kinetis.ld
+++ b/cpu/kinetis/ldscripts/kinetis.ld
@@ -27,10 +27,10 @@ _flashsec_length = 0x10;
 
 MEMORY
 {
-    vectors (rx)   : ORIGIN = _rom_start_addr, LENGTH = _vectors_length
-    flashsec (rx)  : ORIGIN = _rom_start_addr + _vectors_length, LENGTH = _flashsec_length
-    rom (rx)       : ORIGIN = _rom_start_addr + _vectors_length + _flashsec_length, LENGTH = _rom_length - (_vectors_length + _flashsec_length)
-    ram (rwx)      : ORIGIN = _ram_start_addr, LENGTH = _ram_length
+    vectors    : ORIGIN = _rom_start_addr, LENGTH = _vectors_length
+    flashsec   : ORIGIN = _rom_start_addr + _vectors_length, LENGTH = _flashsec_length
+    rom (rx)   : ORIGIN = _rom_start_addr + _vectors_length + _flashsec_length, LENGTH = _rom_length - (_vectors_length + _flashsec_length)
+    ram (!rx)  : ORIGIN = _ram_start_addr, LENGTH = _ram_length
 }
 
 SECTIONS


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

vectors and flashsec memory segments will not be considered for orphan
sections if attributes `(rx)` are only given for the rom segment.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

extended in #9089 
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->