### PR TITLE
net/nanocoap: Build message with coap_pkt_t

### DIFF
--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -383,6 +383,15 @@ ssize_t coap_build_hdr(coap_hdr_t *hdr, unsigned type, uint8_t *token, size_t to
     return sizeof(coap_hdr_t) + token_len;
 }
 
+void coap_pkt_init(coap_pkt_t *pkt, uint8_t *buf, size_t len, size_t header_len)
+{
+    memset(pkt, 0, sizeof(coap_pkt_t));
+    pkt->hdr = (coap_hdr_t *)buf;
+    pkt->token = buf + sizeof(coap_hdr_t);
+    pkt->payload = buf + header_len;
+    pkt->payload_len = len - header_len;
+}
+
 static int _decode_value(unsigned val, uint8_t **pkt_pos_ptr, uint8_t *pkt_end)
 {
     uint8_t *pkt_pos = *pkt_pos_ptr;
@@ -593,6 +602,85 @@ size_t coap_put_option_uri(uint8_t *buf, uint16_t lastonum, const char *uri, uin
     }
 
     return bufpos - buf;
+}
+
+/* Common functionality for addition of an option */
+static ssize_t _add_opt_pkt(coap_pkt_t *pkt, uint16_t optnum, uint8_t *val,
+                            size_t val_len)
+{
+    assert(pkt->options_len < NANOCOAP_NOPTS_MAX);
+
+    uint16_t lastonum = (pkt->options_len)
+            ? pkt->options[pkt->options_len - 1].opt_num : 0;
+    assert(optnum >= lastonum);
+
+    size_t optlen = coap_put_option(pkt->payload, lastonum, optnum, val, val_len);
+    assert(pkt->payload_len > optlen);
+
+    pkt->options[pkt->options_len].opt_num = optnum;
+    pkt->options[pkt->options_len].offset = pkt->payload - (uint8_t *)pkt->hdr;
+    pkt->options_len++;
+    pkt->payload += optlen;
+    pkt->payload_len -= optlen;
+
+    return optlen;
+}
+
+ssize_t coap_opt_add_string(coap_pkt_t *pkt, uint16_t optnum, const char *string,
+                           char separator)
+{
+    size_t unread_len = strlen(string);
+    if (!unread_len) {
+        return 0;
+    }
+    char *uripos = (char *)string;
+    size_t write_len = 0;
+
+    while (unread_len) {
+        size_t part_len;
+        uripos++;
+        uint8_t *part_start = (uint8_t *)uripos;
+
+        while (unread_len--) {
+            if ((*uripos == separator) || (*uripos == '\0')) {
+                break;
+            }
+            uripos++;
+        }
+
+        part_len = (uint8_t *)uripos - part_start;
+
+        if (part_len) {
+            if (pkt->options_len == NANOCOAP_NOPTS_MAX) {
+                return -ENOSPC;
+            }
+            write_len += _add_opt_pkt(pkt, optnum, part_start, part_len);
+        }
+    }
+
+    return write_len;
+}
+
+ssize_t coap_opt_add_uint(coap_pkt_t *pkt, uint16_t optnum, uint32_t value)
+{
+    uint32_t tmp = value;
+    unsigned tmp_len = _encode_uint(&tmp);
+    return _add_opt_pkt(pkt, optnum, (uint8_t *)&tmp, tmp_len);
+}
+
+ssize_t coap_opt_finish(coap_pkt_t *pkt, uint16_t flags)
+{
+    if (flags & COAP_OPT_FINISH_PAYLOAD) {
+        assert(pkt->payload_len > 1);
+
+        *pkt->payload++ = 0xFF;
+        pkt->payload_len--;
+    }
+    else {
+        pkt->payload_len = 0;
+    }
+
+    return pkt->payload - (uint8_t *)pkt->hdr;
 }
 
 ssize_t coap_well_known_core_default_handler(coap_pkt_t *pkt, uint8_t *buf, \

--- a/tests/unittests/tests-nanocoap/tests-nanocoap.c
+++ b/tests/unittests/tests-nanocoap/tests-nanocoap.c
@@ -13,6 +13,7 @@
  */
 #include <errno.h>
 #include <stdint.h>
+#include <stdbool.h>
 
 #include "embUnit.h"
 
@@ -45,10 +46,111 @@ static void test_nanocoap__hdr(void)
     TEST_ASSERT_EQUAL_STRING((char *)path, (char *)path_tmp);
 }
 
+/*
+ * Client GET request with simple path. Test request generation.
+ * Request /time resource from libcoap example
+ */
+static void test_nanocoap__get_req(void)
+{
+    uint8_t buf[128];
+    coap_pkt_t pkt;
+    uint16_t msgid = 0xABCD;
+    uint8_t token[2] = {0xDA, 0xEC};
+    char path[] = "/time";
+    size_t total_hdr_len = 6;
+    size_t total_opt_len = 5;
+
+    size_t len = coap_build_hdr((coap_hdr_t *)&buf[0], COAP_TYPE_NON,
+                                &token[0], 2, COAP_METHOD_GET, msgid);
+    TEST_ASSERT_EQUAL_INT(total_hdr_len, len);
+
+    coap_pkt_init(&pkt, &buf[0], sizeof(buf), len);
+
+    TEST_ASSERT_EQUAL_INT(COAP_METHOD_GET, coap_get_code(&pkt));
+    TEST_ASSERT_EQUAL_INT(2, coap_get_token_len(&pkt));
+    TEST_ASSERT_EQUAL_INT(total_hdr_len, coap_get_total_hdr_len(&pkt));
+    TEST_ASSERT_EQUAL_INT(COAP_TYPE_NON, coap_get_type(&pkt));
+    TEST_ASSERT_EQUAL_INT(122, pkt.payload_len);
+
+    len = coap_opt_add_string(&pkt, COAP_OPT_URI_PATH, &path[0], '/');
+    TEST_ASSERT_EQUAL_INT(total_opt_len, len);
+
+    char uri[10] = {0};
+    coap_get_uri(&pkt, (uint8_t *)&uri[0]);
+    TEST_ASSERT_EQUAL_STRING((char *)path, (char *)uri);
+
+    len = coap_opt_finish(&pkt, COAP_OPT_FINISH_NONE);
+    TEST_ASSERT_EQUAL_INT(total_hdr_len + total_opt_len, len);
+}
+
+/*
+ * Builds on get_req test, to test payload and Content-Format option.
+ */
+static void test_nanocoap__put_req(void)
+{
+    uint8_t buf[128];
+    coap_pkt_t pkt;
+    uint16_t msgid = 0xABCD;
+    uint8_t token[2] = {0xDA, 0xEC};
+    char path[] = "/value";
+    size_t total_hdr_len = 6;
+    size_t uri_opt_len = 6;
+    size_t fmt_opt_len = 1;
+
+    size_t len = coap_build_hdr((coap_hdr_t *)&buf[0], COAP_TYPE_NON,
+                                &token[0], 2, COAP_METHOD_PUT, msgid);
+    TEST_ASSERT_EQUAL_INT(total_hdr_len, len);
+
+    coap_pkt_init(&pkt, &buf[0], sizeof(buf), len);
+
+    TEST_ASSERT_EQUAL_INT(COAP_METHOD_PUT, coap_get_code(&pkt));
+    TEST_ASSERT_EQUAL_INT(122, pkt.payload_len);
+
+    len = coap_opt_add_string(&pkt, COAP_OPT_URI_PATH, &path[0], '/');
+    TEST_ASSERT_EQUAL_INT(uri_opt_len, len);
+
+    len = coap_opt_add_uint(&pkt, COAP_OPT_CONTENT_FORMAT, COAP_FORMAT_TEXT);
+    TEST_ASSERT_EQUAL_INT(fmt_opt_len, len);
+    TEST_ASSERT_EQUAL_INT(COAP_FORMAT_TEXT, coap_get_content_type(&pkt));
+
+    len = coap_opt_finish(&pkt, COAP_OPT_FINISH_PAYLOAD);
+    TEST_ASSERT_EQUAL_INT(total_hdr_len + uri_opt_len + fmt_opt_len + 1, len);
+    TEST_ASSERT_EQUAL_INT(0xFF, *(pkt.payload - 1));
+    TEST_ASSERT_EQUAL_INT(&buf[0] + 128 - pkt.payload, pkt.payload_len);
+}
+
+/*
+ * Builds on get_req test, to test path with multiple segments.
+ */
+static void test_nanocoap__get_multi_path(void)
+{
+    uint8_t buf[128];
+    coap_pkt_t pkt;
+    uint16_t msgid = 0xABCD;
+    uint8_t token[2] = {0xDA, 0xEC};
+    char path[] = "/ab/cde";
+    size_t uri_opt_len = 7;
+
+    size_t len = coap_build_hdr((coap_hdr_t *)&buf[0], COAP_TYPE_NON,
+                                &token[0], 2, COAP_METHOD_GET, msgid);
+
+    coap_pkt_init(&pkt, &buf[0], sizeof(buf), len);
+
+    len = coap_opt_add_string(&pkt, COAP_OPT_URI_PATH, &path[0], '/');
+    TEST_ASSERT_EQUAL_INT(uri_opt_len, len);
+
+    char uri[10] = {0};
+    coap_get_uri(&pkt, (uint8_t *)&uri[0]);
+    TEST_ASSERT_EQUAL_STRING((char *)path, (char *)uri);
+}
+
 Test *tests_nanocoap_tests(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
         new_TestFixture(test_nanocoap__hdr),
+        new_TestFixture(test_nanocoap__get_req),
+        new_TestFixture(test_nanocoap__put_req),
+        new_TestFixture(test_nanocoap__get_multi_path),
     };
 
     EMB_UNIT_TESTCALLER(nanocoap_tests, NULL, NULL, fixtures);


### PR DESCRIPTION
### Contribution description
Adds an API to nanocoap to use a coap_pkt_t to build a message, including options. Builds on existing buffer-based functions. Use of the coap_pkt_t struct makes it easier to manage options.

Includes:

- coap_pkt_init()
- coap_opt_add_string()
- coap_opt_add_uint()
- coap_opt_finish()

This approach also allows integration by gcoap, bringing the APIs closer together. 

### Issues/PRs references
Implements ideas described in #9048 and #8831. Provides an API useful to #8920.