### PR TITLE
gcoap: make message queue size configurable

### DIFF
--- a/sys/include/net/gcoap.h
+++ b/sys/include/net/gcoap.h
@@ -227,7 +227,9 @@ extern "C" {
 /**
  * @brief  Size for module message queue
  */
+#ifndef GCOAP_MSG_QUEUE_SIZE
 #define GCOAP_MSG_QUEUE_SIZE    (4)
+#endif
 
 /**
  * @brief   Server port; use RFC 7252 default if not defined

--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -92,16 +92,17 @@ static gcoap_state_t _coap_state = {
 
 static kernel_pid_t _pid = KERNEL_PID_UNDEF;
 static char _msg_stack[GCOAP_STACK_SIZE];
+static msg_t _msg_queue[GCOAP_MSG_QUEUE_SIZE];
 static sock_udp_t _sock;
 
 
 /* Event/Message loop for gcoap _pid thread. */
 static void *_event_loop(void *arg)
 {
-    msg_t msg_rcvd, msg_queue[GCOAP_MSG_QUEUE_SIZE];
+    msg_t msg_rcvd;
     (void)arg;
 
-    msg_init_queue(msg_queue, GCOAP_MSG_QUEUE_SIZE);
+    msg_init_queue(_msg_queue, GCOAP_MSG_QUEUE_SIZE);
 
     sock_udp_ep_t local;
     memset(&local, 0, sizeof(sock_udp_ep_t));


### PR DESCRIPTION
### Contribution description
For a massive setup with multiple CoAP GET clients I'm currently doing for some experiments of mine the default queue length given by `gcoap` turned out to be way too low. Since this configurability also allows for very big queues (in my experiment setup I used at times e.g. 128) I moved the queue out of the thread's stack context to a global context.

### Issues/PRs references
None