### PR TITLE
sys: netopt: add checksum and busy options

### DIFF
--- a/sys/include/net/netopt.h
+++ b/sys/include/net/netopt.h
@@ -539,6 +539,13 @@ typedef enum {
      */
     NETOPT_BLE_CTX,
 
+    /**
+     * @brief   (@ref netopt_enable_t) enable hardware checksumming
+     *
+     * If enabled, enable hardware checksumming of incoming frames.
+     */
+    NETOPT_CHECKSUM,
+
     /* add more options if needed */
 
     /**

--- a/sys/include/net/netopt.h
+++ b/sys/include/net/netopt.h
@@ -546,6 +546,14 @@ typedef enum {
      */
     NETOPT_CHECKSUM,
 
+    /**
+     * @brief   (@ref netopt_enable_t) enable busy mode
+     *
+     * When set, the hardware will enter busy mode, in which it will not accept
+     * incoming frames until unset.
+     */
+    NETOPT_BUSY,
+
     /* add more options if needed */
 
     /**

--- a/sys/net/crosslayer/netopt/netopt.c
+++ b/sys/net/crosslayer/netopt/netopt.c
@@ -90,6 +90,7 @@ static const char *_netopt_strmap[] = {
     [NETOPT_TX_RETRIES_NEEDED]     = "NETOPT_TX_RETRIES_NEEDED",
     [NETOPT_6LO_IPHC]              = "NETOPT_6LO_IPHC",
     [NETOPT_BLE_CTX]               = "NETOPT_BLE_CTX",
+    [NETOPT_CHECKSUM]              = "NETOPT_CHECKSUM",
     [NETOPT_NUMOF]                 = "NETOPT_NUMOF",
 };
 

--- a/sys/net/crosslayer/netopt/netopt.c
+++ b/sys/net/crosslayer/netopt/netopt.c
@@ -91,6 +91,7 @@ static const char *_netopt_strmap[] = {
     [NETOPT_6LO_IPHC]              = "NETOPT_6LO_IPHC",
     [NETOPT_BLE_CTX]               = "NETOPT_BLE_CTX",
     [NETOPT_CHECKSUM]              = "NETOPT_CHECKSUM",
+    [NETOPT_BUSY]                  = "NETOPT_BUSY",
     [NETOPT_NUMOF]                 = "NETOPT_NUMOF",
 };
 

--- a/sys/shell/commands/sc_gnrc_netif.c
+++ b/sys/shell/commands/sc_gnrc_netif.c
@@ -71,7 +71,8 @@ static const struct {
     { "rtr_adv", NETOPT_IPV6_SND_RTR_ADV },
     { "iq_invert", NETOPT_IQ_INVERT },
     { "rx_single", NETOPT_SINGLE_RECEIVE },
-    { "chan_hop", NETOPT_CHANNEL_HOP }
+    { "chan_hop", NETOPT_CHANNEL_HOP },
+    { "checksum", NETOPT_CHECKSUM }
 };
 
 /* utility functions */
@@ -150,6 +151,7 @@ static void _set_usage(char *cmd_name)
          "       * \"freq\" - sets the \"channel\" center frequency\n"
          "       * \"channel\" - sets the frequency channel\n"
          "       * \"chan\" - alias for \"channel\"\n"
+         "       * \"checksum\" - set checksumming on-off\n"
          "       * \"csma_retries\" - set max. number of channel access attempts\n"
          "       * \"encrypt\" - set the encryption on-off\n"
          "       * \"hop_limit\" - set hop limit\n"
@@ -274,6 +276,10 @@ static void _print_netopt(netopt_t opt)
 
         case NETOPT_CODING_RATE:
             printf("coding rate");
+            break;
+
+        case NETOPT_CHECKSUM:
+            printf("checksum");
             break;
 
         default:

--- a/sys/shell/commands/sc_gnrc_netif.c
+++ b/sys/shell/commands/sc_gnrc_netif.c
@@ -60,6 +60,7 @@ static const struct {
     { "ack_req", NETOPT_ACK_REQ },
     { "autoack", NETOPT_AUTOACK },
     { "autocca", NETOPT_AUTOCCA },
+    { "busy", NETOPT_BUSY },
     { "csma", NETOPT_CSMA },
     { "encrypt", NETOPT_ENCRYPTION },
     { "mac_no_sleep", NETOPT_MAC_NO_SLEEP },
@@ -147,6 +148,7 @@ static void _set_usage(char *cmd_name)
          "       * \"addr\" - sets (short) address\n"
          "       * \"addr_long\" - sets long address\n"
          "       * \"addr_short\" - alias for \"addr\"\n"
+         "       * \"busy\" - set busy mode on-off\n"
          "       * \"cca_threshold\" - set ED threshold during CCA in dBm\n"
          "       * \"freq\" - sets the \"channel\" center frequency\n"
          "       * \"channel\" - sets the frequency channel\n"
@@ -280,6 +282,10 @@ static void _print_netopt(netopt_t opt)
 
         case NETOPT_CHECKSUM:
             printf("checksum");
+            break;
+
+        case NETOPT_BUSY:
+            printf("busy");
             break;
 
         default:


### PR DESCRIPTION
### Contribution description

I'm experimenting with KNX/EIB transceivers ([TPUART](http://www.hqs.sbt.siemens.com/cps_product_data/gamma-b2b/tpuart.pdf)/[NCN5120](http://www.onsemi.com/pub/Collateral/NCN5120-D.PDF)) and Netdev/GNRC. I know GNRC is a generic IP network stack, but so far so good 😄.

I've found the need for two additional Netdev options: 

* `NETOPT_CHECKSUM` — instructs the transceiver to add checksums to each incoming frame, so (in my case) one doesn't have to wait 2.5ms to see if the frame is completely received.
* `NETOPT_BUSY` — instruct the transceiver to enable busy mode, which will auto-NACK incoming frames.

I think the options are named generic enough to be useful for other transceivers, if applicable.

### Issues/PRs references

None