### PR TITLE
cpu: ldscript memory attribute corrections

### DIFF
--- a/cpu/cc2538/ldscripts/cc2538nf11.ld
+++ b/cpu/cc2538/ldscripts/cc2538nf11.ld
@@ -19,10 +19,10 @@
 /* Memory Space Definitions: */
 MEMORY
 {
-    rom   (rx ) : ORIGIN = 0x00200000, LENGTH = 128K - 44
-    cca   (rx ) : ORIGIN = 0x0027ffd4, LENGTH = 44
-    sram1 (rwx) : ORIGIN = 0x20004000, LENGTH = 16K
-    ram   (rwx) : ORIGIN = 0x20004000, LENGTH = 16K
+    rom (rx)    : ORIGIN = 0x00200000, LENGTH = 128K - 44
+    cca         : ORIGIN = 0x0027ffd4, LENGTH = 44
+    sram1       : ORIGIN = 0x20004000, LENGTH = 16K
+    ram (w!rx)  : ORIGIN = 0x20004000, LENGTH = 16K
 }
 
 /* MCU Specific Section Definitions */

--- a/cpu/cc2538/ldscripts/cc2538nf23.ld
+++ b/cpu/cc2538/ldscripts/cc2538nf23.ld
@@ -19,11 +19,11 @@
 /* Memory Space Definitions: */
 MEMORY
 {
-    rom   (rx ) : ORIGIN = 0x00200000, LENGTH = 256K - 44
-    cca   (rx ) : ORIGIN = 0x0027ffd4, LENGTH = 44
-    sram0 (rwx) : ORIGIN = 0x20000000, LENGTH = 16K /* Lost in PM2 and PM3 */
-    sram1 (rwx) : ORIGIN = 0x20004000, LENGTH = 16K
-    ram   (rwx) : ORIGIN = 0x20000000, LENGTH = 32K
+    rom (rx)    : ORIGIN = 0x00200000, LENGTH = 256K - 44
+    cca         : ORIGIN = 0x0027ffd4, LENGTH = 44
+    sram0       : ORIGIN = 0x20000000, LENGTH = 16K /* Lost in PM2 and PM3 */
+    sram1       : ORIGIN = 0x20004000, LENGTH = 16K
+    ram (w!rx)  : ORIGIN = 0x20000000, LENGTH = 32K
 }
 
 /* MCU Specific Section Definitions */

--- a/cpu/cc2538/ldscripts/cc2538nf53.ld
+++ b/cpu/cc2538/ldscripts/cc2538nf53.ld
@@ -19,11 +19,11 @@
 /* Memory Space Definitions: */
 MEMORY
 {
-    rom   (rx ) : ORIGIN = 0x00200000, LENGTH = 512K - 44
-    cca   (rx ) : ORIGIN = 0x0027ffd4, LENGTH = 44
-    sram0 (rwx) : ORIGIN = 0x20000000, LENGTH = 16K /* Lost in PM2 and PM3 */
-    sram1 (rwx) : ORIGIN = 0x20004000, LENGTH = 16K
-    ram   (rwx) : ORIGIN = 0x20000000, LENGTH = 32K
+    rom (rx)    : ORIGIN = 0x00200000, LENGTH = 512K - 44
+    cca         : ORIGIN = 0x0027ffd4, LENGTH = 44
+    sram0       : ORIGIN = 0x20000000, LENGTH = 16K /* Lost in PM2 and PM3 */
+    sram1       : ORIGIN = 0x20004000, LENGTH = 16K
+    ram (w!rx)  : ORIGIN = 0x20000000, LENGTH = 32K
 }
 
 /* MCU Specific Section Definitions */

--- a/cpu/cc2538/ldscripts/cc2538sf53.ld
+++ b/cpu/cc2538/ldscripts/cc2538sf53.ld
@@ -19,9 +19,9 @@
 /* Memory Space Definitions: */
 MEMORY
 {
-    rom   (rx ) : ORIGIN = 0x00200000, LENGTH = 512K - 44
-    cca   (rx ) : ORIGIN = 0x0027ffd4, LENGTH = 44
-    ram   (rwx) : ORIGIN = 0x20000000, LENGTH = 32K
+    rom (rx)    : ORIGIN = 0x00200000, LENGTH = 512K - 44
+    cca         : ORIGIN = 0x0027ffd4, LENGTH = 44
+    ram (w!rx)  : ORIGIN = 0x20000000, LENGTH = 32K
 }
 
 /* MCU Specific Section Definitions */

--- a/cpu/cc26x0/ldscripts/cc26x0f128.ld
+++ b/cpu/cc26x0/ldscripts/cc26x0f128.ld
@@ -11,9 +11,9 @@
 /* Memory Space Definitions: */
 MEMORY
 {
-    rom  (rx ) : ORIGIN = 0x00000000, LENGTH = 0x00020000 - 88 /* technically, it's 128K */
-    gpram  (rwx) : ORIGIN = 0x11000000, LENGTH = 8K /* configurable as cache. 20K here, 8K there, and 2K in the ld-script of cc26x0ware */
-    ram    (rwx) : ORIGIN = 0x20000000, LENGTH = 20K /* sram */
+    rom (rx)   : ORIGIN = 0x00000000, LENGTH = 0x00020000 - 88 /* technically, it's 128K */
+    gpram      : ORIGIN = 0x11000000, LENGTH = 8K /* configurable as cache. 20K here, 8K there, and 2K in the ld-script of cc26x0ware */
+    ram (w!rx) : ORIGIN = 0x20000000, LENGTH = 20K /* sram */
 }
 
 INCLUDE cortexm_base.ld

--- a/cpu/cortexm_common/ldscripts/cortexm.ld
+++ b/cpu/cortexm_common/ldscripts/cortexm.ld
@@ -23,7 +23,7 @@ _boot_offset = DEFINED( _rom_offset ) ? _rom_offset : 0x0 ;
 MEMORY
 {
     rom (rx)    : ORIGIN = _rom_start_addr + _boot_offset, LENGTH = _rom_length - _boot_offset
-    ram (rwx)   : ORIGIN = _ram_start_addr,                LENGTH = _ram_length
+    ram (w!rx)  : ORIGIN = _ram_start_addr,                LENGTH = _ram_length
 }
 
 INCLUDE cortexm_base.ld

--- a/cpu/cortexm_common/ldscripts/cortexm_base.ld
+++ b/cpu/cortexm_common/ldscripts/cortexm_base.ld
@@ -115,7 +115,7 @@ SECTIONS
         _estack = .;
     } > ram
 
-    .relocate : AT (_etext)
+    .relocate :
     {
         . = ALIGN(4);
         _srelocate = .;
@@ -124,7 +124,7 @@ SECTIONS
         KEEP (*(.openocd .openocd.*))
         . = ALIGN(4);
         _erelocate = .;
-    } > ram
+    } > ram AT> rom
 
     /* .bss section which is used for uninitialized data */
     .bss (NOLOAD) :

--- a/cpu/ezr32wg/ldscripts/ezr32wg330f256r60.ld
+++ b/cpu/ezr32wg/ldscripts/ezr32wg330f256r60.ld
@@ -21,7 +21,7 @@
 MEMORY
 {
     rom (rx)    : ORIGIN = 0x00000000, LENGTH = 256K
-    ram (rwx)   : ORIGIN = 0x20000000, LENGTH = 32K
+    ram (w!rx)  : ORIGIN = 0x20000000, LENGTH = 32K
 }
 
 INCLUDE cortexm_base.ld

--- a/cpu/lm4f120/ldscripts/LM4F120H5QR.ld
+++ b/cpu/lm4f120/ldscripts/LM4F120H5QR.ld
@@ -20,7 +20,7 @@
 MEMORY
 {
     rom (rx)    : ORIGIN = 0x00000000, LENGTH = 256K
-    ram (rwx)   : ORIGIN = 0x20000000, LENGTH = 32K
+    ram (w!rx)  : ORIGIN = 0x20000000, LENGTH = 32K
 }
 
 INCLUDE cortexm_base.ld

--- a/cpu/lpc1768/ldscripts/lpc1768.ld
+++ b/cpu/lpc1768/ldscripts/lpc1768.ld
@@ -21,9 +21,9 @@
 MEMORY
 {
     rom (rx)        : ORIGIN = 0x00000000, LENGTH = 512K
-    ram (rwx)       : ORIGIN = 0x100000C8, LENGTH = (32K - 0xC8)
-    usb_ram (rwx)   : ORIGIN = 0x2007C000, LENGTH = 16K
-    eth_ram (rwx)   : ORIGIN = 0x20080000, LENGTH = 16K
+    ram (w!rx)      : ORIGIN = 0x100000C8, LENGTH = (32K - 0xC8)
+    usb_ram         : ORIGIN = 0x2007C000, LENGTH = 16K
+    eth_ram         : ORIGIN = 0x20080000, LENGTH = 16K
 }
 
 INCLUDE cortexm_base.ld

--- a/cpu/lpc2387/ldscripts/lpc2387.ld
+++ b/cpu/lpc2387/ldscripts/lpc2387.ld
@@ -9,10 +9,10 @@
 /* specify the LPC2387 memory areas (see LPC2387 datasheet page 15)  */
 MEMORY
 {
-    flash               : ORIGIN = 0,          LENGTH = 504K    /* FLASH ROM 512kByte without ISP bootloader*/
+    flash (rx)          : ORIGIN = 0,          LENGTH = 504K    /* FLASH ROM 512kByte without ISP bootloader*/
     infomem             : ORIGIN = 0x0007D000, LENGTH = 4K      /* Last sector in FLASH ROM for config data */
     ram_battery         : ORIGIN = 0xE0084000, LENGTH = 2K      /* Battery RAM                              */
-    ram                 : ORIGIN = 0x40000000, LENGTH = 64K     /* LOCAL ON-CHIP STATIC RAM                 */
+    ram (w!rx)          : ORIGIN = 0x40000000, LENGTH = 64K     /* LOCAL ON-CHIP STATIC RAM                 */
     ram_usb             : ORIGIN = 0x7FD00000, LENGTH = 16K     /* USB RAM  !!! first 1024 bytes are occupied from GPDMA for MCI */
     ram_ethernet        : ORIGIN = 0x7FE00000, LENGTH = 16K     /* ethernet RAM                             */
 }

--- a/cpu/mips_pic32mz/ldscripts/pic32mz2048_uhi.ld
+++ b/cpu/mips_pic32mz/ldscripts/pic32mz2048_uhi.ld
@@ -67,7 +67,7 @@ PROVIDE (__use_excpt_boot = 0);
 EXTERN (__register_excpt_boot);
 
 ASSERT (DEFINED(__register_excpt_boot) || __use_excpt_boot == 0,
-	"Registration for boot context is required for UHI chaining")
+        "Registration for boot context is required for UHI chaining")
 
 /* Control if subnormal floating-point values are flushed to zero in
    hardware.  This applies to both FPU and MSA operations.  */
@@ -77,8 +77,8 @@ PROVIDE (__flush_to_zero = 1);
    quiet or verbose exception handling above */
 EXTERN (__exception_handle);
 PROVIDE(__exception_handle = (DEFINED(__exception_handle_quiet)
-				      ? __exception_handle_quiet
-				      : __exception_handle_verbose));
+                                      ? __exception_handle_quiet
+                                      : __exception_handle_verbose));
 PROVIDE(_mips_handle_exception = __exception_handle);
 
 /*
@@ -122,13 +122,13 @@ SECTIONS
 {
   /* Start of bootrom */
   .lowerbootflashalias __bev_override : /* Runs uncached (from 0xBfc00000) until I$ is
-			       initialized. */
+                               initialized. */
   AT (__lower_boot_flash_start)
   {
     __base = .;
 
-    *(.reset)		/* Reset entry point. */
-    *(.boot)		/* Boot code. */
+    *(.reset)           /* Reset entry point. */
+    *(.boot)            /* Boot code. */
     . = ALIGN(8);
 
     . = __base + 0xff40; /*Alternate Config bits (lower Alias)*/
@@ -234,12 +234,12 @@ SECTIONS
     /* Leave space for all the vector entries */
     . = __base + 0x200 + (__isr_vec_space * __isr_vec_count);
     ASSERT(__isr_vec_space == (DEFINED(__isr_vec_sw0)
-			       ? __isr_vec_sw1 - __isr_vec_sw0
-			       : __isr_vec_space),
-	   "Actual ISR vector spacing does not match __isr_vec_space");
+                               ? __isr_vec_sw1 - __isr_vec_sw0
+                               : __isr_vec_space),
+           "Actual ISR vector spacing does not match __isr_vec_space");
     ASSERT(__base + 0x200 == (DEFINED(__isr_vec_sw0)
-			      ? __isr_vec_sw0 & 0xfffffffe : __base + 0x200),
-	   "__isr_vec_sw0 is not placed at EBASE + 0x200");
+                              ? __isr_vec_sw0 & 0xfffffffe : __base + 0x200),
+           "__isr_vec_sw0 is not placed at EBASE + 0x200");
     . = ALIGN(8);
   } = 0
 

--- a/cpu/nrf51/ldscripts/nrf51x22xxaa.ld
+++ b/cpu/nrf51/ldscripts/nrf51x22xxaa.ld
@@ -21,7 +21,7 @@
 MEMORY
 {
     rom (rx)    : ORIGIN = 0x00000000, LENGTH = 256K
-    ram (rwx)   : ORIGIN = 0x20000000, LENGTH = 16K
+    ram (w!rx)  : ORIGIN = 0x20000000, LENGTH = 16K
 }
 
 INCLUDE cortexm_base.ld

--- a/cpu/nrf51/ldscripts/nrf51x22xxab.ld
+++ b/cpu/nrf51/ldscripts/nrf51x22xxab.ld
@@ -21,7 +21,7 @@
 MEMORY
 {
     rom (rx)    : ORIGIN = 0x00000000, LENGTH = 128K
-    ram (rwx)   : ORIGIN = 0x20000000, LENGTH = 16K
+    ram (w!rx)  : ORIGIN = 0x20000000, LENGTH = 16K
 }
 
 INCLUDE cortexm_base.ld

--- a/cpu/nrf51/ldscripts/nrf51x22xxac.ld
+++ b/cpu/nrf51/ldscripts/nrf51x22xxac.ld
@@ -21,7 +21,7 @@
 MEMORY
 {
     rom (rx)    : ORIGIN = 0x00000000, LENGTH = 256K
-    ram (rwx)   : ORIGIN = 0x20000000, LENGTH = 32K
+    ram (w!rx)  : ORIGIN = 0x20000000, LENGTH = 32K
 }
 
 INCLUDE cortexm_base.ld

--- a/cpu/nrf52/ldscripts/nrf52832xxaa.ld
+++ b/cpu/nrf52/ldscripts/nrf52832xxaa.ld
@@ -25,7 +25,7 @@ INCLUDE multislot.ld
 MEMORY
 {
     rom (rx)    : ORIGIN = 0x00000000 + boot_offset, LENGTH = rom_length
-    ram (rwx)   : ORIGIN = 0x20000000,               LENGTH = 64K
+    ram (w!rx)  : ORIGIN = 0x20000000,               LENGTH = 64K
 }
 
 INCLUDE cortexm_base.ld

--- a/cpu/nrf52/ldscripts/nrf52832xxaa_sd.ld
+++ b/cpu/nrf52/ldscripts/nrf52832xxaa_sd.ld
@@ -20,8 +20,8 @@
 
 MEMORY
 {
-  rom (rx) : ORIGIN = 0x1f000, LENGTH = 0x61000
-  ram (rwx) :  ORIGIN = 0x20002800, LENGTH = 0xD800
+    rom (rx)    : ORIGIN =    0x1f000, LENGTH = 0x61000
+    ram (w!rx)  : ORIGIN = 0x20002800, LENGTH = 0xD800
 }
 
 INCLUDE cortexm_base.ld

--- a/cpu/nrf52/ldscripts/nrf52840xxaa.ld
+++ b/cpu/nrf52/ldscripts/nrf52840xxaa.ld
@@ -21,7 +21,7 @@
 MEMORY
 {
     rom (rx)    : ORIGIN = 0x00000000, LENGTH = 1024K
-    ram (rwx)   : ORIGIN = 0x20000000, LENGTH = 256K
+    ram (w!rx)  : ORIGIN = 0x20000000, LENGTH = 256K
 }
 
 INCLUDE cortexm_base.ld

--- a/cpu/nrf52/ldscripts/nrf52840xxaa_sd.ld
+++ b/cpu/nrf52/ldscripts/nrf52840xxaa_sd.ld
@@ -20,8 +20,8 @@
 
 MEMORY
 {
-  rom (rx) : ORIGIN = 0x1f000, LENGTH = 0xe1000
-  ram (rwx) :  ORIGIN = 0x20002800, LENGTH = 0x3D800
+    rom (rx)    : ORIGIN =    0x1f000, LENGTH = 0xe1000
+    ram (w!rx)  : ORIGIN = 0x20002800, LENGTH = 0x3D800
 }
 
 INCLUDE cortexm_base.ld

--- a/cpu/sam0_common/ldscripts/samd21j18a_arduino_bootloader.ld
+++ b/cpu/sam0_common/ldscripts/samd21j18a_arduino_bootloader.ld
@@ -21,7 +21,7 @@
 MEMORY
 {
     rom (rx)    : ORIGIN = 0x00002000, LENGTH = 256K-0x2000
-    ram (rwx)   : ORIGIN = 0x20000000, LENGTH = 32K
+    ram (w!rx)  : ORIGIN = 0x20000000, LENGTH = 32K
 }
 
 INCLUDE cortexm_base.ld

--- a/cpu/sam_common/ldscripts/sam3x8e.ld
+++ b/cpu/sam_common/ldscripts/sam3x8e.ld
@@ -21,7 +21,7 @@
 MEMORY
 {
     rom (rx)    : ORIGIN = 0x00080000, LENGTH = 512K
-    ram (rwx)   : ORIGIN = 0x20070000, LENGTH = 96K
+    ram (w!rx)  : ORIGIN = 0x20070000, LENGTH = 96K
 }
 
 INCLUDE cortexm_base.ld

--- a/cpu/stm32_common/ldscripts/stm32_common.ld
+++ b/cpu/stm32_common/ldscripts/stm32_common.ld
@@ -22,7 +22,7 @@ ccmram_length = DEFINED( ccmram_len ) ? ccmram_len : 0x0 ;
 
 MEMORY
 {
-    ccmram (rwx): ORIGIN = 0x10000000, LENGTH = ccmram_length
+    ccmram  : ORIGIN = 0x10000000, LENGTH = ccmram_length
 }
 
 INCLUDE cortexm.ld


### PR DESCRIPTION

### Contribution description

Using attributes (rx) on only the ROM segment will make the linker use that segment for orphan sections with read-only or executable contents.
Having a correct default placement for read-only and executable sections makes it easier to write augmentation ldscripts for adding more sections, such as XFA (#7523), because the linker will then place any added sections in ROM.
Any writable sections which need relocating during boot still needs the `> ram AT> rom` specifications like it is done in the platform specific ldscripts.

Quote GNU ld manual https://sourceware.org/binutils/docs/ld/MEMORY.html

>The attr string is an optional list of attributes that specify whether to use a particular memory region for an input section which is not explicitly mapped in the linker script. As described in SECTIONS, if you do not specify an output section for some input section, the linker will create an output section with the same name as the input section. If you define region attributes, the linker will use them to select the memory region for the output section that it creates. 

### Issues/PRs references

based on #9084 
useful in #7523 
https://sourceware.org/binutils/docs/ld/MEMORY.html