### PR TITLE
pkg/qDSA: disble arm asm version for cortexm > 0plus

### DIFF
--- a/pkg/qDSA/Makefile.dep
+++ b/pkg/qDSA/Makefile.dep
@@ -1,3 +1,7 @@
-ifneq (,$(filter atmega_common cortexm_common,$(USEMODULE)))
+ifneq (,$(filter cortex-m0%,$(CPU_ARCH)))
+  USEMODULE += qDSA_asm
+endif
+
+ifneq (,$(filter atmega_common,$(USEMODULE)))
   USEMODULE += qDSA_asm
 endif

--- a/pkg/qDSA/Makefile.include
+++ b/pkg/qDSA/Makefile.include
@@ -1,4 +1,4 @@
-ifneq (,$(filter cortexm_common,$(USEMODULE)))
+ifneq (,$(filter cortex-m0%,$(CPU_ARCH)))
   QDSA_IMPL ?= arm
 else
 ifneq (,$(filter atmega_common,$(USEMODULE)))


### PR DESCRIPTION
### Contribution description

Release testing showed that qDSA's arm implementation hard faults on Cortex-M3 and higher.
This PR disables the ARM assembler version for those CPU's for now.

### Issues/PRs references

https://github.com/RIOT-OS/Release-Specs/issues/62#issuecomment-384364005