### PR TITLE
murdock: enable nrf52dk for on-hardware tests

### DIFF
--- a/.murdock
+++ b/.murdock
@@ -1,6 +1,6 @@
 #!/bin/sh
 
-: ${TEST_BOARDS_AVAILABLE:="samr21-xpro"}
+: ${TEST_BOARDS_AVAILABLE:="nrf52dk samr21-xpro"}
 : ${TEST_BOARDS_LLVM_COMPILE:="iotlab-m3 native nrf52dk mulle nucleo-f401re samr21-xpro slstk3402a"}
 
 export RIOT_CI_BUILD=1


### PR DESCRIPTION
### Contribution description

This PR enables on-hardware tests on two nrf52dk boards.

nrf52dk uses ```$(HEXFILE)``` as flashfile. One of the commits makes an exception for this. IMO, this is ugly, but will go away as soon as #8838 is merged.

### Issues/PRs references

#8838