### PR TITLE
cpu/stm32: add CPU_LINE_* variable and use it for stm32f0 and stm32f4

### DIFF
--- a/cpu/stm32_common/Makefile.include
+++ b/cpu/stm32_common/Makefile.include
@@ -23,8 +23,16 @@ export INCLUDES += -I$(RIOTCPU)/stm32_common/include
 
 include $(RIOTCPU)/stm32_common/stm32_mem_lengths.mk
 
+# Get CPU_LINE_ variable
+-include $(RIOTCPU)/$(CPU)/stm32_line.mk
+CPU_LINE ?= $(shell echo $(CPU_MODEL) | cut -c -9 | tr 'a-z-' 'A-Z_')xx
+
+# Set CFLAGS
+export CFLAGS += -D$(CPU_LINE) -DCPU_LINE_$(CPU_LINE)
+
 info-stm32:
 	@$(COLOR_ECHO) "CPU: $(CPU_MODEL)"
+	@$(COLOR_ECHO) "\tLine: $(CPU_LINE)"
 	@$(COLOR_ECHO) "\tPin count:\t$(STM32_PINCOUNT)"
 	@$(COLOR_ECHO) "\tROM size:\t$(ROM_LEN)"
 	@$(COLOR_ECHO) "\tRAM size:\t$(RAM_LEN)"

--- a/cpu/stm32_common/Makefile.include
+++ b/cpu/stm32_common/Makefile.include
@@ -21,7 +21,11 @@ LINKER_SCRIPT ?= stm32_common.ld
 # export the common include directory
 export INCLUDES += -I$(RIOTCPU)/stm32_common/include
 
+# Compute ROM_LEN and RAM_LEN
 include $(RIOTCPU)/stm32_common/stm32_mem_lengths.mk
+KB := 1024
+LEN := $(shell echo $(ROM_LEN) | sed 's/K//')
+FLASHSIZE := $(shell echo $$(( $(LEN) * $(KB) )) )
 
 # Get CPU_LINE_ variable
 -include $(RIOTCPU)/$(CPU)/stm32_line.mk
@@ -29,12 +33,13 @@ CPU_LINE ?= $(shell echo $(CPU_MODEL) | cut -c -9 | tr 'a-z-' 'A-Z_')xx
 
 # Set CFLAGS
 export CFLAGS += -D$(CPU_LINE) -DCPU_LINE_$(CPU_LINE)
+export CFLAGS += -DSTM32_FLASHSIZE=$(FLASHSIZE)U
 
 info-stm32:
 	@$(COLOR_ECHO) "CPU: $(CPU_MODEL)"
 	@$(COLOR_ECHO) "\tLine: $(CPU_LINE)"
 	@$(COLOR_ECHO) "\tPin count:\t$(STM32_PINCOUNT)"
-	@$(COLOR_ECHO) "\tROM size:\t$(ROM_LEN)"
+	@$(COLOR_ECHO) "\tROM size:\t$(ROM_LEN) ($(FLASHSIZE) Bytes)"
 	@$(COLOR_ECHO) "\tRAM size:\t$(RAM_LEN)"
 
 ifneq (,$(CCMRAM_LEN))

--- a/cpu/stm32f0/include/cpu_conf.h
+++ b/cpu/stm32f0/include/cpu_conf.h
@@ -25,27 +25,8 @@
 
 #include "cpu_conf_common.h"
 
-#ifdef CPU_MODEL_STM32F051R8
-#include "vendor/stm32f051x8.h"
-#endif
-#ifdef CPU_MODEL_STM32F091RC
-#include "vendor/stm32f091xc.h"
-#endif
-#ifdef CPU_MODEL_STM32F072RB
-#include "vendor/stm32f072xb.h"
-#endif
-#ifdef CPU_MODEL_STM32F070RB
-#include "vendor/stm32f070xb.h"
-#endif
-#ifdef CPU_MODEL_STM32F030R8
-#include "vendor/stm32f030x8.h"
-#endif
-#ifdef CPU_MODEL_STM32F042K6
-#include "vendor/stm32f042x6.h"
-#endif
-#ifdef CPU_MODEL_STM32F031K6
-#include "vendor/stm32f031x6.h"
-#endif
+#include "vendor/stm32f0xx.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -55,13 +36,13 @@ extern "C" {
  * @{
  */
 #define CPU_DEFAULT_IRQ_PRIO            (1U)
-#if defined(CPU_MODEL_STM32F030R8)
+#if defined(CPU_LINE_STM32F030x8)
 #define CPU_IRQ_NUMOF                   (29U)
-#elif defined(CPU_MODEL_STM32F031K6)
+#elif defined(CPU_LINE_STM32F031x6)
 #define CPU_IRQ_NUMOF                   (28U)
-#elif defined(CPU_MODEL_STM32F051R8) || defined(CPU_MODEL_STM32F091RC)
+#elif defined(CPU_LINE_STM32F051x8) || defined(CPU_LINE_STM32F091xC)
 #define CPU_IRQ_NUMOF                   (31U)
-#else /* CPU_MODEL_STM32F042K6, CPU_MODEL_STM32F070RB, CPU_MODEL_STM32F072RB */
+#else
 #define CPU_IRQ_NUMOF                   (32U)
 #endif
 /** @} */
@@ -74,21 +55,14 @@ extern "C" {
  *
  * @{
  */
-#if defined(CPU_MODEL_STM32F091RC) || defined(CPU_MODEL_STM32F072RB)
+#if defined(CPU_LINE_STM32F091xC) || defined(CPU_LINE_STM32F072xB)
 #define FLASHPAGE_SIZE      (2048U)
-#elif defined(CPU_MODEL_STM32F051R8) || defined(CPU_MODEL_STM32F042K6) \
-   || defined(CPU_MODEL_STM32F070RB) || defined(CPU_MODEL_STM32F030R8)
+#elif defined(CPU_LINE_STM32F051x8) || defined(CPU_LINE_STM32F042x6) \
+   || defined(CPU_LINE_STM32F070xB) || defined(CPU_LINE_STM32F030x8)
 #define FLASHPAGE_SIZE      (1024U)
 #endif
 
-#if defined(CPU_MODEL_STM32F091RC)
-#define FLASHPAGE_NUMOF     (128U)
-#elif defined(CPU_MODEL_STM32F051R8) || defined(CPU_MODEL_STM32F072RB) \
-   || defined(CPU_MODEL_STM32F030R8) || defined(CPU_MODEL_STM32F070RB)
-#define FLASHPAGE_NUMOF     (64U)
-#elif defined(CPU_MODEL_STM32F042K6)
-#define FLASHPAGE_NUMOF     (32U)
-#endif
+#define FLASHPAGE_NUMOF     (STM32_FLASHSIZE / FLASHPAGE_SIZE)
 
 /* The minimum block size which can be written is 2B. However, the erase
  * block is always FLASHPAGE_SIZE.

--- a/cpu/stm32f0/include/vendor/stm32f0xx.h
+++ b/cpu/stm32f0/include/vendor/stm32f0xx.h
@@ -1,0 +1,242 @@
+/**
+  ******************************************************************************
+  * @file    stm32f0xx.h
+  * @author  MCD Application Team
+  * @brief   CMSIS STM32F0xx Device Peripheral Access Layer Header File.
+  *
+  *          The file is the unique include file that the application programmer
+  *          is using in the C source code, usually in main.c. This file contains:
+  *           - Configuration section that allows to select:
+  *              - The STM32F0xx device used in the target application
+  *              - To use or not the peripherals drivers in application code(i.e.
+  *                code will be based on direct access to peripherals registers
+  *                rather than drivers API), this option is controlled by
+  *                "#define USE_HAL_DRIVER"
+  *
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/** @addtogroup CMSIS
+  * @{
+  */
+
+/** @addtogroup stm32f0xx
+  * @{
+  */
+
+#ifndef __STM32F0xx_H
+#define __STM32F0xx_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif /* __cplusplus */
+
+/** @addtogroup Library_configuration_section
+  * @{
+  */
+
+/**
+  * @brief STM32 Family
+  */
+#if !defined  (STM32F0)
+#define STM32F0
+#endif /* STM32F0 */
+
+/* Uncomment the line below according to the target STM32 device used in your
+   application
+  */
+
+#if !defined (STM32F030x6) && !defined (STM32F030x8) &&                           \
+    !defined (STM32F031x6) && !defined (STM32F038xx) &&                           \
+    !defined (STM32F042x6) && !defined (STM32F048xx) && !defined (STM32F070x6) && \
+    !defined (STM32F051x8) && !defined (STM32F058xx) &&                           \
+    !defined (STM32F071xB) && !defined (STM32F072xB) && !defined (STM32F078xx) && !defined (STM32F070xB) && \
+    !defined (STM32F091xC) && !defined (STM32F098xx) && !defined (STM32F030xC)
+  /* #define STM32F030x6 */  /*!< STM32F030x4, STM32F030x6 Devices (STM32F030xx microcontrollers where the Flash memory ranges between 16 and 32 Kbytes)              */
+  /* #define STM32F030x8 */  /*!< STM32F030x8 Devices (STM32F030xx microcontrollers where the Flash memory is 64 Kbytes)                                              */
+  /* #define STM32F031x6 */  /*!< STM32F031x4, STM32F031x6 Devices (STM32F031xx microcontrollers where the Flash memory ranges between 16 and 32 Kbytes)              */
+  /* #define STM32F038xx */  /*!< STM32F038xx Devices (STM32F038xx microcontrollers where the Flash memory is 32 Kbytes)                                              */
+  /* #define STM32F042x6 */  /*!< STM32F042x4, STM32F042x6 Devices (STM32F042xx microcontrollers where the Flash memory ranges between 16 and 32 Kbytes)              */
+  /* #define STM32F048x6 */  /*!< STM32F048xx Devices (STM32F042xx microcontrollers where the Flash memory is 32 Kbytes)                                              */
+  /* #define STM32F051x8 */  /*!< STM32F051x4, STM32F051x6, STM32F051x8 Devices (STM32F051xx microcontrollers where the Flash memory ranges between 16 and 64 Kbytes) */
+  /* #define STM32F058xx */  /*!< STM32F058xx Devices (STM32F058xx microcontrollers where the Flash memory is 64 Kbytes)                                              */
+  /* #define STM32F070x6 */  /*!< STM32F070x6 Devices (STM32F070x6 microcontrollers where the Flash memory ranges between 16 and 32 Kbytes)                           */
+  /* #define STM32F070xB */  /*!< STM32F070xB Devices (STM32F070xB microcontrollers where the Flash memory ranges between 64 and 128 Kbytes)                          */
+  /* #define STM32F071xB */  /*!< STM32F071x8, STM32F071xB Devices (STM32F071xx microcontrollers where the Flash memory ranges between 64 and 128 Kbytes)             */
+  /* #define STM32F072xB */  /*!< STM32F072x8, STM32F072xB Devices (STM32F072xx microcontrollers where the Flash memory ranges between 64 and 128 Kbytes)             */
+  /* #define STM32F078xx */  /*!< STM32F078xx Devices (STM32F078xx microcontrollers where the Flash memory is 128 Kbytes)                                             */
+  /* #define STM32F030xC */  /*!< STM32F030xC Devices (STM32F030xC microcontrollers where the Flash memory is 256 Kbytes)                                             */
+  /* #define STM32F091xC */  /*!< STM32F091xB, STM32F091xC Devices (STM32F091xx microcontrollers where the Flash memory ranges between 128 and 256 Kbytes)            */
+  /* #define STM32F098xx */  /*!< STM32F098xx Devices (STM32F098xx microcontrollers where the Flash memory is 256 Kbytes)                                             */
+#endif
+
+/*  Tip: To avoid modifying this file each time you need to switch between these
+        devices, you can define the device in your toolchain compiler preprocessor.
+  */
+#if !defined  (USE_HAL_DRIVER)
+/**
+ * @brief Comment the line below if you will not use the peripherals drivers.
+   In this case, these drivers will not be included and the application code will
+   be based on direct access to peripherals registers
+   */
+  /*#define USE_HAL_DRIVER */
+#endif /* USE_HAL_DRIVER */
+
+/**
+  * @brief CMSIS Device version number V2.3.2
+  */
+#define __STM32F0_DEVICE_VERSION_MAIN   (0x02) /*!< [31:24] main version */
+#define __STM32F0_DEVICE_VERSION_SUB1   (0x03) /*!< [23:16] sub1 version */
+#define __STM32F0_DEVICE_VERSION_SUB2   (0x02) /*!< [15:8]  sub2 version */
+#define __STM32F0_DEVICE_VERSION_RC     (0x00) /*!< [7:0]  release candidate */
+#define __STM32F0_DEVICE_VERSION        ((__STM32F0_DEVICE_VERSION_MAIN << 24)\
+                                        |(__STM32F0_DEVICE_VERSION_SUB1 << 16)\
+                                        |(__STM32F0_DEVICE_VERSION_SUB2 << 8 )\
+                                        |(__STM32F0_DEVICE_VERSION_RC))
+
+/**
+  * @}
+  */
+
+/** @addtogroup Device_Included
+  * @{
+  */
+
+#if defined(STM32F030x6)
+  #include "stm32f030x6.h"
+#elif defined(STM32F030x8)
+  #include "stm32f030x8.h"
+#elif defined(STM32F031x6)
+  #include "stm32f031x6.h"
+#elif defined(STM32F038xx)
+  #include "stm32f038xx.h"
+#elif defined(STM32F042x6)
+  #include "stm32f042x6.h"
+#elif defined(STM32F048xx)
+  #include "stm32f048xx.h"
+#elif defined(STM32F051x8)
+  #include "stm32f051x8.h"
+#elif defined(STM32F058xx)
+  #include "stm32f058xx.h"
+#elif defined(STM32F070x6)
+  #include "stm32f070x6.h"
+#elif defined(STM32F070xB)
+  #include "stm32f070xb.h"
+#elif defined(STM32F071xB)
+  #include "stm32f071xb.h"
+#elif defined(STM32F072xB)
+  #include "stm32f072xb.h"
+#elif defined(STM32F078xx)
+  #include "stm32f078xx.h"
+#elif defined(STM32F091xC)
+  #include "stm32f091xc.h"
+#elif defined(STM32F098xx)
+  #include "stm32f098xx.h"
+#elif defined(STM32F030xC)
+  #include "stm32f030xc.h"
+#else
+ #error "Please select first the target STM32F0xx device used in your application (in stm32f0xx.h file)"
+#endif
+
+/**
+  * @}
+  */
+
+/** @addtogroup Exported_types
+  * @{
+  */
+typedef enum
+{
+  RESET = 0,
+  SET = !RESET
+} FlagStatus, ITStatus;
+
+typedef enum
+{
+  DISABLE = 0,
+  ENABLE = !DISABLE
+} FunctionalState;
+#define IS_FUNCTIONAL_STATE(STATE) (((STATE) == DISABLE) || ((STATE) == ENABLE))
+
+typedef enum
+{
+  ERROR = 0,
+  SUCCESS = !ERROR
+} ErrorStatus;
+
+/**
+  * @}
+  */
+
+
+/** @addtogroup Exported_macros
+  * @{
+  */
+#define SET_BIT(REG, BIT)     ((REG) |= (BIT))
+
+#define CLEAR_BIT(REG, BIT)   ((REG) &= ~(BIT))
+
+#define READ_BIT(REG, BIT)    ((REG) & (BIT))
+
+#define CLEAR_REG(REG)        ((REG) = (0x0))
+
+#define WRITE_REG(REG, VAL)   ((REG) = (VAL))
+
+#define READ_REG(REG)         ((REG))
+
+#define MODIFY_REG(REG, CLEARMASK, SETMASK)  WRITE_REG((REG), (((READ_REG(REG)) & (~(CLEARMASK))) | (SETMASK)))
+
+
+/**
+  * @}
+  */
+
+#if defined (USE_HAL_DRIVER)
+ #include "stm32f0xx_hal.h"
+#endif /* USE_HAL_DRIVER */
+
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif /* __STM32F0xx_H */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+
+
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/cpu/stm32f0/stm32_line.mk
+++ b/cpu/stm32f0/stm32_line.mk
@@ -1,0 +1,27 @@
+# Compute CPU_LINE
+LINE := $(shell echo $(CPU_MODEL) | tr 'a-z-' 'A-Z_' | sed -E -e 's/^STM32F([0-9][0-9][0-9])(.)(.)/\1 \2 \3/')
+TYPE := $(word 1, $(LINE))
+MODEL1 := $(word 2, $(LINE))
+MODEL2 := $(word 3, $(LINE))
+
+ifneq (, $(filter $(TYPE), 030 031 042 070))
+  ifneq (, $(filter $(MODEL2), 4 6))
+    CPU_LINE = STM32F$(TYPE)x6
+  else ifneq (, $(filter $(MODEL2), 8))
+    CPU_LINE = STM32F$(TYPE)x8
+  else ifneq (, $(filter $(MODEL2), B))
+    CPU_LINE = STM32F$(TYPE)xB
+  endif
+else ifneq (, $(filter $(TYPE), 051))
+  CPU_LINE = STM32F$(TYPE)x8
+else ifneq (, $(filter $(TYPE), 071 072))
+  CPU_LINE = STM32F$(TYPE)xB
+else ifneq (, $(filter $(TYPE), 091))
+  CPU_LINE = STM32F$(TYPE)xC
+else
+  CPU_LINE = STM32F$(TYPE)xx
+endif
+
+ifeq ($(CPU_LINE), )
+  $(error Unsupported CPU)
+endif

--- a/cpu/stm32f0/vectors.c
+++ b/cpu/stm32f0/vectors.c
@@ -80,7 +80,7 @@ ISR_VECTOR(1) const isr_t vector_cpu[CPU_IRQ_NUMOF] = {
     [22] = isr_tim17,                /* [22] TIM17 global Interrupt */
     [25] = isr_spi1,                 /* [25] SPI1 global Interrupt */
 
-#if defined(CPU_MODEL_STM32F030R8)
+#if defined(CPU_LINE_STM32F030x8)
     [ 4] = isr_rcc,                  /* [ 4] RCC global Interrupt */
     [ 5] = isr_exti,                 /* [ 5] EXTI Line 0 and 1 Interrupt */
     [ 6] = isr_exti,                 /* [ 6] EXTI Line 2 and 3 Interrupt */
@@ -97,7 +97,7 @@ ISR_VECTOR(1) const isr_t vector_cpu[CPU_IRQ_NUMOF] = {
     [26] = isr_spi2,                 /* [26] SPI2 global Interrupt */
     [27] = isr_usart1,               /* [27] USART1 global Interrupt */
     [28] = isr_usart2,               /* [28] USART2 global Interrupt */
-#elif defined(CPU_MODEL_STM32F031K6)
+#elif defined(CPU_LINE_STM32F031x6)
     [ 1] = isr_pvd,                  /* [ 1] PVD Interrupt through EXTI Lines 16 */
     [ 4] = isr_rcc,                  /* [ 4] RCC global Interrupt */
     [ 5] = isr_exti,                 /* [ 5] EXTI Line 0 and 1 Interrupt */
@@ -111,7 +111,7 @@ ISR_VECTOR(1) const isr_t vector_cpu[CPU_IRQ_NUMOF] = {
     [15] = isr_tim2,                 /* [15] TIM2 global Interrupt */
     [23] = isr_i2c1,                 /* [23] I2C1 Event Interrupt & EXTI Line23 Interrupt (I2C1 wakeup) */
     [27] = isr_usart1,               /* [27] USART1 global Interrupt & EXTI Line25 Interrupt (USART1 wakeup) */
-#elif defined(CPU_MODEL_STM32F042K6)
+#elif defined(CPU_LINE_STM32F042x6)
     [ 1] = isr_pvd_vddio2,           /* [ 1] PVD & VDDIO2 Interrupts through EXTI Lines 16 and 31 */
     [ 4] = isr_rcc_crs,              /* [ 4] RCC & CRS Global Interrupts */
     [ 5] = isr_exti,                 /* [ 5] EXTI Line 0 and 1 Interrupts */
@@ -130,7 +130,7 @@ ISR_VECTOR(1) const isr_t vector_cpu[CPU_IRQ_NUMOF] = {
     [28] = isr_usart2,               /* [28] USART2 global Interrupt */
     [30] = isr_cec_can,              /* [30] CEC and CAN global Interrupts & EXTI Line27 Interrupt */
     [31] = isr_usb,                  /* [31] USB global Interrupts & EXTI Line18 Interrupt */
-#elif defined(CPU_MODEL_STM32F051R8)
+#elif defined(CPU_LINE_STM32F051x8)
     [ 1] = isr_pvd,                  /* [ 1] PVD Interrupt through EXTI Lines 16 */
     [ 4] = isr_rcc,                  /* [ 4] RCC global Interrupt */
     [ 5] = isr_exti,                 /* [ 5] EXTI Line 0 and 1 Interrupts */
@@ -151,7 +151,7 @@ ISR_VECTOR(1) const isr_t vector_cpu[CPU_IRQ_NUMOF] = {
     [27] = isr_usart1,               /* [27] USART1 global Interrupt & EXTI Line25 Interrupt (USART1 wakeup) */
     [28] = isr_usart2,               /* [28] USART2 global Interrupt */
     [30] = isr_cec_can,              /* [30] CEC and CAN global Interrupts & EXTI Line27 Interrupt */
-#elif defined(CPU_MODEL_STM32F070RB)
+#elif defined(CPU_LINE_STM32F070xB)
     [ 4] = isr_rcc,                  /* [ 4] RCC global Interrupt */
     [ 5] = isr_exti,                 /* [ 5] EXTI Line 0 and 1 Interrupt */
     [ 6] = isr_exti,                 /* [ 6] EXTI Line 2 and 3 Interrupt */
@@ -171,7 +171,7 @@ ISR_VECTOR(1) const isr_t vector_cpu[CPU_IRQ_NUMOF] = {
     [28] = isr_usart2,               /* [28] USART2 global Interrupt */
     [29] = isr_usart3_4,             /* [29] USART3 and USART4 global Interrupt */
     [31] = isr_usb,                  /* [31] USB global Interrupt  & EXTI Line18 Interrupt */
-#elif defined(CPU_MODEL_STM32F072RB)
+#elif defined(CPU_LINE_STM32F072xB)
     [ 1] = isr_pvd_vddio2,           /* [ 1] PVD & VDDIO2 Interrupt through EXTI Lines 16 and 31 */
     [ 4] = isr_rcc_crs,              /* [ 4] RCC & CRS global Interrupt */
     [ 5] = isr_exti,                 /* [ 5] EXTI Line 0 and 1 Interrupt */
@@ -195,7 +195,7 @@ ISR_VECTOR(1) const isr_t vector_cpu[CPU_IRQ_NUMOF] = {
     [29] = isr_usart3_4,             /* [29] USART3 and USART4 global Interrupt */
     [30] = isr_cec_can,              /* [30] CEC and CAN global Interrupts & EXTI Line27 Interrupt */
     [31] = isr_usb,                  /* [31] USB global Interrupt  & EXTI Line18 Interrupt */
-#elif defined(CPU_MODEL_STM32F091RC)
+#elif defined(CPU_LINE_STM32F091xC)
     [ 1] = isr_pvd_vddio2,           /* [ 1] PVD & VDDIO2 Interrupts through EXTI Lines 16 and 31 */
     [ 4] = isr_rcc_crs,              /* [ 4] RCC & CRS global Interrupts */
     [ 5] = isr_exti,                 /* [ 5] EXTI Line 0 and 1 Interrupts */

--- a/cpu/stm32f4/include/cpu_conf.h
+++ b/cpu/stm32f4/include/cpu_conf.h
@@ -25,35 +25,7 @@
 
 #include "cpu_conf_common.h"
 
-#if defined(CPU_MODEL_STM32F401RE)
-#include "vendor/stm32f401xe.h"
-#elif defined(CPU_MODEL_STM32F407VG)
-#include "vendor/stm32f407xx.h"
-#elif defined(CPU_MODEL_STM32F410RB)
-#include "vendor/stm32f410rx.h"
-#elif defined(CPU_MODEL_STM32F411RE)
-#include "vendor/stm32f411xe.h"
-#elif defined(CPU_MODEL_STM32F412ZG)
-#include "vendor/stm32f412zx.h"
-#elif defined(CPU_MODEL_STM32F413CG) || defined(CPU_MODEL_STM32F413RG) \
-    || defined(CPU_MODEL_STM32F413MG) || defined(CPU_MODEL_STM32F413VG) \
-    || defined(CPU_MODEL_STM32F413ZG) || defined(CPU_MODEL_STM32F413CH) \
-    || defined(CPU_MODEL_STM32F413RH) || defined(CPU_MODEL_STM32F413MH) \
-    || defined(CPU_MODEL_STM32F413VH) || defined(CPU_MODEL_STM32F413ZH)
-#include "vendor/stm32f413xx.h"
-#elif defined(CPU_MODEL_STM32F415RG)
-#include "vendor/stm32f415xx.h"
-#elif defined(CPU_MODEL_STM32F423CH) || defined(CPU_MODEL_STM32F423RH) \
-    || defined(CPU_MODEL_STM32F423MH) || defined(CPU_MODEL_STM32F423VH) \
-    || defined(CPU_MODEL_STM32F423ZH)
-#include "vendor/stm32f423xx.h"
-#elif defined(CPU_MODEL_STM32F429ZI)
-#include "vendor/stm32f429xx.h"
-#elif defined(CPU_MODEL_STM32F437VG)
-#include "vendor/stm32f437xx.h"
-#elif defined(CPU_MODEL_STM32F446RE) || defined(CPU_MODEL_STM32F446ZE)
-#include "vendor/stm32f446xx.h"
-#endif
+#include "vendor/stm32f4xx.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -64,27 +36,19 @@ extern "C" {
  * @{
  */
 #define CPU_DEFAULT_IRQ_PRIO            (1U)
-#if defined(CPU_MODEL_STM32F401RE)
+#if defined(CPU_LINE_STM32F401xE)
 #define CPU_IRQ_NUMOF                   (85U)
-#elif defined(CPU_MODEL_STM32F407VG) || defined(CPU_MODEL_STM32F415RG)
+#elif defined(CPU_LINE_STM32F407xx) || defined(CPU_LINE_STM32F415xx)
 #define CPU_IRQ_NUMOF                   (82U)
-#elif defined(CPU_MODEL_STM32F410RB)
+#elif defined(CPU_LINE_STM32F410Rx)
 #define CPU_IRQ_NUMOF                   (98U)
-#elif defined(CPU_MODEL_STM32F411RE)
+#elif defined(CPU_LINE_STM32F411xE)
 #define CPU_IRQ_NUMOF                   (86U)
-#elif defined(CPU_MODEL_STM32F412ZG) || defined(CPU_MODEL_STM32F446RE) \
-    || defined(CPU_MODEL_STM32F446ZE)
+#elif defined(CPU_LINE_STM32F412Zx) || defined(CPU_LINE_STM32F446xx)
 #define CPU_IRQ_NUMOF                   (97U)
-#elif defined(CPU_MODEL_STM32F413CG) || defined(CPU_MODEL_STM32F413RG) \
-    || defined(CPU_MODEL_STM32F413MG) || defined(CPU_MODEL_STM32F413VG) \
-    || defined(CPU_MODEL_STM32F413ZG) || defined(CPU_MODEL_STM32F413CH) \
-    || defined(CPU_MODEL_STM32F413RH) || defined(CPU_MODEL_STM32F413MH) \
-    || defined(CPU_MODEL_STM32F413VH) || defined(CPU_MODEL_STM32F413ZH) \
-    || defined(CPU_MODEL_STM32F423CH) || defined(CPU_MODEL_STM32F423RH) \
-    || defined(CPU_MODEL_STM32F423MH) || defined(CPU_MODEL_STM32F423VH) \
-    || defined(CPU_MODEL_STM32F423ZH)
+#elif defined(CPU_LINE_STM32F413xx) || defined(CPU_LINE_STM32F423xx)
 #define CPU_IRQ_NUMOF                   (102U)
-#elif defined(CPU_MODEL_STM32F429ZI) || defined(CPU_MODEL_STM32F437VG)
+#elif defined(CPU_LINE_STM32F429xx) || defined(CPU_LINE_STM32F437xx)
 #define CPU_IRQ_NUMOF                   (91U)
 #endif
 #define CPU_FLASH_BASE                  FLASH_BASE

--- a/cpu/stm32f4/include/periph_cpu.h
+++ b/cpu/stm32f4/include/periph_cpu.h
@@ -48,20 +48,13 @@ enum {
 /**
  * @brief   Available number of ADC devices
  */
-#if defined(CPU_MODEL_STM32F401RE) || defined(CPU_MODEL_STM32F410RB) \
-    || defined(CPU_MODEL_STM32F411RE) || defined(CPU_MODEL_STM32F412ZG) \
-    || defined(CPU_MODEL_STM32F413CG) || defined(CPU_MODEL_STM32F413RG) \
-    || defined(CPU_MODEL_STM32F413MG) || defined(CPU_MODEL_STM32F413VG) \
-    || defined(CPU_MODEL_STM32F413ZG) || defined(CPU_MODEL_STM32F413CH) \
-    || defined(CPU_MODEL_STM32F413RH) || defined(CPU_MODEL_STM32F413MH) \
-    || defined(CPU_MODEL_STM32F413VH) || defined(CPU_MODEL_STM32F413ZH) \
-    || defined(CPU_MODEL_STM32F423CH) || defined(CPU_MODEL_STM32F423RH) \
-    || defined(CPU_MODEL_STM32F423MH) || defined(CPU_MODEL_STM32F423VH) \
-    || defined(CPU_MODEL_STM32F423ZH)
+#if defined(CPU_LINE_STM32F401xE) || defined(CPU_LINE_STM32F410Rx) \
+    || defined(CPU_LINE_STM32F411xE) || defined(CPU_LINE_STM32F412Zx) \
+    || defined(CPU_LINE_STM32F413xx) || defined(CPU_LINE_STM32F423xx)
 #define ADC_DEVS            (1U)
-#elif defined(CPU_MODEL_STM32F407VG) || defined(CPU_MODEL_STM32F415RG) \
-    || defined(CPU_MODEL_STM32F429ZI) || defined(CPU_MODEL_STM32F437VG) \
-    || defined(CPU_MODEL_STM32F446RE) || defined(CPU_MODEL_STM32F446ZE)
+#elif defined(CPU_LINE_STM32F407xx) || defined(CPU_LINE_STM32F415xx) \
+    || defined(CPU_LINE_STM32F429xx) || defined(CPU_LINE_STM32F437xx) \
+    || defined(CPU_LINE_STM32F446xx)
 #define ADC_DEVS            (3U)
 #endif
 

--- a/cpu/stm32f4/include/vendor/stm32f4xx.h
+++ b/cpu/stm32f4/include/vendor/stm32f4xx.h
@@ -1,0 +1,271 @@
+/**
+  ******************************************************************************
+  * @file    stm32f4xx.h
+  * @author  MCD Application Team
+  * @version V2.6.1
+  * @date    14-February-2017
+  * @brief   CMSIS STM32F4xx Device Peripheral Access Layer Header File.
+  *
+  *          The file is the unique include file that the application programmer
+  *          is using in the C source code, usually in main.c. This file contains:
+  *           - Configuration section that allows to select:
+  *              - The STM32F4xx device used in the target application
+  *              - To use or not the peripherals drivers in application code(i.e.
+  *                code will be based on direct access to peripherals registers
+  *                rather than drivers API), this option is controlled by
+  *                "#define USE_HAL_DRIVER"
+  *
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/** @addtogroup CMSIS
+  * @{
+  */
+
+/** @addtogroup stm32f4xx
+  * @{
+  */
+
+#ifndef __STM32F4xx_H
+#define __STM32F4xx_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif /* __cplusplus */
+
+/** @addtogroup Library_configuration_section
+  * @{
+  */
+
+/**
+  * @brief STM32 Family
+  */
+#if !defined  (STM32F4)
+#define STM32F4
+#endif /* STM32F4 */
+
+/* Uncomment the line below according to the target STM32 device used in your
+   application
+  */
+#if !defined (STM32F405xx) && !defined (STM32F415xx) && !defined (STM32F407xx) && !defined (STM32F417xx) && \
+    !defined (STM32F427xx) && !defined (STM32F437xx) && !defined (STM32F429xx) && !defined (STM32F439xx) && \
+    !defined (STM32F401xC) && !defined (STM32F401xE) && !defined (STM32F410Tx) && !defined (STM32F410Cx) && \
+    !defined (STM32F410Rx) && !defined (STM32F411xE) && !defined (STM32F446xx) && !defined (STM32F469xx) && \
+    !defined (STM32F479xx) && !defined (STM32F412Cx) && !defined (STM32F412Rx) && !defined (STM32F412Vx) && \
+    !defined (STM32F412Zx) && !defined (STM32F413xx) && !defined (STM32F423xx)
+  /* #define STM32F405xx */   /*!< STM32F405RG, STM32F405VG and STM32F405ZG Devices */
+  /* #define STM32F415xx */   /*!< STM32F415RG, STM32F415VG and STM32F415ZG Devices */
+  /* #define STM32F407xx */   /*!< STM32F407VG, STM32F407VE, STM32F407ZG, STM32F407ZE, STM32F407IG  and STM32F407IE Devices */
+  /* #define STM32F417xx */   /*!< STM32F417VG, STM32F417VE, STM32F417ZG, STM32F417ZE, STM32F417IG and STM32F417IE Devices */
+  /* #define STM32F427xx */   /*!< STM32F427VG, STM32F427VI, STM32F427ZG, STM32F427ZI, STM32F427IG and STM32F427II Devices */
+  /* #define STM32F437xx */   /*!< STM32F437VG, STM32F437VI, STM32F437ZG, STM32F437ZI, STM32F437IG and STM32F437II Devices */
+  /* #define STM32F429xx */   /*!< STM32F429VG, STM32F429VI, STM32F429ZG, STM32F429ZI, STM32F429BG, STM32F429BI, STM32F429NG,
+                                   STM32F439NI, STM32F429IG  and STM32F429II Devices */
+  /* #define STM32F439xx */   /*!< STM32F439VG, STM32F439VI, STM32F439ZG, STM32F439ZI, STM32F439BG, STM32F439BI, STM32F439NG,
+                                   STM32F439NI, STM32F439IG and STM32F439II Devices */
+  /* #define STM32F401xC */   /*!< STM32F401CB, STM32F401CC, STM32F401RB, STM32F401RC, STM32F401VB and STM32F401VC Devices */
+  /* #define STM32F401xE */   /*!< STM32F401CD, STM32F401RD, STM32F401VD, STM32F401CE, STM32F401RE and STM32F401VE Devices */
+  /* #define STM32F410Tx */   /*!< STM32F410T8 and STM32F410TB Devices */
+  /* #define STM32F410Cx */   /*!< STM32F410C8 and STM32F410CB Devices */
+  /* #define STM32F410Rx */   /*!< STM32F410R8 and STM32F410RB Devices */
+  /* #define STM32F411xE */   /*!< STM32F411CC, STM32F411RC, STM32F411VC, STM32F411CE, STM32F411RE and STM32F411VE Devices */
+  /* #define STM32F446xx */   /*!< STM32F446MC, STM32F446ME, STM32F446RC, STM32F446RE, STM32F446VC, STM32F446VE, STM32F446ZC,
+                                   and STM32F446ZE Devices */
+  /* #define STM32F469xx */   /*!< STM32F469AI, STM32F469II, STM32F469BI, STM32F469NI, STM32F469AG, STM32F469IG, STM32F469BG,
+                                   STM32F469NG, STM32F469AE, STM32F469IE, STM32F469BE and STM32F469NE Devices */
+  /* #define STM32F479xx */   /*!< STM32F479AI, STM32F479II, STM32F479BI, STM32F479NI, STM32F479AG, STM32F479IG, STM32F479BG
+                                   and STM32F479NG Devices */
+  /* #define STM32F412Cx */   /*!< STM32F412CEU and STM32F412CGU Devices */
+  /* #define STM32F412Zx */   /*!< STM32F412ZET, STM32F412ZGT, STM32F412ZEJ and STM32F412ZGJ Devices */
+  /* #define STM32F412Vx */   /*!< STM32F412VET, STM32F412VGT, STM32F412VEH and STM32F412VGH Devices */
+  /* #define STM32F412Rx */   /*!< STM32F412RET, STM32F412RGT, STM32F412REY and STM32F412RGY Devices */
+  /* #define STM32F413xx */   /*!< STM32F413CH, STM32F413MH, STM32F413RH, STM32F413VH, STM32F413ZH, STM32F413CG, STM32F413MG,
+                                   STM32F413RG, STM32F413VG and STM32F413ZG Devices */
+  /* #define STM32F423xx */   /*!< STM32F423CH, STM32F423RH, STM32F423VH and STM32F423ZH Devices */
+#endif
+
+/*  Tip: To avoid modifying this file each time you need to switch between these
+        devices, you can define the device in your toolchain compiler preprocessor.
+  */
+#if !defined  (USE_HAL_DRIVER)
+/**
+ * @brief Comment the line below if you will not use the peripherals drivers.
+   In this case, these drivers will not be included and the application code will
+   be based on direct access to peripherals registers
+   */
+  /*#define USE_HAL_DRIVER */
+#endif /* USE_HAL_DRIVER */
+
+/**
+  * @brief CMSIS version number V2.6.1
+  */
+#define __STM32F4xx_CMSIS_VERSION_MAIN   (0x02U) /*!< [31:24] main version */
+#define __STM32F4xx_CMSIS_VERSION_SUB1   (0x06U) /*!< [23:16] sub1 version */
+#define __STM32F4xx_CMSIS_VERSION_SUB2   (0x01U) /*!< [15:8]  sub2 version */
+#define __STM32F4xx_CMSIS_VERSION_RC     (0x00U) /*!< [7:0]  release candidate */
+#define __STM32F4xx_CMSIS_VERSION        ((__STM32F4xx_CMSIS_VERSION_MAIN << 24)\
+                                         |(__STM32F4xx_CMSIS_VERSION_SUB1 << 16)\
+                                         |(__STM32F4xx_CMSIS_VERSION_SUB2 << 8 )\
+                                         |(__STM32F4xx_CMSIS_VERSION))
+
+/**
+  * @}
+  */
+
+/** @addtogroup Device_Included
+  * @{
+  */
+
+#if defined(STM32F405xx)
+  #include "stm32f405xx.h"
+#elif defined(STM32F415xx)
+  #include "stm32f415xx.h"
+#elif defined(STM32F407xx)
+  #include "stm32f407xx.h"
+#elif defined(STM32F417xx)
+  #include "stm32f417xx.h"
+#elif defined(STM32F427xx)
+  #include "stm32f427xx.h"
+#elif defined(STM32F437xx)
+  #include "stm32f437xx.h"
+#elif defined(STM32F429xx)
+  #include "stm32f429xx.h"
+#elif defined(STM32F439xx)
+  #include "stm32f439xx.h"
+#elif defined(STM32F401xC)
+  #include "stm32f401xc.h"
+#elif defined(STM32F401xE)
+  #include "stm32f401xe.h"
+#elif defined(STM32F410Tx)
+  #include "stm32f410tx.h"
+#elif defined(STM32F410Cx)
+  #include "stm32f410cx.h"
+#elif defined(STM32F410Rx)
+  #include "stm32f410rx.h"
+#elif defined(STM32F411xE)
+  #include "stm32f411xe.h"
+#elif defined(STM32F446xx)
+  #include "stm32f446xx.h"
+#elif defined(STM32F469xx)
+  #include "stm32f469xx.h"
+#elif defined(STM32F479xx)
+  #include "stm32f479xx.h"
+#elif defined(STM32F412Cx)
+  #include "stm32f412cx.h"
+#elif defined(STM32F412Zx)
+  #include "stm32f412zx.h"
+#elif defined(STM32F412Rx)
+  #include "stm32f412rx.h"
+#elif defined(STM32F412Vx)
+  #include "stm32f412vx.h"
+#elif defined(STM32F413xx)
+  #include "stm32f413xx.h"
+#elif defined(STM32F423xx)
+  #include "stm32f423xx.h"
+#else
+ #error "Please select first the target STM32F4xx device used in your application (in stm32f4xx.h file)"
+#endif
+
+/**
+  * @}
+  */
+
+/** @addtogroup Exported_types
+  * @{
+  */
+typedef enum
+{
+  RESET = 0U,
+  SET = !RESET
+} FlagStatus, ITStatus;
+
+typedef enum
+{
+  DISABLE = 0U,
+  ENABLE = !DISABLE
+} FunctionalState;
+#define IS_FUNCTIONAL_STATE(STATE) (((STATE) == DISABLE) || ((STATE) == ENABLE))
+
+typedef enum
+{
+  ERROR = 0U,
+  SUCCESS = !ERROR
+} ErrorStatus;
+
+/**
+  * @}
+  */
+
+
+/** @addtogroup Exported_macro
+  * @{
+  */
+#define SET_BIT(REG, BIT)     ((REG) |= (BIT))
+
+#define CLEAR_BIT(REG, BIT)   ((REG) &= ~(BIT))
+
+#define READ_BIT(REG, BIT)    ((REG) & (BIT))
+
+#define CLEAR_REG(REG)        ((REG) = (0x0))
+
+#define WRITE_REG(REG, VAL)   ((REG) = (VAL))
+
+#define READ_REG(REG)         ((REG))
+
+#define MODIFY_REG(REG, CLEARMASK, SETMASK)  WRITE_REG((REG), (((READ_REG(REG)) & (~(CLEARMASK))) | (SETMASK)))
+
+#define POSITION_VAL(VAL)     (__CLZ(__RBIT(VAL)))
+
+
+/**
+  * @}
+  */
+
+#if defined (USE_HAL_DRIVER)
+ #include "stm32f4xx_hal.h"
+#endif /* USE_HAL_DRIVER */
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif /* __STM32F4xx_H */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+
+
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/cpu/stm32f4/stm32_line.mk
+++ b/cpu/stm32f4/stm32_line.mk
@@ -1,0 +1,23 @@
+# Compute CPU_LINE
+LINE := $(shell echo $(CPU_MODEL) | tr 'a-z-' 'A-Z_' | sed -E -e 's/^STM32F([0-9][0-9][0-9])(.)(.)/\1 \2 \3/')
+TYPE := $(word 1, $(LINE))
+MODEL1 := $(word 2, $(LINE))
+MODEL2 := $(word 3, $(LINE))
+
+ifneq (, $(filter $(TYPE), 401))
+  ifneq (, $(filter $(MODEL2), B C))
+    CPU_LINE = STM32F$(TYPE)xC
+  else ifneq (, $(filter $(MODEL2), D E))
+    CPU_LINE = STM32F$(TYPE)xE
+  endif
+else ifneq (, $(filter $(TYPE), 410 412))
+  CPU_LINE = STM32F$(TYPE)$(MODEL1)x
+else ifneq (, $(filter $(TYPE), 411))
+  CPU_LINE = STM32F$(TYPE)xE
+else
+  CPU_LINE = STM32F$(TYPE)xx
+endif
+
+ifeq ($(CPU_LINE), )
+  $(error Unsupported CPU)
+endif

--- a/cpu/stm32f4/vectors.c
+++ b/cpu/stm32f4/vectors.c
@@ -186,7 +186,7 @@ ISR_VECTOR(1) const isr_t vector_cpu[CPU_IRQ_NUMOF] = {
     [71] = isr_usart6,               /* [71] USART6 global interrupt */
     [81] = isr_fpu,                  /* [81] FPU global interrupt */
 
-#if defined(CPU_MODEL_STM32F401RE)
+#if defined(CPU_LINE_STM32F401xE)
     [18] = isr_adc,                  /* [18] ADC1, ADC2 and ADC3 global Interrupts */
     [25] = isr_tim1_up_tim10,        /* [25] TIM1 Update Interrupt and TIM10 global interrupt */
     [28] = isr_tim2,                 /* [28] TIM2 global Interrupt */
@@ -199,7 +199,7 @@ ISR_VECTOR(1) const isr_t vector_cpu[CPU_IRQ_NUMOF] = {
     [72] = isr_i2c3_ev,              /* [72] I2C3 event interrupt */
     [73] = isr_i2c3_er,              /* [73] I2C3 error interrupt */
     [84] = isr_spi4,                 /* [84] SPI4 global Interrupt */
-#elif defined(CPU_MODEL_STM32F407VG)
+#elif defined(CPU_LINE_STM32F407xx)
     [18] = isr_adc,                  /* [18] ADC1, ADC2 and ADC3 global Interrupts */
     [19] = isr_can1_tx,              /* [19] CAN1 TX Interrupt */
     [20] = isr_can1_rx0,             /* [20] CAN1 RX0 Interrupt */
@@ -236,7 +236,7 @@ ISR_VECTOR(1) const isr_t vector_cpu[CPU_IRQ_NUMOF] = {
     [76] = isr_otg_hs_wkup,          /* [76] USB OTG HS Wakeup through EXTI interrupt */
     [77] = isr_otg_hs,               /* [77] USB OTG HS global interrupt */
     [78] = isr_dcmi,                 /* [78] DCMI global interrupt */
-#elif defined(CPU_MODEL_STM32F410RB)
+#elif defined(CPU_LINE_STM32F410Rx)
     [18] = isr_adc,                  /* [18] ADC1 global Interrupts */
     [25] = isr_tim1_up,              /* [25] TIM1 Update Interrupt */
     [54] = isr_tim6_dac,             /* [54] TIM6 global Interrupt and DAC Global Interrupt */
@@ -245,7 +245,7 @@ ISR_VECTOR(1) const isr_t vector_cpu[CPU_IRQ_NUMOF] = {
     [95] = isr_fmpi2c1_ev,           /* [95] FMPI2C1 Event Interrupt */
     [96] = isr_fmpi2c1_er,           /* [96] FMPI2C1 Error Interrupt */
     [97] = isr_lptim1,               /* [97] LPTIM1 interrupt */
-#elif defined(CPU_MODEL_STM32F411RE)
+#elif defined(CPU_LINE_STM32F411xE)
     [18] = isr_adc,                  /* [18] ADC1, ADC2 and ADC3 global Interrupts */
     [25] = isr_tim1_up_tim10,        /* [25] TIM1 Update Interrupt and TIM10 global interrupt */
     [28] = isr_tim2,                 /* [28] TIM2 global Interrupt */
@@ -259,7 +259,7 @@ ISR_VECTOR(1) const isr_t vector_cpu[CPU_IRQ_NUMOF] = {
     [73] = isr_i2c3_er,              /* [73] I2C3 error interrupt */
     [84] = isr_spi4,                 /* [84] SPI4 global Interrupt */
     [85] = isr_spi5,                 /* [85] SPI5 global Interrupt */
-#elif defined(CPU_MODEL_STM32F412ZG)
+#elif defined(CPU_LINE_STM32F412Zx)
     [18] = isr_adc,                  /* [18] ADC1, ADC2 and ADC3 global Interrupts */
     [19] = isr_can1_tx,              /* [19] CAN1 TX Interrupt */
     [20] = isr_can1_rx0,             /* [20] CAN1 RX0 Interrupt */
@@ -294,11 +294,7 @@ ISR_VECTOR(1) const isr_t vector_cpu[CPU_IRQ_NUMOF] = {
     [92] = isr_quadspi,              /* [92] QuadSPI global Interrupt */
     [95] = isr_fmpi2c1_ev,           /* [95] FMPI2C1 Event Interrupt */
     [96] = isr_fmpi2c1_er,           /* [96] FMPI2C1 Error Interrupt */
-#elif defined(CPU_MODEL_STM32F413CG) || defined(CPU_MODEL_STM32F413RG) \
-    || defined(CPU_MODEL_STM32F413MG) || defined(CPU_MODEL_STM32F413VG) \
-    || defined(CPU_MODEL_STM32F413ZG) || defined(CPU_MODEL_STM32F413CH) \
-    || defined(CPU_MODEL_STM32F413RH) || defined(CPU_MODEL_STM32F413MH) \
-    || defined(CPU_MODEL_STM32F413VH) || defined(CPU_MODEL_STM32F413ZH)
+#elif defined(CPU_LINE_STM32F413xx)
     [18] = isr_adc,                  /* [18] ADC1, ADC2 and ADC3 global Interrupts */
     [19] = isr_can1_tx,              /* [19] CAN1 TX Interrupt */
     [20] = isr_can1_rx0,             /* [20] CAN1 RX0 Interrupt */
@@ -349,7 +345,7 @@ ISR_VECTOR(1) const isr_t vector_cpu[CPU_IRQ_NUMOF] = {
     [99] = isr_dfsdm2_flt1,          /* [99] DFSDM2 Filter 1 global Interrupt */
     [100] = isr_dfsdm2_flt2,          /* [100] DFSDM2 Filter 2 global Interrupt */
     [101] = isr_dfsdm2_flt3,          /* [101] DFSDM2 Filter 3 global Interrupt */
-#elif defined(CPU_MODEL_STM32F415RG)
+#elif defined(CPU_LINE_STM32F415xx)
     [18] = isr_adc,                  /* [18] ADC1, ADC2 and ADC3 global Interrupts */
     [19] = isr_can1_tx,              /* [19] CAN1 TX Interrupt */
     [20] = isr_can1_rx0,             /* [20] CAN1 RX0 Interrupt */
@@ -385,9 +381,7 @@ ISR_VECTOR(1) const isr_t vector_cpu[CPU_IRQ_NUMOF] = {
     [77] = isr_otg_hs,               /* [77] USB OTG HS global interrupt */
     [79] = isr_cryp,                 /* [79] CRYP crypto global interrupt */
     [80] = isr_hash_rng,             /* [80] Hash and Rng global interrupt */
-#elif defined(CPU_MODEL_STM32F423CH) || defined(CPU_MODEL_STM32F423RH) \
-    || defined(CPU_MODEL_STM32F423MH) || defined(CPU_MODEL_STM32F423VH) \
-    || defined(CPU_MODEL_STM32F423ZH)
+#elif defined(CPU_LINE_STM32F423xx)
     [18] = isr_adc,                  /* [18] ADC1, ADC2 and ADC3 global Interrupts */
     [19] = isr_can1_tx,              /* [19] CAN1 TX Interrupt */
     [20] = isr_can1_rx0,             /* [20] CAN1 RX0 Interrupt */
@@ -439,7 +433,7 @@ ISR_VECTOR(1) const isr_t vector_cpu[CPU_IRQ_NUMOF] = {
     [99] = isr_dfsdm2_flt1,          /* [99] DFSDM2 Filter 1 global Interrupt */
     [100] = isr_dfsdm2_flt2,          /* [100] DFSDM2 Filter 2 global Interrupt */
     [101] = isr_dfsdm2_flt3,          /* [101] DFSDM2 Filter 3 global Interrupt */
-#elif defined(CPU_MODEL_STM32F429ZI)
+#elif defined(CPU_LINE_STM32F429xx)
     [18] = isr_adc,                  /* [18] ADC1, ADC2 and ADC3 global Interrupts */
     [19] = isr_can1_tx,              /* [19] CAN1 TX Interrupt */
     [20] = isr_can1_rx0,             /* [20] CAN1 RX0 Interrupt */
@@ -485,7 +479,7 @@ ISR_VECTOR(1) const isr_t vector_cpu[CPU_IRQ_NUMOF] = {
     [88] = isr_ltdc,                 /* [88] LTDC global Interrupt */
     [89] = isr_ltdc_er,              /* [89] LTDC Error global Interrupt */
     [90] = isr_dma2d,                /* [90] DMA2D global Interrupt */
-#elif defined(CPU_MODEL_STM32F437VG)
+#elif defined(CPU_LINE_STM32F437xx)
     [18] = isr_adc,                  /* [18] ADC1, ADC2 and ADC3 global Interrupts */
     [19] = isr_can1_tx,              /* [19] CAN1 TX Interrupt */
     [20] = isr_can1_rx0,             /* [20] CAN1 RX0 Interrupt */
@@ -531,7 +525,7 @@ ISR_VECTOR(1) const isr_t vector_cpu[CPU_IRQ_NUMOF] = {
     [86] = isr_spi6,                 /* [86] SPI6 global Interrupt */
     [87] = isr_sai1,                 /* [87] SAI1 global Interrupt */
     [90] = isr_dma2d,                /* [90] DMA2D global Interrupt */
-#elif defined(CPU_MODEL_STM32F446RE) || defined(CPU_MODEL_STM32F446ZE)
+#elif defined(CPU_LINE_STM32F446xx)
     [18] = isr_adc,                  /* [18] ADC1, ADC2 and ADC3 global Interrupts */
     [19] = isr_can1_tx,              /* [19] CAN1 TX Interrupt */
     [20] = isr_can1_rx0,             /* [20] CAN1 RX0 Interrupt */


### PR DESCRIPTION

### Contribution description

Most of the stm32 configuration can be shared by 'line'. This PR adds a variable CPU_LINE_* (e.g. CPU_LINE_STM32F401) which can be used to group configurations. This avoid having to list all cpus from the line with `defined(...)`.

I changed only in stm32f4 so far, to show how it works and maybe discuss a bit. The rest can be done in other PRs anyway.

### Issues/PRs references

Based on #9079 