### PR TITLE
cpu: efm32: fix for cpp support.

### DIFF
--- a/cpu/efm32/Makefile.features
+++ b/cpu/efm32/Makefile.features
@@ -1,6 +1,5 @@
 FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_flashpage
-FEATURES_PROVIDED += periph_pm
 
 FEATURES_CONFLICT += periph_rtc:periph_rtt
 FEATURES_CONFLICT_MSG += "On the EFM32, the RTC and RTT map to the same hardware peripheral."
@@ -8,3 +7,5 @@ FEATURES_CONFLICT_MSG += "On the EFM32, the RTC and RTT map to the same hardware
 ifeq (1,$(EFM32_TNRG))
   FEATURES_PROVIDED += periph_hwrng
 endif
+
+include $(RIOTCPU)/cortexm_common/Makefile.features

--- a/tests/unittests/Makefile
+++ b/tests/unittests/Makefile
@@ -19,6 +19,7 @@ BOARD_INSUFFICIENT_MEMORY := airfy-beacon \
                              chronos \
                              ek-lm4f120xl \
                              feather-m0 \
+                             ikea-tradfri \
                              limifrog-v1 maple-mini \
                              mbed_lpc1768 \
                              mega-xplained \
@@ -56,10 +57,13 @@ BOARD_INSUFFICIENT_MEMORY := airfy-beacon \
                              samd21-xpro \
                              samr21-xpro \
                              seeeduino_arch-pro \
+                             slstk3401a \
+                             sltb001a \
                              slwstk6220a \
                              sodaq-autonomo \
                              sodaq-explorer \
                              spark-core \
+                             stk3600 \
                              stm32f0discovery \
                              stm32f3discovery \
                              teensy31 \


### PR DESCRIPTION
### Contribution description

This fixes a missing include of `cpu/cortexm_common/Makefile.features`, which defines C++ support and `periph_pm`. 

I don't know why I missed that one, but there was no reason to leave it out.

### Issues/PRs references

#9093 