### PR TITLE
tests: unittests: disable for new efm32 boards.

### DIFF
--- a/tests/unittests/Makefile
+++ b/tests/unittests/Makefile
@@ -103,6 +103,7 @@ ARM_CORTEX_M_BOARDS := airfy-beacon \
                        frdm-k22f \
                        frdm-k64f \
                        frdm-kw41z \
+                       ikea-tradfri \
                        iotlab-a8-m3 \
                        iotlab-m3 \
                        limifrog-v1 \
@@ -157,11 +158,15 @@ ARM_CORTEX_M_BOARDS := airfy-beacon \
                        saml21-xpro \
                        samr21-xpro \
                        seeeduino_arch-pro \
+                       slstk3401a \
                        sltb001a \
+                       slwstk6000b \
                        slwstk6220a \
                        sodaq-autonomo \
                        sodaq-explorer \
                        spark-core \
+                       stk3600 \
+                       stk3700 \
                        stm32f0discovery \
                        stm32f3discovery \
                        stm32f4discovery \


### PR DESCRIPTION
### Contribution description

Blacklist the (new) EFM32 boards in `tests/unittests` so that the build doesn't fail. I forgot to add them. That's why #9097 fails.

### Issues/PRs references

#9097 