### PR TITLE
sys/saul_reg: support for saul context parameter

### DIFF
--- a/boards/mega-xplained/include/board.h
+++ b/boards/mega-xplained/include/board.h
@@ -67,11 +67,14 @@ extern "C" {
  * @{
  */
 /* LED0,2 currently unsupported due to lack of GPIO_OD support */
-#define LED1_PIN     GPIO_PIN(PORT_B, 3)
-#define LED1_MODE    GPIO_OUT
+#define LED_PORT_PIN0    GPIO_PIN(PORT_B, 0)
 
-#define LED3_PIN     GPIO_PIN(PORT_B, 2)
-#define LED3_MODE    GPIO_OUT
+#define LED1_PIN         GPIO_PIN(PORT_B, 3)
+#define LED1_MODE        GPIO_OUT
+
+#define LED3_PIN         GPIO_PIN(PORT_B, 2)
+#define LED3_MODE        GPIO_OUT
+
 /** @} */
 
 /**
@@ -94,13 +97,15 @@ extern "C" {
  * @name    Button pin configuration
  * @{
  */
-#define BTN0_PIN     GPIO_PIN(PORT_B, 0)
-#define BTN0_MODE    GPIO_IN
-
-#define BTN1_PIN     GPIO_PIN(PORT_B, 1)
-#define BTN1_MODE    GPIO_IN
+#define BTN_PORT_PIN0    GPIO_PIN(PORT_B, 0)
 
 /* BTN2 currently unsupported due to lack of GPIO_OD support */
+#define BTN0_PIN         GPIO_PIN(PORT_B, 0)
+#define BTN0_MODE        GPIO_IN
+
+#define BTN1_PIN         GPIO_PIN(PORT_B, 1)
+#define BTN1_MODE        GPIO_IN
+/** @} */
 
 /**
  * @name    ADC NTC, light sensor, and filter lines

--- a/boards/mega-xplained/include/gpio_params.h
+++ b/boards/mega-xplained/include/gpio_params.h
@@ -34,28 +34,20 @@ extern "C" {
 static const  saul_gpio_params_t saul_gpio_params[] =
 {
     {
-        .name = "Button 0",
-        .pin  = BTN0_PIN,
+        .name = "Button %u",
+        .pin = BTN_PORT_PIN0,
+        .pinlist = (1 << (BTN0_PIN - BTN_PORT_PIN0))
+                   | (1 << (BTN1_PIN - BTN_PORT_PIN0)),
         .mode = BTN0_MODE,
-        .flags = SAUL_GPIO_INVERTED,
-    },
-    {
-        .name = "Button 1",
-        .pin  = BTN1_PIN,
-        .mode = BTN1_MODE,
         .flags = SAUL_GPIO_INVERTED,
     },
     /* BTN2, LED0,2 currently unsupported due to lack of GPIO_OD support */
     {
-        .name = "LED 1",
-        .pin = LED1_PIN,
+        .name = "LED %u",
+        .pin = LED_PORT_PIN0,
+        .pinlist = (1 << (LED1_PIN - LED_PORT_PIN0))
+                   | (1 << (LED3_PIN - LED_PORT_PIN0)),
         .mode = LED1_MODE,
-        .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
-    },
-    {
-        .name = "LED 3",
-        .pin = LED3_PIN,
-        .mode = LED3_MODE,
         .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
     }
 };

--- a/drivers/adcxx1c/adcxx1c_saul.c
+++ b/drivers/adcxx1c/adcxx1c_saul.c
@@ -24,8 +24,10 @@
 #include "saul.h"
 #include "adcxx1c.h"
 
-static int read_adc(const void *dev, phydat_t *res)
+static int read_adc(const void *dev, const uint8_t ctxt, phydat_t *res)
 {
+    (void)ctxt;
+
     adcxx1c_read_raw((const adcxx1c_t *)dev, res->val);
 
     res->unit = UNIT_NONE;

--- a/drivers/ads101x/ads101x_saul.c
+++ b/drivers/ads101x/ads101x_saul.c
@@ -31,8 +31,10 @@
  * (5/8) * 2^16 = 40960 */
 #define CONV_TO_B10    (40960L)
 
-static int read_adc(const void *dev, phydat_t *res)
+static int read_adc(const void *dev, const uint8_t ctxt, phydat_t *res)
 {
+    (void)ctxt;
+
     /* Change the mux channel */
     ads101x_set_mux_gain((const ads101x_t *)dev,
                          ((ads101x_t *)dev)->params.mux_gain);

--- a/drivers/adxl345/adxl345_saul.c
+++ b/drivers/adxl345/adxl345_saul.c
@@ -21,8 +21,10 @@
 #include "saul.h"
 #include "adxl345.h"
 
-static int read_acc(const void *dev, phydat_t *res)
+static int read_acc(const void *dev, const uint8_t ctxt, phydat_t *res)
 {
+    (void)ctxt;
+
     adxl345_read((const adxl345_t *)dev, (adxl345_data_t *)res->val);
 
     res->unit = UNIT_G;

--- a/drivers/bmp180/bmp180_saul.c
+++ b/drivers/bmp180/bmp180_saul.c
@@ -25,16 +25,20 @@
 #include "bmp180.h"
 #include "xtimer.h"
 
-static int read_temperature(const void *dev, phydat_t *res)
+static int read_temperature(const void *dev, const uint8_t ctxt, phydat_t *res)
 {
+    (void)ctxt;
+
     res->val[0] = bmp180_read_temperature((const bmp180_t *)dev);
     res->unit = UNIT_TEMP_C;
     res->scale = -1;
     return 1;
 }
 
-static int read_pressure(const void *dev, phydat_t *res)
+static int read_pressure(const void *dev, const uint8_t ctxt, phydat_t *res)
 {
+    (void)ctxt;
+
     res->val[0] = bmp180_read_pressure((const bmp180_t *)dev) / 100;
     res->unit = UNIT_PA;
     res->scale = 2;

--- a/drivers/bmx055/bmx055_saul.c
+++ b/drivers/bmx055/bmx055_saul.c
@@ -22,8 +22,10 @@
 #include "saul.h"
 #include "bmx055.h"
 
-static int read_mag(const void *dev, phydat_t *res)
+static int read_mag(const void *dev, const uint8_t ctxt, phydat_t *res)
 {
+    (void)ctxt;
+
     if (bmx055_mag_read((bmx055_t *)dev, (int16_t *)res) != BMX055_OK) {
         return 0;
     }
@@ -32,8 +34,10 @@ static int read_mag(const void *dev, phydat_t *res)
     return 3;
 }
 
-static int read_acc(const void *dev, phydat_t *res)
+static int read_acc(const void *dev, const uint8_t ctxt, phydat_t *res)
 {
+    (void)ctxt;
+
     if (bmx055_acc_read((bmx055_t *)dev, (int16_t *)res) != BMX055_OK) {
         return 0;
     }
@@ -42,8 +46,10 @@ static int read_acc(const void *dev, phydat_t *res)
     return 3;
 }
 
-static int read_gyro(const void *dev, phydat_t *res)
+static int read_gyro(const void *dev, const uint8_t ctxt, phydat_t *res)
 {
+    (void)ctxt;
+
     if (bmx055_gyro_read((bmx055_t *)dev, (int16_t *)res) != BMX055_OK) {
         return 0;
     }

--- a/drivers/bmx280/bmx280_saul.c
+++ b/drivers/bmx280/bmx280_saul.c
@@ -24,8 +24,10 @@
 
 #include "bmx280.h"
 
-static int read_temperature(const void *dev, phydat_t *res)
+static int read_temperature(const void *dev, const uint8_t ctxt, phydat_t *res)
 {
+    (void)ctxt;
+
     res->val[0] = bmx280_read_temperature((const bmx280_t *)dev);
     res->unit = UNIT_TEMP_C;
     res->scale = -2;
@@ -33,8 +35,10 @@ static int read_temperature(const void *dev, phydat_t *res)
     return 1;
 }
 
-static int read_pressure(const void *dev, phydat_t *res)
+static int read_pressure(const void *dev, const uint8_t ctxt, phydat_t *res)
 {
+    (void)ctxt;
+
     res->val[0] = bmx280_read_pressure((const bmx280_t *)dev) / 100;
     res->unit = UNIT_PA;
     res->scale = 2;
@@ -43,8 +47,10 @@ static int read_pressure(const void *dev, phydat_t *res)
 }
 
 #ifdef MODULE_BME280
-static int read_relative_humidity(const void *dev, phydat_t *res)
+static int read_relative_humidity(const void *dev, const uint8_t ctxt, phydat_t *res)
 {
+    (void)ctxt;
+
     res->val[0] = bme280_read_humidity((const bmx280_t *)dev);
     res->unit = UNIT_PERCENT;
     res->scale = -2;

--- a/drivers/dht/dht_saul.c
+++ b/drivers/dht/dht_saul.c
@@ -53,13 +53,17 @@ static int check_and_read(const void *dev, phydat_t *res, int16_t *val, uint8_t 
     return 1;
 }
 
-static int read_temp(const void *dev, phydat_t *res)
+static int read_temp(const void *dev, const uint8_t ctxt, phydat_t *res)
 {
+    (void)ctxt;
+
     return check_and_read(dev, res, &temp, UNIT_TEMP_C);
 }
 
-static int read_hum(const void *dev, phydat_t *res)
+static int read_hum(const void *dev, const uint8_t ctxt, phydat_t *res)
 {
+    (void)ctxt;
+
     return check_and_read(dev, res, &hum, UNIT_PERCENT);
 }
 

--- a/drivers/fxos8700/fxos8700_saul.c
+++ b/drivers/fxos8700/fxos8700_saul.c
@@ -23,8 +23,10 @@
 #include "saul.h"
 #include "fxos8700.h"
 
-static int read_mag(const void *dev, phydat_t *res)
+static int read_mag(const void *dev, const uint8_t ctxt, phydat_t *res)
 {
+    (void)ctxt;
+
     if (fxos8700_read_cached(dev, NULL, (fxos8700_measurement_t *)res)
         != FXOS8700_OK) {
         /* Read failure */
@@ -35,8 +37,10 @@ static int read_mag(const void *dev, phydat_t *res)
     return 3;
 }
 
-static int read_acc(const void *dev, phydat_t *res)
+static int read_acc(const void *dev, const uint8_t ctxt, phydat_t *res)
 {
+    (void)ctxt;
+
     if (fxos8700_read_cached(dev, (fxos8700_measurement_t *)res, NULL)
         != FXOS8700_OK) {
         /* Read failure */

--- a/drivers/grove_ledbar/grove_ledbar_saul.c
+++ b/drivers/grove_ledbar/grove_ledbar_saul.c
@@ -24,8 +24,10 @@
 #include "saul.h"
 #include "grove_ledbar.h"
 
-static int set_ledbar(const void *dev, phydat_t *res)
+static int set_ledbar(const void *dev, const uint8_t ctxt, phydat_t *res)
 {
+    (void)ctxt;
+
     uint8_t lvl = (uint8_t)res->val[0];
     grove_ledbar_set((grove_ledbar_t *)dev, lvl);
     return 1;

--- a/drivers/hdc1000/hdc1000_saul.c
+++ b/drivers/hdc1000/hdc1000_saul.c
@@ -23,8 +23,10 @@
 #include "saul.h"
 #include "hdc1000.h"
 
-static int read_temp(const void *dev, phydat_t *res)
+static int read_temp(const void *dev, const uint8_t ctxt, phydat_t *res)
 {
+    (void)ctxt;
+
     if (hdc1000_read_cached((const hdc1000_t *)dev, &(res->val[0]), NULL) != HDC1000_OK) {
         return -ECANCELED;
     }
@@ -35,8 +37,10 @@ static int read_temp(const void *dev, phydat_t *res)
     return 1;
 }
 
-static int read_hum(const void *dev, phydat_t *res)
+static int read_hum(const void *dev, const uint8_t ctxt, phydat_t *res)
 {
+    (void)ctxt;
+
     if (hdc1000_read_cached((const hdc1000_t *)dev, NULL, &(res->val[0])) != HDC1000_OK) {
         return -ECANCELED;
     }

--- a/drivers/hts221/hts221_saul.c
+++ b/drivers/hts221/hts221_saul.c
@@ -23,8 +23,10 @@
 #include "saul.h"
 #include "hts221.h"
 
-static int read_temp(const void *dev, phydat_t *res)
+static int read_temp(const void *dev, const uint8_t ctxt, phydat_t *res)
 {
+    (void)ctxt;
+
     if (hts221_read_temperature((const hts221_t *)dev, &res->val[0]) != HTS221_OK) {
         return -ECANCELED;
     }
@@ -34,8 +36,10 @@ static int read_temp(const void *dev, phydat_t *res)
     return 1;
 }
 
-static int read_hum(const void *dev, phydat_t *res)
+static int read_hum(const void *dev, const uint8_t ctxt, phydat_t *res)
 {
+    (void)ctxt;
+
     if (hts221_read_humidity((const hts221_t *)dev, (uint16_t *)&res->val[0]) != HTS221_OK) {
         return -ECANCELED;
     }

--- a/drivers/include/saul.h
+++ b/drivers/include/saul.h
@@ -111,14 +111,15 @@ enum {
  * Actuators can chose to either just return -ENOTSUP or to return their current
  * set value (e.g. useful for reading back the current state of a switch)
  *
- * @param[in] dev       device descriptor of the target device
- * @param[out] res      data read from the device
+ * @param[in] dev     device descriptor of the target device
+ * @param[in] ctxt    context for target device
+ * @param[out] res    data read from the device
  *
  * @return  number of values written into to result data structure [1-3]
  * @return  -ENOTSUP if the device does not support this operation
  * @return  -ECANCELED on other errors
  */
-typedef int(*saul_read_t)(const void *dev, phydat_t *res);
+typedef int(*saul_read_t)(const void *dev, const uint8_t ctxt, phydat_t *res);
 
 /**
  * @brief   Write a value (a set of values) to a device
@@ -131,14 +132,15 @@ typedef int(*saul_read_t)(const void *dev, phydat_t *res);
  * For actuators this function is used to influence the actuators state, e.g.
  * switching a switch or setting the speed of a motor.
  *
- * @param[in] dev       device descriptor of the target device
- * @param[in] data      data to write to the device
+ * @param[in] dev     device descriptor of the target device
+ * @param[in] ctxt    context for target device
+ * @param[in] data    data to write to the device
  *
  * @return  number of values actually processed by the device [1-3]
  * @return  -ENOTSUP if the device does not support this operation
  * @return  -ECANCELED on other errors
  */
-typedef int(*saul_write_t)(const void *dev, phydat_t *data);
+typedef int(*saul_write_t)(const void *dev, const uint8_t ctxt, phydat_t *data);
 
 /**
  * @brief   Definition of the RIOT actuator/sensor interface
@@ -152,7 +154,7 @@ typedef struct {
 /**
  * @brief   Default not supported function
  */
-int saul_notsup(const void *dev, phydat_t *dat);
+int saul_notsup(const void *dev, const uint8_t ctxt, phydat_t *dat);
 
 /**
  * @brief   Helper function converts a class ID to a string

--- a/drivers/include/saul/periph.h
+++ b/drivers/include/saul/periph.h
@@ -19,6 +19,8 @@
 #ifndef SAUL_PERIPH_H
 #define SAUL_PERIPH_H
 
+#include "saul_reg.h"
+
 #if MODULE_SAUL_GPIO || DOXYGEN
 #include "periph/gpio.h"
 #endif /* MODULE_SAUL_GPIO */
@@ -45,10 +47,11 @@ typedef enum {
  * @brief   Direct mapped GPIO configuration values
  */
 typedef struct {
-    const char *name;           /**< name of the device connected to this pin */
-    gpio_t pin;                 /**< GPIO pin to initialize and expose */
-    gpio_mode_t mode;           /**< pin mode to use */
-    saul_gpio_flags_t flags;    /**< Configuration flags */
+    const char *name;            /**< name of the device(s) on this pin */
+    gpio_t pin;                  /**< GPIO pin offset for ctxtlist */
+    saul_ctxt_list_t pinlist;    /**< bit list of pins to map */
+    gpio_mode_t mode;            /**< pin mode to use */
+    saul_gpio_flags_t flags;     /**< Configuration flags */
 } saul_gpio_params_t;
 #endif /* MODULE_SAUL_GPIO */
 
@@ -57,9 +60,10 @@ typedef struct {
  * @brief   Direct mapped ADC configuration values
  */
 typedef struct {
-    const char *name;       /**< name of the device connected to this pin */
-    adc_t line;             /**< ADC line to initialize and expose */
-    adc_res_t res;          /**< ADC resolution */
+    const char *name;             /**< name of the device(s) on this pin */
+    adc_t line;                   /**< ADC line offset for ctxtlist */
+    saul_ctxt_list_t linelist;    /**< bit list of lines to expose */
+    adc_res_t res;                /**< ADC resolution */
 } saul_adc_params_t;
 #endif /* MODULE_SAUL_ADC */
 

--- a/drivers/io1_xplained/io1_xplained_saul.c
+++ b/drivers/io1_xplained/io1_xplained_saul.c
@@ -26,8 +26,10 @@
 
 static float temperature;
 
-static int read_temperature(const void *dev, phydat_t *res)
+static int read_temperature(const void *dev, const uint8_t ctxt, phydat_t *res)
 {
+    (void)ctxt;
+
     const io1_xplained_t *io1 = (const io1_xplained_t *)dev;
     at30tse75x_get_temperature(&io1->temp, &temperature);
     res->val[0] = (int)(temperature * 100.0);

--- a/drivers/isl29020/isl29020_saul.c
+++ b/drivers/isl29020/isl29020_saul.c
@@ -23,8 +23,10 @@
 #include "saul.h"
 #include "isl29020.h"
 
-static int read(const void *dev, phydat_t *res)
+static int read(const void *dev, const uint8_t ctxt, phydat_t *res)
 {
+    (void)ctxt;
+
     res->val[0] = (int16_t)isl29020_read((const isl29020_t *)dev);
     memset(&(res->val[1]), 0, 2 * sizeof(int16_t));
     res->unit = UNIT_CD;

--- a/drivers/jc42/jc42_saul.c
+++ b/drivers/jc42/jc42_saul.c
@@ -25,8 +25,10 @@
 
 
 
-static int read_temperature(const void *dev, phydat_t *res)
+static int read_temperature(const void *dev, const uint8_t ctxt, phydat_t *res)
 {
+    (void)ctxt;
+
     int16_t temperature;
 
     jc42_get_temperature((const jc42_t *)dev, &temperature);

--- a/drivers/l3g4200d/l3g4200d_saul.c
+++ b/drivers/l3g4200d/l3g4200d_saul.c
@@ -23,8 +23,10 @@
 #include "saul.h"
 #include "l3g4200d.h"
 
-static int read(const void *dev, phydat_t *res)
+static int read(const void *dev, const uint8_t ctxt, phydat_t *res)
 {
+    (void)ctxt;
+
     l3g4200d_read((const l3g4200d_t *)dev, (l3g4200d_data_t *)res);
     res->unit = UNIT_DPS;
     res->scale = 0;

--- a/drivers/lis2dh12/lis2dh12_saul.c
+++ b/drivers/lis2dh12/lis2dh12_saul.c
@@ -21,8 +21,10 @@
 #include "saul.h"
 #include "lis2dh12.h"
 
-static int read_accelerometer(const void *dev, phydat_t *res)
+static int read_accelerometer(const void *dev, const uint8_t ctxt, phydat_t *res)
 {
+    (void)ctxt;
+
     if (lis2dh12_read((const lis2dh12_t *)dev, res->val) != LIS2DH12_OK) {
         return 0;
     }

--- a/drivers/lis3dh/lis3dh_saul.c
+++ b/drivers/lis3dh/lis3dh_saul.c
@@ -24,8 +24,10 @@
 #include "saul.h"
 #include "lis3dh.h"
 
-static int read_acc(const void *dev, phydat_t *res)
+static int read_acc(const void *dev, const uint8_t ctxt, phydat_t *res)
 {
+    (void)ctxt;
+
     lis3dh_data_t xyz;
 
     int err = lis3dh_read_xyz((const lis3dh_t *)dev, &xyz);

--- a/drivers/lis3mdl/lis3mdl_saul.c
+++ b/drivers/lis3mdl/lis3mdl_saul.c
@@ -23,8 +23,10 @@
 #include "saul.h"
 #include "lis3mdl.h"
 
-static int read_mag(const void *dev, phydat_t *res)
+static int read_mag(const void *dev, const uint8_t ctxt, phydat_t *res)
 {
+    (void)ctxt;
+
     const lis3mdl_t *d = (const lis3mdl_t *)dev;
 
     lis3mdl_read_mag(d, (lis3mdl_3d_data_t *)res);

--- a/drivers/lps331ap/lps331ap_saul.c
+++ b/drivers/lps331ap/lps331ap_saul.c
@@ -23,16 +23,20 @@
 #include "saul.h"
 #include "lps331ap.h"
 
-static int read_pres(const void *dev, phydat_t *res)
+static int read_pres(const void *dev, const uint8_t ctxt, phydat_t *res)
 {
+    (void)ctxt;
+
     res->val[0] = (int16_t)lps331ap_read_pres((const lps331ap_t *)dev);
     res->unit = UNIT_BAR;
     res->scale = -3;
     return 1;
 }
 
-static int read_temp(const void *dev, phydat_t *res)
+static int read_temp(const void *dev, const uint8_t ctxt, phydat_t *res)
 {
+    (void)ctxt;
+
     res->val[0] = (int16_t)(lps331ap_read_temp((const lps331ap_t *)dev) / 10);
     res->unit = UNIT_TEMP_C;
     /* above division by ten leads to °C * 10^-2*/

--- a/drivers/lsm303dlhc/lsm303dlhc_saul.c
+++ b/drivers/lsm303dlhc/lsm303dlhc_saul.c
@@ -23,8 +23,10 @@
 #include "saul.h"
 #include "lsm303dlhc.h"
 
-static int read_acc(const void *dev, phydat_t *res)
+static int read_acc(const void *dev, const uint8_t ctxt, phydat_t *res)
 {
+    (void)ctxt;
+
     const lsm303dlhc_t *d = (const lsm303dlhc_t *)dev;
     lsm303dlhc_read_acc(d, (lsm303dlhc_3d_data_t *)res);
 
@@ -39,8 +41,10 @@ static int read_acc(const void *dev, phydat_t *res)
     return 3;
 }
 
-static int read_mag(const void *dev, phydat_t *res)
+static int read_mag(const void *dev, const uint8_t ctxt, phydat_t *res)
 {
+    (void)ctxt;
+
     const lsm303dlhc_t *d = (const lsm303dlhc_t *)dev;
 
     lsm303dlhc_read_mag(d, (lsm303dlhc_3d_data_t *)res);

--- a/drivers/lsm6dsl/lsm6dsl_saul.c
+++ b/drivers/lsm6dsl/lsm6dsl_saul.c
@@ -23,8 +23,10 @@
 #include "lsm6dsl.h"
 #include "saul.h"
 
-static int read_acc(const void *dev, phydat_t *res)
+static int read_acc(const void *dev, const uint8_t ctxt, phydat_t *res)
 {
+    (void)ctxt;
+
     int ret = lsm6dsl_read_acc((const lsm6dsl_t *)dev, (lsm6dsl_3d_data_t *)res);
     if (ret < 0) {
         return -ECANCELED;
@@ -36,8 +38,10 @@ static int read_acc(const void *dev, phydat_t *res)
     return 3;
 }
 
-static int read_gyro(const void *dev, phydat_t *res)
+static int read_gyro(const void *dev, const uint8_t ctxt, phydat_t *res)
 {
+    (void)ctxt;
+
     int ret = lsm6dsl_read_gyro((const lsm6dsl_t *)dev, (lsm6dsl_3d_data_t *)res);
     if (ret < 0) {
         return -ECANCELED;
@@ -49,8 +53,10 @@ static int read_gyro(const void *dev, phydat_t *res)
     return 3;
 }
 
-static int read_temp(const void *dev, phydat_t *res)
+static int read_temp(const void *dev, const uint8_t ctxt, phydat_t *res)
 {
+    (void)ctxt;
+
     if (lsm6dsl_read_temp((const lsm6dsl_t *)dev, (int16_t *)&res[0]) < 0) {
         return -ECANCELED;
     }

--- a/drivers/mag3110/mag3110_saul.c
+++ b/drivers/mag3110/mag3110_saul.c
@@ -24,8 +24,10 @@
 #include "saul.h"
 #include "mag3110.h"
 
-static int read_mag(const void *dev, phydat_t *res)
+static int read_mag(const void *dev, const uint8_t ctxt, phydat_t *res)
 {
+    (void)ctxt;
+
     mag3110_read((const mag3110_t *)dev, (mag3110_data_t *)res);
 
     res->unit = UNIT_GS;

--- a/drivers/mma8x5x/mma8x5x_saul.c
+++ b/drivers/mma8x5x/mma8x5x_saul.c
@@ -25,8 +25,10 @@
 #include "saul.h"
 #include "mma8x5x.h"
 
-static int read_acc(const void *dev, phydat_t *res)
+static int read_acc(const void *dev, const uint8_t ctxt, phydat_t *res)
 {
+    (void)ctxt;
+
     mma8x5x_read((const mma8x5x_t *)dev, (mma8x5x_data_t *)res);
 
     res->unit = UNIT_G;

--- a/drivers/mpl3115a2/mpl3115a2_saul.c
+++ b/drivers/mpl3115a2/mpl3115a2_saul.c
@@ -25,8 +25,10 @@
 #include "saul.h"
 #include "mpl3115a2.h"
 
-static int read_pressure(const void *dev, phydat_t *res)
+static int read_pressure(const void *dev, const uint8_t ctxt, phydat_t *res)
 {
+    (void)ctxt;
+
     uint8_t state;
     uint32_t pressure;
     if (mpl3115a2_read_pressure((const mpl3115a2_t *)dev,
@@ -42,8 +44,10 @@ static int read_pressure(const void *dev, phydat_t *res)
     return 1;
 }
 
-static int read_temperature(const void *dev, phydat_t *res)
+static int read_temperature(const void *dev, const uint8_t ctxt, phydat_t *res)
 {
+    (void)ctxt;
+
     int16_t temperature;
     if (mpl3115a2_read_temp((const mpl3115a2_t *)dev, &temperature) != MPL3115A2_OK) {
         LOG_ERROR("[SAUL] mpl3115a2_read_temp failed!\n");

--- a/drivers/mpu9150/mpu9150_saul.c
+++ b/drivers/mpu9150/mpu9150_saul.c
@@ -23,8 +23,10 @@
 #include "saul.h"
 #include "mpu9150.h"
 
-static int read_acc(const void *dev, phydat_t *res)
+static int read_acc(const void *dev, const uint8_t ctxt, phydat_t *res)
 {
+    (void)ctxt;
+
     int ret = mpu9150_read_accel((const mpu9150_t *)dev, (mpu9150_results_t *)res);
     if (ret < 0) {
         return -ECANCELED;
@@ -36,8 +38,10 @@ static int read_acc(const void *dev, phydat_t *res)
     return 3;
 }
 
-static int read_gyro(const void *dev, phydat_t *res)
+static int read_gyro(const void *dev, const uint8_t ctxt, phydat_t *res)
 {
+    (void)ctxt;
+
     int ret = mpu9150_read_gyro((const mpu9150_t *)dev, (mpu9150_results_t *)res);
     if (ret < 0) {
         return -ECANCELED;
@@ -49,8 +53,10 @@ static int read_gyro(const void *dev, phydat_t *res)
     return 3;
 }
 
-static int read_mag(const void *dev, phydat_t *res)
+static int read_mag(const void *dev, const uint8_t ctxt, phydat_t *res)
 {
+    (void)ctxt;
+
     int ret = mpu9150_read_compass((const mpu9150_t *)dev, (mpu9150_results_t *)res);
     if (ret < 0) {
         return -ECANCELED;

--- a/drivers/pir/pir_saul.c
+++ b/drivers/pir/pir_saul.c
@@ -23,7 +23,9 @@
 #include "saul.h"
 #include "pir.h"
 
-static int read_occup(const void *dev, phydat_t *res) {
+static int read_occup(const void *dev, const uint8_t ctxt, phydat_t *res) {
+    (void)ctxt;
+
     pir_t *d = (pir_t *)dev;
     if (pir_get_occupancy(d, &(res->val[0]))) {
         /* Read failure */

--- a/drivers/pulse_counter/pulse_counter_saul.c
+++ b/drivers/pulse_counter/pulse_counter_saul.c
@@ -23,16 +23,20 @@
 #include "saul.h"
 #include "pulse_counter.h"
 
-static int read_pulse_counter(const void *dev, phydat_t *res)
+static int read_pulse_counter(const void *dev, const uint8_t ctxt, phydat_t *res)
 {
+    (void)ctxt;
+
     res->val[0] = pulse_counter_read_with_reset(dev);
     res->unit  = UNIT_NONE;
     res->scale = 0;
     return 1;
 }
 
-static int write_pulse_counter(const void *dev, phydat_t *data)
+static int write_pulse_counter(const void *dev, const uint8_t ctxt, phydat_t *data)
 {
+    (void)ctxt;
+
     pulse_counter_reset(dev);
     (void) data;
     return 1;

--- a/drivers/saul/adc_saul.c
+++ b/drivers/saul/adc_saul.c
@@ -26,10 +26,10 @@
 #include "periph/adc.h"
 
 
-static int read_adc(const void *dev, phydat_t *res)
+static int read_adc(const void *dev, const uint8_t ctxt, phydat_t *res)
 {
     const saul_adc_params_t *params = *((const saul_adc_params_t **)dev);
-    res->val[0] = adc_sample(params->line, params->res);
+    res->val[0] = adc_sample(params->line + ctxt, params->res);
     memset(&(res->val[1]), 0, 2 * sizeof(res->val[1]));
     /* Raw ADC reading has no unit */
     res->unit = UNIT_NONE;

--- a/drivers/saul/gpio_saul.c
+++ b/drivers/saul/gpio_saul.c
@@ -26,12 +26,12 @@
 #include "saul/periph.h"
 
 
-static int read(const void *dev, phydat_t *res)
+static int read(const void *dev, const uint8_t ctxt, phydat_t *res)
 {
     const saul_gpio_params_t *p = (const saul_gpio_params_t *)dev;
     int inverted = (p->flags & SAUL_GPIO_INVERTED);
 
-    res->val[0] = (gpio_read(p->pin)) ? !inverted : inverted;
+    res->val[0] = (gpio_read(p->pin + ctxt)) ? !inverted : inverted;
 
     memset(&(res->val[1]), 0, 2 * sizeof(int16_t));
     res->unit = UNIT_BOOL;
@@ -39,13 +39,13 @@ static int read(const void *dev, phydat_t *res)
     return 1;
 }
 
-static int write(const void *dev, phydat_t *state)
+static int write(const void *dev, const uint8_t ctxt, phydat_t *state)
 {
     const saul_gpio_params_t *p = (const saul_gpio_params_t *)dev;
     int inverted = (p->flags & SAUL_GPIO_INVERTED);
     int value = (state->val[0] ? !inverted : inverted);
 
-    gpio_write(p->pin, value);
+    gpio_write(p->pin + ctxt, value);
     return 1;
 }
 

--- a/drivers/saul/saul.c
+++ b/drivers/saul/saul.c
@@ -22,9 +22,10 @@
 
 #include "saul.h"
 
-int saul_notsup(const void *dev, phydat_t *dat)
+int saul_notsup(const void *dev, const uint8_t ctxt, phydat_t *dat)
 {
     (void)dev;
+    (void)ctxt;
     (void)dat;
     return -ENOTSUP;
 }

--- a/drivers/sht1x/sht1x_saul.c
+++ b/drivers/sht1x/sht1x_saul.c
@@ -52,8 +52,10 @@ static int read(const sht1x_dev_t *dev, int16_t *temp, int16_t *hum)
     return -1;
 }
 
-static int read_temp(const void *dev, phydat_t *res)
+static int read_temp(const void *dev, const uint8_t ctxt, phydat_t *res)
 {
+    (void)ctxt;
+
     if (read(dev, &res->val[0], NULL) == 0) {
         res->unit = UNIT_TEMP_C;
         res->scale = -2;
@@ -63,8 +65,10 @@ static int read_temp(const void *dev, phydat_t *res)
     return -ECANCELED;
 }
 
-static int read_hum(const void *dev, phydat_t *res)
+static int read_hum(const void *dev, const uint8_t ctxt, phydat_t *res)
 {
+    (void)ctxt;
+
     if (read(dev, NULL, &res->val[0]) == 0) {
         res->unit = UNIT_PERCENT;
         res->scale = -2;

--- a/drivers/si114x/si114x_saul.c
+++ b/drivers/si114x/si114x_saul.c
@@ -23,8 +23,10 @@
 #include "si114x.h"
 #include "xtimer.h"
 
-static int read_uv(const void *dev, phydat_t *res)
+static int read_uv(const void *dev, const uint8_t ctxt, phydat_t *res)
 {
+    (void)ctxt;
+
     si114x_t *d = (si114x_t *)dev;
 
     res->val[0] = si114x_read_uv(d);
@@ -33,8 +35,10 @@ static int read_uv(const void *dev, phydat_t *res)
     return 1;
 }
 
-static int read_ir(const void *dev, phydat_t *res)
+static int read_ir(const void *dev, const uint8_t ctxt, phydat_t *res)
 {
+    (void)ctxt;
+
     si114x_t *d = (si114x_t *)dev;
 
     res->val[0] = si114x_read_ir(d);
@@ -43,8 +47,10 @@ static int read_ir(const void *dev, phydat_t *res)
     return 1;
 }
 
-static int read_visible(const void *dev, phydat_t *res)
+static int read_visible(const void *dev, const uint8_t ctxt, phydat_t *res)
 {
+    (void)ctxt;
+
     si114x_t *d = (si114x_t *)dev;
 
     res->val[0] = si114x_read_visible(d);
@@ -53,8 +59,10 @@ static int read_visible(const void *dev, phydat_t *res)
     return 1;
 }
 
-static int read_distance(const void *dev, phydat_t *res)
+static int read_distance(const void *dev, const uint8_t ctxt, phydat_t *res)
 {
+    (void)ctxt;
+
     si114x_t *d = (si114x_t *)dev;
 
     res->val[0] = si114x_read_distance(d);

--- a/drivers/si70xx/si70xx_saul.c
+++ b/drivers/si70xx/si70xx_saul.c
@@ -22,8 +22,10 @@
 
 #include "si70xx.h"
 
-static int read_temperature(const void *dev, phydat_t *res)
+static int read_temperature(const void *dev, const uint8_t ctxt, phydat_t *res)
 {
+    (void)ctxt;
+
     res->val[0] = (int32_t) si70xx_get_temperature((const si70xx_t *)dev);
     res->unit = UNIT_TEMP_C;
     res->scale = -2;
@@ -31,8 +33,10 @@ static int read_temperature(const void *dev, phydat_t *res)
     return 1;
 }
 
-static int read_relative_humidity(const void *dev, phydat_t *res)
+static int read_relative_humidity(const void *dev, const uint8_t ctxt, phydat_t *res)
 {
+    (void)ctxt;
+
     res->val[0] = (int32_t) si70xx_get_relative_humidity((const si70xx_t *)dev);
     res->unit = UNIT_PERCENT;
     res->scale = -2;

--- a/drivers/tcs37727/tcs37727_saul.c
+++ b/drivers/tcs37727/tcs37727_saul.c
@@ -23,8 +23,10 @@
 #include "saul.h"
 #include "tcs37727.h"
 
-static int read(const void *dev, phydat_t *res)
+static int read(const void *dev, const uint8_t ctxt, phydat_t *res)
 {
+    (void)ctxt;
+
     tcs37727_data_t val;
 
     tcs37727_read((const tcs37727_t *)dev, &val);

--- a/drivers/tmp006/tmp006_saul.c
+++ b/drivers/tmp006/tmp006_saul.c
@@ -23,8 +23,10 @@
 #include "saul.h"
 #include "tmp006.h"
 
-static int read_temp(const void *dev, phydat_t *res)
+static int read_temp(const void *dev, const uint8_t ctxt, phydat_t *res)
 {
+    (void)ctxt;
+
     if (tmp006_read_temperature((const tmp006_t *)dev, &res->val[0],
                                 &res->val[1]) != TMP006_OK) {
         return -ECANCELED;

--- a/drivers/tsl2561/tsl2561_saul.c
+++ b/drivers/tsl2561/tsl2561_saul.c
@@ -23,8 +23,10 @@
 #include "tsl2561.h"
 #include "xtimer.h"
 
-static int read_illuminance(const void *dev, phydat_t *res)
+static int read_illuminance(const void *dev, const uint8_t ctxt, phydat_t *res)
 {
+    (void)ctxt;
+
     res->val[0] = tsl2561_read_illuminance((const tsl2561_t *)dev);
     res->unit = UNIT_LUX;
     res->scale = 0;

--- a/drivers/veml6070/veml6070_saul.c
+++ b/drivers/veml6070/veml6070_saul.c
@@ -24,8 +24,10 @@
 #include "veml6070.h"
 #include "xtimer.h"
 
-static int read_uv(const void *dev, phydat_t *res)
+static int read_uv(const void *dev, const uint8_t ctxt, phydat_t *res)
 {
+    (void)ctxt;
+
     res->val[0] = veml6070_read_uv((const veml6070_t *)dev);
     res->unit = UNIT_NONE;
     res->scale = -1;

--- a/sys/auto_init/saul/auto_init_adc.c
+++ b/sys/auto_init/saul/auto_init_adc.c
@@ -61,8 +61,24 @@ void auto_init_adc(void)
         saul_reg_entries[i].dev = &saul_adcs[i];
         saul_reg_entries[i].name = p->name;
         saul_reg_entries[i].driver = &adc_saul_driver;
-        /* initialize the ADC line */
-        adc_init(p->line);
+
+        /* initialize the ADC line(s) */
+        if (p->linelist == 0) {
+            /* ignore empty linelist */
+            adc_init(p->line);
+        }
+        else {
+            for (unsigned j = 0; j < 8 * sizeof(p->linelist); j++) {
+                /* check to see if this context bit is enabled */
+                if ((p->linelist >> j) & 0x1) {
+                    adc_init(p->line + j);
+                }
+            }
+        }
+
+        /* populate context list */
+        saul_reg_entries[i].ctxtlist = p->linelist;
+
         /* add to registry */
         saul_reg_add(&(saul_reg_entries[i]));
     }

--- a/sys/include/saul_reg.h
+++ b/sys/include/saul_reg.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2015 Freie Universität Berlin
+ *               2018 Acutam Automation, LLC
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -19,6 +20,7 @@
  * @brief       SAUL registry interface definition
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author      Matthew Blue <matthew.blue.neuro@gmail.com>
  */
 
 #ifndef SAUL_REG_H
@@ -33,6 +35,13 @@
 extern "C" {
 #endif
 
+#ifndef SAUL_HAVE_CTXT_LIST_T
+/**
+ * @brief   SAUL context list type
+ */
+typedef uint16_t saul_ctxt_list_t;
+#endif
+
 /**
  * @brief   SAUL registry entry
  */
@@ -41,6 +50,7 @@ typedef struct saul_reg {
     void *dev;                      /**< pointer to the device descriptor */
     const char *name;               /**< string identifier for the device */
     saul_driver_t const *driver;    /**< the devices read callback */
+    saul_ctxt_list_t ctxtlist;      /**< bitfield of valid context numbers */
 } saul_reg_t;
 
 /**
@@ -54,6 +64,31 @@ typedef struct {
  * @brief   Export the SAUL registry as global variable
  */
 extern saul_reg_t *saul_reg;
+
+/**
+ * @brief   SAUL pointer and context
+ *
+ * @note    The SAUL registry is comprised of real members and imaginary
+ *          duplicates. If a device is added to the registry, it will add
+ *          a number of duplicates without using additional system resources.
+ *          This is intended to make support easier for devices with an array
+ *          of similar inputs/outputs (such as GPIO expanders, or analog muxes)
+ */
+typedef struct saul_ctxt_ptr {
+    saul_reg_t *reg;    /**< pointer to device in SAUL registry */
+    uint8_t ctxt;       /**< context supplied to device */
+    uint8_t num;        /**< num of enabled device in ctxtlist */
+} saul_ctxt_ptr_t;
+
+/**
+ * @brief   Saul registry iterate function callback type for saul_reg_iter
+ *
+ * @param[in] num         number of the device and context in registry
+ * @param[in] ctxt_ptr    pointer and context of entry
+ * @param[in] arg         generic optional argument
+ */
+typedef void (*saul_reg_iter_t)(unsigned num,
+                                saul_ctxt_ptr_t ctxt_ptr, void *arg);
 
 /**
  * @brief   Register a device with the SAUL registry
@@ -82,12 +117,13 @@ int saul_reg_rm(saul_reg_t *dev);
 /**
  * @brief   Find a device by it's position in the registry
  *
- * @param[in] pos       position to look up
+ * @param[in] pos          position to look up
+ * @param[out] ctxt_ptr    context + pointer to device
  *
  * @return      pointer to the device at position specified by @p pos
  * @return      NULL if no device is registered at that position
  */
-saul_reg_t *saul_reg_find_nth(int pos);
+saul_reg_t *saul_reg_find_nth(saul_ctxt_ptr_t *ctxt_ptr, int pos);
 
 /**
  * @brief   Find the first device of the given type in the registry
@@ -112,28 +148,38 @@ saul_reg_t *saul_reg_find_name(const char *name);
 /**
  * @brief   Read data from the given device
  *
- * @param[in] dev       device to read from
- * @param[out] res      location to store the results in
+ * @param[in] dev     pointer to device to read from
+ * @param[in] ctxt    context for device to write to
+ * @param[out] res    location to store the results in
  *
  * @return      the number of data elements read to @p res [1-3]
  * @return      -ENODEV if given device is invalid
  * @return      -ENOTSUP if read operation is not supported by the device
  * @return      -ECANCELED on device errors
  */
-int saul_reg_read(saul_reg_t *dev, phydat_t *res);
+int saul_reg_read(saul_reg_t *dev, uint8_t ctxt, phydat_t *res);
 
 /**
  * @brief   Write data to the given device
  *
- * @param[in] dev       device to write to
- * @param[in] data      data to write to the device
+ * @param[in] dev     pointer to device to write to
+ * @param[in] ctxt    context for device to write to
+ * @param[in] data    data to write to the device
  *
  * @return      the number of data elements processed by the device
  * @return      -ENODEV if given device is invalid
  * @return      -ENOTSUP if read operation is not supported by the device
  * @return      -ECANCELED on device errors
  */
-int saul_reg_write(saul_reg_t *dev, phydat_t *data);
+int saul_reg_write(saul_reg_t *dev, uint8_t ctxt, phydat_t *data);
+
+/**
+ * @brief   Run a function on every device and context in the registry
+ *
+ * @param[in] func  function to run on each entry
+ * @param[in] arg   argument for the function
+ */
+void saul_reg_iter(saul_reg_iter_t func, void *arg);
 
 #ifdef __cplusplus
 }

--- a/sys/saul_reg/saul_reg.c
+++ b/sys/saul_reg/saul_reg.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2015 Freie Universität Berlin
+ *               2018 Acutam Automation, LLC
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -14,6 +15,7 @@
  * @brief       SAUL registry implementation
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author      Matthew Blue <matthew.blue.neuro@gmail.com>
  *
  * @}
  */
@@ -76,14 +78,48 @@ int saul_reg_rm(saul_reg_t *dev)
     return 0;
 }
 
-saul_reg_t *saul_reg_find_nth(int pos)
+saul_reg_t *saul_reg_find_nth(saul_ctxt_ptr_t *ctxt_ptr, int pos)
 {
-    saul_reg_t *tmp = saul_reg;
+    /* initialize ctxt_ptr */
+    ctxt_ptr->reg = saul_reg;
+    ctxt_ptr->ctxt = 0;
+    ctxt_ptr->num = 0;
 
-    for (int i = 0; (i < pos) && tmp; i++) {
-        tmp = tmp->next;
+    int i = 0;
+
+    while (ctxt_ptr->reg) {
+        /* if ctxtlist is empty, ignore it */
+        if (ctxt_ptr->reg->ctxtlist == 0) {
+            if (i == pos) {
+                return ctxt_ptr->reg;
+            }
+            ctxt_ptr->reg = ctxt_ptr->reg->next;
+            i++;
+            continue;
+        }
+
+        /* if ctxtlist is not empty, examine it bitwise */
+        ctxt_ptr->num = 0;
+        for (unsigned j = 0; j < 8 * sizeof(ctxt_ptr->reg->ctxtlist); j++) {
+            /* check to see if this context bit is enabled */
+            if ((ctxt_ptr->reg->ctxtlist >> j) & 0x1) {
+                if (i == pos) {
+                    ctxt_ptr->ctxt = j;
+                    return ctxt_ptr->reg;
+                }
+
+                /* increment num of enabled item in ctxtlist */
+                ctxt_ptr->num++;
+
+                /* increment list counter, as if context is real list item */
+                i++;
+            }
+        }
+
+        ctxt_ptr->reg = ctxt_ptr->reg->next;
     }
-    return tmp;
+
+    return ctxt_ptr->reg;
 }
 
 saul_reg_t *saul_reg_find_type(uint8_t type)
@@ -112,18 +148,56 @@ saul_reg_t *saul_reg_find_name(const char *name)
     return NULL;
 }
 
-int saul_reg_read(saul_reg_t *dev, phydat_t *res)
+int saul_reg_read(saul_reg_t *dev, uint8_t ctxt, phydat_t *res)
 {
     if (dev == NULL) {
         return -ENODEV;
     }
-    return dev->driver->read(dev->dev, res);
+    return dev->driver->read(dev->dev, ctxt, res);
 }
 
-int saul_reg_write(saul_reg_t *dev, phydat_t *data)
+int saul_reg_write(saul_reg_t *dev, uint8_t ctxt, phydat_t *data)
 {
     if (dev == NULL) {
         return -ENODEV;
     }
-    return dev->driver->write(dev->dev, data);
+    return dev->driver->write(dev->dev, ctxt, data);
+}
+
+void saul_reg_iter(saul_reg_iter_t func, void *arg)
+{
+    saul_ctxt_ptr_t ctxt_ptr = { .reg = saul_reg };
+
+    unsigned i = 0;
+
+    while (ctxt_ptr.reg) {
+        ctxt_ptr.ctxt = 0;
+        ctxt_ptr.num = 0;
+
+        /* if ctxtlist is empty, ignore it */
+        if (ctxt_ptr.reg->ctxtlist == 0) {
+            func(i, ctxt_ptr, arg);
+
+            ctxt_ptr.reg = ctxt_ptr.reg->next;
+            i++;
+            continue;
+        }
+
+        for (; ctxt_ptr.ctxt < 8 * sizeof(ctxt_ptr.reg->ctxtlist);
+             ctxt_ptr.ctxt++) {
+
+            /* check to see if this context bit is enabled */
+            if ((ctxt_ptr.reg->ctxtlist >> ctxt_ptr.ctxt) & 0x1) {
+                func(i, ctxt_ptr, arg);
+
+                /* increment num of enabled item in ctxtlist */
+                ctxt_ptr.num++;
+
+                /* increment list counter, as if context is real list item */
+                i++;
+            }
+        }
+
+        ctxt_ptr.reg = ctxt_ptr.reg->next;
+    }
 }

--- a/tests/driver_bmx055/main.c
+++ b/tests/driver_bmx055/main.c
@@ -43,7 +43,7 @@ int main(void)
         }
 
         while (dev) {
-            int dim = saul_reg_read(dev, &res);
+            int dim = saul_reg_read(dev, 0, &res);
             printf("\nDev: %s\tType: %s\n", dev->name,
                    saul_class_to_str(dev->driver->type));
             phydat_dump(&res, dim);

--- a/tests/saul/main.c
+++ b/tests/saul/main.c
@@ -45,7 +45,7 @@ int main(void)
         }
 
         while (dev) {
-            int dim = saul_reg_read(dev, &res);
+            int dim = saul_reg_read(dev, 0, &res);
             printf("\nDev: %s\tType: %s\n", dev->name,
                    saul_class_to_str(dev->driver->type));
             phydat_dump(&res, dim);

--- a/tests/unittests/tests-saul_reg/tests-saul_reg.c
+++ b/tests/unittests/tests-saul_reg/tests-saul_reg.c
@@ -30,10 +30,10 @@ static const saul_driver_t s1_dri = { NULL, NULL, SAUL_SENSE_TEMP };
 static const saul_driver_t s2_dri = { NULL, NULL, SAUL_SENSE_LIGHT };
 static const saul_driver_t s3_dri = { NULL, NULL, SAUL_ACT_LED_RGB };
 
-static saul_reg_t s0 = { NULL, NULL, "S0", &s0_dri };
-static saul_reg_t s1 = { NULL, NULL, "S1", &s1_dri };
-static saul_reg_t s2 = { NULL, NULL, "S2", &s2_dri };
-static saul_reg_t s3 = { NULL, NULL, "S3", &s3_dri };
+static saul_reg_t s0 = { NULL, NULL, "S0", &s0_dri, 0 };
+static saul_reg_t s1 = { NULL, NULL, "S1", &s1_dri, 0 };
+static saul_reg_t s2 = { NULL, NULL, "S2", &s2_dri, 0 };
+static saul_reg_t s3 = { NULL, NULL, "S3", &s3_dri, 0 };
 
 
 static int count(void)
@@ -104,15 +104,17 @@ static void test_reg_add(void)
 
 static void test_reg_find_nth(void)
 {
-    saul_reg_t *dev = saul_reg_find_nth(0);
+    saul_ctxt_ptr_t ctxt_ptr;
+
+    saul_reg_t *dev = saul_reg_find_nth(&ctxt_ptr, 0);
     TEST_ASSERT_NOT_NULL(dev);
     TEST_ASSERT_EQUAL_STRING("S0", dev->name);
 
-    dev = saul_reg_find_nth(2);
+    dev = saul_reg_find_nth(&ctxt_ptr, 2);
     TEST_ASSERT_NOT_NULL(dev);
     TEST_ASSERT_EQUAL_STRING("S2", dev->name);
 
-    dev = saul_reg_find_nth(17);
+    dev = saul_reg_find_nth(&ctxt_ptr, 17);
     TEST_ASSERT_NULL(dev);
 }
 


### PR DESCRIPTION
Note: some of this initial description is now obsolete. The complex / imaginary analogy was dropped, since it was confusing. The method of passing the context parameter is now a conventional argument (which is simpler, but requires more changes).

### Description:
Currently SAUL does not handle large arrays of nearly identical devices well. For example, if you want to write to a large number of GPIO pins, or read from a lot of analog inputs, you must currently have a struct with separate parameters for each of them. It would be nice to be able to tell SAUL that you have an array of devices, and to share all parameters between them except for an index value.

### My idea on how to do this:
- The SAUL registry is set up to contain both real devices and imaginary duplicates of devices. They are "imaginary" since they do not have their own dev and params structs.
- The number of members in the registry and the ordering in the registry takes into account imaginary members (which all appear together, in order of their index value).
- Pointers to registry members are replaced with "complex" pointers, which are comprised of a real pointer, and an "imaginary" index value.
- SAUL initialization functions only take real values (since they are not actually separate devices), other functions should just pretend that they have separate devices.

### How the duplicates would be used:
- If foo driver supports duplicates, then it should have a global const foo_imag_count defined in its foo_params.h file.
- Foo driver's auto_init_foo.c should take imag_count and put it into ```saul_entries[i].imag_count``` in auto_init_foo.
- When calling saul_reg_read / saul_reg_write and ```dev.imag != 0``` the value of imag is stuffed into the first byte of the device descriptor. The first element of the device descriptor struct MUST be a byte intended for this use. C guarantees that the address of the first element is the same as the address of the struct. This value could also be passed by changing the definitions of saul_read_t and saul_write_t, but that would require a much more extensive rewrite.
- Some other misc. things would need to be tweaked, such as foo_saul_info could use sprintf to put imag into the name of the device. You could get a nice output from the saul command, e.g. "Arduino Pin %u".

This is intended to be as conservative a change as possible, with almost all new behavior confined to when ```imag_count > 0```.

Currently changes in this PR are limited to an example, because I want to wait for some feedback on the method before doing more extensive edits.

### See also:
- #9054 for a driver that needs something like what is offered here.
- The mux in drivers/ads101x could also use this.