### PR TITLE
makefiles/info.inc.mk: add a info-debug-variable-% target

### DIFF
--- a/makefiles/info.inc.mk
+++ b/makefiles/info.inc.mk
@@ -1,6 +1,7 @@
 .PHONY: info-objsize info-buildsizes info-build info-boards-supported \
         info-features-missing info-modules info-cpu \
-        info-features-provided info-features-required
+        info-features-provided info-features-required \
+        info-debug-variable-%
 
 info-objsize:
 	@case "$(SORTROW)" in \
@@ -125,3 +126,6 @@ info-features-required:
 
 info-features-missing:
 	@for i in $(sort $(filter-out $(FEATURES_PROVIDED), $(FEATURES_REQUIRED))); do echo $$i; done
+
+info-debug-variable-%:
+	@echo $($*)


### PR DESCRIPTION
### Contribution description

Add a target to print an internal variable value.

Usage: make info-debug-variable-VARIABLENAME

Example: 

    make info-debug-variable-ELFFILE
    /path/to/riot/examples/hello-world/bin/native/hello-world.elf

Suggestions on the target name are welcomed.

### Issues/PRs references

I want to show that an internal value did not change with a refactoring.
Could also help having internal informations.