### PR TITLE
Makefile.include: use RIOTTOOLS variable for included files

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -13,12 +13,12 @@ RIOTMAKE       ?= $(RIOTBASE)/makefiles
 RIOTPKG        ?= $(RIOTBASE)/pkg
 RIOTTOOLS      ?= $(RIOTBASE)/dist/tools
 RIOTPROJECT    ?= $(shell git rev-parse --show-toplevel 2>/dev/null || pwd)
-GITCACHE       ?= $(RIOTBASE)/dist/tools/git/git-cache
+GITCACHE       ?= $(RIOTTOOLS)/git/git-cache
 APPDIR         ?= $(CURDIR)
 BINDIRBASE     ?= $(APPDIR)/bin
 BINDIR         ?= $(BINDIRBASE)/$(BOARD)
 PKGDIRBASE     ?= $(BINDIRBASE)/pkg/$(BOARD)
-DLCACHE        ?= $(RIOTBASE)/dist/tools/dlcache/dlcache.sh
+DLCACHE        ?= $(RIOTTOOLS)/dlcache/dlcache.sh
 DLCACHE_DIR    ?= $(RIOTBASE)/.dlcache
 
 __DIRECTORY_VARIABLES := \
@@ -457,7 +457,7 @@ term: $(filter flash, $(MAKECMDGOALS)) $(TERMDEPS)
 	$(TERMPROG) $(TERMFLAGS)
 
 list-ttys:
-	$(Q)$(RIOTBASE)/dist/tools/usb-serial/list-ttys.sh
+	$(Q)$(RIOTTOOLS)/usb-serial/list-ttys.sh
 
 doc:
 	make -BC $(RIOTBASE) doc
@@ -493,7 +493,7 @@ eclipsesym.xml: $(CURDIR)/eclipsesym.xml
 
 $(CURDIR)/eclipsesym.xml:
 	$(Q)printf "%s\n" $(CC) $(CFLAGS_WITH_MACROS) $(INCLUDES) | \
-		$(RIOTBASE)/dist/tools/eclipsesym/cmdline2xml.sh > $@
+		$(RIOTTOOLS)/eclipsesym/cmdline2xml.sh > $@
 
 # Export variables used throughout the whole make system:
 include $(RIOTMAKE)/vars.inc.mk
@@ -597,7 +597,7 @@ ifneq (,$(filter iotlab-m3 wsn430-v1_3b wsn430-v1_4,$(BOARD)))
 endif
 
 # Include desvirt Makefile
-include $(RIOTBASE)/dist/tools/desvirt/Makefile.desvirt
+include $(RIOTTOOLS)/desvirt/Makefile.desvirt
 
 # include bindist target
 include $(RIOTMAKE)/bindist.inc.mk
@@ -611,7 +611,7 @@ include $(RIOTMAKE)/modules.inc.mk
 .PHONY: $(RIOTBUILD_CONFIG_HEADER_C)
 $(RIOTBUILD_CONFIG_HEADER_C):
 	@mkdir -p '$(dir $@)'
-	$(Q)'$(RIOTBASE)/dist/tools/genconfigheader/genconfigheader.sh' '$@' $(CFLAGS_WITH_MACROS)
+	$(Q)'$(RIOTTOOLS)/genconfigheader/genconfigheader.sh' '$@' $(CFLAGS_WITH_MACROS)
 
 CFLAGS_WITH_MACROS := $(CFLAGS)
 

--- a/dist/tools/desvirt/Makefile.desvirt
+++ b/dist/tools/desvirt/Makefile.desvirt
@@ -1,7 +1,7 @@
 TOOL_NAME=desvirt
 TOOL_URL=https://github.com/des-testbed/desvirt.git
 TOOL_VERSION=master
-TOOL_DIR=$(RIOTBASE)/dist/tools/$(TOOL_NAME)/$(TOOL_NAME)
+TOOL_DIR=$(RIOTTOOLS)/$(TOOL_NAME)/$(TOOL_NAME)
 
 .PHONY: desvirt-check desvirt-check-topo-file desvirt-check-topo-args desvirt-clean \
         desvirt-distclean desvirt-define desvirt-undefine desvirt-start desvirt-stop desvirt-list

--- a/makefiles/mcuboot.mk
+++ b/makefiles/mcuboot.mk
@@ -1,6 +1,6 @@
 ifdef MCUBOOT_SLOT0_SIZE
 
-IMGTOOL ?= $(RIOTBASE)/dist/tools/mcuboot/imgtool.py
+IMGTOOL ?= $(RIOTTOOLS)/mcuboot/imgtool.py
 override IMGTOOL := $(abspath $(IMGTOOL))
 
 BINFILE ?= $(BINDIR)/$(APPLICATION).bin


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Use RIOTTOOLS variable for Makefile.include and files included by it

Follow up to #9067 and part of #8821 


### Testing

I am using https://github.com/RIOT-OS/RIOT/pull/9101 for testing, that's why this branch depends on it. It can be removed before merging. So not really "Waiting on it" just should not be merged without removing the commit.

I get the same output with only #9101 and with this PR added for the following test script

```
#! /bin/sh

make info-debug-variable-GITCACHE
make info-debug-variable-DLCACHE

make list-ttys QUIET=0

rm eclipsesym.xml
make eclipsesym.xml
ls eclipsesym.xml

# include of Makefile.desvirt did not crash when doing make

rm ${PWD}/bin/native/riotbuild/riotbuild.h
make ${PWD}/bin/native/riotbuild/riotbuild.h
ls ${PWD}/bin/native/riotbuild/riotbuild.h

make info-debug-variable-TOOL_DIR

make info-debug-variable-IMGTOOL BOARD=acd52832                          
```

### Issues/PRs references

Follow up to #9067 and part of #8821
Depends on ~#9101~
