### PR TITLE
cortexm: const ISR vectors

### DIFF
--- a/cpu/cortexm_common/vectors_cortexm.c
+++ b/cpu/cortexm_common/vectors_cortexm.c
@@ -375,7 +375,7 @@ __attribute__((weak,alias("dummy_handler_default"))) void isr_pendsv(void);
 __attribute__((weak,alias("dummy_handler_default"))) void isr_systick(void);
 
 /* define Cortex-M base interrupt vectors */
-ISR_VECTOR(0) cortexm_base_t cortex_vector_base = {
+ISR_VECTOR(0) const cortexm_base_t cortex_vector_base = {
     &_estack,
     {
         /* entry point of the program */

--- a/cpu/kinetis/isr_kinetis.c
+++ b/cpu/kinetis/isr_kinetis.c
@@ -223,4 +223,4 @@ WEAK_DEFAULT void isr_wdog_ewm(void);
  * tables, or link the table from a different CPU, and catch many other mistakes. */
 /* We subtract the expected number of used vectors, which are: The initial stack
  * pointer + the Cortex-M common IRQs + the Kinetis CPU specific IRQs */
-ISR_VECTOR(99) const isr_t vector_padding[(0x400 / sizeof(isr_t)) - 1 - CPU_NONISR_EXCEPTIONS - CPU_IRQ_NUMOF];
+ISR_VECTOR(99) const isr_t vector_padding[(0x400 / sizeof(isr_t)) - 1 - CPU_NONISR_EXCEPTIONS - CPU_IRQ_NUMOF] = {0};


### PR DESCRIPTION

### Contribution description

This fixes a problem where the section and memory segment used by the ISR vectors is incorrectly marked as writable in the ELF file. This confuses the `size` program where the ISR vector size counts towards .data instead of towards .text on Kinetis based boards.

This is a bugfix but it does not need to be backported, too minor.

### Issues/PRs references
