### PR TITLE
tests/libfixmath_unittests: fix for iotlab-m3 and samr21-xpro [backport 2018.04]

### DIFF
--- a/tests/libfixmath_unittests/Makefile
+++ b/tests/libfixmath_unittests/Makefile
@@ -15,6 +15,8 @@ ifneq (,$(filter native,$(BOARD)))
   export LINKFLAGS += -lm
 endif
 
+USEMODULE += printf_float
+
 include $(RIOTBASE)/Makefile.include
 
 test:

--- a/tests/libfixmath_unittests/tests/01-run.py
+++ b/tests/libfixmath_unittests/tests/01-run.py
@@ -9,9 +9,13 @@
 import os
 import sys
 
+# Float and print operations are slow on boards
+# Got 80 iotlab-m3 and 250 on samr21-xpro
+TIMEOUT = 300
+
 
 def testfunc(child):
-    child.expect('SUCCESS')
+    child.expect('SUCCESS', timeout=TIMEOUT)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
# Backport of #9100

### Contribution description

The test is missing `printf_float` dependency to run on boards.
Also increase timeout as required for `iotlab-m3` and `samr21-xpro`.

### Issues/PRs references

https://github.com/RIOT-OS/Release-Specs/issues/62#issuecomment-387421737