### PR TITLE
examples/gnrc_border_router: use RIOTTOOLS variable

### DIFF
--- a/examples/gnrc_border_router/Makefile
+++ b/examples/gnrc_border_router/Makefile
@@ -91,10 +91,10 @@ TERMDEPS += uhcpd-daemon
 .PHONY: uhcpd-daemon
 
 uhcpd-daemon: host-tools
-	$(RIOTBASE)/dist/tools/uhcpd/bin/uhcpd $(TAP) $(IPV6_PREFIX) &
+	$(RIOTTOOLS)/uhcpd/bin/uhcpd $(TAP) $(IPV6_PREFIX) &
 else
 # We override the `make term` command to use ethos
-TERMPROG ?= sudo sh $(RIOTBASE)/dist/tools/ethos/start_network.sh
+TERMPROG ?= sudo sh $(RIOTTOOLS)/ethos/start_network.sh
 TERMFLAGS ?= $(PORT) $(TAP) $(IPV6_PREFIX)
 
 # We depend on the ethos host tools to run the border router, we build them
@@ -107,7 +107,7 @@ include $(RIOTBASE)/Makefile.include
 .PHONY: host-tools
 
 host-tools:
-	$(Q)env -u CC -u CFLAGS make -C $(RIOTBASE)/dist/tools
+	$(Q)env -u CC -u CFLAGS make -C $(RIOTTOOLS)
 
 # Set a custom channel if needed
 ifneq (,$(filter cc110x,$(USEMODULE)))          # radio is cc110x sub-GHz


### PR DESCRIPTION
### Contribution description

Use RIOTTOOLS for gnrc_border_router

Follow up to #9067 and part of #8821 

### Tests

```
make BOARD=native -n uhcpd-daemon
# env -u CC -u CFLAGS make -C /riotdir/RIOT/dist/tools
# /riotdir/RIOT/dist/tools/uhcpd/bin/uhcpd tap0 2001:db8::/64 &

make BOARD=samr21-xpro term
# make -C ethos
# make[2]: Nothing to be done for 'all'.
# make -C uhcpd
# make[2]: Nothing to be done for 'all'.
# sudo sh /riotdir/RIOT/dist/tools/ethos/start_network.sh /dev/ttyACM0 tap0 2001:db8::/64
```

### Issues/PRs references

Follow up to #9067 and part of #8821 