### PR TITLE
sys/icmpv6_hdr_print: replace PRIu8 by PRIu16

### DIFF
--- a/sys/net/network_layer/icmpv6/icmpv6_hdr_print.c
+++ b/sys/net/network_layer/icmpv6/icmpv6_hdr_print.c
@@ -21,7 +21,8 @@
 
 void icmpv6_hdr_print(icmpv6_hdr_t *hdr)
 {
-    printf("   type: %3" PRIu8 "  code: %3" PRIu8 "\n", hdr->type, hdr->code);
+    printf("   type: %3" PRIu16 "  code: %3" PRIu16 "\n",
+           (uint16_t)hdr->type, (uint16_t)hdr->code);
     printf("   cksum: 0x%04" PRIx16 "\n", byteorder_ntohs(hdr->csum));
 }
 /** @} */


### PR DESCRIPTION
### Contribution description

PRIu8 is not supported on samr21-xpro:

    type:   hu  code:   hu

After fix

    type: 133  code:   0

Found by running 'tests/gnrc_netif'

### Issues/PRs references

None