### PR TITLE
tests/trickle: initialize prev_now in main

### DIFF
--- a/tests/trickle/main.c
+++ b/tests/trickle/main.c
@@ -60,6 +60,7 @@ int main(void)
 {
     msg_t msg;
     unsigned counter = 0;
+    prev_now = xtimer_now_usec();
 
     trickle_start(sched_active_pid, &trickle, TRICKLE_MSG, TR_IMIN,
                   TR_IDOUBLINGS, TR_REDCONST);


### PR DESCRIPTION
### Contribution description

Having `prev_now` initialized to 0 breaks tests on `arduino-zero` and
`arduino-mega2560` as `xtimer_now_usec` is way bigger (72k on `arduino-zero`).

Issue found in:
* #9052 and proposed fix by ZetaR60
* https://github.com/RIOT-OS/Release-Specs/issues/62#issuecomment-387421737

### Issues/PRs references

#9052 and https://github.com/RIOT-OS/Release-Specs/issues/62#issuecomment-387421737