### PR TITLE
sys/uart_stdio: compile with -Wno-cast-function-type

### DIFF
--- a/sys/uart_stdio/Makefile
+++ b/sys/uart_stdio/Makefile
@@ -1,1 +1,4 @@
+ifeq (gnu, $(TOOLCHAIN))
+  CFLAGS += -Wno-cast-function-type
+endif
 include $(RIOTBASE)/Makefile.base


### PR DESCRIPTION
### Contribution description

This PR disables gcc's "cast-function-type" warning for uart_stdio. 

Fixes

```
uart_stdio.c: In function 'uart_stdio_init':
uart_stdio.c:89:52: error: cast between incompatible function types from 'int (*)(isrpipe_t *, char)' {aka 'int (*)(struct <anonymous> *, char)'} to 'void (*)(void *, uint8_t)' {aka 'void (*)(void *, unsigned char)'} [-Werror=cast-function-type]
     uart_init(UART_STDIO_DEV, UART_STDIO_BAUDRATE, (uart_rx_cb_t) isrpipe_write_one, &uart_stdio_isrpipe);
```

(new with gcc 8.1)