### PR TITLE
cpu/cortexm: explicitly set -march=armv6s-m for crotexm0(plus)

### DIFF
--- a/makefiles/arch/cortexm.inc.mk
+++ b/makefiles/arch/cortexm.inc.mk
@@ -3,11 +3,18 @@ export TARGET_ARCH ?= arm-none-eabi
 
 # define build specific options
 export CFLAGS_CPU   = -mcpu=$(MCPU) -mlittle-endian -mthumb $(CFLAGS_FPU)
+
 ifneq (llvm,$(TOOLCHAIN))
 # Clang (observed with v3.7) does not understand  -mno-thumb-interwork, only add if
 # not building with LLVM
 export CFLAGS      += -mno-thumb-interwork
+
+# work around https://gcc.gnu.org/bugzilla/show_bug.cgi?id=85606
+ifneq (,$(filter cortex-m0%,$(CPU_ARCH)))
+  CFLAGS_CPU += -march=armv6s-m
 endif
+endif
+
 export CFLAGS_LINK  = -ffunction-sections -fdata-sections -fno-builtin -fshort-enums
 export CFLAGS_DBG  ?= -ggdb -g3
 export CFLAGS_OPT  ?= -Os


### PR DESCRIPTION
### Contribution description

Works around a regression in gcc 8.1.
See https://gcc.gnu.org/bugzilla/show_bug.cgi?id=85606.

### Issues/PRs references

Fixes #9120.