### PR TITLE
gnrc/netif/hdr.h: Optimized structure layout

### DIFF
--- a/sys/include/net/gnrc/netif/hdr.h
+++ b/sys/include/net/gnrc/netif/hdr.h
@@ -85,8 +85,8 @@ typedef struct {
     uint8_t dst_l2addr_len;     /**< length of l2 destination address in byte */
     kernel_pid_t if_pid;        /**< PID of network interface */
     uint8_t flags;              /**< flags as defined above */
-    int16_t rssi;               /**< rssi of received packet in dBm (optional) */
     uint8_t lqi;                /**< lqi of received packet (optional) */
+    int16_t rssi;               /**< rssi of received packet in dBm (optional) */
 } gnrc_netif_hdr_t;
 
 /**


### PR DESCRIPTION
Reordered struct members to not waste memory due to padding. Sorting struct
members by alignment requirements is an easy approach to optimize structs
for memory usage, so this strategy was applied here.

Before:
``` C
typedef struct {
    uint8_t src_l2addr_len;
    uint8_t dst_l2addr_len;
    kernel_pid_t if_pid;    // <-- 16 bit, is aligned to 16 bit
    uint8_t flags;
    uint8_t __padding_byte; // <-- Inserted to fulfill padding requirements
    int16_t rssi;           // <-- 16 bit, is NOT aligned to 16 bit
    uint8_t lqi;
} gnrc_netif_hdr_t;
```

Now:

``` C
typedef struct {
    uint8_t src_l2addr_len;
    uint8_t dst_l2addr_len;
    kernel_pid_t if_pid;    // <-- 16 bit, is aligned to 16 bit
    uint8_t flags;
    uint8_t lqi;
    int16_t rssi;           // <-- 16 bit, is aligned to 16 bit
} gnrc_netif_hdr_t;
```