### PR TITLE
cpu: efm32: provide non-standard UART modes

### DIFF
--- a/boards/ikea-tradfri/include/periph_conf.h
+++ b/boards/ikea-tradfri/include/periph_conf.h
@@ -126,6 +126,9 @@ static const uart_conf_t uart_config[] = {
         .tx_pin = GPIO_PIN(PB, 14),
         .loc = USART_ROUTELOC0_RXLOC_LOC9 |
                USART_ROUTELOC0_TXLOC_LOC9,
+#if EFM32_UART_MODES
+        .mode = UART_MODE_8N1,
+#endif
         .cmu = cmuClock_USART0,
         .irq = USART0_RX_IRQn
     }

--- a/boards/slstk3401a/include/periph_conf.h
+++ b/boards/slstk3401a/include/periph_conf.h
@@ -175,6 +175,9 @@ static const uart_conf_t uart_config[] = {
         .tx_pin = GPIO_PIN(PA, 0),
         .loc = USART_ROUTELOC0_RXLOC_LOC0 |
                USART_ROUTELOC0_TXLOC_LOC0,
+#if EFM32_UART_MODES
+        .mode = UART_MODE_8N1,
+#endif
         .cmu = cmuClock_USART0,
         .irq = USART0_RX_IRQn
     },
@@ -184,6 +187,9 @@ static const uart_conf_t uart_config[] = {
         .tx_pin = GPIO_PIN(PC, 6),
         .loc = USART_ROUTELOC0_RXLOC_LOC11 |
                USART_ROUTELOC0_TXLOC_LOC11,
+#if EFM32_UART_MODES
+        .mode = UART_MODE_8N1,
+#endif
         .cmu = cmuClock_USART1,
         .irq = USART1_RX_IRQn
     },
@@ -193,6 +199,9 @@ static const uart_conf_t uart_config[] = {
         .tx_pin = GPIO_PIN(PD, 10),
         .loc = LEUART_ROUTELOC0_RXLOC_LOC18 |
                LEUART_ROUTELOC0_TXLOC_LOC18,
+#if EFM32_UART_MODES
+        .mode = UART_MODE_8N1,
+#endif
         .cmu = cmuClock_LEUART0,
         .irq = LEUART0_IRQn
     }

--- a/boards/sltb001a/include/periph_conf.h
+++ b/boards/sltb001a/include/periph_conf.h
@@ -176,6 +176,9 @@ static const uart_conf_t uart_config[] = {
         .tx_pin = GPIO_PIN(PA, 0),
         .loc = USART_ROUTELOC0_RXLOC_LOC0 |
                USART_ROUTELOC0_TXLOC_LOC0,
+#if EFM32_UART_MODES
+        .mode = UART_MODE_8N1,
+#endif
         .cmu = cmuClock_USART0,
         .irq = USART0_RX_IRQn
     },
@@ -185,6 +188,9 @@ static const uart_conf_t uart_config[] = {
         .tx_pin = GPIO_PIN(PC, 7),
         .loc = USART_ROUTELOC0_RXLOC_LOC11 |
                USART_ROUTELOC0_TXLOC_LOC11,
+#if EFM32_UART_MODES
+        .mode = UART_MODE_8N1,
+#endif
         .cmu = cmuClock_USART1,
         .irq = USART1_RX_IRQn
     },
@@ -194,6 +200,9 @@ static const uart_conf_t uart_config[] = {
         .tx_pin = GPIO_PIN(PD, 10),
         .loc = LEUART_ROUTELOC0_RXLOC_LOC18 |
                LEUART_ROUTELOC0_TXLOC_LOC18,
+#if EFM32_UART_MODES
+        .mode = UART_MODE_8N1,
+#endif
         .cmu = cmuClock_LEUART0,
         .irq = LEUART0_IRQn
     }

--- a/boards/slwstk6000b/include/periph_conf.h
+++ b/boards/slwstk6000b/include/periph_conf.h
@@ -177,6 +177,9 @@ static const uart_conf_t uart_config[] = {
         .tx_pin = MODULE_PIN_F6,
         .loc = USART_ROUTELOC0_RXLOC_LOC0 |
                USART_ROUTELOC0_TXLOC_LOC0,
+#if EFM32_UART_MODES
+        .mode = UART_MODE_8N1,
+#endif
         .cmu = cmuClock_USART0,
         .irq = USART0_RX_IRQn
     }

--- a/boards/stk3600/include/periph_conf.h
+++ b/boards/stk3600/include/periph_conf.h
@@ -237,6 +237,9 @@ static const uart_conf_t uart_config[] = {
         .rx_pin = GPIO_PIN(PE, 1),
         .tx_pin = GPIO_PIN(PE, 0),
         .loc = UART_ROUTE_LOCATION_LOC1,
+#if EFM32_UART_MODES
+        .mode = UART_MODE_8N1,
+#endif
         .cmu = cmuClock_UART0,
         .irq = UART0_RX_IRQn
     },
@@ -245,6 +248,9 @@ static const uart_conf_t uart_config[] = {
         .rx_pin = GPIO_PIN(PD, 1),
         .tx_pin = GPIO_PIN(PD, 0),
         .loc = USART_ROUTE_LOCATION_LOC1,
+#if EFM32_UART_MODES
+        .mode = UART_MODE_8N1,
+#endif
         .cmu = cmuClock_USART1,
         .irq = USART1_RX_IRQn
     },
@@ -253,6 +259,9 @@ static const uart_conf_t uart_config[] = {
         .rx_pin = GPIO_PIN(PD, 5),
         .tx_pin = GPIO_PIN(PD, 4),
         .loc = LEUART_ROUTE_LOCATION_LOC0,
+#if EFM32_UART_MODES
+        .mode = UART_MODE_8N1,
+#endif
         .cmu = cmuClock_LEUART0,
         .irq = LEUART0_IRQn
     }

--- a/boards/stk3700/include/periph_conf.h
+++ b/boards/stk3700/include/periph_conf.h
@@ -237,6 +237,9 @@ static const uart_conf_t uart_config[] = {
         .rx_pin = GPIO_PIN(PE, 1),
         .tx_pin = GPIO_PIN(PE, 0),
         .loc = UART_ROUTE_LOCATION_LOC1,
+#if EFM32_UART_MODES
+        .mode = UART_MODE_8N1,
+#endif
         .cmu = cmuClock_UART0,
         .irq = UART0_RX_IRQn
     },
@@ -245,6 +248,9 @@ static const uart_conf_t uart_config[] = {
         .rx_pin = GPIO_PIN(PD, 1),
         .tx_pin = GPIO_PIN(PD, 0),
         .loc = USART_ROUTE_LOCATION_LOC1,
+#if EFM32_UART_MODES
+        .mode = UART_MODE_8N1,
+#endif
         .cmu = cmuClock_USART1,
         .irq = USART1_RX_IRQn
     },
@@ -253,6 +259,9 @@ static const uart_conf_t uart_config[] = {
         .rx_pin = GPIO_PIN(PD, 5),
         .tx_pin = GPIO_PIN(PD, 4),
         .loc = LEUART_ROUTE_LOCATION_LOC0,
+#if EFM32_UART_MODES
+        .mode = UART_MODE_8N1,
+#endif
         .cmu = cmuClock_LEUART0,
         .irq = LEUART0_IRQn
     }

--- a/cpu/efm32/Makefile.features
+++ b/cpu/efm32/Makefile.features
@@ -1,3 +1,5 @@
+include $(RIOTCPU)/efm32/efm32-features.mk
+
 FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_flashpage
 
@@ -6,6 +8,10 @@ FEATURES_CONFLICT_MSG += "On the EFM32, the RTC and RTT map to the same hardware
 
 ifeq (1,$(EFM32_TNRG))
   FEATURES_PROVIDED += periph_hwrng
+endif
+
+ifeq (1,$(EFM32_UART_MODES))
+  export CFLAGS += -DEFM32_UART_MODES=1
 endif
 
 include $(RIOTCPU)/cortexm_common/Makefile.features

--- a/cpu/efm32/efm32-features.mk
+++ b/cpu/efm32/efm32-features.mk
@@ -1,0 +1,4 @@
+# This file provides defaults for additional EFM32-specific features. You
+# should override them from the command line, or in your Makefile. Note that
+# some features may not be applicable to all EFM32 boards or CPUs.
+export EFM32_UART_MODES ?= 0

--- a/cpu/efm32/include/periph_cpu.h
+++ b/cpu/efm32/include/periph_cpu.h
@@ -360,13 +360,30 @@ typedef struct {
 /** @} */
 
 /**
+ * @brief   Internal macro for combining UART modes data bits (x), stop bits
+ *          (y, in half bits) and parity (z).
+ */
+#define UART_MODE(x, y, z)      ((z << 8) | ((y * 2) << 4) | x)
+
+/**
+ * @brief   Internal, pre-defined UART modes.
+ * @{
+ */
+#define UART_MODE_8N1           UART_MODE(8, 1, 0)
+#define UART_MODE_8E1           UART_MODE(8, 1, 2)
+/** @} */
+
+/**
  * @brief   UART device configuration.
  */
 typedef struct {
     void *dev;              /**< UART, USART or LEUART device used */
     gpio_t rx_pin;          /**< pin used for RX */
     gpio_t tx_pin;          /**< pin used for TX */
-    uint32_t loc;           /**< location of USART pins */
+    uint32_t loc;           /**< location of UART pins */
+#if EFM32_UART_MODES
+    uint32_t mode;          /**< UART mode of operation */
+#endif
     CMU_Clock_TypeDef cmu;  /**< the device CMU channel */
     IRQn_Type irq;          /**< the devices base IRQ channel */
 } uart_conf_t;

--- a/cpu/efm32/periph/uart.c
+++ b/cpu/efm32/periph/uart.c
@@ -26,8 +26,10 @@
 #include "periph/gpio.h"
 
 #include "em_usart.h"
+#include "em_usart_utils.h"
 #if LOW_POWER_ENABLED && defined(LEUART_COUNT) && LEUART_COUNT > 0
 #include "em_leuart.h"
+#include "em_leuart_utils.h"
 #endif
 
 /**
@@ -73,6 +75,11 @@ int uart_init(uart_t dev, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
 
         init.enable = usartDisable;
         init.baudrate = baudrate;
+#if EFM32_UART_MODES
+        init.databits = USART_DataBits2Def((uart_config[dev].mode >> 0) & 0xf);
+        init.stopbits = USART_StopBits2Def((uart_config[dev].mode >> 4) & 0xf);
+        init.parity = USART_Parity2Def((uart_config[dev].mode >> 8) & 0xf);
+#endif
 
         USART_InitAsync(uart, &init);
 
@@ -104,6 +111,11 @@ int uart_init(uart_t dev, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
 
         init.enable = leuartDisable;
         init.baudrate = baudrate;
+#if EFM32_UART_MODES
+        init.databits = LEUART_DataBits2Def((uart_config[dev].mode >> 0) & 0xf);
+        init.stopbits = LEUART_StopBits2Def((uart_config[dev].mode >> 4) & 0xf);
+        init.parity = LEUART_Parity2Def((uart_config[dev].mode >> 8) & 0xf);
+#endif
 
         LEUART_Init(leuart, &init);
 

--- a/pkg/gecko_sdk/Makefile
+++ b/pkg/gecko_sdk/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME=gecko_sdk
 PKG_URL=https://github.com/basilfx/RIOT-gecko-sdk
-PKG_VERSION=d381e526d68a2d0c951f37040c1c2e168ac66cd6
+PKG_VERSION=a5e7be18ef3d7947ab6f04f9cd74f8808da7aece
 PKG_LICENSE=Zlib
 
 ifneq ($(CPU),efm32)


### PR DESCRIPTION
### Contribution description
I need non-standard UART modes for some (KNX) transceivers that want 8E1. This PR adds them as an option to the `uart_config` struct, similar to how it was done for some Kinetis boards. The default remains 8N1, for both USART and LEUART. 

Conversion methods were added to Gecko-SDK (see [this commit](https://github.com/basilfx/RIOT-gecko-sdk/commit/412328e299f6b9352f295257d5d86e40615c5963)), which minimizes the changes in the RIOT code and provides a clean abstraction for both USART and LEUART.

### Issues/PRs references
#5899, #7165