### PR TITLE
mtd_spi_nor: add 4-byte address flash support

### DIFF
--- a/drivers/include/mtd_spi_nor.h
+++ b/drivers/include/mtd_spi_nor.h
@@ -140,6 +140,13 @@ extern const mtd_desc_t mtd_spi_nor_driver;
  * sensible for default values. */
 extern const mtd_spi_nor_opcode_t mtd_spi_nor_opcode_default;
 
+/**
+ * @brief   Default 4-byte addresses opcodes
+ *
+ * Commands for 4-byte addresses chips (above 128Mb)
+ */
+extern const mtd_spi_nor_opcode_t mtd_spi_nor_opcode_default_4bytes;
+
 #ifdef __cplusplus
 }
 #endif

--- a/drivers/mtd_spi_nor/mtd_spi_nor_configs.c
+++ b/drivers/mtd_spi_nor/mtd_spi_nor_configs.c
@@ -42,4 +42,20 @@ const mtd_spi_nor_opcode_t mtd_spi_nor_opcode_default = {
     .wake            = 0xab,
 };
 
+const mtd_spi_nor_opcode_t mtd_spi_nor_opcode_default_4bytes = {
+    .rdid            = 0x9f,
+    .wren            = 0x06,
+    .rdsr            = 0x05,
+    .wrsr            = 0x01,
+    .read            = 0x13,
+    .read_fast       = 0x0c,
+    .page_program    = 0x12,
+    .sector_erase    = 0x21,
+    .block_erase_32k = 0x5c,
+    .block_erase     = 0xdc,
+    .chip_erase      = 0xc7,
+    .sleep           = 0xb9,
+    .wake            = 0xab,
+};
+
 /** @} */


### PR DESCRIPTION
### Contribution description

Add opcodes for 4-byte addresses commands with a SPI NOR flash, this is needed for flashes bigger than 128Mb.
The commands come from MX25L25645G datasheet.

### Issues/PRs references

None