### PR TITLE
driver : Netdev implementation for cc430

### DIFF
--- a/cpu/cc430/Makefile
+++ b/cpu/cc430/Makefile
@@ -2,4 +2,9 @@ MODULE = cpu
 
 DIRS = $(RIOTCPU)/msp430_common periph
 
+# cc430_rf radio driver
+ifneq (,$(filter cc430_rf,$(USEMODULE)))
+  DIRS += radio gnrc_cc110x
+endif
+
 include $(RIOTBASE)/Makefile.base

--- a/cpu/cc430/gnrc_cc110x/Makefile
+++ b/cpu/cc430/gnrc_cc110x/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/cpu/cc430/gnrc_cc110x/gnrc_cc110x.c
+++ b/cpu/cc430/gnrc_cc110x/gnrc_cc110x.c
@@ -1,0 +1,197 @@
+/*
+ * Copyright (C) 2015 Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+#include <assert.h>
+
+#include <sys/uio.h>
+
+#include "net/netdev.h"
+#include "net/gnrc.h"
+#include "cc430_rf_netdev.h"
+#include "cc430_rf_internal.h"
+#include "net/gnrc/netif.h"
+#include "od.h"
+
+#define ENABLE_DEBUG    (0)
+#include "debug.h"
+
+static int _send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
+{
+    cc110x_pkt_t cc110x_pkt;
+    netdev_t *dev = netif->dev;
+    netdev_cc110x_t *netdev_cc110x = (netdev_cc110x_t *) dev;
+    cc110x_t *cc110x = &netdev_cc110x->cc110x;
+
+    assert(pkt != NULL);
+    assert(dev->driver == &netdev_cc110x_driver);
+
+    gnrc_netif_hdr_t *netif_hdr;
+    gnrc_pktsnip_t *payload;
+
+    payload = pkt->next;
+
+    if (pkt->type != GNRC_NETTYPE_NETIF) {
+        DEBUG("gnrc_cc110x: First header was not generic netif header\n");
+        gnrc_pktbuf_release(pkt);
+        return -EBADMSG;
+    }
+
+    netif_hdr = (gnrc_netif_hdr_t *) pkt->data;
+
+    /* set up header */
+    if (netif_hdr->src_l2addr_len == 1) {
+        uint8_t *_src_addr = gnrc_netif_hdr_get_src_addr(netif_hdr);
+        cc110x_pkt.phy_src = *_src_addr;
+    }
+    else {
+        cc110x_pkt.phy_src = cc110x->radio_address;
+    }
+
+    if (netif_hdr->flags & (GNRC_NETIF_HDR_FLAGS_BROADCAST |
+                GNRC_NETIF_HDR_FLAGS_MULTICAST)) {
+        cc110x_pkt.address = 0;
+    }
+    else {
+        uint8_t *_dst_addr = gnrc_netif_hdr_get_dst_addr(netif_hdr);
+        cc110x_pkt.address = _dst_addr[netif_hdr->dst_l2addr_len-1];
+    }
+
+    switch (payload->type) {
+#ifdef MODULE_GNRC_SIXLOWPAN
+        case GNRC_NETTYPE_SIXLOWPAN:
+            cc110x_pkt.flags = 1;
+            break;
+#endif
+        default:
+            cc110x_pkt.flags = 0;
+    }
+
+    iolist_t iolist = {
+        .iol_base = (char *)&cc110x_pkt,
+        .iol_len = sizeof(cc110x_pkt_t)
+    };
+
+    unsigned payload_len = 0;
+    uint8_t *pos = cc110x_pkt.data;
+
+    while (payload) {
+        payload_len += payload->size;
+
+        if (payload_len > CC430_MAX_DATA_LENGTH) {
+            DEBUG("gnrc_cc110x: payload length exceeds maximum"
+                    "(%u>%u)\n", payload_len, CC430_MAX_DATA_LENGTH);
+            gnrc_pktbuf_release(pkt);
+            return -EBADMSG;
+        }
+
+        memcpy(pos, payload->data, payload->size);
+        pos += payload->size;
+        payload = payload->next;
+    }
+
+    /* pkt has been copied into cc110x_pkt, we're done with it. */
+    gnrc_pktbuf_release(pkt);
+
+    cc110x_pkt.length = (uint8_t) payload_len + CC430_HEADER_LENGTH;
+
+    DEBUG("gnrc_cc110x: sending packet from %u to %u with payload "
+            "length %u\n",
+            (unsigned)cc110x_pkt.phy_src,
+            (unsigned)cc110x_pkt.address,
+            (unsigned)cc110x_pkt.length);
+
+    return dev->driver->send(dev, &iolist);
+}
+
+static gnrc_pktsnip_t *_recv(gnrc_netif_t *netif)
+{
+    netdev_t *dev = netif->dev;
+    cc110x_t *cc110x = &((netdev_cc110x_t*) dev)->cc110x;
+
+    cc110x_pkt_t *cc110x_pkt = &cc110x->pkt_buf.packet;
+
+    int payload_length = cc110x_pkt->length - CC430_HEADER_LENGTH;
+
+    int nettype;
+
+    int addr_len;
+    switch (cc110x_pkt->flags) {
+#ifdef MODULE_GNRC_SIXLOWPAN
+        case 1:
+            addr_len = 8;
+            nettype = GNRC_NETTYPE_SIXLOWPAN;
+            break;
+#endif
+        default:
+            addr_len = 1;
+            nettype = GNRC_NETTYPE_UNDEF;
+    }
+
+    /* copy packet payload into pktbuf */
+    gnrc_pktsnip_t *pkt = gnrc_pktbuf_add(NULL, cc110x_pkt->data,
+            payload_length, nettype);
+
+    if(!pkt) {
+        DEBUG("gnrc_cc110x: _recv: cannot allocate pktsnip.\n");
+        return NULL;
+    }
+
+
+    gnrc_pktsnip_t *netif_hdr;
+    netif_hdr = gnrc_pktbuf_add(NULL, NULL,
+            sizeof(gnrc_netif_hdr_t) + 2*addr_len,
+            GNRC_NETTYPE_NETIF);
+
+    if (netif_hdr == NULL) {
+        DEBUG("gnrc_cc110x: no space left in packet buffer\n");
+        gnrc_pktbuf_release(pkt);
+        return NULL;
+    }
+
+    gnrc_netif_hdr_init(netif_hdr->data, addr_len, addr_len);
+    if (addr_len == 8) {
+        uint64_t src_addr = cc110x_pkt->phy_src;
+        uint64_t dst_addr = cc110x_pkt->address;
+        gnrc_netif_hdr_set_src_addr(netif_hdr->data, (uint8_t*)&src_addr, addr_len);
+        gnrc_netif_hdr_set_dst_addr(netif_hdr->data, (uint8_t*)&dst_addr, addr_len);
+    }
+    else {
+        gnrc_netif_hdr_set_src_addr(netif_hdr->data, (uint8_t*)&cc110x_pkt->phy_src, addr_len);
+        gnrc_netif_hdr_set_dst_addr(netif_hdr->data, (uint8_t*)&cc110x_pkt->address, addr_len);
+    }
+
+    ((gnrc_netif_hdr_t *)netif_hdr->data)->if_pid = thread_getpid();
+    ((gnrc_netif_hdr_t *)netif_hdr->data)->lqi = cc110x->pkt_buf.lqi;
+    ((gnrc_netif_hdr_t *)netif_hdr->data)->rssi = cc110x->pkt_buf.rssi;
+
+    DEBUG("gnrc_cc110x: received packet from %02x of length %u\n",
+            (unsigned)cc110x_pkt->phy_src,
+            (unsigned)cc110x_pkt->length-CC430_HEADER_LENGTH);
+#if defined(MODULE_OD) && ENABLE_DEBUG
+    od_hex_dump(cc110x_pkt->data, payload_length, OD_WIDTH_DEFAULT);
+#endif
+
+
+    pkt->next = netif_hdr;
+
+    return pkt;
+}
+
+static const gnrc_netif_ops_t _cc110x_ops = {
+    .send = _send,
+    .recv = _recv,
+    .get = gnrc_netif_get_from_netdev,
+    .set = gnrc_netif_set_from_netdev,
+};
+
+gnrc_netif_t *gnrc_netif_cc110x_create(char *stack, int stacksize, char priority,
+                                       char *name, netdev_t *dev)
+{
+    return gnrc_netif_create(stack, stacksize, priority, name, dev,
+                             &_cc110x_ops);
+}

--- a/cpu/cc430/include/cc430_rf_getset.h
+++ b/cpu/cc430/include/cc430_rf_getset.h
@@ -1,0 +1,40 @@
+/*
+ * Copyright (C) 2018 Baptiste Cartier
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_cc430
+ * @{
+ *
+ * @file
+ * @brief       Getters and setter for the cc430
+ *
+ * @author      Baptiste Cartier
+ */
+
+#ifndef CC430_RF_GETSET_H
+#define CC430_RF_GETSET_H
+
+#include <stdint.h>
+
+#include "cc430_rf_internal.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+uint8_t cc430_get_max_packet_size(void);
+int8_t cc430_set_channel(cc110x_t *dev, uint8_t channr);
+uint8_t cc430_get_radio_state(void);
+uint8_t cc430_set_address(cc110x_t *dev, uint8_t address);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* CC430_RF_GETSET_H */
+/** @} */

--- a/cpu/cc430/include/cc430_rf_internal.h
+++ b/cpu/cc430/include/cc430_rf_internal.h
@@ -1,0 +1,314 @@
+/*
+ * Copyright (C) 2018 Baptiste Cartier
+ * Copyright (C) 2015 Kaspar Schleiser <kaspar@schleiser.de>
+ * Copyright (C) 2014 Freie Universität Berlin
+ * Copyright (C) 2013 INRIA
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_cc430
+ * @{
+ *
+ * @file
+ * @brief       Data structures and variables for the cc430 driver interface, based on the cc110x driver interface
+ *
+ * @author      Baptiste Cartier
+ */
+
+#ifndef CC430_RF_INTERNAL_H
+#define CC430_RF_INTERNAL_H
+
+#include <stdint.h>
+#include <msp430.h> // generic file for register name, I/O, ...
+#include "net/gnrc/nettype.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+#define CC110X_RSSI_OFFSET          (74)
+
+#define CC430_PKT_SIZE_LENGTH       (1)
+
+#define CC430_FIFO_SIZE             (64)
+
+#define CC430_HEADER_LENGTH         (3)                                                             /**< Header covers SRC, DST and
+                                                                                                         FLAGS */
+#define CC430_MAX_DATA_LENGTH       (CC430_FIFO_SIZE - CC430_HEADER_LENGTH - CC430_PKT_SIZE_LENGTH) /*Max data length = size of FIFO - length of header - 1 byte for packet size
+                                                                                                     * Max size is based on FIFO size for now, some work should be done to allow up to 255 data length*/
+
+#define CC430_MAX_PACKET_SIZE       (CC430_FIFO_SIZE - CC430_PKT_SIZE_LENGTH)
+
+#define CC430_BROADCAST_ADDRESS     (0x00)  /**< CC110X broadcast address */
+
+#define MIN_UID                     (0x01)  /**< Minimum UID of a node is
+                                                 1 */
+#define MAX_UID                     (0xFF)  /**< Maximum UID of a node is
+                                                 255 */
+
+#define MIN_CHANNR                  (0)     /**< Minimum channel number */
+#define MAX_CHANNR                  (24)    /**< Maximum channel number */
+
+#define CC110X_PACKET_LENGTH        (64)    /**< max packet length = 64 bytes for the moment */
+#define CC110X_SYNC_WORD_TX_TIME    (90000) /**< loop count (max. timeout ~15ms)
+                                                 to wait for sync word to be
+                                                 transmitted (GDO2 from low to
+                                                 high) */
+
+#ifndef CC430_DEFAULT_CHANNEL
+#define CC430_DEFAULT_CHANNEL      (0)  /**< The default channel number */
+#endif
+#define CC430_MIN_CHANNR           (0)  /**< lowest possible channel number */
+#define CC430_MAX_CHANNR           (0)  /**< highest possible channel number */
+
+#define CONF_REG_SIZE   (47)            /* There are 47 8-bit configuration registers */
+#define cc430_radio_POWER_OUTPUT_MINUS_30DBM       (0x03)
+#define cc430_radio_POWER_OUTPUT_MINUS_12DBM       (0x25)
+#define cc430_radio_POWER_OUTPUT_MINUS_6DBM        (0x2D)
+#define cc430_radio_POWER_OUTPUT_0DBM              (0x8D)
+#define cc430_radio_POWER_OUTPUT_10DBM             (0xC3)
+#define cc430_radio_POWER_OUTPUT_MAX               (0xC0)
+#define cc430_radio_POWER_OUTPUT_DEFAULT_8_8DBM    (0xC6)
+
+#define RADIOINSTRW_MINUS_30DBM              (0x7E03)
+#define RADIOINSTRW_MINUS_12DBM              (0x7E25)
+#define RADIOINSTRW_MINUS_6DBM               (0x7E2D)
+#define RADIOINSTRW_0DBM                     (0x7E8D)
+#define RADIOINSTRW_10DBM                    (0x7EC3)
+#define RADIOINSTRW_MAX                      (0x7EC0)
+#define RADIOINSTRW_DEFAULT_8_8DBM           (0x7EC6)
+
+#define TX_TO_IDLE_TIME     (10)        // TX to IDLE, no calibration: ~1us   => 0.3us *10 = 3us
+#define RX_TO_IDLE_TIME     (2)         // RX to IDLE, no calibration: ~0.1us => 0.3*2 = 0.6us
+#define IDLE_TO_RX_TIME     (300)       // IDLE to RX, no calibration: 75.1us => 0.3*300 = 90us
+
+/**
+ * @name    State values for state machine
+ * @{
+ */
+enum {
+    RADIO_UNKNOWN,
+    RADIO_IDLE,
+    RADIO_TX_BUSY,
+    RADIO_RX,
+    RADIO_RX_BUSY,
+    RADIO_PWD,
+};
+/** @} */
+
+/**
+ * @brief array holding cc110x register values
+ */
+extern char cc110x_conf[];
+
+/**
+ * @brief   CC110X layer 0 protocol
+ *
+ * <pre>
+   ---------------------------------------------------
+ |        |         |         |       |            |
+ | Length | Address | PhySrc  | Flags |    Data    |
+ |        |         |         |       |            |
+   ---------------------------------------------------
+   1 byte   1 byte    1 byte   1 byte   <= 60 bytes
+
+   Flags:
+        Bit | Meaning
+        --------------------
+        7:4 | -
+        3:1 | Protocol
+          0 | Identification
+   </pre>
+   Notes:
+   \li length & address are given by CC110X
+   \li Identification is increased is used to scan duplicates. It must be increased
+    for each new packet and kept for packet retransmissions.
+ */
+typedef struct __attribute__((packed)){
+    uint8_t length;                         /**< Length of the packet (without length byte) */
+    uint8_t address;                        /**< Destination address */
+    uint8_t phy_src;                        /**< Source address (physical source) */
+    uint8_t flags;                          /**< Flags */
+    uint8_t data[CC430_MAX_DATA_LENGTH];    /**< Data (high layer protocol) */
+} cc110x_pkt_t;
+
+/**
+ * @brief struct holding cc110x packet + metadata
+ */
+typedef struct {
+    uint8_t rssi;                           /**< RSSI value */
+    uint8_t lqi;                            /**< link quality indicator */
+    uint8_t pos;                            /**< I have no clue. */
+    cc110x_pkt_t packet;                    /**< whole packet */
+} cc110x_pkt_buf_t;
+
+/**
+ * @brief enum for holding cc110x radio on/off state */
+enum cc110x_radio_mode {
+    RADIO_MODE_GET  = -1,                   /**< leave mode unchanged */
+    RADIO_MODE_OFF  = 0,                    /**< turn radio off */
+    RADIO_MODE_ON   = 1                     /**< turn radio on */
+};
+
+/**
+ * @brief enum for radio module FSM state */
+enum cc110x_radio_state {
+    SLEEP,
+    IDLE,
+    XOFF,
+    MANCAL,
+    FS_WAKEUP,
+    CALIBRATE,
+    SETTLING,
+    RX,
+    TXRX_SETTLING,
+    RX_OVERFLOW,
+    FSTXON,
+    TX,
+    RXTX_SETTLING,
+    TX_UNDERFLOW,
+    STATE_READ_ERROR
+};
+
+/**
+ * @brief   CC110x register configuration
+ */
+typedef struct {
+    uint8_t _IOCFG2;        /**< GDO2 output pin configuration */
+    uint8_t _IOCFG1;        /**< GDO1 output pin configuration */
+    uint8_t _IOCFG0;        /**< GDO0 output pin configuration */
+    uint8_t _FIFOTHR;       /**< RX FIFO and TX FIFO thresholds */
+    uint8_t _SYNC1;         /**< Sync word, high byte */
+    uint8_t _SYNC0;         /**< Sync word, low byte */
+    uint8_t _PKTLEN;        /**< Packet length */
+    uint8_t _PKTCTRL1;      /**< Packet automation control */
+    uint8_t _PKTCTRL0;      /**< Packet automation control */
+    uint8_t _ADDR;          /**< Device address */
+    uint8_t _CHANNR;        /**< Channel number */
+    uint8_t _FSCTRL1;       /**< Frequency synthesizer control */
+    uint8_t _FSCTRL0;       /**< Frequency synthesizer control */
+    uint8_t _FREQ2;         /**< Frequency control word, high byte */
+    uint8_t _FREQ1;         /**< Frequency control word, middle byte */
+    uint8_t _FREQ0;         /**< Frequency control word, low byte */
+    uint8_t _MDMCFG4;       /**< Modem configuration */
+    uint8_t _MDMCFG3;       /**< Modem configuration */
+    uint8_t _MDMCFG2;       /**< Modem configuration */
+    uint8_t _MDMCFG1;       /**< Modem configuration */
+    uint8_t _MDMCFG0;       /**< Modem configuration */
+    uint8_t _DEVIATN;       /**< Modem deviation setting */
+    uint8_t _MCSM2;         /**< Main Radio Control State Machine configuration */
+    uint8_t _MCSM1;         /**< Main Radio Control State Machine configuration */
+    uint8_t _MCSM0;         /**< Main Radio Control State Machine configuration */
+    uint8_t _FOCCFG;        /**< Frequency Offset Compensation configuration */
+    uint8_t _BSCFG;         /**< Bit Synchronization configuration */
+    uint8_t _AGCCTRL2;      /**< AGC control */
+    uint8_t _AGCCTRL1;      /**< AGC control */
+    uint8_t _AGCCTRL0;      /**< AGC control */
+    uint8_t _WOREVT1;       /**< High byte Event 0 timeout */
+    uint8_t _WOREVT0;       /**< Low byte Event 0 timeout */
+    uint8_t _WORCTRL;       /**< Wake On Radio control */
+    uint8_t _FREND1;        /**< Front end RX configuration */
+    uint8_t _FREND0;        /**< Front end TX configuration */
+    uint8_t _FSCAL3;        /**< Frequency synthesizer calibration */
+    uint8_t _FSCAL2;        /**< Frequency synthesizer calibration */
+    uint8_t _FSCAL1;        /**< Frequency synthesizer calibration */
+    uint8_t _FSCAL0;        /**< Frequency synthesizer calibration */
+    uint8_t _RES1;          /**< Reserved, read as 0x00 */
+    uint8_t _RES0;          /**< Reserved, read as 0x00 */
+    uint8_t _FSTEST;        /**< Frequency synthesizer calibration control */
+    uint8_t _PTEST;         /**< Production test */
+    uint8_t _AGCTEST;       /**< AGC test */
+    uint8_t _TEST2;         /**< Test 2 */
+    uint8_t _TEST1;         /**< Test 1 */
+    uint8_t _TEST0;         /**< Test 0 */
+} cc110x_reg_t;
+
+/**
+ * @brief   CC110x radio configuration
+ */
+typedef struct {
+    cc110x_reg_t reg_cfg;       /**< CC110X register configuration */
+    uint8_t pa_power;           /**< Output power setting */
+} cc110x_cfg_t;
+
+/**
+ * @brief   Radio Control Flags
+ */
+typedef struct {
+    uint8_t _RSSI;              /**< The RSSI value of last received packet */
+    uint8_t _LQI;               /**< The LQI value of the last received packet */
+} cc110x_flags_t;
+
+/**
+ * @brief   Statistic interface for debugging
+ */
+typedef struct cc110x_statistic {
+    uint32_t packets_in;                /**< total nr of packets received */
+    uint32_t packets_in_crc_fail;       /**< dropped because of invalid crc */
+    uint32_t packets_in_while_tx;       /**< receive while tx */
+    uint32_t raw_packets_out;           /**< packets sent */
+} cc110x_statistic_t;
+
+/**
+ * @brief   Forward declaration
+ */
+typedef struct cc110x cc110x_t;
+
+/**
+ * @brief   Struct for holding cc110x device state
+ */
+struct cc110x {
+
+    cc110x_statistic_t cc110x_statistic;        /**< Statistic values for
+                                                     debugging */
+
+    uint8_t radio_state;                        /**< Radio state */
+    uint8_t radio_channel;                      /**< current Radio channel */
+    uint8_t radio_address;                      /**< current Radio address */
+
+    cc110x_pkt_buf_t pkt_buf;                   /**< RX/TX buffer */
+    void (*isr_cb)(cc110x_t *dev, void *arg);   /**< isr callback */
+    void *isr_cb_arg;                           /**< isr callback argument */
+#ifdef MODULE_GNRC_NETIF
+    gnrc_nettype_t proto;                       /**< protocol the radio expects */
+#endif
+};
+
+void cc430_radio_delay_rf(volatile uint32_t p);
+
+uint8_t cc430_radio_strobe(uint8_t strobe);
+
+uint8_t cc430_radio_read_single_reg(uint8_t addr);
+
+void cc430_radio_write_single_reg(uint8_t addr, uint8_t value);
+
+void cc430_radio_read_burst_reg(uint8_t addr, void *buffer, uint8_t count);
+
+void cc430_radio_write_burst_reg(uint8_t addr, void *buffer, uint8_t count);
+
+void cc430_radio_write_rf_reg(const uint8_t rf_setting[][2], uint8_t size);
+
+void cc430_radio_reset_radio_core(void);
+
+int8_t cc430_radio_write_pa_table(uint8_t value);
+
+void cc430_radio_transmit(void *buffer, uint8_t length);
+
+void cc430_radio_receive(void *buffer, uint8_t *length);
+
+void cc430_radio_receive_off(void);
+
+void cc430_radio_receive_on(void);
+
+void cc430_radio_transmit_bigger_than_fifotx(void *buffer, uint8_t length);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* CC430_RF_INTERNAL_H */
+/** @} */

--- a/cpu/cc430/include/cc430_rf_netdev.h
+++ b/cpu/cc430/include/cc430_rf_netdev.h
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2018 Baptiste Cartier
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ *
+ */
+
+/**
+ * @ingroup     cpu_cc430
+ * @{
+ *
+ * @file
+ * @brief       Netdev interface to CC430 radio driver, based on the cc110x Netdev interface
+ *
+ * @author      Baptiste Cartier
+ */
+
+#ifndef CC430_RF_NETDEV_H
+#define CC430_RF_NETDEV_H
+
+#include "net/netdev.h"
+#include "cc430_rf_internal.h"
+#include "cc430_rf_getset.h"
+#include <errno.h>
+
+#include "net/gnrc.h"
+
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Implementation of netdev_driver_t for CC110X device
+ */
+extern const netdev_driver_t netdev_cc110x_driver;
+
+/**
+ * @brief cc110x netdev struct
+ */
+typedef struct netdev_cc110x {
+    netdev_t netdev;
+    cc110x_t cc110x;
+} netdev_cc110x_t;
+
+/**
+ * @brief   Received packet status information for cc110x radios
+ */
+typedef struct netdev_radio_rx_info netdev_cc110x_rx_info_t;
+
+void _irq_handler(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* CC430_RF_NETDEV_H */
+/** @} */

--- a/cpu/cc430/radio/Makefile
+++ b/cpu/cc430/radio/Makefile
@@ -1,0 +1,3 @@
+MODULE = cc430_rf
+
+include $(RIOTBASE)/Makefile.base

--- a/cpu/cc430/radio/cc430_rf_getset.c
+++ b/cpu/cc430/radio/cc430_rf_getset.c
@@ -1,0 +1,122 @@
+/*
+ * Copyright (C) 2016 MUTEX NZ Ltd.
+ * Copyright (C) 2015 Loci Controls Inc.
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ *
+ */
+
+/**
+ * @ingroup     cpu_cc430
+ * @{
+ *
+ * @file
+ * @brief       Getter and setter functions for the cc430_rf driver
+ *
+ * @author      Aaron Sowry <aaron@mutex.nz>
+ * @author      Ian Martin <ian@locicontrols.com>
+ *
+ * @}
+ */
+
+#include "cc430_rf_getset.h"
+
+uint8_t cc430_get_max_packet_size(void)
+{
+    return CC430_MAX_PACKET_SIZE;
+}
+
+
+int8_t cc430_set_channel(cc110x_t *dev, uint8_t channr)
+{
+
+    if (channr > MAX_CHANNR) {
+        return -1;
+    }
+
+    cc430_radio_write_single_reg(CHANNR, channr);
+    dev->radio_channel = channr;
+
+    return channr;
+}
+
+
+uint8_t cc430_set_address(cc110x_t *dev, uint8_t address)
+{
+    if (!(address < MIN_UID)) {
+        if (dev->radio_state != RADIO_UNKNOWN) {
+            cc430_radio_write_single_reg(ADDR, address);
+            dev->radio_address = address;
+            return address;
+        }
+    }
+
+    return 0;
+}
+
+uint8_t cc430_get_radio_state(void)
+{
+    uint8_t stateRead;
+    uint8_t state;
+
+    stateRead = cc430_radio_read_single_reg(MARCSTATE);
+
+    switch (stateRead) {
+        case 0:
+            state = SLEEP;
+            break;
+        case 1:
+            state = IDLE;
+            break;
+        case 2:
+            state = XOFF;
+            break;
+        case 3:
+        case 4:
+        case 5:
+            state = MANCAL;
+            break;
+        case 6:
+        case 7:
+            state = FS_WAKEUP;
+        case 8:
+        case 12:
+            state = CALIBRATE;
+            break;
+        case 9:
+        case 10:
+        case 11:
+            state = SETTLING;
+            break;
+        case 13:
+        case 14:
+        case 15:
+            state = RX;
+            break;
+        case 16:
+            state = TXRX_SETTLING;
+            break;
+        case 17:
+            state = RX_OVERFLOW;
+            break;
+        case 18:
+            state = FSTXON;
+        case 19:
+        case 20:
+            state = TX;
+            break;
+        case 21:
+            state = RXTX_SETTLING;
+            break;
+        case 22:
+            state = TX_UNDERFLOW;
+            break;
+        default:
+            state = STATE_READ_ERROR;
+            break;
+    }
+    return state;
+}
+

--- a/cpu/cc430/radio/cc430_rf_getset.c
+++ b/cpu/cc430/radio/cc430_rf_getset.c
@@ -81,6 +81,7 @@ uint8_t cc430_get_radio_state(void)
         case 6:
         case 7:
             state = FS_WAKEUP;
+            break;
         case 8:
         case 12:
             state = CALIBRATE;
@@ -103,6 +104,7 @@ uint8_t cc430_get_radio_state(void)
             break;
         case 18:
             state = FSTXON;
+            break;
         case 19:
         case 20:
             state = TX;
@@ -119,4 +121,3 @@ uint8_t cc430_get_radio_state(void)
     }
     return state;
 }
-

--- a/cpu/cc430/radio/cc430_rf_internal.c
+++ b/cpu/cc430/radio/cc430_rf_internal.c
@@ -1,0 +1,380 @@
+/*
+ * Copyright (C) 2018 Baptiste Cartier
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     cpu_cc430
+ * @{
+ *
+ * @file        cc430_rf_internal.c
+ * @brief       Definitions for radio function
+ *
+ * API for the cc1101 radio module embedded on the cc430
+ *
+ * @author      Baptiste Cartier
+ * @}
+ */
+
+#include <msp430.h> // generic file for register name, I/O, ...
+
+#include "cc430_rf_internal.h"
+#include "cc430_rf_netdev.h"
+
+
+/**
+ * @brief   Managing the CC1101 interrupt vector, here only used if radio module in receive mode
+ */
+#pragma vector=CC1101_VECTOR
+__attribute__((interrupt(CC1101_VECTOR)))
+void CC1101_ISR(void)
+{
+    if (RF1AIV == RF1AIV_RFIFG4) {
+        _irq_handler();
+    }
+}
+
+/**
+ * @brief   Simple delay.
+ *
+ * @param[in]  uint32_t p      Number of loop of the delay
+ *
+ */
+void cc430_radio_delay_rf(volatile uint32_t p)
+{
+    while (p) {
+        p--;
+    }
+}
+
+
+/**
+ * @brief   Send a command to the radio module
+ *
+ * @param[in]   uint8_t strobe      Type of command to be sent
+ *
+ * @return      uint8_t statusByte  value of the RF1ASTATB register,
+ *                                  or 0 if invalid strobe command
+ */
+uint8_t cc430_radio_strobe(uint8_t strobe)
+{
+    uint8_t statusByte = 0;
+    uint16_t gdo_state;
+
+    // Check for valid strobe command
+    if ((strobe == 0xBD) || ((strobe >= RF_SRES) && (strobe <= RF_SNOP))) {
+        // Clear the Status read flag
+        RF1AIFCTL1 &= ~(RFSTATIFG);
+
+        // Wait for radio to be ready for next instruction
+        while (!(RF1AIFCTL1 & RFINSTRIFG)) {
+        }
+
+        // Write the strobe instruction
+        if ((strobe > RF_SRES) && (strobe < RF_SNOP)) {
+            gdo_state = cc430_radio_read_single_reg(IOCFG2);    // buffer IOCFG2 state
+            cc430_radio_write_single_reg(IOCFG2, 0x29);         // chip-ready to GDO2
+
+            RF1AINSTRB = strobe;
+            if ((RF1AIN & 0x04) == 0x04) {  // chip at sleep mode
+                if ((strobe == RF_SXOFF) || (strobe == RF_SPWD) || (strobe == RF_SWOR)) {
+                }
+                else {
+                    while ((RF1AIN & 0x04) == 0x04) {
+                    }                         // chip-ready ?
+                    // Delay for ~810usec at 1.05MHz CPU clock, see erratum RF1A7
+                    __delay_cycles(850);
+                }
+            }
+            cc430_radio_write_single_reg(IOCFG2, gdo_state); // restore IOCFG2 setting
+
+            while (!(RF1AIFCTL1 & RFSTATIFG));
+        }
+        else {                      // chip active mode (SRES)
+            RF1AINSTRB = strobe;
+        }
+        statusByte = RF1ASTATB;
+    }
+    return statusByte;
+}
+
+
+/**
+ * @brief   Read the value of single register
+ *
+ * @param[in]   uint8_t addr        Address of the register to be read
+ *
+ * @return      uint8_t data_out    value of the register
+ */
+uint8_t cc430_radio_read_single_reg(uint8_t addr)
+{
+    uint8_t data_out;
+
+    // Check for valid configuration register address, 0x3E refers to PATABLE
+    if ((addr <= TEST0) || (addr == PATABLE)) {
+        // Send address + Instruction + 1 dummy byte (auto-read)
+        RF1AINSTR1B = (addr | RF_SNGLREGRD);
+    }
+    else {
+        // Send address + Instruction + 1 dummy byte (auto-read)
+        RF1AINSTR1B = (addr | RF_STATREGRD);
+    }
+
+    while (!(RF1AIFCTL1 & RFDOUTIFG)) {
+    }
+    data_out = RF1ADOUT1B;                    // Read data and clears the RFDOUTIFG
+
+    return data_out;
+}
+
+
+/**
+ * @brief   Write to a single cc1101 register
+ *
+ * @param[in]  uint8_t addr       Address of the register
+ * @param[in]  uint8_t value      Value to be written
+ *
+ */
+void cc430_radio_write_single_reg(uint8_t addr, uint8_t value)
+{
+    // Wait for the Radio to be ready for next instruction
+    while (!(RF1AIFCTL1 & RFINSTRIFG)) {
+    }
+    RF1AINSTRB = (addr | RF_REGWR);         // Send address + Instruction
+    RF1ADINB = value;                       // Write data in
+
+    __no_operation();
+}
+
+
+
+/**
+ * @brief   Read sequentially from a base address multiple times
+ *
+ * @param[in]  uint8_t addr     Address of the first register
+ * @param[out] void * buffer    Values of the registers are written here,
+ *                              buffer must be of size uint8_t
+ * @param[in]  uint8_t count    Number of register to be read
+ *
+ */
+void cc430_radio_read_burst_reg(uint8_t addr, void *buffer, uint8_t count)
+{
+    uint8_t i;
+
+    while (!(RF1AIFCTL1 & RFINSTRIFG)) {
+    }                                           // Wait for INSTRIFG
+    RF1AINSTR1B = (addr | RF_REGRD);            // Send addr of first conf. reg. to be read
+                                                // ... and the burst-register read instruction
+    for (i = 0; i < (count - 1); i++) {
+        // Wait for the Radio Core to update the RF1ADOUTB reg
+        while (!(RFDOUTIFG & RF1AIFCTL1)) {
+        }
+        ((uint8_t *)buffer)[i] = RF1ADOUT1B;        // Read DOUT from Radio Core + clears RFDOUTIFG
+        // Also initiates auo-read for next DOUT byte
+    }
+    ((uint8_t *)buffer)[count - 1] = RF1ADOUT0B;             // Store the last DOUT from Radio Core
+}
+
+
+/**
+ * @brief   Write sequentially to a base address multiple times
+ *
+ * @param[in]  uint8_t addr     Address of the first register
+ * @param[in] void * buffer    Values of the registers are written here,
+ *                              buffer must be of size uint8_t
+ * @param[in]  uint8_t count    Number of register to be read
+ *
+ */
+void cc430_radio_write_burst_reg(uint8_t addr, void *buffer, uint8_t count)
+{
+    uint8_t i;
+
+    // Wait for the Radio to be ready for next instruction
+    while (!(RF1AIFCTL1 & RFINSTRIFG)) {
+    }
+    RF1AINSTRW = ((addr | RF_REGWR) << 8) + ((uint8_t *)buffer)[0]; // Send address + Instruction
+
+    for (i = 1; i < count; i++) {
+        RF1ADINB = ((uint8_t *)buffer)[i];      // Send data
+        while (!(RFDINIFG & RF1AIFCTL1)) {
+        }                                       // Wait for TX to finish
+    }
+    i = RF1ADOUTB;                              // Reset RFDOUTIFG flag which contains status byte
+}
+
+
+/**
+ * @brief   Write in multiple registers of the cc1101 in any order
+ *
+ * @param[in]  uint8_t rf_setting rf_setting[i][0] address of the register, rf_setting[i][1] value to be written
+ * @param[in]  uint8_t size       number of register to be modified
+ *
+ */
+void cc430_radio_write_rf_reg(const uint8_t rf_setting[][2], uint8_t size)
+{
+    uint8_t i;
+
+    for (i = 0; i < (size); i++) {
+        cc430_radio_write_single_reg(rf_setting[i][0], rf_setting[i][1]);
+    }
+}
+
+
+/**
+ * @brief   Reset the radio core with a SRES command
+ */
+void cc430_radio_reset_radio_core(void)
+{
+    cc430_radio_strobe(RF_SRES);                            // Reset the Radio Core
+    cc430_radio_strobe(RF_SNOP);                            // Reset Radio Pointer
+}
+
+
+
+/**
+ * @brief   Set the power output of the radio module
+ *
+ * @param[in]  uint8_t value      output needed, defined in rf1a.h
+ *
+ * @return 1 if setting the state was successful, 0 otherwise.
+ */
+int8_t cc430_radio_write_pa_table(uint8_t value)
+{
+    uint8_t valueRead = 0;
+    uint16_t rf1ainstrw_value;
+
+
+    switch (value) {
+        case cc430_radio_POWER_OUTPUT_MINUS_30DBM:
+            rf1ainstrw_value = RADIOINSTRW_MINUS_30DBM;
+            break;
+
+        case cc430_radio_POWER_OUTPUT_MINUS_12DBM:
+            rf1ainstrw_value = RADIOINSTRW_MINUS_12DBM;
+            break;
+
+        case cc430_radio_POWER_OUTPUT_MINUS_6DBM:
+            rf1ainstrw_value = RADIOINSTRW_MINUS_6DBM;
+            break;
+
+        case cc430_radio_POWER_OUTPUT_0DBM:
+            rf1ainstrw_value = RADIOINSTRW_0DBM;
+            break;
+
+        case cc430_radio_POWER_OUTPUT_10DBM:
+            rf1ainstrw_value = RADIOINSTRW_10DBM;
+            break;
+
+        case cc430_radio_POWER_OUTPUT_MAX:
+            rf1ainstrw_value = RADIOINSTRW_MAX;
+            break;
+
+        case cc430_radio_POWER_OUTPUT_DEFAULT_8_8DBM:
+            rf1ainstrw_value = RADIOINSTRW_DEFAULT_8_8DBM;
+            break;
+
+        default:
+            return 0;
+            break;
+    }
+
+
+    while (valueRead != value) {
+        /* Write the power output to the PA_TABLE and verify the write operation.  */
+        uint8_t i = 0;
+
+        /* wait for radio to be ready for next instruction */
+        while (!(RF1AIFCTL1 & RFINSTRIFG)) {
+        }
+
+        RF1AINSTRW = rf1ainstrw_value;
+
+        /* wait for radio to be ready for next instruction */
+        while (!(RF1AIFCTL1 & RFINSTRIFG)) {
+        }
+        RF1AINSTR1B = RF_PATABRD;
+
+        // Traverse PATABLE pointers to read
+        for (i = 0; i < 7; i++) {
+            while (!(RF1AIFCTL1 & RFDOUTIFG)) {
+            }
+            valueRead = RF1ADOUT1B;
+        }
+        while (!(RF1AIFCTL1 & RFDOUTIFG)) {
+        }
+        valueRead = RF1ADOUTB;
+    }
+
+    return 1;
+}
+
+
+
+/**
+ * @brief   Transmit data with the radio module. User must make sure
+ * they do not overflow the TXBuffer of the radio module
+ *
+ * @param[in]  void * buffer      buffer of bytes to be sent
+ * @param[in]  uint8_t length     number of bytes to be sent
+ *
+ */
+void cc430_radio_transmit(void *buffer, uint8_t length)
+{
+    RF1AIES |= BIT9;
+    RF1AIFG &= ~BIT9;                         // Clear pending interrupts
+
+
+    cc430_radio_write_burst_reg(RF_TXFIFOWR, buffer, length);
+    cc430_radio_strobe( RF_STX );                         // cc430_radio_strobe STX
+}
+
+
+/**
+ * @brief   Receive data with the radio module, will put the callling thread to sleep until data as been received
+ * Size of data received cannot exceed the size of RXBuffer of the radio module. If paquets bigger than RXBuffer must be received,
+ * cc430_radio_receive must be called the right amount of times
+ *
+ * @param[out]  void * buffer      buffer of bytes to be written to
+ * @param[out]  uint8_t length     number of bytes to be received
+ *
+ */
+
+void cc430_radio_receive(void *buffer, uint8_t *length)
+{
+    *length = cc430_radio_read_single_reg(RXBYTES);
+    cc430_radio_read_burst_reg(RF_RXFIFORD, buffer, *length);
+}
+
+/**
+ * @brief   Disable the reception mode
+ *
+ */
+void cc430_radio_receive_off(void)
+{
+    RF1AIE &= ~BIT4;                            // Disable RX interrupts
+    RF1AIFG &= ~BIT4;                           // Clear pending IFG
+
+    // Previous state has been Rx
+    cc430_radio_strobe( RF_SIDLE );
+    cc430_radio_delay_rf(RX_TO_IDLE_TIME);
+    cc430_radio_strobe( RF_SFRX);      /* Flush the receive FIFO of any residual data */
+}
+
+/**
+ * @brief   Enable the reception mode
+ *
+ */
+void cc430_radio_receive_on(void)
+{
+    RF1AIFG &= ~BIT4;                           // Clear a pending interrupt
+    RF1AIE |= BIT4;                             // Enable the interrupt
+
+    // Previous state has been Tx
+    cc430_radio_strobe( RF_SIDLE );
+    cc430_radio_delay_rf(TX_TO_IDLE_TIME);
+    cc430_radio_strobe( RF_SRX );
+    cc430_radio_delay_rf(IDLE_TO_RX_TIME);
+}

--- a/cpu/cc430/radio/cc430_rf_netdev.c
+++ b/cpu/cc430/radio/cc430_rf_netdev.c
@@ -1,0 +1,279 @@
+/*
+ * Copyright (C) 2016 MUTEX NZ Ltd
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ *
+ */
+
+/**
+ * @ingroup     cpu_cc430
+ * @{
+ *
+ * @file
+ * @brief       Netdev adaption for the CC430 RF driver
+ *
+ * @author      Aaron Sowry <aaron@mutex.nz>
+ *
+ * @}
+ */
+
+
+#include "cc430_rf_netdev.h"
+
+
+#define ENABLE_DEBUG        (0)
+#include "debug.h"
+
+
+/* Reference pointer for the IRQ handler */
+static netdev_t *_dev;
+
+
+
+void _irq_handler(void)
+{
+    if (_dev->event_callback) {
+        _dev->event_callback(_dev, NETDEV_EVENT_ISR);
+    }
+}
+
+static inline int _get_iid(netdev_t *netdev, eui64_t *value, size_t max_len)
+{
+    cc110x_t *cc110x = &((netdev_cc110x_t *) netdev)->cc110x;
+    uint8_t *eui64 = (uint8_t *) value;
+
+    if (max_len < sizeof(eui64_t)) {
+        return -EOVERFLOW;
+    }
+
+    /* make address compatible to https://tools.ietf.org/html/rfc6282#section-3.2.2*/
+    memset(eui64, 0, sizeof(eui64_t));
+    eui64[3] = 0xff;
+    eui64[4] = 0xfe;
+    eui64[7] = cc110x->radio_address;
+
+    return sizeof(eui64_t);
+}
+
+static int _get(netdev_t *netdev, netopt_t opt, void *value, size_t max_len)
+{
+    cc110x_t *cc110x = &((netdev_cc110x_t *)netdev)->cc110x;
+
+    if (cc110x == NULL) {
+        return -ENODEV;
+    }
+
+    switch (opt) {
+        case NETOPT_DEVICE_TYPE:
+            *((uint16_t *) value) = NETDEV_TYPE_CC110X;
+            return 2;
+#ifdef MODULE_GNRC_NETIF
+        case NETOPT_PROTO:
+            *((gnrc_nettype_t *)value) = cc110x->proto;
+            return sizeof(gnrc_nettype_t);
+#endif
+        case NETOPT_CHANNEL:
+            *((uint16_t *)value) = (uint16_t)cc110x->radio_channel;
+            return 2;
+        case NETOPT_ADDRESS:
+            *((uint8_t *)value) = cc110x->radio_address;
+            return 1;
+        case NETOPT_MAX_PACKET_SIZE:
+            *((uint8_t *)value) = cc430_get_max_packet_size();
+            return 1;
+        case NETOPT_IPV6_IID:
+            return _get_iid(netdev, value, max_len);
+        case NETOPT_ADDR_LEN:
+        case NETOPT_SRC_LEN:
+            *((uint16_t *)value) = sizeof(cc110x->radio_address);
+            return sizeof(uint16_t);
+        default:
+            break;
+    }
+
+    return -ENOTSUP;
+}
+
+static int _set(netdev_t *dev, netopt_t opt, const void *value, size_t value_len)
+{
+    cc110x_t *cc110x = &((netdev_cc110x_t *) dev)->cc110x;
+
+    switch (opt) {
+        case NETOPT_CHANNEL:
+        {
+            const uint8_t *arg = value;
+            uint8_t channel = arg[value_len - 1];
+            #if CC430_MIN_CHANNR
+            if (channel < CC430_MIN_CHANNR) {
+                return -EINVAL;
+            }
+            #endif /* CC430_MIN_CHANNR */
+            if (channel > CC430_MIN_CHANNR) {
+                return -EINVAL;
+            }
+            if (cc430_set_channel(cc110x, channel) == -1) {
+                return -EINVAL;
+            }
+            return 1;
+        }
+        case NETOPT_ADDRESS:
+            if (value_len < 1) {
+                return -EINVAL;
+            }
+            if (!cc430_set_address(cc110x, *(const uint8_t *)value)) {
+                return -EINVAL;
+            }
+            return 1;
+#ifdef MODULE_GNRC_NETIF
+        case NETOPT_PROTO:
+            if (value_len != sizeof(gnrc_nettype_t)) {
+                return -EINVAL;
+            }
+            else {
+                cc110x->proto = (gnrc_nettype_t) value;
+                return sizeof(gnrc_nettype_t);
+            }
+            break;
+#endif
+        default:
+            return -ENOTSUP;
+    }
+
+    return 0;
+}
+
+static int _send(netdev_t *dev, const iolist_t *iolist)
+{
+    netdev_cc110x_t *netdev_cc110x = (netdev_cc110x_t *)dev;
+    cc110x_pkt_t *cc110x_pkt = iolist->iol_base;
+    uint8_t state_was_RX = 0;
+
+    uint16_t size;
+
+    switch (netdev_cc110x->cc110x.radio_state) {
+        case RADIO_RX_BUSY:
+        case RADIO_TX_BUSY:
+            return -EAGAIN;
+    }
+    netdev_cc110x->cc110x.radio_state = RADIO_TX_BUSY;
+    /*
+     * Number of bytes to send is:
+     * length of phy payload (packet->length)
+     * + size of length field (1 byte)
+     */
+    size = cc110x_pkt->length + 1;
+
+    if (size > cc430_get_max_packet_size()) {
+        return -ENOSPC;
+    }
+
+    /* set source address */
+    cc110x_pkt->phy_src = netdev_cc110x->cc110x.radio_address;
+
+    /* Put CC110x in IDLE mode to flush the FIFO */
+    cc430_radio_strobe(RF_SIDLE);
+
+    cc430_radio_delay_rf(RX_TO_IDLE_TIME);
+    /* Flush TX FIFO to be sure it is empty */
+    cc430_radio_strobe(RF_SFTX);
+    /* Transmit the packet*/
+    cc430_radio_transmit(cc110x_pkt, size);
+
+    netdev_cc110x->cc110x.radio_state = RADIO_IDLE;
+
+    return (int)size;
+}
+
+static int _recv(netdev_t *dev, void *buf, size_t len, void *info)
+{
+
+    cc110x_t *cc110x = &((netdev_cc110x_t *) dev)->cc110x;
+
+    //(void) dev;
+    (void) info;
+    size_t pkt_len;
+    uint8_t bytesRead;
+    uint8_t bytesInRxFIFO;
+
+    if (buf == NULL) {
+        /* GNRC wants to know how much data we've got for it */
+        cc430_radio_read_burst_reg(RF_RXFIFORD, &pkt_len, 1);
+
+        /* Make sure pkt_len is sane */
+        if (pkt_len > cc430_get_max_packet_size()) {
+            cc430_radio_strobe(RF_SFRX);
+            return -EOVERFLOW;
+        }
+
+        if (len > 0) {
+            /* GNRC wants us to drop the packet */
+            cc430_radio_strobe(RF_SFRX);
+        }
+
+        return pkt_len;
+    }
+    else {
+        /* GNRC is expecting len bytes of data */
+        pkt_len = len;
+    }
+
+    ((uint8_t *)buf)[0] = pkt_len;
+    cc430_radio_read_burst_reg(RF_RXFIFORD, &(((uint8_t *)buf)[1]), pkt_len);
+
+    /* Read the Received Signal Strength Indication (RSSI) */
+    cc110x->pkt_buf.rssi = cc430_radio_read_single_reg(RSSI);
+
+    /* Read the Link Quality Indication (LQI) */
+    cc110x->pkt_buf.lqi = cc430_radio_read_single_reg(LQI);
+
+    if (info != NULL) {
+        netdev_cc110x_rx_info_t *cc110x_info = info;
+
+        if (cc110x->pkt_buf.rssi >= 128) {
+            cc110x_info->rssi = ((int16_t)cc110x->pkt_buf.rssi - 256) / 2 - CC110X_RSSI_OFFSET;
+        }
+        else {
+            cc110x_info->rssi = (int16_t)cc110x->pkt_buf.rssi / 2 - CC110X_RSSI_OFFSET;
+        }
+
+        cc110x_info->lqi = cc110x->pkt_buf.lqi;
+    }
+
+    cc430_radio_strobe(RF_SFRX);
+
+    return pkt_len;
+}
+
+static void _isr(netdev_t *dev)
+{
+    dev->event_callback(dev, NETDEV_EVENT_RX_COMPLETE);
+}
+
+static int _init(netdev_t *dev)
+{
+    cc110x_t *cc110x = &((netdev_cc110x_t *) dev)->cc110x;
+
+    _dev = dev;
+
+    /* Get the device address*/
+    cc110x->radio_address = cc430_radio_read_single_reg(ADDR);
+
+    /*Get the device channel*/
+    cc110x->radio_channel = cc430_radio_read_single_reg(CHANNR);
+
+    cc430_radio_receive_on();
+    ((netdev_cc110x_t *)dev)->cc110x.radio_state = RADIO_RX;
+
+    return 0;
+}
+
+const netdev_driver_t netdev_cc110x_driver = {
+    .send = _send,
+    .recv = _recv,
+    .init = _init,
+    .get = _get,
+    .set = _set,
+    .isr = _isr
+};

--- a/cpu/cc430/radio/cc430_rf_netdev.c
+++ b/cpu/cc430/radio/cc430_rf_netdev.c
@@ -148,7 +148,6 @@ static int _send(netdev_t *dev, const iolist_t *iolist)
 {
     netdev_cc110x_t *netdev_cc110x = (netdev_cc110x_t *)dev;
     cc110x_pkt_t *cc110x_pkt = iolist->iol_base;
-    uint8_t state_was_RX = 0;
 
     uint16_t size;
 
@@ -191,11 +190,8 @@ static int _recv(netdev_t *dev, void *buf, size_t len, void *info)
 
     cc110x_t *cc110x = &((netdev_cc110x_t *) dev)->cc110x;
 
-    //(void) dev;
     (void) info;
     size_t pkt_len;
-    uint8_t bytesRead;
-    uint8_t bytesInRxFIFO;
 
     if (buf == NULL) {
         /* GNRC wants to know how much data we've got for it */


### PR DESCRIPTION
### Contribution description

Netdev implementation for the cc430 cpu, based on the cc110x driver.

cc430 has a integrated cc1101-like radio module which is used through register manipulation and does not use any communication bus (SPI...) , therefor the cc110x driver can not be used.

This netdev implementation heavily based on the cc110x driver for RIOT, most of the credit goes to the authors of the  cc110x driver.

This implementation should offer the same capabilities as the cc110x driver, and responds to the same netopt_t options.