### PR TITLE
native: Define PROVIDES_PM_SET_LOWEST

### DIFF
--- a/cpu/native/include/periph_cpu.h
+++ b/cpu/native/include/periph_cpu.h
@@ -42,6 +42,7 @@ extern "C" {
  * @{
  */
 #define PROVIDES_PM_OFF
+#define PROVIDES_PM_SET_LOWEST
 /** @} */
 
 #ifdef __cplusplus


### PR DESCRIPTION


### Contribution description

Avoid multiple definition of pm_set_lowest

### Issues/PRs references

#8711 