### PR TITLE
boards/stm32l476g-disco: initial basic support

### DIFF
--- a/boards/stm32l476g-disco/Makefile
+++ b/boards/stm32l476g-disco/Makefile
@@ -1,0 +1,3 @@
+MODULE = board
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/stm32l476g-disco/Makefile.dep
+++ b/boards/stm32l476g-disco/Makefile.dep
@@ -1,0 +1,3 @@
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += saul_gpio
+endif

--- a/boards/stm32l476g-disco/Makefile.features
+++ b/boards/stm32l476g-disco/Makefile.features
@@ -1,0 +1,9 @@
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_gpio
+FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart
+
+# The board MPU family (used for grouping by the CI system)
+FEATURES_MCU_GROUP = cortex_m4_2
+
+-include $(RIOTCPU)/stm32l4/Makefile.features

--- a/boards/stm32l476g-disco/Makefile.include
+++ b/boards/stm32l476g-disco/Makefile.include
@@ -1,0 +1,15 @@
+# the cpu to build for
+export CPU = stm32l4
+export CPU_MODEL = stm32l476vg
+
+# define the default port depending on the host OS
+PORT_LINUX ?= /dev/ttyACM0
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
+
+# setup serial terminal
+include $(RIOTMAKE)/tools/serial.inc.mk
+
+export DEBUG_ADAPTER ?= stlink
+
+# this board uses openocd
+include $(RIOTMAKE)/tools/openocd.inc.mk

--- a/boards/stm32l476g-disco/board.c
+++ b/boards/stm32l476g-disco/board.c
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2018 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_stm32l476g-disco
+ * @{
+ *
+ * @file
+ * @brief       Board specific implementations for the STM32L476G-DISCO board
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ * @}
+ */
+
+#include "board.h"
+#include "periph/gpio.h"
+
+void board_init(void)
+{
+    /* initialize LEDs */
+    gpio_init(LED0_PIN, GPIO_OUT);
+    gpio_init(LED1_PIN, GPIO_OUT);
+
+    /* initialize the CPU */
+    cpu_init();
+}

--- a/boards/stm32l476g-disco/include/board.h
+++ b/boards/stm32l476g-disco/include/board.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2018 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    boards_stm32l476g-disco STM32L476G-DISCO
+ * @ingroup     boards
+ * @brief       Support for the STM32L476G-DISCO board
+ * @{
+ *
+ * @file
+ * @brief       Board specific definitions for the STM32L476G-DISCO board
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include <stdint.h>
+
+#include "cpu.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    LED pin definitions and handlers
+ * @{
+ */
+#define LED0_PIN            GPIO_PIN(PORT_B, 2)
+#define LED0_MASK           (1 << 2)
+
+#define LED0_ON             (GPIOB->BSRR = LED0_MASK)
+#define LED0_OFF            (GPIOB->BSRR = (LED0_MASK << 16))
+#define LED0_TOGGLE         (GPIOB->ODR  ^= LED0_MASK)
+
+#define LED1_PIN            GPIO_PIN(PORT_E, 8)
+#define LED1_MASK           (1 << 8)
+
+#define LED1_ON             (GPIOE->BSRR = LED1_MASK)
+#define LED1_OFF            (GPIOE->BSRR = (LED1_MASK << 16))
+#define LED1_TOGGLE         (GPIOE->ODR  ^= LED1_MASK)
+/** @} */
+
+/**
+ * @name   Joystick buttons
+ * @{
+ */
+#define BTN0_PIN            GPIO_PIN(PORT_A, 0) /**< Center button pin  */
+#define BTN0_MODE           GPIO_IN_PD          /**< Center button mode */
+
+#define BTN1_PIN            GPIO_PIN(PORT_A, 1) /**< Left button pin    */
+#define BTN1_MODE           GPIO_IN_PD          /**< Left button mode   */
+
+#define BTN2_PIN            GPIO_PIN(PORT_A, 5) /**< Down button pin    */
+#define BTN2_MODE           GPIO_IN_PD          /**< Down button mode   */
+
+#define BTN3_PIN            GPIO_PIN(PORT_A, 2) /**< Right button pin   */
+#define BTN3_MODE           GPIO_IN_PD          /**< Right button mode  */
+
+#define BTN4_PIN            GPIO_PIN(PORT_A, 3) /**< Up button pin      */
+#define BTN4_MODE           GPIO_IN_PD          /**< Up button mode     */
+/** @} */
+
+/**
+ * @brief   Initialize board specific hardware, including clock, LEDs and std-IO
+ */
+void board_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/stm32l476g-disco/include/gpio_params.h
+++ b/boards/stm32l476g-disco/include/gpio_params.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) Inria 2018
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup   boards_stm32l476g-disco
+ * @{
+ *
+ * @file
+ * @brief     Board specific configuration of direct mapped GPIOs
+ *
+ * @author    Alexandre Abadie <alexandre.abadie@inria.fr>
+ */
+
+#ifndef GPIO_PARAMS_H
+#define GPIO_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    GPIO pin configuration
+ */
+static const  saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name = "LD4",
+        .pin = LED0_PIN,
+        .mode = GPIO_OUT
+    },
+    {
+        .name = "LD5",
+        .pin = LED1_PIN,
+        .mode = GPIO_OUT
+    },
+    {
+        .name = "Joystick (Center)",
+        .pin = BTN0_PIN,
+        .mode = BTN0_MODE
+    },
+    {
+        .name = "Joystick (Left)",
+        .pin = BTN1_PIN,
+        .mode = BTN1_MODE
+    },
+    {
+        .name = "Joystick (Down)",
+        .pin = BTN2_PIN,
+        .mode = BTN2_MODE
+    },
+    {
+        .name = "Joystick (Right)",
+        .pin = BTN3_PIN,
+        .mode = BTN3_MODE
+    },
+    {
+        .name = "Joystick (Up)",
+        .pin = BTN4_PIN,
+        .mode = BTN4_MODE
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_PARAMS_H */
+/** @} */

--- a/boards/stm32l476g-disco/include/periph_conf.h
+++ b/boards/stm32l476g-disco/include/periph_conf.h
@@ -1,0 +1,147 @@
+/*
+ * Copyright (C) 2018 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_stm32l476g-disco
+ * @{
+ *
+ * @file
+ * @brief       Peripheral MCU configuration for the STM32L476G-DISCO board
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+#include "periph_cpu.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Clock system configuration
+ * @{
+ */
+/* 0: no external high speed crystal available
+ * else: actual crystal frequency [in Hz] */
+#define CLOCK_HSE           (0)
+/* 0: no external low speed crystal available,
+ * 1: external crystal available (always 32.768kHz) */
+#define CLOCK_LSE           (1)
+/* 0: enable MSI only if HSE isn't available
+ * 1: always enable MSI (e.g. if USB or RNG is used)*/
+#define CLOCK_MSI_ENABLE    (1)
+/* 0: disable Hardware auto calibration with LSE
+ * 1: enable Hardware auto calibration with LSE (PLL-mode)*/
+#define CLOCK_MSI_LSE_PLL   (1)
+/* give the target core clock (HCLK) frequency [in Hz], maximum: 80MHz */
+#define CLOCK_CORECLOCK     (80000000U)
+/* PLL configuration: make sure your values are legit!
+ *
+ * compute by: CORECLOCK = (((PLL_IN / M) * N) / R)
+ * with:
+ * PLL_IN:  input clock, HSE or MSI @ 48MHz
+ * M:       pre-divider,  allowed range: [1:8]
+ * N:       multiplier,   allowed range: [8:86]
+ * R:       post-divider, allowed range: [2,4,6,8]
+ *
+ * Also the following constraints need to be met:
+ * (PLL_IN / M)     -> [4MHz:16MHz]
+ * (PLL_IN / M) * N -> [64MHz:344MHz]
+ * CORECLOCK        -> 80MHz MAX!
+ */
+#define CLOCK_PLL_M         (6)
+#define CLOCK_PLL_N         (20)
+#define CLOCK_PLL_R         (2)
+/* peripheral clock setup */
+#define CLOCK_AHB_DIV       RCC_CFGR_HPRE_DIV1
+#define CLOCK_AHB           (CLOCK_CORECLOCK / 1)
+#define CLOCK_APB1_DIV      RCC_CFGR_PPRE1_DIV4
+#define CLOCK_APB1          (CLOCK_CORECLOCK / 4)
+#define CLOCK_APB2_DIV      RCC_CFGR_PPRE2_DIV2
+#define CLOCK_APB2          (CLOCK_CORECLOCK / 2)
+/** @} */
+
+/**
+ * @name    Timer configuration
+ * @{
+ */
+static const timer_conf_t timer_config[] = {
+    {
+        .dev      = TIM5,
+        .max      = 0xffffffff,
+        .rcc_mask = RCC_APB1ENR1_TIM5EN,
+        .bus      = APB1,
+        .irqn     = TIM5_IRQn
+    }
+};
+
+#define TIMER_0_ISR         isr_tim5
+
+#define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
+/** @} */
+
+/**
+ * @name    UART configuration
+ * @{
+ */
+static const uart_conf_t uart_config[] = {
+    {
+        .dev        = USART2,
+        .rcc_mask   = RCC_APB1ENR1_USART2EN,
+        .rx_pin     = GPIO_PIN(PORT_D, 6),
+        .tx_pin     = GPIO_PIN(PORT_D, 5),
+        .rx_af      = GPIO_AF7,
+        .tx_af      = GPIO_AF7,
+        .bus        = APB1,
+        .irqn       = USART2_IRQn,
+#ifdef UART_USE_DMA
+        .dma_stream = 6,
+        .dma_chan   = 4
+#endif
+    }
+};
+
+#define UART_0_ISR          (isr_usart2)
+
+#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+/** @} */
+
+/**
+ * @name    ADC configuration
+ * @{
+ */
+#define ADC_NUMOF           (0)
+/** @} */
+
+/**
+ * @name    RTT configuration
+ *
+ * On the STM32Lx platforms, we always utilize the LPTIM1.
+ * @{
+ */
+#define RTT_NUMOF           (1)
+#define RTT_FREQUENCY       (1024U)             /* 32768 / 2^n */
+#define RTT_MAX_VALUE       (0x0000ffff)        /* 16-bit timer */
+/** @} */
+
+/**
+ * @name   RTC configuration
+ * @{
+ */
+#define RTC_NUMOF           (1)
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_CONF_H */
+/** @} */

--- a/cpu/stm32l4/include/cpu_conf.h
+++ b/cpu/stm32l4/include/cpu_conf.h
@@ -27,7 +27,7 @@
 
 #if defined(CPU_MODEL_STM32L496ZG)
 #include "vendor/stm32l496xx.h"
-#elif defined(CPU_MODEL_STM32L476RG)
+#elif defined(CPU_MODEL_STM32L476RG) || defined(CPU_MODEL_STM32L476VG)
 #include "vendor/stm32l476xx.h"
 #elif defined(CPU_MODEL_STM32L475VG)
 #include "vendor/stm32l475xx.h"

--- a/cpu/stm32l4/vectors.c
+++ b/cpu/stm32l4/vectors.c
@@ -179,8 +179,9 @@ ISR_VECTOR(1) const isr_t vector_cpu[CPU_IRQ_NUMOF] = {
     [USB_IRQn                ] = isr_usb,                  /* [67] USB event Interrupt */
     [CRS_IRQn                ] = isr_crs,                  /* [82] CRS global interrupt */
 #endif
-#if defined(CPU_MODEL_STM32L476RG) || defined(CPU_MODEL_STM32L475VG) || \
-    defined(CPU_MODEL_STM32L452RE) || defined(CPU_MODEL_STM32L496ZG)
+#if defined(CPU_MODEL_STM32L476RG) || defined(CPU_MODEL_STM32L476VG) || \
+    defined(CPU_MODEL_STM32L475VG) || defined(CPU_MODEL_STM32L452RE) || \
+    defined(CPU_MODEL_STM32L496ZG)
     [ADC1_2_IRQn             ] = isr_adc1_2,               /* [18] ADC1, ADC2 SAR global Interrupts */
     [TIM1_TRG_COM_TIM17_IRQn ] = isr_tim1_trg_com_tim17,   /* [26] TIM1 Trigger and Commutation Interrupt and TIM17 global interrupt */
     [TIM3_IRQn               ] = isr_tim3,                 /* [29] TIM3 global Interrupt */
@@ -193,7 +194,8 @@ ISR_VECTOR(1) const isr_t vector_cpu[CPU_IRQ_NUMOF] = {
     [DFSDM1_FLT0_IRQn        ] = isr_dfsdm1_flt0,          /* [61] DFSDM1 Filter 0 global Interrupt */
     [DFSDM1_FLT1_IRQn        ] = isr_dfsdm1_flt1,          /* [62] DFSDM1 Filter 1 global Interrupt */
 #endif
-#if defined(CPU_MODEL_STM32L476RG) || defined(CPU_MODEL_STM32L475VG)
+#if defined(CPU_MODEL_STM32L476RG) || defined(CPU_MODEL_STM32L476VG) || \
+    defined(CPU_MODEL_STM32L475VG)
     [TIM4_IRQn               ] = isr_tim4,                 /* [30] TIM4 global Interrupt */
     [DFSDM1_FLT3_IRQn        ] = isr_dfsdm1_flt3,          /* [42] DFSDM1 Filter 3 global Interrupt */
     [TIM8_BRK_IRQn           ] = isr_tim8_brk,             /* [43] TIM8 Break Interrupt */
@@ -209,11 +211,12 @@ ISR_VECTOR(1) const isr_t vector_cpu[CPU_IRQ_NUMOF] = {
     [SAI2_IRQn               ] = isr_sai2,                 /* [75] Serial Audio Interface 2 global interrupt */
 #endif
 #if defined(CPU_MODEL_STM32L432KC) || defined(CPU_MODEL_STM32L476RG) || \
-    defined(CPU_MODEL_STM32L475VG) || defined(CPU_MODEL_STM32L496ZG)
+    defined(CPU_MODEL_STM32L476VG) || defined(CPU_MODEL_STM32L475VG) || \
+    defined(CPU_MODEL_STM32L496ZG)
     [TIM7_IRQn               ] = isr_tim7,                 /* [55] TIM7 global interrupt */
     [SWPMI1_IRQn             ] = isr_swpmi1,               /* [76] Serial Wire Interface 1 global interrupt */
 #endif
-#if defined(CPU_MODEL_STM32L476RG)
+#if defined(CPU_MODEL_STM32L476RG) || defined(CPU_MODEL_STM32L476VG)
     [LCD_IRQn                ] = isr_lcd,                  /* [78] LCD global interrupt */
 #endif
 #if defined(CPU_MODEL_STM32L496ZG)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR adds an initial basic support for the [stm32l476g-disco](http://www.st.com/en/evaluation-tools/32l476gdiscovery.html) board.

What is configured for now:
- one timer
- one UART
- RTC and RTT
- on-boards LEDs and joystick buttons

All tested and works.

TODO: add documentation.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

This will benefit from #8475.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->