### PR TITLE
core: Make assert() be an expression.

### DIFF
--- a/core/include/assert.h
+++ b/core/include/assert.h
@@ -101,10 +101,7 @@ NORETURN void _assert_failure(const char *file, unsigned line);
  *
  * @see http://pubs.opengroup.org/onlinepubs/9699919799/functions/assert.html
  */
-#define assert(cond) \
-    if (!(cond)) { \
-        _assert_failure(RIOT_FILE_RELATIVE, __LINE__); \
-    }
+#define assert(cond) ((cond) ? (void)0 :  _assert_failure(RIOT_FILE_RELATIVE, __LINE__))
 #else
 #define assert(cond) ((cond) ? (void)0 : core_panic(PANIC_ASSERT_FAIL, assert_crash_message))
 #endif


### PR DESCRIPTION
I was having some problems with code that expected the assert() macro to behave as an expression. Specifically, it was used with the comma operator like:
```
(expr_with_side_effects, assert(some_condition))
```

The "verbose" alternative for assert() was causing problems because it was defined with an if block. This PR solves that.