### PR TITLE
 tests/unittests: add empty list clist_foreach case 

### DIFF
--- a/core/include/clist.h
+++ b/core/include/clist.h
@@ -325,24 +325,28 @@ static inline clist_node_t *clist_remove(clist_node_t *list, clist_node_t *node)
  * The pointer supplied by @p arg will be passed to every call to @p func.
  *
  * If @p func returns non-zero, traversal will be aborted like when calling
- * break within a for loop.
+ * break within a for loop, returning the corresponding node.
  *
  * @param[in]       list        List to traverse.
  * @param[in]       func        Function to call for each member.
  * @param[in]       arg         Pointer to pass to every call to @p func
+ *
+ * @returns         NULL on empty list or full traversal
+ * @returns         node that caused @p func(node, arg) to exit non-zero
  */
-static inline void clist_foreach(clist_node_t *list, int(*func)(clist_node_t *, void *), void *arg)
+static inline clist_node_t *clist_foreach(clist_node_t *list, int(*func)(clist_node_t *, void *), void *arg)
 {
     clist_node_t *node = list->next;
-    if (! node) {
-        return;
+    if (node) {
+        do {
+            node = node->next;
+            if (func(node, arg)) {
+                return node;
+            }
+        } while (node != list->next);
     }
-    do {
-        node = node->next;
-        if (func(node, arg)) {
-            return;
-        }
-    } while (node != list->next);
+
+    return NULL;
 }
 
 /**

--- a/tests/unittests/tests-core/tests-core-clist.c
+++ b/tests/unittests/tests-core/tests-core-clist.c
@@ -237,13 +237,19 @@ static int _foreach_test_trampoline(clist_node_t *node, void *arg)
 
 static void test_clist_foreach(void)
 {
+    void *res;
     list_node_t *list = &test_clist;
+
+    _foreach_called = 0;
+    res = clist_foreach(list, _foreach_test_trampoline, NULL);
+    TEST_ASSERT(_foreach_called == 0);
+    TEST_ASSERT(res == NULL);
 
     for (int i = 0; i < TEST_CLIST_LEN; i++) {
         clist_rpush(list, &tests_clist_buf[i]);
     }
 
-    void *res = clist_foreach(list, _foreach_test_trampoline, NULL);
+    res = clist_foreach(list, _foreach_test_trampoline, NULL);
 
     TEST_ASSERT(_foreach_called == _foreach_abort_after);
     TEST_ASSERT(res == &tests_clist_buf[_foreach_abort_after-1]);

--- a/tests/unittests/tests-core/tests-core-clist.c
+++ b/tests/unittests/tests-core/tests-core-clist.c
@@ -243,9 +243,10 @@ static void test_clist_foreach(void)
         clist_rpush(list, &tests_clist_buf[i]);
     }
 
-    clist_foreach(list, _foreach_test_trampoline, NULL);
+    void *res = clist_foreach(list, _foreach_test_trampoline, NULL);
 
     TEST_ASSERT(_foreach_called == _foreach_abort_after);
+    TEST_ASSERT(res == &tests_clist_buf[_foreach_abort_after-1]);
 
     _foreach_called = 0;
     for (int i = 0; i < TEST_CLIST_LEN; i++) {
@@ -253,9 +254,10 @@ static void test_clist_foreach(void)
     }
 
     _foreach_abort_after = (TEST_CLIST_LEN + 1);
-    clist_foreach(list, _foreach_test_trampoline, NULL);
+    res = clist_foreach(list, _foreach_test_trampoline, NULL);
 
     TEST_ASSERT(_foreach_called == TEST_CLIST_LEN);
+    TEST_ASSERT(res == NULL);
 }
 
 static int _cmp(clist_node_t *a, clist_node_t *b)


### PR DESCRIPTION
### Contribution description

Add clist_foreach empty list test case which should:

* not call `func`
* return `NULL`

### Issues/PRs references

Follow up to and depending on #9017