### PR TITLE
pkg/libcose: Use RIOT random_bytes instead of randombytes

### DIFF
--- a/pkg/libcose/patches/0001-RIOT-Use-RIOT-random_bytes-function-instead-of-rando.patch
+++ b/pkg/libcose/patches/0001-RIOT-Use-RIOT-random_bytes-function-instead-of-rando.patch
@@ -1,0 +1,46 @@
+From 2d37e015c9fbf3711a7f931564983b20f2267da4 Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Joakim=20Nohlg=C3=A5rd?= <joakim.nohlgard@eistec.se>
+Date: Tue, 15 May 2018 13:24:16 +0200
+Subject: [PATCH] RIOT: Use RIOT random_bytes function instead of randombytes
+
+---
+ src/crypt/hacl.c | 6 +++---
+ 1 file changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/src/crypt/hacl.c b/src/crypt/hacl.c
+index a16dbd7e30..cb4808d684 100644
+--- a/src/crypt/hacl.c
++++ b/src/crypt/hacl.c
+@@ -18,10 +18,10 @@
+ #include <stdint.h>
+ #include <stdlib.h>
+ #include <string.h>
++#include "random.h"
+ 
+ extern void Hacl_Ed25519_sign(uint8_t *signature, uint8_t *secret, uint8_t *msg, uint32_t len1);
+ extern bool Hacl_Ed25519_verify(uint8_t *public, uint8_t *msg, uint32_t len1, uint8_t *signature);
+-extern void randombytes(uint8_t *target, uint64_t n);
+ 
+ int cose_crypto_aead_encrypt_chachapoly(uint8_t *c,
+                                         size_t *clen,
+@@ -65,7 +65,7 @@ ssize_t cose_crypto_keygen_chachapoly(uint8_t *sk, size_t len)
+     if (len < COSE_CRYPTO_AEAD_CHACHA20POLY1305_KEYBYTES) {
+         return COSE_ERR_NOMEM;
+     }
+-    randombytes(sk, COSE_CRYPTO_AEAD_CHACHA20POLY1305_KEYBYTES);
++    random_bytes(sk, COSE_CRYPTO_AEAD_CHACHA20POLY1305_KEYBYTES);
+     return COSE_CRYPTO_AEAD_CHACHA20POLY1305_KEYBYTES;
+ }
+ 
+@@ -74,7 +74,7 @@ size_t cose_crypto_aead_nonce_chachapoly(uint8_t *nonce, size_t len)
+     if (len < COSE_CRYPTO_AEAD_CHACHA20POLY1305_NONCEBYTES) {
+         return 0;
+     }
+-    randombytes(nonce, COSE_CRYPTO_AEAD_CHACHA20POLY1305_NONCEBYTES);
++    random_bytes(nonce, COSE_CRYPTO_AEAD_CHACHA20POLY1305_NONCEBYTES);
+     return COSE_CRYPTO_AEAD_CHACHA20POLY1305_NONCEBYTES;
+ }
+ 
+-- 
+2.17.0
+


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

The randombytes wrapper function causes multiple definition linking errors on the unittests when building both tweetnacl and hacl at the same time. The 64 bit n argument is only used with a literal decimal constant 32 in the implementation, so there's no need to have a 64 bit argument there. 

### Issues/PRs references

needed by #8711 
similar to #9138 #9139