### PR TITLE
boards/common/atmega: initialize watchdog

### DIFF
--- a/boards/common/atmega/board.c
+++ b/boards/common/atmega/board.c
@@ -31,6 +31,7 @@ void led_init(void);
 
 void board_init(void)
 {
+    atmega_wdog_init();
     atmega_set_prescaler(CPU_ATMEGA_CLK_SCALE_INIT);
     atmega_stdio_init();
     cpu_init();

--- a/cpu/atmega_common/include/cpu.h
+++ b/cpu/atmega_common/include/cpu.h
@@ -124,6 +124,23 @@ static inline void atmega_set_prescaler(uint8_t clk_scale)
 }
 
 /**
+ * @brief   Initializes watchdog
+ */
+static inline void atmega_wdog_init(void)
+{
+    /* Reset the watchdog if the reboot was triggered due to it */
+    if (MCUSR & (1 << WDRF)) {
+        MCUSR &= ~(1 << WDRF);
+
+        /* Enable watchdog change */
+        WDTCSR |= 1 << WDCE;
+
+        /* Clear settings within 4 cycles */
+        WDTCSR = 0;
+    }
+}
+
+/**
  * @brief   Initializes avrlibc stdio
  */
 void atmega_stdio_init(void);


### PR DESCRIPTION
This initializes the watchdog on ATmega boards if a watchdog reset occurred, preventing reboot loops when using the reboot command.

Adapted from #6837 

Fixes #6836 