### PR TITLE
Interrupt context switch

### DIFF
--- a/core/msg.c
+++ b/core/msg.c
@@ -165,7 +165,7 @@ static int _msg_send(msg_t *m, kernel_pid_t target_pid, bool block, unsigned sta
         sched_set_status(target, STATUS_PENDING);
 
         irq_restore(state);
-        thread_yield_higher();
+
     }
 
     return 1;
@@ -207,8 +207,11 @@ int msg_send_int(msg_t *m, kernel_pid_t target_pid)
         msg_t *target_message = (msg_t*) target->wait_data;
         *target_message = *m;
         sched_set_status(target, STATUS_PENDING);
-
+#if !defined(ISR_CONTEXT_SWITCH_ALLOWED)
         sched_context_switch_request = 1;
+#else
+        thread_yield_higher();
+#endif
         return 1;
     }
     else {
@@ -272,7 +275,11 @@ int msg_reply_int(msg_t *m, msg_t *reply)
     msg_t *target_message = (msg_t*) target->wait_data;
     *target_message = *reply;
     sched_set_status(target, STATUS_PENDING);
-    sched_context_switch_request = 1;
+#if !defined(ISR_CONTEXT_SWITCH_ALLOWED)
+        sched_context_switch_request = 1;
+#else
+        thread_yield_higher();
+#endif
     return 1;
 }
 

--- a/core/thread_flags.c
+++ b/core/thread_flags.c
@@ -114,7 +114,11 @@ inline int __attribute__((always_inline)) thread_flags_wake(thread_t *thread)
     if (wakeup) {
         DEBUG("_thread_flags_wake(): waking up pid %"PRIkernel_pid"\n", thread->pid);
         sched_set_status(thread, STATUS_PENDING);
+#if !defined(ISR_CONTEXT_SWITCH_ALLOWED)
         sched_context_switch_request = 1;
+#else
+        thread_yield_higher();
+#endif
     }
 
     return wakeup;

--- a/cpu/atmega_common/periph/timer.c
+++ b/cpu/atmega_common/periph/timer.c
@@ -174,11 +174,12 @@ static inline void _isr(tim_t tim, int chan)
     *ctx[tim].mask &= ~(1 << (chan + OCIE1A));
     ctx[tim].cb(ctx[tim].arg, chan);
 
+#if !defined(ISR_CONTEXT_SWITCH_ALLOWED)
     if (sched_context_switch_request) {
         thread_yield();
         thread_yield_isr();
     }
-
+#endif
     __exit_isr();
 }
 #endif

--- a/cpu/atmega_common/periph/uart.c
+++ b/cpu/atmega_common/periph/uart.c
@@ -168,10 +168,12 @@ static inline void isr_handler(int num)
 {
     isr_ctx[num].rx_cb(isr_ctx[num].arg, dev[num]->DR);
 
+#if !defined(ISR_CONTEXT_SWITCH_ALLOWED)
     if (sched_context_switch_request) {
         thread_yield();
         thread_yield_isr();
     }
+#endif
 }
 
 #ifdef UART_0_ISR

--- a/cpu/atmega_common/thread_arch.c
+++ b/cpu/atmega_common/thread_arch.c
@@ -237,8 +237,6 @@ void thread_yield_higher(void) {
         __context_restore();
 
         __exit_isr();
-    PORTF |= (1 << 6);
-    PORTF &= ~(1 << 6);
         __asm__ volatile("reti");
 #endif
     }

--- a/sys/evtimer/evtimer.c
+++ b/sys/evtimer/evtimer.c
@@ -150,9 +150,12 @@ void evtimer_add(evtimer_t *evtimer, evtimer_event_t *event)
         _set_timer(&evtimer->timer, event->offset);
     }
     irq_restore(state);
+#if !defined(ISR_CONTEXT_SWITCH_ALLOWED)
     if (sched_context_switch_request) {
         thread_yield_higher();
     }
+#endif
+
 }
 
 void evtimer_del(evtimer_t *evtimer, evtimer_event_t *event)


### PR DESCRIPTION
This is a PR to reduce overhead for platforms which allow ISR context swap.

As for now the procedure is as follows:
1. ISR enter
1. Calback
1. Do something, thread_yield, check for ISR, signalize with flag, return to caller.
1. Check for flag, swap context.

This can be reduced.
1. ISR enter
1. Calback
1. Do something, swap context.

As of now the feature can be enabled with a CFLAG.
```
CFLAGS= -DISR_CONTEXT_SWITCH_ALLOWED
```

and only the atmega platform was changed accordingly.

Following tests run successfull.
- tests/xtimer_msg_receive_timeout
- tests/xtimer_periodic_wakeup
- tests/xtimer_remove
- tests/xtimer_remove
- tests/xtimer_reset
- tests/xtimer_usleep
- tests/xtimer_usleep_short

The question is, how to implement this that it works for all platforms or can be enabled and disabled.
Where to place `ISR_CONTEXT_SWITCH_ALLOWED` ?
As for now it has to be placed at the test or example Makefile.
Any suggestions are welcome.

This is a followup of https://github.com/RIOT-OS/RIOT/pull/8988 

This is WIP. 

All comparison for `irq_is_in()` can be moved to `thread_yield_higher` thus moving the check from multiple places to the dependend platform.