### PR TITLE
net/nanocoap: sort Options

### DIFF
--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -226,6 +226,13 @@ extern "C" {
 /** @} */
 
 /**
+ * @brief Allows sorting Options in coap_opt_finish() when enabled (1).
+ */
+#ifndef COAP_OPTIONS_SORT
+#define COAP_OPTIONS_SORT       (0)
+#endif
+
+/**
  * @name coap_opt_finish() flag parameter values
  *
  * Directs packet/buffer updates when user finishes adding options
@@ -235,6 +242,8 @@ extern "C" {
 #define COAP_OPT_FINISH_NONE     (0x0000)
 /** @brief    expect a payload to follow */
 #define COAP_OPT_FINISH_PAYLOAD  (0x0001)
+/** @brief    sort Options; only valid when COAP_OPTIONS_SORT enabled */
+#define COAP_OPT_FINISH_SORT     (0x0002)
 /** @} */
 
 /**

--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -226,13 +226,6 @@ extern "C" {
 /** @} */
 
 /**
- * @brief Allows sorting Options in coap_opt_finish() when enabled (1).
- */
-#ifndef COAP_OPTIONS_SORT
-#define COAP_OPTIONS_SORT       (0)
-#endif
-
-/**
  * @name coap_opt_finish() flag parameter values
  *
  * Directs packet/buffer updates when user finishes adding options

--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -240,6 +240,17 @@ extern "C" {
 /** @} */
 
 /**
+ * @brief Default flags for coap_opt_finish()
+ */
+#ifndef COAP_OPT_FINISH_DEFAULTS
+#ifdef MODULE_NANOCOAP_OPTIONS_SORT
+#define COAP_OPT_FINISH_DEFAULTS   COAP_OPT_FINISH_SORT
+#else
+#define COAP_OPT_FINISH_DEFAULTS   COAP_OPT_FINISH_NONE
+#endif
+#endif
+
+/**
  * @brief   Raw CoAP PDU header structure
  */
 typedef struct __attribute__((packed)) {
@@ -570,7 +581,9 @@ ssize_t coap_opt_add_uint(coap_pkt_t *pkt, uint16_t optnum, uint32_t value);
  * @post pkt.payload_len is maximum bytes available for payload
  *
  * @param[in,out] pkt         pkt to update
- * @param[in]     flags       see COAP_OPT_FINISH... macros
+ * @param[in]     flags       see COAP_OPT_FINISH... macros; the values
+ *                            provided in this parameter are combined with
+ *                            COAP_OPT_FINISH_DEFAULTS
  *
  * @return        total number of bytes written to buffer
  */

--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2016-17 Kaspar Schleiser <kaspar@schleiser.de>
+ * Copyright (C) 2018 Ken Bannister <kb2ma@runbox.com>
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -10,6 +11,32 @@
  * @defgroup    net_nanocoap nanocoap small CoAP library
  * @ingroup     net
  * @brief       Provides CoAP functionality optimized for minimal resource usage
+ *
+ * nanocoap includes both server-side request handling and response generation,
+ * and client-side request generation.
+ *
+ * ## Write Options and Payload ##
+ *
+ * For both server responses and client requests, CoAP uses an Option mechanism
+ * to encode message metadata that is not required for each message. For
+ * example, the resource URI path is required only for a request, and is encoded
+ * as the Uri-Path option.
+ *
+ * nanocoap provides two APIs for writing CoAP options:
+ *
+ * - a minimal API that requires only a reference to the buffer; however, the
+ *    caller must remember and provide the last option number written, as well
+ *    as the buffer position
+ *
+ * - a convenient API that uses a coap_pkt_t struct to track each option as it
+ *   is written
+ *
+ * By default, the caller *must* write options in order by option number
+ * (see "CoAP option numbers", below). However, the struct-based API supports
+ * use of the `nanocoap_options_sort` submodule. This submodule allows the user
+ * to enter options in any order, and then sorts them in coap_opt_finish(). By
+ * default, options are sorted automatically. However, by redefining
+ * COAP_OPT_FINISH_DEFAULTS, the caller can choose when to sort.
  *
  * @{
  *

--- a/sys/include/net/nanocoap_opt_sort.h
+++ b/sys/include/net/nanocoap_opt_sort.h
@@ -1,0 +1,44 @@
+/*
+ * Copyright (C) 2018 Ken Bannister <kb2ma@runbox.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     net_nanocoap
+ *
+ * @{
+ *
+ * @file
+ * @brief       nanocoap options sort functions
+ *
+ * @author      Ken Bannister <kb2ma@runbox.com>
+ */
+
+#ifndef NET_NANOCOAP_OPT_SORT_H
+#define NET_NANOCOAP_OPT_SORT_H
+
+#include <stdbool.h>
+
+#include "net/nanocoap.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Test that options are sorted by option number
+ *
+ * @param[in]  pkt     structure referencing options
+ *
+ * @returns    true if sorted
+ */
+bool coap_opt_sorted(coap_pkt_t *pkt);
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* NET_NANOCOAP_OPT_SORT_H */
+/** @} */

--- a/sys/net/application_layer/nanocoap/Makefile
+++ b/sys/net/application_layer/nanocoap/Makefile
@@ -1,3 +1,3 @@
-SRC := nanocoap.c
+SRC := nanocoap.c common.c
 SUBMODULES := 1
 include $(RIOTBASE)/Makefile.base

--- a/sys/net/application_layer/nanocoap/common.c
+++ b/sys/net/application_layer/nanocoap/common.c
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2016-17 Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     net_nanocoap
+ * @{
+ *
+ * @file
+ * @brief       common internal functions
+ *
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * @}
+ */
+
+#include <errno.h>
+
+#include "net/nanocoap.h"
+
+#define ENABLE_DEBUG (0)
+#include "debug.h"
+
+int _decode_value(unsigned val, uint8_t **pkt_pos_ptr, uint8_t *pkt_end)
+{
+    uint8_t *pkt_pos = *pkt_pos_ptr;
+    size_t left = pkt_end - pkt_pos;
+    int res;
+
+    switch (val) {
+        case 13:
+        {
+            /* An 8-bit unsigned integer follows the initial byte and
+               indicates the Option Delta minus 13. */
+            if (left < 1) {
+                return -ENOSPC;
+            }
+            uint8_t delta = *pkt_pos++;
+            res = delta + 13;
+            break;
+        }
+        case 14:
+        {
+            /* A 16-bit unsigned integer in network byte order follows
+             * the initial byte and indicates the Option Delta minus
+             * 269. */
+            if (left < 2) {
+                return -ENOSPC;
+            }
+            uint16_t delta;
+            uint8_t *_tmp = (uint8_t *)&delta;
+            *_tmp++ = *pkt_pos++;
+            *_tmp++ = *pkt_pos++;
+            res = ntohs(delta) + 269;
+            break;
+        }
+        case 15:
+            /* Reserved for the Payload Marker.  If the field is set to
+             * this value but the entire byte is not the payload
+             * marker, this MUST be processed as a message format
+             * error. */
+            return -EBADMSG;
+        default:
+            res = val;
+    }
+
+    *pkt_pos_ptr = pkt_pos;
+    return res;
+}
+
+uint8_t *_parse_option(coap_pkt_t *pkt, uint8_t *pkt_pos, uint16_t *delta, int *opt_len)
+{
+    uint8_t *hdr_end = pkt->payload;
+
+    if (pkt_pos == hdr_end) {
+        return NULL;
+    }
+
+    uint8_t option_byte = *pkt_pos++;
+
+    *delta = _decode_value(option_byte >> 4, &pkt_pos, hdr_end);
+    *opt_len = _decode_value(option_byte & 0xf, &pkt_pos, hdr_end);
+
+    return pkt_pos;
+}

--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -616,7 +616,10 @@ ssize_t coap_opt_finish(coap_pkt_t *pkt, uint16_t flags)
     if (flags & COAP_OPT_FINISH_SORT) {
         _sort_opts(pkt);
     }
+#else
+    assert(flags ^ COAP_OPT_FINISH_SORT);
 #endif
+
     if (flags & COAP_OPT_FINISH_PAYLOAD) {
         assert(pkt->payload_len > 1);
 

--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2016-18 Kaspar Schleiser <kaspar@schleiser.de>
+ * Copyright (C) 2018 Ken Bannister <kb2ma@runbox.com>
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -14,6 +15,7 @@
  * @brief       Nanocoap implementation
  *
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ * @author      Ken Bannister <kb2ma@runbox.com>
  *
  * @}
  */

--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -612,6 +612,8 @@ ssize_t coap_opt_add_uint(coap_pkt_t *pkt, uint16_t optnum, uint32_t value)
 
 ssize_t coap_opt_finish(coap_pkt_t *pkt, uint16_t flags)
 {
+    flags |= COAP_OPT_FINISH_DEFAULTS;
+
 #ifdef MODULE_NANOCOAP_OPTIONS_SORT
     if (flags & COAP_OPT_FINISH_SORT) {
         _sort_opts(pkt);

--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -28,10 +28,13 @@
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
-static int _decode_value(unsigned val, uint8_t **pkt_pos_ptr, uint8_t *pkt_end);
 int coap_get_option_uint(coap_pkt_t *pkt, unsigned opt_num, uint32_t *target);
 static uint32_t _decode_uint(uint8_t *pkt_pos, unsigned nbytes);
 static size_t _encode_uint(uint32_t *val);
+
+extern int _decode_value(unsigned val, uint8_t **pkt_pos_ptr, uint8_t *pkt_end);
+extern uint8_t *_parse_option(coap_pkt_t *pkt, uint8_t *pkt_pos, uint16_t *delta, int *opt_len);
+extern ssize_t _sort_opts(coap_pkt_t *pkt);
 
 /* http://tools.ietf.org/html/rfc7252#section-3
  *  0                   1                   2                   3
@@ -145,22 +148,6 @@ uint8_t *coap_find_option(coap_pkt_t *pkt, unsigned opt_num)
         optpos++;
     }
     return NULL;
-}
-
-static uint8_t *_parse_option(coap_pkt_t *pkt, uint8_t *pkt_pos, uint16_t *delta, int *opt_len)
-{
-    uint8_t *hdr_end = pkt->payload;
-
-    if (pkt_pos == hdr_end) {
-        return NULL;
-    }
-
-    uint8_t option_byte = *pkt_pos++;
-
-    *delta = _decode_value(option_byte >> 4, &pkt_pos, hdr_end);
-    *opt_len = _decode_value(option_byte & 0xf, &pkt_pos, hdr_end);
-
-    return pkt_pos;
 }
 
 int coap_get_option_uint(coap_pkt_t *pkt, unsigned opt_num, uint32_t *target)
@@ -392,53 +379,6 @@ void coap_pkt_init(coap_pkt_t *pkt, uint8_t *buf, size_t len, size_t header_len)
     pkt->payload_len = len - header_len;
 }
 
-static int _decode_value(unsigned val, uint8_t **pkt_pos_ptr, uint8_t *pkt_end)
-{
-    uint8_t *pkt_pos = *pkt_pos_ptr;
-    size_t left = pkt_end - pkt_pos;
-    int res;
-
-    switch (val) {
-        case 13:
-        {
-            /* An 8-bit unsigned integer follows the initial byte and
-               indicates the Option Delta minus 13. */
-            if (left < 1) {
-                return -ENOSPC;
-            }
-            uint8_t delta = *pkt_pos++;
-            res = delta + 13;
-            break;
-        }
-        case 14:
-        {
-            /* A 16-bit unsigned integer in network byte order follows
-             * the initial byte and indicates the Option Delta minus
-             * 269. */
-            if (left < 2) {
-                return -ENOSPC;
-            }
-            uint16_t delta;
-            uint8_t *_tmp = (uint8_t *)&delta;
-            *_tmp++ = *pkt_pos++;
-            *_tmp++ = *pkt_pos++;
-            res = ntohs(delta) + 269;
-            break;
-        }
-        case 15:
-            /* Reserved for the Payload Marker.  If the field is set to
-             * this value but the entire byte is not the payload
-             * marker, this MUST be processed as a message format
-             * error. */
-            return -EBADMSG;
-        default:
-            res = val;
-    }
-
-    *pkt_pos_ptr = pkt_pos;
-    return res;
-}
-
 static uint32_t _decode_uint(uint8_t *pkt_pos, unsigned nbytes)
 {
     assert(nbytes <= 4);
@@ -497,7 +437,7 @@ static unsigned _put_delta_optlen(uint8_t *buf, unsigned offset, unsigned shift,
 
 size_t coap_put_option(uint8_t *buf, uint16_t lastonum, uint16_t onum, uint8_t *odata, size_t olen)
 {
-#if COAP_OPTIONS_SORT
+#ifdef MODULE_NANOCOAP_OPTIONS_SORT
     unsigned delta = (lastonum <= onum) ? (onum - lastonum) : 0;
 #else
     assert(lastonum <= onum);
@@ -628,76 +568,6 @@ static ssize_t _add_opt_pkt(coap_pkt_t *pkt, uint16_t optnum, uint8_t *val,
     return optlen;
 }
 
-#if COAP_OPTIONS_SORT
-/*
- * Sort the stored message options by option number. Rewrite the buffer and
- * update the options attributes in the pkt struct.
- *
- * pkt[inout]     Packet for sort
- * returns        0 on success
- */
-static ssize_t _sort_opts(coap_pkt_t *pkt)
-{
-    if (pkt->options_len <= 1) {
-        return 0;
-    }
-
-    uint8_t *options = (uint8_t *)pkt->hdr + coap_get_total_hdr_len(pkt);
-    /* scratch buffer to hold sorted options, with extra space to handle any
-     * large option header */
-    uint8_t scratch[(pkt->payload - options) + 4];
-    uint8_t *scratch_pos = &scratch[0];
-
-    unsigned sorted   = 0;        /* count of sorted elements */
-    uint8_t *next_pos = options;
-
-    do {
-        // find next option to write
-        unsigned i, best_i = sorted;
-        for (i = sorted+1; i < pkt->options_len; i++) {
-            if (pkt->options[i].opt_num < pkt->options[best_i].opt_num) {
-                best_i = i;
-            }
-        }
-        i = best_i;
-        /* prepare to relocate option memo currently at sorted location */
-        coap_optpos_t bubble_opt;
-        bubble_opt.opt_num = pkt->options[sorted].opt_num;
-        bubble_opt.offset  = pkt->options[sorted].offset;
-
-        /* read selected option */
-        uint16_t delta;      // unused
-        int option_len;
-        uint8_t *val = _parse_option(pkt, (uint8_t *)pkt->hdr + pkt->options[i].offset,
-                                     &delta, &option_len);
-
-        /* write option to scratch buffer */
-        uint8_t *last_pos = next_pos;
-        next_pos += coap_put_option(scratch_pos,
-                                    sorted ? pkt->options[sorted-1].opt_num : 0,
-                                    pkt->options[i].opt_num, val, option_len);
-        scratch_pos += (next_pos - last_pos);
-
-        /* update pkt->options record and save bubbled option */
-        pkt->options[sorted].opt_num = pkt->options[i].opt_num;
-        pkt->options[sorted].offset  = last_pos - (uint8_t *)pkt->hdr;
-        if (i != sorted) {
-            pkt->options[i].opt_num = bubble_opt.opt_num;
-            pkt->options[i].offset  = bubble_opt.offset;
-        }
-    } while (++sorted < pkt->options_len);
-
-    int len_delta = next_pos - pkt->payload;
-    DEBUG("sort moves payload by %d\n", len_delta);
-
-    memcpy(options, &scratch[0], next_pos - options);
-
-    pkt->payload     += len_delta;
-    pkt->payload_len -= len_delta;
-    return 0;
-}
-#endif
-
 ssize_t coap_opt_add_string(coap_pkt_t *pkt, uint16_t optnum, const char *string,
                            char separator)
 {
@@ -742,7 +612,7 @@ ssize_t coap_opt_add_uint(coap_pkt_t *pkt, uint16_t optnum, uint32_t value)
 
 ssize_t coap_opt_finish(coap_pkt_t *pkt, uint16_t flags)
 {
-#if COAP_OPTIONS_SORT
+#ifdef MODULE_NANOCOAP_OPTIONS_SORT
     if (flags & COAP_OPT_FINISH_SORT) {
         _sort_opts(pkt);
     }

--- a/sys/net/application_layer/nanocoap/options_sort.c
+++ b/sys/net/application_layer/nanocoap/options_sort.c
@@ -96,3 +96,13 @@ ssize_t _sort_opts(coap_pkt_t *pkt)
     pkt->payload_len -= len_delta;
     return 0;
 }
+
+bool coap_opt_sorted(coap_pkt_t *pkt)
+{
+    for (unsigned i = 1; i < pkt->options_len; i++) {
+        if (pkt->options[i].opt_num < pkt->options[i-1].opt_num) {
+            return false;
+        }
+    }
+    return true;
+}

--- a/sys/net/application_layer/nanocoap/options_sort.c
+++ b/sys/net/application_layer/nanocoap/options_sort.c
@@ -1,0 +1,98 @@
+/*
+ * Copyright (C) 2018 Ken Bannister <kb2ma@runbox.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     net_nanocoap
+ * @{
+ *
+ * @file
+ * @brief       nanocoap options sorting functions
+ *
+ * @author      Ken Bannister <kb2ma@runbox.com>
+ *
+ * @}
+ */
+
+#include <errno.h>
+#include <string.h>
+#include <stdio.h>
+
+#include "net/nanocoap.h"
+
+#define ENABLE_DEBUG (0)
+#include "debug.h"
+
+extern uint8_t *_parse_option(coap_pkt_t *pkt, uint8_t *pkt_pos, uint16_t *delta, int *opt_len);
+
+/*
+ * Sort the stored message options by option number. Rewrite the buffer and
+ * update the options attributes in the pkt struct.
+ *
+ * pkt[inout]     Packet for sort
+ * returns        0 on success
+ */
+ssize_t _sort_opts(coap_pkt_t *pkt)
+{
+    if (pkt->options_len <= 1) {
+        return 0;
+    }
+
+    uint8_t *options = (uint8_t *)pkt->hdr + coap_get_total_hdr_len(pkt);
+    /* scratch buffer to hold sorted options, with extra space to handle any
+     * large option header */
+    uint8_t scratch[(pkt->payload - options) + 4];
+    uint8_t *scratch_pos = &scratch[0];
+
+    unsigned sorted   = 0;        /* count of sorted elements */
+    uint8_t *next_pos = options;
+
+    do {
+        // find next option to write
+        unsigned i, best_i = sorted;
+        for (i = sorted+1; i < pkt->options_len; i++) {
+            if (pkt->options[i].opt_num < pkt->options[best_i].opt_num) {
+                best_i = i;
+            }
+        }
+        i = best_i;
+        /* prepare to relocate option memo currently at sorted location */
+        coap_optpos_t bubble_opt;
+        bubble_opt.opt_num = pkt->options[sorted].opt_num;
+        bubble_opt.offset  = pkt->options[sorted].offset;
+
+        /* read selected option */
+        uint16_t delta;      // unused
+        int option_len;
+        uint8_t *val = _parse_option(pkt, (uint8_t *)pkt->hdr + pkt->options[i].offset,
+                                     &delta, &option_len);
+
+        /* write option to scratch buffer */
+        uint8_t *last_pos = next_pos;
+        next_pos += coap_put_option(scratch_pos,
+                                    sorted ? pkt->options[sorted-1].opt_num : 0,
+                                    pkt->options[i].opt_num, val, option_len);
+        scratch_pos += (next_pos - last_pos);
+
+        /* update pkt->options record and save bubbled option */
+        pkt->options[sorted].opt_num = pkt->options[i].opt_num;
+        pkt->options[sorted].offset  = last_pos - (uint8_t *)pkt->hdr;
+        if (i != sorted) {
+            pkt->options[i].opt_num = bubble_opt.opt_num;
+            pkt->options[i].offset  = bubble_opt.offset;
+        }
+    } while (++sorted < pkt->options_len);
+
+    int len_delta = next_pos - pkt->payload;
+    DEBUG("sort moves payload by %d\n", len_delta);
+
+    memcpy(options, &scratch[0], next_pos - options);
+
+    pkt->payload     += len_delta;
+    pkt->payload_len -= len_delta;
+    return 0;
+}

--- a/tests/unittests/tests-nanocoap/Makefile.include
+++ b/tests/unittests/tests-nanocoap/Makefile.include
@@ -1,1 +1,2 @@
 USEMODULE += nanocoap
+USEMODULE += nanocoap_options_sort

--- a/tests/unittests/tests-nanocoap/tests-nanocoap.c
+++ b/tests/unittests/tests-nanocoap/tests-nanocoap.c
@@ -19,6 +19,7 @@
 #include "embUnit.h"
 
 #include "net/nanocoap.h"
+#include "net/nanocoap_opt_sort.h"
 
 #include "unittests-constants.h"
 #include "tests-nanocoap.h"
@@ -148,6 +149,7 @@ static void test_nanocoap__get_multi_path(void)
 #ifdef MODULE_NANOCOAP_OPTIONS_SORT
 /*
  * Builds on put_req test, to test resorting options in option number order.
+ * Also verifies coap_opt_sorted().
  */
 static void test_nanocoap__put_opt_sort(void)
 {
@@ -164,7 +166,12 @@ static void test_nanocoap__put_opt_sort(void)
     /* out of order; 12, 11 */
     coap_opt_add_uint(&pkt, COAP_OPT_CONTENT_FORMAT, COAP_FORMAT_TEXT);
     coap_opt_add_string(&pkt, COAP_OPT_URI_PATH, &path[0], '/');
+
+    TEST_ASSERT(!coap_opt_sorted(&pkt));
+
     len = coap_opt_finish(&pkt, COAP_OPT_FINISH_SORT);
+
+    TEST_ASSERT(coap_opt_sorted(&pkt));
 
     memset(&pkt, 0, sizeof(coap_pkt_t));
     int res = coap_parse(&pkt, &buf[0], len);

--- a/tests/unittests/tests-nanocoap/tests-nanocoap.c
+++ b/tests/unittests/tests-nanocoap/tests-nanocoap.c
@@ -145,7 +145,7 @@ static void test_nanocoap__get_multi_path(void)
     TEST_ASSERT_EQUAL_STRING((char *)path, (char *)uri);
 }
 
-#if COAP_OPTIONS_SORT
+#ifdef MODULE_NANOCOAP_OPTIONS_SORT
 /*
  * Builds on put_req test, to test resorting options in option number order.
  */
@@ -248,7 +248,7 @@ Test *tests_nanocoap_tests(void)
         new_TestFixture(test_nanocoap__get_req),
         new_TestFixture(test_nanocoap__put_req),
         new_TestFixture(test_nanocoap__get_multi_path),
-#if COAP_OPTIONS_SORT
+#ifdef MODULE_NANOCOAP_OPTIONS_SORT
         new_TestFixture(test_nanocoap__put_opt_sort),
         new_TestFixture(test_nanocoap__put_opt_sort_presorted),
         new_TestFixture(test_nanocoap__put_opt_sort_1opt),

--- a/tests/unittests/tests-nanocoap/tests-nanocoap.c
+++ b/tests/unittests/tests-nanocoap/tests-nanocoap.c
@@ -14,6 +14,7 @@
 #include <errno.h>
 #include <stdint.h>
 #include <stdbool.h>
+#include <string.h>
 
 #include "embUnit.h"
 
@@ -144,6 +145,102 @@ static void test_nanocoap__get_multi_path(void)
     TEST_ASSERT_EQUAL_STRING((char *)path, (char *)uri);
 }
 
+#if COAP_OPTIONS_SORT
+/*
+ * Builds on put_req test, to test resorting options in option number order.
+ */
+static void test_nanocoap__put_opt_sort(void)
+{
+    uint8_t buf[128];
+    coap_pkt_t pkt;
+    uint16_t msgid = 0xABCD;
+    uint8_t token[2] = {0xDA, 0xEC};
+    char path[] = "/ab/cd";
+
+    size_t len = coap_build_hdr((coap_hdr_t *)&buf[0], COAP_TYPE_NON,
+                                &token[0], 2, COAP_METHOD_PUT, msgid);
+    coap_pkt_init(&pkt, &buf[0], sizeof(buf), len);
+
+    /* out of order; 12, 11 */
+    coap_opt_add_uint(&pkt, COAP_OPT_CONTENT_FORMAT, COAP_FORMAT_TEXT);
+    coap_opt_add_string(&pkt, COAP_OPT_URI_PATH, &path[0], '/');
+    len = coap_opt_finish(&pkt, COAP_OPT_FINISH_SORT);
+
+    memset(&pkt, 0, sizeof(coap_pkt_t));
+    int res = coap_parse(&pkt, &buf[0], len);
+    TEST_ASSERT_EQUAL_INT(0, res);
+
+    /* value is "/" on failure; implicit path when Uri-Path absent */
+    char uri[10] = {0};
+    coap_get_uri(&pkt, (uint8_t *)&uri[0]);
+    TEST_ASSERT_EQUAL_STRING((char *)path, (char *)uri);
+
+    TEST_ASSERT_EQUAL_INT(COAP_FORMAT_TEXT, coap_get_content_type(&pkt));
+}
+
+/*
+ * Builds on put_opt_sort test, to test resorting options already in order.
+ */
+static void test_nanocoap__put_opt_sort_presorted(void)
+{
+    uint8_t buf[128];
+    coap_pkt_t pkt;
+    uint16_t msgid = 0xABCD;
+    uint8_t token[2] = {0xDA, 0xEC};
+    char path[] = "/ab";
+
+    size_t len = coap_build_hdr((coap_hdr_t *)&buf[0], COAP_TYPE_NON,
+                                &token[0], 2, COAP_METHOD_PUT, msgid);
+    coap_pkt_init(&pkt, &buf[0], sizeof(buf), len);
+
+    coap_opt_add_uint(&pkt, COAP_OPT_OBSERVE, 0);
+    coap_opt_add_string(&pkt, COAP_OPT_URI_PATH, &path[0], '/');
+    coap_opt_add_uint(&pkt, COAP_OPT_CONTENT_FORMAT, COAP_FORMAT_TEXT);
+    len = coap_opt_finish(&pkt, COAP_OPT_FINISH_SORT);
+
+    memset(&pkt, 0, sizeof(coap_pkt_t));
+    int res = coap_parse(&pkt, &buf[0], len);
+    TEST_ASSERT_EQUAL_INT(0, res);
+
+    /* no API to retrieve observe option value */
+
+    /* value is "/" on failure; implicit path when Uri-Path absent */
+    char uri[10] = {0};
+    coap_get_uri(&pkt, (uint8_t *)&uri[0]);
+    TEST_ASSERT_EQUAL_STRING((char *)path, (char *)uri);
+
+    TEST_ASSERT_EQUAL_INT(COAP_FORMAT_TEXT, coap_get_content_type(&pkt));
+}
+
+/*
+ * Builds on put_opt_sort test, to test no-op case with a single option.
+ */
+static void test_nanocoap__put_opt_sort_1opt(void)
+{
+    uint8_t buf[128];
+    coap_pkt_t pkt;
+    uint16_t msgid = 0xABCD;
+    uint8_t token[2] = {0xDA, 0xEC};
+    char path[] = "/ab";
+
+    size_t len = coap_build_hdr((coap_hdr_t *)&buf[0], COAP_TYPE_NON,
+                                &token[0], 2, COAP_METHOD_PUT, msgid);
+    coap_pkt_init(&pkt, &buf[0], sizeof(buf), len);
+
+    coap_opt_add_string(&pkt, COAP_OPT_URI_PATH, &path[0], '/');
+    len = coap_opt_finish(&pkt, COAP_OPT_FINISH_SORT);
+
+    memset(&pkt, 0, sizeof(coap_pkt_t));
+    int res = coap_parse(&pkt, &buf[0], len);
+    TEST_ASSERT_EQUAL_INT(0, res);
+
+    /* value is "/" on failure; implicit path when Uri-Path absent */
+    char uri[10] = {0};
+    coap_get_uri(&pkt, (uint8_t *)&uri[0]);
+    TEST_ASSERT_EQUAL_STRING((char *)path, (char *)uri);
+}
+#endif
+
 Test *tests_nanocoap_tests(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
@@ -151,6 +248,11 @@ Test *tests_nanocoap_tests(void)
         new_TestFixture(test_nanocoap__get_req),
         new_TestFixture(test_nanocoap__put_req),
         new_TestFixture(test_nanocoap__get_multi_path),
+#if COAP_OPTIONS_SORT
+        new_TestFixture(test_nanocoap__put_opt_sort),
+        new_TestFixture(test_nanocoap__put_opt_sort_presorted),
+        new_TestFixture(test_nanocoap__put_opt_sort_1opt),
+#endif
     };
 
     EMB_UNIT_TESTCALLER(nanocoap_tests, NULL, NULL, fixtures);


### PR DESCRIPTION
### Contribution description
Allows the user to add CoAP Options out of option number order via the `coap_opt_add_[string|buf|uint](pkt, ...)` functions. Provides a flag for `coap_opt_finish()` to sort the options. This code for this capability is compiled conditionally by enabling a new macro, COAP_OPTIONS_SORT, which is disabled by default. This conditional approach allows the user to trade off API simplicity for code/memory space and speed.

### Issues/PRs references
Implements ideas described in #9048 and #8831.