### PR TITLE
trickle: remove msg_time member from struct

### DIFF
--- a/sys/include/trickle.h
+++ b/sys/include/trickle.h
@@ -58,7 +58,6 @@ typedef struct {
     trickle_callback_t callback;    /**< callback function and parameter that
                                          trickle calls after each interval */
     msg_t msg;                      /**< the msg_t to use for intervals */
-    uint64_t msg_time;              /**< interval in ms */
     xtimer_t msg_timer;             /**< xtimer to send a msg_t to the target
                                          thread for a new interval */
 } trickle_t;

--- a/sys/trickle/trickle.c
+++ b/sys/trickle/trickle.c
@@ -51,8 +51,8 @@ void trickle_interval(trickle_t *trickle)
     /* old_interval == trickle->I / 2 */
     trickle->t = random_uint32_range(old_interval, trickle->I);
 
-    trickle->msg_time = (trickle->t + diff) * MS_PER_SEC;
-    xtimer_set_msg64(&trickle->msg_timer, trickle->msg_time, &trickle->msg,
+    uint64_t msg_time = (trickle->t + diff) * US_PER_MS;
+    xtimer_set_msg64(&trickle->msg_timer, msg_time, &trickle->msg,
                      trickle->pid);
 }
 


### PR DESCRIPTION
xtimer_set_msg64 offset is in μs and trickle is in ms, the timer values
should thus be multiplied with `US_PER_MS` and not with `MS_PER_SEC`.

Doesn't change any functionality, but prevents confusion with the timer
units.

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->