### PR TITLE
tests/xtimer_now64: Start time measure after print

### DIFF
--- a/tests/xtimer_now64_continuity/main.c
+++ b/tests/xtimer_now64_continuity/main.c
@@ -34,8 +34,8 @@ int main(void)
     uint64_t diff_min = UINT64_MAX;
     uint64_t diff_max = 0;
     uint64_t diff_sum = 0;
-    xtimer_ticks64_t before = xtimer_now64();
     print_str("[START]\n");
+    xtimer_ticks64_t before = xtimer_now64();
     while(--n) {
         xtimer_ticks64_t now = xtimer_now64();
         xtimer_ticks64_t diff = xtimer_diff64(now, before);


### PR DESCRIPTION
Printing can take a lot of time over a serial connection. On the atmega board it takes more than 2 ms, skewing the first measurement over the threshold value and causing a test failure. 

This PR moves the print statement above the first measumerement to prevent the skew.