### PR TITLE
kinetis: GPIO: Enable the correct IRQn on CM0+

### DIFF
--- a/cpu/kinetis/include/cpu_conf_kinetis.h
+++ b/cpu/kinetis/include/cpu_conf_kinetis.h
@@ -155,6 +155,7 @@ extern "C"
 #define LPTMR0_IRQn LPTimer_IRQn
 #define PIT_TCTRL_CHN_MASK   (0x4u)
 #define PIT_TCTRL_CHN_SHIFT  (2)
+#define PORT_IRQS   { PORTA_IRQn, PORTB_IRQn, PORTC_IRQn, PORTD_IRQn, PORTE_IRQn }
 #endif /* MK20D7_H_ */
 /** @} */
 

--- a/cpu/kinetis/periph/gpio.c
+++ b/cpu/kinetis/periph/gpio.c
@@ -113,6 +113,7 @@ static isr_ctx_t isr_ctx[CTX_NUMOF];
  */
 static uint32_t isr_map[ISR_MAP_SIZE];
 
+static const uint8_t port_irqs[] = PORT_IRQS;
 
 static inline PORT_Type *port(gpio_t pin)
 {
@@ -217,9 +218,11 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
 
     /* clear interrupt flags */
     port(pin)->ISFR &= ~(1 << pin_num(pin));
+
     /* enable global port interrupts in the NVIC */
-    NVIC_EnableIRQ(PORTA_IRQn + port_num(pin));
-    /* finally, enable the interrupt for the select pin */
+    NVIC_EnableIRQ(port_irqs[port_num(pin)]);
+
+    /* finally, enable the interrupt for the selected pin */
     port(pin)->PCR[pin_num(pin)] |= flank;
     return 0;
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Address a problem where gpio_init_int activates the wrong IRQn in the NVIC on KW41Z when trying to set up interrupts on PORTC.

### Issues/PRs references

none