### PR TITLE
core/debug: fix debug.h use within ISRs

### DIFF
--- a/core/include/debug.h
+++ b/core/include/debug.h
@@ -52,7 +52,7 @@ extern "C" {
 #include "cpu_conf.h"
 #define DEBUG_PRINT(...) \
     do { \
-        if ((sched_active_thread == NULL) || (sched_active_thread->stack_size > THREAD_EXTRA_STACKSIZE_PRINTF)) { \
+        if ((sched_active_thread == NULL) || (sched_active_thread->stack_size >= THREAD_EXTRA_STACKSIZE_PRINTF)) { \
             printf(__VA_ARGS__); \
         } \
         else { \


### PR DESCRIPTION
If you attempt to use DEBUG messages within ISRs on some platforms (tested on mega-xplained) it complains "Cannot debug, stack too small". This PR allows DEBUG messages to be used.