### PR TITLE
cpu/stm32_common: implements hwcrypto API for stm32 AES

### DIFF
--- a/boards/ikea-tradfri/include/periph_conf.h
+++ b/boards/ikea-tradfri/include/periph_conf.h
@@ -54,8 +54,21 @@ extern "C" {
 /** @} */
 
 /**
- * @name    RTC configuration
+ * @brief   Hardware crypto configuration
  * @{
+ */
+static const hwcrypto_conf_t hwcrypto_config[] = {
+    {
+        .dev = CRYPTO,
+        .cmu = cmuClock_CRYPTO
+    }
+};
+
+#define HWCRYPTO_NUMOF      PERIPH_NUMOF(hwcrypto_config)
+/** @} */
+
+/**
+ * @brief   RTC configuration
  */
 #define RTC_NUMOF           (1U)
 /** @} */

--- a/boards/native/Makefile.dep
+++ b/boards/native/Makefile.dep
@@ -19,3 +19,5 @@ ifneq (,$(filter socket_zep,$(USEMODULE)))
   USEMODULE += checksum
   USEMODULE += random
 endif
+
+-include $(RIOTCPU)/native/Makefile.dep

--- a/boards/native/board_init.c
+++ b/boards/native/board_init.c
@@ -15,6 +15,7 @@
  */
 #include <stdio.h>
 #include "board.h"
+#include "periph/init.h"
 
 #include "board_internal.h"
 
@@ -30,6 +31,9 @@ void board_init(void)
 {
     LED0_OFF;
     LED1_ON;
+
+    /* trigger static peripheral initialization */
+    periph_init();
 
     puts("RIOT native board initialized.");
 }

--- a/boards/nucleo-f412zg/include/periph_conf.h
+++ b/boards/nucleo-f412zg/include/periph_conf.h
@@ -72,6 +72,29 @@ extern "C" {
 /** @} */
 
 /**
+ * @name    DMA streams configuration
+ * @{
+ */
+#ifdef MODULE_PERIPH_DMA
+static const dma_conf_t dma_config[] = {
+    { .stream = 4  },
+    { .stream = 14 },
+    { .stream = 6  },
+    { .stream = 10 },
+    { .stream = 8  },
+};
+
+#define DMA_0_ISR  isr_dma1_stream4
+#define DMA_1_ISR  isr_dma2_stream6
+#define DMA_2_ISR  isr_dma1_stream6
+#define DMA_3_ISR  isr_dma2_stream2
+#define DMA_4_ISR  isr_dma2_stream0
+
+#define DMA_NUMOF           (sizeof(dma_config) / sizeof(dma_config[0]))
+#endif
+/** @} */
+
+/**
  * @name    Timer configuration
  * @{
  */
@@ -104,9 +127,9 @@ static const uart_conf_t uart_config[] = {
         .tx_af      = GPIO_AF7,
         .bus        = APB1,
         .irqn       = USART3_IRQn,
-#ifdef UART_USE_DMA
-        .dma_stream = 6,
-        .dma_chan   = 4
+#ifdef MODULE_PERIPH_DMA
+        .dma        = 0,
+        .dma_chan   = 7,
 #endif
     },
     {
@@ -118,9 +141,9 @@ static const uart_conf_t uart_config[] = {
         .tx_af      = GPIO_AF8,
         .bus        = APB2,
         .irqn       = USART6_IRQn,
-#ifdef UART_USE_DMA
-        .dma_stream = 5,
-        .dma_chan   = 4
+#ifdef MODULE_PERIPH_DMA
+        .dma        = 1,
+        .dma_chan   = 5,
 #endif
     },
     {
@@ -132,9 +155,9 @@ static const uart_conf_t uart_config[] = {
         .tx_af      = GPIO_AF7,
         .bus        = APB2,
         .irqn       = USART2_IRQn,
-#ifdef UART_USE_DMA
-        .dma_stream = 4,
-        .dma_chan   = 4
+#ifdef MODULE_PERIPH_DMA
+        .dma        = 3,
+        .dma_chan   = 4,
 #endif
     },
 };
@@ -212,7 +235,13 @@ static const spi_conf_t spi_config[] = {
         .cs_pin   = GPIO_PIN(PORT_A, 4),
         .af       = GPIO_AF5,
         .rccmask  = RCC_APB2ENR_SPI1EN,
-        .apbbus   = APB2
+        .apbbus   = APB2,
+#ifdef MODULE_PERIPH_DMA
+        .tx_dma   = 3,
+        .tx_dma_chan = 2,
+        .rx_dma   = 4,
+        .rx_dma_chan = 3,
+#endif
     }
 };
 

--- a/boards/sltb001a/include/periph_conf.h
+++ b/boards/sltb001a/include/periph_conf.h
@@ -85,6 +85,20 @@ static const adc_chan_conf_t adc_channel_config[] = {
 /** @} */
 
 /**
+ * @brief   Hardware crypto configuration
+ * @{
+ */
+static const hwcrypto_conf_t hwcrypto_config[] = {
+    {
+        .dev = CRYPTO,
+        .cmu = cmuClock_CRYPTO
+    }
+};
+
+#define HWCRYPTO_NUMOF      PERIPH_NUMOF(hwcrypto_config)
+/** @} */
+
+/**
  * @name    I2C configuration
  * @{
  */

--- a/boards/stk3600/include/periph_conf.h
+++ b/boards/stk3600/include/periph_conf.h
@@ -105,6 +105,11 @@ static const dac_chan_conf_t dac_channel_config[] = {
 /** @} */
 
 /**
+ * @brief   Hardware crypto configuration
+ */
+#define HWCRYPTO_NUMOF      (1)
+
+/**
  * @name    I2C configuration
  * @{
  */

--- a/boards/stk3700/include/periph_conf.h
+++ b/boards/stk3700/include/periph_conf.h
@@ -105,6 +105,11 @@ static const dac_chan_conf_t dac_channel_config[] = {
 /** @} */
 
 /**
+ * @brief   Hardware crypto configuration
+ */
+#define HWCRYPTO_NUMOF      (1)
+
+/**
  * @name    I2C configuration
  * @{
  */

--- a/cpu/efm32/Makefile.dep
+++ b/cpu/efm32/Makefile.dep
@@ -1,3 +1,7 @@
+ifneq (,$(filter periph_hwcrypto,$(USEMODULE)))
+  USEMODULE += periph_hwcrypto_series$(EFM32_SERIES)
+endif
+
 ifneq (,$(filter periph_rtc,$(USEMODULE)))
   USEMODULE += periph_rtc_series$(EFM32_SERIES)
 endif

--- a/cpu/efm32/Makefile.features
+++ b/cpu/efm32/Makefile.features
@@ -2,6 +2,8 @@ include $(RIOTCPU)/efm32/efm32-features.mk
 
 FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_flashpage
+FEATURES_PROVIDED += periph_hwcrypto
+FEATURES_PROVIDED += periph_pm
 
 FEATURES_CONFLICT += periph_rtc:periph_rtt
 FEATURES_CONFLICT_MSG += "On the EFM32, the RTC and RTT map to the same hardware peripheral."

--- a/cpu/efm32/include/periph_cpu.h
+++ b/cpu/efm32/include/periph_cpu.h
@@ -213,16 +213,28 @@ typedef enum {
 #endif /* ndef DOXYGEN */
 
 /**
- * @brief   Override hardware crypto supported methods.
+ * @brief   Hardware crypto configuration.
  * @{
  */
+#ifdef _SILICON_LABS_32B_SERIES_0
 #define HAVE_HWCRYPTO_AES128
 #ifdef AES_CTRL_AES256
 #define HAVE_HWCRYPTO_AES256
 #endif
+#endif
+
 #ifdef _SILICON_LABS_32B_SERIES_1
+#define HAVE_HWCRYPTO_AES128
+#define HAVE_HWCRYPTO_AES256
 #define HAVE_HWCRYPTO_SHA1
 #define HAVE_HWCRYPTO_SHA256
+#endif
+
+#ifdef _SILICON_LABS_32B_SERIES_1
+typedef struct {
+    CRYPTO_TypeDef *dev;    /**< crypto device used */
+    CMU_Clock_TypeDef cmu;  /**< the device CMU channel */
+} hwcrypto_conf_t;
 #endif
 /** @} */
 

--- a/cpu/efm32/periph/hwcrypto_series0.c
+++ b/cpu/efm32/periph/hwcrypto_series0.c
@@ -1,0 +1,296 @@
+/*
+ * Copyright (C) 2016-2018 Bas Stottelaar <basstottelaar@gmail.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_efm32
+ * @ingroup     drivers_periph_hwcrypto
+ *
+ * @{
+ *
+ * @file
+ * @brief       Low-level hardware crypto driver implementation
+ *
+ * @author      Bas Stottelaar <basstottelaar@gmail.com>
+ *
+ * @}
+ */
+
+#include <string.h>
+
+#include "mutex.h"
+#include "assert.h"
+
+#include "periph/hwcrypto.h"
+
+#include "em_cmu.h"
+#include "em_aes.h"
+
+/**
+ * @brief   Type definition of the hardware crypto device state.
+ */
+typedef struct {
+    hwcrypto_cipher_t cipher;
+    hwcrypto_mode_t mode;
+    uint8_t key[32] __attribute__((aligned));
+    union {
+        uint8_t iv[16] __attribute__((aligned));
+        uint8_t counter[16] __attribute__((aligned));
+    } opts;
+} state_t;
+
+/**
+ * @brief   Type of a 128-bit counter.
+ */
+typedef struct {
+    uint64_t hi;
+    uint64_t lo;
+} counter128_t;
+
+/**
+ * @brief   Global lock to ensure mutual exclusive access to hardware crypto
+ *          device.
+ */
+static mutex_t hwcrypto_lock = MUTEX_INIT;
+
+/**
+ * @brief   Hardware crypto device state.
+ */
+static state_t state;
+
+/**
+ * @brief   Helper for incrementing a 128-bit counter.
+ */
+static void hwcrypto_cipher_increment(uint8_t *ctr)
+{
+    counter128_t *counter = (counter128_t *)ctr;
+
+    /* on overflow of low, increment high */
+    if (counter->lo == 0) {
+        counter->hi++;
+    }
+}
+
+int hwcrypto_init(hwcrypto_t dev)
+{
+    assert(dev < HWCRYPTO_NUMOF);
+
+    /* enable clocks */
+    CMU_ClockEnable(cmuClock_HFPER, true);
+    CMU_ClockEnable(cmuClock_AES, true);
+
+    return 0;
+}
+
+int hwcrypto_cipher_init(hwcrypto_t dev, hwcrypto_cipher_t cipher, hwcrypto_mode_t mode)
+{
+    (void) dev;
+
+    /* check if cipher is supported */
+    if (!hwcrypto_cipher_supported(dev, cipher)) {
+        return -1;
+    }
+
+    /* initialize state */
+    state.cipher = cipher;
+    state.mode = mode;
+
+    return 0;
+}
+
+int hwcrypto_cipher_set(hwcrypto_t dev, hwcrypto_opt_t option, const void *value, uint32_t size)
+{
+    (void) dev;
+
+    switch (option) {
+        case HWCRYPTO_OPT_KEY:
+            if (state.cipher == HWCRYPTO_AES128 && size == 16) {
+                memcpy(state.key, value, 16);
+            }
+            else if (state.cipher == HWCRYPTO_AES256 && size == 32) {
+                memcpy(state.key, value, 32);
+            }
+            else {
+                /* incorrect size */
+                return -2;
+            }
+
+            break;
+        case HWCRYPTO_OPT_IV:
+            if (state.mode != HWCRYPTO_MODE_CBC &&
+                state.mode != HWCRYPTO_MODE_OFB &&
+                state.mode != HWCRYPTO_MODE_CFB
+                ) {
+                /* other modes don't use iv */
+                return -1;
+            }
+
+            if (size != 16) {
+                /* incorrect iv size */
+                return -2;
+            }
+
+            memcpy(state.opts.iv, value, 16);
+            break;
+        case HWCRYPTO_OPT_COUNTER:
+            if (state.mode != HWCRYPTO_MODE_CTR) {
+                /* other modes don't use counter */
+                return -1;
+            }
+
+            if (size != 16) {
+                /* incorrect counter size */
+                return -2;
+            }
+
+            memcpy(state.opts.counter, value, 16);
+            break;
+        default:
+            /* option not supported */
+            return -1;
+    }
+
+    return 0;
+}
+
+static int hwcrypto_cipher_encrypt_decrypt(const uint8_t *plain_block, uint8_t *cipher_block, uint32_t block_size, bool encrypt)
+{
+    /* blocks must be aligned */
+    assert(!((intptr_t) plain_block & 0x03));
+    assert(!((intptr_t) cipher_block & 0x03));
+
+    /* block size must be multiple of 16 */
+    if ((block_size % 16) != 0) {
+        return -2;
+    }
+
+    switch (state.cipher) {
+        case HWCRYPTO_AES128:
+            switch (state.mode) {
+                case HWCRYPTO_MODE_ECB:
+                    AES_ECB128(cipher_block, plain_block, block_size, state.key, encrypt);
+                    break;
+                case HWCRYPTO_MODE_CBC:
+                    AES_CBC128(cipher_block, plain_block, block_size, state.key, state.opts.iv, encrypt);
+                    break;
+                case HWCRYPTO_MODE_CFB:
+                    AES_CFB128(cipher_block, plain_block, block_size, state.key, state.opts.iv, encrypt);
+                    break;
+                case HWCRYPTO_MODE_OFB:
+                    AES_OFB128(cipher_block, plain_block, block_size, state.key, state.opts.iv);
+                    break;
+                case HWCRYPTO_MODE_CTR:
+                    AES_CTR128(cipher_block, plain_block, block_size, state.key, state.opts.counter, hwcrypto_cipher_increment);
+                    break;
+                default:
+                    return -1;
+            }
+
+            break;
+        case HWCRYPTO_AES256:
+            switch (state.mode) {
+                case HWCRYPTO_MODE_ECB:
+                    AES_ECB256(cipher_block, plain_block, block_size, state.key, encrypt);
+                    break;
+                case HWCRYPTO_MODE_CBC:
+                    AES_CBC256(cipher_block, plain_block, block_size, state.key, state.opts.iv, encrypt);
+                    break;
+                case HWCRYPTO_MODE_CFB:
+                    AES_CFB256(cipher_block, plain_block, block_size, state.key, state.opts.iv, encrypt);
+                    break;
+                case HWCRYPTO_MODE_OFB:
+                    AES_OFB256(cipher_block, plain_block, block_size, state.key, state.opts.iv);
+                    break;
+                case HWCRYPTO_MODE_CTR:
+                    AES_CTR256(cipher_block, plain_block, block_size, state.key, state.opts.counter, hwcrypto_cipher_increment);
+                    break;
+                default:
+                    return -1;
+            }
+
+            break;
+        default:
+            return -1;
+    }
+
+    return block_size;
+}
+
+int hwcrypto_cipher_encrypt(hwcrypto_t dev, const uint8_t *plain_block, uint8_t *cipher_block, uint32_t block_size)
+{
+    (void) dev;
+
+    return hwcrypto_cipher_encrypt_decrypt(plain_block, cipher_block, block_size, true);
+}
+
+int hwcrypto_cipher_decrypt(hwcrypto_t dev, const uint8_t *cipher_block, uint8_t *plain_block, uint32_t block_size)
+{
+    (void) dev;
+
+    return hwcrypto_cipher_encrypt_decrypt(cipher_block, plain_block, block_size, false);
+}
+
+int hwcrypto_hash_init(hwcrypto_t dev, hwcrypto_hash_t hash)
+{
+    (void) dev;
+    (void) hash;
+
+    /* not supported */
+    return -1;
+}
+
+int hwcrypto_hash_update(hwcrypto_t dev, const uint8_t *block, uint32_t block_size)
+{
+    (void) dev;
+    (void) block;
+    (void) block_size;
+
+    /* not supported */
+    return -1;
+}
+
+int hwcrypto_hash_final(hwcrypto_t dev, uint8_t *result, uint32_t result_size)
+{
+    (void) dev;
+    (void) result;
+    (void) result_size;
+
+    /* not supported */
+    return -1;
+}
+
+int hwcrypto_acquire(hwcrypto_t dev)
+{
+    (void) dev;
+
+    mutex_lock(&hwcrypto_lock);
+
+    return 0;
+}
+
+int hwcrypto_release(hwcrypto_t dev)
+{
+    (void) dev;
+
+    mutex_unlock(&hwcrypto_lock);
+
+    return 0;
+}
+
+void hwcrypto_poweron(hwcrypto_t dev)
+{
+    (void) dev;
+
+    CMU_ClockEnable(cmuClock_AES, true);
+}
+
+void hwcrypto_poweroff(hwcrypto_t dev)
+{
+    (void) dev;
+
+    CMU_ClockEnable(cmuClock_AES, false);
+}

--- a/cpu/efm32/periph/hwcrypto_series1.c
+++ b/cpu/efm32/periph/hwcrypto_series1.c
@@ -1,0 +1,296 @@
+/*
+ * Copyright (C) 2016-2018 Bas Stottelaar <basstottelaar@gmail.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_efm32
+ * @ingroup     drivers_periph_hwcrypto
+ *
+ * @{
+ *
+ * @file
+ * @brief       Low-level hardware crypto driver implementation for EFM32
+ *              Series 1 MCUs
+ *
+ * @author      Bas Stottelaar <basstottelaar@gmail.com>
+ *
+ * @}
+ */
+
+#include <string.h>
+
+#include "mutex.h"
+#include "assert.h"
+
+#include "periph/hwcrypto.h"
+
+#include "em_cmu.h"
+#include "em_crypto.h"
+
+/**
+ * @brief   Type definition of the hardware crypto device state.
+ */
+typedef union {
+    struct {
+        hwcrypto_cipher_t cipher;
+        hwcrypto_mode_t mode;
+        uint8_t key[32] __attribute__((aligned));
+        union {
+            uint8_t iv[16] __attribute__((aligned));
+            uint8_t counter[16] __attribute__((aligned));
+        } opts;
+    } cipher;
+    struct {
+        hwcrypto_hash_t hash;
+        uint8_t digest[32] __attribute__((aligned));
+    } hash;
+} state_t;
+
+/**
+ * @brief   Global lock to ensure mutual exclusive access to crypto hardware.
+ */
+static mutex_t hwcrypto_lock[HWCRYPTO_NUMOF];
+
+/**
+ * @brief   Hardware crypto device state.
+ */
+static state_t state[HWCRYPTO_NUMOF];
+
+int hwcrypto_init(hwcrypto_t dev)
+{
+    assert(dev < HWCRYPTO_NUMOF);
+
+    /* enable clocks */
+    CMU_ClockEnable(cmuClock_HFPER, true);
+    CMU_ClockEnable(hwcrypto_config[dev].cmu, true);
+
+    /* initialize lock */
+    mutex_init(&hwcrypto_lock[dev]);
+
+    return 0;
+}
+
+int hwcrypto_cipher_init(hwcrypto_t dev, hwcrypto_cipher_t cipher, hwcrypto_mode_t mode)
+{
+    /* check if cipher is supported */
+    if (!hwcrypto_cipher_supported(dev, cipher)) {
+        return -1;
+    }
+
+    /* initialize state */
+    state[dev].cipher.cipher = cipher;
+    state[dev].cipher.mode = mode;
+
+    return 0;
+}
+
+int hwcrypto_cipher_set(hwcrypto_t dev, hwcrypto_opt_t option, const void *value, uint32_t size)
+{
+    switch (option) {
+        case HWCRYPTO_OPT_KEY:
+            if (state[dev].cipher.cipher == HWCRYPTO_AES128) {
+                memcpy(state[dev].cipher.key, value, 16);
+            }
+            else if (state[dev].cipher.cipher == HWCRYPTO_AES256) {
+                memcpy(state[dev].cipher.key, value, 32);
+            }
+            else {
+                /* incorrect size */
+                return -2;
+            }
+
+            break;
+        case HWCRYPTO_OPT_IV:
+            if (state[dev].cipher.mode != HWCRYPTO_MODE_CBC &&
+                state[dev].cipher.mode != HWCRYPTO_MODE_OFB &&
+                state[dev].cipher.mode != HWCRYPTO_MODE_CFB
+                ) {
+                /* other modes don't use iv */
+                return -1;
+            }
+
+            if (size != 16) {
+                /* incorrect iv size */
+                return -2;
+            }
+
+            memcpy(state[dev].cipher.opts.iv, value, 16);
+            break;
+        case HWCRYPTO_OPT_COUNTER:
+            if (state[dev].cipher.mode != HWCRYPTO_MODE_CTR) {
+                /* other modes don't use counter */
+                return -1;
+            }
+
+            if (size != 16) {
+                /* incorrect counter size */
+                return -2;
+            }
+
+            memcpy(state[dev].cipher.opts.counter, value, 16);
+            break;
+        default:
+            /* option not supported */
+            return -1;
+    }
+
+    return 0;
+}
+
+static int hwcrypto_cipher_encrypt_decrypt(hwcrypto_t dev, const uint8_t *plain_block, uint8_t *cipher_block, uint32_t block_size, bool encrypt)
+{
+    /* blocks must be aligned */
+    assert(!((intptr_t) plain_block & 0x03));
+    assert(!((intptr_t) cipher_block & 0x03));
+
+    if ((block_size % 16) != 0) {
+        /* invalid block size */
+        return -2;
+    }
+
+    switch (state[dev].cipher.cipher) {
+        case HWCRYPTO_AES128:
+            switch (state[dev].cipher.mode) {
+                case HWCRYPTO_MODE_ECB:
+                    CRYPTO_AES_ECB128(hwcrypto_config[dev].dev, cipher_block, plain_block, block_size, state[dev].cipher.key, encrypt);
+                    break;
+                case HWCRYPTO_MODE_CBC:
+                    CRYPTO_AES_CBC128(hwcrypto_config[dev].dev, cipher_block, plain_block, block_size, state[dev].cipher.key, state[dev].cipher.opts.iv, encrypt);
+                    break;
+                case HWCRYPTO_MODE_CFB:
+                    CRYPTO_AES_CFB128(hwcrypto_config[dev].dev, cipher_block, plain_block, block_size, state[dev].cipher.key, state[dev].cipher.opts.iv, encrypt);
+                    break;
+                case HWCRYPTO_MODE_OFB:
+                    CRYPTO_AES_OFB128(hwcrypto_config[dev].dev, cipher_block, plain_block, block_size, state[dev].cipher.key, state[dev].cipher.opts.iv);
+                    break;
+                case HWCRYPTO_MODE_CTR:
+                    CRYPTO_AES_CTR128(hwcrypto_config[dev].dev, cipher_block, plain_block, block_size, state[dev].cipher.key, state[dev].cipher.opts.counter, NULL);
+                    break;
+                default:
+                    return -1;
+            }
+
+            break;
+        case HWCRYPTO_AES256:
+            switch (state[dev].cipher.mode) {
+                case HWCRYPTO_MODE_ECB:
+                    CRYPTO_AES_ECB256(hwcrypto_config[dev].dev, cipher_block, plain_block, block_size, state[dev].cipher.key, encrypt);
+                    break;
+                case HWCRYPTO_MODE_CBC:
+                    CRYPTO_AES_CBC256(hwcrypto_config[dev].dev, cipher_block, plain_block, block_size, state[dev].cipher.key, state[dev].cipher.opts.iv, encrypt);
+                    break;
+                case HWCRYPTO_MODE_CFB:
+                    CRYPTO_AES_CFB256(hwcrypto_config[dev].dev, cipher_block, plain_block, block_size, state[dev].cipher.key, state[dev].cipher.opts.iv, encrypt);
+                    break;
+                case HWCRYPTO_MODE_OFB:
+                    CRYPTO_AES_OFB256(hwcrypto_config[dev].dev, cipher_block, plain_block, block_size, state[dev].cipher.key, state[dev].cipher.opts.iv);
+                    break;
+                case HWCRYPTO_MODE_CTR:
+                    CRYPTO_AES_CTR256(hwcrypto_config[dev].dev, cipher_block, plain_block, block_size, state[dev].cipher.key, state[dev].cipher.opts.counter, NULL);
+                    break;
+                default:
+                    return -1;
+            }
+
+            break;
+        default:
+            return -1;
+    }
+
+    return block_size;
+}
+
+int hwcrypto_cipher_encrypt(hwcrypto_t dev, const uint8_t *plain_block, uint8_t *cipher_block, uint32_t block_size)
+{
+    return hwcrypto_cipher_encrypt_decrypt(dev, plain_block, cipher_block, block_size, true);
+}
+
+int hwcrypto_cipher_decrypt(hwcrypto_t dev, const uint8_t *cipher_block, uint8_t *plain_block, uint32_t block_size)
+{
+    return hwcrypto_cipher_encrypt_decrypt(dev, cipher_block, plain_block, block_size, false);
+}
+
+int hwcrypto_hash_init(hwcrypto_t dev, hwcrypto_hash_t hash)
+{
+    /* check if hash is supported */
+    if (!hwcrypto_hash_supported(dev, hash)) {
+        return -1;
+    }
+
+    /* initialie state */
+    state[dev].hash.hash = hash;
+
+    return 0;
+}
+
+int hwcrypto_hash_update(hwcrypto_t dev, const uint8_t *block, uint32_t block_size)
+{
+    switch (state[dev].hash.hash) {
+        case HWCRYPTO_SHA1:
+            CRYPTO_SHA_1(hwcrypto_config[dev].dev, block, block_size, state[dev].hash.digest);
+            break;
+        case HWCRYPTO_SHA256:
+            CRYPTO_SHA_256(hwcrypto_config[dev].dev, block, block_size, state[dev].hash.digest);
+            break;
+        default:
+            /* hash not supported */
+            return -1;
+    }
+
+    return block_size;
+}
+
+int hwcrypto_hash_final(hwcrypto_t dev, uint8_t *result, uint32_t result_size)
+{
+    switch (state[dev].hash.hash) {
+        case HWCRYPTO_SHA1:
+            if (result_size > sizeof(CRYPTO_SHA1_Digest_TypeDef)) {
+                /* result size larger than digest size */
+                return -2;
+            }
+
+            memcpy(result, state[dev].hash.digest, result_size);
+            break;
+        case HWCRYPTO_SHA256:
+            if (result_size > sizeof(CRYPTO_SHA256_Digest_TypeDef)) {
+                /* result size larger than digest size */
+                return -2;
+            }
+
+            memcpy(result, state[dev].hash.digest, result_size);
+            break;
+        default:
+            /* hash not supported */
+            return -1;
+    }
+
+    return result_size;
+}
+
+int hwcrypto_acquire(hwcrypto_t dev)
+{
+    mutex_lock(&hwcrypto_lock[dev]);
+
+    return 0;
+}
+
+int hwcrypto_release(hwcrypto_t dev)
+{
+    mutex_unlock(&hwcrypto_lock[dev]);
+
+    return 0;
+}
+
+void hwcrypto_poweron(hwcrypto_t dev)
+{
+    CMU_ClockEnable(hwcrypto_config[dev].cmu, true);
+}
+
+void hwcrypto_poweroff(hwcrypto_t dev)
+{
+    CMU_ClockEnable(hwcrypto_config[dev].cmu, false);
+}

--- a/cpu/native/Makefile.dep
+++ b/cpu/native/Makefile.dep
@@ -1,0 +1,5 @@
+# Link OpenSSL for hardware crypto emulation
+ifneq (,$(filter periph_hwcrypto,$(USEMODULE)))
+    LINKFLAGS += `pkg-config --libs openssl`
+    CFLAGS += `pkg-config --cflags openssl`
+endif

--- a/cpu/native/Makefile.features
+++ b/cpu/native/Makefile.features
@@ -1,4 +1,5 @@
 FEATURES_PROVIDED += cpp
 FEATURES_PROVIDED += periph_cpuid
+FEATURES_PROVIDED += periph_hwcrypto
 FEATURES_PROVIDED += periph_hwrng
 FEATURES_PROVIDED += periph_pm

--- a/cpu/native/Makefile.include
+++ b/cpu/native/Makefile.include
@@ -5,6 +5,9 @@ ifeq ($(BUILDOSXNATIVE),1)
     export NATIVEINCLUDES += -I$(RIOTCPU)/native/osx-libc-extra
 endif
 
+# include common hardware crypto functions
+USEMODULE += periph_common
+
 USEMODULE += periph
 USEMODULE += periph_uart
 

--- a/cpu/native/include/periph_conf.h
+++ b/cpu/native/include/periph_conf.h
@@ -21,6 +21,13 @@
 #endif
 
 /**
+ * @name Number of hardware crypto devices
+ * @{
+ */
+#define HWCRYPTO_NUMOF      (1U)
+/** @} */
+
+/**
  * @name hardware timer clock skew avoidance
  * @{
  */

--- a/cpu/native/include/periph_cpu.h
+++ b/cpu/native/include/periph_cpu.h
@@ -33,6 +33,19 @@ extern "C" {
 #endif
 
 /**
+ * @name    Hardware crypto configuration
+ * @{
+ */
+#define HAVE_HWCRYPTO_AES128
+#define HAVE_HWCRYPTO_AES256
+#define HAVE_HWCRYPTO_SHA1
+#define HAVE_HWCRYPTO_SHA224
+#define HAVE_HWCRYPTO_SHA256
+#define HAVE_HWCRYPTO_SHA384
+#define HAVE_HWCRYPTO_SHA512
+/** @} */
+
+/**
  * @brief   Prevent shared timer functions from being used
  */
 #define PERIPH_TIMER_PROVIDES_SET

--- a/cpu/native/periph/hwcrypto.c
+++ b/cpu/native/periph/hwcrypto.c
@@ -1,0 +1,280 @@
+/*
+ * Copyright (C) 2016-2018 Bas Stottelaar <basstottelaar@gmail.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     native_cpu
+ * @ingroup     drivers_periph_hwcrypto
+ *
+ * @{
+ *
+ * @file
+ * @brief       Hardware crypto driver implementation for native
+ *
+ * @author      Bas Stottelaar <basstottelaar@gmail.com>
+ *
+ * @}
+ */
+
+#include <string.h>
+
+#include <openssl/sha.h>
+#include <openssl/aes.h>
+#include <openssl/rsa.h>
+
+#include "mutex.h"
+#include "assert.h"
+
+#include "periph/hwcrypto.h"
+
+/**
+ * @brief   Type definition of the hardware crypto device state.
+ */
+typedef union {
+    struct {
+        hwcrypto_cipher_t cipher;
+        hwcrypto_mode_t mode;
+        uint8_t key[32] __attribute__((aligned));
+        union {
+            uint8_t iv[16] __attribute__((aligned));
+            uint8_t counter[16] __attribute__((aligned));
+        } opts;
+    } cipher;
+    struct {
+        hwcrypto_hash_t hash;
+        union {
+            SHA_CTX sha1;
+            SHA256_CTX sha256;
+            SHA512_CTX sha512;
+        } sha;
+    } hash;
+} state_t;
+
+/**
+ * @brief   Global lock to ensure mutual exclusive access to crypto hardware.
+ */
+static mutex_t hwcrypto_lock[HWCRYPTO_NUMOF];
+
+/**
+ * @brief   Hardware crypto device state.
+ */
+static state_t state[HWCRYPTO_NUMOF];
+
+void hwcrypto_init(hwcrypto_t dev)
+{
+    assert(dev < HWCRYPTO_NUMOF);
+
+    /* initialize lock */
+    mutex_init(&hwcrypto_lock[dev]);
+
+    /* clear the state */
+    memset(&state[dev], 0, sizeof(state_t));
+}
+
+int hwcrypto_cipher_init(hwcrypto_t dev, hwcrypto_cipher_t cipher, hwcrypto_mode_t mode)
+{
+    /* check if cipher is supported */
+    if (!hwcrypto_cipher_supported(dev, cipher)) {
+        return HWCRYPTO_NOTSUP;
+    }
+
+    /* initialize state */
+    state[dev].cipher.cipher = cipher;
+    state[dev].cipher.mode = mode;
+
+    return HWCRYPTO_OK;
+}
+
+int hwcrypto_cipher_set(hwcrypto_t dev, hwcrypto_opt_t option, const void *value, uint32_t size)
+{
+    switch (option) {
+        case HWCRYPTO_OPT_KEY:
+            if (state[dev].cipher.cipher == HWCRYPTO_AES128 && size == 16) {
+                memcpy(state[dev].cipher.key, value, 16);
+            }
+            else if (state[dev].cipher.cipher == HWCRYPTO_AES256 && size == 32) {
+                memcpy(state[dev].cipher.key, value, 32);
+            }
+            else {
+                return HWCRYPTO_INVALID;
+            }
+
+            break;
+        case HWCRYPTO_OPT_IV:
+            if (state[dev].cipher.mode != HWCRYPTO_MODE_CBC &&
+                state[dev].cipher.mode != HWCRYPTO_MODE_OFB &&
+                state[dev].cipher.mode != HWCRYPTO_MODE_CFB
+                ) {
+                return HWCRYPTO_NOTSUP;
+            }
+
+            if (size != 16) {
+                return HWCRYPTO_INVALID;
+            }
+
+            memcpy(state[dev].cipher.opts.iv, value, 16);
+            break;
+        case HWCRYPTO_OPT_COUNTER:
+            if (state[dev].cipher.mode != HWCRYPTO_MODE_CTR) {
+                return HWCRYPTO_NOTSUP;
+            }
+
+            if (size != 16) {
+                return HWCRYPTO_INVALID;
+            }
+
+            memcpy(state[dev].cipher.opts.counter, value, 16);
+            break;
+        default:
+            return HWCRYPTO_NOTSUP;
+    }
+
+    return HWCRYPTO_OK;
+}
+
+static int hwcrypto_cipher_encrypt_decrypt(hwcrypto_t dev, const uint8_t *plain_block, uint8_t *cipher_block, uint32_t block_size, bool encrypt)
+{
+    (void) dev;
+    (void) plain_block;
+    (void) cipher_block;
+    (void) block_size;
+    (void) encrypt;
+
+    return HWCRYPTO_NOTSUP;
+}
+
+int hwcrypto_cipher_encrypt(hwcrypto_t dev, const uint8_t *plain_block, uint8_t *cipher_block, uint32_t block_size)
+{
+    return hwcrypto_cipher_encrypt_decrypt(dev, plain_block, cipher_block, block_size, true);
+}
+
+int hwcrypto_cipher_decrypt(hwcrypto_t dev, const uint8_t *cipher_block, uint8_t *plain_block, uint32_t block_size)
+{
+    return hwcrypto_cipher_encrypt_decrypt(dev, cipher_block, plain_block, block_size, false);
+}
+
+int hwcrypto_hash_init(hwcrypto_t dev, hwcrypto_hash_t hash)
+{
+    /* check if hash algorithm is supported */
+    if (!hwcrypto_hash_supported(dev, hash)) {
+        return HWCRYPTO_NOTSUP;
+    }
+
+    /* initialize state */
+    state[dev].hash.hash = hash;
+
+    switch (hash) {
+        case HWCRYPTO_SHA1:
+            SHA1_Init(&state[dev].hash.sha.sha1);
+            break;
+        case HWCRYPTO_SHA224:
+            SHA224_Init(&state[dev].hash.sha.sha256);
+            break;
+        case HWCRYPTO_SHA256:
+            SHA256_Init(&state[dev].hash.sha.sha256);
+            break;
+        case HWCRYPTO_SHA384:
+            SHA384_Init(&state[dev].hash.sha.sha512);
+            break;
+        case HWCRYPTO_SHA512:
+            SHA512_Init(&state[dev].hash.sha.sha512);
+            break;
+        default:
+            return HWCRYPTO_NOTSUP;
+    }
+
+    return HWCRYPTO_OK;
+}
+
+int hwcrypto_hash_update(hwcrypto_t dev, const uint8_t *block, uint32_t block_size)
+{
+    switch (state[dev].hash.hash) {
+        case HWCRYPTO_SHA1:
+            SHA1_Update(&state[dev].hash.sha.sha1, block, block_size);
+            break;
+        case HWCRYPTO_SHA224:
+            SHA224_Update(&state[dev].hash.sha.sha256, block, block_size);
+            break;
+        case HWCRYPTO_SHA256:
+            SHA256_Update(&state[dev].hash.sha.sha256, block, block_size);
+            break;
+        case HWCRYPTO_SHA384:
+            SHA384_Update(&state[dev].hash.sha.sha512, block, block_size);
+            break;
+        case HWCRYPTO_SHA512:
+            SHA512_Update(&state[dev].hash.sha.sha512, block, block_size);
+            break;
+        default:
+            return HWCRYPTO_NOTSUP;
+    }
+
+    return block_size;
+}
+
+int hwcrypto_hash_final(hwcrypto_t dev, uint8_t *result, uint32_t result_size)
+{
+    uint8_t tmp[64];
+
+    switch (state[dev].hash.hash) {
+        case HWCRYPTO_SHA1:
+            if (result_size > 20) {
+                return HWCRYPTO_INVALID;
+            }
+
+            SHA1_Final(tmp, &state[dev].hash.sha.sha1);
+            break;
+        case HWCRYPTO_SHA224:
+            if (result_size > 28) {
+                return HWCRYPTO_INVALID;
+            }
+
+            SHA224_Final(tmp, &state[dev].hash.sha.sha256);
+            break;
+        case HWCRYPTO_SHA256:
+            if (result_size > 32) {
+                return HWCRYPTO_INVALID;
+            }
+
+            SHA256_Final(tmp, &state[dev].hash.sha.sha256);
+            break;
+        case HWCRYPTO_SHA384:
+            if (result_size > 48) {
+                return HWCRYPTO_INVALID;
+            }
+
+            SHA384_Final(tmp, &state[dev].hash.sha.sha512);
+            break;
+        case HWCRYPTO_SHA512:
+            if (result_size > 64) {
+                return HWCRYPTO_INVALID;
+            }
+
+            SHA512_Final(tmp, &state[dev].hash.sha.sha512);
+            break;
+        default:
+            return HWCRYPTO_NOTSUP;
+    }
+
+    /* copy the number of bytes requested */
+    memcpy(result, tmp, result_size);
+
+    return result_size;
+}
+
+int hwcrypto_acquire(hwcrypto_t dev)
+{
+    mutex_lock(&hwcrypto_lock[dev]);
+
+    return HWCRYPTO_OK;
+}
+
+int hwcrypto_release(hwcrypto_t dev)
+{
+    mutex_unlock(&hwcrypto_lock[dev]);
+
+    return HWCRYPTO_OK;
+}

--- a/cpu/stm32_common/Makefile.dep
+++ b/cpu/stm32_common/Makefile.dep
@@ -1,0 +1,3 @@
+ifneq (,$(filter periph_hwcrypto,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_dma
+endif

--- a/cpu/stm32_common/Makefile.include
+++ b/cpu/stm32_common/Makefile.include
@@ -1,6 +1,8 @@
 # export the CPU family so we can differentiate between them in the code
 FAM = $(shell echo $(CPU_FAM) | tr 'a-z-' 'A-Z_')
 export CFLAGS += -DCPU_FAM_$(FAM)
+CPU_LINE = CPU_LINE_$(shell echo $(CPU_MODEL) | cut -c -9 | tr 'a-z-' 'A-Z_')
+export CFLAGS += -D$(CPU_LINE)
 
 # include common periph module
 USEMODULE += periph_common
@@ -25,6 +27,7 @@ include $(RIOTCPU)/stm32_common/stm32_mem_lengths.mk
 
 info-stm32:
 	@$(COLOR_ECHO) "CPU: $(CPU_MODEL)"
+	@$(COLOR_ECHO) "\tLine: $(CPU_LINE)"
 	@$(COLOR_ECHO) "\tPin count:\t$(STM32_PINCOUNT)"
 	@$(COLOR_ECHO) "\tROM size:\t$(ROM_LEN)"
 	@$(COLOR_ECHO) "\tRAM size:\t$(RAM_LEN)"

--- a/cpu/stm32_common/include/periph_cpu_common.h
+++ b/cpu/stm32_common/include/periph_cpu_common.h
@@ -372,6 +372,22 @@ typedef struct {
 #endif
 } spi_conf_t;
 
+#ifdef CPU_LINE_STM32F423
+#define HAVE_HWCRYPTO_AES128
+#define HAVE_HWCRYPTO_AES256
+
+typedef struct {
+    AES_TypeDef *aes_dev;
+    uint32_t rccmask;
+    uint8_t ahbbus;
+#ifdef MODULE_PERIPH_DMA
+    dma_t in_dma;
+    uint8_t in_dma_chan;
+    dma_t out_dma;
+    uint8_t out_dma_chan;
+#endif
+} hwcrypto_conf_t;
+#endif
 
 /**
  * @brief   Get the actual bus clock frequency for the APB buses

--- a/cpu/stm32_common/periph/hwcrypto.c
+++ b/cpu/stm32_common/periph/hwcrypto.c
@@ -222,11 +222,11 @@ static int hwcrypto_cipher_encrypt_decrypt(hwcrypto_t hwcrypto, const uint8_t *i
     dma_acquire(hwcrypto_config[hwcrypto].out_dma);
 
     dma_configure(hwcrypto_config[hwcrypto].in_dma, hwcrypto_config[hwcrypto].in_dma_chan,
-                  in, (void *)&dev(hwcrypto)->DINR, block_size,
+                  in, (void *)&dev(hwcrypto)->DINR, block_size / 4,
                   DMA_MEM_TO_PERIPH, DMA_INC_SRC_ADDR | DMA_DATA_WIDTH_WORD);
 
     dma_configure(hwcrypto_config[hwcrypto].out_dma, hwcrypto_config[hwcrypto].out_dma_chan,
-                  (const void *)&dev(hwcrypto)->DOUTR, out, block_size,
+                  (const void *)&dev(hwcrypto)->DOUTR, out, block_size / 4,
                   DMA_PERIPH_TO_MEM, DMA_INC_DST_ADDR | DMA_DATA_WIDTH_WORD);
 
     dma_start(hwcrypto_config[hwcrypto].in_dma);

--- a/cpu/stm32_common/periph/hwcrypto.c
+++ b/cpu/stm32_common/periph/hwcrypto.c
@@ -1,0 +1,317 @@
+/*
+ * Copyright (C) 2018 OTA keys S.A.
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_stm32_common
+ * @ingroup     drivers_periph_hwcrypto
+ *
+ * @{
+ *
+ * @file
+ * @brief       Low-level hardware crypto driver implementation
+ *
+ * @author      Vincent Dupont <vincent@otakeys.com>
+ *
+ * @}
+ */
+
+#include <string.h>
+
+#include "mutex.h"
+#include "assert.h"
+
+#define ENABLE_DEBUG    (0)
+#include "debug.h"
+
+#include "periph/hwcrypto.h"
+
+#ifdef STM32_PM_STOP
+#include "pm_layered.h"
+#endif
+
+/**
+ * @brief   Type definition of the hardware crypto device state.
+ */
+typedef struct {
+    hwcrypto_cipher_t cipher;
+    hwcrypto_mode_t mode;
+    uint8_t key[32] __attribute__((aligned));
+    union {
+        uint8_t iv[16] __attribute__((aligned));
+        uint8_t counter[16] __attribute__((aligned));
+    } opts;
+} state_t;
+
+/**
+ * @brief   Global lock to ensure mutual exclusive access to hardware crypto
+ *          device.
+ */
+static mutex_t hwcrypto_lock = MUTEX_INIT;
+
+/**
+ * @brief   Hardware crypto device state.
+ */
+static state_t state;
+
+static inline AES_TypeDef *dev(hwcrypto_t hwcrypto)
+{
+    return hwcrypto_config[hwcrypto].aes_dev;
+}
+
+void hwcrypto_init(hwcrypto_t dev)
+{
+    assert(dev < HWCRYPTO_NUMOF);
+}
+
+int hwcrypto_cipher_init(hwcrypto_t dev, hwcrypto_cipher_t cipher, hwcrypto_mode_t mode)
+{
+    assert(dev < HWCRYPTO_NUMOF);
+
+    if (!hwcrypto_cipher_supported(dev, cipher)) {
+        return HWCRYPTO_NOTSUP;
+    }
+
+    if (mode != HWCRYPTO_MODE_ECB &&
+            mode != HWCRYPTO_MODE_CBC &&
+            mode != HWCRYPTO_MODE_CTR) {
+        return HWCRYPTO_NOTSUP;
+    }
+
+    state.cipher = cipher;
+    state.mode = mode;
+
+    return HWCRYPTO_OK;
+}
+
+int hwcrypto_cipher_set(hwcrypto_t dev, hwcrypto_opt_t option, const void *value, uint32_t size)
+{
+    (void) dev;
+
+    switch (option) {
+        case HWCRYPTO_OPT_KEY:
+            if (state.cipher == HWCRYPTO_AES128 && size == 16) {
+                memcpy(state.key, value, 16);
+            }
+            else if (state.cipher == HWCRYPTO_AES256 && size == 32) {
+                memcpy(state.key, value, 32);
+            }
+            else {
+                /* incorrect size */
+                return HWCRYPTO_INVALID;
+            }
+
+            break;
+        case HWCRYPTO_OPT_IV:
+            if (state.mode != HWCRYPTO_MODE_CBC) {
+                return HWCRYPTO_NOTSUP;
+            }
+
+            if (size != 16) {
+                return HWCRYPTO_INVALID;
+            }
+
+            memcpy(state.opts.iv, value, 16);
+            break;
+        case HWCRYPTO_OPT_COUNTER:
+            if (state.mode != HWCRYPTO_MODE_CTR) {
+                return HWCRYPTO_NOTSUP;
+            }
+
+            if (size != 16) {
+                return HWCRYPTO_INVALID;
+            }
+
+            memcpy(state.opts.counter, value, 16);
+            break;
+        default:
+            return HWCRYPTO_NOTSUP;
+    }
+
+    return HWCRYPTO_OK;
+}
+
+static uint32_t chaining_mode(hwcrypto_mode_t mode)
+{
+    switch (mode) {
+    case HWCRYPTO_MODE_ECB:
+        return 0;
+    case HWCRYPTO_MODE_CBC:
+        return AES_CR_CHMOD_0;
+    case HWCRYPTO_MODE_CTR:
+        return AES_CR_CHMOD_1;
+    default:
+        return 0;
+    }
+}
+
+static int hwcrypto_cipher_encrypt_decrypt(hwcrypto_t hwcrypto, const uint8_t *in,
+                                           uint8_t *out, uint32_t block_size,
+                                           bool encrypt)
+{
+    /* blocks must be aligned */
+    assert(!((intptr_t) in & 0x03));
+    assert(!((intptr_t) out & 0x03));
+
+    /* block size must be multiple of 16 */
+    if ((block_size % 16) != 0) {
+        return HWCRYPTO_INVALID;
+    }
+
+    /* Swap bytes */
+    dev(hwcrypto)->CR = AES_CR_DATATYPE_1;
+    /* Set chaining mode */
+    dev(hwcrypto)->CR |= chaining_mode(state.mode);
+    /* Copy key */
+    uint32_t *p;
+    int i = 0;
+    if (state.cipher == HWCRYPTO_AES256) {
+        dev(hwcrypto)->CR |= AES_CR_KEYSIZE;
+        p = (uint32_t *)&dev(hwcrypto)->KEYR7;
+        for (; i < 4; i++, p--) {
+            *p = state.key[4 * i + 3] | ((uint32_t) state.key[4 * i + 2] << 8) |
+                    ((uint32_t) state.key[4 * i + 1] << 16) |
+                    ((uint32_t) state.key[4 * i] << 24);
+        }
+    }
+    p = (uint32_t *)&dev(hwcrypto)->KEYR3;
+    for (int j = i + 4; i < j; i++, p--) {
+        *p = state.key[4 * i + 3] | ((uint32_t) state.key[4 * i + 2] << 8) |
+                ((uint32_t) state.key[4 * i + 1] << 16) |
+                ((uint32_t) state.key[4 * i] << 24);
+    }
+    if (!encrypt) {
+        /* Key derivation */
+        if (state.mode == HWCRYPTO_MODE_CBC || state.mode == HWCRYPTO_MODE_ECB) {
+            dev(hwcrypto)->CR |= AES_CR_CCFC;
+            dev(hwcrypto)->CR |= AES_CR_MODE_0;
+            dev(hwcrypto)->CR |= AES_CR_EN;
+            while ((dev(hwcrypto)->SR & AES_SR_CCF) == 0) { }
+        }
+        /* Decryption mode */
+        dev(hwcrypto)->CR &= ~AES_CR_EN;
+        dev(hwcrypto)->CR &= ~AES_CR_MODE;
+        dev(hwcrypto)->CR |= AES_CR_MODE_1;
+        DEBUG("CR=0x%08" PRIX32 "\n", dev(hwcrypto)->CR);
+    }
+    /* Copy IV */
+    if (state.mode == HWCRYPTO_MODE_CBC) {
+        p = (uint32_t *)&dev(hwcrypto)->IVR3;
+        for (int i = 0; i < 4; i++, p--) {
+            *p = state.opts.iv[4 * i + 3] | ((uint32_t) state.opts.iv[4 * i + 2] << 8) |
+                    ((uint32_t) state.opts.iv[4 * i + 1] << 16) |
+                    ((uint32_t) state.opts.iv[4 * i] << 24);
+        }
+    }
+    /* Copy counter */
+    if (state.mode == HWCRYPTO_MODE_CTR) {
+        p = (uint32_t *)&dev(hwcrypto)->IVR3;
+        for (int i = 0; i < 4; i++, p--) {
+            *p = state.opts.counter[4 * i + 3] | ((uint32_t) state.opts.counter[4 * i + 2] << 8) |
+                    ((uint32_t) state.opts.counter[4 * i + 1] << 16) |
+                    ((uint32_t) state.opts.counter[4 * i] << 24);
+        }
+    }
+
+    /* Set-up DMA transfer */
+    dma_acquire(hwcrypto_config[hwcrypto].in_dma);
+    dma_acquire(hwcrypto_config[hwcrypto].out_dma);
+
+    dma_configure(hwcrypto_config[hwcrypto].in_dma, hwcrypto_config[hwcrypto].in_dma_chan,
+                  in, (void *)&dev(hwcrypto)->DINR, block_size,
+                  DMA_MEM_TO_PERIPH, DMA_INC_SRC_ADDR | DMA_DATA_WIDTH_WORD);
+
+    dma_configure(hwcrypto_config[hwcrypto].out_dma, hwcrypto_config[hwcrypto].out_dma_chan,
+                  (const void *)&dev(hwcrypto)->DOUTR, out, block_size,
+                  DMA_PERIPH_TO_MEM, DMA_INC_DST_ADDR | DMA_DATA_WIDTH_WORD);
+
+    dma_start(hwcrypto_config[hwcrypto].in_dma);
+    dma_start(hwcrypto_config[hwcrypto].out_dma);
+
+    dev(hwcrypto)->CR |= AES_CR_EN;
+    dev(hwcrypto)->CR |= AES_CR_DMAINEN | AES_CR_DMAOUTEN;
+
+    dma_wait(hwcrypto_config[hwcrypto].in_dma);
+    dma_wait(hwcrypto_config[hwcrypto].out_dma);
+
+    dma_stop(hwcrypto_config[hwcrypto].in_dma);
+    dma_stop(hwcrypto_config[hwcrypto].out_dma);
+
+    dma_release(hwcrypto_config[hwcrypto].in_dma);
+    dma_release(hwcrypto_config[hwcrypto].out_dma);
+
+    /* Turn off AES */
+    dev(hwcrypto)->CR = 0;
+
+    return block_size;
+}
+
+int hwcrypto_cipher_encrypt(hwcrypto_t dev, const uint8_t *plain_block,
+                            uint8_t *cipher_block, uint32_t block_size)
+{
+    return hwcrypto_cipher_encrypt_decrypt(dev, plain_block, cipher_block, block_size, true);
+}
+
+int hwcrypto_cipher_decrypt(hwcrypto_t dev, const uint8_t *cipher_block,
+                            uint8_t *plain_block, uint32_t block_size)
+{
+    return hwcrypto_cipher_encrypt_decrypt(dev, cipher_block, plain_block, block_size, false);
+}
+
+int hwcrypto_hash_init(hwcrypto_t dev, hwcrypto_hash_t hash)
+{
+    (void) dev;
+    (void) hash;
+
+    return HWCRYPTO_NOTSUP;
+}
+
+int hwcrypto_hash_update(hwcrypto_t dev, const uint8_t *block, uint32_t block_size)
+{
+    (void) dev;
+    (void) block;
+    (void) block_size;
+
+    return HWCRYPTO_NOTSUP;
+}
+
+int hwcrypto_hash_final(hwcrypto_t dev, uint8_t *result, uint32_t result_size)
+{
+    (void) dev;
+    (void) result;
+    (void) result_size;
+
+    return HWCRYPTO_NOTSUP;
+}
+
+int hwcrypto_acquire(hwcrypto_t dev)
+{
+    assert(dev < HWCRYPTO_NUMOF);
+
+    mutex_lock(&hwcrypto_lock);
+
+#ifdef STM32_PM_STOP
+    pm_block(STM32_PM_STOP);
+#endif
+    periph_clk_en(hwcrypto_config[dev].ahbbus, hwcrypto_config[dev].rccmask);
+
+    return HWCRYPTO_OK;
+}
+
+int hwcrypto_release(hwcrypto_t dev)
+{
+    assert(dev < HWCRYPTO_NUMOF);
+
+    periph_clk_dis(hwcrypto_config[dev].ahbbus, hwcrypto_config[dev].rccmask);
+#ifdef STM32_PM_STOP
+    pm_unblock(STM32_PM_STOP);
+#endif
+
+    mutex_unlock(&hwcrypto_lock);
+
+    return HWCRYPTO_OK;
+}

--- a/cpu/stm32_common/periph/uart.c
+++ b/cpu/stm32_common/periph/uart.c
@@ -131,7 +131,7 @@ static inline void send_byte(uart_t uart, uint8_t byte)
 #endif
 }
 
-static inline void wait_for_tx_complete(uart_t uart)
+static void wait_for_tx_complete(uart_t uart)
 {
 #if defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32L0) \
     || defined(CPU_FAM_STM32F3) || defined(CPU_FAM_STM32L4) \

--- a/cpu/stm32_common/periph/uart.c
+++ b/cpu/stm32_common/periph/uart.c
@@ -131,7 +131,7 @@ static inline void send_byte(uart_t uart, uint8_t byte)
 #endif
 }
 
-static void wait_for_tx_complete(uart_t uart)
+static inline void wait_for_tx_complete(uart_t uart)
 {
 #if defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32L0) \
     || defined(CPU_FAM_STM32F3) || defined(CPU_FAM_STM32L4) \

--- a/cpu/stm32f2/Makefile.features
+++ b/cpu/stm32f2/Makefile.features
@@ -1,3 +1,4 @@
+FEATURES_PROVIDED += periph_dma
 FEATURES_PROVIDED += periph_hwrng
 
 -include $(RIOTCPU)/stm32_common/Makefile.features

--- a/cpu/stm32f2/Makefile.features
+++ b/cpu/stm32f2/Makefile.features
@@ -1,4 +1,3 @@
-FEATURES_PROVIDED += periph_dma
 FEATURES_PROVIDED += periph_hwrng
 
 -include $(RIOTCPU)/stm32_common/Makefile.features

--- a/cpu/stm32f4/Makefile.features
+++ b/cpu/stm32f4/Makefile.features
@@ -1,3 +1,4 @@
+FEATURES_PROVIDED += periph_dma
 FEATURES_PROVIDED += periph_hwrng
 
 # the granularity of provided feature definition for STMs is currently by CPU

--- a/cpu/stm32f4/Makefile.features
+++ b/cpu/stm32f4/Makefile.features
@@ -1,4 +1,5 @@
 FEATURES_PROVIDED += periph_hwrng
+FEATURES_PROVIDED += periph_hwcrypto
 
 # the granularity of provided feature definition for STMs is currently by CPU
 # sub-family (e.g., stm32f[1234]).  Unfortunately, only some of e.g., the

--- a/cpu/stm32f4/Makefile.features
+++ b/cpu/stm32f4/Makefile.features
@@ -1,4 +1,3 @@
-FEATURES_PROVIDED += periph_dma
 FEATURES_PROVIDED += periph_hwrng
 
 # the granularity of provided feature definition for STMs is currently by CPU

--- a/cpu/stm32f4/include/cpu_conf.h
+++ b/cpu/stm32f4/include/cpu_conf.h
@@ -25,33 +25,29 @@
 
 #include "cpu_conf_common.h"
 
-#if defined(CPU_MODEL_STM32F401RE)
+#if defined(CPU_LINE_STM32F401)
 #include "vendor/stm32f401xe.h"
-#elif defined(CPU_MODEL_STM32F407VG)
+#elif defined(CPU_LINE_STM32F407)
 #include "vendor/stm32f407xx.h"
-#elif defined(CPU_MODEL_STM32F410RB)
+#elif defined(CPU_LINE_STM32F410)
 #include "vendor/stm32f410rx.h"
-#elif defined(CPU_MODEL_STM32F411RE)
+#elif defined(CPU_LINE_STM32F411)
 #include "vendor/stm32f411xe.h"
-#elif defined(CPU_MODEL_STM32F412ZG)
+#elif defined(CPU_LINE_STM32F412)
 #include "vendor/stm32f412zx.h"
-#elif defined(CPU_MODEL_STM32F413CG) || defined(CPU_MODEL_STM32F413RG) \
-    || defined(CPU_MODEL_STM32F413MG) || defined(CPU_MODEL_STM32F413VG) \
-    || defined(CPU_MODEL_STM32F413ZG) || defined(CPU_MODEL_STM32F413CH) \
-    || defined(CPU_MODEL_STM32F413RH) || defined(CPU_MODEL_STM32F413MH) \
-    || defined(CPU_MODEL_STM32F413VH) || defined(CPU_MODEL_STM32F413ZH)
+#elif defined(CPU_LINE_STM32F413)
 #include "vendor/stm32f413xx.h"
-#elif defined(CPU_MODEL_STM32F415RG)
+#elif defined(CPU_LINE_STM32F415)
 #include "vendor/stm32f415xx.h"
-#elif defined(CPU_MODEL_STM32F423CH) || defined(CPU_MODEL_STM32F423RH) \
-    || defined(CPU_MODEL_STM32F423MH) || defined(CPU_MODEL_STM32F423VH) \
-    || defined(CPU_MODEL_STM32F423ZH)
+#elif defined(CPU_LINE_STM32F423)
 #include "vendor/stm32f423xx.h"
-#elif defined(CPU_MODEL_STM32F429ZI)
+#elif defined(CPU_LINE_STM32F446)
+#include "vendor/stm32f446xx.h"
+#elif defined(CPU_LINE_STM32F429)
 #include "vendor/stm32f429xx.h"
-#elif defined(CPU_MODEL_STM32F437VG)
+#elif defined(CPU_LINE_STM32F437)
 #include "vendor/stm32f437xx.h"
-#elif defined(CPU_MODEL_STM32F446RE) || defined(CPU_MODEL_STM32F446ZE)
+#elif defined(CPU_LINE_STM32F446)
 #include "vendor/stm32f446xx.h"
 #endif
 
@@ -64,27 +60,19 @@ extern "C" {
  * @{
  */
 #define CPU_DEFAULT_IRQ_PRIO            (1U)
-#if defined(CPU_MODEL_STM32F401RE)
+#if defined(CPU_LINE_STM32F401)
 #define CPU_IRQ_NUMOF                   (85U)
-#elif defined(CPU_MODEL_STM32F407VG) || defined(CPU_MODEL_STM32F415RG)
+#elif defined(CPU_LINE_STM32F407) || defined(CPU_LINE_STM32F415)
 #define CPU_IRQ_NUMOF                   (82U)
-#elif defined(CPU_MODEL_STM32F410RB)
+#elif defined(CPU_LINE_STM32F410)
 #define CPU_IRQ_NUMOF                   (98U)
-#elif defined(CPU_MODEL_STM32F411RE)
+#elif defined(CPU_LINE_STM32F411)
 #define CPU_IRQ_NUMOF                   (86U)
-#elif defined(CPU_MODEL_STM32F412ZG) || defined(CPU_MODEL_STM32F446RE) \
-    || defined(CPU_MODEL_STM32F446ZE)
+#elif defined(CPU_LINE_STM32F412) || defined(CPU_LINE_STM32F446)
 #define CPU_IRQ_NUMOF                   (97U)
-#elif defined(CPU_MODEL_STM32F413CG) || defined(CPU_MODEL_STM32F413RG) \
-    || defined(CPU_MODEL_STM32F413MG) || defined(CPU_MODEL_STM32F413VG) \
-    || defined(CPU_MODEL_STM32F413ZG) || defined(CPU_MODEL_STM32F413CH) \
-    || defined(CPU_MODEL_STM32F413RH) || defined(CPU_MODEL_STM32F413MH) \
-    || defined(CPU_MODEL_STM32F413VH) || defined(CPU_MODEL_STM32F413ZH) \
-    || defined(CPU_MODEL_STM32F423CH) || defined(CPU_MODEL_STM32F423RH) \
-    || defined(CPU_MODEL_STM32F423MH) || defined(CPU_MODEL_STM32F423VH) \
-    || defined(CPU_MODEL_STM32F423ZH)
+#elif defined(CPU_LINE_STM32F413) || defined(CPU_LINE_STM32F423)
 #define CPU_IRQ_NUMOF                   (102U)
-#elif defined(CPU_MODEL_STM32F429ZI) || defined(CPU_MODEL_STM32F437VG)
+#elif defined(CPU_LINE_STM32F429) || defined(CPU_LINE_STM32F437)
 #define CPU_IRQ_NUMOF                   (91U)
 #endif
 #define CPU_FLASH_BASE                  FLASH_BASE

--- a/cpu/stm32f4/include/periph_cpu.h
+++ b/cpu/stm32f4/include/periph_cpu.h
@@ -48,20 +48,11 @@ enum {
 /**
  * @brief   Available number of ADC devices
  */
-#if defined(CPU_MODEL_STM32F401RE) || defined(CPU_MODEL_STM32F410RB) \
-    || defined(CPU_MODEL_STM32F411RE) || defined(CPU_MODEL_STM32F412ZG) \
-    || defined(CPU_MODEL_STM32F413CG) || defined(CPU_MODEL_STM32F413RG) \
-    || defined(CPU_MODEL_STM32F413MG) || defined(CPU_MODEL_STM32F413VG) \
-    || defined(CPU_MODEL_STM32F413ZG) || defined(CPU_MODEL_STM32F413CH) \
-    || defined(CPU_MODEL_STM32F413RH) || defined(CPU_MODEL_STM32F413MH) \
-    || defined(CPU_MODEL_STM32F413VH) || defined(CPU_MODEL_STM32F413ZH) \
-    || defined(CPU_MODEL_STM32F423CH) || defined(CPU_MODEL_STM32F423RH) \
-    || defined(CPU_MODEL_STM32F423MH) || defined(CPU_MODEL_STM32F423VH) \
-    || defined(CPU_MODEL_STM32F423ZH)
+#if defined(CPU_LINE_STM32F401) || defined(CPU_LINE_STM32F411) \
+    || defined(CPU_LINE_STM32F413) || defined(CPU_LINE_STM32F423)
 #define ADC_DEVS            (1U)
-#elif defined(CPU_MODEL_STM32F407VG) || defined(CPU_MODEL_STM32F415RG) \
-    || defined(CPU_MODEL_STM32F429ZI) || defined(CPU_MODEL_STM32F437VG) \
-    || defined(CPU_MODEL_STM32F446RE) || defined(CPU_MODEL_STM32F446ZE)
+#elif defined(CPU_LINE_STM32F407) || defined(CPU_LINE_STM32F415) \
+    || defined(CPU_LINE_STM32F446) || defined(CPU_LINE_STM32F429)
 #define ADC_DEVS            (3U)
 #endif
 

--- a/cpu/stm32f4/vectors.c
+++ b/cpu/stm32f4/vectors.c
@@ -186,7 +186,7 @@ ISR_VECTOR(1) const isr_t vector_cpu[CPU_IRQ_NUMOF] = {
     [71] = isr_usart6,               /* [71] USART6 global interrupt */
     [81] = isr_fpu,                  /* [81] FPU global interrupt */
 
-#if defined(CPU_MODEL_STM32F401RE)
+#if defined(CPU_LINE_STM32F401)
     [18] = isr_adc,                  /* [18] ADC1, ADC2 and ADC3 global Interrupts */
     [25] = isr_tim1_up_tim10,        /* [25] TIM1 Update Interrupt and TIM10 global interrupt */
     [28] = isr_tim2,                 /* [28] TIM2 global Interrupt */
@@ -199,7 +199,7 @@ ISR_VECTOR(1) const isr_t vector_cpu[CPU_IRQ_NUMOF] = {
     [72] = isr_i2c3_ev,              /* [72] I2C3 event interrupt */
     [73] = isr_i2c3_er,              /* [73] I2C3 error interrupt */
     [84] = isr_spi4,                 /* [84] SPI4 global Interrupt */
-#elif defined(CPU_MODEL_STM32F407VG)
+#elif defined(CPU_LINE_STM32F407)
     [18] = isr_adc,                  /* [18] ADC1, ADC2 and ADC3 global Interrupts */
     [19] = isr_can1_tx,              /* [19] CAN1 TX Interrupt */
     [20] = isr_can1_rx0,             /* [20] CAN1 RX0 Interrupt */
@@ -236,7 +236,7 @@ ISR_VECTOR(1) const isr_t vector_cpu[CPU_IRQ_NUMOF] = {
     [76] = isr_otg_hs_wkup,          /* [76] USB OTG HS Wakeup through EXTI interrupt */
     [77] = isr_otg_hs,               /* [77] USB OTG HS global interrupt */
     [78] = isr_dcmi,                 /* [78] DCMI global interrupt */
-#elif defined(CPU_MODEL_STM32F410RB)
+#elif defined(CPU_LINE_STM32F410)
     [18] = isr_adc,                  /* [18] ADC1 global Interrupts */
     [25] = isr_tim1_up,              /* [25] TIM1 Update Interrupt */
     [54] = isr_tim6_dac,             /* [54] TIM6 global Interrupt and DAC Global Interrupt */
@@ -245,7 +245,7 @@ ISR_VECTOR(1) const isr_t vector_cpu[CPU_IRQ_NUMOF] = {
     [95] = isr_fmpi2c1_ev,           /* [95] FMPI2C1 Event Interrupt */
     [96] = isr_fmpi2c1_er,           /* [96] FMPI2C1 Error Interrupt */
     [97] = isr_lptim1,               /* [97] LPTIM1 interrupt */
-#elif defined(CPU_MODEL_STM32F411RE)
+#elif defined(CPU_LINE_STM32F411)
     [18] = isr_adc,                  /* [18] ADC1, ADC2 and ADC3 global Interrupts */
     [25] = isr_tim1_up_tim10,        /* [25] TIM1 Update Interrupt and TIM10 global interrupt */
     [28] = isr_tim2,                 /* [28] TIM2 global Interrupt */
@@ -259,7 +259,7 @@ ISR_VECTOR(1) const isr_t vector_cpu[CPU_IRQ_NUMOF] = {
     [73] = isr_i2c3_er,              /* [73] I2C3 error interrupt */
     [84] = isr_spi4,                 /* [84] SPI4 global Interrupt */
     [85] = isr_spi5,                 /* [85] SPI5 global Interrupt */
-#elif defined(CPU_MODEL_STM32F412ZG)
+#elif defined(CPU_LINE_STM32F412)
     [18] = isr_adc,                  /* [18] ADC1, ADC2 and ADC3 global Interrupts */
     [19] = isr_can1_tx,              /* [19] CAN1 TX Interrupt */
     [20] = isr_can1_rx0,             /* [20] CAN1 RX0 Interrupt */
@@ -294,11 +294,7 @@ ISR_VECTOR(1) const isr_t vector_cpu[CPU_IRQ_NUMOF] = {
     [92] = isr_quadspi,              /* [92] QuadSPI global Interrupt */
     [95] = isr_fmpi2c1_ev,           /* [95] FMPI2C1 Event Interrupt */
     [96] = isr_fmpi2c1_er,           /* [96] FMPI2C1 Error Interrupt */
-#elif defined(CPU_MODEL_STM32F413CG) || defined(CPU_MODEL_STM32F413RG) \
-    || defined(CPU_MODEL_STM32F413MG) || defined(CPU_MODEL_STM32F413VG) \
-    || defined(CPU_MODEL_STM32F413ZG) || defined(CPU_MODEL_STM32F413CH) \
-    || defined(CPU_MODEL_STM32F413RH) || defined(CPU_MODEL_STM32F413MH) \
-    || defined(CPU_MODEL_STM32F413VH) || defined(CPU_MODEL_STM32F413ZH)
+#elif defined(CPU_LINE_STM32F413)
     [18] = isr_adc,                  /* [18] ADC1, ADC2 and ADC3 global Interrupts */
     [19] = isr_can1_tx,              /* [19] CAN1 TX Interrupt */
     [20] = isr_can1_rx0,             /* [20] CAN1 RX0 Interrupt */
@@ -349,7 +345,7 @@ ISR_VECTOR(1) const isr_t vector_cpu[CPU_IRQ_NUMOF] = {
     [99] = isr_dfsdm2_flt1,          /* [99] DFSDM2 Filter 1 global Interrupt */
     [100] = isr_dfsdm2_flt2,          /* [100] DFSDM2 Filter 2 global Interrupt */
     [101] = isr_dfsdm2_flt3,          /* [101] DFSDM2 Filter 3 global Interrupt */
-#elif defined(CPU_MODEL_STM32F415RG)
+#elif defined(CPU_LINE_STM32F415)
     [18] = isr_adc,                  /* [18] ADC1, ADC2 and ADC3 global Interrupts */
     [19] = isr_can1_tx,              /* [19] CAN1 TX Interrupt */
     [20] = isr_can1_rx0,             /* [20] CAN1 RX0 Interrupt */
@@ -385,9 +381,7 @@ ISR_VECTOR(1) const isr_t vector_cpu[CPU_IRQ_NUMOF] = {
     [77] = isr_otg_hs,               /* [77] USB OTG HS global interrupt */
     [79] = isr_cryp,                 /* [79] CRYP crypto global interrupt */
     [80] = isr_hash_rng,             /* [80] Hash and Rng global interrupt */
-#elif defined(CPU_MODEL_STM32F423CH) || defined(CPU_MODEL_STM32F423RH) \
-    || defined(CPU_MODEL_STM32F423MH) || defined(CPU_MODEL_STM32F423VH) \
-    || defined(CPU_MODEL_STM32F423ZH)
+#elif defined(CPU_LINE_STM32F423)
     [18] = isr_adc,                  /* [18] ADC1, ADC2 and ADC3 global Interrupts */
     [19] = isr_can1_tx,              /* [19] CAN1 TX Interrupt */
     [20] = isr_can1_rx0,             /* [20] CAN1 RX0 Interrupt */
@@ -439,7 +433,7 @@ ISR_VECTOR(1) const isr_t vector_cpu[CPU_IRQ_NUMOF] = {
     [99] = isr_dfsdm2_flt1,          /* [99] DFSDM2 Filter 1 global Interrupt */
     [100] = isr_dfsdm2_flt2,          /* [100] DFSDM2 Filter 2 global Interrupt */
     [101] = isr_dfsdm2_flt3,          /* [101] DFSDM2 Filter 3 global Interrupt */
-#elif defined(CPU_MODEL_STM32F429ZI)
+#elif defined(CPU_LINE_STM32F429)
     [18] = isr_adc,                  /* [18] ADC1, ADC2 and ADC3 global Interrupts */
     [19] = isr_can1_tx,              /* [19] CAN1 TX Interrupt */
     [20] = isr_can1_rx0,             /* [20] CAN1 RX0 Interrupt */
@@ -485,7 +479,7 @@ ISR_VECTOR(1) const isr_t vector_cpu[CPU_IRQ_NUMOF] = {
     [88] = isr_ltdc,                 /* [88] LTDC global Interrupt */
     [89] = isr_ltdc_er,              /* [89] LTDC Error global Interrupt */
     [90] = isr_dma2d,                /* [90] DMA2D global Interrupt */
-#elif defined(CPU_MODEL_STM32F437VG)
+#elif defined(CPU_LINE_STM32F437)
     [18] = isr_adc,                  /* [18] ADC1, ADC2 and ADC3 global Interrupts */
     [19] = isr_can1_tx,              /* [19] CAN1 TX Interrupt */
     [20] = isr_can1_rx0,             /* [20] CAN1 RX0 Interrupt */
@@ -531,7 +525,7 @@ ISR_VECTOR(1) const isr_t vector_cpu[CPU_IRQ_NUMOF] = {
     [86] = isr_spi6,                 /* [86] SPI6 global Interrupt */
     [87] = isr_sai1,                 /* [87] SAI1 global Interrupt */
     [90] = isr_dma2d,                /* [90] DMA2D global Interrupt */
-#elif defined(CPU_MODEL_STM32F446RE) || defined(CPU_MODEL_STM32F446ZE)
+#elif defined(CPU_LINE_STM32F446)
     [18] = isr_adc,                  /* [18] ADC1, ADC2 and ADC3 global Interrupts */
     [19] = isr_can1_tx,              /* [19] CAN1 TX Interrupt */
     [20] = isr_can1_rx0,             /* [20] CAN1 RX0 Interrupt */

--- a/cpu/stm32f7/Makefile.features
+++ b/cpu/stm32f7/Makefile.features
@@ -1,2 +1,4 @@
+FEATURES_PROVIDED += periph_dma
 FEATURES_PROVIDED += periph_hwrng
+
 -include $(RIOTCPU)/stm32_common/Makefile.features

--- a/cpu/stm32f7/Makefile.features
+++ b/cpu/stm32f7/Makefile.features
@@ -1,4 +1,3 @@
-FEATURES_PROVIDED += periph_dma
 FEATURES_PROVIDED += periph_hwrng
 
 -include $(RIOTCPU)/stm32_common/Makefile.features

--- a/cpu/stm32f7/Makefile.features
+++ b/cpu/stm32f7/Makefile.features
@@ -1,3 +1,2 @@
 FEATURES_PROVIDED += periph_hwrng
-
 -include $(RIOTCPU)/stm32_common/Makefile.features

--- a/drivers/include/periph/hwcrypto.h
+++ b/drivers/include/periph/hwcrypto.h
@@ -1,0 +1,394 @@
+/*
+ * Copyright (C) 2016-2018 Bas Stottelaar <basstottelaar@gmail.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    drivers_periph_hwcrypt Hardware Crypto
+ * @ingroup     drivers_periph
+ * @brief       Low-level hardware crypto peripheral driver
+ *
+ * Modern CPUs may be equipped with a hardware crypto peripheral to speed up
+ * cryptographical operations such as (as)symmetric ciphers and hashing
+ * algorithms. With no or little intervention, the CPU can typically execute
+ * more operations than the software alternative.
+ *
+ * This driver provides an abstract for the different ciphers and hashes that
+ * may be supported. Using HAVE_HWCRYPTO_xxx defines, software may choose to
+ * use the hardware crypto alternative, or fall back to a software variant if
+ * not defined.
+ *
+ * Current interface is optimized for (as)symmetric block ciphers and block
+ * hashes. It supports multiple hardware crypto peripherals, including limited
+ * support.
+ *
+ * All operations block until they are finished. Operations may change the
+ * internal peripheral state (e.g. load the key, keep the digest interally),
+ * therefore must be used to control mutual exclusive access.
+ *
+ * @{
+ * @file
+ * @brief       Low-level hardware crypto driver interface definitions
+ *
+ * @author      Bas Stottelaar <basstottelaar@gmail.com>
+ */
+
+#ifndef HWCRYPTO_H
+#define HWCRYPTO_H
+
+#include <stdint.h>
+
+#include "periph_cpu.h"
+#include "periph_conf.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef HAVE_HWCRYPTO_T
+/**
+ * @brief   Hardware crypto type identifier
+ */
+typedef unsigned int hwcrypto_t;
+#endif
+
+/**
+ * @brief   Supported ciphers.
+ *
+ * Define HAVE_HWCRYPTO_xxx in periph_cpu.h for each supported cipher.
+ *
+ * Extend at will, but also update drivers/periph_common/hwcrypto.c.
+ */
+typedef enum {
+    HWCRYPTO_AES128,                  /**< AES128 cipher */
+    HWCRYPTO_AES192,                  /**< AES192 cipher */
+    HWCRYPTO_AES256,                  /**< AES256 cipher */
+    HWCRYPTO_DES,                     /**< DES cipher */
+    HWCRYPTO_3DES,                    /**< 3DES cipher */
+    HWCRYPTO_TWOFISH,                 /**< Two-fish cipher */
+    HWCRYPTO_RSA512,                  /**< RSA512 cipher */
+    HWCRYPTO_RSA1024,                 /**< RSA1024 cipher */
+    HWCRYPTO_RSA2048,                 /**< RSA2048 cipher */
+    HWCRYPTO_RSA4096,                 /**< RSA4096 cipher */
+    HWCRYPTO_ECC128,                  /**< ECC128 cipher */
+    HWCRYPTO_ECC192,                  /**< ECC192 cipher */
+    HWCRYPTO_ECC256,                  /**< ECC256 cipher */
+    HWCRYPT_CIPHER_NUMOF              /**< number of ciphers available */
+} hwcrypto_cipher_t;
+
+/**
+ * @brief   Supported hashing algorithms.
+ *
+ * Define HAVE_HWCRYPTO_xxx in periph_cpu.h for each supported hashing
+ * algorithm.
+ *
+ * Extend at will, but also update drivers/periph_common/hwcrypto.c.
+ */
+typedef enum {
+    HWCRYPTO_MD4,                     /**< MD4 hashing algorithm */
+    HWCRYPTO_MD5,                     /**< MD5 hashing algorithm */
+    HWCRYPTO_SHA1,                    /**< SHA1 hashing algorithm */
+    HWCRYPTO_SHA3,                    /**< SHA3 hashing algorithm */
+    HWCRYPTO_SHA224,                  /**< SHA224 hashing algorithm */
+    HWCRYPTO_SHA256,                  /**< SHA256 hashing algorithm */
+    HWCRYPTO_SHA384,                  /**< SHA384 hashing algorithm */
+    HWCRYPTO_SHA512,                  /**< SHA512 hashing algorithm */
+    HWCRYPT_HASH_NUMOF                /**< number of hashes available */
+} hwcrypto_hash_t;
+
+/**
+ * @brief   Setup options for cipher and hash methods.
+ *
+ * Extend at will.
+ */
+typedef enum {
+    HWCRYPTO_OPT_KEY,
+    HWCRYPTO_OPT_IV,
+    HWCRYPTO_OPT_COUNTER,
+    HWCRYPTO_OPT_PADDING,
+} hwcrypto_opt_t;
+
+/**
+ * @brief   Supported cipher modes of operation, to be used with
+ *          @p HWCRYPTO_OPT_MODE.
+ *
+ * Extend at will.
+ */
+typedef enum {
+    HWCRYPTO_MODE_NONE,               /**< no mode */
+    HWCRYPTO_MODE_ECB,                /**< electronic codebook mode */
+    HWCRYPTO_MODE_CBC,                /**< cipher block chaining mode */
+    HWCRYPTO_MODE_CFB,                /**< cipher feedback mode */
+    HWCRYPTO_MODE_OFB,                /**< output feedback mode */
+    HWCRYPTO_MODE_CTR                 /**< counter mode */
+} hwcrypto_mode_t;
+
+/**
+ * @brief   Determine if the given hardware crypto peripheral supports the
+ *          given cipher.
+ *
+ * This method should not require the peripheral to be initialized. It will
+ * also not change its state.
+ *
+ * The method should return a deterministic result.
+ *
+ * @param[in] dev           the device
+ * @param[in] cipher        cipher to check
+ *
+ * @return                  nonzero value if supported
+ * @return                  0 if unsupported
+ */
+int hwcrypto_cipher_supported(hwcrypto_t dev, hwcrypto_cipher_t cipher);
+
+/**
+ * @brief   Determine if the given hardware crypto peripheral supports the
+ *          given hashing algorithm.
+ *
+ * This method should not require the peripheral to be initialized. It will
+ * also not change its state.
+ *
+ * The method should return a deterministic result.
+ *
+ * @param[in] dev           the device
+ * @param[in] hash          hashing algorithm to check
+ *
+ * @return                  nonzero value if supported
+ * @return                  0 if unsupported
+ */
+int hwcrypto_hash_supported(hwcrypto_t dev, hwcrypto_hash_t hash);
+
+/**
+ * @brief   Initialize the hardware crypto peripheral.
+ *
+ * The peripheral should be turned on in this method.
+ *
+ * @param[in] dev           the device to initialize
+ *
+ * @return                  0 on success
+ * @return                  -1 if an error occurs
+ */
+int hwcrypto_init(hwcrypto_t dev);
+
+/**
+ * @brief   Initialize hardware crypto device for a given encryption or
+ *          decryption algorithm.
+ *
+ * The implementation must use a key (size) as defined by the cipher. It must
+ * not apply a different key scheduling algorithm.
+ *
+ * The mode parameter can be used to change the cipher's mode of operation. If
+ * a mode does not apply, use @p HWCRYPTO_MODE_NONE.
+ *
+ * This operation may alter the peripheral's state, therefore it should be used
+ * exclusively. A peripheral may become uninitialized after it is powered off
+ * and on inbetween.
+ *
+ * @param[in] dev           the device to initialize
+ * @param[in] cipher        cipher to initialize
+ * @param[in] mode          cipher mode of operation.
+ *
+ * @return                  0 on success
+ * @return                  -1 if cipher is not supported
+ * @return                  -2 if device could not be prepared
+ */
+int hwcrypto_cipher_init(hwcrypto_t dev,
+                         hwcrypto_cipher_t cipher,
+                         hwcrypto_mode_t mode);
+
+/**
+ * @brief   Set an option for the given hardware crypto device in cipher mode.
+ *
+ * If the given option or value is not supported by the cipher, an error code
+ * is returned.
+ *
+ * This operation may alter the peripheral's state, therefore it should be used
+ * exclusively. A peripheral may become uninitialized after it is powered off
+ * and on inbetween.
+ *
+ * The peripheral's state is undefined if this method is used after one or more
+ * encryption or decryption round(s).
+ *
+ * A hardware crypto device not initialized for cipher mode may produce
+ * unexpected results.
+ *
+ * @param[in] dev           the device to initialize
+ * @param[in] option        option from @p hwcrypto_opt_t to initialize
+ * @param[in] value         pointer to option value
+ * @param[in] size          option size
+ *
+ * @return                  0 on success
+ * @return                  -1 if option is not supported or applicable
+ * @return                  -2 if value is not supported or applicable
+ */
+int hwcrypto_cipher_set(hwcrypto_t dev,
+                        hwcrypto_opt_t option,
+                        const void* value,
+                        uint32_t size);
+
+/**
+ * @brief   Perform a cipher encrypt operation for an initialized hardware
+ *          crypto device in cipher mode.
+ *
+ * The plain block may overlap with the cipher block, but not partially.
+ *
+ * The method must accept block sizes that are a multiple of the smallest block
+ * size. This allows for minimal CPU intervention for large blocks of data.
+ *
+ * This operation may alter the peripheral's state, therefore it should be used
+ * exclusively. A peripheral may become uninitialized after it is powered off
+ * and on inbetween.
+ *
+ * A hardware crypto device not initialized for cipher mode may produce
+ * unexpected results.
+ *
+ * @param[in] dev           the device to initialize
+ * @param[in] plain_block   the plain input buffer
+ * @param[out] cipher_block the cipher output buffer (may overlap plain_block)
+ * @param[in] block_size    size of the plain_block and cipher_block in bytes
+ *
+ * @return                  0 on success
+ * @return                  -1 if cipher operation not supported
+ * @return                  -2 if block_size is invalid
+ */
+int hwcrypto_cipher_encrypt(hwcrypto_t dev,
+                            const uint8_t *plain_block,
+                            uint8_t *cipher_block,
+                            uint32_t block_size);
+
+/**
+ * @brief   Perform a cipher decrypt operation for an initialized hardware
+ *          crypto device in cipher mode
+ *
+ * The cipher block may overlap with the plain block, but not partially.
+ *
+ * The method must accept block sizes that are a multiple of the smallest block
+ * size. This allows for minimal CPU intervention for large blocks of data.
+ *
+ * This operation may alter the peripheral's state, therefore it should be used
+ * exclusively. A peripheral may become uninitialized after it is powered off
+ * and on inbetween.
+ *
+ * A hardware crypto device not initialized for cipher mode may produce
+ * unexpected results.
+ *
+ * @param[in] dev           the device to initialize
+ * @param[in] cipher_block  the cipher input buffer
+ * @param[out] plain_block  the plain output buffer (may overlap cipher_block)
+ * @param[in] block_size    size of the cipher_block and plain_block in bytes
+ *
+ * @return                  0 on success
+ * @return                  -1 if cipher operation not supported
+ * @return                  -2 if block_size is invalid
+ */
+int hwcrypto_cipher_decrypt(hwcrypto_t dev,
+                            const uint8_t *cipher_block,
+                            uint8_t *plain_block,
+                            uint32_t block_size);
+
+/**
+ * @brief   Initialize hardware crypto device for a given hashing algorithm.
+ *
+ * This operation may alter the peripheral's state, therefore it should be used
+ * exclusively. A peripheral may become uninitialized after it is powered off
+ * and on inbetween.
+ *
+ * @param[in] dev           the device to initialize
+ * @param[in] hash          desired hash algorithm
+ *
+ * @return                  0 on success
+ * @return                  -1 if hash is not supported
+ * @return                  -2 if device could not be prepared
+ */
+int hwcrypto_hash_init(hwcrypto_t dev, hwcrypto_hash_t hash);
+
+/**
+ * @brief   Update the digest with a block of data.
+ *
+ * This operation may alter the peripheral's state, therefore it should be used
+ * exclusively. A peripheral may become uninitialized after it is powered off
+ * and on inbetween.
+ *
+ * A hardware crypto device not initialized for hashing may produce unexpected
+ * results.
+ *
+ * @param[in] dev           the device to initialize
+ * @param[in] block         block of data to update digest with
+ * @param[in] block_size    number of bytes in data block
+ *
+ * @return                  number of bytes added to digest
+ * @return                  -1 if hash is not supported
+ * @return                  -2 if block_size is incorrect
+ * @return                  -3 if digest could not be updated
+ */
+int hwcrypto_hash_update(hwcrypto_t dev,
+                         const uint8_t* block,
+                         uint32_t block_size);
+
+/**
+ * @brief   Finalize the hash and copy the result to result buffer.
+ *
+ * This operation may alter the peripheral's state, therefore it should be used
+ * exclusively. A peripheral may become uninitialized after it is powered off
+ * and on inbetween.
+ *
+ * A hardware crypto device not initialized for hashing may produce unexpected
+ * results.
+ *
+ * @param[in] dev           the device to initialize
+ * @param[out] cipher       result output buffer
+ * @param[in] result_size   number of bytes to copy from digest to result
+ *
+ * @return                  number of bytes copied
+ * @return                  -1 if hash is not supported
+ * @returned                -2 if @p result_size exceeds hash size
+ */
+int hwcrypto_hash_final(hwcrypto_t dev,
+                        uint8_t* result,
+                        uint32_t result_size);
+
+/**
+ * @brief   Get mutually exclusive access to the hardware crypto peripheral.
+ *
+ * In case the peripheral is busy, this function will block until the
+ * peripheral is available again.
+ *
+ * @param[in] dev           the device to initialize
+ *
+ * @return                  0 on success
+ * @return                  -1 on error
+ */
+int hwcrypto_acquire(hwcrypto_t dev);
+
+/**
+ * @brief   Release the hardware crypto peripheral to be used by others.
+ *
+ * @param[in] dev           the device to initialize
+ *
+ * @return                  0 on success
+ * @return                  -1 on error
+ */
+int hwcrypto_release(hwcrypto_t dev);
+
+/**
+ * @brief   Power on the hardware crypto peripheral.
+ *
+ * @param[in] dev           the device to initialize
+ */
+void hwcrypto_poweron(hwcrypto_t dev);
+
+/**
+ * @brief   Power off the hardware crypto peripheral.
+ *
+ * @param[in] dev           the device to initialize
+ */
+void hwcrypto_poweroff(hwcrypto_t dev);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* HWCRYPTO_H */
+/** @} */

--- a/drivers/periph_common/hwcrypto.c
+++ b/drivers/periph_common/hwcrypto.c
@@ -24,7 +24,7 @@
 /**
  * @brief Bitmap of supported ciphers.
  */
-static uint32_t cipher_bitmap = (
+static const uint32_t cipher_bitmap = (
 #ifdef HAVE_HWCRYPTO_AES128
     (1 << HWCRYPTO_AES128) +
 #endif
@@ -66,7 +66,7 @@ static uint32_t cipher_bitmap = (
 #endif
     0);
 
-inline int hwcrypto_cipher_supported(hwcrypto_t dev, hwcrypto_cipher_t cipher)
+inline bool hwcrypto_cipher_supported(hwcrypto_t dev, hwcrypto_cipher_t cipher)
 {
     (void) dev;
 
@@ -78,7 +78,7 @@ inline int hwcrypto_cipher_supported(hwcrypto_t dev, hwcrypto_cipher_t cipher)
 /**
  * @brief Bitmap of supported hashes.
  */
-static uint32_t hash_bitmap = (
+static const uint32_t hash_bitmap = (
 #ifdef HAVE_HWCRYPTO_MD4
     (1 << HWCRYPTO_MD4) +
 #endif
@@ -105,7 +105,7 @@ static uint32_t hash_bitmap = (
 #endif
     0);
 
-inline int hwcrypto_hash_supported(hwcrypto_t dev, hwcrypto_hash_t hash)
+inline bool hwcrypto_hash_supported(hwcrypto_t dev, hwcrypto_hash_t hash)
 {
     (void) dev;
 

--- a/drivers/periph_common/hwcrypto.c
+++ b/drivers/periph_common/hwcrypto.c
@@ -1,0 +1,114 @@
+/*
+ * Copyright (C) 2016-2018 Bas Stottelaar <basstottelaar@gmail.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers
+ * @{
+ *
+ * @file
+ * @brief       Shared hardware crypto code
+ *
+ * @author      Bas Stottelaar <basstottelaar@gmail.com>
+ *
+ * @}
+ */
+
+#include "periph/hwcrypto.h"
+
+#ifndef PERIPH_HWCRYPTO_PROVIDES_CIPHER_SUPPORTED
+/**
+ * @brief Bitmap of supported ciphers.
+ */
+static uint32_t cipher_bitmap = (
+#ifdef HAVE_HWCRYPTO_AES128
+    (1 << HWCRYPTO_AES128) +
+#endif
+#ifdef HAVE_HWCRYPTO_AES192
+    (1 << HWCRYPTO_AES192) +
+#endif
+#ifdef HAVE_HWCRYPTO_AES256
+    (1 << HWCRYPTO_AES256) +
+#endif
+#ifdef HAVE_HWCRYPTO_DES
+    (1 << HWCRYPTO_DES) +
+#endif
+#ifdef HAVE_HWCRYPTO_3DES
+    (1 << HWCRYPTO_3DES) +
+#endif
+#ifdef HAVE_HWCRYPTO_TWOFISH
+    (1 << HWCRYPTO_TWOFISH) +
+#endif
+#ifdef HAVE_HWCRYPTO_RSA512
+    (1 << HWCRYPTO_RSA512) +
+#endif
+#ifdef HAVE_HWCRYPTO_RSA1024
+    (1 << HWCRYPTO_RSA1024) +
+#endif
+#ifdef HAVE_HWCRYPTO_RSA2048
+    (1 << HWCRYPTO_RSA2048) +
+#endif
+#ifdef HAVE_HWCRYPTO_RSA4096
+    (1 << HWCRYPTO_RSA4096) +
+#endif
+#ifdef HAVE_HWCRYPTO_ECC128
+    (1 << HWCRYPTO_ECC128) +
+#endif
+#ifdef HAVE_HWCRYPTO_ECC192
+    (1 << HWCRYPTO_ECC192) +
+#endif
+#ifdef HAVE_HWCRYPTO_ECC256
+    (1 << HWCRYPTO_ECC256) +
+#endif
+    0);
+
+inline int hwcrypto_cipher_supported(hwcrypto_t dev, hwcrypto_cipher_t cipher)
+{
+    (void) dev;
+
+    return cipher_bitmap & (1 << cipher);
+}
+#endif /* PERIPH_HWCRYPTO_PROVIDES_CIPHER_SUPPORTED */
+
+#ifndef PERIPH_HWCRYPTO_PROVIDES_HASH_SUPPORTED
+/**
+ * @brief Bitmap of supported hashes.
+ */
+static uint32_t hash_bitmap = (
+#ifdef HAVE_HWCRYPTO_MD4
+    (1 << HWCRYPTO_MD4) +
+#endif
+#ifdef HAVE_HWCRYPTO_MD5
+    (1 << HWCRYPTO_MD5) +
+#endif
+#ifdef HAVE_HWCRYPTO_SHA1
+    (1 << HWCRYPTO_SHA1) +
+#endif
+#ifdef HAVE_HWCRYPTO_SHA3
+    (1 << HWCRYPTO_SHA3) +
+#endif
+#ifdef HAVE_HWCRYPTO_SHA224
+    (1 << HWCRYPTO_SHA224) +
+#endif
+#ifdef HAVE_HWCRYPTO_SHA256
+    (1 << HWCRYPTO_SHA256) +
+#endif
+#ifdef HAVE_HWCRYPTO_SHA384
+    (1 << HWCRYPTO_SHA384) +
+#endif
+#ifdef HAVE_HWCRYPTO_SHA512
+    (1 << HWCRYPTO_SHA512) +
+#endif
+    0);
+
+inline int hwcrypto_hash_supported(hwcrypto_t dev, hwcrypto_hash_t hash)
+{
+    (void) dev;
+
+    return hash_bitmap & (1 << hash);
+}
+#endif /* PERIPH_HWCRYPTO_PROVIDES_HASH_SUPPORTED */

--- a/drivers/periph_common/init.c
+++ b/drivers/periph_common/init.c
@@ -16,6 +16,7 @@
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ * @author      Bas Stottelaar <basstottelaar@gmail.com>
  *
  * @}
  */
@@ -25,6 +26,9 @@
 #endif
 #ifdef MODULE_PERIPH_RTC
 #include "periph/rtc.h"
+#endif
+#ifdef MODULE_PERIPH_HWCRYPTO
+#include "periph/hwcrypto.h"
 #endif
 #ifdef MODULE_PERIPH_HWRNG
 #include "periph/hwrng.h"
@@ -42,6 +46,13 @@ void periph_init(void)
     /* Initialize RTC */
 #ifdef MODULE_PERIPH_RTC
     rtc_init();
+#endif
+
+#ifdef MODULE_PERIPH_HWCRYPTO
+    /* initialize hardware crypto devices */
+    for (unsigned i = 0; i < HWCRYPTO_NUMOF; i++) {
+        hwcrypto_init(HWCRYPTO_DEV(i));
+    }
 #endif
 
 #ifdef MODULE_PERIPH_HWRNG

--- a/tests/periph_hwcrypto/Makefile
+++ b/tests/periph_hwcrypto/Makefile
@@ -1,5 +1,5 @@
 APPLICATION = periph_hwcrypto
-BOARD ?= stk3600
+BOARD ?= native
 include ../Makefile.tests_common
 
 FEATURES_REQUIRED = periph_hwcrypto

--- a/tests/periph_hwcrypto/Makefile
+++ b/tests/periph_hwcrypto/Makefile
@@ -1,0 +1,7 @@
+APPLICATION = periph_hwcrypto
+BOARD ?= stk3600
+include ../Makefile.tests_common
+
+FEATURES_REQUIRED = periph_hwcrypto
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/periph_hwcrypto/Makefile
+++ b/tests/periph_hwcrypto/Makefile
@@ -2,6 +2,6 @@ APPLICATION = periph_hwcrypto
 BOARD ?= native
 include ../Makefile.tests_common
 
-FEATURES_REQUIRED = periph_hwcrypto
+FEATURES_REQUIRED += periph_hwcrypto
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/periph_hwcrypto/README.md
+++ b/tests/periph_hwcrypto/README.md
@@ -1,0 +1,8 @@
+Expected result
+===============
+You should be presented with the RIOT shell, providing you with commands to initialize a board
+as master or slave, and to send and receive data via SPI.
+
+Background
+==========
+Test for the low-level SPI driver.

--- a/tests/periph_hwcrypto/README.md
+++ b/tests/periph_hwcrypto/README.md
@@ -1,8 +1,10 @@
 Expected result
 ===============
-You should be presented with the RIOT shell, providing you with commands to initialize a board
-as master or slave, and to send and receive data via SPI.
+This application will run all supported hardware accelerated ciphers and hashing algorithms.
+
+For the ones supported, no error should be raised. Note that this test only checks if the
+implementation works, and does not verify results against reference results.
 
 Background
 ==========
-Test for the low-level SPI driver.
+Test for the low-level hardware crypto driver.

--- a/tests/periph_hwcrypto/main.c
+++ b/tests/periph_hwcrypto/main.c
@@ -1,0 +1,262 @@
+/*
+ * Copyright (C) 2016-2018 Bas Stottelaar <basstottelaar@gmail.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Hardware crypto device tests.
+ *
+ * @author      Bas Stottelaar <basstottelaar@gmail.com>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "periph/hwcrypto.h"
+
+/**
+ * @brief   Dummy data buffer.
+ */
+static uint8_t data[32] __attribute__((aligned));
+
+/**
+ * @brief   Dummy key.
+ */
+static uint8_t key[32] __attribute__((aligned));
+
+/**
+ * @brief   Dummy initialization vector.
+ */
+static uint8_t iv[32] __attribute__((aligned));
+
+/**
+ * @brief   Dummy counter vector.
+ */
+static uint8_t counter[32] __attribute__((aligned));
+
+#if defined(HAVE_HWCRYPTO_AES128) || defined(HAVE_HWCRYPTO_AES256)
+static void test_cipher(hwcrypto_t dev, char *name, hwcrypto_cipher_t cipher, hwcrypto_mode_t mode, uint8_t key_size, uint8_t block_size)
+{
+    int result;
+
+    printf("Testing %s\n", name);
+
+    /* check if hash is supported */
+    if (!hwcrypto_cipher_supported(dev, cipher)) {
+        puts("Cipher not supported.");
+        return;
+    }
+
+    /* initialize hwcrypto module */
+    result = hwcrypto_init(dev);
+
+    if (result != 0) {
+        printf("Unable to init: %d\n", result);
+        return;
+    }
+
+    /* turn it on */
+    hwcrypto_poweron(dev);
+
+    /* acquire hwcrypto module */
+    result = hwcrypto_acquire(dev);
+
+    if (result != 0) {
+        printf("Unable to acquire: %d\n", result);
+        hwcrypto_release(dev);
+
+        return;
+    }
+
+    /* initialize cipher */
+    result = hwcrypto_cipher_init(dev, cipher, mode);
+
+    if (result != 0) {
+        printf("Unable to init cipher: %d\n", result);
+        hwcrypto_release(dev);
+
+        return;
+    }
+
+    result = hwcrypto_cipher_set(dev, HWCRYPTO_OPT_KEY, key, key_size);
+
+    if (result != 0) {
+        printf("Unable to set key: %d\n", result);
+        hwcrypto_release(dev);
+
+        return;
+    }
+
+    if (mode == HWCRYPTO_MODE_CBC || mode == HWCRYPTO_MODE_CFB || mode == HWCRYPTO_MODE_OFB) {
+        result = hwcrypto_cipher_set(dev, HWCRYPTO_OPT_IV, iv, 16);
+
+        if (result != 0) {
+            printf("Unable to set iv: %d\n", result);
+            hwcrypto_release(dev);
+
+            return;
+        }
+    }
+    else if (mode == HWCRYPTO_MODE_CTR) {
+        result = hwcrypto_cipher_set(dev, HWCRYPTO_OPT_COUNTER, counter, 16);
+
+        if (result != 0) {
+            printf("Unable to set counter: %d\n", result);
+            hwcrypto_release(dev);
+
+            return;
+        }
+    }
+
+    /* test encryption */
+    result = hwcrypto_cipher_encrypt(dev, data, data, block_size);
+
+    if (result != block_size) {
+        printf("Unable to encrypt: %d\n", result);
+        hwcrypto_release(dev);
+
+        return;
+    }
+
+    /* test decryption */
+    result = hwcrypto_cipher_decrypt(dev, data, data, block_size);
+
+    if (result != block_size) {
+        printf("Unable to decrypt: %d\n", result);
+        hwcrypto_release(dev);
+
+        return;
+    }
+
+    /* release it */
+    hwcrypto_release(dev);
+
+    /* power it off */
+    hwcrypto_poweroff(dev);
+}
+#endif
+
+#if defined(HAVE_HWCRYPTO_SHA1) || defined(HAVE_HWCRYPTO_SHA256)
+static void test_hash(hwcrypto_t dev, char *name, hwcrypto_hash_t hash, uint8_t block_size)
+{
+    int result;
+
+    printf("Testing %s\n", name);
+
+    /* check if hash is supported */
+    if (!hwcrypto_hash_supported(dev, hash)) {
+        puts("Hash not supported.");
+        return;
+    }
+
+    /* initialize hwcrypto module */
+    result = hwcrypto_init(dev);
+
+    if (result != 0) {
+        printf("Unable to init: %d\n", result);
+        return;
+    }
+
+    /* turn it on */
+    hwcrypto_poweron(dev);
+
+    /* acquire hwcrypto module */
+    result = hwcrypto_acquire(dev);
+
+    if (result != 0) {
+        printf("Unable to acquire: %d\n", result);
+        hwcrypto_release(dev);
+
+        return;
+    }
+
+    /* initialize hash */
+    result = hwcrypto_hash_init(dev, hash);
+
+    if (result != 0) {
+        printf("Unable to init hash: %d\n", result);
+        hwcrypto_release(dev);
+
+        return;
+    }
+
+    /* test hashing */
+    result = hwcrypto_hash_update(dev, data, block_size);
+
+    if (result != block_size) {
+        printf("Unable to hash: %d\n", result);
+        hwcrypto_release(dev);
+
+        return;
+    }
+
+    result = hwcrypto_hash_final(dev, data, block_size);
+
+    if (result != block_size) {
+        printf("Unable to finalize hash: %d\n", result);
+        hwcrypto_release(dev);
+
+        return;
+    }
+
+    /* release it */
+    hwcrypto_release(dev);
+
+    /* power it off */
+    hwcrypto_poweroff(dev);
+}
+#endif
+
+int main(void)
+{
+    puts("HWCRYPTO peripheral driver test\n");
+    puts("In this test, the supported cipher and hash functions will be "
+         "tested on each hardware crypto peripheral. It will test the "
+         "implementation only, not the results.\n");
+
+    /* run a test for every hardware crypto peripheral */
+    for (int i = 0; i < (int) HWCRYPTO_NUMOF; i++) {
+        hwcrypto_t dev = (hwcrypto_t) i;
+
+#ifdef HAVE_HWCRYPTO_AES128
+        /* AES-128 tests */
+        test_cipher(dev, "AES-128 ECB", HWCRYPTO_AES128, HWCRYPTO_MODE_ECB, 16, 16);
+        test_cipher(dev, "AES-128 CBC", HWCRYPTO_AES128, HWCRYPTO_MODE_CBC, 16, 16);
+        test_cipher(dev, "AES-128 CFB", HWCRYPTO_AES128, HWCRYPTO_MODE_CFB, 16, 16);
+        test_cipher(dev, "AES-128 OFB", HWCRYPTO_AES128, HWCRYPTO_MODE_OFB, 16, 16);
+        test_cipher(dev, "AES-128 CTR", HWCRYPTO_AES128, HWCRYPTO_MODE_CTR, 16, 16);
+#endif
+
+#ifdef HAVE_HWCRYPTO_AES256
+        /* AES-256 tests */
+        test_cipher(dev, "AES-256 ECB", HWCRYPTO_AES256, HWCRYPTO_MODE_ECB, 32, 16);
+        test_cipher(dev, "AES-256 CBC", HWCRYPTO_AES256, HWCRYPTO_MODE_CBC, 32, 16);
+        test_cipher(dev, "AES-256 CFB", HWCRYPTO_AES256, HWCRYPTO_MODE_CFB, 32, 16);
+        test_cipher(dev, "AES-256 OFB", HWCRYPTO_AES256, HWCRYPTO_MODE_OFB, 32, 16);
+        test_cipher(dev, "AES-256 CTR", HWCRYPTO_AES256, HWCRYPTO_MODE_CTR, 32, 16);
+#endif
+
+#ifdef HAVE_HWCRYPTO_SHA1
+        /* SHA-1 tests */
+        test_hash(dev, "SHA-1", HWCRYPTO_SHA1, 20);
+#endif
+
+#ifdef HAVE_HWCRYPTO_SHA256
+        /* SHA-256 tests */
+        test_hash(dev, "SHA-256", HWCRYPTO_SHA256, 32);
+#endif
+    }
+
+    puts("Testing done!\n");
+
+    return 0;
+}

--- a/tests/periph_hwcrypto/main.c
+++ b/tests/periph_hwcrypto/main.c
@@ -56,21 +56,10 @@ static void test_cipher(hwcrypto_t dev, char *name, hwcrypto_cipher_t cipher, hw
         return;
     }
 
-    /* initialize hwcrypto module */
-    result = hwcrypto_init(dev);
-
-    if (result != 0) {
-        printf("Unable to init: %d\n", result);
-        return;
-    }
-
-    /* turn it on */
-    hwcrypto_poweron(dev);
-
     /* acquire hwcrypto module */
     result = hwcrypto_acquire(dev);
 
-    if (result != 0) {
+    if (result != HWCRYPTO_OK) {
         printf("Unable to acquire: %d\n", result);
         hwcrypto_release(dev);
 
@@ -80,7 +69,7 @@ static void test_cipher(hwcrypto_t dev, char *name, hwcrypto_cipher_t cipher, hw
     /* initialize cipher */
     result = hwcrypto_cipher_init(dev, cipher, mode);
 
-    if (result != 0) {
+    if (result != HWCRYPTO_OK) {
         printf("Unable to init cipher: %d\n", result);
         hwcrypto_release(dev);
 
@@ -89,7 +78,7 @@ static void test_cipher(hwcrypto_t dev, char *name, hwcrypto_cipher_t cipher, hw
 
     result = hwcrypto_cipher_set(dev, HWCRYPTO_OPT_KEY, key, key_size);
 
-    if (result != 0) {
+    if (result != HWCRYPTO_OK) {
         printf("Unable to set key: %d\n", result);
         hwcrypto_release(dev);
 
@@ -99,7 +88,7 @@ static void test_cipher(hwcrypto_t dev, char *name, hwcrypto_cipher_t cipher, hw
     if (mode == HWCRYPTO_MODE_CBC || mode == HWCRYPTO_MODE_CFB || mode == HWCRYPTO_MODE_OFB) {
         result = hwcrypto_cipher_set(dev, HWCRYPTO_OPT_IV, iv, 16);
 
-        if (result != 0) {
+        if (result != HWCRYPTO_OK) {
             printf("Unable to set iv: %d\n", result);
             hwcrypto_release(dev);
 
@@ -109,7 +98,7 @@ static void test_cipher(hwcrypto_t dev, char *name, hwcrypto_cipher_t cipher, hw
     else if (mode == HWCRYPTO_MODE_CTR) {
         result = hwcrypto_cipher_set(dev, HWCRYPTO_OPT_COUNTER, counter, 16);
 
-        if (result != 0) {
+        if (result != HWCRYPTO_OK) {
             printf("Unable to set counter: %d\n", result);
             hwcrypto_release(dev);
 
@@ -139,9 +128,6 @@ static void test_cipher(hwcrypto_t dev, char *name, hwcrypto_cipher_t cipher, hw
 
     /* release it */
     hwcrypto_release(dev);
-
-    /* power it off */
-    hwcrypto_poweroff(dev);
 }
 #endif
 
@@ -158,21 +144,10 @@ static void test_hash(hwcrypto_t dev, char *name, hwcrypto_hash_t hash, uint8_t 
         return;
     }
 
-    /* initialize hwcrypto module */
-    result = hwcrypto_init(dev);
-
-    if (result != 0) {
-        printf("Unable to init: %d\n", result);
-        return;
-    }
-
-    /* turn it on */
-    hwcrypto_poweron(dev);
-
     /* acquire hwcrypto module */
     result = hwcrypto_acquire(dev);
 
-    if (result != 0) {
+    if (result != HWCRYPTO_OK) {
         printf("Unable to acquire: %d\n", result);
         hwcrypto_release(dev);
 
@@ -182,7 +157,7 @@ static void test_hash(hwcrypto_t dev, char *name, hwcrypto_hash_t hash, uint8_t 
     /* initialize hash */
     result = hwcrypto_hash_init(dev, hash);
 
-    if (result != 0) {
+    if (result != HWCRYPTO_OK) {
         printf("Unable to init hash: %d\n", result);
         hwcrypto_release(dev);
 
@@ -210,9 +185,6 @@ static void test_hash(hwcrypto_t dev, char *name, hwcrypto_hash_t hash, uint8_t 
 
     /* release it */
     hwcrypto_release(dev);
-
-    /* power it off */
-    hwcrypto_poweroff(dev);
 }
 #endif
 
@@ -225,7 +197,7 @@ int main(void)
 
     /* run a test for every hardware crypto peripheral */
     for (int i = 0; i < (int) HWCRYPTO_NUMOF; i++) {
-        hwcrypto_t dev = (hwcrypto_t) i;
+        hwcrypto_t dev = HWCRYPTO_DEV(i);
 
 #ifdef HAVE_HWCRYPTO_AES128
         /* AES-128 tests */

--- a/tests/periph_hwcrypto/main.c
+++ b/tests/periph_hwcrypto/main.c
@@ -26,7 +26,7 @@
 /**
  * @brief   Dummy data buffer.
  */
-static uint8_t data[32] __attribute__((aligned));
+static uint8_t data[64] __attribute__((aligned));
 
 /**
  * @brief   Dummy key.
@@ -222,9 +222,24 @@ int main(void)
         test_hash(dev, "SHA-1", HWCRYPTO_SHA1, 20);
 #endif
 
+#ifdef HAVE_HWCRYPTO_SHA224
+        /* SHA-224 tests */
+        test_hash(dev, "SHA-224", HWCRYPTO_SHA224, 28);
+#endif
+
 #ifdef HAVE_HWCRYPTO_SHA256
         /* SHA-256 tests */
         test_hash(dev, "SHA-256", HWCRYPTO_SHA256, 32);
+#endif
+
+#ifdef HAVE_HWCRYPTO_SHA384
+        /* SHA-384 tests */
+        test_hash(dev, "SHA-384", HWCRYPTO_SHA384, 48);
+#endif
+
+#ifdef HAVE_HWCRYPTO_SHA512
+        /* SHA-512 tests */
+        test_hash(dev, "SHA-512", HWCRYPTO_SHA512, 64);
 #endif
     }
 


### PR DESCRIPTION

### Contribution description

This is a try to implement #8775 with stm32. It seems there are different hwcrypto periphs among stm32 families. The one I tried is on stm32f423, but it seems to be the same as on stm32l series (I didn't check it thoroughly though).

### Issues/PRs references

Based on #8775 (hwcrypto), #9096 (stm32f423) and #7658 (DMA)