### PR TITLE
cpu/lpc2387: Fixed broken SPI driver

### DIFF
--- a/cpu/lpc2387/periph/spi.c
+++ b/cpu/lpc2387/periph/spi.c
@@ -47,8 +47,6 @@ void spi_init(spi_t bus)
 {
     assert(bus == SPI_DEV(0));
 
-    /* interface setup */
-    SSP0CR0 = 7;
     /* configure pins */
     spi_init_pins(bus);
     /*  power off the bus (default is on) */
@@ -81,6 +79,8 @@ int spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t clk)
     mutex_lock(&lock);
     /*  power on */
     PCONP |= (PCSSP0);
+    /* interface setup */
+    SSP0CR0 = 7;
 
     /* configure bus clock */
     lpc2387_pclk_scale(CLOCK_CORECLOCK / 1000, (uint32_t)clk, &pclksel, &cpsr);


### PR DESCRIPTION
In commit 513b20ffd328934c58af169e2bce0c0a01eddee2 the SPI API was changed to
power up an configure the SPI bus on spi_acquire(). Sadly, the lpc2387 SPI
apparently needs to be reconfigured after each power up. This commit moves
the initialization code from spi_init() to spi_acquire() and restores the
order of initialization steps as before said commit.

With this commit, the CC1100 transceiver of the MSBA2 board becomes usable
again.

This fixes Issue https://github.com/RIOT-OS/RIOT/issues/6857