### PR TITLE
cpu/stm32-common: add support for lpuart

### DIFF
--- a/boards/b-l072z-lrwan1/include/periph_conf.h
+++ b/boards/b-l072z-lrwan1/include/periph_conf.h
@@ -81,7 +81,9 @@ static const uart_conf_t uart_config[] = {
         .rx_af      = GPIO_AF4,
         .tx_af      = GPIO_AF4,
         .bus        = APB1,
-        .irqn       = USART2_IRQn
+        .irqn       = USART2_IRQn,
+        .type       = STM32_USART,
+        .clk_src    = 0, /* Use APB clock */
     },
     {
         .dev        = USART1,
@@ -91,7 +93,9 @@ static const uart_conf_t uart_config[] = {
         .rx_af      = GPIO_AF4,
         .tx_af      = GPIO_AF4,
         .bus        = APB2,
-        .irqn       = USART1_IRQn
+        .irqn       = USART1_IRQn,
+        .type       = STM32_USART,
+        .clk_src    = 0, /* Use APB clock */
     },
 };
 

--- a/boards/b-l475e-iot01a/include/periph_conf.h
+++ b/boards/b-l475e-iot01a/include/periph_conf.h
@@ -102,6 +102,8 @@ static const uart_conf_t uart_config[] = {
         .tx_af      = GPIO_AF7,
         .bus        = APB2,
         .irqn       = USART1_IRQn,
+        .type       = STM32_USART,
+        .clk_src    = 0, /* Use APB clock */
 #ifdef UART_USE_DMA
         .dma_stream = 6,
         .dma_chan   = 4
@@ -116,6 +118,8 @@ static const uart_conf_t uart_config[] = {
         .tx_af      = GPIO_AF8,
         .bus        = APB1,
         .irqn       = UART4_IRQn,
+        .type       = STM32_USART,
+        .clk_src    = 0, /* Use APB clock */
 #ifdef UART_USE_DMA
         .dma_stream = 5,
         .dma_chan   = 4

--- a/boards/nucleo-l031k6/include/periph_conf.h
+++ b/boards/nucleo-l031k6/include/periph_conf.h
@@ -85,7 +85,9 @@ static const uart_conf_t uart_config[] = {
         .rx_af      = GPIO_AF4,
         .tx_af      = GPIO_AF4,
         .bus        = APB1,
-        .irqn       = USART2_IRQn
+        .irqn       = USART2_IRQn,
+        .type       = STM32_USART,
+        .clk_src    = 0, /* Use APB clock */
     }
 };
 

--- a/boards/nucleo-l053r8/include/periph_conf.h
+++ b/boards/nucleo-l053r8/include/periph_conf.h
@@ -85,7 +85,9 @@ static const uart_conf_t uart_config[] = {
         .rx_af      = GPIO_AF4,
         .tx_af      = GPIO_AF4,
         .bus        = APB1,
-        .irqn       = USART2_IRQn
+        .irqn       = USART2_IRQn,
+        .type       = STM32_USART,
+        .clk_src    = 0, /* Use APB clock */
     },
     {
         .dev        = USART1,
@@ -95,7 +97,9 @@ static const uart_conf_t uart_config[] = {
         .rx_af      = GPIO_AF4,
         .tx_af      = GPIO_AF4,
         .bus        = APB2,
-        .irqn       = USART1_IRQn
+        .irqn       = USART1_IRQn,
+        .type       = STM32_USART,
+        .clk_src    = 0, /* Use APB clock */
     }
 };
 

--- a/boards/nucleo-l073rz/Makefile.features
+++ b/boards/nucleo-l073rz/Makefile.features
@@ -2,6 +2,7 @@
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_lpuart
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_spi

--- a/boards/nucleo-l073rz/include/periph_conf.h
+++ b/boards/nucleo-l073rz/include/periph_conf.h
@@ -85,7 +85,9 @@ static const uart_conf_t uart_config[] = {
         .rx_af      = GPIO_AF4,
         .tx_af      = GPIO_AF4,
         .bus        = APB1,
-        .irqn       = USART2_IRQn
+        .irqn       = USART2_IRQn,
+        .type       = STM32_USART,
+        .clk_src    = 0, /* Use APB clock */
     },
     {
         .dev        = USART1,
@@ -95,23 +97,32 @@ static const uart_conf_t uart_config[] = {
         .rx_af      = GPIO_AF4,
         .tx_af      = GPIO_AF4,
         .bus        = APB2,
-        .irqn       = USART1_IRQn
+        .irqn       = USART1_IRQn,
+        .type       = STM32_USART,
+        .clk_src    = 0, /* Use APB clock */
     },
+#ifdef MODULE_PERIPH_LPUART
     {
-        .dev        = USART4,
-        .rcc_mask   = RCC_APB1ENR_USART4EN,
+        .dev        = LPUART1,
+        .rcc_mask   = RCC_APB1ENR_LPUART1EN,
         .rx_pin     = GPIO_PIN(PORT_C, 11),
         .tx_pin     = GPIO_PIN(PORT_C, 10),
-        .rx_af      = GPIO_AF6,
-        .tx_af      = GPIO_AF6,
+        .rx_af      = GPIO_AF0,
+        .tx_af      = GPIO_AF0,
         .bus        = APB1,
-        .irqn       = USART4_5_IRQn
+        .irqn       = LPUART1_IRQn,
+        .type       = STM32_LPUART,
+        .clk_src    = 0, /* Use APB clock */
     },
+#endif
 };
 
 #define UART_0_ISR          (isr_usart2)
 #define UART_1_ISR          (isr_usart1)
-#define UART_2_ISR          (isr_usart4_5)
+
+#ifdef MODULE_PERIPH_LPUART
+#define UART_2_ISR          (isr_rng_lpuart1)
+#endif
 
 #define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
 /** @} */

--- a/boards/nucleo-l432kc/include/periph_conf.h
+++ b/boards/nucleo-l432kc/include/periph_conf.h
@@ -105,7 +105,9 @@ static const uart_conf_t uart_config[] = {
         .rx_af      = GPIO_AF3,
         .tx_af      = GPIO_AF7,
         .bus        = APB1,
-        .irqn       = USART2_IRQn
+        .irqn       = USART2_IRQn,
+        .type       = STM32_USART,
+        .clk_src    = 0, /* Use APB clock */
     },
     {
         .dev        = USART1,
@@ -115,7 +117,9 @@ static const uart_conf_t uart_config[] = {
         .rx_af      = GPIO_AF7,
         .tx_af      = GPIO_AF7,
         .bus        = APB2,
-        .irqn       = USART1_IRQn
+        .irqn       = USART1_IRQn,
+        .type       = STM32_USART,
+        .clk_src    = 0, /* Use APB clock */
     },
 };
 

--- a/boards/nucleo-l433rc/Makefile.dep
+++ b/boards/nucleo-l433rc/Makefile.dep
@@ -1,1 +1,3 @@
+FEATURES_REQUIRED += periph_lpuart
+
 include $(RIOTBOARD)/common/nucleo/Makefile.dep

--- a/boards/nucleo-l433rc/Makefile.features
+++ b/boards/nucleo-l433rc/Makefile.features
@@ -1,5 +1,6 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_gpio periph_gpio_irq
+FEATURES_PROVIDED += periph_lpuart
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_rtt

--- a/boards/nucleo-l433rc/Makefile.include
+++ b/boards/nucleo-l433rc/Makefile.include
@@ -2,10 +2,5 @@
 export CPU = stm32l4
 export CPU_MODEL = stm32l433rc
 
-# stdio is not available over st-link but on the Arduino TX/RX pins
-# A serial to USB converter plugged to the host is required
-PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
-
 # load the common Makefile.include for Nucleo boards
 include $(RIOTBOARD)/common/nucleo64/Makefile.include

--- a/boards/nucleo-l433rc/include/periph_conf.h
+++ b/boards/nucleo-l433rc/include/periph_conf.h
@@ -107,6 +107,18 @@ static const timer_conf_t timer_config[] = {
  */
 static const uart_conf_t uart_config[] = {
     {
+        .dev        = LPUART1,
+        .rcc_mask   = RCC_APB1ENR2_LPUART1EN,
+        .rx_pin     = GPIO_PIN(PORT_A, 3),
+        .tx_pin     = GPIO_PIN(PORT_A, 2),
+        .rx_af      = GPIO_AF8,
+        .tx_af      = GPIO_AF8,
+        .bus        = APB12,
+        .irqn       = LPUART1_IRQn,
+        .type       = STM32_LPUART,
+        .clk_src    = 0, /* Use APB clock */
+    },
+    {
         .dev        = USART1,
         .rcc_mask   = RCC_APB2ENR_USART1EN,
         .rx_pin     = GPIO_PIN(PORT_A, 10),
@@ -115,6 +127,8 @@ static const uart_conf_t uart_config[] = {
         .tx_af      = GPIO_AF7,
         .bus        = APB2,
         .irqn       = USART1_IRQn,
+        .type       = STM32_USART,
+        .clk_src    = 0, /* Use APB clock */
 #ifdef UART_USE_DMA
         .dma_stream = 5,
         .dma_chan   = 4
@@ -122,7 +136,8 @@ static const uart_conf_t uart_config[] = {
     }
 };
 
-#define UART_0_ISR          (isr_usart1)
+#define UART_0_ISR          (isr_lpuart1)
+#define UART_1_ISR          (isr_usart1)
 
 #define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
 /** @} */

--- a/boards/nucleo-l452re/include/periph_conf.h
+++ b/boards/nucleo-l452re/include/periph_conf.h
@@ -118,6 +118,8 @@ static const uart_conf_t uart_config[] = {
         .tx_af      = GPIO_AF7,
         .bus        = APB1,
         .irqn       = USART2_IRQn,
+        .type       = STM32_USART,
+        .clk_src    = 0, /* Use APB clock */
     },
     {
         .dev        = USART3,
@@ -128,6 +130,8 @@ static const uart_conf_t uart_config[] = {
         .tx_af      = GPIO_AF7,
         .bus        = APB1,
         .irqn       = USART3_IRQn,
+        .type       = STM32_USART,
+        .clk_src    = 0, /* Use APB clock */
     }
 };
 

--- a/boards/nucleo-l476rg/include/periph_conf.h
+++ b/boards/nucleo-l476rg/include/periph_conf.h
@@ -121,6 +121,8 @@ static const uart_conf_t uart_config[] = {
         .tx_af      = GPIO_AF7,
         .bus        = APB1,
         .irqn       = USART2_IRQn,
+        .type       = STM32_USART,
+        .clk_src    = 0, /* Use APB clock */
 #ifdef UART_USE_DMA
         .dma_stream = 6,
         .dma_chan   = 4
@@ -135,6 +137,8 @@ static const uart_conf_t uart_config[] = {
         .tx_af      = GPIO_AF7,
         .bus        = APB1,
         .irqn       = USART3_IRQn,
+        .type       = STM32_USART,
+        .clk_src    = 0, /* Use APB clock */
 #ifdef UART_USE_DMA
         .dma_stream = 5,
         .dma_chan   = 4
@@ -149,6 +153,8 @@ static const uart_conf_t uart_config[] = {
         .tx_af      = GPIO_AF7,
         .bus        = APB2,
         .irqn       = USART1_IRQn,
+        .type       = STM32_USART,
+        .clk_src    = 0, /* Use APB clock */
 #ifdef UART_USE_DMA
         .dma_stream = 4,
         .dma_chan   = 4

--- a/boards/nucleo-l496zg/include/periph_conf.h
+++ b/boards/nucleo-l496zg/include/periph_conf.h
@@ -121,6 +121,8 @@ static const uart_conf_t uart_config[] = {
         .tx_af      = GPIO_AF7,
         .bus        = APB1,
         .irqn       = USART3_IRQn,
+        .type       = STM32_USART,
+        .clk_src    = 0, /* Use APB clock */
 #ifdef UART_USE_DMA
         .dma_stream = 5,
         .dma_chan   = 4

--- a/boards/stm32l476g-disco/include/periph_conf.h
+++ b/boards/stm32l476g-disco/include/periph_conf.h
@@ -102,6 +102,8 @@ static const uart_conf_t uart_config[] = {
         .tx_af      = GPIO_AF7,
         .bus        = APB1,
         .irqn       = USART2_IRQn,
+        .type       = STM32_USART,
+        .clk_src    = 0, /* Use APB clock */
 #ifdef UART_USE_DMA
         .dma_stream = 6,
         .dma_chan   = 4

--- a/cpu/stm32_common/cpu_common.c
+++ b/cpu/stm32_common/cpu_common.c
@@ -51,6 +51,11 @@ uint32_t periph_apb_clk(uint8_t bus)
     if (bus == APB1) {
         return CLOCK_APB1;
     }
+#if defined (CPU_FAM_STM32L4)
+    else if (bus == APB12) {
+        return CLOCK_APB1;
+    }
+#endif
     else {
         return CLOCK_APB2;
     }
@@ -74,6 +79,11 @@ void periph_clk_en(bus_t bus, uint32_t mask)
         case APB2:
             RCC->APB2ENR |= mask;
             break;
+#if defined(CPU_FAM_STM32L4)
+        case APB12:
+            RCC->APB1ENR2 |= mask;
+            break;
+#endif
 #if defined(CPU_FAM_STM32L0)
         case AHB:
             RCC->AHBENR |= mask;
@@ -122,6 +132,11 @@ void periph_clk_dis(bus_t bus, uint32_t mask)
         case APB2:
             RCC->APB2ENR &= ~(mask);
             break;
+#if defined(CPU_FAM_STM32L4)
+        case APB12:
+            RCC->APB1ENR2 &= ~(mask);
+            break;
+#endif
 #if defined(CPU_FAM_STM32L0)
         case AHB:
             RCC->AHBENR &= ~(mask);

--- a/cpu/stm32_common/include/periph_cpu_common.h
+++ b/cpu/stm32_common/include/periph_cpu_common.h
@@ -96,6 +96,9 @@ extern "C" {
 typedef enum {
     APB1,           /**< APB1 bus */
     APB2,           /**< APB2 bus */
+#if defined(CPU_FAM_STM32L4)
+    APB12,          /**< AHB1 bus, second register */
+#endif
 #if defined(CPU_FAM_STM32L0)
     AHB,            /**< AHB bus */
     IOP,            /**< IOP bus */
@@ -333,6 +336,14 @@ typedef struct {
 } qdec_conf_t;
 
 /**
+ * @brief UART hardware module types
+ */
+typedef enum {
+    STM32_USART,            /**< STM32 USART module type */
+    STM32_LPUART,           /**< STM32 Low-power UART (LPUART) module type */
+} uart_type_t;
+
+/**
  * @brief   Structure for UART configuration data
  */
 typedef struct {
@@ -357,6 +368,10 @@ typedef struct {
     gpio_af_t cts_af;       /**< alternate function for CTS pin */
     gpio_af_t rts_af;       /**< alternate function for RTS pin */
 #endif
+#endif
+#if defined(CPU_FAM_STM32L0) || defined(CPU_FAM_STM32L4)
+    uart_type_t type;       /**< hardware module type (USART or LPUART) */
+    uint32_t clk_src;       /**< clock source used for UART */
 #endif
 } uart_conf_t;
 

--- a/tests/periph_uart/Makefile
+++ b/tests/periph_uart/Makefile
@@ -3,6 +3,7 @@ include ../Makefile.tests_common
 BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno nucleo-f031k6
 
 FEATURES_REQUIRED = periph_uart
+FEATURES_OPTIONAL = periph_lpuart  # STM32 L0 and L4 provides lpuart support
 
 USEMODULE += shell
 USEMODULE += xtimer


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR adds support for LPUART to STM32 CPUs.
The current implementation is highly inspired from the kinetis one. It's possible to choose a specific clock to use the LPUART. LSE clock will allow the UART to run while in deep sleep mode but I didn't test this.

The nucleo-l433rc configuration was updated to have the stdio available via st-link (USB) and the nucleo-l073 configuration was also updated with the third UART mapped to LPUART1.

Looking at STM32 cpus that we support, only LPUART1 is available. That's why some part of the implementation are specific to this.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->