### PR TITLE
gpio.h/cb_mux API change and interim compatibilty

### DIFF
--- a/cpu/atmega_common/periph/gpio.c
+++ b/cpu/atmega_common/periph/gpio.c
@@ -148,7 +148,6 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
 int gpio_init_int(gpio_int_t *entry, gpio_t pin, gpio_mode_t mode,
                   gpio_flank_t flank, gpio_cb_t cb, void *arg)
 {
-    /* FIXME: utilize gpio.h/cb_mux API change */
     (void)entry;
 
     int8_t int_num = _int_num(pin);

--- a/cpu/atmega_common/periph/gpio.c
+++ b/cpu/atmega_common/periph/gpio.c
@@ -145,9 +145,12 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
     return 0;
 }
 
-int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
-                  gpio_cb_t cb, void *arg)
+int gpio_init_int(gpio_int_t *entry, gpio_t pin, gpio_mode_t mode,
+                  gpio_flank_t flank, gpio_cb_t cb, void *arg)
 {
+    /* FIXME: utilize gpio.h/cb_mux API change */
+    (void)entry;
+
     int8_t int_num = _int_num(pin);
 
     /* mode not supported */

--- a/cpu/cc2538/include/periph_cpu.h
+++ b/cpu/cc2538/include/periph_cpu.h
@@ -49,6 +49,14 @@ typedef uint32_t gpio_t;
 /** @} */
 
 /**
+ * @name    Define a custom type for cb_mux cbid
+ * @{
+ */
+#define HAVE_CB_MUX_CBID_T
+typedef uint32_t cb_mux_cbid_t;
+/** @} */
+
+/**
  * @name    Power management configuration
  * @{
  */

--- a/cpu/cc2538/periph/gpio.c
+++ b/cpu/cc2538/periph/gpio.c
@@ -118,9 +118,12 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
     return 0;
 }
 
-int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
-                  gpio_cb_t cb, void *arg)
+int gpio_init_int(gpio_int_t *entry, gpio_t pin, gpio_mode_t mode,
+                  gpio_flank_t flank, gpio_cb_t cb, void *arg)
 {
+    /* FIXME: utilize gpio.h/cb_mux API change */
+    (void)entry;
+
     if (gpio_init(pin, mode) != 0) {
         return -1;
     }

--- a/cpu/cc2538/periph/gpio.c
+++ b/cpu/cc2538/periph/gpio.c
@@ -121,7 +121,6 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
 int gpio_init_int(gpio_int_t *entry, gpio_t pin, gpio_mode_t mode,
                   gpio_flank_t flank, gpio_cb_t cb, void *arg)
 {
-    /* FIXME: utilize gpio.h/cb_mux API change */
     (void)entry;
 
     if (gpio_init(pin, mode) != 0) {

--- a/cpu/cc26x0/periph/gpio.c
+++ b/cpu/cc26x0/periph/gpio.c
@@ -51,9 +51,12 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
     return 0;
 }
 
-int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
-                   gpio_cb_t cb, void *arg)
+int gpio_init_int(gpio_int_t *entry, gpio_t pin, gpio_mode_t mode,
+                  gpio_flank_t flank, gpio_cb_t cb, void *arg)
 {
+    /* FIXME: utilize gpio.h/cb_mux API change */
+    (void)entry;
+
     int init = gpio_init(pin, mode);
     if (init != 0)
         return init;

--- a/cpu/cc26x0/periph/gpio.c
+++ b/cpu/cc26x0/periph/gpio.c
@@ -54,7 +54,6 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
 int gpio_init_int(gpio_int_t *entry, gpio_t pin, gpio_mode_t mode,
                   gpio_flank_t flank, gpio_cb_t cb, void *arg)
 {
-    /* FIXME: utilize gpio.h/cb_mux API change */
     (void)entry;
 
     int init = gpio_init(pin, mode);

--- a/cpu/efm32/include/periph_cpu.h
+++ b/cpu/efm32/include/periph_cpu.h
@@ -130,6 +130,14 @@ typedef uint32_t gpio_t;
 /** @} */
 
 /**
+ * @name    Define a custom type for cb_mux cbid
+ * @{
+ */
+#define HAVE_CB_MUX_CBID_T
+typedef uint32_t cb_mux_cbid_t;
+/** @} */
+
+/**
  * @brief   Definition of a fitting UNDEF value.
  */
 #define GPIO_UNDEF          (0xffffffff)

--- a/cpu/efm32/periph/gpio.c
+++ b/cpu/efm32/periph/gpio.c
@@ -72,9 +72,12 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
     return 0;
 }
 
-int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
-                  gpio_cb_t cb, void *arg)
+int gpio_init_int(gpio_int_t *entry, gpio_t pin, gpio_mode_t mode,
+                  gpio_flank_t flank, gpio_cb_t cb, void *arg)
 {
+    /* FIXME: utilize gpio.h/cb_mux API change */
+    (void)entry;
+
     int result = gpio_init(pin, mode);
 
     if (result != 0) {

--- a/cpu/efm32/periph/gpio.c
+++ b/cpu/efm32/periph/gpio.c
@@ -75,7 +75,6 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
 int gpio_init_int(gpio_int_t *entry, gpio_t pin, gpio_mode_t mode,
                   gpio_flank_t flank, gpio_cb_t cb, void *arg)
 {
-    /* FIXME: utilize gpio.h/cb_mux API change */
     (void)entry;
 
     int result = gpio_init(pin, mode);

--- a/cpu/ezr32wg/include/periph_cpu.h
+++ b/cpu/ezr32wg/include/periph_cpu.h
@@ -70,6 +70,14 @@ typedef uint32_t gpio_t;
 /** @} */
 
 /**
+ * @name    Define a custom type for cb_mux cbid
+ * @{
+ */
+#define HAVE_CB_MUX_CBID_T
+typedef uint32_t cb_mux_cbid_t;
+/** @} */
+
+/**
  * @brief   Definition of a fitting UNDEF value
  */
 #define GPIO_UNDEF          (0xffffffff)

--- a/cpu/ezr32wg/periph/gpio.c
+++ b/cpu/ezr32wg/periph/gpio.c
@@ -80,9 +80,12 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
     return 0;
 }
 
-int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
-                    gpio_cb_t cb, void *arg)
+int gpio_init_int(gpio_int_t *entry, gpio_t pin, gpio_mode_t mode,
+                  gpio_flank_t flank, gpio_cb_t cb, void *arg)
 {
+    /* FIXME: utilize gpio.h/cb_mux API change */
+    (void)entry;
+
     uint32_t pin_pos = _pin_pos(pin);
 
     /* configure as input */

--- a/cpu/ezr32wg/periph/gpio.c
+++ b/cpu/ezr32wg/periph/gpio.c
@@ -83,7 +83,6 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
 int gpio_init_int(gpio_int_t *entry, gpio_t pin, gpio_mode_t mode,
                   gpio_flank_t flank, gpio_cb_t cb, void *arg)
 {
-    /* FIXME: utilize gpio.h/cb_mux API change */
     (void)entry;
 
     uint32_t pin_pos = _pin_pos(pin);

--- a/cpu/fe310/periph/gpio.c
+++ b/cpu/fe310/periph/gpio.c
@@ -102,7 +102,6 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
 int gpio_init_int(gpio_int_t *entry, gpio_t pin, gpio_mode_t mode,
                   gpio_flank_t flank, gpio_cb_t cb, void *arg)
 {
-    /* FIXME: utilize gpio.h/cb_mux API change */
     (void)entry;
 
     /* Configure pin */

--- a/cpu/fe310/periph/gpio.c
+++ b/cpu/fe310/periph/gpio.c
@@ -99,9 +99,12 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
     return 0;
 }
 
-int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
-                  gpio_cb_t cb, void *arg)
+int gpio_init_int(gpio_int_t *entry, gpio_t pin, gpio_mode_t mode,
+                  gpio_flank_t flank, gpio_cb_t cb, void *arg)
 {
+    /* FIXME: utilize gpio.h/cb_mux API change */
+    (void)entry;
+
     /* Configure pin */
     if (gpio_init(pin, mode) != 0) {
         return -1;

--- a/cpu/kinetis/include/periph_cpu.h
+++ b/cpu/kinetis/include/periph_cpu.h
@@ -39,6 +39,14 @@ typedef uint16_t gpio_t;
 /** @} */
 
 /**
+ * @name    Define a custom type for cb_mux cbid
+ * @{
+ */
+#define HAVE_CB_MUX_CBID_T
+typedef uint16_t cb_mux_cbid_t;
+/** @} */
+
+/**
  * @brief   Definition of a fitting UNDEF value
  */
 #define GPIO_UNDEF          (0xffff)

--- a/cpu/kinetis/periph/gpio.c
+++ b/cpu/kinetis/periph/gpio.c
@@ -197,9 +197,12 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
     return 0;
 }
 
-int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
-                  gpio_cb_t cb, void *arg)
+int gpio_init_int(gpio_int_t *entry, gpio_t pin, gpio_mode_t mode,
+                  gpio_flank_t flank, gpio_cb_t cb, void *arg)
 {
+    /* FIXME: utilize gpio.h/cb_mux API change */
+    (void)entry;
+
     if (gpio_init(pin, mode) < 0) {
         return -1;
     }

--- a/cpu/kinetis/periph/gpio.c
+++ b/cpu/kinetis/periph/gpio.c
@@ -200,7 +200,6 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
 int gpio_init_int(gpio_int_t *entry, gpio_t pin, gpio_mode_t mode,
                   gpio_flank_t flank, gpio_cb_t cb, void *arg)
 {
-    /* FIXME: utilize gpio.h/cb_mux API change */
     (void)entry;
 
     if (gpio_init(pin, mode) < 0) {

--- a/cpu/lm4f120/include/periph_cpu.h
+++ b/cpu/lm4f120/include/periph_cpu.h
@@ -37,6 +37,14 @@ typedef uint32_t gpio_t;
 #define GPIO_PIN(x,y) ((gpio_t)((x<<4) | y))
 /** @} */
 
+/**
+ * @name    Define a custom type for cb_mux cbid
+ * @{
+ */
+#define HAVE_CB_MUX_CBID_T
+typedef uint32_t cb_mux_cbid_t;
+/** @} */
+
 #ifndef DOXYGEN
 /**
  * @brief   Override GPIO modes

--- a/cpu/lm4f120/periph/gpio.c
+++ b/cpu/lm4f120/periph/gpio.c
@@ -164,7 +164,6 @@ void isr_gpio_portf(void){
 int gpio_init_int(gpio_int_t *entry, gpio_t pin, gpio_mode_t mode,
                   gpio_flank_t flank, gpio_cb_t cb, void *arg)
 {
-    /* FIXME: utilize gpio.h/cb_mux API change */
     (void)entry;
 
     const uint8_t port_num = _port_num(pin);

--- a/cpu/lm4f120/periph/gpio.c
+++ b/cpu/lm4f120/periph/gpio.c
@@ -161,9 +161,12 @@ void isr_gpio_portf(void){
     _isr_gpio(5);
 }
 
-int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
-                  gpio_cb_t cb, void *arg)
+int gpio_init_int(gpio_int_t *entry, gpio_t pin, gpio_mode_t mode,
+                  gpio_flank_t flank, gpio_cb_t cb, void *arg)
 {
+    /* FIXME: utilize gpio.h/cb_mux API change */
+    (void)entry;
+
     const uint8_t port_num = _port_num(pin);
     const uint32_t port_addr = _port_base[port_num];
     const uint32_t icr_reg_addr = port_addr + GPIO_ICR_R_OFF;

--- a/cpu/lpc1768/include/periph_cpu.h
+++ b/cpu/lpc1768/include/periph_cpu.h
@@ -37,6 +37,14 @@ typedef uint8_t gpio_t;
 /** @} */
 
 /**
+ * @name    Define a custom type for cb_mux cbid
+ * @{
+ */
+#define HAVE_CB_MUX_CBID_T
+typedef uint8_t cb_mux_cbid_t;
+/** @} */
+
+/**
  * @brief   Define a custom GPIO_PIN macro for the lpc1768
  */
 #define GPIO_PIN(port, pin)     (gpio_t)((port << 5) | pin)

--- a/cpu/lpc1768/periph/gpio.c
+++ b/cpu/lpc1768/periph/gpio.c
@@ -127,9 +127,12 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
     return 0;
 }
 
-int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
-                  gpio_cb_t cb, void *arg)
+int gpio_init_int(gpio_int_t *entry, gpio_t pin, gpio_mode_t mode,
+                  gpio_flank_t flank, gpio_cb_t cb, void *arg)
 {
+    /* FIXME: utilize gpio.h/cb_mux API change */
+    (void)entry;
+
     /* only certain pins can be used as interrupt pins */
     if (_port(pin) != 0 && _port(pin) != 2) {
         return -1;

--- a/cpu/lpc1768/periph/gpio.c
+++ b/cpu/lpc1768/periph/gpio.c
@@ -130,7 +130,6 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
 int gpio_init_int(gpio_int_t *entry, gpio_t pin, gpio_mode_t mode,
                   gpio_flank_t flank, gpio_cb_t cb, void *arg)
 {
-    /* FIXME: utilize gpio.h/cb_mux API change */
     (void)entry;
 
     /* only certain pins can be used as interrupt pins */

--- a/cpu/lpc2387/periph/gpio.c
+++ b/cpu/lpc2387/periph/gpio.c
@@ -94,9 +94,12 @@ int gpio_init_mux(unsigned pin, unsigned mux)
     return 0;
 }
 
-int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
-                  gpio_cb_t cb, void *arg)
+int gpio_init_int(gpio_int_t *entry, gpio_t pin, gpio_mode_t mode,
+                  gpio_flank_t flank, gpio_cb_t cb, void *arg)
 {
+    /* FIXME: utilize gpio.h/cb_mux API change */
+    (void)entry;
+
     (void)mode;
 
     DEBUG("gpio_init_int(): pin %u\n", pin);

--- a/cpu/lpc2387/periph/gpio.c
+++ b/cpu/lpc2387/periph/gpio.c
@@ -97,9 +97,7 @@ int gpio_init_mux(unsigned pin, unsigned mux)
 int gpio_init_int(gpio_int_t *entry, gpio_t pin, gpio_mode_t mode,
                   gpio_flank_t flank, gpio_cb_t cb, void *arg)
 {
-    /* FIXME: utilize gpio.h/cb_mux API change */
     (void)entry;
-
     (void)mode;
 
     DEBUG("gpio_init_int(): pin %u\n", pin);

--- a/cpu/mips_pic32_common/periph/gpio.c
+++ b/cpu/mips_pic32_common/periph/gpio.c
@@ -172,9 +172,10 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
     return 0;
 }
 
-int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
-                  gpio_cb_t cb, void *arg)
+int gpio_init_int(gpio_int_t *entry, gpio_t pin, gpio_mode_t mode,
+                  gpio_flank_t flank, gpio_cb_t cb, void *arg)
 {
+    (void)entry;
     (void)pin;
     (void)mode;
     (void)flank;

--- a/cpu/msp430fxyz/include/periph_cpu.h
+++ b/cpu/msp430fxyz/include/periph_cpu.h
@@ -37,6 +37,14 @@ typedef uint16_t gpio_t;
 /** @} */
 
 /**
+ * @name    Define a custom type for cb_mux cbid
+ * @{
+ */
+#define HAVE_CB_MUX_CBID_T
+typedef uint16_t cb_mux_cbid_t;
+/** @} */
+
+/**
  * @brief   Definition of a fitting UNDEF value
  */
 #define GPIO_UNDEF          (0xffff)

--- a/cpu/msp430fxyz/periph/gpio.c
+++ b/cpu/msp430fxyz/periph/gpio.c
@@ -102,7 +102,6 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
 int gpio_init_int(gpio_int_t *entry, gpio_t pin, gpio_mode_t mode,
                   gpio_flank_t flank, gpio_cb_t cb, void *arg)
 {
-    /* FIXME: utilize gpio.h/cb_mux API change */
     (void)entry;
 
     msp_port_isr_t *port = _isr_port(pin);

--- a/cpu/msp430fxyz/periph/gpio.c
+++ b/cpu/msp430fxyz/periph/gpio.c
@@ -99,9 +99,12 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
     return 0;
 }
 
-int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
-                    gpio_cb_t cb, void *arg)
+int gpio_init_int(gpio_int_t *entry, gpio_t pin, gpio_mode_t mode,
+                  gpio_flank_t flank, gpio_cb_t cb, void *arg)
 {
+    /* FIXME: utilize gpio.h/cb_mux API change */
+    (void)entry;
+
     msp_port_isr_t *port = _isr_port(pin);
 
     /* check if port, pull resistor and flank configuration are valid */

--- a/cpu/native/periph/gpio.c
+++ b/cpu/native/periph/gpio.c
@@ -26,8 +26,10 @@ int gpio_init(gpio_t pin, gpio_mode_t mode) {
   return -1;
 }
 
-int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
-                  gpio_cb_t cb, void *arg){
+int gpio_init_int(gpio_int_t *entry, gpio_t pin, gpio_mode_t mode,
+                  gpio_flank_t flank, gpio_cb_t cb, void *arg)
+{
+  (void) entry;
   (void) pin;
   (void) mode;
   (void) flank;

--- a/cpu/nrf5x_common/periph/gpio.c
+++ b/cpu/nrf5x_common/periph/gpio.c
@@ -87,7 +87,6 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
 int gpio_init_int(gpio_int_t *entry, gpio_t pin, gpio_mode_t mode,
                   gpio_flank_t flank, gpio_cb_t cb, void *arg)
 {
-    /* FIXME: utilize gpio.h/cb_mux API change */
     (void)entry;
 
     /* disable external interrupt in case one is active */

--- a/cpu/nrf5x_common/periph/gpio.c
+++ b/cpu/nrf5x_common/periph/gpio.c
@@ -84,9 +84,12 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
     return 0;
 }
 
-int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
-                  gpio_cb_t cb, void *arg)
+int gpio_init_int(gpio_int_t *entry, gpio_t pin, gpio_mode_t mode,
+                  gpio_flank_t flank, gpio_cb_t cb, void *arg)
 {
+    /* FIXME: utilize gpio.h/cb_mux API change */
+    (void)entry;
+
     /* disable external interrupt in case one is active */
     NRF_GPIOTE->INTENSET &= ~(GPIOTE_INTENSET_IN0_Msk);
     /* save callback */

--- a/cpu/sam0_common/include/periph_cpu_common.h
+++ b/cpu/sam0_common/include/periph_cpu_common.h
@@ -50,6 +50,14 @@ typedef uint32_t gpio_t;
 /** @} */
 
 /**
+ * @name    Define a custom type for cb_mux cbid
+ * @{
+ */
+#define HAVE_CB_MUX_CBID_T
+typedef uint32_t cb_mux_cbid_t;
+/** @} */
+
+/**
  * @brief   Definition of a fitting UNDEF value
  */
 #define GPIO_UNDEF          (0xffffffff)

--- a/cpu/sam0_common/periph/gpio.c
+++ b/cpu/sam0_common/periph/gpio.c
@@ -111,9 +111,12 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
     return 0;
 }
 
-int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
-                  gpio_cb_t cb, void *arg)
+int gpio_init_int(gpio_int_t *entry, gpio_t pin, gpio_mode_t mode,
+                  gpio_flank_t flank, gpio_cb_t cb, void *arg)
 {
+    /* FIXME: utilize gpio.h/cb_mux API change */
+    (void)entry;
+
     int exti = _exti(pin);
 
     /* make sure EIC channel is valid */

--- a/cpu/sam0_common/periph/gpio.c
+++ b/cpu/sam0_common/periph/gpio.c
@@ -114,7 +114,6 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
 int gpio_init_int(gpio_int_t *entry, gpio_t pin, gpio_mode_t mode,
                   gpio_flank_t flank, gpio_cb_t cb, void *arg)
 {
-    /* FIXME: utilize gpio.h/cb_mux API change */
     (void)entry;
 
     int exti = _exti(pin);

--- a/cpu/sam3/include/periph_cpu.h
+++ b/cpu/sam3/include/periph_cpu.h
@@ -36,6 +36,14 @@ typedef uint32_t gpio_t;
 /** @} */
 
 /**
+ * @name    Define a custom type for cb_mux cbid
+ * @{
+ */
+#define HAVE_CB_MUX_CBID_T
+typedef uint32_t cb_mux_cbid_t;
+/** @} */
+
+/**
  * @brief Definition of a fitting UNDEF value
  */
 #define GPIO_UNDEF          (0xffffffff)

--- a/cpu/sam3/periph/gpio.c
+++ b/cpu/sam3/periph/gpio.c
@@ -191,9 +191,12 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
     return 0;
 }
 
-int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
-                  gpio_cb_t cb, void *arg)
+int gpio_init_int(gpio_int_t *entry, gpio_t pin, gpio_mode_t mode,
+                  gpio_flank_t flank, gpio_cb_t cb, void *arg)
 {
+    /* FIXME: utilize gpio.h/cb_mux API change */
+    (void)entry;
+
     Pio *port = _port(pin);
     int pin_num = _pin_num(pin);
     int port_num = _port_num(pin);

--- a/cpu/sam3/periph/gpio.c
+++ b/cpu/sam3/periph/gpio.c
@@ -194,7 +194,6 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
 int gpio_init_int(gpio_int_t *entry, gpio_t pin, gpio_mode_t mode,
                   gpio_flank_t flank, gpio_cb_t cb, void *arg)
 {
-    /* FIXME: utilize gpio.h/cb_mux API change */
     (void)entry;
 
     Pio *port = _port(pin);

--- a/cpu/stm32_common/include/periph_cpu_common.h
+++ b/cpu/stm32_common/include/periph_cpu_common.h
@@ -120,6 +120,14 @@ typedef enum {
 #define HAVE_GPIO_T
 typedef uint32_t gpio_t;
 /** @} */
+
+/**
+ * @name    Define a custom type for cb_mux cbid
+ * @{
+ */
+#define HAVE_CB_MUX_CBID_T
+typedef uint32_t cb_mux_cbid_t;
+/** @} */
 #endif
 
 /**

--- a/cpu/stm32_common/periph/gpio.c
+++ b/cpu/stm32_common/periph/gpio.c
@@ -102,9 +102,12 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
     return 0;
 }
 
-int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
-                  gpio_cb_t cb, void *arg)
+int gpio_init_int(gpio_int_t *entry, gpio_t pin, gpio_mode_t mode,
+                  gpio_flank_t flank, gpio_cb_t cb, void *arg)
 {
+    /* FIXME: utilize gpio.h/cb_mux API change */
+    (void)entry;
+
     int pin_num = _pin_num(pin);
     int port_num = _port_num(pin);
 

--- a/cpu/stm32_common/periph/gpio.c
+++ b/cpu/stm32_common/periph/gpio.c
@@ -105,7 +105,6 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
 int gpio_init_int(gpio_int_t *entry, gpio_t pin, gpio_mode_t mode,
                   gpio_flank_t flank, gpio_cb_t cb, void *arg)
 {
-    /* FIXME: utilize gpio.h/cb_mux API change */
     (void)entry;
 
     int pin_num = _pin_num(pin);

--- a/cpu/stm32f1/periph/gpio.c
+++ b/cpu/stm32f1/periph/gpio.c
@@ -99,9 +99,12 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
     return 0; /* all OK */
 }
 
-int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
-                  gpio_cb_t cb, void *arg)
+int gpio_init_int(gpio_int_t *entry, gpio_t pin, gpio_mode_t mode,
+                  gpio_flank_t flank, gpio_cb_t cb, void *arg)
 {
+    /* FIXME: utilize gpio.h/cb_mux API change */
+    (void)entry;
+
     int pin_num = _pin_num(pin);
 
     /* disable interrupts on the channel we want to edit (just in case) */

--- a/cpu/stm32f1/periph/gpio.c
+++ b/cpu/stm32f1/periph/gpio.c
@@ -102,7 +102,6 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
 int gpio_init_int(gpio_int_t *entry, gpio_t pin, gpio_mode_t mode,
                   gpio_flank_t flank, gpio_cb_t cb, void *arg)
 {
-    /* FIXME: utilize gpio.h/cb_mux API change */
     (void)entry;
 
     int pin_num = _pin_num(pin);

--- a/drivers/adcxx1c/adcxx1c.c
+++ b/drivers/adcxx1c/adcxx1c.c
@@ -36,6 +36,14 @@
  * value 0x20: cycle time = Tconvert x 64 */
 #define CONF_TEST_VALUE (0x20)
 
+/* Interrupt struct for gpio_init_int */
+#if GPIO_USE_INT_ENTRY
+static gpio_int_t int_entry;
+#define INT_ENTRY (&int_entry)
+#else
+#define INT_ENTRY (NULL)
+#endif
+
 int adcxx1c_init(adcxx1c_t *dev, const adcxx1c_params_t *params)
 {
     assert(dev && params);
@@ -114,7 +122,8 @@ int adcxx1c_enable_alert(adcxx1c_t *dev, adcxx1c_cb_t cb, void *arg)
         dev->cb = cb;
         dev->arg = arg;
         /* alert active low */
-        gpio_init_int(dev->params.alert_pin, GPIO_IN, GPIO_FALLING, _alert_cb, dev);
+        gpio_init_int(INT_ENTRY, dev->params.alert_pin, GPIO_IN,
+                      GPIO_FALLING, _alert_cb, dev);
     }
 
     return ADCXX1C_OK;

--- a/drivers/adcxx1c/adcxx1c.c
+++ b/drivers/adcxx1c/adcxx1c.c
@@ -36,13 +36,8 @@
  * value 0x20: cycle time = Tconvert x 64 */
 #define CONF_TEST_VALUE (0x20)
 
-/* Interrupt struct for gpio_init_int */
-#if GPIO_USE_INT_ENTRY
-static gpio_int_t int_entry;
-#define INT_ENTRY (&int_entry)
-#else
-#define INT_ENTRY (NULL)
-#endif
+/* Memory allocation for GPIO interrupt entry (if enabled) */
+GPIO_ALLOC_INT(1);
 
 int adcxx1c_init(adcxx1c_t *dev, const adcxx1c_params_t *params)
 {
@@ -122,7 +117,7 @@ int adcxx1c_enable_alert(adcxx1c_t *dev, adcxx1c_cb_t cb, void *arg)
         dev->cb = cb;
         dev->arg = arg;
         /* alert active low */
-        gpio_init_int(INT_ENTRY, dev->params.alert_pin, GPIO_IN,
+        gpio_init_int(GPIO_GET_ALLOC(0), dev->params.alert_pin, GPIO_IN,
                       GPIO_FALLING, _alert_cb, dev);
     }
 

--- a/drivers/ads101x/ads101x.c
+++ b/drivers/ads101x/ads101x.c
@@ -40,6 +40,14 @@
 #define I2C (dev->params.i2c)
 #define ADDR (dev->params.addr)
 
+/* Interrupt struct for gpio_init_int */
+#if GPIO_USE_INT_ENTRY
+static gpio_int_t int_entry;
+#define INT_ENTRY (&int_entry)
+#else
+#define INT_ENTRY (NULL)
+#endif
+
 static int _ads101x_init_test(i2c_t i2c, uint8_t addr);
 
 int ads101x_init(ads101x_t *dev, const ads101x_params_t *params)
@@ -174,7 +182,8 @@ int ads101x_enable_alert(ads101x_alert_t *dev,
     /* Enable interrupt */
     dev->arg = arg;
     dev->cb = cb;
-    gpio_init_int(dev->params.alert_pin, GPIO_IN, GPIO_FALLING, cb, arg);
+    gpio_init_int(INT_ENTRY, dev->params.alert_pin,
+                  GPIO_IN, GPIO_FALLING, cb, arg);
 
     return ADS101X_OK;
 }

--- a/drivers/ads101x/ads101x.c
+++ b/drivers/ads101x/ads101x.c
@@ -40,13 +40,8 @@
 #define I2C (dev->params.i2c)
 #define ADDR (dev->params.addr)
 
-/* Interrupt struct for gpio_init_int */
-#if GPIO_USE_INT_ENTRY
-static gpio_int_t int_entry;
-#define INT_ENTRY (&int_entry)
-#else
-#define INT_ENTRY (NULL)
-#endif
+/* Memory allocation for GPIO interrupt entry (if enabled) */
+GPIO_ALLOC_INT(1);
 
 static int _ads101x_init_test(i2c_t i2c, uint8_t addr);
 
@@ -182,7 +177,7 @@ int ads101x_enable_alert(ads101x_alert_t *dev,
     /* Enable interrupt */
     dev->arg = arg;
     dev->cb = cb;
-    gpio_init_int(INT_ENTRY, dev->params.alert_pin,
+    gpio_init_int(GPIO_GET_ALLOC(0), dev->params.alert_pin,
                   GPIO_IN, GPIO_FALLING, cb, arg);
 
     return ADS101X_OK;

--- a/drivers/at86rf2xx/at86rf2xx_netdev.c
+++ b/drivers/at86rf2xx/at86rf2xx_netdev.c
@@ -60,13 +60,8 @@ const netdev_driver_t at86rf2xx_driver = {
     .set = _set,
 };
 
-/* Interrupt struct for gpio_init_int */
-#if GPIO_USE_INT_ENTRY
-static gpio_int_t int_entry;
-#define INT_ENTRY (&int_entry)
-#else
-#define INT_ENTRY (NULL)
-#endif
+/* Memory allocation for GPIO interrupt entry (if enabled) */
+GPIO_ALLOC_INT(1);
 
 static void _irq_handler(void *arg)
 {
@@ -87,7 +82,7 @@ static int _init(netdev_t *netdev)
     gpio_clear(dev->params.sleep_pin);
     gpio_init(dev->params.reset_pin, GPIO_OUT);
     gpio_set(dev->params.reset_pin);
-    gpio_init_int(INT_ENTRY, dev->params.int_pin, GPIO_IN,
+    gpio_init_int(GPIO_GET_ALLOC(0), dev->params.int_pin, GPIO_IN,
                   GPIO_RISING, _irq_handler, dev);
 
     /* reset device to default values and put it into RX state */

--- a/drivers/at86rf2xx/at86rf2xx_netdev.c
+++ b/drivers/at86rf2xx/at86rf2xx_netdev.c
@@ -60,6 +60,14 @@ const netdev_driver_t at86rf2xx_driver = {
     .set = _set,
 };
 
+/* Interrupt struct for gpio_init_int */
+#if GPIO_USE_INT_ENTRY
+static gpio_int_t int_entry;
+#define INT_ENTRY (&int_entry)
+#else
+#define INT_ENTRY (NULL)
+#endif
+
 static void _irq_handler(void *arg)
 {
     netdev_t *dev = (netdev_t *) arg;
@@ -79,7 +87,8 @@ static int _init(netdev_t *netdev)
     gpio_clear(dev->params.sleep_pin);
     gpio_init(dev->params.reset_pin, GPIO_OUT);
     gpio_set(dev->params.reset_pin);
-    gpio_init_int(dev->params.int_pin, GPIO_IN, GPIO_RISING, _irq_handler, dev);
+    gpio_init_int(INT_ENTRY, dev->params.int_pin, GPIO_IN,
+                  GPIO_RISING, _irq_handler, dev);
 
     /* reset device to default values and put it into RX state */
     at86rf2xx_reset(dev);

--- a/drivers/ata8520e/ata8520e.c
+++ b/drivers/ata8520e/ata8520e.c
@@ -50,13 +50,8 @@
 #define TX_TIMEOUT           (8U)             /* 8 s */
 #define TX_RX_TIMEOUT        (50U)            /* 50 s */
 
-/* Interrupt struct for gpio_init_int */
-#if GPIO_USE_INT_ENTRY
-static gpio_int_t int_entry;
-#define INT_ENTRY (&int_entry)
-#else
-#define INT_ENTRY (NULL)
-#endif
+/* Memory allocation for GPIO interrupt entry (if enabled) */
+GPIO_ALLOC_INT(1);
 
 static void _print_atmel_status(uint8_t status)
 {
@@ -250,7 +245,7 @@ int ata8520e_init(ata8520e_t *dev, const ata8520e_params_t *params)
     memcpy(&dev->params, params, sizeof(ata8520e_params_t));
 
     /* Initialize pins*/
-    if (gpio_init_int(INT_ENTRY, INTPIN, GPIO_IN_PD,
+    if (gpio_init_int(GPIO_GET_ALLOC(0), INTPIN, GPIO_IN_PD,
                       GPIO_FALLING, _irq_handler, dev) < 0 ) {
         DEBUG("[ata8520e] ERROR: Interrupt pin not initialized\n");
         return -ATA8520E_ERR_GPIO_INT;

--- a/drivers/ata8520e/ata8520e.c
+++ b/drivers/ata8520e/ata8520e.c
@@ -50,6 +50,14 @@
 #define TX_TIMEOUT           (8U)             /* 8 s */
 #define TX_RX_TIMEOUT        (50U)            /* 50 s */
 
+/* Interrupt struct for gpio_init_int */
+#if GPIO_USE_INT_ENTRY
+static gpio_int_t int_entry;
+#define INT_ENTRY (&int_entry)
+#else
+#define INT_ENTRY (NULL)
+#endif
+
 static void _print_atmel_status(uint8_t status)
 {
     DEBUG("[ata8520e] Atmel status: %d\n", status);
@@ -242,7 +250,7 @@ int ata8520e_init(ata8520e_t *dev, const ata8520e_params_t *params)
     memcpy(&dev->params, params, sizeof(ata8520e_params_t));
 
     /* Initialize pins*/
-    if (gpio_init_int(INTPIN, GPIO_IN_PD,
+    if (gpio_init_int(INT_ENTRY, INTPIN, GPIO_IN_PD,
                       GPIO_FALLING, _irq_handler, dev) < 0 ) {
         DEBUG("[ata8520e] ERROR: Interrupt pin not initialized\n");
         return -ATA8520E_ERR_GPIO_INT;

--- a/drivers/cc110x/cc110x-netdev.c
+++ b/drivers/cc110x/cc110x-netdev.c
@@ -37,6 +37,14 @@
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
 
+/* Interrupt struct for gpio_init_int */
+#if GPIO_USE_INT_ENTRY
+static gpio_int_t int_entry;
+#define INT_ENTRY (&int_entry)
+#else
+#define INT_ENTRY (NULL)
+#endif
+
 static int _send(netdev_t *dev, const iolist_t *iolist)
 {
     DEBUG("%s:%u\n", __func__, __LINE__);
@@ -200,8 +208,8 @@ static int _init(netdev_t *dev)
 
     cc110x_t *cc110x = &((netdev_cc110x_t*) dev)->cc110x;
 
-    gpio_init_int(cc110x->params.gdo2, GPIO_IN, GPIO_BOTH,
-                  &_netdev_cc110x_isr, (void*)dev);
+    gpio_init_int(INT_ENTRY, cc110x->params.gdo2, GPIO_IN,
+                  GPIO_BOTH, &_netdev_cc110x_isr, (void*)dev);
 
     gpio_set(cc110x->params.gdo2);
     gpio_irq_disable(cc110x->params.gdo2);

--- a/drivers/cc110x/cc110x-netdev.c
+++ b/drivers/cc110x/cc110x-netdev.c
@@ -37,13 +37,8 @@
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
 
-/* Interrupt struct for gpio_init_int */
-#if GPIO_USE_INT_ENTRY
-static gpio_int_t int_entry;
-#define INT_ENTRY (&int_entry)
-#else
-#define INT_ENTRY (NULL)
-#endif
+/* Memory allocation for GPIO interrupt entry (if enabled) */
+GPIO_ALLOC_INT(1);
 
 static int _send(netdev_t *dev, const iolist_t *iolist)
 {
@@ -208,7 +203,7 @@ static int _init(netdev_t *dev)
 
     cc110x_t *cc110x = &((netdev_cc110x_t*) dev)->cc110x;
 
-    gpio_init_int(INT_ENTRY, cc110x->params.gdo2, GPIO_IN,
+    gpio_init_int(GPIO_GET_ALLOC(0), cc110x->params.gdo2, GPIO_IN,
                   GPIO_BOTH, &_netdev_cc110x_isr, (void*)dev);
 
     gpio_set(cc110x->params.gdo2);

--- a/drivers/cc2420/cc2420_netdev.c
+++ b/drivers/cc2420/cc2420_netdev.c
@@ -55,13 +55,8 @@ const netdev_driver_t cc2420_driver = {
     .set = _set,
 };
 
-/* Interrupt struct for gpio_init_int */
-#if GPIO_USE_INT_ENTRY
-static gpio_int_t int_entry;
-#define INT_ENTRY (&int_entry)
-#else
-#define INT_ENTRY (NULL)
-#endif
+/* Memory allocation for GPIO interrupt entry (if enabled) */
+GPIO_ALLOC_INT(1);
 
 static void _irq_handler(void *arg)
 {
@@ -121,7 +116,7 @@ static int _init(netdev_t *netdev)
     gpio_init(dev->params.pin_cca, GPIO_IN);
     gpio_init(dev->params.pin_sfd, GPIO_IN);
     gpio_init(dev->params.pin_fifo, GPIO_IN);
-    gpio_init_int(INT_ENTRY, dev->params.pin_fifop, GPIO_IN,
+    gpio_init_int(GPIO_GET_ALLOC(0), dev->params.pin_fifop, GPIO_IN,
                   GPIO_RISING, _irq_handler, dev);
 
     /* initialize the chip select line and the SPI bus */

--- a/drivers/cc2420/cc2420_netdev.c
+++ b/drivers/cc2420/cc2420_netdev.c
@@ -55,6 +55,14 @@ const netdev_driver_t cc2420_driver = {
     .set = _set,
 };
 
+/* Interrupt struct for gpio_init_int */
+#if GPIO_USE_INT_ENTRY
+static gpio_int_t int_entry;
+#define INT_ENTRY (&int_entry)
+#else
+#define INT_ENTRY (NULL)
+#endif
+
 static void _irq_handler(void *arg)
 {
     netdev_t *dev = (netdev_t *)arg;
@@ -113,7 +121,8 @@ static int _init(netdev_t *netdev)
     gpio_init(dev->params.pin_cca, GPIO_IN);
     gpio_init(dev->params.pin_sfd, GPIO_IN);
     gpio_init(dev->params.pin_fifo, GPIO_IN);
-    gpio_init_int(dev->params.pin_fifop, GPIO_IN, GPIO_RISING, _irq_handler, dev);
+    gpio_init_int(INT_ENTRY, dev->params.pin_fifop, GPIO_IN,
+                  GPIO_RISING, _irq_handler, dev);
 
     /* initialize the chip select line and the SPI bus */
     spi_init_cs(dev->params.spi, dev->params.pin_cs);

--- a/drivers/enc28j60/enc28j60.c
+++ b/drivers/enc28j60/enc28j60.c
@@ -74,13 +74,8 @@
 #define BUF_RX_START                (0)
 #define BUF_RX_END                  (BUF_TX_START - 2)
 
-/* Interrupt struct for gpio_init_int */
-#if GPIO_USE_INT_ENTRY
-static gpio_int_t int_entry;
-#define INT_ENTRY (&int_entry)
-#else
-#define INT_ENTRY (NULL)
-#endif
+/* Memory allocation for GPIO interrupt entry (if enabled) */
+GPIO_ALLOC_INT(1);
 
 static void switch_bank(enc28j60_t *dev, int8_t bank)
 {
@@ -332,7 +327,7 @@ static int nd_init(netdev_t *netdev)
         DEBUG("[enc28j60] init: error initializing the CS pin [%i]\n", res);
         return -1;
     }
-    gpio_init_int(INT_ENTRY, dev->int_pin, GPIO_IN,
+    gpio_init_int(GPIO_GET_ALLOC(0), dev->int_pin, GPIO_IN,
                   GPIO_FALLING, on_int, (void *)dev);
 
     /* wait at least 1ms and then release device from reset state */

--- a/drivers/enc28j60/enc28j60.c
+++ b/drivers/enc28j60/enc28j60.c
@@ -74,6 +74,13 @@
 #define BUF_RX_START                (0)
 #define BUF_RX_END                  (BUF_TX_START - 2)
 
+/* Interrupt struct for gpio_init_int */
+#if GPIO_USE_INT_ENTRY
+static gpio_int_t int_entry;
+#define INT_ENTRY (&int_entry)
+#else
+#define INT_ENTRY (NULL)
+#endif
 
 static void switch_bank(enc28j60_t *dev, int8_t bank)
 {
@@ -325,7 +332,8 @@ static int nd_init(netdev_t *netdev)
         DEBUG("[enc28j60] init: error initializing the CS pin [%i]\n", res);
         return -1;
     }
-    gpio_init_int(dev->int_pin, GPIO_IN, GPIO_FALLING, on_int, (void *)dev);
+    gpio_init_int(INT_ENTRY, dev->int_pin, GPIO_IN,
+                  GPIO_FALLING, on_int, (void *)dev);
 
     /* wait at least 1ms and then release device from reset state */
     xtimer_usleep(DELAY_RESET);

--- a/drivers/encx24j600/encx24j600.c
+++ b/drivers/encx24j600/encx24j600.c
@@ -79,6 +79,14 @@ static const netdev_driver_t netdev_driver_encx24j600 = {
     .set = netdev_eth_set,
 };
 
+/* Interrupt struct for gpio_init_int */
+#if GPIO_USE_INT_ENTRY
+static gpio_int_t int_entry;
+#define INT_ENTRY (&int_entry)
+#else
+#define INT_ENTRY (NULL)
+#endif
+
 static inline void lock(encx24j600_t *dev) {
     spi_acquire(dev->spi, dev->cs, SPI_MODE, SPI_CLK);
 }
@@ -243,7 +251,8 @@ static int _init(netdev_t *encdev)
     if (spi_init_cs(dev->spi, dev->cs) != SPI_OK) {
         return -1;
     }
-    gpio_init_int(dev->int_pin, GPIO_IN_PU, GPIO_FALLING, encx24j600_isr, (void*)dev);
+    gpio_init_int(INT_ENTRY, dev->int_pin, GPIO_IN_PU,
+                  GPIO_FALLING, encx24j600_isr, (void*)dev);
 
     lock(dev);
 

--- a/drivers/encx24j600/encx24j600.c
+++ b/drivers/encx24j600/encx24j600.c
@@ -79,13 +79,8 @@ static const netdev_driver_t netdev_driver_encx24j600 = {
     .set = netdev_eth_set,
 };
 
-/* Interrupt struct for gpio_init_int */
-#if GPIO_USE_INT_ENTRY
-static gpio_int_t int_entry;
-#define INT_ENTRY (&int_entry)
-#else
-#define INT_ENTRY (NULL)
-#endif
+/* Memory allocation for GPIO interrupt entry (if enabled) */
+GPIO_ALLOC_INT(1);
 
 static inline void lock(encx24j600_t *dev) {
     spi_acquire(dev->spi, dev->cs, SPI_MODE, SPI_CLK);
@@ -251,7 +246,7 @@ static int _init(netdev_t *encdev)
     if (spi_init_cs(dev->spi, dev->cs) != SPI_OK) {
         return -1;
     }
-    gpio_init_int(INT_ENTRY, dev->int_pin, GPIO_IN_PU,
+    gpio_init_int(GPIO_GET_ALLOC(0), dev->int_pin, GPIO_IN_PU,
                   GPIO_FALLING, encx24j600_isr, (void*)dev);
 
     lock(dev);

--- a/drivers/include/periph/gpio.h
+++ b/drivers/include/periph/gpio.h
@@ -123,15 +123,19 @@ typedef enum {
 typedef cb_mux_t gpio_int_t;
 
 /**
- * @brief   Tell users of periph/gpio.h to use new behavior
+ * @brief   Memory allocation for interrupt callback information
+ *
+ * This only enables memory allocation if periph_cpu.h enables it by defining
+ * GPIO_USE_INT_ENTRY, otherwise returns NULL.
  */
-#ifndef GPIO_USE_INT_ENTRY
-#ifdef MODULE_CB_MUX
-#define GPIO_USE_INT_ENTRY    (1)
-#else /* MODULE_CB_MUX */
-#define GPIO_USE_INT_ENTRY    (0)
-#endif /* MODULE_CB_MUX */
-#endif /* GPIO_USE_INT_ENTRY */
+#ifdef GPIO_USE_INT_ENTRY
+#define GPIO_ALLOC_INT(n)    static gpio_int_t gpio_int_entry[n]
+#define GPIO_GET_ALLOC(n)    gpio_int_entry[n]
+#else
+/* no-op */
+#define GPIO_ALLOC_INT(n)    do {} while (0)
+#define GPIO_GET_ALLOC(n)    (NULL)
+#endif
 
 /**
  * @brief   Signature of event callback functions triggered from interrupts

--- a/drivers/include/periph/gpio.h
+++ b/drivers/include/periph/gpio.h
@@ -133,7 +133,7 @@ typedef cb_mux_t gpio_int_t;
 #define GPIO_GET_ALLOC(n)    gpio_int_entry[n]
 #else
 /* no-op */
-#define GPIO_ALLOC_INT(n)    do {} while (0)
+#define GPIO_ALLOC_INT(n)    ;
 #define GPIO_GET_ALLOC(n)    (NULL)
 #endif
 

--- a/drivers/include/periph/gpio.h
+++ b/drivers/include/periph/gpio.h
@@ -55,6 +55,7 @@
 
 #include <limits.h>
 
+#include "cb_mux.h"
 #include "periph_cpu.h"
 #include "periph_conf.h"
 
@@ -117,14 +118,30 @@ typedef enum {
 #endif
 
 /**
- * @brief   Signature of event callback functions triggered from interrupts
- *
- * @param[in] arg       optional context for the callback
+ * @brief   Structure to hold interrupt callback information
  */
-typedef void (*gpio_cb_t)(void *arg);
+typedef cb_mux_t gpio_int_t;
 
 /**
- * @brief   Default interrupt context for GPIO pins
+ * @brief   Tell users of periph/gpio.h to use new behavior
+ */
+#ifndef GPIO_USE_INT_ENTRY
+#ifdef MODULE_CB_MUX
+#define GPIO_USE_INT_ENTRY    (1)
+#else /* MODULE_CB_MUX */
+#define GPIO_USE_INT_ENTRY    (0)
+#endif /* MODULE_CB_MUX */
+#endif /* GPIO_USE_INT_ENTRY */
+
+/**
+ * @brief   Signature of event callback functions triggered from interrupts
+ */
+typedef cb_mux_cb_t gpio_cb_t;
+
+/**
+ * @brief   Default interrupt context for GPIO pins (DEPRECATED)
+ *
+ * @note    In the process of being removed in favor of cb_mux entries
  */
 #ifndef HAVE_GPIO_ISR_CTX_T
 typedef struct {
@@ -156,6 +173,7 @@ int gpio_init(gpio_t pin, gpio_mode_t mode);
  *
  * The interrupt is activated automatically after the initialization.
  *
+ * @param[in] entry     structure to hold callback information
  * @param[in] pin       pin to initialize
  * @param[in] mode      mode of the pin, see @c gpio_mode_t
  * @param[in] flank     define the active flank(s)
@@ -165,8 +183,8 @@ int gpio_init(gpio_t pin, gpio_mode_t mode);
  * @return              0 on success
  * @return              -1 on error
  */
-int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
-                  gpio_cb_t cb, void *arg);
+int gpio_init_int(gpio_int_t *entry, gpio_t pin, gpio_mode_t mode,
+                  gpio_flank_t flank, gpio_cb_t cb, void *arg);
 
 /**
  * @brief   Enable pin interrupt if configured as interrupt source

--- a/drivers/isl29125/isl29125.c
+++ b/drivers/isl29125/isl29125.c
@@ -32,6 +32,14 @@
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
 
+/* Interrupt struct for gpio_init_int */
+#if GPIO_USE_INT_ENTRY
+static gpio_int_t int_entry;
+#define INT_ENTRY (&int_entry)
+#else
+#define INT_ENTRY (NULL)
+#endif
+
 /***********************************************************************
  * public API implementation
  **********************************************************************/
@@ -140,7 +148,8 @@ int isl29125_init_int(isl29125_t *dev, isl29125_interrupt_status_t interrupt_sta
     DEBUG("isl29125_init: i2c_write_reg(ISL29125_REG_HTHHB)\n");
     (void) i2c_write_reg(dev->i2c, ISL29125_I2C_ADDRESS, ISL29125_REG_HTHHB, hthhb);
 
-    if (gpio_init_int(dev->gpio, GPIO_IN, GPIO_FALLING, cb, arg) < 0) {
+    if (gpio_init_int(INT_ENTRY, dev->gpio, GPIO_IN,
+                      GPIO_FALLING, cb, arg) < 0) {
         DEBUG("error: gpio_init_int failed\n");
         return -1;
     }

--- a/drivers/isl29125/isl29125.c
+++ b/drivers/isl29125/isl29125.c
@@ -32,13 +32,8 @@
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
 
-/* Interrupt struct for gpio_init_int */
-#if GPIO_USE_INT_ENTRY
-static gpio_int_t int_entry;
-#define INT_ENTRY (&int_entry)
-#else
-#define INT_ENTRY (NULL)
-#endif
+/* Memory allocation for GPIO interrupt entry (if enabled) */
+GPIO_ALLOC_INT(1);
 
 /***********************************************************************
  * public API implementation
@@ -148,7 +143,7 @@ int isl29125_init_int(isl29125_t *dev, isl29125_interrupt_status_t interrupt_sta
     DEBUG("isl29125_init: i2c_write_reg(ISL29125_REG_HTHHB)\n");
     (void) i2c_write_reg(dev->i2c, ISL29125_I2C_ADDRESS, ISL29125_REG_HTHHB, hthhb);
 
-    if (gpio_init_int(INT_ENTRY, dev->gpio, GPIO_IN,
+    if (gpio_init_int(GPIO_GET_ALLOC(0), dev->gpio, GPIO_IN,
                       GPIO_FALLING, cb, arg) < 0) {
         DEBUG("error: gpio_init_int failed\n");
         return -1;

--- a/drivers/kw2xrf/kw2xrf.c
+++ b/drivers/kw2xrf/kw2xrf.c
@@ -40,6 +40,14 @@
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
 
+/* Interrupt struct for gpio_init_int */
+#if GPIO_USE_INT_ENTRY
+static gpio_int_t int_entry;
+#define INT_ENTRY (&int_entry)
+#else
+#define INT_ENTRY (NULL)
+#endif
+
 static void kw2xrf_set_address(kw2xrf_t *dev)
 {
     DEBUG("[kw2xrf] set MAC addresses\n");
@@ -78,7 +86,8 @@ int kw2xrf_init(kw2xrf_t *dev, gpio_cb_t cb)
     kw2xrf_set_out_clk(dev);
     kw2xrf_disable_interrupts(dev);
     /* set up GPIO-pin used for IRQ */
-    gpio_init_int(dev->params.int_pin, GPIO_IN, GPIO_FALLING, cb, dev);
+    gpio_init_int(INT_ENTRY, dev->params.int_pin,
+                  GPIO_IN, GPIO_FALLING, cb, dev);
 
     kw2xrf_abort_sequence(dev);
     kw2xrf_update_overwrites(dev);

--- a/drivers/kw2xrf/kw2xrf.c
+++ b/drivers/kw2xrf/kw2xrf.c
@@ -40,13 +40,8 @@
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
 
-/* Interrupt struct for gpio_init_int */
-#if GPIO_USE_INT_ENTRY
-static gpio_int_t int_entry;
-#define INT_ENTRY (&int_entry)
-#else
-#define INT_ENTRY (NULL)
-#endif
+/* Memory allocation for GPIO interrupt entry (if enabled) */
+GPIO_ALLOC_INT(1);
 
 static void kw2xrf_set_address(kw2xrf_t *dev)
 {
@@ -86,7 +81,7 @@ int kw2xrf_init(kw2xrf_t *dev, gpio_cb_t cb)
     kw2xrf_set_out_clk(dev);
     kw2xrf_disable_interrupts(dev);
     /* set up GPIO-pin used for IRQ */
-    gpio_init_int(INT_ENTRY, dev->params.int_pin,
+    gpio_init_int(GPIO_GET_ALLOC(0), dev->params.int_pin,
                   GPIO_IN, GPIO_FALLING, cb, dev);
 
     kw2xrf_abort_sequence(dev);

--- a/drivers/lc709203f/lc709203f.c
+++ b/drivers/lc709203f/lc709203f.c
@@ -23,13 +23,8 @@
 #define ENABLE_DEBUG        (0)
 #include "debug.h"
 
-/* Interrupt struct for gpio_init_int */
-#if GPIO_USE_INT_ENTRY
-static gpio_int_t int_entry;
-#define INT_ENTRY (&int_entry)
-#else
-#define INT_ENTRY (NULL)
-#endif
+/* Memory allocation for GPIO interrupt entry (if enabled) */
+GPIO_ALLOC_INT(1);
 
 /*
  * does a crc check and returns the checksum
@@ -61,7 +56,7 @@ int lc709203f_init(lc709203f_t *dev, const lc709203f_params_t *params)
     dev->params = *params;
     dev->bus = params->bus;
     dev->addr = params->addr;
-    gpio_init_int(INT_ENTRY, dev->params.alarm_pin, GPIO_IN,
+    gpio_init_int(GPIO_GET_ALLOC(0), dev->params.alarm_pin, GPIO_IN,
                   GPIO_FALLING, dev->cb, dev->arg);
     i2c_acquire(dev->bus);
     if (i2c_init_master(dev->bus, I2C_SPEED_FAST)) {

--- a/drivers/lc709203f/lc709203f.c
+++ b/drivers/lc709203f/lc709203f.c
@@ -23,6 +23,14 @@
 #define ENABLE_DEBUG        (0)
 #include "debug.h"
 
+/* Interrupt struct for gpio_init_int */
+#if GPIO_USE_INT_ENTRY
+static gpio_int_t int_entry;
+#define INT_ENTRY (&int_entry)
+#else
+#define INT_ENTRY (NULL)
+#endif
+
 /*
  * does a crc check and returns the checksum
  */
@@ -53,7 +61,8 @@ int lc709203f_init(lc709203f_t *dev, const lc709203f_params_t *params)
     dev->params = *params;
     dev->bus = params->bus;
     dev->addr = params->addr;
-    gpio_init_int(dev->params.alarm_pin, GPIO_IN, GPIO_FALLING, dev->cb, dev->arg);
+    gpio_init_int(INT_ENTRY, dev->params.alarm_pin, GPIO_IN,
+                  GPIO_FALLING, dev->cb, dev->arg);
     i2c_acquire(dev->bus);
     if (i2c_init_master(dev->bus, I2C_SPEED_FAST)) {
         i2c_release(dev->bus);

--- a/drivers/mrf24j40/mrf24j40_netdev.c
+++ b/drivers/mrf24j40/mrf24j40_netdev.c
@@ -39,13 +39,8 @@
 
 #define _MAX_MHR_OVERHEAD   (25)
 
-/* Interrupt struct for gpio_init_int */
-#if GPIO_USE_INT_ENTRY
-static gpio_int_t int_entry;
-#define INT_ENTRY (&int_entry)
-#else
-#define INT_ENTRY (NULL)
-#endif
+/* Memory allocation for GPIO interrupt entry (if enabled) */
+GPIO_ALLOC_INT(1);
 
 static void _irq_handler(void *arg)
 {
@@ -65,7 +60,7 @@ static int _init(netdev_t *netdev)
     spi_init_cs(dev->params.spi, dev->params.cs_pin);
     gpio_init(dev->params.reset_pin, GPIO_OUT);
     gpio_set(dev->params.reset_pin);
-    gpio_init_int(INT_ENTRY, dev->params.int_pin, GPIO_IN,
+    gpio_init_int(GPIO_GET_ALLOC(0), dev->params.int_pin, GPIO_IN,
                   GPIO_RISING, _irq_handler, dev);
 
 #ifdef MODULE_NETSTATS_L2

--- a/drivers/mrf24j40/mrf24j40_netdev.c
+++ b/drivers/mrf24j40/mrf24j40_netdev.c
@@ -39,6 +39,14 @@
 
 #define _MAX_MHR_OVERHEAD   (25)
 
+/* Interrupt struct for gpio_init_int */
+#if GPIO_USE_INT_ENTRY
+static gpio_int_t int_entry;
+#define INT_ENTRY (&int_entry)
+#else
+#define INT_ENTRY (NULL)
+#endif
+
 static void _irq_handler(void *arg)
 {
     netdev_t *dev = (netdev_t *) arg;
@@ -57,7 +65,8 @@ static int _init(netdev_t *netdev)
     spi_init_cs(dev->params.spi, dev->params.cs_pin);
     gpio_init(dev->params.reset_pin, GPIO_OUT);
     gpio_set(dev->params.reset_pin);
-    gpio_init_int(dev->params.int_pin, GPIO_IN, GPIO_RISING, _irq_handler, dev);
+    gpio_init_int(INT_ENTRY, dev->params.int_pin, GPIO_IN,
+                  GPIO_RISING, _irq_handler, dev);
 
 #ifdef MODULE_NETSTATS_L2
     memset(&netdev->stats, 0, sizeof(netstats_t));

--- a/drivers/nrf24l01p/nrf24l01p.c
+++ b/drivers/nrf24l01p/nrf24l01p.c
@@ -34,13 +34,8 @@
 #define SPI_MODE            SPI_MODE_0
 #define SPI_CLK             SPI_CLK_400KHZ
 
-/* Interrupt struct for gpio_init_int */
-#if GPIO_USE_INT_ENTRY
-static gpio_int_t int_entry;
-#define INT_ENTRY (&int_entry)
-#else
-#define INT_ENTRY (NULL)
-#endif
+/* Memory allocation for GPIO interrupt entry (if enabled) */
+GPIO_ALLOC_INT(1);
 
 int nrf24l01p_read_reg(const nrf24l01p_t *dev, char reg, char *answer)
 {
@@ -89,7 +84,7 @@ int nrf24l01p_init(nrf24l01p_t *dev, spi_t spi, gpio_t ce, gpio_t cs, gpio_t irq
     spi_init_cs(dev->spi, dev->cs);
 
     /* Init IRQ pin */
-    gpio_init_int(INT_ENTRY, dev->irq, GPIO_IN_PU,
+    gpio_init_int(GPIO_GET_ALLOC(0), dev->irq, GPIO_IN_PU,
                   GPIO_FALLING, nrf24l01p_rx_cb, dev);
 
     /* Test the SPI connection */

--- a/drivers/nrf24l01p/nrf24l01p.c
+++ b/drivers/nrf24l01p/nrf24l01p.c
@@ -34,6 +34,14 @@
 #define SPI_MODE            SPI_MODE_0
 #define SPI_CLK             SPI_CLK_400KHZ
 
+/* Interrupt struct for gpio_init_int */
+#if GPIO_USE_INT_ENTRY
+static gpio_int_t int_entry;
+#define INT_ENTRY (&int_entry)
+#else
+#define INT_ENTRY (NULL)
+#endif
+
 int nrf24l01p_read_reg(const nrf24l01p_t *dev, char reg, char *answer)
 {
     /* Acquire exclusive access to the bus. */
@@ -81,7 +89,8 @@ int nrf24l01p_init(nrf24l01p_t *dev, spi_t spi, gpio_t ce, gpio_t cs, gpio_t irq
     spi_init_cs(dev->spi, dev->cs);
 
     /* Init IRQ pin */
-    gpio_init_int(dev->irq, GPIO_IN_PU, GPIO_FALLING, nrf24l01p_rx_cb, dev);
+    gpio_init_int(INT_ENTRY, dev->irq, GPIO_IN_PU,
+                  GPIO_FALLING, nrf24l01p_rx_cb, dev);
 
     /* Test the SPI connection */
     if (spi_acquire(dev->spi, dev->cs, SPI_MODE, SPI_CLK) != SPI_OK) {

--- a/drivers/pir/pir.c
+++ b/drivers/pir/pir.c
@@ -29,13 +29,8 @@
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
-/* Interrupt struct for gpio_init_int */
-#if GPIO_USE_INT_ENTRY
-static gpio_int_t int_entry;
-#define INT_ENTRY (&int_entry)
-#else
-#define INT_ENTRY (NULL)
-#endif
+/* Memory allocation for GPIO interrupt entry (if enabled) */
+GPIO_ALLOC_INT(1);
 
 /**********************************************************************
  * internal API declaration
@@ -68,7 +63,7 @@ int pir_init(pir_t *dev, const pir_params_t *params)
         gpio_mode = GPIO_IN_PU;
     }
 
-    if (gpio_init_int(INT_ENTRY, dev->p.gpio, gpio_mode,
+    if (gpio_init_int(GPIO_GET_ALLOC(0), dev->p.gpio, gpio_mode,
                       GPIO_BOTH, pir_callback, dev)) {
         return PIR_NOGPIO;
     }
@@ -185,7 +180,7 @@ static int pir_activate_int(pir_t *dev)
         gpio_mode = GPIO_IN_PU;
     }
 
-    if (gpio_init_int(INT_ENTRY, dev->p.gpio, gpio_mode,
+    if (gpio_init_int(GPIO_GET_ALLOC(0), dev->p.gpio, gpio_mode,
                       GPIO_BOTH, pir_callback, dev)) {
         return PIR_NOGPIO;
     }

--- a/drivers/pir/pir.c
+++ b/drivers/pir/pir.c
@@ -29,6 +29,14 @@
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
+/* Interrupt struct for gpio_init_int */
+#if GPIO_USE_INT_ENTRY
+static gpio_int_t int_entry;
+#define INT_ENTRY (&int_entry)
+#else
+#define INT_ENTRY (NULL)
+#endif
+
 /**********************************************************************
  * internal API declaration
  **********************************************************************/
@@ -60,7 +68,8 @@ int pir_init(pir_t *dev, const pir_params_t *params)
         gpio_mode = GPIO_IN_PU;
     }
 
-    if (gpio_init_int(dev->p.gpio, gpio_mode, GPIO_BOTH, pir_callback, dev)) {
+    if (gpio_init_int(INT_ENTRY, dev->p.gpio, gpio_mode,
+                      GPIO_BOTH, pir_callback, dev)) {
         return PIR_NOGPIO;
     }
     return PIR_OK;
@@ -176,7 +185,8 @@ static int pir_activate_int(pir_t *dev)
         gpio_mode = GPIO_IN_PU;
     }
 
-    if (gpio_init_int(dev->p.gpio, gpio_mode, GPIO_BOTH, pir_callback, dev)) {
+    if (gpio_init_int(INT_ENTRY, dev->p.gpio, gpio_mode,
+                      GPIO_BOTH, pir_callback, dev)) {
         return PIR_NOGPIO;
     }
     return PIR_OK;

--- a/drivers/pn532/pn532.c
+++ b/drivers/pn532/pn532.c
@@ -78,13 +78,8 @@
 /* Length for passive listings */
 #define LIST_PASSIVE_LEN_14443(num)   (num * 20)
 
-/* Interrupt struct for gpio_init_int */
-#if GPIO_USE_INT_ENTRY
-static gpio_int_t int_entry;
-#define INT_ENTRY (&int_entry)
-#else
-#define INT_ENTRY (NULL)
-#endif
+/* Memory allocation for GPIO interrupt entry (if enabled) */
+GPIO_ALLOC_INT(1);
 
 #if ENABLE_DEBUG
 #define PRINTBUFF printbuff
@@ -122,7 +117,7 @@ int pn532_init(pn532_t *dev, const pn532_params_t *params, pn532_mode_t mode)
 
     dev->conf = params;
 
-    gpio_init_int(INT_ENTRY, dev->conf->irq, GPIO_IN_PU,
+    gpio_init_int(GPIO_GET_ALLOC(0), dev->conf->irq, GPIO_IN_PU,
                   GPIO_FALLING, _nfc_event, (void *)dev);
 
     gpio_init(dev->conf->reset, GPIO_OUT);

--- a/drivers/pn532/pn532.c
+++ b/drivers/pn532/pn532.c
@@ -78,6 +78,14 @@
 /* Length for passive listings */
 #define LIST_PASSIVE_LEN_14443(num)   (num * 20)
 
+/* Interrupt struct for gpio_init_int */
+#if GPIO_USE_INT_ENTRY
+static gpio_int_t int_entry;
+#define INT_ENTRY (&int_entry)
+#else
+#define INT_ENTRY (NULL)
+#endif
+
 #if ENABLE_DEBUG
 #define PRINTBUFF printbuff
 static void printbuff(uint8_t *buff, unsigned len)
@@ -114,8 +122,8 @@ int pn532_init(pn532_t *dev, const pn532_params_t *params, pn532_mode_t mode)
 
     dev->conf = params;
 
-    gpio_init_int(dev->conf->irq, GPIO_IN_PU, GPIO_FALLING,
-                  _nfc_event, (void *)dev);
+    gpio_init_int(INT_ENTRY, dev->conf->irq, GPIO_IN_PU,
+                  GPIO_FALLING, _nfc_event, (void *)dev);
 
     gpio_init(dev->conf->reset, GPIO_OUT);
     gpio_set(dev->conf->reset);

--- a/drivers/pulse_counter/pulse_counter.c
+++ b/drivers/pulse_counter/pulse_counter.c
@@ -26,13 +26,8 @@
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
 
-/* Interrupt struct for gpio_init_int */
-#if GPIO_USE_INT_ENTRY
-static gpio_int_t int_entry;
-#define INT_ENTRY (&int_entry)
-#else
-#define INT_ENTRY (NULL)
-#endif
+/* Memory allocation for GPIO interrupt entry (if enabled) */
+GPIO_ALLOC_INT(1);
 
 /* Accumulate pulse count */
 static void pulse_counter_trigger(void *arg)
@@ -54,7 +49,7 @@ int pulse_counter_init(pulse_counter_t *dev, const pulse_counter_params_t *param
         gpio_mode = GPIO_IN_PD;
     }
 
-    if (gpio_init_int(INT_ENTRY, params->gpio, gpio_mode,
+    if (gpio_init_int(GPIO_GET_ALLOC(0), params->gpio, gpio_mode,
                       params->gpio_flank, pulse_counter_trigger, dev)) {
         return -1;
     }

--- a/drivers/pulse_counter/pulse_counter.c
+++ b/drivers/pulse_counter/pulse_counter.c
@@ -26,6 +26,14 @@
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
 
+/* Interrupt struct for gpio_init_int */
+#if GPIO_USE_INT_ENTRY
+static gpio_int_t int_entry;
+#define INT_ENTRY (&int_entry)
+#else
+#define INT_ENTRY (NULL)
+#endif
+
 /* Accumulate pulse count */
 static void pulse_counter_trigger(void *arg)
 {
@@ -46,7 +54,8 @@ int pulse_counter_init(pulse_counter_t *dev, const pulse_counter_params_t *param
         gpio_mode = GPIO_IN_PD;
     }
 
-    if (gpio_init_int(params->gpio, gpio_mode, params->gpio_flank, pulse_counter_trigger, dev)) {
+    if (gpio_init_int(INT_ENTRY, params->gpio, gpio_mode,
+                      params->gpio_flank, pulse_counter_trigger, dev)) {
         return -1;
     }
 

--- a/drivers/sx127x/sx127x.c
+++ b/drivers/sx127x/sx127x.c
@@ -40,13 +40,8 @@
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
-/* Interrupt struct for gpio_init_int */
-#if GPIO_USE_INT_ENTRY
-static gpio_int_t int_entry[4];
-#define INT_ENTRY(n)    (&(int_entry[n]))
-#else
-#define INT_ENTRY(n)    (NULL)
-#endif
+/* Memory allocation for GPIO interrupt entry (if enabled) */
+GPIO_ALLOC_INT(4);
 
 /* Internal functions */
 static int _init_spi(sx127x_t *dev);
@@ -218,28 +213,28 @@ static void sx127x_on_dio3_isr(void *arg)
 /* Internal event handlers */
 static int _init_gpios(sx127x_t *dev)
 {
-    int res = gpio_init_int(INT_ENTRY(0), dev->params.dio0_pin, GPIO_IN,
+    int res = gpio_init_int(GPIO_GET_ALLOC(0), dev->params.dio0_pin, GPIO_IN,
                             GPIO_RISING, sx127x_on_dio0_isr, dev);
     if (res < 0) {
         DEBUG("[sx127x] error: failed to initialize DIO0 pin\n");
         return res;
     }
 
-    res = gpio_init_int(INT_ENTRY(1), dev->params.dio1_pin, GPIO_IN,
+    res = gpio_init_int(GPIO_GET_ALLOC(1), dev->params.dio1_pin, GPIO_IN,
                         GPIO_RISING, sx127x_on_dio1_isr, dev);
     if (res < 0) {
         DEBUG("[sx127x] error: failed to initialize DIO1 pin\n");
         return res;
     }
 
-    res = gpio_init_int(INT_ENTRY(2), dev->params.dio2_pin, GPIO_IN,
+    res = gpio_init_int(GPIO_GET_ALLOC(2), dev->params.dio2_pin, GPIO_IN,
                         GPIO_RISING, sx127x_on_dio2_isr, dev);
     if (res < 0) {
         DEBUG("[sx127x] error: failed to initialize DIO2 pin\n");
         return res;
     }
 
-    res = gpio_init_int(INT_ENTRY(3), dev->params.dio3_pin, GPIO_IN,
+    res = gpio_init_int(GPIO_GET_ALLOC(3), dev->params.dio3_pin, GPIO_IN,
                         GPIO_RISING, sx127x_on_dio3_isr, dev);
     if (res < 0) {
         DEBUG("[sx127x] error: failed to initialize DIO3 pin\n");

--- a/drivers/sx127x/sx127x.c
+++ b/drivers/sx127x/sx127x.c
@@ -40,6 +40,14 @@
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
+/* Interrupt struct for gpio_init_int */
+#if GPIO_USE_INT_ENTRY
+static gpio_int_t int_entry[4];
+#define INT_ENTRY(n)    (&(int_entry[n]))
+#else
+#define INT_ENTRY(n)    (NULL)
+#endif
+
 /* Internal functions */
 static int _init_spi(sx127x_t *dev);
 static int _init_gpios(sx127x_t *dev);
@@ -210,29 +218,29 @@ static void sx127x_on_dio3_isr(void *arg)
 /* Internal event handlers */
 static int _init_gpios(sx127x_t *dev)
 {
-    int res = gpio_init_int(dev->params.dio0_pin, GPIO_IN, GPIO_RISING,
-                            sx127x_on_dio0_isr, dev);
+    int res = gpio_init_int(INT_ENTRY(0), dev->params.dio0_pin, GPIO_IN,
+                            GPIO_RISING, sx127x_on_dio0_isr, dev);
     if (res < 0) {
         DEBUG("[sx127x] error: failed to initialize DIO0 pin\n");
         return res;
     }
 
-    res = gpio_init_int(dev->params.dio1_pin, GPIO_IN, GPIO_RISING,
-                         sx127x_on_dio1_isr, dev);
+    res = gpio_init_int(INT_ENTRY(1), dev->params.dio1_pin, GPIO_IN,
+                        GPIO_RISING, sx127x_on_dio1_isr, dev);
     if (res < 0) {
         DEBUG("[sx127x] error: failed to initialize DIO1 pin\n");
         return res;
     }
 
-    res = gpio_init_int(dev->params.dio2_pin, GPIO_IN, GPIO_RISING,
-                        sx127x_on_dio2_isr, dev);
+    res = gpio_init_int(INT_ENTRY(2), dev->params.dio2_pin, GPIO_IN,
+                        GPIO_RISING, sx127x_on_dio2_isr, dev);
     if (res < 0) {
         DEBUG("[sx127x] error: failed to initialize DIO2 pin\n");
         return res;
     }
 
-    res = gpio_init_int(dev->params.dio3_pin, GPIO_IN, GPIO_RISING,
-                        sx127x_on_dio3_isr, dev);
+    res = gpio_init_int(INT_ENTRY(3), dev->params.dio3_pin, GPIO_IN,
+                        GPIO_RISING, sx127x_on_dio3_isr, dev);
     if (res < 0) {
         DEBUG("[sx127x] error: failed to initialize DIO3 pin\n");
         return res;

--- a/drivers/w5100/w5100.c
+++ b/drivers/w5100/w5100.c
@@ -45,13 +45,8 @@
 
 static const netdev_driver_t netdev_driver_w5100;
 
-/* Interrupt struct for gpio_init_int */
-#if GPIO_USE_INT_ENTRY
-static gpio_int_t int_entry;
-#define INT_ENTRY (&int_entry)
-#else
-#define INT_ENTRY (NULL)
-#endif
+/* Memory allocation for GPIO interrupt entry (if enabled) */
+GPIO_ALLOC_INT(1);
 
 static inline void send_addr(w5100_t *dev, uint16_t addr)
 {
@@ -131,7 +126,8 @@ void w5100_setup(w5100_t *dev, const w5100_params_t *params)
 
     /* initialize the chip select pin and the external interrupt pin */
     spi_init_cs(dev->p.spi, dev->p.cs);
-    gpio_init_int(INT_ENTRY, dev->p.evt, GPIO_IN, GPIO_FALLING, extint, dev);
+    gpio_init_int(GPIO_GET_ALLOC(0), dev->p.evt, GPIO_IN,
+                  GPIO_FALLING, extint, dev);
 }
 
 static int init(netdev_t *netdev)

--- a/drivers/w5100/w5100.c
+++ b/drivers/w5100/w5100.c
@@ -45,6 +45,14 @@
 
 static const netdev_driver_t netdev_driver_w5100;
 
+/* Interrupt struct for gpio_init_int */
+#if GPIO_USE_INT_ENTRY
+static gpio_int_t int_entry;
+#define INT_ENTRY (&int_entry)
+#else
+#define INT_ENTRY (NULL)
+#endif
+
 static inline void send_addr(w5100_t *dev, uint16_t addr)
 {
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
@@ -123,7 +131,7 @@ void w5100_setup(w5100_t *dev, const w5100_params_t *params)
 
     /* initialize the chip select pin and the external interrupt pin */
     spi_init_cs(dev->p.spi, dev->p.cs);
-    gpio_init_int(dev->p.evt, GPIO_IN, GPIO_FALLING, extint, dev);
+    gpio_init_int(INT_ENTRY, dev->p.evt, GPIO_IN, GPIO_FALLING, extint, dev);
 }
 
 static int init(netdev_t *netdev)

--- a/tests/buttons/main.c
+++ b/tests/buttons/main.c
@@ -27,13 +27,8 @@
 
 #define TEST_FLANK      GPIO_FALLING
 
-/* Interrupt struct for gpio_init_int */
-#if GPIO_USE_INT_ENTRY
-static gpio_int_t int_entry[4];
-#define INT_ENTRY(n)    (&(int_entry[n]))
-#else
-#define INT_ENTRY(n)    (NULL)
-#endif
+/* Memory allocation for GPIO interrupt entry (if enabled) */
+GPIO_ALLOC_INT(4);
 
 #ifdef BTN0_PIN /* assuming that first button is always BTN0 */
 static void cb(void *arg)
@@ -47,7 +42,7 @@ int main(void)
     int cnt = 0;
     /* get the number of available buttons and init interrupt handler */
 #ifdef BTN0_PIN
-    if (gpio_init_int(INT_ENTRY(0), BTN0_PIN, BTN0_MODE,
+    if (gpio_init_int(GPIO_GET_ALLOC(0), BTN0_PIN, BTN0_MODE,
                       TEST_FLANK, cb, (void *)cnt) < 0) {
         puts("[FAILED] init BTN0!");
         return 1;
@@ -55,7 +50,7 @@ int main(void)
     ++cnt;
 #endif
 #ifdef BTN1_PIN
-    if (gpio_init_int(INT_ENTRY(1), BTN1_PIN, BTN1_MODE,
+    if (gpio_init_int(GPIO_GET_ALLOC(1), BTN1_PIN, BTN1_MODE,
                       TEST_FLANK, cb, (void *)cnt) < 0) {
         puts("[FAILED] init BTN1!");
         return 1;
@@ -63,7 +58,7 @@ int main(void)
     ++cnt;
 #endif
 #ifdef BTN2_PIN
-    if (gpio_init_int(INT_ENTRY(2), BTN2_PIN, BTN2_MODE,
+    if (gpio_init_int(GPIO_GET_ALLOC(2), BTN2_PIN, BTN2_MODE,
                       TEST_FLANK, cb, (void *)cnt) < 0) {
         puts("[FAILED] init BTN2!");
         return 1;
@@ -71,7 +66,7 @@ int main(void)
     ++cnt;
 #endif
 #ifdef BTN3_PIN
-    if (gpio_init_int(INT_ENTRY(3), BTN3_PIN, BTN3_MODE,
+    if (gpio_init_int(GPIO_GET_ALLOC(3), BTN3_PIN, BTN3_MODE,
                       TEST_FLANK, cb, (void *)cnt) < 0) {
         puts("[FAILED] init BTN3!");
         return 1;

--- a/tests/buttons/main.c
+++ b/tests/buttons/main.c
@@ -27,6 +27,14 @@
 
 #define TEST_FLANK      GPIO_FALLING
 
+/* Interrupt struct for gpio_init_int */
+#if GPIO_USE_INT_ENTRY
+static gpio_int_t int_entry[4];
+#define INT_ENTRY(n)    (&(int_entry[n]))
+#else
+#define INT_ENTRY(n)    (NULL)
+#endif
+
 #ifdef BTN0_PIN /* assuming that first button is always BTN0 */
 static void cb(void *arg)
 {
@@ -39,28 +47,32 @@ int main(void)
     int cnt = 0;
     /* get the number of available buttons and init interrupt handler */
 #ifdef BTN0_PIN
-    if (gpio_init_int(BTN0_PIN, BTN0_MODE, TEST_FLANK, cb, (void *)cnt) < 0) {
+    if (gpio_init_int(INT_ENTRY(0), BTN0_PIN, BTN0_MODE,
+                      TEST_FLANK, cb, (void *)cnt) < 0) {
         puts("[FAILED] init BTN0!");
         return 1;
     }
     ++cnt;
 #endif
 #ifdef BTN1_PIN
-    if (gpio_init_int(BTN1_PIN, BTN1_MODE, TEST_FLANK, cb, (void *)cnt) < 0) {
+    if (gpio_init_int(INT_ENTRY(1), BTN1_PIN, BTN1_MODE,
+                      TEST_FLANK, cb, (void *)cnt) < 0) {
         puts("[FAILED] init BTN1!");
         return 1;
     }
     ++cnt;
 #endif
 #ifdef BTN2_PIN
-    if (gpio_init_int(BTN2_PIN, BTN2_MODE, TEST_FLANK, cb, (void *)cnt) < 0) {
+    if (gpio_init_int(INT_ENTRY(2), BTN2_PIN, BTN2_MODE,
+                      TEST_FLANK, cb, (void *)cnt) < 0) {
         puts("[FAILED] init BTN2!");
         return 1;
     }
     ++cnt;
 #endif
 #ifdef BTN3_PIN
-    if (gpio_init_int(BTN3_PIN, BTN3_MODE, TEST_FLANK, cb, (void *)cnt) < 0) {
+    if (gpio_init_int(INT_ENTRY(3), BTN3_PIN, BTN3_MODE,
+                      TEST_FLANK, cb, (void *)cnt) < 0) {
         puts("[FAILED] init BTN3!");
         return 1;
     }

--- a/tests/cb_mux/main.c
+++ b/tests/cb_mux/main.c
@@ -53,7 +53,7 @@ int main(void)
 
     for (num = 0; num < 5; num++) {
         entries[num].cb = cb;
-        entries[num].arg = (void *)num;
+        entries[num].arg = (void *)(uintptr_t)num;
         entries[num].cbid = num;
     }
 
@@ -114,7 +114,7 @@ int main(void)
     while (num < 5) {
         cb_mux_add(&cb_mux_head, &(entries[num]));
 
-        printf("Added entry %i\n", num);
+        printf("Added entry %u\n", (unsigned)num);
 
         num = cb_mux_find_free_id(cb_mux_head);
     }
@@ -125,7 +125,7 @@ int main(void)
 
     for (num = 0; num < 5; num++) {
         if ((uintptr_t)entries[num].info & (1 << ITER_TEST)) {
-            printf("Entry %i was updated correctly\n", num);
+            printf("Entry %u was updated correctly\n", (unsigned)num);
         }
     }
 

--- a/tests/driver_lis3dh/main.c
+++ b/tests/driver_lis3dh/main.c
@@ -33,13 +33,8 @@
 
 static volatile int int1_count = 0;
 
-/* Interrupt struct for gpio_init_int */
-#if GPIO_USE_INT_ENTRY
-static gpio_int_t int_entry;
-#define INT_ENTRY (&int_entry)
-#else
-#define INT_ENTRY (NULL)
-#endif
+/* Memory allocation for GPIO interrupt entry (if enabled) */
+GPIO_ALLOC_INT(1);
 
 static void test_int1(void *arg)
 {
@@ -118,8 +113,8 @@ int main(void)
     }
 
     puts("Set INT1 callback");
-    if (gpio_init_int(INT_ENTRY, lis3dh_params[0].int1, GPIO_IN, GPIO_RISING,
-                      test_int1, (void*)&int1_count) == 0) {
+    if (gpio_init_int(GPIO_GET_ALLOC(0), lis3dh_params[0].int1, GPIO_IN,
+                      GPIO_RISING, test_int1, (void*)&int1_count) == 0) {
         puts("[OK]");
     }
     else {

--- a/tests/driver_lis3dh/main.c
+++ b/tests/driver_lis3dh/main.c
@@ -33,6 +33,14 @@
 
 static volatile int int1_count = 0;
 
+/* Interrupt struct for gpio_init_int */
+#if GPIO_USE_INT_ENTRY
+static gpio_int_t int_entry;
+#define INT_ENTRY (&int_entry)
+#else
+#define INT_ENTRY (NULL)
+#endif
+
 static void test_int1(void *arg)
 {
     volatile int *int1_count_ptr = arg;
@@ -110,7 +118,7 @@ int main(void)
     }
 
     puts("Set INT1 callback");
-    if (gpio_init_int(lis3dh_params[0].int1, GPIO_IN, GPIO_RISING,
+    if (gpio_init_int(INT_ENTRY, lis3dh_params[0].int1, GPIO_IN, GPIO_RISING,
                       test_int1, (void*)&int1_count) == 0) {
         puts("[OK]");
     }

--- a/tests/periph_gpio/main.c
+++ b/tests/periph_gpio/main.c
@@ -28,13 +28,8 @@
 
 #define BENCH_RUNS_DEFAULT      (1000UL * 1000)
 
-/* Interrupt struct for gpio_init_int */
-#if GPIO_USE_INT_ENTRY
-static gpio_int_t int_entry;
-#define INT_ENTRY (&int_entry)
-#else
-#define INT_ENTRY (NULL)
-#endif
+/* Memory allocation for GPIO interrupt entry (if enabled) */
+GPIO_ALLOC_INT(1);
 
 static void cb(void *arg)
 {
@@ -148,7 +143,7 @@ static int init_int(int argc, char **argv)
         }
     }
 
-    if (gpio_init_int(INT_ENTRY, GPIO_PIN(po, pi), mode,
+    if (gpio_init_int(GPIO_GET_ALLOC(0), GPIO_PIN(po, pi), mode,
                       flank, cb, (void *)pi) < 0) {
         printf("error: init_int of GPIO_PIN(%i, %i) failed\n", po, pi);
         return 1;

--- a/tests/periph_gpio/main.c
+++ b/tests/periph_gpio/main.c
@@ -28,6 +28,14 @@
 
 #define BENCH_RUNS_DEFAULT      (1000UL * 1000)
 
+/* Interrupt struct for gpio_init_int */
+#if GPIO_USE_INT_ENTRY
+static gpio_int_t int_entry;
+#define INT_ENTRY (&int_entry)
+#else
+#define INT_ENTRY (NULL)
+#endif
+
 static void cb(void *arg)
 {
     printf("INT: external interrupt from pin %i\n", (int)arg);
@@ -140,7 +148,8 @@ static int init_int(int argc, char **argv)
         }
     }
 
-    if (gpio_init_int(GPIO_PIN(po, pi), mode, flank, cb, (void *)pi) < 0) {
+    if (gpio_init_int(INT_ENTRY, GPIO_PIN(po, pi), mode,
+                      flank, cb, (void *)pi) < 0) {
         printf("error: init_int of GPIO_PIN(%i, %i) failed\n", po, pi);
         return 1;
     }


### PR DESCRIPTION
This PR adds support for cb_mux in periph/gpio.h to be used for managing interrupts.

Specific changes:
- gpio_init_int now has an additional argument: a pointer to the passed cb_mux entry
- All CPUs currently ignore entry using ```(void)entry;```
- If ```MODULE_CB_MUX``` is enabled and gpio_init_int is called, that file will also declare a global cb_mux entry and pass it to gpio_init_int.
- If ```MODULE_CB_MUX``` is disabled and gpio_init_int is called, a NULL pointer is passed to it.

This set up permits CPUs to set up cb_mux on a case by case basis, and not have any changes to the behavior of anything that does not implement it.

Depends on: #8993