### PR TITLE
boards/f4vi1: fix potential build issue in uart conf

### DIFF
--- a/boards/f4vi1/include/periph_conf.h
+++ b/boards/f4vi1/include/periph_conf.h
@@ -98,7 +98,7 @@ static const uart_conf_t uart_config[] = {
         .rx_af      = GPIO_AF8,
         .tx_af      = GPIO_AF8,
         .bus        = APB2,
-        .irqn       = USART6_IRQn
+        .irqn       = USART6_IRQn,
 #ifdef UART_USE_DMA
         .dma_stream = 14,
         .dma_chan   = 5


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

While working on #9158, I noticed a potential build issue with the f4vi1 board when DMA is enabled with UART (even if it's an unimplemented feature).

The fix is obvious.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->