### PR TITLE
drivers: Various minor improvments of the cc110x driver

### DIFF
--- a/drivers/cc110x/cc110x-netdev.c
+++ b/drivers/cc110x/cc110x-netdev.c
@@ -201,7 +201,7 @@ static int _init(netdev_t *dev)
     cc110x_t *cc110x = &((netdev_cc110x_t*) dev)->cc110x;
 
     gpio_init_int(cc110x->params.gdo2, GPIO_IN, GPIO_BOTH,
-            &_netdev_cc110x_isr, (void*)dev);
+                  &_netdev_cc110x_isr, (void*)dev);
 
     gpio_set(cc110x->params.gdo2);
     gpio_irq_disable(cc110x->params.gdo2);

--- a/drivers/cc110x/cc110x-rxtx.c
+++ b/drivers/cc110x/cc110x-rxtx.c
@@ -43,6 +43,25 @@
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
+const char *cc110x_state_to_text(uint8_t state)
+{
+    switch (state){
+    case RADIO_IDLE:
+        return "idle";
+    case RADIO_TX_BUSY:
+        return "tx busy";
+    case RADIO_RX:
+        return "rx";
+    case RADIO_RX_BUSY:
+        return "rx busy";
+    case RADIO_PWD:
+        return "pwd";
+    case RADIO_UNKNOWN:
+        return "unknown";
+    }
+    return "invalid";
+}
+
 static void _rx_abort(cc110x_t *dev)
 {
     gpio_irq_disable(dev->params.gdo2);

--- a/drivers/cc110x/cc110x.c
+++ b/drivers/cc110x/cc110x.c
@@ -151,7 +151,7 @@ void cc110x_switch_to_rx(cc110x_t *dev)
 
     dev->radio_state = RADIO_RX;
 
-    cc110x_write_reg(dev, CC110X_IOCFG2, 0x6);
+    cc110x_write_reg(dev, CC110X_IOCFG2, CC110X_GDO_HIGH_ON_SYNC_WORD);
     cc110x_strobe(dev, CC110X_SRX);
 
     gpio_irq_enable(dev->params.gdo2);

--- a/drivers/cc110x/gnrc_cc110x/gnrc_cc110x.c
+++ b/drivers/cc110x/gnrc_cc110x/gnrc_cc110x.c
@@ -103,7 +103,10 @@ static int _send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
             "length %u\n",
             (unsigned)cc110x_pkt.phy_src,
             (unsigned)cc110x_pkt.address,
-            (unsigned)cc110x_pkt.length);
+            (unsigned)payload_len);
+#if defined(MODULE_OD) && ENABLE_DEBUG
+    od_hex_dump(cc110x_pkt.data, payload_len, OD_WIDTH_DEFAULT);
+#endif
 
     return dev->driver->send(dev, &iolist);
 }

--- a/drivers/cc110x/include/cc110x-defines.h
+++ b/drivers/cc110x/include/cc110x-defines.h
@@ -208,6 +208,42 @@ extern "C" {
 #define CC110X_RXFIFO       (0x3F)      /**< RX FIFO: Read operations read from the RX FIFO (SB: +0x80; BURST: +0xC0) */
 /** @} */
 
+
+/**
+ * @name GDO configuration values
+ *
+ * Values that can be written to the GDO0, GDO1 and GDO2 configuration registers
+ * @{
+ */
+
+/** @brief GDO goes high when RX FIFO is filled at or above threshold */
+#define CC110X_GDO_HIGH_ON_RX_FIFO_ABOVE_THRESHOLD   (0x00)
+/**
+ * @brief GDO goes high when RX FIFO is filled at or above threshold or when
+ *        packet is fully received
+ */
+#define CC110X_GDO_HIGH_ON_RX_FIFO_FILLED_OR_PKT_END (0x01)
+/** @brief GDO goes low when TX FIFO is filled less than threshold */
+#define CC110X_GDO_LOW_ON_TX_FIFO_BELOW_THRESHOLD    (0x02)
+/** @brief  GDO goes low when TX FIFO becomes empty */
+#define CC110X_GDO_LOW_ON_TX_FIFO_EMPTY              (0x03)
+/** @brief  GDO goes high when RX FIFO overflows */
+#define CC110X_GDO_HIGH_ON_RX_FIFO_OVERFLOW          (0x04)
+/** @brief GDO goes high when TX FIFO underflows */
+#define CC110X_GDO_HIGH_ON_TX_FIFO_UNDERFLOW         (0x05)
+/**
+ * @brief GDO goes high when sync word was just received until the packet is
+ *        fully received, or when sync word has been send until packet is fully
+ *        send
+ */
+#define CC110X_GDO_HIGH_ON_SYNC_WORD                 (0x06)
+/**
+ * @brief GDO goes high when a packet is received and CRC is correct.
+ *        Goes back to low when first byte of RX fifo has been read
+ */
+#define CC110X_GDO_HIGH_ON_PACKET_RECEIVED           (0x07)
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif

--- a/drivers/cc110x/include/cc110x-interface.h
+++ b/drivers/cc110x/include/cc110x-interface.h
@@ -35,7 +35,7 @@ extern "C" {
  * @{
  */
 char *cc110x_get_marc_state(cc110x_t *dev);
-char *cc110x_state_to_text(uint8_t state);
+const char *cc110x_state_to_text(uint8_t state);
 int cc110x_rd_set_mode(cc110x_t *dev, int mode);
 uint8_t cc110x_get_buffer_pos(cc110x_t *dev);
 void cc110x_isr_handler(cc110x_t *dev, void(*callback)(void*), void*arg);

--- a/drivers/cc110x/include/cc110x-internal.h
+++ b/drivers/cc110x/include/cc110x-internal.h
@@ -29,6 +29,7 @@ extern "C" {
 #endif
 
 #define CC110X_RXBUF_SIZE           (2)
+#define CC110X_FIFO_LENGTH          (64)
 #define CC110X_MAX_DATA_LENGTH      (58+64)
 
 #define CC110X_HEADER_LENGTH        (3)     /**< Header covers SRC, DST and

--- a/drivers/include/cc110x.h
+++ b/drivers/include/cc110x.h
@@ -33,11 +33,11 @@ extern "C" {
  * @brief   Struct for holding cc110x IO parameters
  */
 typedef struct cc110x_params {
-    spi_t spi;          /**< what */
-    gpio_t cs;          /**< does */
-    gpio_t gdo0;        /**< this */
-    gpio_t gdo1;        /**< look */
-    gpio_t gdo2;        /**< like */
+    spi_t spi;          /**< SPI bus the CC110x is connected to */
+    gpio_t cs;          /**< GPIO connected to the chip select pin of the CC110x */
+    gpio_t gdo0;        /**< GPIO connected to the GDO0 pin of the CC110x */
+    gpio_t gdo1;        /**< GPIO connected to the GDO1 pin of the CC110x */
+    gpio_t gdo2;        /**< GPIO connected to the GDO2 pin of the CC110x */
 } cc110x_params_t;
 
 /**


### PR DESCRIPTION
This PR contains a number of minor improvements of the cc110x driver:
- Improved code readability by fixing documentation, replacing magic numbers by preprocessor macros, and fixing indentation
- Improved debug output `ENABLE_DEBUG` is set
- Implemented a missing function that is referenced if `ENABLE_DEBUG` is set

This PR fixes issue https://github.com/RIOT-OS/RIOT/issues/8115 at least partly.

Even though this PR is completely boring, I tested the code on the MSBA2 boards, on which the cc110x works just like before.