### PR TITLE
drivers/ads101x: update I2C API

### DIFF
--- a/drivers/ads101x/ads101x.c
+++ b/drivers/ads101x/ads101x.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2017 OTA keys S.A.
- *               2018 Matthew Blue <matthew.blue.neuro@gmail.com>
+ *               2018 Acutam Automation, LLC
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level

--- a/drivers/ads101x/ads101x_saul.c
+++ b/drivers/ads101x/ads101x_saul.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2017 OTA keys S.A.
- *               2018 Matthew Blue <matthew.blue.neuro@gmail.com>
+ *               2018 Acutam Automation, LLC
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level

--- a/drivers/ads101x/include/ads101x_params.h
+++ b/drivers/ads101x/include/ads101x_params.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2017 OTA keys S.A.
- *               2018 Matthew Blue <matthew.blue.neuro@gmail.com>
+ *               2018 Acutam Automation, LLC
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level

--- a/drivers/ads101x/include/ads101x_regs.h
+++ b/drivers/ads101x/include/ads101x_regs.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2017 OTA keys S.A.
- *               2018 Matthew Blue <matthew.blue.neuro@gmail.com>
+ *               2018 Acutam Automation, LLC
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level

--- a/drivers/include/ads101x.h
+++ b/drivers/include/ads101x.h
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2017 OTA keys S.A.
- *               2018 Matthew Blue <matthew.blue.neuro@gmail.com>
+ *               2018 Acutam Automation, LLC
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level

--- a/sys/auto_init/saul/auto_init_ads101x.c
+++ b/sys/auto_init/saul/auto_init_ads101x.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2017 OTA keys S.A.
- *               2018 Matthew Blue <matthew.blue.neuro@gmail.com>
+ *               2018 Acutam Automation, LLC
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level

--- a/tests/driver_ads101x/main.c
+++ b/tests/driver_ads101x/main.c
@@ -1,6 +1,6 @@
 /*
  * Copyright (C) 2017 OTA keys S.A.
- *               2018 Matthew Blue <matthew.blue.neuro@gmail.com>
+ *               2018 Acutam Automation, LLC
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level


### PR DESCRIPTION
This is a WIP update to ads101x's I2C API usage. Currently untested due to lack of API update to atmega_common. See also: #6577 and #9162