### PR TITLE
evtimer: use conversion macro US_PER_MS

### DIFF
--- a/sys/evtimer/evtimer.c
+++ b/sys/evtimer/evtimer.c
@@ -94,7 +94,7 @@ static void _del_event_from_list(evtimer_t *evtimer, evtimer_event_t *event)
 
 static void _set_timer(xtimer_t *timer, uint32_t offset_ms)
 {
-    uint64_t offset_us = (uint64_t)offset_ms * 1000;
+    uint64_t offset_us = (uint64_t)offset_ms * US_PER_MS;
 
     DEBUG("evtimer: now=%" PRIu32 " us setting xtimer to %" PRIu32 ":%" PRIu32 " us\n",
           xtimer_now_usec(), (uint32_t)(offset_us >> 32), (uint32_t)(offset_us));


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

see title, that's it


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->