### PR TITLE
periph/i2c: add default fallback wrappers I2C functions

### DIFF
--- a/drivers/include/periph/i2c.h
+++ b/drivers/include/periph/i2c.h
@@ -31,7 +31,7 @@
  * // next we write the register address, but create no STOP condition when done
  * i2c_write_byte(dev, device_addr, reg_addr, (i2C_NOSTOP | I2C_ADDR10));
  * // and now we read the register value
- * i2c_read(dev, device_addr, &reg_value, 1, I2C_ADDR10);
+ * i2c_read_byte(dev, device_addr, &reg_value, I2C_ADDR10);
  * // finally we have to release the bus
  * i2c_release(dev);
  * @endcode
@@ -46,9 +46,9 @@
  * // first, acquire the shared bus again
  * i2c_acquire(dev);
  * // write the 16-bit register address to the device and prevent STOP condition
- * i2c_write(dev, device_addr, reg_addr, I2C_NOSTOP);
+ * i2c_write_byte(dev, device_addr, reg_addr, I2C_NOSTOP);
  * // and write the data after a REPEATED START
- * i2c_write(dev, device_addr, reg_data, 2, 0);
+ * i2c_write_bytes(dev, device_addr, reg_data, 2, 0);
  * // and finally free the bus again
  * i2c_release(dev);
  * @endcode
@@ -254,21 +254,6 @@ int i2c_acquire(i2c_t dev);
 void i2c_release(i2c_t dev);
 
 /**
- * @brief   Read data from the given I2C device
- *
- * @param[in]  dev          I2C peripheral device
- * @param[in]  addr         7-bit or 10-bit device address (right-aligned)
- * @param[out] data         memory location to store received data
- * @param[in]  len          the number of bytes to read into @p data
- * @param[in]  flags        optional flags (see @ref i2c_flags_t)
- *
- * @return                  I2C_ACK on successful transfer of @p len byte
- * @return                  I2C_ADDR_NACK if response to address byte was NACK
- * @return                  I2C_ERR for any other error
- */
-int i2c_read(i2c_t dev, uint16_t addr, void *data, size_t len, uint8_t flags);
-
-/**
  * @brief   Convenience function for reading one byte from a given register
  *          address
  *
@@ -331,8 +316,7 @@ int i2c_read_regs(i2c_t dev, uint16_t addr, uint16_t reg,
 int i2c_read_byte(i2c_t dev, uint16_t addr, void *data, uint8_t flags);
 
 /**
- * @brief   Convenience function for reading one byte from a given register
- *          address
+ * @brief   Convenience function for reading bytes from a device
  *
  * @note    This function is using a repeated start sequence for reading from
  *          the specified register address.
@@ -350,22 +334,6 @@ int i2c_read_byte(i2c_t dev, uint16_t addr, void *data, uint8_t flags);
 
 int i2c_read_bytes(i2c_t dev, uint16_t addr,
                    void *data, size_t len, uint8_t flags);
-
-/**
- * @brief   Write data from/to the given I2C device
- *
- * @param[in]  dev          I2C peripheral device
- * @param[in]  addr         7-bit or 10-bit device address (right-aligned)
- * @param[out] data         array holding the received bytes
- * @param[in]  len          the number of bytes to write
- * @param[in]  flags        optional flags (see @ref i2c_flags_t)
- *
- * @return                  I2C_ACK on successful transfer of @p len byte
- * @return                  I2C_ADDR_NACK if response to address byte was NACK
- * @return                  I2C_ERR for any other error
- */
-int i2c_write(i2c_t dev, uint16_t addr,
-              const void *data, size_t len, uint8_t flags);
 
 /**
  * @brief   Convenience function for writing a single byte onto the bus

--- a/drivers/periph_common/i2c.c
+++ b/drivers/periph_common/i2c.c
@@ -1,0 +1,109 @@
+/*
+ * Copyright (C) 2018 Mesotic SAS <dylan.laduranty@mesotic.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     drivers
+ * @{
+ *
+ * @file
+ * @brief       common I2C function fallback implementations
+ *
+ * @author      Dylan Laduranty <dylan.laduranty@mesotic.com>
+ *
+ * @}
+ */
+
+#include "board.h"
+#include "cpu.h"
+#include "periph/i2c.h"
+
+#ifdef I2C_NUMOF
+
+#ifdef PERIPH_I2C_NEED_READ_REG
+int i2c_read_reg(ic2_t dev, uint16_t addr, uint16_t reg,
+                 void *data, uint8_t flags)
+{
+	return i2c_read_regs(dev, addr, reg, data, 1, flags);
+}
+#endif /* PERIPH_I2C_NEED_READ_REG */
+
+#ifdef PERIPH_I2C_NEED_READ_REGS
+int i2c_read_regs(ic2_t dev, uint16_t addr, uint16_t reg,
+                  void *data, size_t len, uint8_t flags);
+{
+	uint16_t data = reg;
+	uint8_t err;
+	/* First set ADDR and register with no stop */
+	err = i2c_write(dev, addr, &data, (flags & I2C_REG16) ? 2 : 1,
+					flags & I2C_NOSTOP );
+	if(err != I2C_ACK)
+	{
+		return err;
+	}
+	/* Then get the data from device */
+    return i2c_read(dev, addr, data, len, flags);
+}
+#endif /* PERIPH_I2C_NEED_READ_REGS */
+
+#ifdef PERIPH_I2C_NEED_READ_BYTE
+int i2c_read_byte(ic2_t dev, uint16_t addr, void *data, uint8_t flags)
+{
+	return i2c_read(dev, addr, data, 1, flags);
+}
+#endif /* PERIPH_I2C_NEED_READ_BYTE */
+
+#ifdef PERIPH_I2C_NEED_READ_BYTES
+int i2c_read_bytes(ic2_t dev, uint16_t addr,
+                   void *data, size_t len, uint8_t flags)
+{
+	return i2c_read(dev, addr, data, len, flags);
+}
+#endif /* PERIPH_I2C_NEED_READ_BYTES */
+
+#ifdef PERIPH_I2C_NEED_WRITE_BYTE
+int i2c_write_byte(i2c_t dev, uint16_t addr, uint8_t data, uint8_t flags)
+{
+	return i2c_write(dev, addr, addr, 1, flags);
+}
+#endif /* PERIPH_I2C_NEED_WRITE_BYTE */
+
+#ifdef PERIPH_I2C_NEED_WRITE_BYTES
+int i2c_write_bytes(i2c_t dev, uint16_t addr, const void *data,
+                    size_t len, uint8_t flags)
+{
+	return i2c_write(dev, addr, addr, len, flags);
+}
+#endif /* PERIPH_I2C_NEED_WRITE_BYTES */
+
+#ifdef PERIPH_I2C_NEED_WRITE_REG
+int i2c_write_reg(i2c_t dev, uint16_t addr, uint16_t reg,
+                  const void *data, size_t len, uint8_t flags)
+{
+	return i2c_write_regs(dev, addr, reg, data, 1);
+}
+#endif /* PERIPH_I2C_NEED_WRITE_REG */
+
+#ifdef PERIPH_I2C_NEED_WRITE_REGS
+int i2c_write_regs(i2c_t dev, uint16_t addr, uint16_t reg,
+                  const void *data, size_t len, uint8_t flags)
+{
+	uint16_t regp = reg;
+	uint8_t err;
+	/* First set ADDR and register with no stop */
+	err = i2c_write(dev, addr, &regp, (flags & I2C_REG16) ? 2 : 1,
+					flags & I2C_NOSTOP );
+	if(err != I2C_ACK)
+	{
+		return err;
+	}
+	/* Then write data to the device */
+    return i2c_write(dev, addr, data, len, flags);
+}
+#endif /* PERIPH_I2C_NEED_WRITE_REGS */
+
+#endif /* I2C_NUMOF */

--- a/drivers/periph_common/i2c.c
+++ b/drivers/periph_common/i2c.c
@@ -7,7 +7,7 @@
  */
 
 /**
- * @ingroup     drivers
+ * @ingroup     drivers_periph_i2c
  * @{
  *
  * @file
@@ -24,85 +24,57 @@
 
 #ifdef I2C_NUMOF
 
-#ifdef PERIPH_I2C_NEED_READ_REG
+#ifdef PERIPH_I2C_NEED_READ_REGS
 int i2c_read_reg(ic2_t dev, uint16_t addr, uint16_t reg,
                  void *data, uint8_t flags)
 {
-	return i2c_read_regs(dev, addr, reg, data, 1, flags);
+    return i2c_read_regs(dev, addr, reg, data, 1, flags);
 }
-#endif /* PERIPH_I2C_NEED_READ_REG */
 
-#ifdef PERIPH_I2C_NEED_READ_REGS
 int i2c_read_regs(ic2_t dev, uint16_t addr, uint16_t reg,
-                  void *data, size_t len, uint8_t flags);
+                  void *data, size_t len, uint8_t flags)
 {
-	uint16_t data = reg;
-	uint8_t err;
-	/* First set ADDR and register with no stop */
-	err = i2c_write(dev, addr, &data, (flags & I2C_REG16) ? 2 : 1,
-					flags & I2C_NOSTOP );
-	if(err != I2C_ACK)
-	{
-		return err;
-	}
-	/* Then get the data from device */
-    return i2c_read(dev, addr, data, len, flags);
+    uint8_t err;
+    /* First set ADDR and register with no stop */
+    err = i2c_write_bytes(dev, addr, &reg, (flags & I2C_REG16) ? 2 : 1,
+                          flags & I2C_NOSTOP );
+    if (err != I2C_ACK) {
+        return err;
+    }
+    /* Then get the data from device */
+    return i2c_read_bytes(dev, addr, data, len, flags);
 }
 #endif /* PERIPH_I2C_NEED_READ_REGS */
 
-#ifdef PERIPH_I2C_NEED_READ_BYTE
 int i2c_read_byte(ic2_t dev, uint16_t addr, void *data, uint8_t flags)
 {
-	return i2c_read(dev, addr, data, 1, flags);
+    return i2c_read_bytes(dev, addr, data, 1, flags);
 }
-#endif /* PERIPH_I2C_NEED_READ_BYTE */
 
-#ifdef PERIPH_I2C_NEED_READ_BYTES
-int i2c_read_bytes(ic2_t dev, uint16_t addr,
-                   void *data, size_t len, uint8_t flags)
-{
-	return i2c_read(dev, addr, data, len, flags);
-}
-#endif /* PERIPH_I2C_NEED_READ_BYTES */
-
-#ifdef PERIPH_I2C_NEED_WRITE_BYTE
 int i2c_write_byte(i2c_t dev, uint16_t addr, uint8_t data, uint8_t flags)
 {
-	return i2c_write(dev, addr, addr, 1, flags);
+    return i2c_write_bytes(dev, addr, addr, 1, flags);
 }
-#endif /* PERIPH_I2C_NEED_WRITE_BYTE */
 
-#ifdef PERIPH_I2C_NEED_WRITE_BYTES
-int i2c_write_bytes(i2c_t dev, uint16_t addr, const void *data,
-                    size_t len, uint8_t flags)
-{
-	return i2c_write(dev, addr, addr, len, flags);
-}
-#endif /* PERIPH_I2C_NEED_WRITE_BYTES */
-
-#ifdef PERIPH_I2C_NEED_WRITE_REG
+#ifdef PERIPH_I2C_NEED_WRITE_REGS
 int i2c_write_reg(i2c_t dev, uint16_t addr, uint16_t reg,
                   const void *data, size_t len, uint8_t flags)
 {
-	return i2c_write_regs(dev, addr, reg, data, 1);
+    return i2c_write_regs(dev, addr, reg, data, 1);
 }
-#endif /* PERIPH_I2C_NEED_WRITE_REG */
 
-#ifdef PERIPH_I2C_NEED_WRITE_REGS
 int i2c_write_regs(i2c_t dev, uint16_t addr, uint16_t reg,
-                  const void *data, size_t len, uint8_t flags)
+                   const void *data, size_t len, uint8_t flags)
 {
-	uint16_t regp = reg;
-	uint8_t err;
-	/* First set ADDR and register with no stop */
-	err = i2c_write(dev, addr, &regp, (flags & I2C_REG16) ? 2 : 1,
-					flags & I2C_NOSTOP );
-	if(err != I2C_ACK)
-	{
-		return err;
-	}
-	/* Then write data to the device */
-    return i2c_write(dev, addr, data, len, flags);
+    uint8_t err;
+    /* First set ADDR and register with no stop */
+    err = i2c_write_bytes(dev, addr, &reg, (flags & I2C_REG16) ? 2 : 1,
+                          flags & I2C_NOSTOP );
+    if (err != I2C_ACK) {
+        return err;
+    }
+    /* Then write data to the device */
+    return i2c_write_bytes(dev, addr, data, len, flags);
 }
 #endif /* PERIPH_I2C_NEED_WRITE_REGS */
 


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR provides the default fallback implementations of basic I2C functions.
Each CPU can overwrite those functions if it's needed.
The behaviour is actually borrowed from SPI bus.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->