### PR TITLE
drivers/periph: fix doxygen groups in implementation

### DIFF
--- a/drivers/periph_common/cpuid.c
+++ b/drivers/periph_common/cpuid.c
@@ -9,7 +9,7 @@
  */
 
 /**
- * @addtogroup  drivers
+ * @ingroup     drivers_periph_cpuid
  * @{
  *
  * @file

--- a/drivers/periph_common/flashpage.c
+++ b/drivers/periph_common/flashpage.c
@@ -7,7 +7,7 @@
  */
 
 /**
- * @ingroup     drivers
+ * @ingroup     drivers_periph_flashpage
  * @{
  *
  * @file

--- a/drivers/periph_common/spi.c
+++ b/drivers/periph_common/spi.c
@@ -8,7 +8,7 @@
  */
 
 /**
- * @ingroup     drivers
+ * @ingroup     drivers_periph_spi
  * @{
  *
  * @file

--- a/drivers/periph_common/timer.c
+++ b/drivers/periph_common/timer.c
@@ -7,7 +7,7 @@
  */
 
 /**
- * @ingroup     drivers
+ * @ingroup     drivers_periph_timer
  * @{
  *
  * @file


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

While reviewing #9167, I realized that some periph implementation files were not added to the right groups.

This PR fixes that.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->