### PR TITLE
Jiminy Support for at86rfr2 transceiver

### DIFF
--- a/boards/jiminy-mega256rfr2/Makefile.dep
+++ b/boards/jiminy-mega256rfr2/Makefile.dep
@@ -1,1 +1,6 @@
+# export board specific dependencies to the global includes-listing
 USEMODULE += boards_common_atmega
+
+ifneq (, $(filter gnrc_netdev_default netdev_default, $(USEMODULE)))
+  USEMODULE += at86rfr2
+endif

--- a/boards/jiminy-mega256rfr2/Makefile.features
+++ b/boards/jiminy-mega256rfr2/Makefile.features
@@ -3,6 +3,7 @@ include $(RIOTBOARD)/common/arduino-atmega/Makefile.features
 # Put defined MCU peripherals here (in alphabetical order)
 # Peripherals are defined in common/arduino-atmega/Makefile.features
 # Add only additional Peripherals
+FEATURES_PROVIDED += radio_at86rf2xx
 
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = avr6

--- a/boards/jiminy-mega256rfr2/include/board.h
+++ b/boards/jiminy-mega256rfr2/include/board.h
@@ -33,8 +33,10 @@ extern "C" {
  * is to use double speed.
  *
  * For 8MHz F_CPU following Baudrate have good error rates
- *  76923
- *  38400
+ *  76800
+ *  38400 Seems to fast for long byte streams, collecting in interrupt to slow.
+ *  19200
+ *   9600
  *
  * Matches this with BAUD in Board/Makefile.include
  *
@@ -88,6 +90,8 @@ extern "C" {
 #define XTIMER_CHAN         (0)
 #define XTIMER_WIDTH        (16)
 #define XTIMER_HZ           (125000UL)
+#define XTIMER_OVERHEAD     (33)
+#define XTIMER_ISR_BACKOFF  (40)
 /** @} */
 
 /**

--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -37,16 +37,18 @@ ifneq (,$(filter at30tse75x,$(USEMODULE)))
   FEATURES_REQUIRED += periph_i2c
 endif
 
-ifneq (,$(filter at86rf2%,$(USEMODULE)))
+ifneq (,$(filter at86rf2% at86rfr2,$(USEMODULE)))
   USEMODULE += at86rf2xx
   USEMODULE += xtimer
   USEMODULE += luid
   USEMODULE += netif
   USEMODULE += ieee802154
   USEMODULE += netdev_ieee802154
+ifneq (,$(filter at86rf2%,$(USEMODULE)))
   FEATURES_REQUIRED += periph_gpio
   FEATURES_REQUIRED += periph_gpio_irq
   FEATURES_REQUIRED += periph_spi
+endif
 endif
 
 ifneq (,$(filter ata8520e,$(USEMODULE)))

--- a/drivers/at86rf2xx/at86rf2xx.c
+++ b/drivers/at86rf2xx/at86rf2xx.c
@@ -1,7 +1,8 @@
 /*
  * Copyright (C) 2013 Alaeddine Weslati <alaeddine.weslati@inria.fr>
- * Copyright (C) 2015 Freie Universität Berlin
+ *               2015 Freie Universität Berlin
  *               2017 HAW Hamburg
+ *               2018 RWTH Aachen
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -21,9 +22,9 @@
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  * @author      Oliver Hahm <oliver.hahm@inria.fr>
  * @author      Sebastian Meiling <s@mlng.net>
+ * @author      Josua Arndt <jarndt@ias.rwth-aachen.de>
  * @}
  */
-
 
 #include "luid.h"
 #include "byteorder.h"
@@ -88,14 +89,15 @@ void at86rf2xx_reset(at86rf2xx_t *dev)
     /* enable safe mode (protect RX FIFO until reading data starts) */
     at86rf2xx_reg_write(dev, AT86RF2XX_REG__TRX_CTRL_2,
                         AT86RF2XX_TRX_CTRL_2_MASK__RX_SAFE_MODE);
-#ifdef MODULE_AT86RF212B
-    at86rf2xx_set_page(dev, AT86RF2XX_DEFAULT_PAGE);
-#endif
 
     /* don't populate masked interrupt flags to IRQ_STATUS register */
     uint8_t tmp = at86rf2xx_reg_read(dev, AT86RF2XX_REG__TRX_CTRL_1);
     tmp &= ~(AT86RF2XX_TRX_CTRL_1_MASK__IRQ_MASK_MODE);
     at86rf2xx_reg_write(dev, AT86RF2XX_REG__TRX_CTRL_1, tmp);
+
+#ifdef MODULE_AT86RF212B
+    at86rf2xx_set_page(dev, AT86RF2XX_DEFAULT_PAGE);
+#endif
 
     /* configure smart idle listening feature */
 #if AT86RF2XX_SMART_IDLE_LISTENING
@@ -116,11 +118,12 @@ void at86rf2xx_reset(at86rf2xx_t *dev)
     tmp |= (AT86RF2XX_TRX_CTRL_0_CLKM_CTRL__OFF);
     at86rf2xx_reg_write(dev, AT86RF2XX_REG__TRX_CTRL_0, tmp);
 
+    /* clear interrupt flags, AT86RF233 Manual p.33*/
+    at86rf2xx_reg_read(dev, AT86RF2XX_REG__IRQ_STATUS);
+
     /* enable interrupts */
     at86rf2xx_reg_write(dev, AT86RF2XX_REG__IRQ_MASK,
                         AT86RF2XX_IRQ_STATUS_MASK__TRX_END);
-    /* clear interrupt flags */
-    at86rf2xx_reg_read(dev, AT86RF2XX_REG__IRQ_STATUS);
 
     /* State to return after receiving or transmitting */
     dev->idle_state = AT86RF2XX_STATE_RX_AACK_ON;

--- a/drivers/at86rf2xx/at86rf2xx_internal.c
+++ b/drivers/at86rf2xx/at86rf2xx_internal.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2013 Alaeddine Weslati <alaeddine.weslati@inria.fr>
- * Copyright (C) 2015 Freie Universität Berlin
+ *               2015 Freie Universität Berlin
+ *               2018 RWTH Aachen
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -18,6 +19,7 @@
  * @author      Thomas Eichinger <thomas.eichinger@fu-berlin.de>
  * @author      Joakim Nohlgård <joakim.nohlgard@eistec.se>
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author      Josua Arndt <jarndt@ias.rwth-aachen.de>
  * @}
  */
 
@@ -27,14 +29,46 @@
 #include "at86rf2xx_internal.h"
 #include "at86rf2xx_registers.h"
 
+#define ENABLE_DEBUG (0)
+#include "debug.h"
+
+#define ENABLE_HEX_DUMP_RX  (0)
+#if ENABLE_HEX_DUMP_RX
+#include "od.h"
+#endif
+
+#ifdef MODULE_AT86RFR2
+/* SOC uses no SPI, but uses memcpy */
+#include <string.h>
+#else
 #define SPIDEV          (dev->params.spi)
 #define CSPIN           (dev->params.cs_pin)
+#endif
 
+#ifndef MODULE_AT86RFR2 /* SOC uses no SPI */
 static inline void getbus(const at86rf2xx_t *dev)
 {
     spi_acquire(SPIDEV, CSPIN, SPI_MODE_0, dev->params.spi_clk);
 }
+#endif
 
+#ifdef MODULE_AT86RFR2
+void at86rf2xx_reg_write(const at86rf2xx_t *dev,
+                         volatile uint8_t *addr, uint8_t value)
+{
+    (void)dev;
+    /* already casted *(volatile uint8_t *) in iom256rfr2, _SFR_MEM8(), _MMIO_BYTE */
+    *(addr) = value;
+}
+
+uint8_t at86rf2xx_reg_read(const at86rf2xx_t *dev,
+                           volatile uint8_t *addr)
+{
+    (void)dev;
+    /* already casted *(volatile uint8_t *) in iom256rfr2 */
+    return *addr;
+}
+#else /* END of MODULE_AT86RFR2 */
 void at86rf2xx_reg_write(const at86rf2xx_t *dev, uint8_t addr, uint8_t value)
 {
     uint8_t reg = (AT86RF2XX_ACCESS_REG | AT86RF2XX_ACCESS_WRITE | addr);
@@ -55,10 +89,15 @@ uint8_t at86rf2xx_reg_read(const at86rf2xx_t *dev, uint8_t addr)
 
     return value;
 }
+#endif
 
 void at86rf2xx_sram_read(const at86rf2xx_t *dev, uint8_t offset,
                          uint8_t *data, size_t len)
 {
+#ifdef MODULE_AT86RFR2
+    (void)dev;
+    memcpy( data, (void *)(AT86RF2XX_REG__TRXFBST + offset), len);
+#else
     uint8_t reg = (AT86RF2XX_ACCESS_SRAM | AT86RF2XX_ACCESS_READ);
 
     getbus(dev);
@@ -66,11 +105,16 @@ void at86rf2xx_sram_read(const at86rf2xx_t *dev, uint8_t offset,
     spi_transfer_byte(SPIDEV, CSPIN, true, offset);
     spi_transfer_bytes(SPIDEV, CSPIN, false, NULL, data, len);
     spi_release(SPIDEV);
+#endif
 }
 
 void at86rf2xx_sram_write(const at86rf2xx_t *dev, uint8_t offset,
                           const uint8_t *data, size_t len)
 {
+#ifdef MODULE_AT86RFR2
+    (void)dev;
+    memcpy((void *)(AT86RF2XX_REG__TRXFBST + offset), data, len);
+#else
     uint8_t reg = (AT86RF2XX_ACCESS_SRAM | AT86RF2XX_ACCESS_WRITE);
 
     getbus(dev);
@@ -78,27 +122,48 @@ void at86rf2xx_sram_write(const at86rf2xx_t *dev, uint8_t offset,
     spi_transfer_byte(SPIDEV, CSPIN, true, offset);
     spi_transfer_bytes(SPIDEV, CSPIN, false, data, NULL, len);
     spi_release(SPIDEV);
+#endif
 }
 
 void at86rf2xx_fb_start(const at86rf2xx_t *dev)
 {
+#ifdef MODULE_AT86RFR2
+    /* nothing to do here */
+    (void)dev;
+#else
     uint8_t reg = AT86RF2XX_ACCESS_FB | AT86RF2XX_ACCESS_READ;
 
     getbus(dev);
     spi_transfer_byte(SPIDEV, CSPIN, true, reg);
+#endif
 }
 
 void at86rf2xx_fb_read(const at86rf2xx_t *dev,
                        uint8_t *data, size_t len)
 {
+#ifdef MODULE_AT86RFR2
+    (void)dev;
+    memcpy( data, (void *)(AT86RF2XX_REG__TRXFBST), len);
+#else
     spi_transfer_bytes(SPIDEV, CSPIN, true, NULL, data, len);
+#endif
+
+#if ENABLE_HEX_DUMP_RX
+    puts("RECEIVED:");
+    od_hex_dump(data, len, OD_WIDTH_DEFAULT);
+#endif
 }
 
 void at86rf2xx_fb_stop(const at86rf2xx_t *dev)
 {
+#ifdef MODULE_AT86RFR2
+    /* nothing to do here */
+    (void)dev;
+#else
     /* transfer one byte (which we ignore) to release the chip select */
     spi_transfer_byte(SPIDEV, CSPIN, false, 1);
     spi_release(SPIDEV);
+#endif
 }
 
 uint8_t at86rf2xx_get_status(const at86rf2xx_t *dev)
@@ -116,7 +181,13 @@ void at86rf2xx_assert_awake(at86rf2xx_t *dev)
 {
     if (at86rf2xx_get_status(dev) == AT86RF2XX_STATE_SLEEP) {
         /* wake up and wait for transition to TRX_OFF */
+#ifdef MODULE_AT86RFR2
+        /* Setting SLPTR bit in TRXPR to 0 returns the radio transceiver
+         * to the TRX_OFF state */
+        *AT86RF2XX_REG__TRXPR &= ~(AT86RF2XX_TRXPR_SLPTR);
+#else
         gpio_clear(dev->params.sleep_pin);
+#endif
         xtimer_usleep(AT86RF2XX_WAKEUP_DELAY);
 
         /* update state: on some platforms, the timer behind xtimer
@@ -134,9 +205,14 @@ void at86rf2xx_assert_awake(at86rf2xx_t *dev)
 void at86rf2xx_hardware_reset(at86rf2xx_t *dev)
 {
     /* trigger hardware reset */
+#ifdef MODULE_AT86RFR2
+    /* set reset Bit */
+    *(AT86RF2XX_REG__TRXPR) |= AT86RF2XX_TRXPR_TRXRST;
+#else
     gpio_clear(dev->params.reset_pin);
     xtimer_usleep(AT86RF2XX_RESET_PULSE_WIDTH);
     gpio_set(dev->params.reset_pin);
+#endif
     xtimer_usleep(AT86RF2XX_RESET_DELAY);
 
     /* update state: if the radio state was P_ON (initialization phase),

--- a/drivers/at86rf2xx/at86rfr2_interrupts.c
+++ b/drivers/at86rf2xx/at86rfr2_interrupts.c
@@ -1,0 +1,201 @@
+/*
+ * Copyright (C) 2018 RWTH Aachen, Josua Arndt <jarndt@ias.rwth-aachen.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_at86rf2xx
+ * @{
+ *
+ * @file
+ * @brief       Implementation of public functions for AT86RF2xx drivers
+ *
+ * @author      Josua Arndt <jarndt@ias.rwth-aachen.de>
+ * @}
+ */
+/* As of now the implementation only supports the atmega256rfr2 */
+#ifdef MODULE_AT86RFR2
+
+#include "board.h"
+#include "avr/interrupt.h"
+#include "sched.h"
+
+#include "at86rf2xx_registers.h"
+#include "at86rf2xx_netdev.h"
+
+/* Debug messages in Interrupts lead to packet loss and bad performance. */
+#define ENABLE_DEBUG (0)
+#include "debug.h"
+
+#ifndef RXTX_LED_ENABLE
+#define RXTX_LED_ENABLE (1)
+#endif
+
+#if RXTX_LED_ENABLE
+#define RXTX_LED_INIT (LED_PORT_DDR |= LED0_MASK)
+#define RXTX_LED_ON   LED0_ON
+#define RXTX_LED_OFF  LED0_OFF
+#endif
+
+#define DEBUG_ATRFR2_PINS (1)
+#ifdef DEBUG_ATRFR2_PINS
+#define DEBUG_ATRFR2_PORT_DDR     (DDRF)
+#define DEBUG_ATRFR2_PORT         (PORTF)
+#define DEBUG_ATRFR2_PIN_TX_START (1 << PORTF7)
+#define DEBUG_ATRFR2_PIN_TX_END   (1 << PORTF6)
+#define DEBUG_ATRFR2_PIN_RX_END   (1 << PORTF5)
+#endif
+
+/* netdev_t to at86rfr2_dev for Interrupt handling */
+netdev_t *at86rfr2_dev = 0;
+
+/* Counting Retries */
+int8_t retries = 0;
+
+void enable_rxtx_led(void)
+{
+
+#if RXTX_LED_ENABLE
+    RXTX_LED_INIT;
+#endif
+
+#if DEBUG_ATRFR2_PINS
+    /*initialize Debug Pins */
+    /* Port Pin as Output */
+    DEBUG_ATRFR2_PORT_DDR |=  (DEBUG_ATRFR2_PIN_TX_START
+                               | DEBUG_ATRFR2_PIN_TX_END | DEBUG_ATRFR2_PIN_RX_END);
+    /* Pin Low */
+    DEBUG_ATRFR2_PORT     &= ~(DEBUG_ATRFR2_PIN_TX_START
+                               | DEBUG_ATRFR2_PIN_TX_END | DEBUG_ATRFR2_PIN_RX_END);
+#endif
+}
+
+/**
+ * @brief ISR for transceiver's receive end interrupt
+ *
+ *  Is triggered when valid data is received. FCS check passed.
+ *  Save IRQ status and inform upper layer of data reception.
+ *
+ * Flow Diagram Manual p. 52 / 63
+ */
+ISR(TRX24_RX_END_vect, ISR_BLOCK){
+    __enter_isr();
+
+#if DEBUG_ATRFR2_PINS
+    DEBUG_ATRFR2_PORT |= DEBUG_ATRFR2_PIN_RX_END;
+#endif
+
+    uint8_t status = *AT86RF2XX_REG__TRX_STATE & AT86RF2XX_TRX_STATUS_MASK__TRX_STATUS;
+    DEBUG("TRX24_RX_END 0x%x\n", status);
+
+    ((at86rf2xx_t *)at86rfr2_dev)->irq_status |= AT86RF2XX_IRQ_STATUS_MASK__RX_END;
+    /* Call upper layer to process received data */
+    at86rfr2_dev->event_callback(at86rfr2_dev, NETDEV_EVENT_ISR);
+
+#if DEBUG_ATRFR2_PINS
+    DEBUG_ATRFR2_PORT &= ~DEBUG_ATRFR2_PIN_RX_END;
+#endif
+
+    __exit_isr();
+}
+
+/**
+ * @brief  Transceiver Frame Address Match, indicates incoming frame
+ *
+ *  Is triggered when Frame with valid Address is received.
+ *  Can be used to wake up MCU from sleep, etc.
+ *
+ * Flow Diagram Manual p. 52 / 63
+ */
+ISR(TRX24_XAH_AMI_vect, ISR_BLOCK){
+    __enter_isr();
+    DEBUG("TRX24_XAH_AMI\n");
+    ((at86rf2xx_t *)at86rfr2_dev)->irq_status |= AT86RF2XX_IRQ_STATUS_MASK__AMI;
+
+    __exit_isr();
+}
+
+/**
+ * @brief ISR for transceiver's transmit end interrupt
+ *
+ *  Is triggered when data or when acknowledge frames where send.
+ *
+ * Flow Diagram Manual p. 52 / 63
+ */
+ISR(TRX24_TX_END_vect, ISR_BLOCK){
+    __enter_isr();
+
+#if DEBUG_ATRFR2_PINS
+    DEBUG_ATRFR2_PORT |= DEBUG_ATRFR2_PIN_TX_END;
+#endif
+    /* This is a short light pulse*/
+#if RXTX_LED_ENABLE
+    RXTX_LED_ON;
+#endif
+
+    at86rf2xx_t *dev = (at86rf2xx_t *) at86rfr2_dev;
+    uint8_t status = *AT86RF2XX_REG__TRX_STATE & AT86RF2XX_TRX_STATUS_MASK__TRX_STATUS;
+    DEBUG("TRX24_TX_END 0x%x\n", status);
+
+    /* only inform upper layer when a transmission was done,
+     * not for sending acknowledge frames if data was received. */
+    if (status != AT86RF2XX_STATE_RX_AACK_ON) {
+        dev->irq_status |= AT86RF2XX_IRQ_STATUS_MASK__TX_END;
+
+        /* Only radios with the XAH_CTRL_2 register support frame retry reporting
+         * but with TX_START and TX_END retries can also be counted */
+        dev->tx_retries = retries;
+        retries = -1;
+
+        /* Call upper layer to process if data was send succesfull */
+        at86rfr2_dev->event_callback(at86rfr2_dev, NETDEV_EVENT_ISR);
+    }
+
+#if RXTX_LED_ENABLE
+    RXTX_LED_OFF;
+#endif
+
+#if DEBUG_ATRFR2_PINS
+    DEBUG_ATRFR2_PORT &= ~DEBUG_ATRFR2_PIN_TX_END;
+#endif
+
+    __exit_isr();
+}
+
+/**
+ * @brief ISR for transceiver's TX_START interrupt
+ *
+ * In procedure TX_ARET the TRX24_TX_START interrupt is issued separately for every
+ * frame transmission and frame retransmission.
+ * Indicates the frame start of a transmitted acknowledge frame in procedure RX_AACK.
+ *
+ * Flow Diagram Manual p. 52 / 63
+ */
+ISR(TRX24_TX_START_vect){
+    /* __enter_isr(); is not neccessary as there is nothing which causes a
+     * thread_yield and the interrupt can not be interrupted by an other ISR */
+
+#if DEBUG_ATRFR2_PINS
+    DEBUG_ATRFR2_PORT |= DEBUG_ATRFR2_PIN_TX_START;
+#endif
+
+    /* This is a short light pulse*/
+#if RXTX_LED_ENABLE
+    RXTX_LED_ON;
+#endif
+
+    retries++;
+
+#if DEBUG_ATRFR2_PINS
+    DEBUG_ATRFR2_PORT &= ~DEBUG_ATRFR2_PIN_TX_START;
+#endif
+
+#if RXTX_LED_ENABLE
+    RXTX_LED_OFF;
+#endif
+}
+
+#endif /* MODULE_AT86RFR2 */

--- a/drivers/at86rf2xx/include/at86rf2xx_internal.h
+++ b/drivers/at86rf2xx/include/at86rf2xx_internal.h
@@ -1,7 +1,8 @@
 /*
  * Copyright (C) 2013 Alaeddine Weslati <alaeddine.weslati@inria.fr>
- * Copyright (C) 2015 Freie Universität Berlin
+ *               2015 Freie Universität Berlin
  *               2017 HAW Hamburg
+ *               2018 RWTH Aachen, Josua Arndt <jarndt@ias.rwth-aachen.de>
  *
  * This file is subject to the terms and conditions of the GNU Lesser General
  * Public License v2.1. See the file LICENSE in the top level directory for more
@@ -19,6 +20,7 @@
  * @author      Thomas Eichinger <thomas.eichinger@fu-berlin.de>
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  * @author      Sebastian Meiling <s@mlng.net>
+ * @author      Josua Arndt <jarndt@ias.rwth-aachen.de>
  */
 
 #ifndef AT86RF2XX_INTERNAL_H
@@ -73,6 +75,18 @@ extern "C" {
  */
 #define AT86RF2XX_RESET_DELAY           (62U)
 
+#ifdef MODULE_AT86RFR2
+/**
+ * netdev_t to at86rfr2_dev for Interrupt handling
+ */
+extern netdev_t *at86rfr2_dev;
+
+/**
+ * \brief Enabling the receive and transmit led and debug pins.
+ */
+void enable_rxtx_led(void);
+#endif
+
 /**
  * @brief   Read from a register at address `addr` from device `dev`.
  *
@@ -81,7 +95,11 @@ extern "C" {
  *
  * @return              the value of the specified register
  */
+#ifdef MODULE_AT86RFR2
+uint8_t at86rf2xx_reg_read(const at86rf2xx_t *dev, volatile uint8_t *addr);
+#else
 uint8_t at86rf2xx_reg_read(const at86rf2xx_t *dev, uint8_t addr);
+#endif
 
 /**
  * @brief   Write to a register at address `addr` from device `dev`.
@@ -90,7 +108,12 @@ uint8_t at86rf2xx_reg_read(const at86rf2xx_t *dev, uint8_t addr);
  * @param[in] addr      address of the register to write
  * @param[in] value     value to write to the given register
  */
+#ifdef MODULE_AT86RFR2
+void at86rf2xx_reg_write(const at86rf2xx_t *dev, volatile uint8_t *addr,
+                         const uint8_t value);
+#else
 void at86rf2xx_reg_write(const at86rf2xx_t *dev, uint8_t addr, uint8_t value);
+#endif
 
 /**
  * @brief   Read a chunk of data from the SRAM of the given device

--- a/drivers/at86rf2xx/include/at86rf2xx_params.h
+++ b/drivers/at86rf2xx/include/at86rf2xx_params.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2015 Kaspar Schleiser <kaspar@schleiser.de>
  *               2015 Hauke Petersen <hauke.petersen@fu-berlin.de>
+ *               2018 RWTH Aachen, Josua Arndt <jarndt@ias.rwth-aachen.de>
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -15,6 +16,7 @@
  *
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author      Josua Arndt <jarndt@ias.rwth-aachen.de>
  */
 
 #ifndef AT86RF2XX_PARAMS_H
@@ -49,7 +51,9 @@ extern "C" {
 #define AT86RF2XX_PARAM_RESET       (GPIO_PIN(0, 3))
 #endif
 
-#ifndef AT86RF2XX_PARAMS
+#if defined(MODULE_AT86RFR2)
+#define AT86RF2XX_PARAMS            { 0 }
+#elif !defined(AT86RF2XX_PARAMS)
 #define AT86RF2XX_PARAMS            { .spi = AT86RF2XX_PARAM_SPI,         \
                                       .spi_clk = AT86RF2XX_PARAM_SPI_CLK, \
                                       .cs_pin = AT86RF2XX_PARAM_CS,       \
@@ -57,6 +61,7 @@ extern "C" {
                                       .sleep_pin = AT86RF2XX_PARAM_SLEEP, \
                                       .reset_pin = AT86RF2XX_PARAM_RESET }
 #endif
+
 /**@}*/
 
 /**

--- a/drivers/at86rf2xx/include/at86rf2xx_registers.h
+++ b/drivers/at86rf2xx/include/at86rf2xx_registers.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2013 Alaeddine Weslati <alaeddine.weslati@inria.fr>
- * Copyright (C) 2015 Freie Universität Berlin
+ *               2015 Freie Universität Berlin
+ *               2018 Josua Arndt <jarndt@ias.rwth-aachen.de>
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -19,6 +20,7 @@
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  * @author      Kévin Roussel <Kevin.Roussel@inria.fr>
+ * @author      Josua Arndt <jarndt@ias.rwth-aachen.de>
  */
 
 #ifndef AT86RF2XX_REGISTERS_H
@@ -38,6 +40,7 @@ extern "C" {
 #define AT86RF231_PARTNUM        (0x03)
 #define AT86RF232_PARTNUM        (0x0a)
 #define AT86RF233_PARTNUM        (0x0b)
+#define AT86RFR2_PARTNUM         (0x94)
 /** @} */
 
 /**
@@ -50,11 +53,140 @@ extern "C" {
 #define AT86RF2XX_PARTNUM           AT86RF232_PARTNUM
 #elif MODULE_AT86RF233
 #define AT86RF2XX_PARTNUM           AT86RF233_PARTNUM
+#elif MODULE_AT86RFR2
+#define AT86RF2XX_PARTNUM           AT86RFR2_PARTNUM
 #else /* MODULE_AT86RF231 as default device */
 #define AT86RF2XX_PARTNUM           AT86RF231_PARTNUM
 #endif
 /** @} */
 
+/*
+ * For external transceiver SPI and all Register bits have to be defined
+ * For SOC systems we use the definition of the iomXXrfrX
+ */
+#ifdef MODULE_AT86RFR2 /* Begin SOC transceiver */
+
+#include <avr/io.h>
+
+/**
+ * @name Register addresses
+ * @{
+ */
+#define AT86RF2XX_REG__TRX_STATUS                               (&TRX_STATUS)
+#define AT86RF2XX_REG__TRX_STATE                                (&TRX_STATE)
+#define AT86RF2XX_REG__TRX_CTRL_0                               (&TRX_CTRL_0)
+#define AT86RF2XX_REG__TRX_CTRL_1                               (&TRX_CTRL_1)
+#define AT86RF2XX_REG__PHY_TX_PWR                               (&PHY_TX_PWR)
+#define AT86RF2XX_REG__PHY_RSSI                                 (&PHY_RSSI)
+#define AT86RF2XX_REG__PHY_ED_LEVEL                             (&PHY_ED_LEVEL)
+#define AT86RF2XX_REG__PHY_CC_CCA                               (&PHY_CC_CCA)
+#define AT86RF2XX_REG__CCA_THRES                                (&CCA_THRES)
+#define AT86RF2XX_REG__RX_CTRL                                  (&RX_CTRL)
+#define AT86RF2XX_REG__SFD_VALUE                                (&SFD_VALUE)
+#define AT86RF2XX_REG__TRX_CTRL_2                               (&TRX_CTRL_2)
+#define AT86RF2XX_REG__ANT_DIV                                  (&ANT_DIV)
+#define AT86RF2XX_REG__IRQ_MASK                                 (&IRQ_MASK)
+#define AT86RF2XX_REG__IRQ_MASK1                                (&IRQ_MASK1)
+#define AT86RF2XX_REG__IRQ_STATUS                               (&IRQ_STATUS)
+#define AT86RF2XX_REG__IRQ_STATUS1                              (&IRQ_STATUS1)
+#define AT86RF2XX_REG__VREG_CTRL                                (&VREG_CTRL)
+#define AT86RF2XX_REG__BATMON                                   (&BATMON)
+#define AT86RF2XX_REG__XOSC_CTRL                                (&XOSC_CTRL)
+#define AT86RF2XX_REG__CC_CTRL_0                                (&CC_CTRL_0)
+#define AT86RF2XX_REG__CC_CTRL_1                                (&CC_CTRL_1)
+#define AT86RF2XX_REG__RX_SYN                                   (&RX_SYN)
+/* TODO not defined register  TRX_RPC _SFR_MEM8(&0x156) */
+#define AT86RF2XX_REG__XAH_CTRL_1                               (&XAH_CTRL_1)
+#define AT86RF2XX_REG__FTN_CTRL                                 (&FTN_CTRL)
+#define AT86RF2XX_REG__PLL_CF                                   (&PLL_CF)
+#define AT86RF2XX_REG__PLL_DCU                                  (&PLL_DCU)
+#define AT86RF2XX_REG__PART_NUM                                 (&PART_NUM)
+#define AT86RF2XX_REG__VERSION_NUM                              (&VERSION_NUM)
+#define AT86RF2XX_REG__MAN_ID_0                                 (&MAN_ID_0)
+#define AT86RF2XX_REG__MAN_ID_1                                 (&MAN_ID_1)
+#define AT86RF2XX_REG__SHORT_ADDR_0                             (&SHORT_ADDR_0)
+#define AT86RF2XX_REG__SHORT_ADDR_1                             (&SHORT_ADDR_1)
+#define AT86RF2XX_REG__PAN_ID_0                                 (&PAN_ID_0)
+#define AT86RF2XX_REG__PAN_ID_1                                 (&PAN_ID_1)
+#define AT86RF2XX_REG__IEEE_ADDR_0                              (&IEEE_ADDR_0)
+#define AT86RF2XX_REG__IEEE_ADDR_1                              (&IEEE_ADDR_1)
+#define AT86RF2XX_REG__IEEE_ADDR_2                              (&IEEE_ADDR_2)
+#define AT86RF2XX_REG__IEEE_ADDR_3                              (&IEEE_ADDR_3)
+#define AT86RF2XX_REG__IEEE_ADDR_4                              (&IEEE_ADDR_4)
+#define AT86RF2XX_REG__IEEE_ADDR_5                              (&IEEE_ADDR_5)
+#define AT86RF2XX_REG__IEEE_ADDR_6                              (&IEEE_ADDR_6)
+#define AT86RF2XX_REG__IEEE_ADDR_7                              (&IEEE_ADDR_7)
+#define AT86RF2XX_REG__XAH_CTRL_0                               (&XAH_CTRL_0)
+#define AT86RF2XX_REG__CSMA_SEED_0                              (&CSMA_SEED_0)
+#define AT86RF2XX_REG__CSMA_SEED_1                              (&CSMA_SEED_1)
+#define AT86RF2XX_REG__CSMA_BE                                  (&CSMA_BE)
+#define AT86RF2XX_REG__TST_CTRL_DIGI                            (&TST_CTRL_DIGI)
+/* TODO not defined register  TST_RX_LENGTH _SFR_MEM8(0x17B) */
+
+/* TODO not defined register  TRXFBST _SFR_MEM8(0x180) */
+/* TODO not defined register  TRXFBEND _SFR_MEM8(0x1FF) */
+ #define AT86RF2XX_REG__TRXFBST                                  (&TRXFBST)
+ #define AT86RF2XX_REG__TRXFBEND                                 (&TRXFBEND)
+
+ #define AT86RF2XX_REG__TRXPR                                    (&TRXPR)
+/** @} */
+
+/**
+ * @name   Bitfield definitions for the TRX_CTRL_0 register
+ * @{
+ */
+#define AT86RF2XX_TRX_CTRL_0_MASK__PMU_EN                       (0x40)
+#define AT86RF2XX_TRX_CTRL_0_MASK__PMU_START                    (0x20)
+#define AT86RF2XX_TRX_CTRL_0_MASK__PMU_IF_INV                   (0x10)
+/** @} */
+
+/**
+ * @name   Bitfield definitions for the TRX_CTRL_1 register
+ * @{
+ */
+#define AT86RF2XX_TRX_CTRL_1_MASK__PA_EXT_EN                    (0x80)
+#define AT86RF2XX_TRX_CTRL_1_MASK__IRQ_2_EXT_EN                 (0x40)
+#define AT86RF2XX_TRX_CTRL_1_MASK__TX_AUTO_CRC_ON               (0x20)
+#define AT86RF2XX_TRX_CTRL_1_MASK__PLL_TX_FLT                   (0x10)
+/** @} */
+
+/**
+ * @name   Bitfield definitions for the TRX_CTRL_2 register
+ * @{
+ */
+#define AT86RF2XX_TRX_CTRL_2_MASK__RX_SAFE_MODE                 (0x80)
+#define AT86RF2XX_TRX_CTRL_2_MASK__OQPSK_DATA_RATE              (0x03)
+/** @} */
+
+/**
+ * @name   Bitfield definitions for the IRQ_MASK/IRQ_STATUS register
+ * @{
+ */
+#define AT86RF2XX_IRQ_STATUS_MASK__AWAKE                 (0x80)
+#define AT86RF2XX_IRQ_STATUS_MASK__TX_END                (0x40)
+#define AT86RF2XX_IRQ_STATUS_MASK__AMI                   (0x20)
+#define AT86RF2XX_IRQ_STATUS_MASK__CCA_ED_DONE           (0x10)
+#define AT86RF2XX_IRQ_STATUS_MASK__RX_END                (0x08)
+#define AT86RF2XX_IRQ_STATUS_MASK__RX_START              (0x04)
+#define AT86RF2XX_IRQ_STATUS_MASK__PLL_UNLOCK            (0x02)
+#define AT86RF2XX_IRQ_STATUS_MASK__PLL_LOCK              (0x01)
+
+/* Map TX_END and RX_END to TRX_END to be compatible to SPI Devices */
+    #define AT86RF2XX_IRQ_STATUS_MASK__TRX_END               (0x48)
+
+/**
+ * @name   Bitfield definitions for the IRQ_MASK1/IRQ_STATUS1 register
+ * @{
+ */
+#define AT86RF2XX_IRQ_STATUS_MASK1__TX_START                 (0x01)
+#define AT86RF2XX_IRQ_STATUS_MASK1__MAF_0_AMI                (0x02)
+#define AT86RF2XX_IRQ_STATUS_MASK1__MAF_1_AMI                (0x04)
+#define AT86RF2XX_IRQ_STATUS_MASK1__MAF_2_AMI                (0x08)
+#define AT86RF2XX_IRQ_STATUS_MASK1__MAF_3_AMI                (0x10)
+/** @} */
+
+/* END SOC transceiver */
+#else /* Begin external spi transceiver */
 /**
  * @name    SPI access specifiers
  * @{
@@ -190,6 +322,7 @@ extern "C" {
 #define AT86RF2XX_IRQ_STATUS_MASK__PLL_LOCK                     (0x01)
 /** @} */
 
+#endif /* END external spi transceiver */
 /**
  * @name    Bitfield definitions for the TRX_STATUS register
  * @{
@@ -212,6 +345,12 @@ extern "C" {
 #define AT86RF2XX_TRX_STATUS__RX_ON_NOCLK                       (0x1C)
 #define AT86RF2XX_TRX_STATUS__RX_AACK_ON_NOCLK                  (0x1D)
 #define AT86RF2XX_TRX_STATUS__BUSY_RX_AACK_NOCLK                (0x1E)
+
+#ifndef MODULE_AT86RFR2 /* not defined for atmega256rfr2 */
+#define AT86RF2XX_TRX_STATUS__RX_ON_NOCLK                       (0x1C)
+#define AT86RF2XX_TRX_STATUS__RX_AACK_ON_NOCLK                  (0x1D)
+#define AT86RF2XX_TRX_STATUS__BUSY_RX_AACK_NOCLK                (0x1E)
+#endif
 #define AT86RF2XX_TRX_STATUS__STATE_TRANSITION_IN_PROGRESS      (0x1F)
 /** @} */
 
@@ -270,6 +409,9 @@ extern "C" {
 #define AT86RF2XX_PHY_TX_PWR_MASK__PA_BUF_LT                    (0xC0)
 #define AT86RF2XX_PHY_TX_PWR_MASK__PA_LT                        (0x30)
 #define AT86RF2XX_PHY_TX_PWR_MASK__TX_PWR                       (0x0F)
+#elif MODULE_AT86RFR2
+#define AT86RF2XX_PHY_TX_PWR_MASK__TX_PWR                       (0x0F)
+#define AT86RF2XX_PHY_TX_PWR_DEFAULT__TX_PWR                    (0x00) /*3.5dBm*/
 #else
 #define AT86RF2XX_PHY_TX_PWR_MASK__TX_PWR                       (0x0F)
 #endif
@@ -291,7 +433,11 @@ extern "C" {
  * @name    Bitfield definitions for the XOSC_CTRL register
  * @{
  */
-#define AT86RF2XX_XOSC_CTRL__XTAL_MODE_CRYSTAL                  (0xF0)
+#if MODULE_AT86RF212B || MODULE_AT86RF231 || MODULE_AT86RFR2
+#define AT86RF2XX_XOSC_CTRL__XTAL_MODE_CRYSTAL                  (0x40)
+#elif MODULE_AT86RF232 || MODULE_AT86RF233
+#define AT86RF2XX_XOSC_CTRL__XTAL_MODE_CRYSTAL                  (0x50)
+#endif
 #define AT86RF2XX_XOSC_CTRL__XTAL_MODE_EXTERNAL                 (0xF0)
 /** @} */
 
@@ -361,6 +507,18 @@ extern "C" {
 #define AT86RF2XX_CSMA_SEED_1__AACK_DIS_ACK                     (0x10)
 #define AT86RF2XX_CSMA_SEED_1__AACK_I_AM_COORD                  (0x08)
 #define AT86RF2XX_CSMA_SEED_1__CSMA_SEED_1                      (0x07)
+/** @} */
+
+/**
+ * @name   Bitfield definitions for the  TRXPR  Transceiver Pin Register
+ * @{
+ */
+#ifdef MODULE_AT86RFR2
+#define AT86RF2XX_TRXPR_ATBE                                    (0x08)
+#define AT86RF2XX_TRXPR_TRXTST                                  (0x04)
+#define AT86RF2XX_TRXPR_SLPTR                                   (0x02)
+#define AT86RF2XX_TRXPR_TRXRST                                  (0x01)
+#endif
 /** @} */
 
 /**

--- a/drivers/include/at86rf2xx.h
+++ b/drivers/include/at86rf2xx.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2015 Freie Universität Berlin
+ *               2018 RWTH Aachen, Josua Arndt <jarndt@ias.rwth-aachen.de>
  *
  * This file is subject to the terms and conditions of the GNU Lesser General
  * Public License v2.1. See the file LICENSE in the top level directory for more
@@ -24,6 +25,7 @@
  * @author      Daniel Krebs <github@daniel-krebs.net>
  * @author      Kévin Roussel <Kevin.Roussel@inria.fr>
  * @author      Joakim Nohlgård <joakim.nohlgard@eistec.se>
+ * @author      Josua Arndt <jarndt@ias.rwth-aachen.de>
  */
 
 #ifndef AT86RF2XX_H
@@ -75,16 +77,18 @@ extern "C" {
 /**
  * @brief   Base (minimal) RSSI value in dBm
  */
-#if MODULE_AT86RF233
-#   define RSSI_BASE_VAL                   (-94)
-#elif MODULE_AT86RF212B
+#if MODULE_AT86RF212B
 /**
- * @note for the default settings in RIOT for the at86rf212b,
- *       for other seetings this value may change.
+ * @note for the default PHY_MODE settings in RIOT for the at86rf212b,
+ *       for other settings this value may change.
  */
 #   define RSSI_BASE_VAL                   (-98)
-#else
+#elif MODULE_AT86RF231 || MODULE_AT86RF232
 #   define RSSI_BASE_VAL                   (-91)
+#elif MODULE_AT86RF233
+#   define RSSI_BASE_VAL                   (-94)
+#elif MODULE_AT86RFR2
+#   define RSSI_BASE_VAL                   (-90)
 #endif
 
 /**
@@ -143,19 +147,19 @@ extern "C" {
  * @name    Flags for device internal states (see datasheet)
  * @{
  */
-#define AT86RF2XX_STATE_P_ON           (0x00)     /**< initial power on */
-#define AT86RF2XX_STATE_BUSY_RX        (0x01)     /**< busy receiving data (basic mode) */
-#define AT86RF2XX_STATE_BUSY_TX        (0x02)     /**< busy transmitting data (basic mode) */
-#define AT86RF2XX_STATE_FORCE_TRX_OFF  (0x03)     /**< force transition to idle */
-#define AT86RF2XX_STATE_RX_ON          (0x06)     /**< listen mode (basic mode) */
-#define AT86RF2XX_STATE_TRX_OFF        (0x08)     /**< idle */
-#define AT86RF2XX_STATE_PLL_ON         (0x09)     /**< ready to transmit */
-#define AT86RF2XX_STATE_SLEEP          (0x0f)     /**< sleep mode */
-#define AT86RF2XX_STATE_BUSY_RX_AACK   (0x11)     /**< busy receiving data (extended mode) */
-#define AT86RF2XX_STATE_BUSY_TX_ARET   (0x12)     /**< busy transmitting data (extended mode) */
-#define AT86RF2XX_STATE_RX_AACK_ON     (0x16)     /**< wait for incoming data */
-#define AT86RF2XX_STATE_TX_ARET_ON     (0x19)     /**< ready for sending data */
-#define AT86RF2XX_STATE_IN_PROGRESS    (0x1f)     /**< ongoing state conversion */
+#define AT86RF2XX_STATE_P_ON           (0x00)       /**< initial power on */
+#define AT86RF2XX_STATE_BUSY_RX        (0x01)       /**< busy receiving data (basic mode) */
+#define AT86RF2XX_STATE_BUSY_TX        (0x02)       /**< busy transmitting data (basic mode) */
+#define AT86RF2XX_STATE_FORCE_TRX_OFF  (0x03)       /**< force transition to idle */
+#define AT86RF2XX_STATE_RX_ON          (0x06)       /**< listen mode (basic mode) */
+#define AT86RF2XX_STATE_TRX_OFF        (0x08)       /**< idle */
+#define AT86RF2XX_STATE_PLL_ON         (0x09)       /**< ready to transmit */
+#define AT86RF2XX_STATE_SLEEP          (0x0f)       /**< sleep mode */
+#define AT86RF2XX_STATE_BUSY_RX_AACK   (0x11)       /**< busy receiving data (extended mode) */
+#define AT86RF2XX_STATE_BUSY_TX_ARET   (0x12)       /**< busy transmitting data (extended mode) */
+#define AT86RF2XX_STATE_RX_AACK_ON     (0x16)       /**< wait for incoming data */
+#define AT86RF2XX_STATE_TX_ARET_ON     (0x19)       /**< ready for sending data */
+#define AT86RF2XX_STATE_IN_PROGRESS    (0x1f)       /**< ongoing state conversion */
 /** @} */
 
 /**
@@ -212,9 +216,21 @@ typedef struct {
     uint8_t pending_tx;                 /**< keep track of pending TX calls
                                              this is required to know when to
                                              return to @ref at86rf2xx_t::idle_state */
-#if AT86RF2XX_HAVE_RETRIES
+#if AT86RF2XX_HAVE_RETRIES || MODULE_AT86RFR2
     /* Only radios with the XAH_CTRL_2 register support frame retry reporting */
     uint8_t tx_retries;                 /**< Number of NOACK retransmissions */
+#endif
+#ifdef MODULE_AT86RFR2
+    /* ATmega256rfr2 signals transceiver events with different interrupts
+     * they have to be stored to mimic the same flow as external transceiver
+     * Use irq_status to map saved interrupts of SOC transceiver,
+     * as they clear after IRQ callback.
+     *
+     *  irq_status = IRQ_STATUS
+     *  irq_status = IRQ_STATUS1
+     * */
+    uint8_t irq_status;                     /**< save irq status */
+    uint8_t irq_status1;                    /**< save irq status1 */
 #endif
     /** @} */
 } at86rf2xx_t;

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -71,6 +71,7 @@ PSEUDOMODULES += od_string
 # include variants of the AT86RF2xx drivers as pseudo modules
 PSEUDOMODULES += at86rf23%
 PSEUDOMODULES += at86rf21%
+PSEUDOMODULES += at86rfr2
 
 # include variants of the BMX280 drivers as pseudo modules
 PSEUDOMODULES += bmp280

--- a/sys/auto_init/netif/auto_init_at86rf2xx.c
+++ b/sys/auto_init/netif/auto_init_at86rf2xx.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2015 Kaspar Schleiser <kaspar@schleiser.de>
+ * Copyright (C) 2018 Josua Arndt <jarndt@ias.rwth-aachen.de>
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -15,6 +16,7 @@
  * @brief   Auto initialization for at86rf2xx network interfaces
  *
  * @author  Kaspar Schleiser <kaspar@schleiser.de>
+ * @author  Josua Arndt <jarndt@ias.rwth-aachen.de>
  */
 
 #ifdef MODULE_AT86RF2XX
@@ -37,12 +39,23 @@
  * @brief   Define stack parameters for the MAC layer thread
  * @{
  */
+#ifndef AT86RF2XX_MAC_STACKSIZE
 #define AT86RF2XX_MAC_STACKSIZE     (THREAD_STACKSIZE_DEFAULT)
+#endif
+
 #ifndef AT86RF2XX_MAC_PRIO
 #define AT86RF2XX_MAC_PRIO          (GNRC_NETIF_PRIO)
 #endif
 
+#ifdef MODULE_AT86RFR2
+/* The atmegarfr2 has a at86rf2xx included with register access no spi required.
+ * As of now it is not intended to support external at86rf2xx devices at the
+ * same time as the On-Chip transceiver drive is in use.
+ */
+#define AT86RF2XX_NUM 1
+#else
 #define AT86RF2XX_NUM (sizeof(at86rf2xx_params) / sizeof(at86rf2xx_params[0]))
+#endif
 
 static at86rf2xx_t at86rf2xx_devs[AT86RF2XX_NUM];
 static char _at86rf2xx_stacks[AT86RF2XX_NUM][AT86RF2XX_MAC_STACKSIZE];


### PR DESCRIPTION
This PR adds support for the at86rfr2 transceiver into the at86rf2xx driver.

This is split out from https://github.com/RIOT-OS/RIOT/pull/8742