### PR TITLE
cpu/stm32f4: fix periph_cpu.h for f412zg and f446ze

### DIFF
--- a/cpu/stm32f4/include/periph_cpu.h
+++ b/cpu/stm32f4/include/periph_cpu.h
@@ -49,7 +49,7 @@ enum {
  * @brief   Available number of ADC devices
  */
 #if defined(CPU_MODEL_STM32F401RE) || defined(CPU_MODEL_STM32F410RB) \
-    || defined(CPU_MODEL_STM32F411RE) \
+    || defined(CPU_MODEL_STM32F411RE) || defined(CPU_MODEL_STM32F412ZG) \
     || defined(CPU_MODEL_STM32F413CG) || defined(CPU_MODEL_STM32F413RG) \
     || defined(CPU_MODEL_STM32F413MG) || defined(CPU_MODEL_STM32F413VG) \
     || defined(CPU_MODEL_STM32F413ZG) || defined(CPU_MODEL_STM32F413CH) \
@@ -59,7 +59,9 @@ enum {
     || defined(CPU_MODEL_STM32F423MH) || defined(CPU_MODEL_STM32F423VH) \
     || defined(CPU_MODEL_STM32F423ZH)
 #define ADC_DEVS            (1U)
-#elif defined(CPU_MODEL_STM32F407VG) || defined(CPU_MODEL_STM32F415RG) || defined(CPU_MODEL_STM32F446RE) || defined(CPU_MODEL_STM32F429ZI)
+#elif defined(CPU_MODEL_STM32F407VG) || defined(CPU_MODEL_STM32F415RG) \
+    || defined(CPU_MODEL_STM32F429ZI) || defined(CPU_MODEL_STM32F446RE) \
+    || defined(CPU_MODEL_STM32F446ZE)
 #define ADC_DEVS            (3U)
 #endif
 


### PR DESCRIPTION
### Contribution description

When working on #8769, I realized that `ADC_DEV` was not defined for stm32f412zg and stm32f446ze.

### Issues/PRs references

#8769