### PR TITLE
periph/i2c: fix unspotted typos

### DIFF
--- a/drivers/periph_common/i2c.c
+++ b/drivers/periph_common/i2c.c
@@ -25,13 +25,13 @@
 #ifdef I2C_NUMOF
 
 #ifdef PERIPH_I2C_NEED_READ_REGS
-int i2c_read_reg(ic2_t dev, uint16_t addr, uint16_t reg,
+int i2c_read_reg(i2c_t dev, uint16_t addr, uint16_t reg,
                  void *data, uint8_t flags)
 {
     return i2c_read_regs(dev, addr, reg, data, 1, flags);
 }
 
-int i2c_read_regs(ic2_t dev, uint16_t addr, uint16_t reg,
+int i2c_read_regs(i2c_t dev, uint16_t addr, uint16_t reg,
                   void *data, size_t len, uint8_t flags)
 {
     uint8_t err;
@@ -46,14 +46,14 @@ int i2c_read_regs(ic2_t dev, uint16_t addr, uint16_t reg,
 }
 #endif /* PERIPH_I2C_NEED_READ_REGS */
 
-int i2c_read_byte(ic2_t dev, uint16_t addr, void *data, uint8_t flags)
+int i2c_read_byte(i2c_t dev, uint16_t addr, void *data, uint8_t flags)
 {
     return i2c_read_bytes(dev, addr, data, 1, flags);
 }
 
 int i2c_write_byte(i2c_t dev, uint16_t addr, uint8_t data, uint8_t flags)
 {
-    return i2c_write_bytes(dev, addr, addr, 1, flags);
+    return i2c_write_bytes(dev, addr, &data, 1, flags);
 }
 
 #ifdef PERIPH_I2C_NEED_WRITE_REGS


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Fix unspotted typos introduced in the new I2C API
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

#9162 #6577

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->