### PR TITLE
drivers/periph/i2c: fixes issues in API

### DIFF
--- a/drivers/include/periph/i2c.h
+++ b/drivers/include/periph/i2c.h
@@ -126,6 +126,12 @@ extern "C" {
 #endif
 
 /**
+ * @todo    Remove dev_enums.h include once all platforms are ported to the
+ *          updated periph interface
+ */
+#include "periph/dev_enums.h"
+
+/**
  * @brief   Default I2C device access macro
  * @{
  */
@@ -165,7 +171,7 @@ typedef unsigned int i2c_t;
 typedef enum {
     I2C_SPEED_LOW = 0,      /**< low speed mode:    ~10kbit/s */
     I2C_SPEED_NORMAL,       /**< normal mode:       ~100kbit/s */
-    I2C_SPEED_FAST,         /**< fast mode:         ~400kbit/sj */
+    I2C_SPEED_FAST,         /**< fast mode:         ~400kbit/s */
     I2C_SPEED_FAST_PLUS,    /**< fast plus mode:    ~1Mbit/s */
     I2C_SPEED_HIGH,         /**< high speed mode:   ~3.4Mbit/s */
 } i2c_speed_t;
@@ -242,7 +248,7 @@ int i2c_init(i2c_t dev);
  *
  * @param[in] dev           I2C device to access
  *
- * @return                  0 on success
+ * @return                  0 on success, -1 on error
  */
 int i2c_acquire(i2c_t dev);
 
@@ -250,8 +256,10 @@ int i2c_acquire(i2c_t dev);
  * @brief   Release the given I2C device to be used by others
  *
  * @param[in] dev           I2C device to release
+ *
+ * @return                  0 on success, -1 on error
  */
-void i2c_release(i2c_t dev);
+int i2c_release(i2c_t dev);
 
 /**
  * @brief   Convenience function for reading one byte from a given register
@@ -378,7 +386,7 @@ int i2c_write_bytes(i2c_t dev, uint16_t addr, const void *data,
  * @param[in]  reg          register address to read from (8- or 16-bit,
  *                          right-aligned)
  * @param[in]  addr         7-bit or 10-bit device address (right-aligned)
- * @param[out] data         memory location to store received data
+ * @param[in]  data         byte to write
  * @param[in]  flags        optional flags (see @ref i2c_flags_t)
  *
  * @return                  I2C_ACK on successful transfer of @p data

--- a/drivers/periph_common/i2c.c
+++ b/drivers/periph_common/i2c.c
@@ -58,9 +58,9 @@ int i2c_write_byte(i2c_t dev, uint16_t addr, uint8_t data, uint8_t flags)
 
 #ifdef PERIPH_I2C_NEED_WRITE_REGS
 int i2c_write_reg(i2c_t dev, uint16_t addr, uint16_t reg,
-                  const void *data, size_t len, uint8_t flags)
+                  uint8_t data, uint8_t flags)
 {
-    return i2c_write_regs(dev, addr, reg, data, 1);
+    return i2c_write_regs(dev, addr, reg, &data, 1, flags);
 }
 
 int i2c_write_regs(i2c_t dev, uint16_t addr, uint16_t reg,


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Fixes remaining issues in the new I2C api (preventing from building when read/write reg function are enabled in CPU implementations)

- non matching doxygen input parameter to i2c_write_reg
- non/matching missing function parameter
- invalid return type to i2c_release

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

#9162 #6577 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->