### PR TITLE
sys/event: make event queue independent from thread

### DIFF
--- a/sys/event/event.c
+++ b/sys/event/event.c
@@ -1,9 +1,23 @@
 /*
  * Copyright (C) 2017 Kaspar Schleiser <kaspar@schleiser.de>
+ *               2018 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
  * directory for more details.
+ */
+
+/**
+ * @ingroup     sys_event
+ * @{
+ *
+ * @file
+ * @brief       Event loop implementation
+ *
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ *
+ * @}
  */
 
 #include <assert.h>
@@ -14,6 +28,12 @@
 #include "clist.h"
 #include "thread.h"
 
+void event_queue_init_detached(event_queue_t *queue)
+{
+    assert(queue);
+    memset(queue, '\0', sizeof(*queue));
+}
+
 void event_queue_init(event_queue_t *queue)
 {
     assert(queue);
@@ -21,17 +41,31 @@ void event_queue_init(event_queue_t *queue)
     queue->waiter = (thread_t *)sched_active_thread;
 }
 
+void event_queue_claim(event_queue_t *queue)
+{
+    assert(queue && (queue->waiter == NULL));
+    queue->waiter = (thread_t *)sched_active_thread;
+}
+
 void event_post(event_queue_t *queue, event_t *event)
 {
-    assert(queue && queue->waiter && event);
+    assert(queue && event);
 
     unsigned state = irq_disable();
     if (!event->list_node.next) {
         clist_rpush(&queue->event_list, &event->list_node);
     }
+    thread_t *waiter = queue->waiter;
     irq_restore(state);
 
-    thread_flags_set(queue->waiter, THREAD_FLAG_EVENT);
+    /* WARNING: there is a minimal chance, that a waiter claims a formerly
+     *          detached queue between the end of the critical section above and
+     *          the block below. In that case, the new waiter will not be woken
+     *          up. This should be fixed at some point once it is safe to call
+     *          thread_flags_set() inside a critical section on all platforms. */
+    if (waiter) {
+        thread_flags_set(waiter, THREAD_FLAG_EVENT);
+    }
 }
 
 void event_cancel(event_queue_t *queue, event_t *event)
@@ -49,8 +83,8 @@ event_t *event_get(event_queue_t *queue)
 {
     unsigned state = irq_disable();
     event_t *result = (event_t *) clist_lpop(&queue->event_list);
-
     irq_restore(state);
+
     if (result) {
         result->list_node.next = NULL;
     }
@@ -59,13 +93,18 @@ event_t *event_get(event_queue_t *queue)
 
 event_t *event_wait(event_queue_t *queue)
 {
-    thread_flags_wait_any(THREAD_FLAG_EVENT);
-    unsigned state = irq_disable();
-    event_t *result = (event_t *) clist_lpop(&queue->event_list);
-    if (clist_rpeek(&queue->event_list)) {
-        queue->waiter->flags |= THREAD_FLAG_EVENT;
-    }
-    irq_restore(state);
+    assert(queue);
+    event_t *result;
+
+    do {
+        unsigned state = irq_disable();
+        result = (event_t *)clist_lpop(&queue->event_list);
+        irq_restore(state);
+        if (result == NULL) {
+            thread_flags_wait_any(THREAD_FLAG_EVENT);
+        }
+    } while (result == NULL);
+
     result->list_node.next = NULL;
     return result;
 }

--- a/tests/events/Makefile
+++ b/tests/events/Makefile
@@ -1,5 +1,7 @@
 include ../Makefile.tests_common
 
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno
+
 FORCE_ASSERTS = 1
 USEMODULE += event_callback
 USEMODULE += event_timeout


### PR DESCRIPTION
### Contribution description
Currently, event queues are tied to the thread in which context they are initialized. While porting `NimBLE`, we did however encounter this as a problem, as the event queue initialization there is done before the actual threads that handle the events are started. A little digging also turned out, that other OSes as `mynewt` or `freeRTOS` do not tie their event queues to a certain thread, but keep them to some extend independent of threads.

This PR proposes a small change to the `sys/event` implementation, as the queue is only tied to a waiting thread once the `event_wait()` function is called. The restriction, that only a single thread is allowed to wait for events at the same time is unchanged, but I documented it a little more obvious.

At least for the `nrf52dk` this changes comes to the cost of an additional 16 bytes of ROM, which seems acceptable to me.

### Issues/PRs references
none