### PR TITLE
xtimer_now64_continuity: Enable test run on CI

### DIFF
--- a/tests/xtimer_now64_continuity/Makefile
+++ b/tests/xtimer_now64_continuity/Makefile
@@ -3,6 +3,8 @@ include ../Makefile.tests_common
 USEMODULE += fmt
 USEMODULE += xtimer
 
+TEST_ON_CI_WHITELIST += all
+
 include $(RIOTBASE)/Makefile.include
 
 test:


### PR DESCRIPTION
### Contribution description

With #9146 merged, it should be safe to enable this test for test runs on the CI

### Issues/PRs references

#9146