### PR TITLE
net/gnrc/rpl: fix doxygen grouping

### DIFF
--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_internal/globals.h
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_internal/globals.h
@@ -31,8 +31,7 @@ extern "C" {
 extern evtimer_msg_t gnrc_rpl_evtimer;
 
 /**
- * @defgroup gnrc_rpl_events RPL events
- * Events for RPL.
+ * @name Events for RPL.
  * @{
  */
 /**
@@ -55,8 +54,7 @@ extern evtimer_msg_t gnrc_rpl_evtimer;
 #define GNRC_RPL_PARENT_PROBE_INTERVAL        (2 * MS_PER_SEC)
 
 /**
- * @defgroup gnrc_rpl_parent_states Parent states
- * State of a RPL parent
+ * @name State of a RPL parent
  * @{
  */
 /**


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

minor fix to correct usage of doxygen grouping


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->