### PR TITLE
pkg: add support for the NimBLE BLE stack

### DIFF
--- a/cpu/nrf5x_common/include/nrfx.h
+++ b/cpu/nrf5x_common/include/nrfx.h
@@ -1,0 +1,35 @@
+/*
+ * Copyright (C) 2018 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup         cpu_nrf5x_common
+ * @{
+ *
+ * @file
+ * @brief           nrfx compatibility layer
+ *
+ * @author          Hauke Petersen <hauke.petersen@fu-berlin.de>
+ */
+
+#ifndef NRFX_H
+#define NRFX_H
+
+#include "cpu_conf.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* nothing else to do here */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* NRFX_H */
+/** @} */

--- a/examples/nimble_gatt/Makefile
+++ b/examples/nimble_gatt/Makefile
@@ -1,0 +1,24 @@
+# name of your application
+APPLICATION = nimble_gatt
+
+# If no BOARD is found in the environment, use this default:
+BOARD ?= nrf52dk
+
+# So far, NimBLE only works on nRF52 based platforms
+BOARD_WHITELIST := nrf52dk nrf52840dk
+
+# This has to be the absolute path to the RIOT base directory:
+RIOTBASE ?= $(CURDIR)/../..
+
+# Include NimBLE
+USEPKG += nimble
+
+# Comment this out to disable code in RIOT that does safety checking
+# which is not needed in a production environment but helps in the
+# development process:
+DEVELHELP ?= 1
+
+# Change this to 0 show compiler invocation lines by default:
+QUIET ?= 1
+
+include $(RIOTBASE)/Makefile.include

--- a/examples/nimble_gatt/README.md
+++ b/examples/nimble_gatt/README.md
@@ -1,0 +1,9 @@
+NimBLE GATT Server Example
+==========================
+This example application configures and runs the NimBLE BLE stack as simple GATT
+server. It will provide two services, the build-in GAP and the build-in GATT
+service. The device will advertise itself by the name `NimBLE on RIOT`.
+
+To interact with the BLE device running this example, use any BLE client that is
+able to discover and interact with GATT services.
+An easy way to get started is to use a smartphone (supporting at least BT 4.0) with Nordic's `nRF Connect` App.

--- a/examples/nimble_gatt/main.c
+++ b/examples/nimble_gatt/main.c
@@ -1,0 +1,135 @@
+/*
+ * Copyright (C) 2018 Freie Universität Berlin
+ *               2018 Codecoup
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     examples
+ * @{
+ *
+ * @file
+ * @brief       BLE peripheral example using NimBLE
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author      Andrzej Kaczmarek <andrzej.kaczmarek@codecoup.pl>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+#include "nimble_riot.h"
+
+#include "nimble/nimble_port.h"
+#include "host/ble_hs.h"
+#include "host/util/util.h"
+#include "services/gap/ble_svc_gap.h"
+#include "services/gatt/ble_svc_gatt.h"
+
+static const char device_name[] = "NimBLE on RIOT";
+static uint8_t own_addr_type;
+
+
+static void start_advertise(void);
+
+static void put_ad(uint8_t ad_type, uint8_t ad_len, const void *ad, uint8_t *buf,
+                   uint8_t *len)
+{
+    buf[(*len)++] = ad_len + 1;
+    buf[(*len)++] = ad_type;
+
+    memcpy(&buf[*len], ad, ad_len);
+
+    *len += ad_len;
+}
+
+static void update_ad(void)
+{
+    uint8_t ad[BLE_HS_ADV_MAX_SZ];
+    uint8_t ad_len = 0;
+    uint8_t ad_flags = BLE_HS_ADV_F_DISC_GEN | BLE_HS_ADV_F_BREDR_UNSUP;
+
+    put_ad(BLE_HS_ADV_TYPE_FLAGS, 1, &ad_flags, ad, &ad_len);
+    put_ad(BLE_HS_ADV_TYPE_COMP_NAME, sizeof(device_name), device_name, ad, &ad_len);
+
+    ble_gap_adv_set_data(ad, ad_len);
+}
+
+static int gap_event_cb(struct ble_gap_event *event, void *arg)
+{
+    (void)arg;
+
+    switch (event->type) {
+        case BLE_GAP_EVENT_CONNECT:
+            if (event->connect.status) {
+                start_advertise();
+            }
+            break;
+
+        case BLE_GAP_EVENT_DISCONNECT:
+            start_advertise();
+            break;
+    }
+
+    return 0;
+}
+
+static void start_advertise(void)
+{
+    struct ble_gap_adv_params advp;
+    int rc;
+
+    memset(&advp, 0, sizeof advp);
+    advp.conn_mode = BLE_GAP_CONN_MODE_UND;
+    advp.disc_mode = BLE_GAP_DISC_MODE_GEN;
+    rc = ble_gap_adv_start(own_addr_type, NULL, BLE_HS_FOREVER,
+                           &advp, gap_event_cb, NULL);
+    assert(rc == 0);
+}
+
+static void app_ble_sync_cb(void)
+{
+    int rc;
+
+    rc = ble_hs_util_ensure_addr(0);
+    assert(rc == 0);
+
+    rc = ble_hs_id_infer_auto(0, &own_addr_type);
+    assert(rc == 0);
+
+    /* generate the advertising data */
+    update_ad();
+
+    start_advertise();
+}
+
+int main(void)
+{
+    puts("NimBLE GATT Server Example");
+
+    /* initialize NimBLE's controller */
+    nimble_riot_controller_init();
+
+    /* register the synchronization callback that is triggered once the host has
+     * finished its initialization */
+    ble_hs_cfg.sync_cb = app_ble_sync_cb;
+
+    /* initialize NimBLE porting layer and the default GATT and GAP services*/
+    nimble_port_init();
+    ble_svc_gap_init();
+    ble_svc_gatt_init();
+
+    /* set the device name */
+    ble_svc_gap_device_name_set(device_name);
+
+    /* and finally run NimBLE's host event loop. The event loop contains a pre-
+     * configured event which will trigger the hosts initialization */
+    nimble_port_run();
+
+    return 0;
+}

--- a/pkg/nimble/Makefile
+++ b/pkg/nimble/Makefile
@@ -1,0 +1,32 @@
+PKG_NAME    = nimble
+PKG_URL     = https://github.com/apache/mynewt-nimble.git
+PKG_VERSION = 050a7108cf56546554b4162f0600ab3b2d7e173f
+PKG_LICENSE = Apache-2.0
+
+TDIR = $(RIOTPKG)/$(PKG_NAME)
+PDIR = $(PKG_BUILDDIR)
+
+# As of now, NimBLE does not build without warnings for -Wextra, so we disable
+# that flag for this package. Will hopefully be fixed some time in the future.
+CFLAGS += -Wno-extra
+
+.PHONY: all
+
+all: git-download
+	"$(MAKE)" -C $(PDIR)/ext/tinycrypt/src/ -f $(TDIR)/ext.tinycrypt.mk
+	"$(MAKE)" -C $(PDIR)/nimble/src -f $(TDIR)/nimble.mk
+	"$(MAKE)" -C $(PDIR)/nimble/host/src/ -f $(TDIR)/nimble.host.mk
+	"$(MAKE)" -C $(PDIR)/nimble/host/services/gap/src/ -f $(TDIR)/service.gap.mk
+	"$(MAKE)" -C $(PDIR)/nimble/host/services/gatt/src/ -f $(TDIR)/service.gatt.mk
+	"$(MAKE)" -C $(PDIR)/nimble/host/util/src/ -f $(TDIR)/nimble.host.util.mk
+	"$(MAKE)" -C $(PDIR)/nimble/host/store/ram/src/ -f $(TDIR)/nimble.host.store.ram.mk
+	"$(MAKE)" -C $(PDIR)/porting/nimble/src/ -f $(TDIR)/porting.nimble.mk
+	"$(MAKE)" -C $(PDIR)/porting/npl/riot/src/ -f $(TDIR)/porting.npl.riot.mk
+
+	"$(MAKE)" -C $(PDIR)/nimble/transport/ram/src/ -f $(TDIR)/transport.ram.mk
+	"$(MAKE)" -C $(PDIR)/nimble/controller/src/ -f $(TDIR)/controller.mk
+	"$(MAKE)" -C $(PDIR)/nimble/drivers/nrf52/src/ -f $(TDIR)/drivers.nrf52.mk
+
+	"$(MAKE)" -C $(TDIR)/contrib/
+
+include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/nimble/Makefile.dep
+++ b/pkg/nimble/Makefile.dep
@@ -1,0 +1,24 @@
+# RIOT specific dependencies
+USEMODULE += posix_semaphore
+USEMODULE += event_callback
+USEMODULE += xtimer
+
+# glue code
+USEMODULE += nimble_riot_contrib
+
+# nimble sub-modules that we build
+USEMODULE += nimble_tinycrypt
+USEMODULE += nimble_host
+USEMODULE += nimble_host_services_gap
+USEMODULE += nimble_host_services_gatt
+USEMODULE += nimble_host_util
+USEMODULE += nimble_host_store_ram
+USEMODULE += nimble_porting_nimble
+USEMODULE += nimble_npl_riot
+
+# nimble controller specific sub-modules
+USEMODULE += nimble_controller
+USEMODULE += nimble_transport_ram
+ifeq (nrf52,$(CPU_FAM))
+  USEMODULE += nimble_drivers_nrf52
+endif

--- a/pkg/nimble/Makefile.include
+++ b/pkg/nimble/Makefile.include
@@ -1,0 +1,34 @@
+NIMIBASE = -I$(PKGDIRBASE)/nimble
+
+# include RIOT glue code headers
+INCLUDES += -I$(RIOTPKG)/nimble/contrib/include
+
+# include tinycrypt headers
+INCLUDES += $(NIMIBASE)/ext/tinycrypt/include
+
+# include the RIOT NPL headers
+INCLUDES += $(NIMIBASE)/porting/npl/riot/include
+
+# include nimble controller headers
+INCLUDES += $(NIMIBASE)/nimble/transport/ram/include
+INCLUDES += $(NIMIBASE)/nimble/controller/include
+INCLUDES += $(NIMIBASE)/nimble/drivers/nrf52/include
+
+# include nimble host headers
+INCLUDES += $(NIMIBASE)/nimble/include
+INCLUDES += $(NIMIBASE)/nimble/host/include
+INCLUDES += $(NIMIBASE)/nimble/host/services/ans/include
+INCLUDES += $(NIMIBASE)/nimble/host/services/bas/include
+INCLUDES += $(NIMIBASE)/nimble/host/services/bleuart/include
+INCLUDES += $(NIMIBASE)/nimble/host/services/gap/include
+INCLUDES += $(NIMIBASE)/nimble/host/services/gatt/include
+INCLUDES += $(NIMIBASE)/nimble/host/services/ias/include
+INCLUDES += $(NIMIBASE)/nimble/host/services/lls/include
+INCLUDES += $(NIMIBASE)/nimble/host/services/tps/include
+INCLUDES += $(NIMIBASE)/nimble/host/store/ram/include
+INCLUDES += $(NIMIBASE)/nimble/host/util/include
+INCLUDES += $(NIMIBASE)/porting/nimble/include
+
+# set environment
+CFLAGS += -DNIMBLE_CFG_CONTROLLER=1
+CFLAGS += -DMYNEWT_VAL_OS_CPUTIME_FREQ=32768

--- a/pkg/nimble/contrib/Makefile
+++ b/pkg/nimble/contrib/Makefile
@@ -1,0 +1,3 @@
+MODULE = nimble_riot_contrib
+
+include $(RIOTBASE)/Makefile.base

--- a/pkg/nimble/contrib/controller_init.c
+++ b/pkg/nimble/contrib/controller_init.c
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2018 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     pkg_nimble
+ * @{
+ *
+ * @file
+ * @brief       Initialization of the nimble controller
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ *
+ * @}
+ */
+
+#include "thread.h"
+#include "nimble_riot.h"
+
+#include "nimble/nimble_port.h"
+
+#ifdef CPU_FAM_NRF52
+#include "nrf_clock.h"
+#endif
+
+static char stack[THREAD_STACKSIZE_DEFAULT];
+
+void nimble_riot_controller_init(void)
+{
+#ifdef CPU_FAM_NRF52
+    clock_start_lf();
+#endif
+
+    /*
+     * Create task where NimBLE LL will run. This one is required as LL has its
+     * own event queue and should have highest priority.
+     */
+    thread_create(stack, sizeof(stack), NIMBLE_CONTROLLER_PRIO, 0,
+                  (thread_task_func_t)nimble_port_ll_task_func,
+                  NULL, "nimble_ctrl");
+}

--- a/pkg/nimble/contrib/include/nimble_riot.h
+++ b/pkg/nimble/contrib/include/nimble_riot.h
@@ -1,0 +1,45 @@
+/*
+ * Copyright (C) 2018 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     pkg_nimble
+ * @{
+ *
+ * @file
+ * @brief       RIOT specific glue functions for integrating NimBLE
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ */
+
+#ifndef NIMBLE_RIOT_H
+#define NIMBLE_RIOT_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Define the priority used for NimBLE's controller thread
+ *
+ * This should be as high as possible.
+ */
+#ifndef NIMBLE_CONTROLLER_PRIO
+#define NIMBLE_CONTROLLER_PRIO      (0)
+#endif
+
+/**
+ * @brief   Starts a thread running NimBLE's controller
+ */
+void nimble_riot_controller_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* NIMBLE_RIOT_H */
+/** @} */

--- a/pkg/nimble/controller.mk
+++ b/pkg/nimble/controller.mk
@@ -1,0 +1,19 @@
+MODULE = nimble_controller
+
+SRC += ble_ll_sched.c
+SRC += ble_ll_xcvr.c
+SRC += ble_ll_whitelist.c
+SRC += ble_ll_ctrl.c
+SRC += ble_ll_hci.c
+SRC += ble_ll_supp_cmd.c
+SRC += ble_ll_adv.c
+SRC += ble_ll_conn.c
+SRC += ble_ll_resolv.c
+SRC += ble_ll_conn_hci.c
+SRC += ble_ll_rand.c
+SRC += ble_ll.c
+SRC += ble_ll_scan.c
+SRC += ble_ll_dtm.c
+SRC += ble_ll_hci_ev.c
+
+include $(RIOTBASE)/Makefile.base

--- a/pkg/nimble/doc.txt
+++ b/pkg/nimble/doc.txt
@@ -1,0 +1,10 @@
+/**
+ * @defgroup pkg_nimble     NimBLE BLE stack
+ * @ingroup  pkg
+ * @ingroup  net
+ * @brief    RIOT port of the NimBLE BLE stack
+ *
+ * This package includes the NimBLE BLE stack to RIOT.
+ *
+ * @see https://github.com/apache/mynewt-nimble
+ */

--- a/pkg/nimble/drivers.nrf52.mk
+++ b/pkg/nimble/drivers.nrf52.mk
@@ -1,0 +1,6 @@
+MODULE = nimble_drivers_nrf52
+
+SRC += ble_hw.c
+SRC += ble_phy.c
+
+include $(RIOTBASE)/Makefile.base

--- a/pkg/nimble/ext.tinycrypt.mk
+++ b/pkg/nimble/ext.tinycrypt.mk
@@ -1,0 +1,10 @@
+MODULE = nimble_tinycrypt
+
+SRC += aes_decrypt.c
+SRC += aes_encrypt.c
+SRC += cmac_mode.c
+SRC += ecc.c
+SRC += ecc_dh.c
+SRC += utils.c
+
+include $(RIOTBASE)/Makefile.base

--- a/pkg/nimble/nimble.host.mk
+++ b/pkg/nimble/nimble.host.mk
@@ -1,0 +1,44 @@
+MODULE = nimble_host
+
+SRC += ble_att.c
+SRC += ble_att_clt.c
+SRC += ble_att_cmd.c
+SRC += ble_att_svr.c
+SRC += ble_eddystone.c
+SRC += ble_gap.c
+SRC += ble_gattc.c
+SRC += ble_gatts.c
+SRC += ble_hs_adv.c
+SRC += ble_hs_atomic.c
+SRC += ble_hs.c
+SRC += ble_hs_cfg.c
+SRC += ble_hs_conn.c
+SRC += ble_hs_dbg.c
+SRC += ble_hs_flow.c
+SRC += ble_hs_hci.c
+SRC += ble_hs_hci_cmd.c
+SRC += ble_hs_hci_evt.c
+SRC += ble_hs_hci_util.c
+SRC += ble_hs_id.c
+SRC += ble_hs_log.c
+SRC += ble_hs_mbuf.c
+SRC += ble_hs_mqueue.c
+SRC += ble_hs_misc.c
+SRC += ble_hs_pvcy.c
+SRC += ble_hs_startup.c
+SRC += ble_ibeacon.c
+SRC += ble_l2cap.c
+SRC += ble_l2cap_coc.c
+SRC += ble_l2cap_sig.c
+SRC += ble_l2cap_sig_cmd.c
+SRC += ble_monitor.c
+SRC += ble_sm_alg.c
+SRC += ble_sm.c
+SRC += ble_sm_cmd.c
+SRC += ble_sm_lgcy.c
+SRC += ble_sm_sc.c
+SRC += ble_store.c
+SRC += ble_store_util.c
+SRC += ble_uuid.c
+
+include $(RIOTBASE)/Makefile.base

--- a/pkg/nimble/nimble.host.store.ram.mk
+++ b/pkg/nimble/nimble.host.store.ram.mk
@@ -1,0 +1,5 @@
+MODULE = nimble_host_store_ram
+
+SRC += ble_store_ram.c
+
+include $(RIOTBASE)/Makefile.base

--- a/pkg/nimble/nimble.host.util.mk
+++ b/pkg/nimble/nimble.host.util.mk
@@ -1,0 +1,5 @@
+MODULE = nimble_host_util
+
+SRC += addr.c
+
+include $(RIOTBASE)/Makefile.base

--- a/pkg/nimble/nimble.mk
+++ b/pkg/nimble/nimble.mk
@@ -1,0 +1,5 @@
+MODULE = nimble
+
+SRC += hci_common.c
+
+include $(RIOTBASE)/Makefile.base

--- a/pkg/nimble/porting.nimble.mk
+++ b/pkg/nimble/porting.nimble.mk
@@ -1,0 +1,16 @@
+MODULE = nimble_porting_nimble
+
+# host specific files
+SRC += nimble_port.c
+SRC += endian.c
+SRC += mem.c
+SRC += os_mbuf.c
+SRC += os_mempool.c
+SRC += os_msys_init.c
+
+# additional files needed for the controller
+SRC += os_cputime.c
+SRC += os_cputime_pwr2.c
+SRC += hal_timer.c
+
+include $(RIOTBASE)/Makefile.base

--- a/pkg/nimble/porting.npl.riot.mk
+++ b/pkg/nimble/porting.npl.riot.mk
@@ -1,0 +1,6 @@
+MODULE = nimble_npl_riot
+
+SRC += npl_os_riot.c
+SRC += nrf5x_isr.c
+
+include $(RIOTBASE)/Makefile.base

--- a/pkg/nimble/service.gap.mk
+++ b/pkg/nimble/service.gap.mk
@@ -1,0 +1,5 @@
+MODULE = nimble_host_services_gap
+
+SRC += ble_svc_gap.c
+
+include $(RIOTBASE)/Makefile.base

--- a/pkg/nimble/service.gatt.mk
+++ b/pkg/nimble/service.gatt.mk
@@ -1,0 +1,5 @@
+MODULE = nimble_host_services_gatt
+
+SRC += ble_svc_gatt.c
+
+include $(RIOTBASE)/Makefile.base

--- a/pkg/nimble/transport.ram.mk
+++ b/pkg/nimble/transport.ram.mk
@@ -1,0 +1,4 @@
+MODULE += nimble_transport_ram
+SRC += ble_hci_ram.c
+
+include $(RIOTBASE)/Makefile.base


### PR DESCRIPTION
### Contribution description
This PR adds the mynewt `NimBLE` BLE stack as a package to RIOT. It comes with a simple example application setting up NimBLE as GATT server and advertising the device.

Current limitations:
- as of now, only `nrf52` based boards are supported, as the `NimBLE` controller does currently only work for these SoCs
- the package is currently based on a non-official branch, as the RIOT support for `NimBLE` is currently in the process of being merged into the `NimBLE` master: https://github.com/apache/mynewt-nimble/pull/111

NOTE: this is initial work, and the support for `NimBLE` will be further improved in the future...

Finally, big thanks to @andrzej-kaczmarek for the awesome collaboration!

### Issues/PRs references
none