### PR TITLE
periph_common/i2c: fix ret code handling

### DIFF
--- a/drivers/periph_common/i2c.c
+++ b/drivers/periph_common/i2c.c
@@ -38,7 +38,7 @@ int i2c_read_regs(i2c_t dev, uint16_t addr, uint16_t reg,
     /* First set ADDR and register with no stop */
     err = i2c_write_bytes(dev, addr, &reg, (flags & I2C_REG16) ? 2 : 1,
                           flags & I2C_NOSTOP );
-    if (err != I2C_ACK) {
+    if (err < 0) {
         return err;
     }
     /* Then get the data from device */
@@ -70,7 +70,7 @@ int i2c_write_regs(i2c_t dev, uint16_t addr, uint16_t reg,
     /* First set ADDR and register with no stop */
     err = i2c_write_bytes(dev, addr, &reg, (flags & I2C_REG16) ? 2 : 1,
                           flags & I2C_NOSTOP );
-    if (err != I2C_ACK) {
+    if (err < 0) {
         return err;
     }
     /* Then write data to the device */


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->
This PR should fix the ret code handling in the default fallback wrapper implementations.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->