### PR TITLE
gnrc_pktdump: print rest of snip as hex if available

### DIFF
--- a/sys/net/gnrc/pktdump/gnrc_pktdump.c
+++ b/sys/net/gnrc/pktdump/gnrc_pktdump.c
@@ -47,6 +47,8 @@ static char _stack[GNRC_PKTDUMP_STACKSIZE];
 
 static void _dump_snip(gnrc_pktsnip_t *pkt)
 {
+    size_t hdr_len = pkt->size;
+
     switch (pkt->type) {
         case GNRC_NETTYPE_UNDEF:
             printf("NETTYPE_UNDEF (%i)\n", pkt->type);
@@ -68,24 +70,28 @@ static void _dump_snip(gnrc_pktsnip_t *pkt)
         case GNRC_NETTYPE_IPV6:
             printf("NETTYPE_IPV6 (%i)\n", pkt->type);
             ipv6_hdr_print(pkt->data);
+            hdr_len = sizeof(ipv6_hdr_t);
             break;
 #endif
 #ifdef MODULE_GNRC_ICMPV6
         case GNRC_NETTYPE_ICMPV6:
             printf("NETTYPE_ICMPV6 (%i)\n", pkt->type);
             icmpv6_hdr_print(pkt->data);
+            hdr_len = sizeof(icmpv6_hdr_t);
             break;
 #endif
 #ifdef MODULE_GNRC_TCP
         case GNRC_NETTYPE_TCP:
             printf("NETTYPE_TCP (%i)\n", pkt->type);
             tcp_hdr_print(pkt->data);
+            hdr_len = sizeof(tcp_hdr_t);
             break;
 #endif
 #ifdef MODULE_GNRC_UDP
         case GNRC_NETTYPE_UDP:
             printf("NETTYPE_UDP (%i)\n", pkt->type);
             udp_hdr_print(pkt->data);
+            hdr_len = sizeof(udp_hdr_t);
             break;
 #endif
 #ifdef MODULE_CCN_LITE_UTILS
@@ -104,6 +110,11 @@ static void _dump_snip(gnrc_pktsnip_t *pkt)
             printf("NETTYPE_UNKNOWN (%i)\n", pkt->type);
             od_hex_dump(pkt->data, pkt->size, OD_WIDTH_DEFAULT);
             break;
+    }
+    if (hdr_len < pkt->size) {
+        size_t size = pkt->size - hdr_len;
+
+        od_hex_dump(((uint8_t *)pkt->data) + hdr_len, size, OD_WIDTH_DEFAULT);
     }
 }
 


### PR DESCRIPTION
### Contribution description
Currently, `gnrc_pktdump` only prints the header part of a snip.
However, if the snip wasn't parsed yet by the corresponding GNRC
module (or the module doesn't exist because the node is e.g. just a
forwarder), additional data might not be printed.

This makes it hard to analyze the data properly (sometimes you not only
want to know where the IPv6 packet is supposed to go, you also want to
know what's in it). So this just prints the rest of the snip as a hex
dump.

### Issues/PRs references
None