### PR TITLE
sys: posix: correct sock type numbers

### DIFF
--- a/sys/posix/include/sys/socket.h
+++ b/sys/posix/include/sys/socket.h
@@ -86,10 +86,10 @@ extern "C" {
  * @name    Socket types
  * @{
  */
-#define SOCK_DGRAM      (1)     /**< Datagram socket */
-#define SOCK_RAW        (2)     /**< Raw socket */
-#define SOCK_SEQPACKET  (3)     /**< Sequenced-packet socket */
-#define SOCK_STREAM     (4)     /**< Stream socket */
+#define SOCK_STREAM     (1)     /**< Stream socket */
+#define SOCK_DGRAM      (2)     /**< Datagram socket */
+#define SOCK_RAW        (3)     /**< Raw socket */
+#define SOCK_SEQPACKET  (5)     /**< Sequenced-packet socket */
 /** @} */
 
 #define SOL_SOCKET      (-1)    /**< Options to be accessed at socket level, not protocol level */


### PR DESCRIPTION
### Contribution description
I am encountering a strange problem using `gnrc_zep`: Oftentimes it works flawlessly, but sometimes (race conditions?), instead of the `sys/socket.h` file from the host machine, `sys/posix/include/sys/socket.h` from RIOT takes precedence. However, the code in `gnrc_zep` interacts with the host (linux) socket API and passing around sock types that differ from linux's is totally wrong for native.

So, this PR changes our sock types to those of linux and openbsd [1,2]. 

[1] https://elixir.bootlin.com/linux/v4.17-rc6/source/include/linux/net.h#L65
[2] https://github.com/openbsd/src/blob/master/sys/sys/socket.h#L64

### Issues/PRs references
none