### PR TITLE
sys/uart_stdio: remove unused rx_cb from header

### DIFF
--- a/sys/include/uart_stdio.h
+++ b/sys/include/uart_stdio.h
@@ -76,14 +76,6 @@ int uart_stdio_read(char* buffer, int len);
  */
 int uart_stdio_write(const char* buffer, int len);
 
-/**
- * @brief internal callback for periph/uart drivers
- *
- * @param[in]   arg     (unused)
- * @param[in]   data    character that has been received
- */
-void uart_stdio_rx_cb(void *arg, uint8_t data);
-
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
### Contribution description
The `uart_stdio_rx_cb()` definition seems to be some outdated leftover, as far as i can tell it is never used/implemented. So we might as well remove it.

### Issues/PRs references
none