### PR TITLE
drivers/lsm6dsl: adapt to new I2C api

### DIFF
--- a/drivers/lsm6dsl/lsm6dsl.c
+++ b/drivers/lsm6dsl/lsm6dsl.c
@@ -56,14 +56,13 @@ int lsm6dsl_init(lsm6dsl_t *dev, const lsm6dsl_params_t *params)
     dev->params = *params;
 
     i2c_acquire(BUS);
-    i2c_init_master(BUS, I2C_SPEED_NORMAL);
 
     /* Reboot */
-    i2c_write_reg(BUS, ADDR, LSM6DSL_REG_CTRL3_C, LSM6DSL_CTRL3_C_BOOT);
+    i2c_write_reg(BUS, ADDR, LSM6DSL_REG_CTRL3_C, LSM6DSL_CTRL3_C_BOOT, 0);
 
     xtimer_usleep(LSM6DSL_BOOT_WAIT);
 
-    if (i2c_read_reg(BUS, ADDR, LSM6DSL_REG_WHO_AM_I, &tmp) != 1) {
+    if (i2c_read_reg(BUS, ADDR, LSM6DSL_REG_WHO_AM_I, &tmp, 0) != 1) {
         i2c_release(BUS);
         DEBUG("[ERROR] lsm6dsl_init: i2c_read_reg LSM6DSL_REG_WHO_AM_I!\n");
         return -LSM6DSL_ERROR_BUS;
@@ -77,19 +76,19 @@ int lsm6dsl_init(lsm6dsl_t *dev, const lsm6dsl_params_t *params)
     /* Set acc odr / full scale */
     tmp = (dev->params.acc_odr << LSM6DSL_CTRL_ODR_SHIFT) |
           (dev->params.acc_fs << LSM6DSL_CTRL_FS_SHIFT);
-    res = i2c_write_reg(BUS, ADDR, LSM6DSL_REG_CTRL1_XL, tmp);
+    res = i2c_write_reg(BUS, ADDR, LSM6DSL_REG_CTRL1_XL, tmp, 0);
     /* Set gyro odr / full scale */
     tmp = (dev->params.gyro_odr << LSM6DSL_CTRL_ODR_SHIFT) |
           (dev->params.gyro_fs << LSM6DSL_CTRL_FS_SHIFT);
-    res += i2c_write_reg(BUS, ADDR, LSM6DSL_REG_CTRL2_G, tmp);
+    res += i2c_write_reg(BUS, ADDR, LSM6DSL_REG_CTRL2_G, tmp, 0);
     /* Set continuous mode */
     uint8_t fifo_odr = MAX(dev->params.acc_odr, dev->params.gyro_odr);
     tmp = (fifo_odr << LSM6DSL_FIFO_CTRL5_FIFO_ODR_SHIFT) |
           LSM6DSL_FIFO_CTRL5_CONTINUOUS_MODE;
-    res += i2c_write_reg(BUS, ADDR, LSM6DSL_REG_FIFO_CTRL5, tmp);
+    res += i2c_write_reg(BUS, ADDR, LSM6DSL_REG_FIFO_CTRL5, tmp, 0);
     tmp = (dev->params.gyro_decimation << LSM6DSL_FIFO_CTRL3_GYRO_DEC_SHIFT) |
           dev->params.acc_decimation;
-    res += i2c_write_reg(BUS, ADDR, LSM6DSL_REG_FIFO_CTRL3, tmp);
+    res += i2c_write_reg(BUS, ADDR, LSM6DSL_REG_FIFO_CTRL3, tmp, 0);
 
     i2c_release(BUS);
 
@@ -106,20 +105,20 @@ int lsm6dsl_read_acc(const lsm6dsl_t *dev, lsm6dsl_3d_data_t *data)
     uint8_t tmp;
 
     i2c_acquire(BUS);
-    i2c_read_reg(BUS, ADDR, LSM6DSL_REG_STATUS_REG, &tmp);
+    i2c_read_reg(BUS, ADDR, LSM6DSL_REG_STATUS_REG, &tmp, 0);
     DEBUG("lsm6dsl status: %x\n", tmp);
 
-    res = i2c_read_reg(BUS, ADDR, LSM6DSL_REG_OUTX_L_XL, &tmp);
+    res = i2c_read_reg(BUS, ADDR, LSM6DSL_REG_OUTX_L_XL, &tmp, 0);
     data->x = tmp;
-    res += i2c_read_reg(BUS, ADDR, LSM6DSL_REG_OUTX_H_XL, &tmp);
+    res += i2c_read_reg(BUS, ADDR, LSM6DSL_REG_OUTX_H_XL, &tmp, 0);
     data->x |= tmp << 8;
-    res += i2c_read_reg(BUS, ADDR, LSM6DSL_REG_OUTY_L_XL, &tmp);
+    res += i2c_read_reg(BUS, ADDR, LSM6DSL_REG_OUTY_L_XL, &tmp, 0);
     data->y = tmp;
-    res += i2c_read_reg(BUS, ADDR, LSM6DSL_REG_OUTY_H_XL, &tmp);
+    res += i2c_read_reg(BUS, ADDR, LSM6DSL_REG_OUTY_H_XL, &tmp, 0);
     data->y |= tmp << 8;
-    res += i2c_read_reg(BUS, ADDR, LSM6DSL_REG_OUTZ_L_XL, &tmp);
+    res += i2c_read_reg(BUS, ADDR, LSM6DSL_REG_OUTZ_L_XL, &tmp, 0);
     data->z = tmp;
-    res += i2c_read_reg(BUS, ADDR, LSM6DSL_REG_OUTZ_H_XL, &tmp);
+    res += i2c_read_reg(BUS, ADDR, LSM6DSL_REG_OUTZ_H_XL, &tmp, 0);
     data->z |= tmp << 8;
     i2c_release(BUS);
 
@@ -142,20 +141,20 @@ int lsm6dsl_read_gyro(const lsm6dsl_t *dev, lsm6dsl_3d_data_t *data)
     uint8_t tmp;
 
     i2c_acquire(BUS);
-    i2c_read_reg(BUS, ADDR, LSM6DSL_REG_STATUS_REG, &tmp);
+    i2c_read_reg(BUS, ADDR, LSM6DSL_REG_STATUS_REG, &tmp, 0);
     DEBUG("lsm6dsl status: %x\n", tmp);
 
-    res = i2c_read_reg(BUS, ADDR, LSM6DSL_REG_OUTX_L_G, &tmp);
+    res = i2c_read_reg(BUS, ADDR, LSM6DSL_REG_OUTX_L_G, &tmp, 0);
     data->x = tmp;
-    res += i2c_read_reg(BUS, ADDR, LSM6DSL_REG_OUTX_H_G, &tmp);
+    res += i2c_read_reg(BUS, ADDR, LSM6DSL_REG_OUTX_H_G, &tmp, 0);
     data->x |= tmp << 8;
-    res += i2c_read_reg(BUS, ADDR, LSM6DSL_REG_OUTY_L_G, &tmp);
+    res += i2c_read_reg(BUS, ADDR, LSM6DSL_REG_OUTY_L_G, &tmp, 0);
     data->y = tmp;
-    res += i2c_read_reg(BUS, ADDR, LSM6DSL_REG_OUTY_H_G, &tmp);
+    res += i2c_read_reg(BUS, ADDR, LSM6DSL_REG_OUTY_H_G, &tmp, 0);
     data->y |= tmp << 8;
-    res += i2c_read_reg(BUS, ADDR, LSM6DSL_REG_OUTZ_L_G, &tmp);
+    res += i2c_read_reg(BUS, ADDR, LSM6DSL_REG_OUTZ_L_G, &tmp, 0);
     data->z = tmp;
-    res += i2c_read_reg(BUS, ADDR, LSM6DSL_REG_OUTZ_H_G, &tmp);
+    res += i2c_read_reg(BUS, ADDR, LSM6DSL_REG_OUTZ_H_G, &tmp, 0);
     data->z |= tmp << 8;
     i2c_release(BUS);
 
@@ -178,12 +177,12 @@ int lsm6dsl_read_temp(const lsm6dsl_t *dev, int16_t *data)
     uint16_t traw;
     /* read raw temperature */
     i2c_acquire(BUS);
-    if (i2c_read_reg(BUS, ADDR, LSM6DSL_REG_OUT_TEMP_L, &tmp) != 1) {
+    if (i2c_read_reg(BUS, ADDR, LSM6DSL_REG_OUT_TEMP_L, &tmp, 0) != 1) {
         i2c_release(BUS);
         return -LSM6DSL_ERROR_BUS;
     }
     traw = tmp;
-    if (i2c_read_reg(BUS, ADDR, LSM6DSL_REG_OUT_TEMP_H, &tmp) != 1) {
+    if (i2c_read_reg(BUS, ADDR, LSM6DSL_REG_OUT_TEMP_H, &tmp, 0) != 1) {
         i2c_release(BUS);
         return -LSM6DSL_ERROR_BUS;
     }
@@ -202,7 +201,7 @@ int lsm6dsl_acc_power_down(const lsm6dsl_t *dev)
     uint8_t tmp;
 
     i2c_acquire(BUS);
-    res = i2c_read_reg(BUS, ADDR, LSM6DSL_REG_CTRL1_XL, &tmp);
+    res = i2c_read_reg(BUS, ADDR, LSM6DSL_REG_CTRL1_XL, &tmp, 0);
     if (res != 1) {
         i2c_release(BUS);
         DEBUG("[ERROR] lsm6dsl_acc_power_down\n");
@@ -210,7 +209,7 @@ int lsm6dsl_acc_power_down(const lsm6dsl_t *dev)
     }
 
     tmp &= ~(LSM6DSL_CTRL_ODR_MASK);
-    res = i2c_write_reg(BUS, ADDR, LSM6DSL_REG_CTRL1_XL, tmp);
+    res = i2c_write_reg(BUS, ADDR, LSM6DSL_REG_CTRL1_XL, tmp, 0);
 
     i2c_release(BUS);
 
@@ -228,7 +227,7 @@ int lsm6dsl_gyro_power_down(const lsm6dsl_t *dev)
     uint8_t tmp;
 
     i2c_acquire(BUS);
-    res = i2c_read_reg(BUS, ADDR, LSM6DSL_REG_CTRL2_G, &tmp);
+    res = i2c_read_reg(BUS, ADDR, LSM6DSL_REG_CTRL2_G, &tmp, 0);
     if (res != 1) {
         i2c_release(BUS);
         DEBUG("[ERROR] lsm6dsl_gyro_power_down\n");
@@ -236,7 +235,7 @@ int lsm6dsl_gyro_power_down(const lsm6dsl_t *dev)
     }
 
     tmp &= ~(LSM6DSL_CTRL_ODR_MASK);
-    res = i2c_write_reg(BUS, ADDR, LSM6DSL_REG_CTRL2_G, tmp);
+    res = i2c_write_reg(BUS, ADDR, LSM6DSL_REG_CTRL2_G, tmp, 0);
 
     i2c_release(BUS);
 
@@ -254,7 +253,7 @@ int lsm6dsl_acc_power_up(const lsm6dsl_t *dev)
     uint8_t tmp;
 
     i2c_acquire(BUS);
-    res = i2c_read_reg(BUS, ADDR, LSM6DSL_REG_CTRL1_XL, &tmp);
+    res = i2c_read_reg(BUS, ADDR, LSM6DSL_REG_CTRL1_XL, &tmp, 0);
     if (res != 1) {
         i2c_release(BUS);
         DEBUG("[ERROR] lsm6dsl_acc_power_up\n");
@@ -263,7 +262,7 @@ int lsm6dsl_acc_power_up(const lsm6dsl_t *dev)
 
     tmp &= ~(LSM6DSL_CTRL_ODR_MASK);
     tmp |= dev->params.acc_odr << LSM6DSL_CTRL_ODR_SHIFT;
-    res = i2c_write_reg(BUS, ADDR, LSM6DSL_REG_CTRL1_XL, tmp);
+    res = i2c_write_reg(BUS, ADDR, LSM6DSL_REG_CTRL1_XL, tmp, 0);
 
     i2c_release(BUS);
 
@@ -281,7 +280,7 @@ int lsm6dsl_gyro_power_up(const lsm6dsl_t *dev)
     uint8_t tmp;
 
     i2c_acquire(BUS);
-    res = i2c_read_reg(BUS, ADDR, LSM6DSL_REG_CTRL2_G, &tmp);
+    res = i2c_read_reg(BUS, ADDR, LSM6DSL_REG_CTRL2_G, &tmp, 0);
     if (res != 1) {
         i2c_release(BUS);
         DEBUG("[ERROR] lsm6dsl_gyro_power_up\n");
@@ -290,7 +289,7 @@ int lsm6dsl_gyro_power_up(const lsm6dsl_t *dev)
 
     tmp &= ~(LSM6DSL_CTRL_ODR_MASK);
     tmp |= dev->params.gyro_odr << LSM6DSL_CTRL_ODR_SHIFT;
-    res = i2c_write_reg(BUS, ADDR, LSM6DSL_REG_CTRL2_G, tmp);
+    res = i2c_write_reg(BUS, ADDR, LSM6DSL_REG_CTRL2_G, tmp, 0);
 
     i2c_release(BUS);
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR adapts the lsm6dsl to the new I2C api.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

#6577 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->