### PR TITLE
drivers/hts221: adapt to new I2C api

### DIFF
--- a/drivers/hts221/hts221.c
+++ b/drivers/hts221/hts221.c
@@ -30,7 +30,6 @@
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
 
-#define I2C_SPEED       I2C_SPEED_FAST
 #define BUS             (dev->p.i2c)
 #define ADDR            (dev->p.addr)
 
@@ -51,7 +50,7 @@ int _humidity_calibration(hts221_t *dev)
     uint8_t buf[2];
     uint8_t reg = HTS221_REGS_H0_RH_X2 | 0x80;
     /* 1. read h0_rh and h1_rh coefficients */
-    if (i2c_read_regs(BUS, ADDR, reg, &buf[0], 2) != 2) {
+    if (i2c_read_regs(BUS, ADDR, reg, &buf[0], 2, 0) != 2) {
         i2c_release(BUS);
         DEBUG("%s: i2c_read_regs failed!\n", DEBUG_FUNC);
         return -HTS221_NOBUS;
@@ -63,7 +62,7 @@ int _humidity_calibration(hts221_t *dev)
           DEBUG_FUNC, dev->h0_rh, dev->h1_rh);
     /* 2. read h0_t0_out */
     reg = HTS221_REGS_H0_T0_OUT_L | 0x80;
-    if (i2c_read_regs(BUS, ADDR, reg, &buf[0], 2) != 2) {
+    if (i2c_read_regs(BUS, ADDR, reg, &buf[0], 2, 0) != 2) {
         i2c_release(BUS);
         DEBUG("%s: i2c_read_regs failed!\n", DEBUG_FUNC);
         return -HTS221_NOBUS;
@@ -72,7 +71,7 @@ int _humidity_calibration(hts221_t *dev)
     dev->h0_t0_out = ((uint16_t)buf[1] << 8) | buf[0];
     /* 3. read h1_t0_out */
     reg = HTS221_REGS_H1_T0_OUT_L | 0x80;
-    if (i2c_read_regs(BUS, ADDR, reg, &buf[0], 2) != 2) {
+    if (i2c_read_regs(BUS, ADDR, reg, &buf[0], 2, 0) != 2) {
         i2c_release(BUS);
         DEBUG("%s: i2c_read_regs failed!\n", DEBUG_FUNC);
         return -HTS221_NOBUS;
@@ -101,14 +100,14 @@ int _temperature_calibration(hts221_t *dev)
     uint8_t tmp;
     /* 1. read t0_degc and t1_degc coefficients */
     uint8_t reg = HTS221_REGS_T0_DEGC_X8 | 0x80;
-    if (i2c_read_regs(BUS, ADDR, reg, &buf[0], 2) != 2) {
+    if (i2c_read_regs(BUS, ADDR, reg, &buf[0], 2, 0) != 2) {
         i2c_release(BUS);
         DEBUG("%s: i2c_read_regs failed!\n", DEBUG_FUNC);
         return -HTS221_NOBUS;
     }
     DEBUG("%s: buf[0]=%u buf[1]=%u\n", DEBUG_FUNC, buf[0], buf[1]);
     /* 2. read t1_t0_msb */
-    if (i2c_read_reg(BUS, ADDR, HTS221_REGS_T1_T0_MSB, &tmp) != 1) {
+    if (i2c_read_reg(BUS, ADDR, HTS221_REGS_T1_T0_MSB, &tmp, 0) != 1) {
         i2c_release(BUS);
         DEBUG("%s: i2c_read_regs failed!\n", DEBUG_FUNC);
         return -HTS221_NOBUS;
@@ -122,7 +121,7 @@ int _temperature_calibration(hts221_t *dev)
           DEBUG_FUNC, dev->t0_degc, dev->t1_degc);
     /* 4. read t0_out */
     reg = HTS221_REGS_T0_OUT_L | 0x80;
-    if (i2c_read_regs(BUS, ADDR, reg, &buf[0], 2) != 2) {
+    if (i2c_read_regs(BUS, ADDR, reg, &buf[0], 2, 0) != 2) {
         i2c_release(BUS);
         DEBUG("%s: i2c_read_regs failed!\n", DEBUG_FUNC);
         return -HTS221_NOBUS;
@@ -131,7 +130,7 @@ int _temperature_calibration(hts221_t *dev)
     dev->t0_out = ((uint16_t)buf[1] << 8) | buf[0];
     /* 5. read t1_out */
     reg = HTS221_REGS_T1_OUT_L | 0x80;
-    if (i2c_read_regs(BUS, ADDR, reg, &buf[0], 2) != 2) {
+    if (i2c_read_regs(BUS, ADDR, reg, &buf[0], 2, 0) != 2) {
         i2c_release(BUS);
         DEBUG("%s: i2c_read_regs failed!\n", DEBUG_FUNC);
         return -HTS221_NOBUS;
@@ -151,37 +150,39 @@ int hts221_init(hts221_t *dev, const hts221_params_t *params)
     memcpy(&dev->p, params, sizeof(hts221_params_t));
     /* initialize the I2C bus */
     i2c_acquire(BUS);
-    if (i2c_init_master(BUS, I2C_SPEED) < 0) {
+    if (i2c_init(BUS) < 0) {
         i2c_release(BUS);
-        DEBUG("%s: i2c_init_master failed!\n", DEBUG_FUNC);
+        DEBUG("%s: i2c_init failed!\n", DEBUG_FUNC);
         return -HTS221_NOBUS;
     }
 
     /* try if we can interact with the device by reading its manufacturer ID */
-    if (i2c_read_reg(BUS, ADDR, HTS221_REGS_WHO_AM_I, &reg) != 1) {
+    if (i2c_read_reg(BUS, ADDR, HTS221_REGS_WHO_AM_I, &reg, 0) != 1) {
         i2c_release(BUS);
         DEBUG("%s: i2c_read_regs HTS221_REGS_WHO_AM_I failed!\n", DEBUG_FUNC);
         return -HTS221_NOBUS;
     }
+
     if (reg != HTS221_DEVICE_ID) {
         i2c_release(BUS);
         DEBUG("%s: invalid HTS221_DEVICE_ID!\n", DEBUG_FUNC);
         return -HTS221_NODEV;
     }
     i2c_release(BUS);
+
     /* reboot device before usage */
     if (hts221_reboot(dev) != HTS221_OK) {
         return -HTS221_NOBUS;
     }
 
     i2c_acquire(BUS);
-    if (i2c_write_reg(BUS, ADDR, HTS221_REGS_AV_CONF, dev->p.avgx) != 1) {
+    if (i2c_write_reg(BUS, ADDR, HTS221_REGS_AV_CONF, dev->p.avgx, 0) != 1) {
         i2c_release(BUS);
         DEBUG("%s: i2c_write_regs HTS221_REGS_AV_CONF failed!\n", DEBUG_FUNC);
         return -HTS221_NOBUS;
     }
     reg = 0;
-    if (i2c_write_reg(BUS, ADDR, HTS221_REGS_CTRL_REG1, reg) != 1) {
+    if (i2c_write_reg(BUS, ADDR, HTS221_REGS_CTRL_REG1, reg, 0) != 1) {
         i2c_release(BUS);
         DEBUG("%s: i2c_write_reg HTS221_REGS_CTRL_REG1 failed!\n", DEBUG_FUNC);
         return -HTS221_NOBUS;
@@ -212,14 +213,14 @@ int hts221_one_shot(const hts221_t *dev)
 
     i2c_acquire(BUS);
     /* second, read current settings */
-    if (i2c_read_reg(BUS, ADDR, HTS221_REGS_CTRL_REG2, &reg) != 1) {
+    if (i2c_read_reg(BUS, ADDR, HTS221_REGS_CTRL_REG2, &reg, 0) != 1) {
         i2c_release(BUS);
         DEBUG("%s: i2c_read_regs HTS221_REGS_CTRL_REG1 failed!\n", DEBUG_FUNC);
         return -HTS221_NOBUS;
     }
     /* third, enable one-shot */
     reg |= HTS221_REGS_CTRL_REG2_OS_EN;
-    if (i2c_write_reg(BUS, ADDR, HTS221_REGS_CTRL_REG2, reg) != 1) {
+    if (i2c_write_reg(BUS, ADDR, HTS221_REGS_CTRL_REG2, reg, 0) != 1) {
         i2c_release(BUS);
         return -HTS221_NOBUS;
     }
@@ -233,14 +234,14 @@ int hts221_set_rate(const hts221_t *dev, const uint8_t rate)
     uint8_t reg;
 
     i2c_acquire(BUS);
-    if (i2c_read_reg(BUS, ADDR, HTS221_REGS_CTRL_REG1, &reg) != 1) {
+    if (i2c_read_reg(BUS, ADDR, HTS221_REGS_CTRL_REG1, &reg, 0) != 1) {
         i2c_release(BUS);
         DEBUG("%s: i2c_read_reg HTS221_REGS_CTRL_REG1 failed!\n", DEBUG_FUNC);
         return -HTS221_NOBUS;
     }
     reg |= rate;
     DEBUG("hts221_set_rate: %u\n", reg);
-    if (i2c_write_reg(BUS, ADDR, HTS221_REGS_CTRL_REG1, reg) != 1) {
+    if (i2c_write_reg(BUS, ADDR, HTS221_REGS_CTRL_REG1, reg, 0) != 1) {
         i2c_release(BUS);
         DEBUG("%s: i2c_write_reg HTS221_REGS_CTRL_REG1 failed!\n", DEBUG_FUNC);
         return -HTS221_NOBUS;
@@ -256,14 +257,14 @@ int hts221_reboot(const hts221_t *dev)
 
     i2c_acquire(BUS);
     reg = HTS221_REGS_CTRL_REG2_BOOT;
-    if (i2c_write_reg(BUS, ADDR, HTS221_REGS_CTRL_REG2, reg) != 1) {
+    if (i2c_write_reg(BUS, ADDR, HTS221_REGS_CTRL_REG2, reg, 0) != 1) {
         i2c_release(BUS);
         DEBUG("%s: i2c_write_reg HTS221_REGS_CTRL_REG2 failed!\n", DEBUG_FUNC);
         return -HTS221_NOBUS;
     }
     /* loop until HTS221_REGS_CTRL_REG2_BOOT == 0 */
     do {
-        i2c_read_reg(BUS, ADDR, HTS221_REGS_CTRL_REG2, &reg);
+        i2c_read_reg(BUS, ADDR, HTS221_REGS_CTRL_REG2, &reg, 0);
     } while (reg & HTS221_REGS_CTRL_REG2_BOOT);
     i2c_release(BUS);
 
@@ -275,7 +276,7 @@ static int _set_power(const hts221_t *dev, const bool active)
     uint8_t reg;
 
     i2c_acquire(BUS);
-    if (i2c_read_reg(BUS, ADDR, HTS221_REGS_CTRL_REG1, &reg) != 1) {
+    if (i2c_read_reg(BUS, ADDR, HTS221_REGS_CTRL_REG1, &reg, 0) != 1) {
         i2c_release(BUS);
         DEBUG("%s: i2c_read_reg HTS221_REGS_CTRL_REG1 failed!\n", DEBUG_FUNC);
         return -HTS221_NOBUS;
@@ -286,7 +287,7 @@ static int _set_power(const hts221_t *dev, const bool active)
     else {
         reg &= ~HTS221_REGS_CTRL_REG1_PD_ACTIVE;
     }
-    if (i2c_write_reg(BUS, ADDR, HTS221_REGS_CTRL_REG1, reg) != 1) {
+    if (i2c_write_reg(BUS, ADDR, HTS221_REGS_CTRL_REG1, reg, 0) != 1) {
         i2c_release(BUS);
         DEBUG("%s: i2c_write_reg HTS221_REGS_CTRL_REG1 failed!\n", DEBUG_FUNC);
         return -HTS221_NOBUS;
@@ -311,7 +312,7 @@ int hts221_get_state(const hts221_t *dev)
     uint8_t reg;
 
     i2c_acquire(BUS);
-    if (i2c_read_reg(BUS, ADDR, HTS221_REGS_STATUS_REG, &reg) != 1) {
+    if (i2c_read_reg(BUS, ADDR, HTS221_REGS_STATUS_REG, &reg, 0) != 1) {
         i2c_release(BUS);
         DEBUG("%s: i2c_read_regs failed!\n", DEBUG_FUNC);
         return -HTS221_NOBUS;
@@ -333,7 +334,8 @@ int hts221_read_humidity(const hts221_t *dev, uint16_t *val)
     /* read raw humidity */
     i2c_acquire(BUS);
     uint8_t reg = HTS221_REGS_HUMIDITY_OUT_L | 0x80;
-    if (i2c_read_regs(BUS, ADDR, reg, &buf[0], 2) != 2) {
+
+    if (i2c_read_regs(BUS, ADDR, reg, &buf[0], 2, 0) != 2) {
         i2c_release(BUS);
         DEBUG("%s: i2c_read_regs failed!\n", DEBUG_FUNC);
         return -HTS221_NOBUS;
@@ -368,7 +370,7 @@ int hts221_read_temperature(const hts221_t *dev, int16_t *val)
     /* read raw t_out */
     i2c_acquire(BUS);
     uint8_t reg = HTS221_REGS_TEMP_OUT_L | 0x80;
-    if (i2c_read_regs(BUS, ADDR, reg, &buf[0], 2) != 2) {
+    if (i2c_read_regs(BUS, ADDR, reg, &buf[0], 2, 0) != 2) {
         i2c_release(BUS);
         DEBUG("%s: i2c_read_regs failed!\n", DEBUG_FUNC);
         return -HTS221_NOBUS;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR adapts the hts221 driver to the new I2C api.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

#6577 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->