### PR TITLE
drivers/i2c: improve common i2c driver

### DIFF
--- a/drivers/periph_common/i2c.c
+++ b/drivers/periph_common/i2c.c
@@ -24,22 +24,23 @@
 
 #ifdef I2C_NUMOF
 
-#ifdef PERIPH_I2C_NEED_READ_REGS
+#ifdef PERIPH_I2C_NEED_READ_REG
 int i2c_read_reg(i2c_t dev, uint16_t addr, uint16_t reg,
                  void *data, uint8_t flags)
 {
     return i2c_read_regs(dev, addr, reg, data, 1, flags);
 }
+#endif /* PERIPH_I2C_NEED_READ_REG */
 
+#ifdef PERIPH_I2C_NEED_READ_REGS
 int i2c_read_regs(i2c_t dev, uint16_t addr, uint16_t reg,
                   void *data, size_t len, uint8_t flags)
 {
-    int8_t err;
     /* First set ADDR and register with no stop */
-    err = i2c_write_bytes(dev, addr, &reg, (flags & I2C_REG16) ? 2 : 1,
-                          flags & I2C_NOSTOP );
-    if (err < 0) {
-        return err;
+    int8_t ret = i2c_write_bytes(dev, addr, &reg, (flags & I2C_REG16) ? 2 : 1,
+                                 flags | I2C_NOSTOP);
+    if (ret < 0) {
+        return ret;
     }
     /* Then get the data from device */
     return i2c_read_bytes(dev, addr, data, len, flags);
@@ -56,25 +57,26 @@ int i2c_write_byte(i2c_t dev, uint16_t addr, uint8_t data, uint8_t flags)
     return i2c_write_bytes(dev, addr, &data, 1, flags);
 }
 
-#ifdef PERIPH_I2C_NEED_WRITE_REGS
+#ifdef PERIPH_I2C_NEED_WRITE_REG
 int i2c_write_reg(i2c_t dev, uint16_t addr, uint16_t reg,
                   uint8_t data, uint8_t flags)
 {
     return i2c_write_regs(dev, addr, reg, &data, 1, flags);
 }
+#endif /* PERIPH_I2C_NEED_WRITE_REG */
 
+#ifdef PERIPH_I2C_NEED_WRITE_REGS
 int i2c_write_regs(i2c_t dev, uint16_t addr, uint16_t reg,
                    const void *data, size_t len, uint8_t flags)
 {
-    int8_t err;
     /* First set ADDR and register with no stop */
-    err = i2c_write_bytes(dev, addr, &reg, (flags & I2C_REG16) ? 2 : 1,
-                          flags & I2C_NOSTOP );
-    if (err < 0) {
-        return err;
+    int8_t ret = i2c_write_bytes(dev, addr, &reg, (flags & I2C_REG16) ? 2 : 1,
+                                 flags | I2C_NOSTOP);
+    if (ret < 0) {
+        return ret;
     }
     /* Then write data to the device */
-    return i2c_write_bytes(dev, addr, data, len, flags);
+    return i2c_write_bytes(dev, addr, data, len, flags | I2C_NOSTART);
 }
 #endif /* PERIPH_I2C_NEED_WRITE_REGS */
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR provides several improvements with the i2c read/write regs function:
- fix reag/write regs function (NOSTART/NOSTOP flags missing)
- use ret variable name instead of err (cosmetic)
- split PERIPH_I2C_NEED_READ/WRITE_REGS to simplify cpu side implementation

This has been tested with hts221 (#9195 ) and lsm6dsl (#9193 )

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

#6577 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->