### PR TITLE
doc: fix quick guide command order

### DIFF
--- a/doc/doxygen/src/mainpage.md
+++ b/doc/doxygen/src/mainpage.md
@@ -55,8 +55,8 @@ call this the `native` port). Try it right now in your terminal window:
 
 ~~~~~~~{.sh}
 git clone git://github.com/RIOT-OS/RIOT.git # assumption: git is pre-installed
-git checkout <LATEST_RELEASE>
 cd RIOT
+git checkout <LATEST_RELEASE>
 ./dist/tools/tapsetup/tapsetup              # create virtual Ethernet
                                             # interfaces to connect multiple
                                             # RIOT instances


### PR DESCRIPTION
git checkout can only work if you've already changed to RIOT folder.