### PR TITLE
drivers/periph_common: init i2c only if module is loaded

### DIFF
--- a/drivers/periph_common/init.c
+++ b/drivers/periph_common/init.c
@@ -36,7 +36,7 @@
 void periph_init(void)
 {
     /* initialize configured I2C devices */
-#ifdef I2C_NUMOF
+#ifdef MODULE_PERIPH_I2C
     for (unsigned i = 0; i < I2C_NUMOF; i++) {
         i2c_init(I2C_DEV(i));
     }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

While refactoring the STM32 i2c drivers in #9202, I noticed that the i2c devices initialization should only be performed when the corresponding module is loaded. This will also be consistent with the other peripherals init (spi, rtc, etc).

This PR adapts this.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

#6577 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->