### PR TITLE
drivers: bmx280: adapt to new I2C api.

### DIFF
--- a/drivers/include/bmx280.h
+++ b/drivers/include/bmx280.h
@@ -164,9 +164,8 @@ typedef struct {
  */
 enum {
     BMX280_OK           =  0,     /**< everything was fine */
-    BMX280_ERR_I2C      = -1,     /**< error initializing the I2C bus */
-    BMX280_ERR_NODEV    = -2,     /**< did not detect BME280 or BMP280 */
-    BMX280_ERR_NOCAL    = -3,     /**< could not read calibration data */
+    BMX280_ERR_NODEV    = -1,     /**< did not detect BME280 or BMP280 */
+    BMX280_ERR_NOCAL    = -2,     /**< could not read calibration data */
 };
 
 /**


### PR DESCRIPTION
### Contribution description

This PR updates the BMx280 driver. Tested this one on the SLTB001A (EFM32, adapted).

It's probably better to wait for #8383, but it was easy to adapt for the time being.

### Issues/PRs references

#6577