### PR TITLE
pkg: u8g2: adapt to new I2C api

### DIFF
--- a/pkg/u8g2/src/csrc/u8g2_riotos.c
+++ b/pkg/u8g2/src/csrc/u8g2_riotos.c
@@ -162,7 +162,6 @@ uint8_t u8x8_byte_riotos_hw_i2c(u8x8_t *u8g2, uint8_t msg, uint8_t arg_int, void
             index += arg_int;
             break;
         case U8X8_MSG_BYTE_INIT:
-            i2c_init_master(dev, I2C_SPEED_FAST);
             break;
         case U8X8_MSG_BYTE_SET_DC:
             break;
@@ -171,7 +170,7 @@ uint8_t u8x8_byte_riotos_hw_i2c(u8x8_t *u8g2, uint8_t msg, uint8_t arg_int, void
             index = 0;
             break;
         case U8X8_MSG_BYTE_END_TRANSFER:
-            i2c_write_bytes(dev, u8x8_GetI2CAddress(u8g2), buffer, index);
+            i2c_write_bytes(dev, u8x8_GetI2CAddress(u8g2), buffer, index, 0);
             i2c_release(dev);
             break;
         default:


### PR DESCRIPTION
### Contribution description

This PR updates the U8G2 package. Tested this one on the STK3600 (EFM32, adapted).

### Issues/PRs references

#6577