### PR TITLE
cpu: efm32: adapt to new I2C interface

### DIFF
--- a/boards/common/silabs/drivers/pic/pic.c
+++ b/boards/common/silabs/drivers/pic/pic.c
@@ -61,8 +61,6 @@ void pic_init(void)
 {
     gpio_init(PIC_INT_WAKE_PIN, GPIO_OD);
     gpio_set(PIC_INT_WAKE_PIN);
-
-    i2c_init_master(PIC_I2C, I2C_SPEED_NORMAL);
 }
 
 void pic_write(uint8_t addr, uint8_t value)
@@ -74,7 +72,7 @@ void pic_write(uint8_t addr, uint8_t value)
     /* write to gpio expander */
     i2c_acquire(PIC_I2C);
     uint8_t bytes[] = { addr, value };
-    i2c_write_bytes(PIC_I2C, PIC_I2C_ADDR, bytes, 2);
+    i2c_write_bytes(PIC_I2C, PIC_I2C_ADDR, bytes, 2, 0);
     i2c_release(PIC_I2C);
 
     /* put PIC in sleep mode again */

--- a/boards/slstk3401a/include/periph_conf.h
+++ b/boards/slstk3401a/include/periph_conf.h
@@ -96,7 +96,8 @@ static const i2c_conf_t i2c_config[] = {
         .loc = I2C_ROUTELOC0_SDALOC_LOC15 |
                I2C_ROUTELOC0_SCLLOC_LOC15,
         .cmu = cmuClock_I2C0,
-        .irq = I2C0_IRQn
+        .irq = I2C0_IRQn,
+        .speed = I2C_SPEED_NORMAL
     }
 };
 

--- a/boards/sltb001a/include/periph_conf.h
+++ b/boards/sltb001a/include/periph_conf.h
@@ -96,8 +96,8 @@ static const i2c_conf_t i2c_config[] = {
         .loc = I2C_ROUTELOC0_SDALOC_LOC15 |
                I2C_ROUTELOC0_SCLLOC_LOC15,
         .cmu = cmuClock_I2C0,
-        .irq = I2C0_IRQn
-
+        .irq = I2C0_IRQn,
+        .speed = I2C_SPEED_NORMAL
     }
 };
 

--- a/boards/slwstk6000b/include/periph_conf.h
+++ b/boards/slwstk6000b/include/periph_conf.h
@@ -98,7 +98,8 @@ static const i2c_conf_t i2c_config[] = {
         .loc = I2C_ROUTELOC0_SDALOC_LOC16 |
                I2C_ROUTELOC0_SCLLOC_LOC14,
         .cmu = cmuClock_I2C0,
-        .irq = I2C0_IRQn
+        .irq = I2C0_IRQn,
+        .speed = I2C_SPEED_NORMAL
     }
 };
 

--- a/boards/stk3600/include/periph_conf.h
+++ b/boards/stk3600/include/periph_conf.h
@@ -115,7 +115,8 @@ static const i2c_conf_t i2c_config[] = {
         .scl_pin = GPIO_PIN(PD, 7),
         .loc = I2C_ROUTE_LOCATION_LOC1,
         .cmu = cmuClock_I2C0,
-        .irq = I2C0_IRQn
+        .irq = I2C0_IRQn,
+        .speed = I2C_SPEED_NORMAL
     },
     {
         .dev = I2C1,
@@ -123,7 +124,8 @@ static const i2c_conf_t i2c_config[] = {
         .scl_pin = GPIO_PIN(PC, 5),
         .loc = I2C_ROUTE_LOCATION_LOC0,
         .cmu = cmuClock_I2C1,
-        .irq = I2C1_IRQn
+        .irq = I2C1_IRQn,
+        .speed = I2C_SPEED_NORMAL
     }
 };
 

--- a/boards/stk3700/include/periph_conf.h
+++ b/boards/stk3700/include/periph_conf.h
@@ -115,7 +115,8 @@ static const i2c_conf_t i2c_config[] = {
         .scl_pin = GPIO_PIN(PD, 7),
         .loc = I2C_ROUTE_LOCATION_LOC1,
         .cmu = cmuClock_I2C0,
-        .irq = I2C0_IRQn
+        .irq = I2C0_IRQn,
+        .speed = I2C_SPEED_NORMAL
     },
     {
         .dev = I2C1,
@@ -123,7 +124,8 @@ static const i2c_conf_t i2c_config[] = {
         .scl_pin = GPIO_PIN(PC, 5),
         .loc = I2C_ROUTE_LOCATION_LOC0,
         .cmu = cmuClock_I2C1,
-        .irq = I2C1_IRQn
+        .irq = I2C1_IRQn,
+        .speed = I2C_SPEED_NORMAL
     }
 };
 

--- a/cpu/efm32/include/periph_cpu.h
+++ b/cpu/efm32/include/periph_cpu.h
@@ -252,7 +252,16 @@ typedef struct {
     uint32_t loc;           /**< location of I2C pins */
     CMU_Clock_TypeDef cmu;  /**< the device CMU channel */
     IRQn_Type irq;          /**< the devices base IRQ channel */
+    uint32_t speed;         /**< the bus speed */
 } i2c_conf_t;
+
+/**
+ * @brief   Declare needed generic I2C functions.
+ * @{
+ */
+#define PERIPH_I2C_NEED_READ_REG
+#define PERIPH_I2C_NEED_WRITE_REG
+/** @} */
 
 #ifndef DOXYGEN
 /**


### PR DESCRIPTION
### Contribution description

This PR updates the EFM32 port to work with the new I2C peripheral interface. I've tested this on the SLTB001A (which has Si7021, BMP280 + I2C power controller), SLSTK3401a (Si7021) and STK3600 (for #9207).

I don't have 10-bit I2C device, nor have I access to something to test 16 bit registers.

### Issues/PRs references

#6577, depends on ~#9205~ and ~#9206~ (or ~#8383~).