### PR TITLE
newlib-nano: Add workaround for systems without nano includes.

### DIFF
--- a/makefiles/libc/newlib.mk
+++ b/makefiles/libc/newlib.mk
@@ -66,6 +66,13 @@ endif
 ifeq (1,$(USE_NEWLIB_NANO))
   # newlib-nano include directory is called either newlib-nano or nano. Use the one we find first.
   NEWLIB_NANO_INCLUDE_DIR ?= $(firstword $(wildcard $(addprefix $(NEWLIB_INCLUDE_DIR)/, newlib-nano nano)))
+
+  # Workaround for systems where the nano header is not installed.
+  # For ArchLinux, see https://bugs.archlinux.org/task/50481
+  ifeq ($(NEWLIB_NANO_INCLUDE_DIR),)
+    NEWLIB_NANO_INCLUDE_DIR = NEWLIB_INCLUDE_DIR
+  endif
+
   # newlib-nano overrides newlib.h and its include dir should therefore go before
   # the regular system include dirs.
   INCLUDES := -isystem $(NEWLIB_NANO_INCLUDE_DIR) $(INCLUDES)


### PR DESCRIPTION
### Contribution description

Some systems (OSX, ArchLinux) do not ship separate headers for newlib nano. All the standard system headers for nano should be the same with the exception of `newlib.h`.

The result for these systems is that the `NEWLIB_NANO_INCLUDE_DIR` is empty and the include line is wrongly formed.

This is a workaroround that reverts to the old behavior of using the non-nano include path if `NEWLIB_NANO_INCLUDE_DIR` is empty.

### Issues/PRs references

Fixes #9214, which was introduced by #9080 .