### PR TITLE
 newlib-nano: fix include directory

### DIFF
--- a/makefiles/libc/newlib.mk
+++ b/makefiles/libc/newlib.mk
@@ -69,9 +69,7 @@ ifneq (1,$(USE_NANO_SPECS_FILE))
   # A cross GCC already knows the target libc include path (build-in at compile time)
   # but Clang, when cross-compiling, needs to be told where to find the headers
   # for the system being built.
-  # We also add -nostdinc to avoid including the host system headers by mistake
-  # in case some header is missing from the cross tool chain
-  NEWLIB_INCLUDES := -isystem $(NEWLIB_INCLUDE_DIR) -nostdinc
+  NEWLIB_INCLUDES := -isystem $(NEWLIB_INCLUDE_DIR)
   NEWLIB_INCLUDES += $(addprefix -isystem ,$(abspath $(wildcard $(dir $(NEWLIB_INCLUDE_DIR))/usr/include)))
   ifeq (1,$(USE_NEWLIB_NANO))
     # newlib-nano include directory is called either newlib-nano or nano. Use the one we find first.

--- a/makefiles/libc/newlib.mk
+++ b/makefiles/libc/newlib.mk
@@ -74,14 +74,11 @@ ifneq (1,$(USE_NANO_SPECS_FILE))
   ifeq (1,$(USE_NEWLIB_NANO))
     # newlib-nano include directory is called either newlib-nano or nano. Use the one we find first.
     NEWLIB_NANO_INCLUDE_DIR ?= $(firstword $(wildcard $(addprefix $(NEWLIB_INCLUDE_DIR)/, newlib-nano nano)))
-    # Workaround for systems where the nano header is not installed.
-    # For ArchLinux, see https://bugs.archlinux.org/task/50481
-    ifeq ($(NEWLIB_NANO_INCLUDE_DIR),)
-      NEWLIB_NANO_INCLUDE_DIR = NEWLIB_INCLUDE_DIR
+    ifneq ($(NEWLIB_NANO_INCLUDE_DIR),)
+      # newlib-nano overrides newlib.h and its include dir should therefore go before
+      # the regular system include dirs, but after the other newlib includes.
+      NEWLIB_INCLUDES += -isystem $(NEWLIB_NANO_INCLUDE_DIR)
     endif
-    # newlib-nano overrides newlib.h and its include dir should therefore go before
-    # the regular system include dirs.
-    INCLUDES := -isystem $(NEWLIB_NANO_INCLUDE_DIR) $(INCLUDES)
   endif
 endif
 

--- a/makefiles/libc/newlib.mk
+++ b/makefiles/libc/newlib.mk
@@ -70,6 +70,8 @@ else
       # newlib-nano overrides newlib.h and its include dir
       # should therefore go before the other newlib includes.
       NEWLIB_INCLUDES := -isystem $(NEWLIB_NANO_INCLUDE_DIR) $(NEWLIB_INCLUDES)
+    else
+      $(warning Could not find newlib nano include dir, using normal newlib)
     endif
   endif
 endif

--- a/makefiles/libc/newlib.mk
+++ b/makefiles/libc/newlib.mk
@@ -14,48 +14,46 @@ ifneq (,$(filter newlib_gnu_source,$(USEMODULE)))
   CFLAGS += -D_GNU_SOURCE=1
 endif
 
+export LINKFLAGS += -lc
+
 ifeq (1,$(USE_NANO_SPECS_FILE))
   export LINKFLAGS += -specs=nano.specs
   export CFLAGS += -specs=nano.specs
-endif
-
-export LINKFLAGS += -lc
-
-# Search for Newlib include directories
-
-# Since Clang is not installed as a separate instance for each crossdev target
-# we need to tell it where to look for platform specific includes (Newlib
-# headers instead of Linux/Glibc headers.)
-# On GCC this is done when building the cross compiler toolchain so we do not
-# actually need to specify the include paths for system includes.
-# Ubuntu gcc-arm-embedded toolchain (https://launchpad.net/gcc-arm-embedded)
-# places newlib headers in several places, but the primary source seem to be
-# /etc/alternatives/gcc-arm-none-eabi-include
-# Gentoo Linux crossdev place the newlib headers in /usr/arm-none-eabi/include
-# Arch Linux also place the newlib headers in /usr/arm-none-eabi/include
-# Ubuntu seem to put a copy of the newlib headers in the same place as
-# Gentoo crossdev, but we prefer to look at /etc/alternatives first.
-# On OSX, newlib includes are possibly located in
-# /usr/local/opt/arm-none-eabi*/arm-none-eabi/include or /usr/local/opt/gcc-arm/arm-none-eabi/include
-NEWLIB_INCLUDE_PATTERNS ?= \
-  /etc/alternatives/gcc-$(TARGET_ARCH)-include \
-  /usr/$(TARGET_ARCH)/include \
-  /usr/local/opt/$(TARGET_ARCH)*/$(TARGET_ARCH)/include \
-  /usr/local/opt/gcc-*/$(TARGET_ARCH)/include \
-
-# Search for a newlib.h inside the above newlib include directory patterns
-NEWLIB_INCLUDE_FILE = $(firstword $(wildcard $(addsuffix /newlib.h,$(NEWLIB_INCLUDE_PATTERNS))))
-
-# If nothing was found we will try to fall back to searching for a cross-gcc in
-# the current PATH and use a relative path for the includes
-ifeq (,$(NEWLIB_INCLUDE_FILE))
-  $(warning newlib.h not found, guessing newlib include path from gcc path)
-  NEWLIB_INCLUDE_DIR := $(abspath $(wildcard $(dir $(shell command -v $(PREFIX)gcc 2>/dev/null))/../$(TARGET_ARCH)/include))
 else
-  NEWLIB_INCLUDE_DIR := $(dir $(NEWLIB_INCLUDE_FILE))
-endif
+  # Search for Newlib include directories
 
-ifneq (1,$(USE_NANO_SPECS_FILE))
+  # Since Clang is not installed as a separate instance for each crossdev target
+  # we need to tell it where to look for platform specific includes (Newlib
+  # headers instead of Linux/Glibc headers.)
+  # On GCC this is done when building the cross compiler toolchain so we do not
+  # actually need to specify the include paths for system includes.
+  # Ubuntu gcc-arm-embedded toolchain (https://launchpad.net/gcc-arm-embedded)
+  # places newlib headers in several places, but the primary source seem to be
+  # /etc/alternatives/gcc-arm-none-eabi-include
+  # Gentoo Linux crossdev place the newlib headers in /usr/arm-none-eabi/include
+  # Arch Linux also place the newlib headers in /usr/arm-none-eabi/include
+  # Ubuntu seem to put a copy of the newlib headers in the same place as
+  # Gentoo crossdev, but we prefer to look at /etc/alternatives first.
+  # On OSX, newlib includes are possibly located in
+  # /usr/local/opt/arm-none-eabi*/arm-none-eabi/include or /usr/local/opt/gcc-arm/arm-none-eabi/include
+  NEWLIB_INCLUDE_PATTERNS ?= \
+    /etc/alternatives/gcc-$(TARGET_ARCH)-include \
+    /usr/$(TARGET_ARCH)/include \
+    /usr/local/opt/$(TARGET_ARCH)*/$(TARGET_ARCH)/include \
+    /usr/local/opt/gcc-*/$(TARGET_ARCH)/include \
+
+  # Search for a newlib.h inside the above newlib include directory patterns
+  NEWLIB_INCLUDE_FILE = $(firstword $(wildcard $(addsuffix /newlib.h,$(NEWLIB_INCLUDE_PATTERNS))))
+
+  # If nothing was found we will try to fall back to searching for a cross-gcc in
+  # the current PATH and use a relative path for the includes
+  ifeq (,$(NEWLIB_INCLUDE_FILE))
+    $(warning newlib.h not found, guessing newlib include path from gcc path)
+    NEWLIB_INCLUDE_DIR := $(abspath $(wildcard $(dir $(shell command -v $(PREFIX)gcc 2>/dev/null))/../$(TARGET_ARCH)/include))
+  else
+    NEWLIB_INCLUDE_DIR := $(dir $(NEWLIB_INCLUDE_FILE))
+  endif
+
   # We use the -isystem gcc/clang argument to add the include
   # directories as system include directories, which means they will not be
   # searched until after all the project specific include directories (-I/path)

--- a/makefiles/libc/newlib.mk
+++ b/makefiles/libc/newlib.mk
@@ -65,9 +65,9 @@ ifneq (1,$(USE_NANO_SPECS_FILE))
     # newlib-nano include directory is called either newlib-nano or nano. Use the one we find first.
     NEWLIB_NANO_INCLUDE_DIR ?= $(firstword $(wildcard $(addprefix $(NEWLIB_INCLUDE_DIR)/, newlib-nano nano)))
     ifneq ($(NEWLIB_NANO_INCLUDE_DIR),)
-      # newlib-nano overrides newlib.h and its include dir should therefore go before
-      # the regular system include dirs, but after the other newlib includes.
-      NEWLIB_INCLUDES += -isystem $(NEWLIB_NANO_INCLUDE_DIR)
+      # newlib-nano overrides newlib.h and its include dir
+      # should therefore go before the other newlib includes.
+      NEWLIB_INCLUDES := -isystem $(NEWLIB_NANO_INCLUDE_DIR) $(NEWLIB_INCLUDES)
     endif
   endif
 endif

--- a/makefiles/libc/newlib.mk
+++ b/makefiles/libc/newlib.mk
@@ -41,6 +41,7 @@ else
     /usr/$(TARGET_ARCH)/include \
     /usr/local/opt/$(TARGET_ARCH)*/$(TARGET_ARCH)/include \
     /usr/local/opt/gcc-*/$(TARGET_ARCH)/include \
+    #
 
   # Search for a newlib.h inside the above newlib include directory patterns
   NEWLIB_INCLUDE_FILE = $(firstword $(wildcard $(addsuffix /newlib.h,$(NEWLIB_INCLUDE_PATTERNS))))

--- a/pkg/ccn-lite/Makefile
+++ b/pkg/ccn-lite/Makefile
@@ -5,7 +5,7 @@ PKG_LICENSE=ISC
 
 .PHONY: all
 
-export RIOT_CFLAGS = $(CFLAGS) $(INCLUDES)
+RIOT_CFLAGS := $(INCLUDES)
 
 TOOLCHAIN_FILE=$(PKG_BUILDDIR)/xcompile-toolchain.cmake
 

--- a/pkg/jerryscript/Makefile.jerryscript
+++ b/pkg/jerryscript/Makefile.jerryscript
@@ -4,8 +4,6 @@ JERRYHEAP  ?= 16
 
 EXT_CFLAGS :=-D__TARGET_RIOT
 
-EXT_CFLAGS += $(CFLAGS)
-
 .PHONY: libjerry riot-jerry flash clean
 
 # all: libjerry riot-jerry

--- a/tests/rmutex/Makefile
+++ b/tests/rmutex/Makefile
@@ -1,5 +1,8 @@
 include ../Makefile.tests_common
 
+# MIPS based boards are black listed due to some issue with newlib and _Atomic
+BOARD_BLACKLIST := mips-malta pic32-clicker pic32-wifire
+
 BOARD_INSUFFICIENT_MEMORY := nucleo-f031k6 nucleo-f042k6 nucleo-l031k6 nucleo-f030r8 \
                              nucleo-l053r8 stm32f0discovery
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Adding the nano.specs file to CFLAGS make sure the correct include directory is found. This way we don't have to explicitly add the include directory.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references
Fixes https://github.com/RIOT-OS/RIOT/issues/9214
Fixes PR #9080 
Alternative to https://github.com/RIOT-OS/RIOT/pull/9215
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->