### PR TITLE
drivers/hts221: remove useless i2c_init call

### DIFF
--- a/drivers/hts221/hts221.c
+++ b/drivers/hts221/hts221.c
@@ -148,14 +148,8 @@ int hts221_init(hts221_t *dev, const hts221_params_t *params)
     uint8_t reg;
 
     memcpy(&dev->p, params, sizeof(hts221_params_t));
-    /* initialize the I2C bus */
-    i2c_acquire(BUS);
-    if (i2c_init(BUS) < 0) {
-        i2c_release(BUS);
-        DEBUG("%s: i2c_init failed!\n", DEBUG_FUNC);
-        return -HTS221_NOBUS;
-    }
 
+    i2c_acquire(BUS);
     /* try if we can interact with the device by reading its manufacturer ID */
     if (i2c_read_reg(BUS, ADDR, HTS221_REGS_WHO_AM_I, &reg, 0) != 1) {
         i2c_release(BUS);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

One leftover from #9195. It's not needed in the current design `i2c_init` is automatically called by the `periph_init` function.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

#6577 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->