### PR TITLE
drivers/periph_i2c: i2c_init should return void

### DIFF
--- a/drivers/include/periph/i2c.h
+++ b/drivers/include/periph/i2c.h
@@ -234,11 +234,8 @@ enum {
  * internally by the i2c_init function!
  *
  * @param[in] dev       the device to initialize
- *
- * @return                  0 on successful initialization
- * @return                  -1 on undefined device given
  */
-int i2c_init(i2c_t dev);
+void i2c_init(i2c_t dev);
 
 /**
  * @brief   Get mutually exclusive access to the given I2C bus


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

With the current design, `i2c_init` is called from `periph_init` and where return code is not used. This PR change this function to return `void `.

If accepted, this PR should be merged before #9202, #7588 and #9208. And these PRs updated after.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

#6577 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->