### PR TITLE
tests/*: pexpect: always expect before sendline

### DIFF
--- a/tests/netstats_l2/tests/01-run.py
+++ b/tests/netstats_l2/tests/01-run.py
@@ -12,6 +12,7 @@ import sys
 
 
 def testfunc(child):
+    child.expect('>')
     child.sendline('ifconfig')
     child.expect(r'       Statistics for Layer 2')
     child.expect(r'        RX packets \d+  bytes \d+')

--- a/tests/ps_schedstatistics/tests/01-run.py
+++ b/tests/ps_schedstatistics/tests/01-run.py
@@ -39,7 +39,6 @@ def _check_startup(child):
 
 
 def _check_help(child):
-    child.sendline('')
     child.expect('>')
     child.sendline('help')
     child.expect_exact('Command              Description')

--- a/tests/ps_schedstatistics/tests/01-run.py
+++ b/tests/ps_schedstatistics/tests/01-run.py
@@ -50,6 +50,7 @@ def _check_help(child):
 
 
 def _check_ps(child):
+    child.expect('>')
     child.sendline('ps')
     for line in PS_EXPECTED:
         child.expect(line)

--- a/tests/rng/tests/01-run.py
+++ b/tests/rng/tests/01-run.py
@@ -13,9 +13,12 @@ import re
 
 def testfunc(child):
     # RNG source
+    child.expect(">")
     child.sendline("source 0")
+    child.expect(">")
     child.sendline("seed 1337")
 
+    child.expect(">")
     child.sendline("fips")
     child.expect("Running FIPS 140-2 test, with seed 1337 using Tiny Mersenne Twister PRNG.")
     child.expect("Monobit test: passed")
@@ -23,6 +26,7 @@ def testfunc(child):
     child.expect("Run test: passed")
     child.expect("Longrun test: passed")
 
+    child.expect(">")
     child.sendline("dump 10")
     child.expect("1555530734")
     child.expect("2178333451")
@@ -35,13 +39,17 @@ def testfunc(child):
     child.expect("3454972398")
     child.expect("1034066532")
 
+    child.expect(">")
     child.sendline("entropy")
     child.expect(re.compile(r"Calculated 7\.994\d{3} bits of entropy from 10000 samples\."))
 
     # Constant source
+    child.expect(">")
     child.sendline("source 1")
+    child.expect(">")
     child.sendline("seed 1337")
 
+    child.expect(">")
     child.sendline("fips")
     child.expect("Running FIPS 140-2 test, with seed 1337 using constant value.")
     child.expect("- Monobit test: failed")
@@ -49,6 +57,7 @@ def testfunc(child):
     child.expect("- Run test: failed")
     child.expect("- Longrun test: passed")
 
+    child.expect(">")
     child.sendline("dump 10")
     child.expect("1337")
     child.expect("1337")
@@ -61,6 +70,7 @@ def testfunc(child):
     child.expect("1337")
     child.expect("1337")
 
+    child.expect(">")
     child.sendline("entropy")
     child.expect(re.compile(r"Calculated 0\.017\d{3} bits of entropy from 10000 samples\."))
 

--- a/tests/shell/tests/01-run.py
+++ b/tests/shell/tests/01-run.py
@@ -28,7 +28,6 @@ EXPECTED_PS = (
 CMDS = {
     'start_test': ('[TEST_START]'),
     'end_test': ('[TEST_END]'),
-    '\n': ('>'),
     '123456789012345678901234567890123456789012345678901234567890':
         ('shell: command not found: '
          '123456789012345678901234567890123456789012345678901234567890'),
@@ -41,6 +40,7 @@ CMDS = {
 
 
 def check_cmd(child, cmd, expected):
+    child.expect('>')
     child.sendline(cmd)
     for line in expected:
         child.expect_exact(line)
@@ -49,6 +49,7 @@ def check_cmd(child, cmd, expected):
 def testfunc(child):
     # check startup message
     child.expect('test_shell.')
+    child.sendline('\n')
 
     # loop other defined commands and expected output
     for cmd, expected in CMDS.items():

--- a/tests/shell/tests/01-run.py
+++ b/tests/shell/tests/01-run.py
@@ -49,7 +49,6 @@ def check_cmd(child, cmd, expected):
 def testfunc(child):
     # check startup message
     child.expect('test_shell.')
-    child.sendline('\n')
 
     # loop other defined commands and expected output
     for cmd, expected in CMDS.items():

--- a/tests/struct_tm_utility/tests/01-run.py
+++ b/tests/struct_tm_utility/tests/01-run.py
@@ -13,6 +13,7 @@ import datetime
 
 
 def _check_help(child):
+    child.expect('>')
     child.sendline('help')
     child.expect_exact('Command              Description')
     child.expect_exact('---------------------------------------')
@@ -28,13 +29,16 @@ def _check_help(child):
 
 def _check_days_in(child):
     # verify usage
+    child.expect('>')
     child.sendline('days_in')
     child.expect_exact('Usage: days_in <Month[1..12]>')
 
     # send an invalid month
+    child.expect('>')
     child.sendline('days_in 13')
     child.expect_exact('Usage: days_in <Month[1..12]>')
 
+    child.expect('>')
     child.sendline('days_in 0')
     child.expect_exact('Usage: days_in <Month[1..12]>')
 
@@ -42,6 +46,7 @@ def _check_days_in(child):
     for m in range(12):
         days = calendar.monthrange(year, m + 1)[1]
         mon = datetime.datetime(year, m + 1, 1).strftime('%b').upper()
+        child.expect('>')
         child.sendline('days_in {}'.format(m + 1))
         child.expect_exact('There are {} days in {} in common years.'
                            .format(days, mon))
@@ -49,10 +54,12 @@ def _check_days_in(child):
 
 def _check_leap_year(child):
     # verify usage
+    child.expect('>')
     child.sendline('leap_year')
     child.expect_exact('Usage: leap_year <Year>')
 
     # send an invalid year
+    child.expect('>')
     child.sendline('leap_year aaaa')
     child.expect_exact('Usage: leap_year <Year>')
 
@@ -60,18 +67,21 @@ def _check_leap_year(child):
                          (2016, 'YES'),
                          (2017, 'NO'),
                          (2018, 'NO')):
+        child.expect('>')
         child.sendline('leap_year {}'.format(year))
         child.expect_exact('Was {} a leap year? {}.'.format(year, leap))
 
 
 def _check_doomsday(child):
     # verify usage
+    child.expect('>')
     child.sendline('doomsday')
     child.expect_exact('Usage: doomsday <Year>')
 
     for year in (2016, 2017):
         dt = (datetime.datetime(year, 3, 1) - datetime.timedelta(days=1))
         doomsday = dt.strftime('%a').upper()
+        child.expect('>')
         child.sendline('doomsday {}'.format(year))
         child.expect_exact('What weekday was MAR 0 of {}? {}.'
                            .format(year, doomsday))
@@ -79,6 +89,7 @@ def _check_doomsday(child):
 
 def _check_day(child):
     # verify usage
+    child.expect('>')
     child.sendline('day')
     child.expect_exact('Usage: day <Year> <Month[1..12]> <Day[1..31]>')
 
@@ -89,17 +100,20 @@ def _check_day(child):
                 dt = datetime.datetime(year, month, day)
                 count = dt.timetuple().tm_yday
                 day_str = dt.strftime('%a').upper()
+                child.expect('>')
                 child.sendline('day {} {} {}'.format(year, month, day))
                 child.expect_exact('What weekday was {}-{:02}-{:02}? '
                                    'The {}(th) day of the year was a {}.'
                                    .format(year, month, day, count, day_str))
 
     # 2016 is a leap year
+    child.expect('>')
     child.sendline('day 2016 2 29')
     child.expect_exact('What weekday was 2016-02-29? '
                        'The 60(th) day of the year was a MON.')
 
     # 2017 is a leap year
+    child.expect('>')
     child.sendline('day 2017 2 29')
     child.expect_exact('The supplied date is invalid, '
                        'but no error should occur.')
@@ -108,6 +122,7 @@ def _check_day(child):
 def _wait_prompt(child):
     child.sendline('')
     child.expect('>')
+    child.sendline('')
 
 
 def testfunc(child):

--- a/tests/struct_tm_utility/tests/01-run.py
+++ b/tests/struct_tm_utility/tests/01-run.py
@@ -119,14 +119,7 @@ def _check_day(child):
                        'but no error should occur.')
 
 
-def _wait_prompt(child):
-    child.sendline('')
-    child.expect('>')
-    child.sendline('')
-
-
 def testfunc(child):
-    _wait_prompt(child)
     _check_help(child)
     _check_days_in(child)
     _check_leap_year(child)


### PR DESCRIPTION
This is my attempt at fixing problems with the Murdock board testing. It intermittently fails on a few of the tests:
```
--- run_test job results (3 failed, 71 passed, 74 total):
    failed:
    tests/ps_schedstatistics/samr21-xpro
    tests/struct_tm_utility/samr21-xpro
    tests/shell/samr21-xpro

    passed:
    tests/gnrc_ipv6_nib_6ln/samr21-xpro
    tests/xtimer_now64_continuity/samr21-xpro
    tests/buttons/samr21-xpro
    tests/thread_msg_block_wo_queue/samr21-xpro
    tests/rmutex/samr21-xpro
    tests/posix_time/samr21-xpro
    tests/sched_testing/samr21-xpro
    tests/evtimer_msg/samr21-xpro
    tests/sizeof_tcb/samr21-xpro
    tests/pkg_micro-ecc/samr21-xpro
    tests/pthread/samr21-xpro
    tests/xtimer_periodic_wakeup/samr21-xpro
    tests/trickle/samr21-xpro
    tests/xtimer_msg/samr21-xpro
    tests/pthread_tls/samr21-xpro
    tests/cb_mux/samr21-xpro
    tests/gnrc_ndp/samr21-xpro
    tests/thread_msg/samr21-xpro
    tests/isr_yield_higher/samr21-xpro
    tests/lwip_sock_ip/samr21-xpro
    tests/xtimer_hang/samr21-xpro
    tests/thread_msg_block_w_queue/samr21-xpro
    tests/posix_semaphore/samr21-xpro
    tests/nhdp/samr21-xpro
    tests/thread_flags_xtimer/samr21-xpro
    tests/xtimer_reset/samr21-xpro
    tests/thread_flags/samr21-xpro
    tests/gnrc_ipv6_nib/samr21-xpro
    tests/cpp11_condition_variable/samr21-xpro
    tests/gnrc_sock_udp/samr21-xpro
    tests/msg_avail/samr21-xpro
    tests/evtimer_underflow/samr21-xpro
    tests/netdev_test/samr21-xpro
    tests/thread_flood/samr21-xpro
    tests/xtimer_usleep_short/samr21-xpro
    tests/periph_timer/samr21-xpro
    tests/fmt_print/samr21-xpro
    tests/xtimer_remove/samr21-xpro
    tests/pthread_cleanup/samr21-xpro
    tests/pthread_barrier/samr21-xpro
    tests/mutex_unlock_and_sleep/samr21-xpro
    tests/pkg_libcoap/samr21-xpro
    tests/events/samr21-xpro
    tests/irq/samr21-xpro
    tests/bloom_bytes/samr21-xpro
    tests/xtimer_msg_receive_timeout/samr21-xpro
    tests/xtimer_usleep/samr21-xpro
    tests/thread_race/samr21-xpro
    tests/pkg_cayenne-lpp/samr21-xpro
    tests/mutex_order/samr21-xpro
    tests/pkg_tinycbor/samr21-xpro
    tests/cpp11_thread/samr21-xpro
    tests/float/samr21-xpro
    tests/pkg_jsmn/samr21-xpro
    tests/thread_cooperation/samr21-xpro
    tests/pthread_cooperation/samr21-xpro
    tests/ssp/samr21-xpro
    tests/pkg_tiny-asn1/samr21-xpro
    tests/thread_exit/samr21-xpro
    tests/pkg_minmea/samr21-xpro
    tests/msg_try_receive/samr21-xpro
    tests/pthread_condition_variable/samr21-xpro
    tests/pipe/samr21-xpro
    tests/thread_basic/samr21-xpro
    tests/msg_send_receive/samr21-xpro
    tests/bitarithm_timings/samr21-xpro
    tests/cb_mux_bench/samr21-xpro
    tests/od/samr21-xpro
    tests/pkg_umorse/samr21-xpro
    tests/cpp11_mutex/samr21-xpro
    tests/gnrc_sock_ip/samr21-xpro
```

Those tests that it fails on are exactly those in which the python test script is sending using pexpect as well as receiving. It is intermittent as well, which suggests timing issues with the commands being issued. I have changed the scripts to ensure that before every send, it waits for the ```>``` shell prompt.