### PR TITLE
boards/msbiot: on-board buttons and saul integration

### DIFF
--- a/boards/msbiot/Makefile.dep
+++ b/boards/msbiot/Makefile.dep
@@ -2,3 +2,7 @@
 ifneq (,$(filter netdev_default gnrc_netdev_default,$(USEMODULE)))
   USEMODULE += cc110x
 endif
+# add support for LEDs and buttons as default saul devices
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += saul_gpio
+endif

--- a/boards/msbiot/Makefile.dep
+++ b/boards/msbiot/Makefile.dep
@@ -6,3 +6,7 @@ endif
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
 endif
+# add support for the MPU-9150 as default saul device
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += mpu9150
+endif

--- a/boards/msbiot/board.c
+++ b/boards/msbiot/board.c
@@ -21,7 +21,7 @@
 #include "board.h"
 #include "periph/gpio.h"
 
-static void leds_init(void);
+static void gpios_init(void);
 
 void board_init(void)
 {
@@ -29,23 +29,27 @@ void board_init(void)
     cpu_init();
 
     /* initialize the boards LEDs */
-    leds_init();
+    gpios_init();
 }
 
 /**
- * @brief Initialize the boards standard LEDs (RED, YELLOW, GREEN)
+ * @brief Initialize the on board GPIO periphs (3 LEDs, 2 buttons)
  *
- * The LED initialization is hard-coded in this function. As the LEDs are soldered
- * onto the board they are fixed to their CPU pins.
+ * The LED and button initialization is hard-coded in this function. As the LEDs
+ * and buttons are soldered onto the board they are fixed to their CPU pins.
  *
  * The LEDs are connected to the following pins:
  * - LED RED:    PB8
  * - LED YELLOW: PB14
  * - LED GREEN:  PB15
+ * - BUTTON T1:  PB13
+ * - BUTTON T2:  PA0
  */
-static void leds_init(void)
+static void gpios_init(void)
 {
     gpio_init(LED0_PIN, GPIO_OUT);
     gpio_init(LED1_PIN, GPIO_OUT);
     gpio_init(LED2_PIN, GPIO_OUT);
+    gpio_init(BUTTON0_PIN, GPIO_IN);
+    gpio_init(BUTTON1_PIN, GPIO_IN);
 }

--- a/boards/msbiot/include/board.h
+++ b/boards/msbiot/include/board.h
@@ -73,6 +73,14 @@ extern "C" {
 /** @} */
 
 /**
+ * @name    Button pin definitions
+ * @{
+ */
+#define BUTTON0_PIN         GPIO_PIN(PORT_B, 13)
+#define BUTTON1_PIN         GPIO_PIN(PORT_A, 0)
+/** @} */
+
+/**
  * @brief   Initialize board specific hardware, including clock, LEDs and std-IO
  */
 void board_init(void);

--- a/boards/msbiot/include/gpio_params.h
+++ b/boards/msbiot/include/gpio_params.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2018 Otto-von-Guericke-Universität Magdeburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_msbiot
+ * @{
+ *
+ * @file
+ * @brief       Board specific configuration of direct mapped GPIOs
+ *
+ * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+ */
+
+#ifndef GPIO_PARAMS_H
+#define GPIO_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    GPIO pin configuration
+ */
+static const  saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name = "red LED",
+        .pin = LED0_PIN,
+        .mode = GPIO_OUT,
+        .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR)
+    },
+    {
+        .name = "yellow LED",
+        .pin = LED1_PIN,
+        .mode = GPIO_OUT,
+        .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR)
+    },
+    {
+        .name = "green LED",
+        .pin = LED2_PIN,
+        .mode = GPIO_OUT,
+        .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR)
+    },
+    {
+        .name = "left button",
+        .pin = BUTTON0_PIN,
+        .mode = GPIO_IN,
+        .flags = 0
+    },
+    {
+        .name = "right button",
+        .pin = BUTTON1_PIN,
+        .mode = GPIO_IN,
+        .flags = 0
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_PARAMS_H */
+/** @} */


### PR DESCRIPTION
This PR adds:
 - support for the on-board buttons
- SAUL integration of on-board buttons and on-board LEDs
- Added the MPU-9150 as default saul device (driver is loaded when module `saul_default` is used)