### PR TITLE
uncrustify: add check for no newline at end of file

### DIFF
--- a/uncrustify-riot.cfg
+++ b/uncrustify-riot.cfg
@@ -24,6 +24,8 @@ nl_func_var_def_blk    = 1        #
 nl_fcall_brace         = remove   # "list_for_each() {" vs "list_for_each()\n{"
 nl_fdef_brace          = add      # "int foo() {" vs "int foo()\n{"
 nl_collapse_empty_body = true     # set while(){\n} to while(){}
+nl_end_of_file         = add      # fix no newline at end of file
+nl_end_of_file_min     = 1        #
 
 #
 # Source code modifications


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR updates RIOT uncrustify configuration to ensure there's at least a newline at end of file. Something that is raised via GitHub interface, but at least this provides an automatic way to fix this.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->