### PR TITLE
shell_commands/ping6: Fixed bug in calculation of average round trip time

### DIFF
--- a/sys/shell/commands/sc_icmpv6_echo.c
+++ b/sys/shell/commands/sc_icmpv6_echo.c
@@ -129,7 +129,7 @@ static void _print_stats(char *addr_str, int success, int count, uint64_t total_
     printf("--- %s ping statistics ---\n", addr_str);
 
     if (success > 0) {
-        uint32_t avg_rtt = (uint32_t)(sum_rtt / count); /* get average */
+        uint32_t avg_rtt = (uint32_t)(sum_rtt / success); /* get average */
         printf("%d packets transmitted, %d received, %d%% packet loss, time %"
                PRIu32 ".06%" PRIu32 " s\n", count, success,
                (100 - ((success * 100) / count)),


### PR DESCRIPTION
The average rout trip time has been to low in case packets were lost, as lost
packets were treated as if that had an RTT of 0.