### PR TITLE
drivers/cc110x: Made address format in debug output consistent

### DIFF
--- a/drivers/cc110x/gnrc_cc110x/gnrc_cc110x.c
+++ b/drivers/cc110x/gnrc_cc110x/gnrc_cc110x.c
@@ -99,7 +99,7 @@ static int _send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
 
     cc110x_pkt.length = (uint8_t) payload_len + CC110X_HEADER_LENGTH;
 
-    DEBUG("gnrc_cc110x: sending packet from %u to %u with payload "
+    DEBUG("gnrc_cc110x: sending packet from %02x to %02x with payload "
             "length %u\n",
             (unsigned)cc110x_pkt.phy_src,
             (unsigned)cc110x_pkt.address,


### PR DESCRIPTION
This is a PR no-brainer.

Right now, on receive the lower layer address of the cc110x is given hexadecimal. But on send the addresses are given decimal. The behavior is changed to always use the hexadecimal format to avoid confusion when debugging.

I believe the hexadecimal format is preferable, as last byte of IPv6 address equals the cc110x address and is also given hexadecimal.