### PR TITLE
drivers/at30tse75x: adapt to new I2C api

### DIFF
--- a/drivers/at30tse75x/at30tse75x.c
+++ b/drivers/at30tse75x/at30tse75x.c
@@ -40,7 +40,7 @@ static int at30tse75x_get_register(const at30tse75x_t *dev, uint8_t reg, uint16_
 {
     i2c_acquire(dev->i2c);
     xtimer_spin(AT30TSE75X_BUS_FREE_TIME_TICKS);
-    if (i2c_read_regs(dev->i2c, dev->addr, reg, data, 2) <= 0) {
+    if (i2c_read_regs(dev->i2c, dev->addr, reg, data, 2, 0) < 0) {
         DEBUG("[at30tse75x] Can't read register 0x%x\n", reg);
         i2c_release(dev->i2c);
         return -1;
@@ -54,7 +54,7 @@ static int at30tse75x_set_register(const at30tse75x_t *dev, uint8_t reg, uint16_
 {
     i2c_acquire(dev->i2c);
     xtimer_spin(AT30TSE75X_BUS_FREE_TIME_TICKS);
-    if (i2c_write_regs(dev->i2c, dev->addr, reg, data, 2) <= 0) {
+    if (i2c_write_regs(dev->i2c, dev->addr, reg, data, 2, 0) < 0) {
         DEBUG("[at30tse75x] Can't write to register 0x%x\n", reg);
         i2c_release(dev->i2c);
         return -1;
@@ -68,7 +68,7 @@ static int at30tse75x_reset(const at30tse75x_t *dev)
 {
     i2c_acquire(dev->i2c);
     xtimer_spin(AT30TSE75X_BUS_FREE_TIME_TICKS);
-    if (i2c_write_byte(dev->i2c, 0x00, AT30TSE75X_CMD__GENERAL_CALL_RESET) != 1) {
+    if (i2c_write_byte(dev->i2c, 0x00, AT30TSE75X_CMD__GENERAL_CALL_RESET, 0) < 0) {
         i2c_release(dev->i2c);
         return -1;
     }
@@ -82,7 +82,7 @@ int at30tse75x_get_config(const at30tse75x_t *dev, uint8_t *data)
 {
     i2c_acquire(dev->i2c);
     xtimer_spin(AT30TSE75X_BUS_FREE_TIME_TICKS);
-    if (i2c_read_reg(dev->i2c, dev->addr, AT30TSE75X_REG__CONFIG, data) <= 0) {
+    if (i2c_read_reg(dev->i2c, dev->addr, AT30TSE75X_REG__CONFIG, data, 0) < 0) {
         DEBUG("[at30tse75x] Can't read CONFIG register\n");
         i2c_release(dev->i2c);
         return -1;
@@ -96,7 +96,7 @@ int at30tse75x_set_config(const at30tse75x_t *dev, uint8_t data)
 {
     i2c_acquire(dev->i2c);
     xtimer_spin(AT30TSE75X_BUS_FREE_TIME_TICKS);
-    if (i2c_write_reg(dev->i2c, dev->addr, AT30TSE75X_REG__CONFIG, data) <= 0) {
+    if (i2c_write_reg(dev->i2c, dev->addr, AT30TSE75X_REG__CONFIG, data, 0) < 0) {
         DEBUG("[at30tse75x] Can't write to CONFIG register\n");
         i2c_release(dev->i2c);
         return -1;
@@ -213,7 +213,7 @@ int at30tse75x_save_config(const at30tse75x_t *dev)
 {
     i2c_acquire(dev->i2c);
     xtimer_spin(AT30TSE75X_BUS_FREE_TIME_TICKS);
-    if(i2c_write_byte(dev->i2c, dev->addr, AT30TSE75X_CMD__SAVE_TO_NVRAM) != 1) {
+    if(i2c_write_byte(dev->i2c, dev->addr, AT30TSE75X_CMD__SAVE_TO_NVRAM, 0) < 0) {
         i2c_release(dev->i2c);
         return -1;
     }
@@ -227,7 +227,7 @@ int at30tse75x_restore_config(const at30tse75x_t *dev)
 {
     i2c_acquire(dev->i2c);
     xtimer_spin(AT30TSE75X_BUS_FREE_TIME_TICKS);
-    if(i2c_write_byte(dev->i2c, dev->addr, AT30TSE75X_CMD__RESTORE_FROM_NVRAM) != 1) {
+    if(i2c_write_byte(dev->i2c, dev->addr, AT30TSE75X_CMD__RESTORE_FROM_NVRAM, 0) < 0) {
         i2c_release(dev->i2c);
         return -1;
     }
@@ -273,7 +273,7 @@ int at30tse75x_get_temperature(const at30tse75x_t *dev, float *temperature)
     return 0;
 }
 
-int at30tse75x_init(at30tse75x_t *dev, i2c_t i2c, i2c_speed_t speed, uint8_t addr)
+int at30tse75x_init(at30tse75x_t *dev, i2c_t i2c, uint8_t addr)
 {
     uint8_t config;
 
@@ -284,14 +284,6 @@ int at30tse75x_init(at30tse75x_t *dev, i2c_t i2c, i2c_speed_t speed, uint8_t add
         return -2;
     }
     dev->addr = addr;
-
-    i2c_acquire(dev->i2c);
-    if(i2c_init_master(dev->i2c, speed) != 0) {
-        DEBUG("[at30tse75x] Can't initialize I2C master\n");
-        i2c_release(dev->i2c);
-        return -1;
-    }
-    i2c_release(dev->i2c);
 
     /* Reset the device */
     if(at30tse75x_reset(dev) != 0) {

--- a/drivers/include/at30tse75x.h
+++ b/drivers/include/at30tse75x.h
@@ -162,7 +162,6 @@ typedef struct {
  *
  * @param[out] dev          device descriptor
  * @param[in] i2c           I2C bus the device is connected to
- * @param[in] speed         I2C speed to use
  * @param[in] addr          I2C address of the device
  *
  * The valid address range is 0x48 - 0x4f depending on the configuration of the
@@ -172,7 +171,7 @@ typedef struct {
  * @return                  -1 on error
  * @return                  -2 on invalid address
  */
-int at30tse75x_init(at30tse75x_t* dev, i2c_t i2c, i2c_speed_t speed, uint8_t addr);
+int at30tse75x_init(at30tse75x_t* dev, i2c_t i2c, uint8_t addr);
 
 /**
  * @brief   Save configuration register to non-volatile backup register

--- a/drivers/io1_xplained/io1_xplained.c
+++ b/drivers/io1_xplained/io1_xplained.c
@@ -41,7 +41,6 @@ int io1_xplained_init(io1_xplained_t *dev, const io1_xplained_params_t *params)
     /* Initialize I2C interface */
     if (at30tse75x_init(&dev->temp,
                         I2C_DEV(0),
-                        I2C_SPEED_NORMAL,
                         (IO1_TEMPERATURE_BASE_ADDR | dev->params.addr)) < 0) {
         DEBUG("[io1_xplained] Cannot initialize temperature sensor.\n");
         return -IO1_XPLAINED_NOTEMP;

--- a/sys/shell/commands/sc_at30tse75x.c
+++ b/sys/shell/commands/sc_at30tse75x.c
@@ -57,7 +57,7 @@ int _at30tse75x_handler(int argc, char **argv)
             }
         }
 
-        error = at30tse75x_init(&dev, i2c_dev, I2C_SPEED_NORMAL, addr);
+        error = at30tse75x_init(&dev, i2c_dev, addr);
         if (error) {
             printf("Error initializing AT30TSE75x sensor on I2C #%u @ 0x%x\n", i2c_dev, addr);
             initialized = false;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR adapts the at30tse75x temperature sensor to the new I2C api.
It can be tested using a samr21-xpro and an IO1 Xplained extension (requires #7588)

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

#6577 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->