### PR TITLE
drivers/cc110x: Fix SPI communication on STM32F4 boards

### DIFF
--- a/boards/msbiot/include/board.h
+++ b/boards/msbiot/include/board.h
@@ -32,11 +32,12 @@ extern "C" {
  * @name    Configure connected CC1101 (radio) device
  * @{
  */
-#define CC110X_PARAM_SPI    SPI_DEV(0)
-#define CC110X_PARAM_CS     GPIO_PIN(PORT_B, 12)
-#define CC110X_PARAM_GDO0   GPIO_PIN(PORT_C, 4)
-#define CC110X_PARAM_GDO1   GPIO_PIN(PORT_A, 6)
-#define CC110X_PARAM_GDO2   GPIO_PIN(PORT_C, 5)
+#define CC110X_PARAM_SPI      SPI_DEV(0)
+#define CC110X_PARAM_CS       GPIO_PIN(PORT_B, 12)
+#define CC110X_PARAM_GDO0     GPIO_PIN(PORT_C, 4)
+#define CC110X_PARAM_GDO1     GPIO_PIN(PORT_A, 6)
+#define CC110X_PARAM_GDO2     GPIO_PIN(PORT_C, 5)
+#define CC110X_PARAM_GDO1_AF  GPIO_AF0
 /** @} */
 
 /**

--- a/drivers/cc110x/cc110x-spi.c
+++ b/drivers/cc110x/cc110x-spi.c
@@ -54,6 +54,10 @@ void cc110x_cs(cc110x_t *dev)
 #ifndef GPIO_READS_SPI_PINS
     gpio_init(dev->params.gdo1, GPIO_IN);
 #endif
+#ifdef CC110X_PARAM_GDO1_AF
+    /* Reconfigure MISO/GDO1 to be used as regular GPIO */
+    gpio_init_af(dev->params.gdo1, CC110X_PARAM_GDO1_AF);
+#endif
     /* CS to low */
     gpio_clear(dev->params.cs);
     /* Wait for SO to go low (voltage regulator


### PR DESCRIPTION
This PR implements the first variant of how to fix issue https://github.com/RIOT-OS/RIOT/issues/9225. Please follow the discussion in the issue before merging, as there is an alternative way to fix the issue.