### PR TITLE
cpu/stm32_common: Reset pin function in gpio_init()

### DIFF
--- a/cpu/stm32_common/periph/gpio.c
+++ b/cpu/stm32_common/periph/gpio.c
@@ -98,6 +98,8 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
     port->OTYPER |=  (((mode >> 4) & 0x1) << pin_num);
     /* set pin speed to maximum */
     port->OSPEEDR |= (3 << (2 * pin_num));
+    /* Clear selected function */
+    port->AFR[(pin_num > 7) ? 1 : 0] &= ~(0xf << ((pin_num & 0x07) * 4));
 
     return 0;
 }


### PR DESCRIPTION
This PR implements the second variant of how to fix issue https://github.com/RIOT-OS/RIOT/issues/9225. Please follow the discussion in the issue before merging, as there is an alternative way to fix the issue.