### PR TITLE
cpu/lpc2387: Fixed invalid call to send_msg in lpc2387-mci.c

### DIFF
--- a/cpu/lpc2387/mci/lpc2387-mci.c
+++ b/cpu/lpc2387/mci/lpc2387-mci.c
@@ -535,7 +535,7 @@ diskio_sta_t mci_initialize(void)
     //for (Timer[0] = 2; Timer[0]; );
     xtimer_usleep(250);
 
-    send_cmd(CMD0, 0, 0, NULL);             /* Enter idle state */
+    send_cmd(CMD0, 0, 0, resp);             /* Enter idle state */
     CardRCA = 0;
 
     /*---- Card is 'idle' state ----*/


### PR DESCRIPTION
At `lpc2387-mci.c:383` in `send_cmd()` an `assert()` enforces that parameter `buff` is not `NULL`. At `lpc2387-mci.c:538` in `mci_initialize()` `send_cmd()` was called with `buff==NULL`.