### PR TITLE
drivers/periph_common/eeprom: move EEPROM definitions to periph_cpu.

### DIFF
--- a/cpu/atmega1281/include/cpu_conf.h
+++ b/cpu/atmega1281/include/cpu_conf.h
@@ -43,13 +43,6 @@ extern "C" {
 #endif
 /** @} */
 
-/**
- * @name    EEPROM configuration
- * @{
- */
-#define EEPROM_SIZE                (4096U)  /* 4kB */
-/** @} */
-
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/atmega1281/include/periph_cpu.h
+++ b/cpu/atmega1281/include/periph_cpu.h
@@ -64,6 +64,13 @@ enum {
 #define I2C_PIN_MASK            (1 << PORTD0) | (1 << PORTD1)
 /** @} */
 
+/**
+ * @name    EEPROM configuration
+ * @{
+ */
+#define EEPROM_SIZE                (4096U)  /* 4kB */
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/atmega1284p/include/cpu_conf.h
+++ b/cpu/atmega1284p/include/cpu_conf.h
@@ -44,13 +44,6 @@ extern "C" {
 #define THREAD_STACKSIZE_IDLE      (128)
 /** @} */
 
-/**
- * @name    EEPROM configuration
- * @{
- */
-#define EEPROM_SIZE                (4096U)  /* 4kB */
-/** @} */
-
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/atmega1284p/include/periph_cpu.h
+++ b/cpu/atmega1284p/include/periph_cpu.h
@@ -61,6 +61,13 @@ enum {
 #define I2C_PIN_MASK            (1 << PORTC0) | (1 << PORTC1)
 /** @} */
 
+/**
+ * @name    EEPROM configuration
+ * @{
+ */
+#define EEPROM_SIZE                (4096U)  /* 4kB */
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/atmega2560/include/cpu_conf.h
+++ b/cpu/atmega2560/include/cpu_conf.h
@@ -42,14 +42,6 @@ extern "C" {
 #define THREAD_STACKSIZE_IDLE      (128)
 /** @} */
 
-/**
- * @name    EEPROM configuration
- * @{
- */
-#define EEPROM_SIZE                (4096U)  /* 4kB */
-/** @} */
-
-
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/atmega2560/include/periph_cpu.h
+++ b/cpu/atmega2560/include/periph_cpu.h
@@ -66,6 +66,13 @@ enum {
 #define I2C_PIN_MASK            (1 << PORTD0) | (1 << PORTD1)
 /** @} */
 
+/**
+ * @name    EEPROM configuration
+ * @{
+ */
+#define EEPROM_SIZE                (4096U)  /* 4kB */
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/atmega256rfr2/include/cpu_conf.h
+++ b/cpu/atmega256rfr2/include/cpu_conf.h
@@ -48,12 +48,5 @@ extern "C" {
 }
 #endif
 
-/**
- * @name    EEPROM configuration
- * @{
- */
-#define EEPROM_SIZE                (8192U)  /* 8kB */
-/** @} */
-
 #endif /* CPU_CONF_H */
 /** @} */

--- a/cpu/atmega256rfr2/include/periph_cpu.h
+++ b/cpu/atmega256rfr2/include/periph_cpu.h
@@ -77,6 +77,13 @@ enum {
 #endif
 /** @}*/
 
+/**
+ * @name    EEPROM configuration
+ * @{
+ */
+#define EEPROM_SIZE                (8192U)  /* 8kB */
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/atmega328p/include/cpu_conf.h
+++ b/cpu/atmega328p/include/cpu_conf.h
@@ -42,13 +42,6 @@ extern "C" {
 #define THREAD_STACKSIZE_IDLE      (128)
 /** @} */
 
-/**
- * @name    EEPROM configuration
- * @{
- */
-#define EEPROM_SIZE                (1024U)  /* 1kB */
-/** @} */
-
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/atmega328p/include/periph_cpu.h
+++ b/cpu/atmega328p/include/periph_cpu.h
@@ -57,6 +57,13 @@ enum {
 #define I2C_PIN_MASK            (1 << PORTC4) | (1 << PORTC5)
 /** @} */
 
+/**
+ * @name    EEPROM configuration
+ * @{
+ */
+#define EEPROM_SIZE                (1024U)  /* 1kB */
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/atmega_common/Makefile.features
+++ b/cpu/atmega_common/Makefile.features
@@ -1,2 +1,2 @@
-FEATURES_PROVIDED += periph_pm
 FEATURES_PROVIDED += periph_eeprom
+FEATURES_PROVIDED += periph_pm

--- a/cpu/stm32l0/Makefile.features
+++ b/cpu/stm32l0/Makefile.features
@@ -1,7 +1,7 @@
+FEATURES_PROVIDED += periph_eeprom
 FEATURES_PROVIDED += periph_flash_common
 FEATURES_PROVIDED += periph_flashpage
 FEATURES_PROVIDED += periph_flashpage_raw
-FEATURES_PROVIDED += periph_eeprom
 FEATURES_PROVIDED += periph_hwrng
 
 BOARDS_WITHOUT_HWRNG += nucleo-l031k6

--- a/cpu/stm32l0/include/cpu_conf.h
+++ b/cpu/stm32l0/include/cpu_conf.h
@@ -79,20 +79,6 @@ extern "C" {
 #define FLASHPAGE_RAW_ALIGNMENT    (4U)
 /** @} */
 
-/**
- * @name    EEPROM configuration
- * @{
- */
-#define EEPROM_START_ADDR          (0x08080000)
-#if defined(CPU_MODEL_STM32L073RZ) || defined(CPU_MODEL_STM32L072CZ)
-#define EEPROM_SIZE                (6144U)  /* 6kB */
-#elif defined(CPU_MODEL_STM32L053R8)
-#define EEPROM_SIZE                (2048U)  /* 2kB */
-#elif defined(CPU_MODEL_STM32L031K6)
-#define EEPROM_SIZE                (1024U)  /* 1kB */
-#endif
-/** @} */
-
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/stm32l0/include/periph_cpu.h
+++ b/cpu/stm32l0/include/periph_cpu.h
@@ -76,6 +76,20 @@ typedef struct {
  */
 #define PM_BLOCKER_INITIAL  { .val_u32 = 0x01010101 }
 
+/**
+ * @name    EEPROM configuration
+ * @{
+ */
+#define EEPROM_START_ADDR          (0x08080000)
+#if defined(CPU_MODEL_STM32L073RZ) || defined(CPU_MODEL_STM32L072CZ)
+#define EEPROM_SIZE                (6144U)  /* 6kB */
+#elif defined(CPU_MODEL_STM32L053R8)
+#define EEPROM_SIZE                (2048U)  /* 2kB */
+#elif defined(CPU_MODEL_STM32L031K6)
+#define EEPROM_SIZE                (1024U)  /* 1kB */
+#endif
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/stm32l1/Makefile.features
+++ b/cpu/stm32l1/Makefile.features
@@ -1,6 +1,6 @@
+FEATURES_PROVIDED += periph_eeprom
 FEATURES_PROVIDED += periph_flash_common
 FEATURES_PROVIDED += periph_flashpage
 FEATURES_PROVIDED += periph_flashpage_raw
-FEATURES_PROVIDED += periph_eeprom
 
 -include $(RIOTCPU)/stm32_common/Makefile.features

--- a/cpu/stm32l1/include/cpu_conf.h
+++ b/cpu/stm32l1/include/cpu_conf.h
@@ -93,18 +93,6 @@ extern "C" {
 #define FLASHPAGE_RAW_ALIGNMENT    (4U)
 /** @} */
 
-/**
- * @name    EEPROM configuration
- * @{
- */
-#define EEPROM_START_ADDR          (0x08080000)
-#if defined(CPU_MODEL_STM32L152RE)
-#define EEPROM_SIZE                (16384UL)  /* 16kB */
-#elif defined(CPU_MODEL_STM32L151RC)
-#define EEPROM_SIZE                (8192U)    /* 8kB */
-#endif
-/** @} */
-
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/stm32l1/include/periph_cpu.h
+++ b/cpu/stm32l1/include/periph_cpu.h
@@ -73,6 +73,18 @@ typedef enum {
 } adc_res_t;
 /** @} */
 
+/**
+ * @name    EEPROM configuration
+ * @{
+ */
+#define EEPROM_START_ADDR          (0x08080000)
+#if defined(CPU_MODEL_STM32L152RE)
+#define EEPROM_SIZE                (16384UL)  /* 16kB */
+#elif defined(CPU_MODEL_STM32L151RC)
+#define EEPROM_SIZE                (8192U)    /* 8kB */
+#endif
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif

--- a/drivers/include/periph/eeprom.h
+++ b/drivers/include/periph/eeprom.h
@@ -24,7 +24,6 @@
 
 #include <stdint.h>
 
-#include "cpu.h"
 #include "periph_cpu.h"
 
 #ifdef __cplusplus

--- a/drivers/periph_common/eeprom.c
+++ b/drivers/periph_common/eeprom.c
@@ -20,7 +20,6 @@
 
 #include <string.h>
 
-#include "cpu.h"
 #include "periph_cpu.h"
 #include "assert.h"
 

--- a/drivers/periph_common/eeprom.c
+++ b/drivers/periph_common/eeprom.c
@@ -19,7 +19,9 @@
  */
 
 #include <string.h>
+
 #include "cpu.h"
+#include "periph_cpu.h"
 #include "assert.h"
 
 /* guard this file, must be done before including periph/eeprom.h */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR cleans up the definitions of internal EEPROM for the supported CPUs. IMHO
it doesn't belong to cpu_conf since it's not a CPU feature, but more a peripheral, as
the name suggests.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references
#8862 
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->