### PR TITLE
drivers/sht11: Added glue for SAUL

### DIFF
--- a/drivers/sht11/sht11_saul.c
+++ b/drivers/sht11/sht11_saul.c
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2018 Otto-von-Guericke-Universität Magdeburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_sht11
+ * @{
+ *
+ * @file
+ * @brief       SHT11 adaption to the RIOT actuator/sensor interface
+ *
+ * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+ *
+ * @}
+ */
+
+#include <string.h>
+
+#include "saul.h"
+#include "sht11.h"
+
+static int read_temp(const void *dev, phydat_t *res)
+{
+    (void)dev;
+    sht11_val_t result;
+    if (sht11_read_sensor(&result, TEMPERATURE) != 1) {
+        return -ECANCELED;
+    }
+    res->val[0] = (uint16_t)(result.temperature*100.0);
+    res->scale = -2;
+    res->unit = UNIT_TEMP_C;
+
+    return 1;
+}
+
+static int read_hum(const void *dev, phydat_t *res)
+{
+    (void)dev;
+    sht11_val_t result;
+    /* We want temperature corrected humidity --> reading temperature as well */
+    if (sht11_read_sensor(&result, HUMIDITY|TEMPERATURE) != 1) {
+        return -ECANCELED;
+    }
+    res->val[0] = (uint16_t)(result.relhum_temp*100.0);
+    res->scale = -2;
+    res->unit = UNIT_PERCENT;
+
+    return 1;
+}
+
+const saul_driver_t sht11_temp_saul_driver = {
+    .read = read_temp,
+    .write = saul_notsup,
+    .type = SAUL_SENSE_TEMP,
+};
+
+const saul_driver_t sht11_hum_saul_driver = {
+    .read = read_hum,
+    .write = saul_notsup,
+    .type = SAUL_SENSE_HUM,
+};

--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -374,6 +374,10 @@ auto_init_mpu9150();
     extern void auto_init_dht(void);
     auto_init_dht();
 #endif
+#ifdef MODULE_SHT11
+    extern void auto_init_sht11(void);
+    auto_init_sht11();
+#endif
 #ifdef MODULE_TMP006
     extern void auto_init_tmp006(void);
     auto_init_tmp006();

--- a/sys/auto_init/saul/auto_init_sht11.c
+++ b/sys/auto_init/saul/auto_init_sht11.c
@@ -1,0 +1,60 @@
+/*
+ * Copyright (C) 2018 Otto-von-Guericke-Universität Magdeburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ *
+ */
+
+/*
+ * @ingroup     auto_init_saul
+ * @{
+ *
+ * @file
+ * @brief       Auto initialization for SHT11 temperature/humidity sensors
+ *
+ * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+ *
+ * @}
+ */
+
+#ifdef MODULE_SHT11
+
+#include "saul_reg.h"
+#include "sht11.h"
+#include "log.h"
+
+/**
+ * @name    Import SAUL endpoints
+ * @{
+ */
+extern const saul_driver_t sht11_temp_saul_driver;
+extern const saul_driver_t sht11_hum_saul_driver;
+/** @} */
+
+/**
+ * @brief   Memory for the SAUL registry entries
+ */
+static saul_reg_t saul_entry_temp = {
+    .dev = NULL,
+    .name = "SHT11",
+    .driver = &sht11_temp_saul_driver,
+};
+static saul_reg_t saul_entry_hum = {
+    .dev = NULL,
+    .name = "SHT11",
+    .driver = &sht11_hum_saul_driver,
+};
+
+void auto_init_sht11(void)
+{
+    LOG_DEBUG("[auto_init_saul] initializing SHT11\n");
+
+    saul_reg_add(&saul_entry_temp);
+    saul_reg_add(&saul_entry_hum);
+}
+
+#else
+typedef int dont_be_pedantic;
+#endif /* MODULE_SHT11 */


### PR DESCRIPTION
This PR adds the code required to read the SHT11 humidity/temperature sensor using SAUL.