### PR TITLE
drivers/isrpipe: changed isrpipe_t content order

### DIFF
--- a/sys/include/isrpipe.h
+++ b/sys/include/isrpipe.h
@@ -35,8 +35,8 @@ extern "C" {
  * @brief   Context structure for isrpipe
  */
 typedef struct {
-    mutex_t mutex;      /**< isrpipe mutex */
     tsrb_t tsrb;        /**< isrpipe thread safe ringbuffer */
+    mutex_t mutex;      /**< isrpipe mutex */
 } isrpipe_t;
 
 /**


### PR DESCRIPTION
Wouldn't it be more handy to change order of content in `isrpipe_t`? 
So `tsrb` functions like `tsrb_full` and `tsrb_empty` can be accessed with an `isrpipe_t`.

`isrpipe_t` extends `tsrb_t` right?