### PR TITLE
sys/embunit: Fix incompatible declaration in outputter.

### DIFF
--- a/sys/embunit/CompilerOutputter.c
+++ b/sys/embunit/CompilerOutputter.c
@@ -35,10 +35,9 @@
 #include <stdio.h>
 #include "CompilerOutputter.h"
 
-static void CompilerOutputter_printHeader(OutputterRef self,TestRef test)
+static void CompilerOutputter_printHeader(OutputterRef self)
 {
     (void)self;
-    (void)test;
 }
 
 static void CompilerOutputter_printStartTest(OutputterRef self,TestRef test)


### PR DESCRIPTION
### Contribution description

`OutputterPrintHeaderFunction` is declared as a function of one parameter but `CompilerOutputter_printHeader` was defined as taking two. Thus the compiler rightly issues a warning:

```
/home/jcarrano/source/vanillaRIOT/sys/embunit/CompilerOutputter.c:76:41: error: 'CompilerOutputter_printHeader' undeclared here (not in a function); did you mean 'CompilerOutputter_printFailure'?
     (OutputterPrintHeaderFunction)      CompilerOutputter_printHeader,
                                         ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

It is a mystery why this code compiled before.