### PR TITLE
makefiles/cflags.inc.mk: add -Wmissing-include-dirs flag 

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -229,7 +229,7 @@ export PREFIX ?= $(if $(TARGET_ARCH),$(TARGET_ARCH)-)
 # Add standard include directories
 INCLUDES += -I$(RIOTBASE)/core/include -I$(RIOTBASE)/drivers/include -I$(RIOTBASE)/sys/include
 INCLUDES += -I$(RIOTCPU)/$(CPU)/include
-INCLUDES += -I$(RIOTBOARD)/$(BOARD)/include
+INCLUDES += $(addprefix -I,$(wildcard $(RIOTBOARD)/$(BOARD)/include))
 
 # process provided features
 -include $(RIOTBOARD)/$(BOARD)/Makefile.features

--- a/makefiles/cflags.inc.mk
+++ b/makefiles/cflags.inc.mk
@@ -60,6 +60,9 @@ CFLAGS += -fno-common
 # Enable all default warnings
 CFLAGS += -Wall
 
+# Warn if a user-supplied include directory does not exist.
+CFLAGS += -Wmissing-include-dirs
+
 ifeq (,$(filter -DDEVELHELP,$(CFLAGS)))
   ifneq (1,$(FORCE_ASSERTS))
     CFLAGS += -DNDEBUG

--- a/pkg/libcoap/Makefile.include
+++ b/pkg/libcoap/Makefile.include
@@ -1,3 +1,2 @@
 INCLUDES += -I$(PKGDIRBASE)/libcoap \
-			-I$(RIOTBASE)/sys/posix/include \
-			-I$(RIOTBASE)/sys/net/include
+			-I$(RIOTBASE)/sys/posix/include

--- a/pkg/openthread/Makefile.include
+++ b/pkg/openthread/Makefile.include
@@ -1,7 +1,6 @@
 OPENTHREAD_DIR = $(RIOTBASE)/pkg/openthread
 
 INCLUDES += -I$(OPENTHREAD_DIR)/include \
-            -I$(OPENTHREAD_DIR)/include/openthread \
             -I$(BINDIRBASE)/pkg/$(BOARD)/openthread/output/include \
             -I$(BINDIRBASE)/pkg/$(BOARD)/openthread/include/openthread \
 

--- a/pkg/tiny-asn1/Makefile
+++ b/pkg/tiny-asn1/Makefile
@@ -3,9 +3,6 @@ PKG_URL = https://gitlab.com/mtausig/tiny-asn1.git
 PKG_VERSION = 82e3a26273900b532e33e5b377f193fa08ee7d1b
 PKG_LICENSE = LGPL-3
 
-export TINYASN1_ROOT=$(CURDIR)
-INCLUDES+=-I$(TINYASN1_ROOT)/src
-
 .PHONY: all
 
 all: git-download

--- a/sys/Makefile.include
+++ b/sys/Makefile.include
@@ -6,10 +6,6 @@ ifneq (,$(filter cbor,$(USEMODULE)))
   USEMODULE_INCLUDES += $(RIOTBASE)/sys/cbor/include
 endif
 
-ifneq (,$(filter crypto,$(USEMODULE)))
-  USEMODULE_INCLUDES += $(RIOTBASE)/include/crypto
-endif
-
 ifneq (,$(filter fib,$(USEMODULE)))
   USEMODULE_INCLUDES += $(RIOTBASE)/sys/posix/include
 endif


### PR DESCRIPTION
### Contribution description

Warn if a user-supplied include directory does not exist.

### Issues/PRs references

None