### PR TITLE
cpu/saml21: Fix possibly uninitialized variable in pm.c.

### DIFF
--- a/cpu/saml21/periph/pm.c
+++ b/cpu/saml21/periph/pm.c
@@ -38,6 +38,7 @@ void pm_set(unsigned mode)
                 DEBUG("pm_set(): setting STANDBY mode.\n");
                 _mode = PM_SLEEPCFG_SLEEPMODE_STANDBY;
                 break;
+            default: /* Falls through */
             case 2:
                 DEBUG("pm_set(): setting IDLE mode.\n");
                 _mode = PM_SLEEPCFG_SLEEPMODE_IDLE2;


### PR DESCRIPTION
### Contribution description

The code in pm.c for saml32 was missing a `default` case, this triggered a `-Wmaybe-unititialized`.

`-Wmaybe-unititialized` warnings are somewhat unreliable (see [this answer](https://stackoverflow.com/a/14132910)). Depending on optimization options, sometimes the compiler is able to detect it (sometimes it gives a false positive). Would it be a good idea to turn this warning back into a warning to avoid having unpredictable compilation errors?
