### PR TITLE
codestyle: fix code style in loops

### DIFF
--- a/boards/avsextrem/board_init.c
+++ b/boards/avsextrem/board_init.c
@@ -41,19 +41,21 @@ void init_clks1(void)
     PLLCON &= ~0x0002;
     pllfeed();
 
-    while (PLLSTAT & BIT25);  /* wait until PLL is disconnected before
-                               * disabling - deadlock otherwise */
+    /* wait until PLL is disconnected before disabling - deadlock otherwise */
+    while (PLLSTAT & BIT25) {}
 
     // Disable PLL
     PLLCON &= ~0x0001;
     pllfeed();
 
-    while (PLLSTAT & BIT24); // wait until PLL is disabled
+    // wait until PLL is disabled
+    while (PLLSTAT & BIT24) {}
 
     SCS |= 0x10;    // main OSC between 15MHz and 24MHz (more stable in tests)
     SCS |= 0x20;     // Enable main OSC
 
-    while (!(SCS & 0x40));   // Wait until main OSC is usable
+    // Wait until main OSC is usable
+    while (!(SCS & 0x40)) {}
 
     /* select main OSC, 16MHz, as the PLL clock source */
     CLKSRCSEL = 0x0001;

--- a/boards/chronos/board_init.c
+++ b/boards/chronos/board_init.c
@@ -59,7 +59,9 @@ void cc430_cpu_init(void)
     // changed is n x 32 x 32 x f_MCLK / f_FLL_reference. See UCS chapter in 5xx
     // UG for optimization.
     // 32 x 32 x 8 MHz / 32,768 Hz = 250000 = MCLK cycles for DCO to settle
-    for (i = 0xFF; i > 0; i--); // Time for flag to set
+
+    // Time for flag to set
+    for (i = 0xFF; i > 0; i--) {}
 
     // Loop until XT1 & DCO stabilizes, use do-while to insure that
     // body is executed at least once

--- a/boards/common/msb-430/board_init.c
+++ b/boards/common/msb-430/board_init.c
@@ -125,7 +125,8 @@ void msp430_init_dco(void)
     do {
         IFG1 &= ~OFIFG;             /* Clear oscillator fault flag */
 
-        for (i = 0xFF; i > 0; i--); /* Time for flag to set */
+        /* Time for flag to set */
+        for (i = 0xFF; i > 0; i--) {}
     }
     while ((IFG1 & OFIFG) != 0);    /* Oscillator fault flag still set? */
 

--- a/boards/common/msb-430/board_init.c
+++ b/boards/common/msb-430/board_init.c
@@ -149,7 +149,8 @@ void msp430_init_dco(void)
     WDTCTL = WDTPW + WDTHOLD;             /* Stop WDT */
     BCSCTL1 |= DIVA1 + DIVA0;             /* ACLK = LFXT1CLK/8 */
 
-    for (i = 0xffff; i > 0; i--) {}       /* Delay for XTAL to settle */
+    /* Delay for XTAL to settle */
+    for (i = 0xffff; i > 0; i--) {}
 
     CCTL2 = CCIS0 + CM0 + CAP;            /* Define CCR2, CAP, ACLK */
     TACTL = TASSEL1 + TACLR + MC1;        /* SMCLK, continous mode */
@@ -158,7 +159,8 @@ void msp430_init_dco(void)
     while (1) {
         unsigned int compare;
 
-        while ((CCTL2 & CCIFG) != CCIFG) {} /* Wait until capture occured! */
+        /* Wait until capture occured! */
+        while ((CCTL2 & CCIFG) != CCIFG) {}
 
         CCTL2 &= ~CCIFG;                    /* Capture occured, clear flag */
         compare = CCR2;                     /* Get current captured SMCLK */

--- a/boards/common/msb-430/board_init.c
+++ b/boards/common/msb-430/board_init.c
@@ -148,7 +148,7 @@ void msp430_init_dco(void)
     WDTCTL = WDTPW + WDTHOLD;             /* Stop WDT */
     BCSCTL1 |= DIVA1 + DIVA0;             /* ACLK = LFXT1CLK/8 */
 
-    for (i = 0xffff; i > 0; i--);         /* Delay for XTAL to settle */
+    for (i = 0xffff; i > 0; i--) {}       /* Delay for XTAL to settle */
 
     CCTL2 = CCIS0 + CM0 + CAP;            /* Define CCR2, CAP, ACLK */
     TACTL = TASSEL1 + TACLR + MC1;        /* SMCLK, continous mode */
@@ -157,7 +157,7 @@ void msp430_init_dco(void)
     while (1) {
         unsigned int compare;
 
-        while ((CCTL2 & CCIFG) != CCIFG);   /* Wait until capture occured! */
+        while ((CCTL2 & CCIFG) != CCIFG) {} /* Wait until capture occured! */
 
         CCTL2 &= ~CCIFG;                    /* Capture occured, clear flag */
         compare = CCR2;                     /* Get current captured SMCLK */

--- a/boards/common/msba2/board_common_init.c
+++ b/boards/common/msba2/board_common_init.c
@@ -45,14 +45,14 @@ init_mam(void)
 void init_clks2(void)
 {
     /* Wait for the PLL to lock to set frequency */
-    while (!(PLLSTAT & BIT26));
+    while (!(PLLSTAT & BIT26)) {}
 
     /* Connect the PLL as the clock source */
     PLLCON = 0x0003;
     pllfeed();
 
     /* Check connect bit status */
-    while (!(PLLSTAT & BIT25));
+    while (!(PLLSTAT & BIT25)) {}
 }
 
 void watchdog_init(void)

--- a/boards/mbed_lpc1768/system.c
+++ b/boards/mbed_lpc1768/system.c
@@ -417,7 +417,7 @@ void SystemInit(void)
     LPC_SC->SCS       = SCS_Val;
 
     if (SCS_Val & (1 << 5)) {             /* If Main Oscillator is enabled */
-        while ((LPC_SC->SCS & (1 << 6)) == 0); /* Wait for Oscillator to be ready */
+        while ((LPC_SC->SCS & (1 << 6)) == 0) {} /* Wait for Oscillator to be ready */
     }
 
     LPC_SC->CCLKCFG   = CCLKCFG_Val;      /* Setup Clock Divider */
@@ -436,13 +436,13 @@ void SystemInit(void)
     LPC_SC->PLL0FEED  = 0xAA;
     LPC_SC->PLL0FEED  = 0x55;
 
-    while (!(LPC_SC->PLL0STAT & (1 << 26))); /* Wait for PLOCK0 */
+    while (!(LPC_SC->PLL0STAT & (1 << 26))) {} /* Wait for PLOCK0 */
 
     LPC_SC->PLL0CON   = 0x03;             /* PLL0 Enable & Connect */
     LPC_SC->PLL0FEED  = 0xAA;
     LPC_SC->PLL0FEED  = 0x55;
 
-    while (!(LPC_SC->PLL0STAT & ((1 << 25) | (1 << 24)))); /* Wait for PLLC0_STAT & PLLE0_STAT */
+    while (!(LPC_SC->PLL0STAT & ((1 << 25) | (1 << 24)))) {} /* Wait for PLLC0_STAT & PLLE0_STAT */
 
 #endif
 
@@ -455,13 +455,13 @@ void SystemInit(void)
     LPC_SC->PLL1FEED  = 0xAA;
     LPC_SC->PLL1FEED  = 0x55;
 
-    while (!(LPC_SC->PLL1STAT & (1 << 10))); /* Wait for PLOCK1 */
+    while (!(LPC_SC->PLL1STAT & (1 << 10))) {} /* Wait for PLOCK1 */
 
     LPC_SC->PLL1CON   = 0x03;             /* PLL1 Enable & Connect */
     LPC_SC->PLL1FEED  = 0xAA;
     LPC_SC->PLL1FEED  = 0x55;
 
-    while (!(LPC_SC->PLL1STAT & ((1 << 9) | (1 << 8)))); /* Wait for PLLC1_STAT & PLLE1_STAT */
+    while (!(LPC_SC->PLL1STAT & ((1 << 9) | (1 << 8)))) {} /* Wait for PLLC1_STAT & PLLE1_STAT */
 
 #else
     LPC_SC->USBCLKCFG = USBCLKCFG_Val;    /* Setup USB Clock Divider */

--- a/boards/mbed_lpc1768/system.c
+++ b/boards/mbed_lpc1768/system.c
@@ -417,7 +417,8 @@ void SystemInit(void)
     LPC_SC->SCS       = SCS_Val;
 
     if (SCS_Val & (1 << 5)) {             /* If Main Oscillator is enabled */
-        while ((LPC_SC->SCS & (1 << 6)) == 0) {} /* Wait for Oscillator to be ready */
+        /* Wait for Oscillator to be ready */
+        while ((LPC_SC->SCS & (1 << 6)) == 0) {}
     }
 
     LPC_SC->CCLKCFG   = CCLKCFG_Val;      /* Setup Clock Divider */
@@ -436,13 +437,15 @@ void SystemInit(void)
     LPC_SC->PLL0FEED  = 0xAA;
     LPC_SC->PLL0FEED  = 0x55;
 
-    while (!(LPC_SC->PLL0STAT & (1 << 26))) {} /* Wait for PLOCK0 */
+    /* Wait for PLOCK0 */
+    while (!(LPC_SC->PLL0STAT & (1 << 26))) {}
 
     LPC_SC->PLL0CON   = 0x03;             /* PLL0 Enable & Connect */
     LPC_SC->PLL0FEED  = 0xAA;
     LPC_SC->PLL0FEED  = 0x55;
 
-    while (!(LPC_SC->PLL0STAT & ((1 << 25) | (1 << 24)))) {} /* Wait for PLLC0_STAT & PLLE0_STAT */
+    /* Wait for PLLC0_STAT & PLLE0_STAT */
+    while (!(LPC_SC->PLL0STAT & ((1 << 25) | (1 << 24)))) {}
 
 #endif
 
@@ -455,13 +458,15 @@ void SystemInit(void)
     LPC_SC->PLL1FEED  = 0xAA;
     LPC_SC->PLL1FEED  = 0x55;
 
-    while (!(LPC_SC->PLL1STAT & (1 << 10))) {} /* Wait for PLOCK1 */
+    /* Wait for PLOCK1 */
+    while (!(LPC_SC->PLL1STAT & (1 << 10))) {}
 
     LPC_SC->PLL1CON   = 0x03;             /* PLL1 Enable & Connect */
     LPC_SC->PLL1FEED  = 0xAA;
     LPC_SC->PLL1FEED  = 0x55;
 
-    while (!(LPC_SC->PLL1STAT & ((1 << 9) | (1 << 8)))) {} /* Wait for PLLC1_STAT & PLLE1_STAT */
+    /* Wait for PLLC1_STAT & PLLE1_STAT */
+    while (!(LPC_SC->PLL1STAT & ((1 << 9) | (1 << 8)))) {}
 
 #else
     LPC_SC->USBCLKCFG = USBCLKCFG_Val;    /* Setup USB Clock Divider */

--- a/boards/msba2/board_init.c
+++ b/boards/msba2/board_init.c
@@ -55,7 +55,7 @@ void init_clks1(void)
 
     SCS |= 0x20;                        /* Enable main OSC */
 
-    while (!(SCS & 0x40));              /* Wait until main OSC is usable */
+    while (!(SCS & 0x40)) {}            /* Wait until main OSC is usable */
 
     /* select main OSC, 16MHz, as the PLL clock source */
     CLKSRCSEL = 0x0001;

--- a/boards/msba2/board_init.c
+++ b/boards/msba2/board_init.c
@@ -55,7 +55,8 @@ void init_clks1(void)
 
     SCS |= 0x20;                        /* Enable main OSC */
 
-    while (!(SCS & 0x40)) {}            /* Wait until main OSC is usable */
+    /* Wait until main OSC is usable */
+    while (!(SCS & 0x40)) {}
 
     /* select main OSC, 16MHz, as the PLL clock source */
     CLKSRCSEL = 0x0001;

--- a/boards/pba-d-01-kw2x/board.c
+++ b/boards/pba-d-01-kw2x/board.c
@@ -51,7 +51,7 @@ static inline void modem_clock_init(void)
     KW2XDRF_GPIO->PSOR = (1 << KW2XDRF_RST_PIN);
 
     /* wait for modem IRQ_B interrupt request */
-    while (KW2XDRF_GPIO->PDIR & (1 << KW2XDRF_IRQ_PIN));
+    while (KW2XDRF_GPIO->PDIR & (1 << KW2XDRF_IRQ_PIN)) {}
 }
 
 void board_init(void)

--- a/boards/seeeduino_arch-pro/system.c
+++ b/boards/seeeduino_arch-pro/system.c
@@ -473,7 +473,7 @@ void SystemInit(void)
     LPC_SC->SCS       = SCS_Val;
 
     if (SCS_Val & (1 << 5)) {             /* If Main Oscillator is enabled */
-        while ((LPC_SC->SCS & (1 << 6)) == 0); /* Wait for Oscillator to be ready */
+        while ((LPC_SC->SCS & (1 << 6)) == 0) {} /* Wait for Oscillator to be ready */
     }
 
     LPC_SC->CCLKCFG   = CCLKCFG_Val;      /* Setup Clock Divider */
@@ -492,13 +492,13 @@ void SystemInit(void)
     LPC_SC->PLL0FEED  = 0xAA;
     LPC_SC->PLL0FEED  = 0x55;
 
-    while (!(LPC_SC->PLL0STAT & (1 << 26))); /* Wait for PLOCK0 */
+    while (!(LPC_SC->PLL0STAT & (1 << 26))) {} /* Wait for PLOCK0 */
 
     LPC_SC->PLL0CON   = 0x03;             /* PLL0 Enable & Connect */
     LPC_SC->PLL0FEED  = 0xAA;
     LPC_SC->PLL0FEED  = 0x55;
 
-    while (!(LPC_SC->PLL0STAT & ((1 << 25) | (1 << 24)))); /* Wait for PLLC0_STAT & PLLE0_STAT */
+    while (!(LPC_SC->PLL0STAT & ((1 << 25) | (1 << 24)))) {} /* Wait for PLLC0_STAT & PLLE0_STAT */
 
 #endif
 
@@ -511,13 +511,13 @@ void SystemInit(void)
     LPC_SC->PLL1FEED  = 0xAA;
     LPC_SC->PLL1FEED  = 0x55;
 
-    while (!(LPC_SC->PLL1STAT & (1 << 10))); /* Wait for PLOCK1 */
+    while (!(LPC_SC->PLL1STAT & (1 << 10))) {} /* Wait for PLOCK1 */
 
     LPC_SC->PLL1CON   = 0x03;             /* PLL1 Enable & Connect */
     LPC_SC->PLL1FEED  = 0xAA;
     LPC_SC->PLL1FEED  = 0x55;
 
-    while (!(LPC_SC->PLL1STAT & ((1 << 9) | (1 << 8)))); /* Wait for PLLC1_STAT & PLLE1_STAT */
+    while (!(LPC_SC->PLL1STAT & ((1 << 9) | (1 << 8)))) {} /* Wait for PLLC1_STAT & PLLE1_STAT */
 
 #else
     LPC_SC->USBCLKCFG = USBCLKCFG_Val;    /* Setup USB Clock Divider */

--- a/boards/seeeduino_arch-pro/system.c
+++ b/boards/seeeduino_arch-pro/system.c
@@ -473,7 +473,8 @@ void SystemInit(void)
     LPC_SC->SCS       = SCS_Val;
 
     if (SCS_Val & (1 << 5)) {             /* If Main Oscillator is enabled */
-        while ((LPC_SC->SCS & (1 << 6)) == 0) {} /* Wait for Oscillator to be ready */
+        /* Wait for Oscillator to be ready */
+        while ((LPC_SC->SCS & (1 << 6)) == 0) {}
     }
 
     LPC_SC->CCLKCFG   = CCLKCFG_Val;      /* Setup Clock Divider */
@@ -492,13 +493,15 @@ void SystemInit(void)
     LPC_SC->PLL0FEED  = 0xAA;
     LPC_SC->PLL0FEED  = 0x55;
 
-    while (!(LPC_SC->PLL0STAT & (1 << 26))) {} /* Wait for PLOCK0 */
+    /* Wait for PLOCK0 */
+    while (!(LPC_SC->PLL0STAT & (1 << 26))) {}
 
     LPC_SC->PLL0CON   = 0x03;             /* PLL0 Enable & Connect */
     LPC_SC->PLL0FEED  = 0xAA;
     LPC_SC->PLL0FEED  = 0x55;
 
-    while (!(LPC_SC->PLL0STAT & ((1 << 25) | (1 << 24)))) {} /* Wait for PLLC0_STAT & PLLE0_STAT */
+    /* Wait for PLLC0_STAT & PLLE0_STAT */
+    while (!(LPC_SC->PLL0STAT & ((1 << 25) | (1 << 24)))) {}
 
 #endif
 
@@ -511,13 +514,15 @@ void SystemInit(void)
     LPC_SC->PLL1FEED  = 0xAA;
     LPC_SC->PLL1FEED  = 0x55;
 
-    while (!(LPC_SC->PLL1STAT & (1 << 10))) {} /* Wait for PLOCK1 */
+    /* Wait for PLOCK1 */
+    while (!(LPC_SC->PLL1STAT & (1 << 10))) {}
 
     LPC_SC->PLL1CON   = 0x03;             /* PLL1 Enable & Connect */
     LPC_SC->PLL1FEED  = 0xAA;
     LPC_SC->PLL1FEED  = 0x55;
 
-    while (!(LPC_SC->PLL1STAT & ((1 << 9) | (1 << 8)))) {} /* Wait for PLLC1_STAT & PLLE1_STAT */
+    /* Wait for PLLC1_STAT & PLLE1_STAT */
+    while (!(LPC_SC->PLL1STAT & ((1 << 9) | (1 << 8)))) {}
 
 #else
     LPC_SC->USBCLKCFG = USBCLKCFG_Val;    /* Setup USB Clock Divider */

--- a/boards/telosb/board.c
+++ b/boards/telosb/board.c
@@ -76,7 +76,8 @@ void msp430_init_dco(void)
     while (1) {
         unsigned int compare;
 
-        while ((CCTL2 & CCIFG) != CCIFG) {} /* Wait until capture occured!*/
+        /* Wait until capture occured!*/
+        while ((CCTL2 & CCIFG) != CCIFG) {}
 
         CCTL2 &= ~CCIFG;                    /* Capture occured, clear flag */
         compare = CCR2;                     /* Get current captured SMCLK */

--- a/boards/telosb/board.c
+++ b/boards/telosb/board.c
@@ -76,7 +76,7 @@ void msp430_init_dco(void)
     while (1) {
         unsigned int compare;
 
-        while ((CCTL2 & CCIFG) != CCIFG);   /* Wait until capture occured!*/
+        while ((CCTL2 & CCIFG) != CCIFG) {} /* Wait until capture occured!*/
 
         CCTL2 &= ~CCIFG;                    /* Capture occured, clear flag */
         compare = CCR2;                     /* Get current captured SMCLK */

--- a/boards/z1/board.c
+++ b/boards/z1/board.c
@@ -147,7 +147,7 @@ void msp430_init_dco(void)
     while (1) {
         unsigned int compare;
 
-        while ((CCTL2 & CCIFG) != CCIFG);   /* Wait until capture occured!*/
+        while ((CCTL2 & CCIFG) != CCIFG) {} /* Wait until capture occured!*/
 
         CCTL2 &= ~CCIFG;                    /* Capture occured, clear flag */
         compare = CCR2;                     /* Get current captured SMCLK */

--- a/boards/z1/board.c
+++ b/boards/z1/board.c
@@ -147,7 +147,8 @@ void msp430_init_dco(void)
     while (1) {
         unsigned int compare;
 
-        while ((CCTL2 & CCIFG) != CCIFG) {} /* Wait until capture occured!*/
+        /* Wait until capture occured!*/
+        while ((CCTL2 & CCIFG) != CCIFG) {}
 
         CCTL2 &= ~CCIFG;                    /* Capture occured, clear flag */
         compare = CCR2;                     /* Get current captured SMCLK */

--- a/cpu/atmega_common/periph/pm.c
+++ b/cpu/atmega_common/periph/pm.c
@@ -45,5 +45,5 @@ void pm_reboot(void)
      */
     irq_disable();
     wdt_enable(WDTO_250MS);
-    while(1);
+    while(1) {}
 }

--- a/cpu/cc2538/cpu.c
+++ b/cpu/cc2538/cpu.c
@@ -81,11 +81,11 @@ static void cpu_clock_init(void)
     SYS_CTRL->cc2538_sys_ctrl_clk_ctrl.CLOCK_CTRL = CLOCK_CTRL_VALUE;
 
     /* Wait for the new clock settings to take effect: */
-    while ((SYS_CTRL->cc2538_sys_ctrl_clk_sta.CLOCK_STA ^ CLOCK_CTRL_VALUE) & CLOCK_STA_MASK);
+    while ((SYS_CTRL->cc2538_sys_ctrl_clk_sta.CLOCK_STA ^ CLOCK_CTRL_VALUE) & CLOCK_STA_MASK) {}
 
 #if SYS_CTRL_OSC32K_USE_XTAL
     /* Wait for the 32-kHz crystal oscillator to stabilize: */
-    while ( SYS_CTRL->cc2538_sys_ctrl_clk_sta.CLOCK_STAbits.SYNC_32K);
-    while (!SYS_CTRL->cc2538_sys_ctrl_clk_sta.CLOCK_STAbits.SYNC_32K);
+    while ( SYS_CTRL->cc2538_sys_ctrl_clk_sta.CLOCK_STAbits.SYNC_32K) {}
+    while (!SYS_CTRL->cc2538_sys_ctrl_clk_sta.CLOCK_STAbits.SYNC_32K) {}
 #endif
 }

--- a/cpu/cc2538/periph/hwrng.c
+++ b/cpu/cc2538/periph/hwrng.c
@@ -36,7 +36,7 @@ void hwrng_init(void)
     SYS_CTRL_RCGCRFC = 1;
 
     /* Wait for the clock ungating to take effect */
-    while (SYS_CTRL_RCGCRFC != 1);
+    while (SYS_CTRL_RCGCRFC != 1) {}
 
     /* Infinite RX - FRMCTRL0[3:2] = 10. This will mess with radio operation */
     RFCORE_XREG_FRMCTRL0 = 0x00000008;
@@ -49,7 +49,7 @@ void hwrng_init(void)
      * have died out. A convenient way to do this is to wait for the RSSI-valid
      * signal to go high."
      */
-    while (!RFCORE->XREG_RSSISTATbits.RSSI_VALID);
+    while (!RFCORE->XREG_RSSISTATbits.RSSI_VALID) {}
 
     /*
      * Form the seed by concatenating bits from IF_ADC in the RF receive path.

--- a/cpu/cc26x0/cpu.c
+++ b/cpu/cc26x0/cpu.c
@@ -51,7 +51,8 @@ void cpu_init(void)
 static void cpu_clock_init(void)
 {
     AON_WUC->AUXCTL |= AUXCTL_AUX_FORCE_ON; /* power on AUX_PD */
-    while(!(AON_WUC->PWRSTAT & PWRSTAT_AUX_PD_ON)) {} /* wait for AUX_PD to be powered on */
+    /* wait for AUX_PD to be powered on */
+    while(!(AON_WUC->PWRSTAT & PWRSTAT_AUX_PD_ON)) {}
     AUX_WUC->MODCLKEN0 |= MODCLKEN0_AUX_DDI0_OSC_EN; /* turn on oscillator interface clock */
 
     DDI_0_OSC->CTL0 |= HF_CLOCK_SOURCE | LF_CLOCK_SOURCE; /* configure HF and LF clocks */

--- a/cpu/cc26x0/cpu.c
+++ b/cpu/cc26x0/cpu.c
@@ -51,7 +51,7 @@ void cpu_init(void)
 static void cpu_clock_init(void)
 {
     AON_WUC->AUXCTL |= AUXCTL_AUX_FORCE_ON; /* power on AUX_PD */
-    while(!(AON_WUC->PWRSTAT & PWRSTAT_AUX_PD_ON)); /* wait for AUX_PD to be powered on */
+    while(!(AON_WUC->PWRSTAT & PWRSTAT_AUX_PD_ON)) {} /* wait for AUX_PD to be powered on */
     AUX_WUC->MODCLKEN0 |= MODCLKEN0_AUX_DDI0_OSC_EN; /* turn on oscillator interface clock */
 
     DDI_0_OSC->CTL0 |= HF_CLOCK_SOURCE | LF_CLOCK_SOURCE; /* configure HF and LF clocks */

--- a/cpu/cc26x0/periph/gpio.c
+++ b/cpu/cc26x0/periph/gpio.c
@@ -38,10 +38,10 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
 
     /* enable GPIO clock */
     PRCM->PDCTL0 |= PDCTL0_PERIPH_ON;
-    while(!(PRCM->PDSTAT0 & PDSTAT0_PERIPH_ON)) ;
+    while(!(PRCM->PDSTAT0 & PDSTAT0_PERIPH_ON)) {}
     PRCM->GPIOCLKGR |= 1;
     PRCM->CLKLOADCTL |= CLKLOADCTL_LOAD;
-    while (!(PRCM->CLKLOADCTL & CLKLOADCTL_LOADDONE)) ;
+    while (!(PRCM->CLKLOADCTL & CLKLOADCTL_LOADDONE)) {}
 
     /* configure the GPIO mode */
     IOC->CFG[pin] = mode;

--- a/cpu/cc26x0/periph/uart.c
+++ b/cpu/cc26x0/periph/uart.c
@@ -53,7 +53,7 @@ int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
 
     /* enable clocks: serial power domain and UART */
     PRCM->PDCTL0SERIAL = 1;
-    while (!(PRCM->PDSTAT0 & PDSTAT0_SERIAL_ON)) ;
+    while (!(PRCM->PDSTAT0 & PDSTAT0_SERIAL_ON)) {}
     uart_poweron(uart);
 
     /* disable and reset the UART */

--- a/cpu/cc430/cc430-adc.c
+++ b/cpu/cc430/cc430-adc.c
@@ -89,7 +89,7 @@ uint16_t adc12_single_conversion(uint16_t ref, uint16_t sht, uint16_t channel)
     /* Wait until ADC12 has finished */
     xtimer_usleep(150);
 
-    while (!adc12_data_ready);
+    while (!adc12_data_ready) {}
 
     /* Shut down ADC12 */
     ADC12CTL0 &= ~(ADC12ENC | ADC12SC | sht);

--- a/cpu/efm32/periph/adc.c
+++ b/cpu/efm32/periph/adc.c
@@ -88,7 +88,7 @@ int adc_sample(adc_t line, adc_res_t res)
     /* start conversion and block until it completes */
     ADC_Start(adc_config[dev].dev, adcStartSingle);
 
-    while (adc_config[dev].dev->STATUS & ADC_STATUS_SINGLEACT);
+    while (adc_config[dev].dev->STATUS & ADC_STATUS_SINGLEACT) {}
 
     int result = ADC_DataSingleGet(adc_config[dev].dev);
 

--- a/cpu/ezr32wg/cpu.c
+++ b/cpu/ezr32wg/cpu.c
@@ -41,11 +41,11 @@ static void clk_init(void)
     /* enable the oscillator */
     CMU->OSCENCMD = CMU_OSCENCMD_HFXOEN;
     /* wait for external oscillator to be stable */
-    while (!(CMU->STATUS & CMU_STATUS_HFXORDY));
+    while (!(CMU->STATUS & CMU_STATUS_HFXORDY)) {}
     /* switch to the external oscillator */
     CMU->CMD = CMU_CMD_HFCLKSEL_HFXO;
     /* wait until clock source is applied */
-    while (!(CMU->STATUS & CMU_STATUS_HFXOSEL));
+    while (!(CMU->STATUS & CMU_STATUS_HFXOSEL)) {}
 #endif
 
     /* set the core clock divider */

--- a/cpu/ezr32wg/periph/uart.c
+++ b/cpu/ezr32wg/periph/uart.c
@@ -92,7 +92,7 @@ int uart_init(uart_t dev, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
 void uart_write(uart_t dev, const uint8_t *data, size_t len)
 {
     for (size_t i = 0; i < len; i++) {
-        while (!(_uart(dev)->STATUS & USART_STATUS_TXBL));
+        while (!(_uart(dev)->STATUS & USART_STATUS_TXBL)) {}
         _uart(dev)->TXDATA = data[i];
     }
 }

--- a/cpu/kinetis/periph/adc.c
+++ b/cpu/kinetis/periph/adc.c
@@ -117,7 +117,8 @@ int kinetis_adc_calibrate(ADC_Type *dev)
 
     dev->SC3 |= ADC_SC3_CAL_MASK;
 
-    while (dev->SC3 & ADC_SC3_CAL_MASK) {} /* wait for calibration to finish */
+    /* wait for calibration to finish */
+    while (dev->SC3 & ADC_SC3_CAL_MASK) {}
 
     while (!(dev->SC1[0] & ADC_SC1_COCO_MASK)) {}
 

--- a/cpu/kinetis/periph/hwrng.c
+++ b/cpu/kinetis/periph/hwrng.c
@@ -44,13 +44,13 @@ void hwrng_read(void *buf, unsigned int num)
     KINETIS_RNGA->CR = RNG_CR_INTM_MASK | RNG_CR_HA_MASK | RNG_CR_GO_MASK;
 
     /* self-seeding */
-    while (!(KINETIS_RNGA->SR & RNG_SR_OREG_LVL_MASK));
+    while (!(KINETIS_RNGA->SR & RNG_SR_OREG_LVL_MASK)) {}
 
     KINETIS_RNGA->ER = KINETIS_RNGA->OR ^ (uint32_t)buf;
 
     while (count < num) {
         /* wait for random data to be ready to read */
-        while (!(KINETIS_RNGA->SR & RNG_SR_OREG_LVL_MASK));
+        while (!(KINETIS_RNGA->SR & RNG_SR_OREG_LVL_MASK)) {}
 
         uint32_t tmp = KINETIS_RNGA->OR;
 

--- a/cpu/lpc1768/periph/uart.c
+++ b/cpu/lpc1768/periph/uart.c
@@ -158,7 +158,8 @@ void uart_write(uart_t uart, const uint8_t *data, size_t len)
     }
 
     for (size_t i = 0; i < len; i++) {
-        while (!(dev->LSR & (1 << 5))) {}     /* wait for THRE bit to be set */
+        /* wait for THRE bit to be set */
+        while (!(dev->LSR & (1 << 5))) {}
         dev->THR = data[i];
     }
 }

--- a/cpu/lpc1768/periph/uart.c
+++ b/cpu/lpc1768/periph/uart.c
@@ -158,7 +158,7 @@ void uart_write(uart_t uart, const uint8_t *data, size_t len)
     }
 
     for (size_t i = 0; i < len; i++) {
-        while (!(dev->LSR & (1 << 5)));       /* wait for THRE bit to be set */
+        while (!(dev->LSR & (1 << 5))) {}     /* wait for THRE bit to be set */
         dev->THR = data[i];
     }
 }

--- a/cpu/lpc2387/mci/lpc2387-mci.c
+++ b/cpu/lpc2387/mci/lpc2387-mci.c
@@ -843,7 +843,8 @@ diskio_result_t mci_write(const unsigned char *buff, unsigned long sector, unsig
         buff += 512;             /* Next user buffer address */
     }
 
-    while (!(XferStat & 0xC)) {} /* Wait for all blocks sent (block underrun) */
+    /* Wait for all blocks sent (block underrun) */
+    while (!(XferStat & 0xC)) {}
 
     if (XferStat & 0x8) {
         count = 1;    /* Abort if any MCI error has occured */

--- a/cpu/lpc2387/mci/lpc2387-mci.c
+++ b/cpu/lpc2387/mci/lpc2387-mci.c
@@ -205,7 +205,7 @@ static void ready_reception(unsigned int blks, unsigned int bs)
     MCI_CLEAR = 0x72A;                      /* Clear status flags */
     MCI_MASK0 = 0x72A;                      /* DataBlockEnd StartBitErr DataEnd RxOverrun DataTimeOut DataCrcFail */
 
-    for (n = 0; bs > 1; bs >>= 1, n += 0x10);
+    for (n = 0; bs > 1; bs >>= 1, n += 0x10) {}
 
     MCI_DATA_CTRL  = n | 0xB;               /* Start to receive data blocks */
 }

--- a/cpu/nrf5x_common/periph/spi.c
+++ b/cpu/nrf5x_common/periph/spi.c
@@ -104,7 +104,7 @@ void spi_transfer_bytes(spi_t bus, spi_cs_t cs, bool cont,
 
         dev(bus)->EVENTS_READY = 0;
         dev(bus)->TXD = (uint8_t)tmp;
-        while (dev(bus)->EVENTS_READY != 1);
+        while (dev(bus)->EVENTS_READY != 1) {}
         tmp = (uint8_t)dev(bus)->RXD;
 
         if (in_buf) {

--- a/cpu/sam3/cpu.c
+++ b/cpu/sam3/cpu.c
@@ -62,7 +62,7 @@ void cpu_init(void)
                      CKGR_MOR_MOSCXTEN |
                      CKGR_MOR_MOSCRCEN);
     /* wait for crystal to be stable */
-    while (!(PMC->PMC_SR & PMC_SR_MOSCXTS));
+    while (!(PMC->PMC_SR & PMC_SR_MOSCXTS)) {}
 
     /* select crystal to clock the main clock */
     PMC->CKGR_MOR = (CKGR_MOR_KEY(MORKEY) |
@@ -71,7 +71,7 @@ void cpu_init(void)
                      CKGR_MOR_MOSCRCEN |
                      CKGR_MOR_MOSCSEL);
     /* wait for main oscillator selection to be complete */
-    while (!(PMC->PMC_SR & PMC_SR_MOSCSELS));
+    while (!(PMC->PMC_SR & PMC_SR_MOSCSELS)) {}
 
     /* setup PLLA */
     PMC->CKGR_PLLAR = (CKGR_PLLAR_ONE |
@@ -79,16 +79,16 @@ void cpu_init(void)
                        CKGR_PLLAR_MULA(CLOCK_PLL_MUL) |
                        CKGR_PLLAR_DIVA(CLOCK_PLL_DIV));
     /* wait for PLL to lock */
-    while (!(PMC->PMC_SR & PMC_SR_LOCKA));
+    while (!(PMC->PMC_SR & PMC_SR_LOCKA)) {}
 
     /* before switching to PLLA, we need to switch to main clock */
     PMC->PMC_MCKR = PMC_MCKR_CSS_MAIN_CLK;
-    while (!(PMC->PMC_SR & PMC_SR_MCKRDY));
+    while (!(PMC->PMC_SR & PMC_SR_MCKRDY)) {}
 
     /* use PLLA as main clock source */
     PMC->PMC_MCKR = PMC_MCKR_CSS_PLLA_CLK;
     /* wait for master clock to be ready */
-    while (!(PMC->PMC_SR & PMC_SR_MCKRDY));
+    while (!(PMC->PMC_SR & PMC_SR_MCKRDY)) {}
 
     /* trigger static peripheral initialization */
     periph_init();

--- a/cpu/sam3/periph/spi.c
+++ b/cpu/sam3/periph/spi.c
@@ -115,9 +115,9 @@ void spi_transfer_bytes(spi_t bus, spi_cs_t cs, bool cont,
     }
     else {
         for (size_t i = 0; i < len; i++) {
-            while (!(dev(bus)->SPI_SR & SPI_SR_TDRE));
+            while (!(dev(bus)->SPI_SR & SPI_SR_TDRE)) {}
             dev(bus)->SPI_TDR = out_buf[i];
-            while (!(dev(bus)->SPI_SR & SPI_SR_RDRF));
+            while (!(dev(bus)->SPI_SR & SPI_SR_RDRF)) {}
             in_buf[i] = dev(bus)->SPI_RDR;
         }
     }

--- a/cpu/samd21/cpu.c
+++ b/cpu/samd21/cpu.c
@@ -164,7 +164,8 @@ static void clk_init(void)
     uint32_t mask = SYSCTRL_PCLKSR_DFLLRDY |
                     SYSCTRL_PCLKSR_DFLLLCKF |
                     SYSCTRL_PCLKSR_DFLLLCKC;
-    while ((SYSCTRL->PCLKSR.reg & mask) != mask) { } /* Wait for DFLL lock */
+    /* Wait for DFLL lock */
+    while ((SYSCTRL->PCLKSR.reg & mask) != mask) { }
 
     /* select the DFLL as source for clock generator 0 (CPU core clock) */
     GCLK->GENDIV.reg =  (GCLK_GENDIV_DIV(1U) | GCLK_GENDIV_ID(0));

--- a/cpu/saml21/periph/rtc.c
+++ b/cpu/saml21/periph/rtc.c
@@ -60,7 +60,7 @@ void rtc_init(void)
                             | OSC32KCTRL_OSC32K_ENABLE;
 
     /* Wait XOSC32K Ready */
-    while (OSC32KCTRL->STATUS.bit.XOSC32KRDY==0);
+    while (OSC32KCTRL->STATUS.bit.XOSC32KRDY==0) {}
 
     /* RTC source clock is external oscillator at 1kHz */
     OSC32KCTRL->RTCCTRL.reg = OSC32KCTRL_RTCCTRL_RTCSEL_XOSC1K;
@@ -82,7 +82,7 @@ void rtc_init(void)
                            | OSC32KCTRL_OSC32K_ENABLE;
 
     /* Wait OSC32K Ready */
-    while (OSC32KCTRL->STATUS.bit.OSC32KRDY==0);
+    while (OSC32KCTRL->STATUS.bit.OSC32KRDY==0) {}
 
     /* RTC uses internal 32,768KHz Oscillator */
     OSC32KCTRL->RTCCTRL.reg = OSC32KCTRL_RTCCTRL_RTCSEL_OSC1K;
@@ -100,7 +100,7 @@ void rtc_init(void)
     /* Software Reset the RTC */
     RTC->MODE2.CTRLA.bit.SWRST = 1;
     /* Wait end of reset */
-    while (RTC->MODE2.CTRLA.bit.SWRST);
+    while (RTC->MODE2.CTRLA.bit.SWRST) {}
 
     /* RTC config with RTC_MODE2_CTRL_CLKREP = 0 (24h) */
     RTC->MODE2.CTRLA.reg = RTC_MODE2_CTRLA_PRESCALER_DIV1024 |  /* CLK_RTC_CNT = 1KHz / 1024 -> 1Hz */
@@ -120,14 +120,14 @@ int rtc_set_time(struct tm *time)
         return -1;
     }
     else {
-        while (RTC->MODE2.SYNCBUSY.bit.CLOCK);
+        while (RTC->MODE2.SYNCBUSY.bit.CLOCK) {}
         RTC->MODE2.CLOCK.reg = RTC_MODE2_CLOCK_YEAR(time->tm_year - reference_year)
                              | RTC_MODE2_CLOCK_MONTH(time->tm_mon + 1)
                              | RTC_MODE2_CLOCK_DAY(time->tm_mday)
                              | RTC_MODE2_CLOCK_HOUR(time->tm_hour)
                              | RTC_MODE2_CLOCK_MINUTE(time->tm_min)
                              | RTC_MODE2_CLOCK_SECOND(time->tm_sec);
-        while (RTC->MODE2.SYNCBUSY.bit.CLOCK);
+        while (RTC->MODE2.SYNCBUSY.bit.CLOCK) {}
     }
    return 0;
 }
@@ -165,7 +165,7 @@ int rtc_set_alarm(struct tm *time, rtc_alarm_cb_t cb, void *arg)
                                            | RTC_MODE2_ALARM_MINUTE(time->tm_min)
                                            | RTC_MODE2_ALARM_SECOND(time->tm_sec);
         RTC->MODE2.Mode2Alarm[0].MASK.reg = RTC_MODE2_MASK_SEL(6);
-        while (RTC->MODE2.SYNCBUSY.bit.ALARM0);
+        while (RTC->MODE2.SYNCBUSY.bit.ALARM0) {}
     }
 
     /* Setup interrupt */
@@ -211,13 +211,13 @@ void rtc_clear_alarm(void)
 void rtc_poweron(void)
 {
     RTC->MODE2.CTRLA.bit.ENABLE = 1;
-    while (RTC->MODE2.SYNCBUSY.bit.ENABLE);
+    while (RTC->MODE2.SYNCBUSY.bit.ENABLE) {}
 }
 
 void rtc_poweroff(void)
 {
     RTC->MODE2.CTRLA.bit.ENABLE = 0;
-    while (RTC->MODE2.SYNCBUSY.bit.ENABLE);
+    while (RTC->MODE2.SYNCBUSY.bit.ENABLE) {}
 }
 
 void isr_rtc(void)

--- a/cpu/stm32_common/periph/spi.c
+++ b/cpu/stm32_common/periph/spi.c
@@ -214,7 +214,7 @@ static void _transfer_no_dma(spi_t bus, const void *out, void *in, size_t len)
     /* transfer data, use shortpath if only sending data */
     if (!inbuf) {
         for (size_t i = 0; i < len; i++) {
-            while (!(dev(bus)->SR & SPI_SR_TXE));
+            while (!(dev(bus)->SR & SPI_SR_TXE)) {}
             *DR = outbuf[i];
         }
         /* wait until everything is finished and empty the receive buffer */
@@ -226,17 +226,17 @@ static void _transfer_no_dma(spi_t bus, const void *out, void *in, size_t len)
     }
     else if (!outbuf) {
         for (size_t i = 0; i < len; i++) {
-            while (!(dev(bus)->SR & SPI_SR_TXE));
+            while (!(dev(bus)->SR & SPI_SR_TXE)) {}
             *DR = 0;
-            while (!(dev(bus)->SR & SPI_SR_RXNE));
+            while (!(dev(bus)->SR & SPI_SR_RXNE)) {}
             inbuf[i] = *DR;
         }
     }
     else {
         for (size_t i = 0; i < len; i++) {
-            while (!(dev(bus)->SR & SPI_SR_TXE));
+            while (!(dev(bus)->SR & SPI_SR_TXE)) {}
             *DR = outbuf[i];
-            while (!(dev(bus)->SR & SPI_SR_RXNE));
+            while (!(dev(bus)->SR & SPI_SR_RXNE)) {}
             inbuf[i] = *DR;
         }
     }

--- a/cpu/stm32f1/periph/rtt.c
+++ b/cpu/stm32f1/periph/rtt.c
@@ -155,7 +155,8 @@ void rtt_poweron(void)
     /* RTC clock source configuration */
     PWR->CR |= PWR_CR_DBP;                   /* Allow access to BKP Domain */
     RCC->BDCR |= RCC_BDCR_LSEON;             /* Enable LSE OSC */
-    while(!(RCC->BDCR & RCC_BDCR_LSERDY)) {} /* Wait till LSE is ready */
+    /* Wait till LSE is ready */
+    while(!(RCC->BDCR & RCC_BDCR_LSERDY)) {}
     RCC->BDCR |= RCC_BDCR_RTCSEL_LSE;        /* Select the RTC Clock Source */
     RCC->BDCR |= RCC_BDCR_RTCEN;             /* enable RTC */
 }

--- a/cpu/stm32l0/periph/adc.c
+++ b/cpu/stm32l0/periph/adc.c
@@ -56,13 +56,15 @@ static void _enable_adc(void)
 {
     if ((ADC1->CR & ADC_CR_ADEN) != 0) {
         ADC1->CR |= ADC_CR_ADDIS;
-        while(ADC1->CR & ADC_CR_ADEN) {} /* Wait for ADC disabled */
+        /* Wait for ADC disabled */
+        while(ADC1->CR & ADC_CR_ADEN) {}
     }
 
     if ((ADC1->CR & ADC_CR_ADEN) == 0) {
         /* Then, start a calibration */
         ADC1->CR |= ADC_CR_ADCAL;
-        while(ADC1->CR & ADC_CR_ADCAL) {} /* Wait for the end of calibration */
+        /* Wait for the end of calibration */
+        while(ADC1->CR & ADC_CR_ADCAL) {}
     }
 
     /* Clear flag */
@@ -80,7 +82,8 @@ static void _disable_adc(void)
     /* Disable ADC */
     if ((ADC1->CR & ADC_CR_ADEN) != 0) {
         ADC1->CR |= ADC_CR_ADDIS;
-        while(ADC1->CR & ADC_CR_ADEN) {} /* Wait for ADC disabled */
+        /* Wait for ADC disabled */
+        while(ADC1->CR & ADC_CR_ADEN) {}
         /* Disable Voltage regulator */
         ADC1->CR = 0;
         ADC1->ISR = 0;

--- a/sys/include/xtimer/implementation.h
+++ b/sys/include/xtimer/implementation.h
@@ -143,7 +143,7 @@ static inline void _xtimer_spin(uint32_t offset) {
     offset = _xtimer_lltimer_mask(offset);
     while (_xtimer_lltimer_mask(_xtimer_lltimer_now() - start) < offset);
 #else
-    while ((_xtimer_lltimer_now() - start) < offset);
+    while ((_xtimer_lltimer_now() - start) < offset) {}
 #endif
 }
 

--- a/sys/newlib_syscalls_default/syscalls.c
+++ b/sys/newlib_syscalls_default/syscalls.c
@@ -89,7 +89,7 @@ void _exit(int n)
 {
     LOG_INFO("#! exit %i: powering off\n", n);
     pm_off();
-    while(1);
+    while (1) {}
 }
 
 /**

--- a/sys/xtimer/xtimer_core.c
+++ b/sys/xtimer/xtimer_core.c
@@ -62,8 +62,8 @@ static inline void xtimer_spin_until(uint32_t target) {
 #if XTIMER_MASK
     target = _xtimer_lltimer_mask(target);
 #endif
-    while (_xtimer_lltimer_now() > target);
-    while (_xtimer_lltimer_now() < target);
+    while (_xtimer_lltimer_now() > target) {}
+    while (_xtimer_lltimer_now() < target) {}
 }
 
 void xtimer_init(void)

--- a/tests/driver_nvram_spi/main.c
+++ b/tests/driver_nvram_spi/main.c
@@ -241,7 +241,7 @@ int main(void)
 
     puts("All tests passed!");
 
-    while(1);
+    while (1) {}
 
     return 0;
 }

--- a/tests/fault_handler/main.c
+++ b/tests/fault_handler/main.c
@@ -48,6 +48,6 @@ int main(void)
     puts(PRINT_MACRO(INVALID_INSTRUCTION));
     INVALID_INSTRUCTION;
     puts("Failed to crash the program, hanging...");
-    while(1);
+    while (1) {}
     return 0;
 }

--- a/tests/thread_race/main.c
+++ b/tests/thread_race/main.c
@@ -60,7 +60,7 @@ static void _spin(void)
     /* Volatile so it is not messed with by optimizations */
     volatile uint8_t i;
 
-    for (i = 0; i < 255; i++) ;
+    for (i = 0; i < 255; i++) {}
 }
 
 int main(void)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR adds curly braces to empty loops which only end with a semicolon. This is done in order to follow our [Coding Convention](https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions), and as a required step towards automatic style checking.

Also, moves inline comments to the top of the loop:
```
while(...) {} /* This is comment */
```
Now becomes:
```
/* This is comment */
while(...) {}
```

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->