### PR TITLE
sys/ps: Use correct define for TLSF information.

### DIFF
--- a/sys/ps/ps.c
+++ b/sys/ps/ps.c
@@ -26,7 +26,7 @@
 #include "xtimer.h"
 #endif
 
-#ifdef MODULE_TLSF
+#ifdef MODULE_TLSF_MALLOC
 #include "tlsf.h"
 #include "tlsf-malloc.h"
 #endif
@@ -145,7 +145,7 @@ void ps(void)
 #ifdef DEVELHELP
     printf("\t%5s %-21s|%13s%6s %6i (%5i)\n", "|", "SUM", "|", "|",
            overall_stacksz, overall_used);
-#   ifdef MODULE_TLSF
+#   ifdef MODULE_TLSF_MALLOC
     puts("\nHeap usage:");
     tlsf_walk_pool(tlsf_get_pool(_tlsf_get_global_control()), NULL, NULL);
 #   endif


### PR DESCRIPTION
### Contribution description

I'm fixing my own bugs here.

The macro MODULE_TLSF_MALLOC indicates if tlsf is being used as the system-wide allocator. MODULE_TLSF only incates if TLSF is present.

PS should check for MODULE_TLSF_MALLOC to decide if heap information should be displayed.

### Issues/PRs references

The error was introduced in PR #9006.