### PR TITLE
WIP try to make shell tests reliable

### DIFF
--- a/dist/tools/testrunner/riot.py
+++ b/dist/tools/testrunner/riot.py
@@ -20,7 +20,7 @@ def expect_shell_prompt(child, sendline=True, *args, **kwargs):
                      shell prompt
     """
     if sendline:
-        child.sendline('')
+        child.sendline('help')
     child.expect(RIOT_PROMPT, *args, **kwargs)
 
 
@@ -41,7 +41,7 @@ def expect_working_shell_prompt(child, timeout=None, sendlinestep=0.5):
 
     # Wait until the shell answers
     while time.time() < (t_end - sendlinestep):
-        child.sendline('')
+        child.sendline('help')
         if 0 == child.expect([RIOT_PROMPT, pexpect.TIMEOUT], timeout=sendlinestep):
             return
 

--- a/dist/tools/testrunner/riot.py
+++ b/dist/tools/testrunner/riot.py
@@ -1,0 +1,49 @@
+# Copyright (C) 2018 Gaëtan Harter <gaetan.harter@fu-berlin.de>
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import time
+
+import pexpect
+
+
+RIOT_PROMPT = '>'
+
+
+def expect_shell_prompt(child, sendline=True, *args, **kwargs):
+    """Wait for shell prompt. It sends a newline if `sendline`.
+
+    :param child: pexpect spawn object
+    :param sendline: set it to True to send a newline before expecting
+                     shell prompt
+    """
+    if sendline:
+        child.sendline('')
+    child.expect(RIOT_PROMPT, *args, **kwargs)
+
+
+def expect_working_shell_prompt(child, timeout=None, sendlinestep=0.5):
+    """Wait for the shell prompt to be working.
+
+    It waits for a first prompt character and sends newline until it is active
+
+    :param child: pexpect spawn object
+    :param timeout: expect timeout, defaults to child.timeout
+    :param sendlinestep: steps for retrying sending newline
+    """
+    timeout = timeout if timeout is not None else child.timeout
+    t_end = time.time() + timeout
+
+    # First prompt character
+    expect_shell_prompt(child, sendline=True, timeout=timeout)
+
+    # Wait until the shell answers
+    while time.time() < (t_end - sendlinestep):
+        child.sendline('')
+        if 0 == child.expect([RIOT_PROMPT, pexpect.TIMEOUT], timeout=sendlinestep):
+            return
+
+    # Do a last one that can timeout
+    expect_shell_prompt(child, sendline=True, timeout=sendlinestep)

--- a/tests/ps_schedstatistics/tests/01-run.py
+++ b/tests/ps_schedstatistics/tests/01-run.py
@@ -55,8 +55,14 @@ def _check_ps(child):
         child.expect(line)
 
 
+def _wait_shell_ready(child):
+    import riot
+    riot.expect_working_shell_prompt(child, sendlinestep=0.5)
+
+
 def testfunc(child):
     _check_startup(child)
+    _wait_shell_ready(child)
     _check_help(child)
     _check_ps(child)
 

--- a/tests/shell/tests/01-run.py
+++ b/tests/shell/tests/01-run.py
@@ -46,9 +46,17 @@ def check_cmd(child, cmd, expected):
         child.expect_exact(line)
 
 
+def _wait_shell_ready(child, *args, **kwargs):
+    import riot
+    riot.expect_working_shell_prompt(child, sendlinestep=0.5, *args, **kwargs)
+
+
 def testfunc(child):
     # check startup message
     child.expect('test_shell.')
+
+    # Wait until shell is ready to get commands
+    _wait_shell_ready(child)
 
     # loop other defined commands and expected output
     for cmd, expected in CMDS.items():

--- a/tests/struct_tm_utility/tests/01-run.py
+++ b/tests/struct_tm_utility/tests/01-run.py
@@ -105,9 +105,9 @@ def _check_day(child):
                        'but no error should occur.')
 
 
-def _wait_prompt(child):
-    child.sendline('')
-    child.expect('>')
+def _wait_prompt(child, *args, **kwargs):
+    import riot
+    riot.expect_working_shell_prompt(child, sendlinestep=0.5)
 
 
 def testfunc(child):


### PR DESCRIPTION
### Contribution description

When running CI tests on nodes, regularly the following tests fail:

    tests/struct_tm_utility/samr21-xpro
    tests/ps_schedstatistics/samr21-xpro
    tests/shell/samr21-xpro

This is an attempt to fix this by waiting that the shell correctly answers to newline characters.

The goal is to re-run the tests several times to check if they are reliable.

### List of executions:

 * Run tests (start time):
    * 5/30/2018, 5:09:21 PM - [Success]
    * 5/30/2018, 5:54:46 PM - [Success]
    * 5/30/2018, 6:18:51 PM - [Success]
    * 5/30/2018, 7:25:42 PM - [Success]
    * ... [todo]
 * Failed tests: 0

### Implementation

I added another module in testrunner for RIOT specific calls.
It was somehow inspired by https://github.com/RIOT-OS/Release-Specs/blob/master/07-multi-hop/IOTLABHelper.py that has riot specific high level expect functions.

### Future work

They are currently implemented as functions, as testrunner returns a pexpect child.
But if refactoring testrunner as a class, this could just be a subclassing and implemented as methods.

### Issues/PRs references

For example https://github.com/RIOT-OS/RIOT/pull/8841#issuecomment-392893606