### PR TITLE
Revert "newlib-nano: add include directory"

### DIFF
--- a/makefiles/libc/newlib.mk
+++ b/makefiles/libc/newlib.mk
@@ -64,8 +64,7 @@ ifeq ($(TOOLCHAIN),llvm)
 endif
 
 ifeq (1,$(USE_NEWLIB_NANO))
-  # newlib-nano include directory is called either newlib-nano or nano. Use the one we find first.
-  NEWLIB_NANO_INCLUDE_DIR ?= $(firstword $(wildcard $(addprefix $(NEWLIB_INCLUDE_DIR)/, newlib-nano nano)))
+  NEWLIB_NANO_INCLUDE_DIR ?= $(NEWLIB_INCLUDE_DIR)/newlib-nano
   # newlib-nano overrides newlib.h and its include dir should therefore go before
   # the regular system include dirs.
   INCLUDES := -isystem $(NEWLIB_NANO_INCLUDE_DIR) $(INCLUDES)


### PR DESCRIPTION
This reverts commit 88aaa623641753c1b9eb164b9b1114e9c2c0700c.

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->
As a temporary fix for #9214. Eventually  #9216 should be improved to properly handle this.


<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->