### PR TITLE
gcoap: don't drop observer on re-register

### DIFF
--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -291,6 +291,7 @@ static size_t _handle_req(coap_pkt_t *pdu, uint8_t *buf, size_t len,
                     && _endpoints_equal(remote, resource_memo->observer)) {
                 /* observer re-registering with new token */
                 memo = resource_memo;
+                observer = resource_memo->observer;
             }
             else if ((empty_slot >= 0) && (resource_memo == NULL)) {
                 int obs_slot = _find_observer(&observer, remote);


### PR DESCRIPTION
### Contribution description
With #9209 gCoAP got the ability to re-register and OBSERVE with a new token, sadly the `observer` variable wasn't set in that fix, so a re-registration actually led to the deletion of the observer (because it
is still `NULL` when the old registration is overwritten in [l. 317](https://github.com/RIOT-OS/RIOT/pull/9253/files#diff-9739e1bd2e91135c214745f71bc5c86aR317))

### Issues/PRs references
#9209 introduced this bug when making this situation possible in the first place

Fixes #9235.