### PR TITLE
sam0_common/i2c.c extra byte fix

### DIFF
--- a/boards/arduino-zero/include/periph_conf.h
+++ b/boards/arduino-zero/include/periph_conf.h
@@ -200,23 +200,21 @@ static const spi_conf_t spi_config[] = {
  * @name I2C configuration
  * @{
  */
-#define I2C_NUMOF          (1U)
-#define I2C_0_EN            1
-#define I2C_1_EN            0
-#define I2C_2_EN            0
-#define I2C_3_EN            0
-#define I2C_IRQ_PRIO        1
 
-#define I2C_0_DEV           SERCOM3->I2CM
-#define I2C_0_IRQ           SERCOM3_IRQn
-#define I2C_0_ISR           isr_sercom3
-/* I2C 0 GCLK */
-#define I2C_0_GCLK_ID       SERCOM3_GCLK_ID_CORE
-#define I2C_0_GCLK_ID_SLOW  SERCOM3_GCLK_ID_SLOW
-/* I2C 0 pin configuration */
-#define I2C_0_SDA           GPIO_PIN(PA, 22)
-#define I2C_0_SCL           GPIO_PIN(PA, 23)
-#define I2C_0_MUX           GPIO_MUX_C
+static const i2c_conf_t i2c_config[] = {
+    {
+        .dev      = &(SERCOM3->I2CM),
+        .speed    = I2C_SPEED_FAST,
+        .sda_pin  = GPIO_PIN(PA, 22),
+        .scl_pin  = GPIO_PIN(PA, 23),
+        .mux      = GPIO_MUX_C,
+        .gclk_src = GCLK_CLKCTRL_GEN_GCLK0,
+        .flags    = I2C_FLAG_NONE
+    }
+};
+
+#define I2C_NUMOF           (sizeof(i2c_config) / sizeof(i2c_config[0]))
+/** @} */
 
 /**
  * @name RTC configuration

--- a/boards/common/arduino-mkr/include/periph_conf.h
+++ b/boards/common/arduino-mkr/include/periph_conf.h
@@ -214,23 +214,18 @@ static const spi_conf_t spi_config[] = {
  * @name I2C configuration
  * @{
  */
-#define I2C_NUMOF          (1U)
-#define I2C_0_EN            1
-#define I2C_1_EN            0
-#define I2C_2_EN            0
-#define I2C_3_EN            0
-#define I2C_IRQ_PRIO        1
-
-#define I2C_0_DEV           SERCOM0->I2CM
-#define I2C_0_IRQ           SERCOM0_IRQn
-#define I2C_0_ISR           isr_sercom0
-/* I2C 0 GCLK */
-#define I2C_0_GCLK_ID       SERCOM0_GCLK_ID_CORE
-#define I2C_0_GCLK_ID_SLOW  SERCOM0_GCLK_ID_SLOW
-/* I2C 0 pin configuration */
-#define I2C_0_SDA           GPIO_PIN(PA, 8) /* SERCOM0-SDA, on-board pull-up */
-#define I2C_0_SCL           GPIO_PIN(PA, 9) /* SERCOM0-SCL, on-board pull-up */
-#define I2C_0_MUX           GPIO_MUX_C
+static const i2c_conf_t i2c_config[] = {
+    {
+        .dev      = &(SERCOM0->I2CM),
+        .speed    = I2C_SPEED_NORMAL,
+        .sda_pin  = GPIO_PIN(PA, 8),
+        .scl_pin  = GPIO_PIN(PA, 9),
+        .mux      = GPIO_MUX_C,
+        .gclk_src = GCLK_CLKCTRL_GEN_GCLK0,
+        .flags    = I2C_FLAG_NONE
+     }
+};
+#define I2C_NUMOF          (sizeof(i2c_config) / sizeof(i2c_config[0]))
 /** @} */
 
 /**

--- a/boards/feather-m0/include/periph_conf.h
+++ b/boards/feather-m0/include/periph_conf.h
@@ -208,23 +208,18 @@ static const spi_conf_t spi_config[] = {
  * @name    I2C configuration
  * @{
  */
-#define I2C_NUMOF           (1U)
-#define I2C_0_EN            1
-#define I2C_1_EN            0
-#define I2C_2_EN            0
-#define I2C_3_EN            0
-#define I2C_IRQ_PRIO        1
-
-#define I2C_0_DEV           SERCOM3->I2CM
-#define I2C_0_IRQ           SERCOM3_IRQn
-#define I2C_0_ISR           isr_sercom3
-/* I2C 0 GCLK */
-#define I2C_0_GCLK_ID       SERCOM3_GCLK_ID_CORE
-#define I2C_0_GCLK_ID_SLOW  SERCOM3_GCLK_ID_SLOW
-/* I2C 0 pin configuration */
-#define I2C_0_SDA           GPIO_PIN(PA, 22) /* SDA pin */
-#define I2C_0_SCL           GPIO_PIN(PA, 23) /* SCL pin */
-#define I2C_0_MUX           GPIO_MUX_C
+static const i2c_conf_t i2c_config[] = {
+    {
+        .dev      = &(SERCOM3->I2CM),
+        .speed    = I2C_SPEED_NORMAL,
+        .sda_pin  = GPIO_PIN(PA, 22),
+        .scl_pin  = GPIO_PIN(PA, 23),
+        .mux      = GPIO_MUX_C,
+        .gclk_src = GCLK_CLKCTRL_GEN_GCLK0,
+        .flags    = I2C_FLAG_NONE
+     }
+};
+#define I2C_NUMOF          (sizeof(i2c_config) / sizeof(i2c_config[0]))
 /** @} */
 
 /**

--- a/boards/samd21-xpro/include/periph_conf.h
+++ b/boards/samd21-xpro/include/periph_conf.h
@@ -240,23 +240,19 @@ static const spi_conf_t spi_config[] = {
  * @name I2C configuration
  * @{
  */
-#define I2C_NUMOF          (1U)
-#define I2C_0_EN            1
-#define I2C_1_EN            0
-#define I2C_2_EN            0
-#define I2C_3_EN            0
-#define I2C_IRQ_PRIO        1
-
-#define I2C_0_DEV           SERCOM2->I2CM
-#define I2C_0_IRQ           SERCOM2_IRQn
-#define I2C_0_ISR           isr_sercom2
-/* I2C 0 GCLK */
-#define I2C_0_GCLK_ID       SERCOM2_GCLK_ID_CORE
-#define I2C_0_GCLK_ID_SLOW  SERCOM2_GCLK_ID_SLOW
-/* I2C 0 pin configuration */
-#define I2C_0_SDA           GPIO_PIN(PA, 8)
-#define I2C_0_SCL           GPIO_PIN(PA, 9)
-#define I2C_0_MUX           GPIO_MUX_D
+static const i2c_conf_t i2c_config[] = {
+    {
+        .dev      = &(SERCOM2->I2CM),
+        .speed    = I2C_SPEED_NORMAL,
+        .sda_pin  = GPIO_PIN(PA, 8),
+        .scl_pin  = GPIO_PIN(PA, 9),
+        .mux      = GPIO_MUX_D,
+        .gclk_src = GCLK_CLKCTRL_GEN_GCLK0,
+        .flags    = I2C_FLAG_NONE
+     }
+};
+#define I2C_NUMOF          (sizeof(i2c_config) / sizeof(i2c_config[0]))
+/** @} */
 
 /**
  * @name RTC configuration

--- a/boards/saml21-xpro/include/periph_conf.h
+++ b/boards/saml21-xpro/include/periph_conf.h
@@ -108,23 +108,19 @@ static const spi_conf_t spi_config[] = {
  * @name    I2C configuration
  * @{
  */
-#define I2C_NUMOF          (1U)
-#define I2C_0_EN            1
-#define I2C_1_EN            0
-#define I2C_2_EN            0
-#define I2C_3_EN            0
-#define I2C_IRQ_PRIO        1
+static const i2c_conf_t i2c_config[] = {
+    {
+        .dev      = &(SERCOM2->I2CM),
+        .speed    = I2C_SPEED_NORMAL,
+        .sda_pin  = GPIO_PIN(PA, 8),
+        .scl_pin  = GPIO_PIN(PA, 9),
+        .mux      = GPIO_MUX_D,
+        .gclk_src = GCLK_PCHCTRL_GEN_GCLK0,
+        .flags    = I2C_FLAG_NONE
+    }
+};
 
-#define I2C_0_DEV           SERCOM2->I2CM
-#define I2C_0_IRQ           SERCOM2_IRQn
-#define I2C_0_ISR           isr_sercom2
-/* I2C 0 GCLK */
-#define I2C_0_GCLK_ID       SERCOM2_GCLK_ID_CORE
-#define I2C_0_GCLK_ID_SLOW  SERCOM2_GCLK_ID_SLOW
-/* I2C 0 pin configuration */
-#define I2C_0_SDA           GPIO_PIN(PA, 8)
-#define I2C_0_SCL           GPIO_PIN(PA, 9)
-#define I2C_0_MUX           GPIO_MUX_D
+#define I2C_NUMOF           (sizeof(i2c_config) / sizeof(i2c_config[0]))
 /** @} */
 
 /**

--- a/boards/samr21-xpro/include/periph_conf.h
+++ b/boards/samr21-xpro/include/periph_conf.h
@@ -211,23 +211,19 @@ static const spi_conf_t spi_config[] = {
  * @name    I2C configuration
  * @{
  */
-#define I2C_NUMOF          (1U)
-#define I2C_0_EN            1
-#define I2C_1_EN            0
-#define I2C_2_EN            0
-#define I2C_3_EN            0
-#define I2C_IRQ_PRIO        1
-
-#define I2C_0_DEV           SERCOM3->I2CM
-#define I2C_0_IRQ           SERCOM3_IRQn
-#define I2C_0_ISR           isr_sercom3
-/* I2C 0 GCLK */
-#define I2C_0_GCLK_ID       SERCOM3_GCLK_ID_CORE
-#define I2C_0_GCLK_ID_SLOW  SERCOM3_GCLK_ID_SLOW
-/* I2C 0 pin configuration */
-#define I2C_0_SDA           GPIO_PIN(PA, 16)
-#define I2C_0_SCL           GPIO_PIN(PA, 17)
-#define I2C_0_MUX           GPIO_MUX_D
+static const i2c_conf_t i2c_config[] = {
+    {
+        .dev      = &(SERCOM3->I2CM),
+        .speed    = I2C_SPEED_NORMAL,
+        .sda_pin  = GPIO_PIN(PA, 16),
+        .scl_pin  = GPIO_PIN(PA, 17),
+        .mux      = GPIO_MUX_D,
+        .gclk_src = GCLK_CLKCTRL_GEN_GCLK0,
+        .flags    = I2C_FLAG_NONE
+     }
+};
+#define I2C_NUMOF          (sizeof(i2c_config) / sizeof(i2c_config[0]))
+/** @} */
 
 /**
  * @name    RTC configuration

--- a/boards/sodaq-autonomo/include/periph_conf.h
+++ b/boards/sodaq-autonomo/include/periph_conf.h
@@ -213,23 +213,19 @@ static const spi_conf_t spi_config[] = {
  * @name    I2C configuration
  * @{
  */
-#define I2C_NUMOF           (1U)
-#define I2C_0_EN            1
-#define I2C_1_EN            0
-#define I2C_2_EN            0
-#define I2C_3_EN            0
-#define I2C_IRQ_PRIO        1
-
-#define I2C_0_DEV           SERCOM2->I2CM
-#define I2C_0_IRQ           SERCOM2_IRQn
-#define I2C_0_ISR           isr_sercom2
-/* I2C 0 GCLK */
-#define I2C_0_GCLK_ID       SERCOM2_GCLK_ID_CORE
-#define I2C_0_GCLK_ID_SLOW  SERCOM2_GCLK_ID_SLOW
-/* I2C 0 pin configuration */
-#define I2C_0_SDA           GPIO_PIN(PA, 12)
-#define I2C_0_SCL           GPIO_PIN(PA, 13)
-#define I2C_0_MUX           GPIO_MUX_C
+static const i2c_conf_t i2c_config[] = {
+    {
+        .dev      = &(SERCOM2->I2CM),
+        .speed    = I2C_SPEED_NORMAL,
+        .sda_pin  = GPIO_PIN(PA, 12),
+        .scl_pin  = GPIO_PIN(PA, 13),
+        .mux      = GPIO_MUX_C,
+        .gclk_src = GCLK_CLKCTRL_GEN_GCLK0,
+        .flags    = I2C_FLAG_NONE
+     }
+};
+#define I2C_NUMOF          (sizeof(i2c_config) / sizeof(i2c_config[0]))
+/** @} */
 
 /**
  * @name    RTC configuration

--- a/boards/sodaq-explorer/include/periph_conf.h
+++ b/boards/sodaq-explorer/include/periph_conf.h
@@ -196,34 +196,28 @@ static const spi_conf_t spi_config[] = {
  * @name I2C configuration
  * @{
  */
-#define I2C_NUMOF          (2U)
-#define I2C_0_EN            1
-#define I2C_1_EN            1
-#define I2C_2_EN            0
-#define I2C_3_EN            0
-#define I2C_IRQ_PRIO        1
+static const i2c_conf_t i2c_config[] = {
+    {
+        .dev      = &(SERCOM1->I2CM),
+        .speed    = I2C_SPEED_NORMAL,
+        .sda_pin  = GPIO_PIN(PA, 16),
+        .scl_pin  = GPIO_PIN(PA, 17),
+        .mux      = GPIO_MUX_C,
+        .gclk_src = GCLK_CLKCTRL_GEN_GCLK0,
+        .flags    = I2C_FLAG_NONE,
+    },
+    {
+        .dev      = &(SERCOM2->I2CM),
+        .speed    = I2C_SPEED_NORMAL,
+        .sda_pin  = GPIO_PIN(PA, 8),
+        .scl_pin  = GPIO_PIN(PA, 9),
+        .mux      = GPIO_MUX_C,
+        .gclk_src = GCLK_CLKCTRL_GEN_GCLK0,
+        .flags    = I2C_FLAG_NONE
+    }
+};
+#define I2C_NUMOF          (sizeof(i2c_config) / sizeof(i2c_config[0]))
 
-#define I2C_0_DEV           SERCOM1->I2CM
-#define I2C_0_IRQ           SERCOM1_IRQn
-#define I2C_0_ISR           isr_sercom1
-/* I2C 0 GCLK */
-#define I2C_0_GCLK_ID       SERCOM1_GCLK_ID_CORE
-#define I2C_0_GCLK_ID_SLOW  SERCOM1_GCLK_ID_SLOW
-/* I2C 0 pin configuration */
-#define I2C_0_SDA           GPIO_PIN(PA, 16)
-#define I2C_0_SCL           GPIO_PIN(PA, 17)
-#define I2C_0_MUX           GPIO_MUX_C
-
-#define I2C_1_DEV           SERCOM2->I2CM
-#define I2C_1_IRQ           SERCOM2_IRQn
-#define I2C_1_ISR           isr_sercom2
-/* I2C 1 GCLK */
-#define I2C_1_GCLK_ID       SERCOM2_GCLK_ID_CORE
-#define I2C_1_GCLK_ID_SLOW  SERCOM2_GCLK_ID_SLOW
-/* I2C 1 pin configuration */
-#define I2C_1_SDA           GPIO_PIN(PA, 8)
-#define I2C_1_SCL           GPIO_PIN(PA, 9)
-#define I2C_1_MUX           GPIO_MUX_C
 /** @} */
 
 /**

--- a/cpu/sam0_common/include/periph_cpu_common.h
+++ b/cpu/sam0_common/include/periph_cpu_common.h
@@ -15,6 +15,7 @@
  * @brief           Common CPU specific definitions for all SAMx21 based CPUs
  *
  * @author          Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author          Dylan Laduranty <dylan.laduranty@mesotic.com>
  */
 
 #ifndef PERIPH_CPU_COMMON_H
@@ -39,6 +40,16 @@ extern "C" {
 #define PERIPH_SPI_NEEDS_TRANSFER_BYTE
 #define PERIPH_SPI_NEEDS_TRANSFER_REG
 #define PERIPH_SPI_NEEDS_TRANSFER_REGS
+/** @} */
+
+/**
+ * @name   Use shared I2C functions
+ * @{
+ */
+#define PERIPH_I2C_NEED_READ_REG
+#define PERIPH_I2C_NEED_READ_REGS
+#define PERIPH_I2C_NEED_WRITE_REG
+#define PERIPH_I2C_NEED_WRITE_REGS
 /** @} */
 
 /**
@@ -231,6 +242,40 @@ typedef struct {
     spi_misopad_t miso_pad; /**< pad to use for MISO line */
     spi_mosipad_t mosi_pad; /**< pad to use for MOSI and CLK line */
 } spi_conf_t;
+/** @} */
+
+/**
+ * @brief   Available SERCOM I2C flag selections
+ */
+typedef enum {
+    I2C_FLAG_NONE            = 0x0,    /**< No flags set */
+    I2C_FLAG_RUN_STANDBY     = 0x1,    /**< run SERCOM in standby mode */
+} i2c_flag_t;
+
+/**
+ * @brief   Override I2C clock speed values
+ */
+#define HAVE_I2C_SPEED_T
+typedef enum {
+    I2C_SPEED_LOW       = 10000U,      /**< low speed mode:    ~10kbit/s */
+    I2C_SPEED_NORMAL    = 100000U,     /**< normal mode:       ~100kbit/s */
+    I2C_SPEED_FAST      = 400000U,     /**< fast mode:         ~400kbit/s */
+    I2C_SPEED_FAST_PLUS = 1000000U,    /**< fast plus mode:    ~1Mbit/s */
+    I2C_SPEED_HIGH      = 3400000U,    /**< high speed mode:   ~3.4Mbit/s */
+} i2c_speed_t;
+
+/**
+ * @brief   I2C device configuration
+ */
+typedef struct {
+    SercomI2cm *dev;        /**< pointer to the used I2C device */
+    i2c_speed_t speed;      /**< baudrate used for the bus */
+    gpio_t scl_pin;         /**< used SCL pin */
+    gpio_t sda_pin;         /**< used MOSI pin */
+    gpio_mux_t mux;         /**< alternate function (mux) */
+    uint8_t gclk_src;       /**< GCLK source which supplys SERCOM */
+    uint8_t flags;          /**< allow SERCOM to run in standby mode */
+} i2c_conf_t;
 
 /**
  * @brief   Set up alternate function (PMUX setting) for a PORT pin

--- a/cpu/sam0_common/periph/i2c.c
+++ b/cpu/sam0_common/periph/i2c.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2014 CLENET Baptiste
+ * Copyright (C) 2018 Mesotic SAS
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -16,6 +17,7 @@
  *
  * @author      Baptiste Clenet <bapclenet@gmail.com>
  * @author      Thomas Eichinger <thomas.eichinger@fu-berlin.de>
+ * @author      Dylan Laduranty <dylan.laduranty@mesotic.com>
  *
  * @}
  */
@@ -45,168 +47,121 @@
 #define SERCOM_I2CM_CTRLA_MODE_I2C_MASTER SERCOM_I2CM_CTRLA_MODE(5)
 #endif
 
-/* static function definitions */
-static void _i2c_poweron(SercomI2cm *sercom);
-static void _i2c_poweroff(SercomI2cm *sercom);
-
-static int _start(SercomI2cm *dev, uint8_t address, uint8_t rw_flag);
+static int _start(SercomI2cm *dev, uint16_t addr);
 static inline int _write(SercomI2cm *dev, const uint8_t *data, int length);
 static inline int _read(SercomI2cm *dev, uint8_t *data, int length);
 static inline void _stop(SercomI2cm *dev);
 static inline int _wait_for_response(SercomI2cm *dev, uint32_t max_timeout_counter);
+static void _i2c_poweron(i2c_t dev);
+static void _i2c_poweroff(i2c_t dev);
 
 /**
  * @brief Array holding one pre-initialized mutex for each I2C device
  */
-static mutex_t locks[] = {
-#if I2C_0_EN
-    [I2C_0] = MUTEX_INIT,
-#endif
-#if I2C_1_EN
-    [I2C_1] = MUTEX_INIT,
-#endif
-#if I2C_2_EN
-    [I2C_2] = MUTEX_INIT
-#endif
-#if I2C_3_EN
-    [I2C_3] = MUTEX_INIT
-#endif
-};
+static mutex_t locks[I2C_NUMOF];
 
-int i2c_init_master(i2c_t dev, i2c_speed_t speed)
+/**
+ * @brief   Shortcut for accessing the used I2C SERCOM device
+ */
+static inline SercomI2cm *bus(i2c_t dev)
 {
-    SercomI2cm *I2CSercom = 0;
-    gpio_t pin_scl = 0;
-    gpio_t pin_sda = 0;
-    gpio_mux_t mux;
-    uint32_t clock_source_speed = 0;
-    uint8_t sercom_gclk_id = 0;
-    uint8_t sercom_gclk_id_slow = 0;
+    return i2c_config[dev].dev;
+}
 
+int i2c_init(i2c_t dev)
+{
     uint32_t timeout_counter = 0;
     int32_t tmp_baud;
 
-    switch (dev) {
-#if I2C_0_EN
-        case I2C_0:
-            I2CSercom = &I2C_0_DEV;
-            pin_sda = I2C_0_SDA;
-            pin_scl = I2C_0_SCL;
-            mux = I2C_0_MUX;
-            clock_source_speed = CLOCK_CORECLOCK;
-            sercom_gclk_id = I2C_0_GCLK_ID;
-            sercom_gclk_id_slow = I2C_0_GCLK_ID_SLOW;
-            break;
-#endif
-        default:
-            DEBUG("I2C FALSE VALUE\n");
-            return -1;
-    }
-
-    /* HACK: fixes cppcheck issue until #7588 is merged. */
-    if (I2CSercom == NULL) {
-        return -1;
-    }
-
+    assert(dev < I2C_NUMOF);
+    /* Initiliaze mutex */
+    mutex_init(&locks[dev]);
     /* DISABLE I2C MASTER */
-    i2c_poweroff(dev);
+    _i2c_poweroff(dev);
 
     /* Reset I2C */
-    I2CSercom->CTRLA.reg = SERCOM_I2CS_CTRLA_SWRST;
-    while (I2CSercom->SYNCBUSY.reg & SERCOM_I2CM_SYNCBUSY_MASK) {}
+    bus(dev)->CTRLA.reg = SERCOM_I2CM_CTRLA_SWRST;
+    while (bus(dev)->SYNCBUSY.reg & SERCOM_I2CM_SYNCBUSY_MASK) {}
 
     /* Turn on power manager for sercom */
-#if CPU_FAM_SAML21
-    /* OK for SERCOM0-4 */
-    MCLK->APBCMASK.reg |= (MCLK_APBCMASK_SERCOM0 << (sercom_gclk_id - SERCOM0_GCLK_ID_CORE));
-#else
-    PM->APBCMASK.reg |= (PM_APBCMASK_SERCOM0 << (sercom_gclk_id - GCLK_CLKCTRL_ID_SERCOM0_CORE_Val));
-#endif
+    sercom_clk_en(bus(dev));
 
     /* I2C using CLK GEN 0 */
+    sercom_set_gen(bus(dev),i2c_config[dev].gclk_src);
 #if CPU_FAM_SAML21
-    GCLK->PCHCTRL[sercom_gclk_id].reg = (GCLK_PCHCTRL_CHEN |
-                         GCLK_PCHCTRL_GEN_GCLK0  );
-    while (GCLK->SYNCBUSY.bit.GENCTRL) {}
-
-    GCLK->PCHCTRL[sercom_gclk_id_slow].reg = (GCLK_PCHCTRL_CHEN |
-                         GCLK_PCHCTRL_GEN_GCLK0  );
+    /* GCLK_ID_SLOW is shared for SERCOM[0..4] */
+    GCLK->PCHCTRL[(sercom_id(bus(dev)) < 5 ?
+                  SERCOM0_GCLK_ID_SLOW : SERCOM5_GCLK_ID_SLOW)].reg =
+    (GCLK_PCHCTRL_CHEN | i2c_config[dev].gclk_src  );
     while (GCLK->SYNCBUSY.bit.GENCTRL) {}
 #else
+    /* GCLK_SERCOMx_SLOW is shared for all sercom */
     GCLK->CLKCTRL.reg = (GCLK_CLKCTRL_CLKEN |
-                         GCLK_CLKCTRL_GEN_GCLK0 |
-                         GCLK_CLKCTRL_ID(sercom_gclk_id));
-    while (GCLK->STATUS.bit.SYNCBUSY) {}
-
-    GCLK->CLKCTRL.reg = (GCLK_CLKCTRL_CLKEN |
-                         GCLK_CLKCTRL_GEN_GCLK0 |
-                         GCLK_CLKCTRL_ID(sercom_gclk_id_slow));
+                         i2c_config[dev].gclk_src |
+                         SERCOM0_GCLK_ID_SLOW);
     while (GCLK->STATUS.bit.SYNCBUSY) {}
 #endif
 
-
     /* Check if module is enabled. */
-    if (I2CSercom->CTRLA.reg & SERCOM_I2CM_CTRLA_ENABLE) {
+    if (bus(dev)->CTRLA.reg & SERCOM_I2CM_CTRLA_ENABLE) {
         DEBUG("STATUS_ERR_DENIED\n");
         return -3;
     }
     /* Check if reset is in progress. */
-    if (I2CSercom->CTRLA.reg & SERCOM_I2CM_CTRLA_SWRST) {
+    if (bus(dev)->CTRLA.reg & SERCOM_I2CM_CTRLA_SWRST) {
         DEBUG("STATUS_BUSY\n");
         return -3;
     }
 
     /************ SERCOM PAD0 - SDA and SERCOM PAD1 - SCL *************/
-    gpio_init_mux(pin_sda, mux);
-    gpio_init_mux(pin_scl, mux);
+    gpio_init_mux(i2c_config[dev].sda_pin, i2c_config[dev].mux);
+    gpio_init_mux(i2c_config[dev].scl_pin, i2c_config[dev].mux);
 
     /* I2C CONFIGURATION */
-    while (I2CSercom->SYNCBUSY.reg & SERCOM_I2CM_SYNCBUSY_MASK) {}
+    while (bus(dev)->SYNCBUSY.reg & SERCOM_I2CM_SYNCBUSY_MASK) {}
 
-    /* Set sercom module to operate in I2C master mode. */
-    I2CSercom->CTRLA.reg = SERCOM_I2CM_CTRLA_MODE_I2C_MASTER;
+    /* Set sercom module to operate in I2C master mode and run in Standby
+    if user requests it */
+    bus(dev)->CTRLA.reg = SERCOM_I2CM_CTRLA_MODE_I2C_MASTER |
+                          (i2c_config[dev].flags & I2C_FLAG_RUN_STANDBY ?
+                              SERCOM_I2CM_CTRLA_RUNSTDBY : 0);
 
     /* Enable Smart Mode (ACK is sent when DATA.DATA is read) */
-    I2CSercom->CTRLB.reg = SERCOM_I2CM_CTRLB_SMEN;
+    bus(dev)->CTRLB.reg = SERCOM_I2CM_CTRLB_SMEN;
 
     /* Find and set baudrate. Read speed configuration. Set transfer
      * speed: SERCOM_I2CM_CTRLA_SPEED(0): Standard-mode (Sm) up to 100
      * kHz and Fast-mode (Fm) up to 400 kHz */
-    switch (speed) {
+    switch (i2c_config[dev].speed) {
         case I2C_SPEED_NORMAL:
-            tmp_baud = (int32_t)(((clock_source_speed + (2 * (100000)) - 1) / (2 * (100000))) - 5);
-            if (tmp_baud < 255 && tmp_baud > 0) {
-                I2CSercom->CTRLA.reg |= SERCOM_I2CM_CTRLA_SPEED(0);
-                I2CSercom->BAUD.reg = SERCOM_I2CM_BAUD_BAUD(tmp_baud);
-            }
-            break;
         case I2C_SPEED_FAST:
-            tmp_baud = (int32_t)(((clock_source_speed + (2 * (400000)) - 1) / (2 * (400000))) - 5);
-            if (tmp_baud < 255 && tmp_baud > 0) {
-                I2CSercom->CTRLA.reg |= SERCOM_I2CM_CTRLA_SPEED(0);
-                I2CSercom->BAUD.reg = SERCOM_I2CM_BAUD_BAUD(tmp_baud);
-            }
+            bus(dev)->CTRLA.reg |= SERCOM_I2CM_CTRLA_SPEED(0);
             break;
         case I2C_SPEED_HIGH:
-            tmp_baud = (int32_t)(((clock_source_speed + (2 * (3400000)) - 1) / (2 * (3400000))) - 1);
-            if (tmp_baud < 255 && tmp_baud > 0) {
-                I2CSercom->CTRLA.reg |= SERCOM_I2CM_CTRLA_SPEED(2);
-                I2CSercom->BAUD.reg = SERCOM_I2CM_BAUD_HSBAUD(tmp_baud);
-            }
+            bus(dev)->CTRLA.reg |= SERCOM_I2CM_CTRLA_SPEED(2);
             break;
         default:
             DEBUG("BAD BAUDRATE\n");
             return -2;
     }
-
+    /* Get the baudrate */
+    tmp_baud = (int32_t)(((CLOCK_CORECLOCK +
+               (2 * (i2c_config[dev].speed)) - 1) /
+               (2 * (i2c_config[dev].speed))) -
+               (i2c_config[dev].speed == I2C_SPEED_HIGH ? 1 : 5));
+    /* Ensure baudrate is within limits */
+    if (tmp_baud < 255 && tmp_baud > 0) {
+        bus(dev)->BAUD.reg = SERCOM_I2CM_BAUD_BAUD(tmp_baud);
+    }
     /* ENABLE I2C MASTER */
-    i2c_poweron(dev);
+    _i2c_poweron(dev);
 
     /* Start timeout if bus state is unknown. */
-    while ((I2CSercom->STATUS.reg & SERCOM_I2CM_STATUS_BUSSTATE_Msk) == BUSSTATE_UNKNOWN) {
+    while ((bus(dev)->STATUS.reg &
+          SERCOM_I2CM_STATUS_BUSSTATE_Msk) == BUSSTATE_UNKNOWN) {
         if (timeout_counter++ >= SAMD21_I2C_TIMEOUT) {
             /* Timeout, force bus state to idle. */
-            I2CSercom->STATUS.reg = BUSSTATE_IDLE;
+            bus(dev)->STATUS.reg = BUSSTATE_IDLE;
         }
     }
     return 0;
@@ -214,196 +169,86 @@ int i2c_init_master(i2c_t dev, i2c_speed_t speed)
 
 int i2c_acquire(i2c_t dev)
 {
-    if (dev >= I2C_NUMOF) {
-        return -1;
-    }
+    assert(dev < I2C_NUMOF);
     mutex_lock(&locks[dev]);
     return 0;
 }
 
 int i2c_release(i2c_t dev)
 {
-    if (dev >= I2C_NUMOF) {
-        return -1;
-    }
+    assert(dev < I2C_NUMOF);
     mutex_unlock(&locks[dev]);
     return 0;
 }
 
-int i2c_read_byte(i2c_t dev, uint8_t address, void *data)
+int i2c_read_bytes(i2c_t dev, uint16_t addr,
+                   void *data, size_t len, uint8_t flags)
 {
-    return i2c_read_bytes(dev, address, data, 1);
-}
+    assert(dev < I2C_NUMOF);
 
-int i2c_read_bytes(i2c_t dev, uint8_t address, void *data, int length)
-{
-    SercomI2cm *i2c;
-
-    switch (dev) {
-#if I2C_0_EN
-        case I2C_0:
-            i2c = &I2C_0_DEV;
-            break;
-#endif
-        default:
-            return -1;
-    }
-
-    /* start transmission and send slave address */
-    if (_start(i2c, address, I2C_FLAG_READ) < 0) {
-        return 0;
+    if (!(flags & I2C_NOSTART)) {
+        /* start transmission and send slave address */
+        if (_start(bus(dev), (addr << 1) | I2C_READ) < 0) {
+            DEBUG("Start command failed\n");
+            return 0;
+        }
     }
     /* read data to register */
-    if (_read(i2c, data, length) < 0) {
+    if (_read(bus(dev), data, len) < 0) {
+        DEBUG("Read command failed\n");
         return 0;
     }
-    _stop(i2c);
+    if (!(flags & I2C_NOSTOP)) {
+        _stop(bus(dev));
+    }
     /* return number of bytes sent */
-    return length;
+    return len;
 }
 
-int i2c_read_reg(i2c_t dev, uint8_t address, uint8_t reg, void *data)
+int i2c_write_bytes(i2c_t dev, uint16_t addr, const void *data, size_t len,
+                    uint8_t flags)
 {
-    return i2c_read_regs(dev, address, reg, data, 1);
+    assert(dev < I2C_NUMOF);
+
+    if (!(flags & I2C_NOSTART)) {
+        if (_start(bus(dev), (addr<<1)) < 0) {
+            DEBUG("Start command failed\n");
+            return 0;
+        }
+    }
+    if (_write(bus(dev), data, len) < 0) {
+        DEBUG("Write command failed\n");
+        return 0;
+    }
+    if (!(flags & I2C_NOSTOP)) {
+        _stop(bus(dev));
+    }
+    return len;
 }
 
-int i2c_read_regs(i2c_t dev, uint8_t address, uint8_t reg, void *data, int length)
+void _i2c_poweron(i2c_t dev)
 {
-    SercomI2cm *i2c;
+    assert(dev < I2C_NUMOF);
 
-    switch (dev) {
-#if I2C_0_EN
-        case I2C_0:
-            i2c = &I2C_0_DEV;
-            break;
-#endif
-        default:
-            return -1;
-    }
-
-    /* start transmission and send slave address */
-    if (_start(i2c, address, I2C_FLAG_WRITE) < 0) {
-        return 0;
-    }
-    /* send register address/command and wait for complete transfer to
-     * be finished */
-    if (_write(i2c, &reg, 1) < 0) {
-        return 0;
-    }
-    return i2c_read_bytes(dev, address, data, length);
-}
-
-int i2c_write_byte(i2c_t dev, uint8_t address, uint8_t data)
-{
-    return i2c_write_bytes(dev, address, &data, 1);
-}
-
-int i2c_write_bytes(i2c_t dev, uint8_t address, const void *data, int length)
-{
-    SercomI2cm *I2CSercom;
-
-    switch (dev) {
-#if I2C_0_EN
-        case I2C_0:
-            I2CSercom = &I2C_0_DEV;
-            break;
-#endif
-        default:
-            return -1;
-    }
-
-    if (_start(I2CSercom, address, I2C_FLAG_WRITE) < 0) {
-        return 0;
-    }
-    if (_write(I2CSercom, data, length) < 0) {
-        return 0;
-    }
-    _stop(I2CSercom);
-    return length;
-}
-
-
-int i2c_write_reg(i2c_t dev, uint8_t address, uint8_t reg, uint8_t data)
-{
-    return i2c_write_regs(dev, address, reg, &data, 1);
-}
-
-int i2c_write_regs(i2c_t dev, uint8_t address, uint8_t reg, const void *data, int length)
-{
-    SercomI2cm *i2c;
-
-    switch (dev) {
-#if I2C_0_EN
-        case I2C_0:
-            i2c = &I2C_0_DEV;
-            break;
-#endif
-        default:
-            return -1;
-    }
-
-    /* start transmission and send slave address */
-    if (_start(i2c, address, I2C_FLAG_WRITE) < 0) {
-        return 0;
-    }
-    /* send register address and wait for complete transfer to be finished */
-    if (_write(i2c, &reg, 1) < 0) {
-        return 0;
-    }
-    /* write data to register */
-    if (_write(i2c, data, length) < 0) {
-        return 0;
-    }
-    /* finish transfer */
-    _stop(i2c);
-    return length;
-}
-
-static void _i2c_poweron(SercomI2cm *sercom)
-{
-    if (sercom == NULL) {
+    if (bus(dev) == NULL) {
         return;
     }
-    sercom->CTRLA.bit.ENABLE = 1;
-    while (sercom->SYNCBUSY.bit.ENABLE) {}
+    bus(dev)->CTRLA.bit.ENABLE = 1;
+    while (bus(dev)->SYNCBUSY.bit.ENABLE) {}
 }
 
-void i2c_poweron(i2c_t dev)
+void _i2c_poweroff(i2c_t dev)
 {
-    switch (dev) {
-#if I2C_0_EN
-        case I2C_0:
-            _i2c_poweron(&I2C_0_DEV);
-            break;
-#endif
-        default:
-            return;
-    }
-}
+    assert(dev < I2C_NUMOF);
 
-static void _i2c_poweroff(SercomI2cm *sercom)
-{
-    if (sercom == NULL) {
+    if (bus(dev) == NULL) {
         return;
     }
-    sercom->CTRLA.bit.ENABLE = 0;
-    while (sercom->SYNCBUSY.bit.ENABLE) {}
+    bus(dev)->CTRLA.bit.ENABLE = 0;
+    while (bus(dev)->SYNCBUSY.bit.ENABLE) {}
 }
 
-void i2c_poweroff(i2c_t dev)
-{
-    switch (dev) {
-#if I2C_0_EN
-        case I2C_0:
-            _i2c_poweroff(&I2C_0_DEV);
-            break;
-#endif
-        default:
-            return;
-    }
-}
-
-static int _start(SercomI2cm *dev, uint8_t address, uint8_t rw_flag)
+static int _start(SercomI2cm *dev, uint16_t addr)
 {
     /* Wait for hardware module to sync */
     DEBUG("Wait for device to be ready\n");
@@ -414,10 +259,10 @@ static int _start(SercomI2cm *dev, uint8_t address, uint8_t rw_flag)
 
     /* Send Start | Address | Write/Read */
     DEBUG("Generate start condition by sending address\n");
-    dev->ADDR.reg = (address << 1) | rw_flag | (0 << SERCOM_I2CM_ADDR_HS_Pos);
+    dev->ADDR.reg = (addr) | (0 << SERCOM_I2CM_ADDR_HS_Pos);
 
     /* Wait for response on bus. */
-    if (rw_flag == I2C_FLAG_READ) {
+    if (addr & I2C_READ) {
         /* Some devices (e.g. SHT2x) can hold the bus while preparing the reply */
         if (_wait_for_response(dev, 100 * SAMD21_I2C_TIMEOUT) < 0)
             return -1;


### PR DESCRIPTION
### Contribution description
This PR provides a workaround for the SAMR I2C reading an extra byte (based on hardware defined in datasheet page 513 or 514).  It also is updates the return values to the error code in the API rework.  It is based off of @dylad PR #9198 and is needed for the periph_i2c in PR #9168 to test it.  That only file that was worked on when diff with #9198 is the cpu/sam0_common/periph/i2c.c

### Issues/PRs references
Issue: #6577 
Based from #9198 
Needed for #9168 
[samr21 datasheet](http://ww1.microchip.com/downloads/en/DeviceDoc/SAM-R21_Datasheet.pdf)