### PR TITLE
pic32-wifire: add support for flashing with pic32prog

### DIFF
--- a/boards/pic32-wifire/Makefile.include
+++ b/boards/pic32-wifire/Makefile.include
@@ -3,4 +3,8 @@ export CPU_MODEL=p32mz2048efg100
 export APPDEPS += $(RIOTCPU)/$(CPU)/$(CPU_MODEL)/$(CPU_MODEL).S
 export USE_UHI_SYSCALLS = 1
 
+PORT_LINUX ?= /dev/ttyUSB0
+BAUD ?= 9600
+include $(RIOTMAKE)/tools/serial.inc.mk
+
 FLASHFILE ?= $(HEXFILE)

--- a/boards/pic32-wifire/Makefile.include
+++ b/boards/pic32-wifire/Makefile.include
@@ -7,4 +7,13 @@ PORT_LINUX ?= /dev/ttyUSB0
 BAUD ?= 9600
 include $(RIOTMAKE)/tools/serial.inc.mk
 
-FLASHFILE ?= $(HEXFILE)
+# pic32prog
+#
+# For PICkit3:
+#
+# * Connect the chipKIT-Wi-Fire to USB
+# * Connect the PICkit3 to ICSP holes
+# * https://docs.creatordev.io/wifire/guides/wifire-programming/
+# * The triangle `▶` goes into the port number 1 (a hole with a square around it)
+#   opposite side of the JP1 ICSP text.
+include $(RIOTMAKE)/tools/pic32prog.inc.mk

--- a/dist/tools/pic32prog/.gitignore
+++ b/dist/tools/pic32prog/.gitignore
@@ -1,0 +1,2 @@
+pic32prog
+bin/

--- a/dist/tools/pic32prog/Makefile
+++ b/dist/tools/pic32prog/Makefile
@@ -1,0 +1,19 @@
+PKG_NAME     = pic32prog
+PKG_URL      = https://github.com/sergev/pic32prog
+PKG_VERSION  = b9f8db3b352804392b02b42475fc42874ac8bf04
+PKG_LICENSE  = GPL-2
+PKG_BUILDDIR = bin
+
+# Building it requires some dependencies, on ubuntu:
+#
+#     sudo apt-get install libusb-dev libusb-1.0-0-dev libudev-dev
+
+all: git-download
+	@echo "[INFO] compiling pic32prog from source now"
+	@env -i PATH=$(PATH) TERM=$(TERM) make -C $(PKG_BUILDDIR)
+	@mv $(PKG_BUILDDIR)/pic32prog pic32prog
+
+distclean::
+	@rm -f pic32prog
+
+include $(RIOTBASE)/pkg/pkg.mk

--- a/makefiles/tools/pic32prog.inc.mk
+++ b/makefiles/tools/pic32prog.inc.mk
@@ -1,0 +1,34 @@
+# pic32prog flasher
+# =================
+#
+# https://github.com/sergev/pic32prog
+#
+# Allow flashing pic32 boards using:
+#  * Microchip PICkit2
+#  * Microchip PICkit3 with script firmware
+#
+#
+# PICkit-3
+# --------
+#
+# This requires changing the firmware to 'scripting mode'
+# Should be done from a Windows computer/virtual machine as described here
+#
+# https://github.com/RIOT-OS/RIOT/blob/master/dist/tools/pic32prog/doc.md
+
+RIOT_PIC32PROG = $(RIOTTOOLS)/pic32prog/pic32prog
+PIC32PROG ?= $(RIOT_PIC32PROG)
+
+FLASHFILE ?= $(HEXFILE)
+
+FLASHER ?= $(PIC32PROG)
+FFLAGS  ?= $(FLASHFILE)
+
+# No reset command, but the board resets on terminal open
+RESET ?=
+RESET_FLAGS ?=
+
+# Compile pic32prog if using the one provided in RIOT
+ifeq ($(PIC32PROG),$(RIOT_PIC32PROG))
+  FLASHDEPS += $(RIOT_PIC32PROG)
+endif

--- a/makefiles/tools/pic32prog.inc.mk
+++ b/makefiles/tools/pic32prog.inc.mk
@@ -15,6 +15,18 @@
 # Should be done from a Windows computer/virtual machine as described here
 #
 # https://github.com/RIOT-OS/RIOT/blob/master/dist/tools/pic32prog/doc.md
+#
+#
+# Udev rule
+# ---------
+#
+# Add yourself to the `plugdev` group, add the following `udev` rule to
+# `/etc/udev/rules.d/26-microchip.rules` and reboot.
+#
+# ```
+# # Adapted from http://en.microstickplus.com/mplabx-on-linux
+# ATTR{idVendor}=="04d8", MODE="664", GROUP="plugdev"
+# ```
 
 RIOT_PIC32PROG = $(RIOTTOOLS)/pic32prog/pic32prog
 PIC32PROG ?= $(RIOT_PIC32PROG)

--- a/makefiles/tools/targets.inc.mk
+++ b/makefiles/tools/targets.inc.mk
@@ -12,6 +12,11 @@ $(RIOTTOOLS)/bossa/bossac:
 	@make -C $(RIOTTOOLS)/bossa
 	@echo "[INFO] bossac binary successfully build!"
 
+$(RIOTTOOLS)/pic32prog/pic32prog: $(RIOTTOOLS)/pic32prog/Makefile
+	@echo "[INFO] $(@F) binary not found - building it from source now"
+	make -C $(@D)
+	@echo "[INFO] $(@F) binary successfully build!"
+
 $(RIOTTOOLS)/edbg/edbg: $(RIOTTOOLS)/edbg/Makefile
 	@echo "[INFO] edbg binary not found - building it from source now"
 	CC= CFLAGS= make -C $(RIOTTOOLS)/edbg


### PR DESCRIPTION
### Contribution description

Add `flash` support for pic32-wifire using `pic32prog`.

Also enable `term` and a dummy `reset` as not supported.
However, connecting to the `uart` already does a reset.

It was tested with a `PICkit3` whose firmware was updated to scripting mode as described here https://github.com/RIOT-OS/RIOT/pull/6092#issuecomment-261987955

A documentation will follow in another PR on the update procedure I used
-> https://github.com/RIOT-OS/RIOT/pull/9260


I am compiling pic32prog from source as it is done for the other tools even if some binaries are available in https://github.com/sergev/pic32prog. I thought it was easier and safer.

### pic32-clicker

Regarding pic32-clicker, it requires a specific way for plugging the flasher (crossing cables) so it would come in a separate PR, also the uart is not available on the USB port directly, so would be another job.


### Testing

Having a PICkit3 flashed with the scripting firmware, connect everything.
```
make BOARD=pic32-wifire flash reset term
```

Despite not having a proper `reset` test can run as `make term` reboots the node.

```
make -C tests/mutex_order BOARD=pic32-wifire flash test
...
2018-05-31 17:22:46,362 - INFO # Test END, check the order of priorities above.
```

Interactive tests do not work as received bytes (uart led is indeed linking) are not given to the shell.


### Issues/PRs references

https://github.com/RIOT-OS/RIOT/pull/6092#issuecomment-261987955

Depends on https://github.com/RIOT-OS/RIOT/pull/9260 for the documentation to be accessible.