### PR TITLE
dist/tools/doccheck: add check for undefined groups

### DIFF
--- a/dist/tools/doccheck/check.sh
+++ b/dist/tools/doccheck/check.sh
@@ -1,6 +1,8 @@
-#!/bin/sh
+#!/usr/bin/env bash
 
 # Copyright 2014 Oliver Hahm <oliver.hahm@inria.fr>
+#           2018 Kaspar Schleiser <kaspar@schleiser.de>
+#           2018 Alexandre Abadie <alexandre.abadie@inria.fr>
 #
 # This file is subject to the terms and conditions of the GNU Lesser
 # General Public License v2.1. See the file LICENSE in the top level
@@ -8,15 +10,61 @@
 
 RIOTBASE=$(readlink -f "$(dirname $(realpath $0))/../../..")
 
+if tput colors &> /dev/null && [ $(tput colors) -ge 8 ]; then
+    CERROR="\e[1;31m"
+    CWARN="\033[1;33m"
+    CRESET="\e[0m"
+else
+    CERROR=
+    CWARN=
+    CRESET=
+fi
+
 ERRORS=$(make -C "${RIOTBASE}" doc 2>&1 | \
             grep '.*warning' | \
             sed "s#${PWD}/\([^:]*\)#\1#g")
 
 if [ -n "${ERRORS}" ]
 then
-    echo "ERROR: Doxygen generates the following warnings:"
+    echo -e "${CERROR}ERROR: Doxygen generates the following warnings:${CRESET}"
     echo "${ERRORS}"
     exit 2
-else
-    exit 0
+fi
+
+exclude_filter() {
+    grep -v -e vendor -e examples -e tests
+}
+
+# Check all groups are defined
+DEFINED_GROUPS=$(git grep @defgroup -- '*.h' '*.c' '*.txt' | \
+                    exclude_filter | \
+                    grep -oE '@defgroup[ ]+[^ ]+' | \
+                    grep -oE '[^ ]+$' | sort -u)
+
+UNDEFINED_GROUPS=$( \
+    for group in $(git grep '@ingroup' -- '*.h' '*.c' '*.txt' | \
+                    exclude_filter | \
+                    grep -oE '[^ ]+$' | sort -u); \
+    do \
+        echo "${DEFINED_GROUPS}" | grep -xq "${group}" || echo "${group}"; \
+    done \
+    )
+
+ALL_RAW_INGROUP=$(git grep '@ingroup' -- '*.h' '*.c' '*.txt' | exclude_filter)
+
+UNDEFINED_GROUPS_PRINT=$( \
+    for group in ${UNDEFINED_GROUPS}; \
+    do \
+        echo -e "\n${CWARN}${group}${CRESET} found in:"; \
+        echo "${ALL_RAW_INGROUP}" | grep "\<${group}\>$" | sort -u | \
+                awk -F: '{ print "\t" $1 }'; \
+    done \
+    )
+
+if [ -n "${UNDEFINED_GROUPS}" ]
+then
+    COUNT=$(echo "${UNDEFINED_GROUPS}" | wc -l)
+    echo -ne "${CWARN}WARNING${CRESET} "
+    echo -e "There are ${CWARN}${COUNT}${CRESET} undefined Doxygen groups:"
+    echo "${UNDEFINED_GROUPS_PRINT}"
 fi


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

As requested in #9264, this PR update the doxygen check script with a check on undefined groups.

For the moment, it's run only if doxygen documentation passes without error and it always returns 0. The undefined groups are printed with a warning message at the beginning.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

Related to #9264 and #8972

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->