### PR TITLE
drivers/fxos8700: adapt to new i2c API

### DIFF
--- a/drivers/fxos8700/fxos8700.c
+++ b/drivers/fxos8700/fxos8700.c
@@ -29,7 +29,7 @@
 static int fxos8700_read_regs(const fxos8700_t* dev, uint8_t reg, uint8_t* data, size_t len)
 {
     i2c_acquire(dev->p.i2c);
-    if (i2c_read_regs(dev->p.i2c, dev->p.addr, reg, (char*) data, len) <= 0) {
+    if (i2c_read_regs(dev->p.i2c, dev->p.addr, reg, (char*) data, len, 0) < 0) {
         DEBUG("[fxos8700] Can't read register 0x%x\n", reg);
         i2c_release(dev->p.i2c);
         return FXOS8700_BUSERR;
@@ -42,7 +42,7 @@ static int fxos8700_read_regs(const fxos8700_t* dev, uint8_t reg, uint8_t* data,
 static int fxos8700_write_regs(const fxos8700_t* dev, uint8_t reg, uint8_t* data, size_t len)
 {
     i2c_acquire(dev->p.i2c);
-    if (i2c_write_regs(dev->p.i2c, dev->p.addr, reg, (char*) data, len) <= 0) {
+    if (i2c_write_regs(dev->p.i2c, dev->p.addr, reg, (char*) data, len, 0) < 0) {
         DEBUG("[fxos8700] Can't write to register 0x%x\n", reg);
         i2c_release(dev->p.i2c);
         return FXOS8700_BUSERR;
@@ -66,13 +66,8 @@ int fxos8700_init(fxos8700_t* dev, const fxos8700_params_t *params)
     dev->p.renew_interval = params->renew_interval;
 
     i2c_acquire(dev->p.i2c);
-    if (i2c_init_master(dev->p.i2c, I2C_SPEED) != 0) {
-        DEBUG("[fxos8700] Can't initialize I2C master\n");
-        i2c_release(dev->p.i2c);
-        return FXOS8700_NOBUS;
-    }
 
-    if (i2c_read_regs(dev->p.i2c, dev->p.addr, FXOS8700_REG_WHO_AM_I, &config, 1) <= 0) {
+    if (i2c_read_regs(dev->p.i2c, dev->p.addr, FXOS8700_REG_WHO_AM_I, &config, 1, 0) < 0) {
         i2c_release(dev->p.i2c);
         DEBUG("[fxos8700] Could not read WHOAMI\n");
         return FXOS8700_NOBUS;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Adapt drivers/fxos8700 to new i2c API
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

#6577 