### PR TITLE
drivers/hih6130: adapt to new i2c API

### DIFF
--- a/drivers/hih6130/hih6130.c
+++ b/drivers/hih6130/hih6130.c
@@ -60,7 +60,7 @@ static inline int hih6130_measurement_request(const hih6130_t *dev)
     i2c_acquire(dev->i2c);
 
     /* An empty write request triggers a new measurement */
-    if (i2c_write_bytes(dev->i2c, dev->addr, NULL, 0) < 0) {
+    if (i2c_write_bytes(dev->i2c, dev->addr, NULL, 0, 0) < 0) {
         i2c_release(dev->i2c);
         return -1;
     }
@@ -84,7 +84,7 @@ static inline int hih6130_get_humidity_temperature_raw(const hih6130_t *dev, uin
 
     i2c_acquire(dev->i2c);
 
-    if (i2c_read_bytes(dev->i2c, dev->addr, &buf[0], sizeof(buf)) != sizeof(buf)) {
+    if (i2c_read_bytes(dev->i2c, dev->addr, &buf[0], sizeof(buf), 0) < 0) {
         i2c_release(dev->i2c);
         return -1;
     }

--- a/tests/driver_hih6130/main.c
+++ b/tests/driver_hih6130/main.c
@@ -39,12 +39,6 @@ int main(void)
     hih6130_t dev;
 
     puts("HIH6130 sensor driver test application\n");
-    printf("Initializing I2C_%i... ", TEST_HIH6130_I2C);
-    if (i2c_init_master(TEST_HIH6130_I2C, I2C_SPEED_FAST) < 0) {
-        puts("[Failed]");
-        return -1;
-    }
-    puts("[OK]");
 
     printf("Initializing HIH6130 sensor at I2C_%i, address 0x%02x... ",
         TEST_HIH6130_I2C, TEST_HIH6130_ADDR);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Adapt drivers/hih6130 to new i2c API


### Issues/PRs references

#6577 