### PR TITLE
examples/gnrc_border_router: fix path to uhcpd in README

### DIFF
--- a/examples/gnrc_border_router/README.md
+++ b/examples/gnrc_border_router/README.md
@@ -20,7 +20,7 @@ make clean all
 ```
 
 Then, you need to compile UHCP.
-This tool is found in `/dist/tools/uhcp`. So, as for `ethos`:
+This tool is found in `/dist/tools/uhcpd`. So, as for `ethos`:
 
 ```bash
 make clean all


### PR DESCRIPTION
examples/gnrc_border_router: fix path to uhcpd in README
