### PR TITLE
periph_common/I2C: introduce new return codes scheme

### DIFF
--- a/drivers/include/periph/i2c.h
+++ b/drivers/include/periph/i2c.h
@@ -193,38 +193,6 @@ typedef enum {
 /** @} */
 
 /**
- * @brief   I2C transfer results
- */
-enum {
-    /**
-     * @brief   All bytes were transferred successfully
-     */
-    I2C_ACK = 0,
-    /**
-     * @brief   NACK when transferring the address byte
-     *
-     * After the address + the read/write bit were send, we got an NACK as
-     * response. This means most probably, that there is no slave with the used
-     * address on the bus, or the slave did just not respond for some reason.
-     */
-    I2C_ADDR_NACK = -1,
-    /**
-     * @brief   NACK while writing data bytes
-     *
-     * The slave responded to a data byte written to it with a NACK.
-     */
-    I2C_DATA_NACK = -2,
-     /**
-      * @brief   Internal error
-      *
-      * This status code is returned, on any other internal error that might
-      * have occurred. Possible reasons are not supported modes (e.g. 10-bit
-      * addressing).
-      */
-    I2C_ERR = -3
-};
-
-/**
  * @brief   Initialize the given I2C bus
  *
  * The given I2C device will be initialized with the parameters as specified in
@@ -272,9 +240,13 @@ int i2c_release(i2c_t dev);
  * @param[out] data         memory location to store received data
  * @param[in]  flags        optional flags (see @ref i2c_flags_t)
  *
- * @return                  I2C_ACK on successful transfer of @p len byte
- * @return                  I2C_ADDR_NACK if response to address byte was NACK
- * @return                  I2C_ERR for any other error
+ * @return                  0 When success
+ * @return                  -EIO When slave device doesn't ACK the byte
+ * @return                  -ENXIO When no devices respond on the address sent on the bus
+ * @return                  -ETIMEDOUT  When timeout occurs before device's response
+ * @return                  -EINVAL When an invalid argument is given
+ * @return                  -EOPNOTSUPP When MCU driver doesn't support the flag operation
+ * @return                  -EAGAIN When a lost bus arbitration occurs
  */
 
 int i2c_read_reg(i2c_t dev, uint16_t addr, uint16_t reg,
@@ -295,9 +267,13 @@ int i2c_read_reg(i2c_t dev, uint16_t addr, uint16_t reg,
  * @param[in]  len          the number of bytes to read into @p data
  * @param[in]  flags        optional flags (see @ref i2c_flags_t)
  *
- * @return                  I2C_ACK on successful transfer of @p len byte
- * @return                  I2C_ADDR_NACK if response to address byte was NACK
- * @return                  I2C_ERR for any other error
+ * @return                  0 When success
+ * @return                  -EIO When slave device doesn't ACK the byte
+ * @return                  -ENXIO When no devices respond on the address sent on the bus
+ * @return                  -ETIMEDOUT  When timeout occurs before device's response
+ * @return                  -EINVAL When an invalid argument is given
+ * @return                  -EOPNOTSUPP When MCU driver doesn't support the flag operation
+ * @return                  -EAGAIN When a lost bus arbitration occurs
  */
 int i2c_read_regs(i2c_t dev, uint16_t addr, uint16_t reg,
                   void *data, size_t len, uint8_t flags);
@@ -313,9 +289,13 @@ int i2c_read_regs(i2c_t dev, uint16_t addr, uint16_t reg,
  * @param[out] data         memory location to store received data
  * @param[in]  flags        optional flags (see @ref i2c_flags_t)
  *
- * @return                  I2C_ACK on successful transfer of @p len byte
- * @return                  I2C_ADDR_NACK if response to address byte was NACK
- * @return                  I2C_ERR for any other error
+ * @return                  0 When success
+ * @return                  -EIO When slave device doesn't ACK the byte
+ * @return                  -ENXIO When no devices respond on the address sent on the bus
+ * @return                  -ETIMEDOUT  When timeout occurs before device's response
+ * @return                  -EINVAL When an invalid argument is given
+ * @return                  -EOPNOTSUPP When MCU driver doesn't support the flag operation
+ * @return                  -EAGAIN When a lost bus arbitration occurs
  */
 
 int i2c_read_byte(i2c_t dev, uint16_t addr, void *data, uint8_t flags);
@@ -332,9 +312,13 @@ int i2c_read_byte(i2c_t dev, uint16_t addr, void *data, uint8_t flags);
  * @param[in]  len          the number of bytes to read into @p data
  * @param[in]  flags        optional flags (see @ref i2c_flags_t)
  *
- * @return                  I2C_ACK on successful transfer of @p len byte
- * @return                  I2C_ADDR_NACK if response to address byte was NACK
- * @return                  I2C_ERR for any other error
+ * @return                  0 When success
+ * @return                  -EIO When slave device doesn't ACK the byte
+ * @return                  -ENXIO When no devices respond on the address sent on the bus
+ * @return                  -ETIMEDOUT  When timeout occurs before device's response
+ * @return                  -EINVAL When an invalid argument is given
+ * @return                  -EOPNOTSUPP When MCU driver doesn't support the flag operation
+ * @return                  -EAGAIN When a lost bus arbitration occurs
  */
 
 int i2c_read_bytes(i2c_t dev, uint16_t addr,
@@ -348,10 +332,13 @@ int i2c_read_bytes(i2c_t dev, uint16_t addr,
  * @param[in] data          byte to write to the device
  * @param[in] flags         optional flags (see @ref i2c_flags_t)
  *
- * @return                  I2C_ACK on successful transfer of @p data
- * @return                  I2C_ADDR_NACK if response to address byte was NACK
- * @return                  I2C_DATA_NACK if response to the data byte was NACK
- * @return                  I2C_ERR for any other error
+ * @return                  0 When success
+ * @return                  -EIO When slave device doesn't ACK the byte
+ * @return                  -ENXIO When no devices respond on the address sent on the bus
+ * @return                  -ETIMEDOUT  When timeout occurs before device's response
+ * @return                  -EINVAL When an invalid argument is given
+ * @return                  -EOPNOTSUPP When MCU driver doesn't support the flag operation
+ * @return                  -EAGAIN When a lost bus arbitration occurs
  */
 int i2c_write_byte(i2c_t dev, uint16_t addr, uint8_t data, uint8_t flags);
 
@@ -364,10 +351,13 @@ int i2c_write_byte(i2c_t dev, uint16_t addr, uint8_t data, uint8_t flags);
  * @param[in] len           the number of bytes to write
  * @param[in] flags         optional flags (see @ref i2c_flags_t)
  *
- * @return                  I2C_ACK on successful transfer of @p data
- * @return                  I2C_ADDR_NACK if response to address byte was NACK
- * @return                  I2C_DATA_NACK if response to the data byte was NACK
- * @return                  I2C_ERR for any other error
+ * @return                  0 When success
+ * @return                  -EIO When slave device doesn't ACK the byte
+ * @return                  -ENXIO When no devices respond on the address sent on the bus
+ * @return                  -ETIMEDOUT  When timeout occurs before device's response
+ * @return                  -EINVAL When an invalid argument is given
+ * @return                  -EOPNOTSUPP When MCU driver doesn't support the flag operation
+ * @return                  -EAGAIN When a lost bus arbitration occurs
  */
 int i2c_write_bytes(i2c_t dev, uint16_t addr, const void *data,
                     size_t len, uint8_t flags);
@@ -386,10 +376,13 @@ int i2c_write_bytes(i2c_t dev, uint16_t addr, const void *data,
  * @param[in]  data         byte to write
  * @param[in]  flags        optional flags (see @ref i2c_flags_t)
  *
- * @return                  I2C_ACK on successful transfer of @p data
- * @return                  I2C_ADDR_NACK if response to address byte was NACK
- * @return                  I2C_DATA_NACK if response to the data byte was NACK
- * @return                  I2C_ERR for any other error
+ * @return                  0 When success
+ * @return                  -EIO When slave device doesn't ACK the byte
+ * @return                  -ENXIO When no devices respond on the address sent on the bus
+ * @return                  -ETIMEDOUT  When timeout occurs before device's response
+ * @return                  -EINVAL When an invalid argument is given
+ * @return                  -EOPNOTSUPP When MCU driver doesn't support the flag operation
+ * @return                  -EAGAIN When a lost bus arbitration occurs
  */
 int i2c_write_reg(i2c_t dev, uint16_t addr, uint16_t reg,
                   uint8_t data, uint8_t flags);
@@ -408,10 +401,13 @@ int i2c_write_reg(i2c_t dev, uint16_t addr, uint16_t reg,
  * @param[in]  len          the number of bytes to write
  * @param[in]  flags        optional flags (see @ref i2c_flags_t)
  *
- * @return                  I2C_ACK on successful transfer of @p data
- * @return                  I2C_ADDR_NACK if response to address byte was NACK
- * @return                  I2C_DATA_NACK if response to the data byte was NACK
- * @return                  I2C_ERR for any other error
+ * @return                  0 When success
+ * @return                  -EIO When slave device doesn't ACK the byte
+ * @return                  -ENXIO When no devices respond on the address sent on the bus
+ * @return                  -ETIMEDOUT  When timeout occurs before device's response
+ * @return                  -EINVAL When an invalid argument is given
+ * @return                  -EOPNOTSUPP When MCU driver doesn't support the flag operation
+ * @return                  -EAGAIN When a lost bus arbitration occurs
  */
 int i2c_write_regs(i2c_t dev, uint16_t addr, uint16_t reg,
                   const void *data, size_t len, uint8_t flags);

--- a/drivers/periph_common/i2c.c
+++ b/drivers/periph_common/i2c.c
@@ -37,8 +37,8 @@ int i2c_read_regs(i2c_t dev, uint16_t addr, uint16_t reg,
                   void *data, size_t len, uint8_t flags)
 {
     /* First set ADDR and register with no stop */
-    int8_t ret = i2c_write_bytes(dev, addr, &reg, (flags & I2C_REG16) ? 2 : 1,
-                                 flags | I2C_NOSTOP);
+    int ret = i2c_write_bytes(dev, addr, &reg, (flags & I2C_REG16) ? 2 : 1,
+                              flags | I2C_NOSTOP);
     if (ret < 0) {
         return ret;
     }
@@ -70,8 +70,8 @@ int i2c_write_regs(i2c_t dev, uint16_t addr, uint16_t reg,
                    const void *data, size_t len, uint8_t flags)
 {
     /* First set ADDR and register with no stop */
-    int8_t ret = i2c_write_bytes(dev, addr, &reg, (flags & I2C_REG16) ? 2 : 1,
-                                 flags | I2C_NOSTOP);
+    int ret = i2c_write_bytes(dev, addr, &reg, (flags & I2C_REG16) ? 2 : 1,
+                              flags | I2C_NOSTOP);
     if (ret < 0) {
         return ret;
     }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR changes the API return codes in order to use errno.

I don't master doxygen mysteries so If there is better way don't hesitate to tell me.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references
#6577 
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->