### PR TITLE
drivers/veml6070: adapt to new I2C api

### DIFF
--- a/drivers/veml6070/veml6070.c
+++ b/drivers/veml6070/veml6070.c
@@ -40,17 +40,11 @@ int veml6070_init(veml6070_t *dev, const veml6070_params_t * params)
 {
     dev->params = *params;
 
-    /* Initialize I2C interface */
-    if (i2c_init_master(dev->params.i2c_dev, I2C_SPEED_NORMAL)) {
-        DEBUG("[Error] I2C device not enabled\n");
-        return -VEML6070_ERR_I2C;
-    }
-
     /* Acquire exclusive access */
     i2c_acquire(dev->params.i2c_dev);
 
     i2c_write_byte(dev->params.i2c_dev, VEML6070_ADDRL,
-                   (uint8_t)(dev->params.itime << 2) | 0x02);
+                   (uint8_t)(dev->params.itime << 2) | 0x02, 0);
 
     /* Release I2C device */
     i2c_release(dev->params.i2c_dev);
@@ -64,8 +58,8 @@ uint16_t veml6070_read_uv(const veml6070_t *dev)
     i2c_acquire(dev->params.i2c_dev);
 
     uint8_t buffer[2];
-    i2c_read_byte(dev->params.i2c_dev, VEML6070_ADDRL, &buffer[0]);
-    i2c_read_byte(dev->params.i2c_dev, VEML6070_ADDRH, &buffer[1]);
+    i2c_read_byte(dev->params.i2c_dev, VEML6070_ADDRL, &buffer[0], 0);
+    i2c_read_byte(dev->params.i2c_dev, VEML6070_ADDRH, &buffer[1], 0);
 
     uint16_t uv = (uint16_t)(buffer[1] << 8) | buffer[0];
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Adapt veml6070 to new I2C api

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

#6577 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->