### PR TITLE
core/assert: provide static_assert for c99

### DIFF
--- a/core/include/assert.h
+++ b/core/include/assert.h
@@ -114,9 +114,12 @@ NORETURN void _assert_failure(const char *file, unsigned line);
 #define static_assert(...) _Static_assert(__VA_ARGS__)
 #else
 /**
- * @brief static_assert dummy for c-version < c11
+ * @brief static_assert for c-version < c11
+ *
+ * Generates a division by zero compile error when cond is false
  */
-#define static_assert(...) struct static_assert_dummy
+#define static_assert(cond, ...) \
+    enum { static_assert_failed_on_div_by_0 = 1 / (!!(cond)) }
 #endif
 #endif
 


### PR DESCRIPTION
This provides a working static_assert for c versions < c11. Should work globally and locally.

Required by #9190 for detecting collisions in gpio_t definitions.

Example return:
```
[liveuser@localhost-live driver_gpio_exp_coll]$ make BOARD=mega-xplained
Building application "tests_driver_gpio_exp_coll" for "mega-xplained" with MCU "atmega1284p".

In file included from /home/liveuser/Desktop/RIOT_gpio_exp/tests/driver_gpio_exp_coll/main.c:20:0:
/home/liveuser/Desktop/RIOT_gpio_exp/core/include/assert.h:123:48: error: division by zero [-Werror=div-by-zero]
     enum { static_assert_failed_on_div_by_0 = 1/(!!(cond)) }
                                               ~^~~~~~~~~~~
/home/liveuser/Desktop/RIOT_gpio_exp/tests/driver_gpio_exp_coll/main.c:202:1: note: in expansion of macro 'static_assert'
 static_assert(COLL_RES, "[driver_gpio_exp_coll] Collision in GPIO_EXP_PIN");
 ^~~~~~~~~~~~~
/home/liveuser/Desktop/RIOT_gpio_exp/core/include/assert.h:123:12: error: enumerator value for 'static_assert_failed_on_div_by_0' is not an integer constant
     enum { static_assert_failed_on_div_by_0 = 1/(!!(cond)) }
            ^
/home/liveuser/Desktop/RIOT_gpio_exp/tests/driver_gpio_exp_coll/main.c:202:1: note: in expansion of macro 'static_assert'
 static_assert(COLL_RES, "[driver_gpio_exp_coll] Collision in GPIO_EXP_PIN");
 ^~~~~~~~~~~~~
cc1: all warnings being treated as errors
make[1]: *** [/home/liveuser/Desktop/RIOT_gpio_exp/Makefile.base:83: /home/liveuser/Desktop/RIOT_gpio_exp/tests/driver_gpio_exp_coll/bin/mega-xplained/application_tests_driver_gpio_exp_coll/main.o] Error 1
make: *** [/home/liveuser/Desktop/RIOT_gpio_exp/tests/driver_gpio_exp_coll/../../Makefile.include:359: /home/liveuser/Desktop/RIOT_gpio_exp/tests/driver_gpio_exp_coll/bin/mega-xplained/application_tests_driver_gpio_exp_coll.a] Error 2

```