### PR TITLE
sys/div: calculate magic numbers at compile time

### DIFF
--- a/cpu/mips32r2_common/periph/timer.c
+++ b/cpu/mips32r2_common/periph/timer.c
@@ -83,7 +83,7 @@ int gettimeofday(struct timeval *__restrict __p, void *__restrict __tz)
     (void)__tz;
 
     uint64_t now = counter * US_PER_MS;
-    __p->tv_sec = div_u64_by_inv(now, div_inv_64(1000000));
+    __p->tv_sec = div_64(now, 1000000UL);
     __p->tv_usec = now - (__p->tv_sec * US_PER_SEC);
 
     return 0;

--- a/cpu/mips32r2_common/periph/timer.c
+++ b/cpu/mips32r2_common/periph/timer.c
@@ -83,7 +83,7 @@ int gettimeofday(struct timeval *__restrict __p, void *__restrict __tz)
     (void)__tz;
 
     uint64_t now = counter * US_PER_MS;
-    __p->tv_sec = div_u64_by_1000000(now);
+    __p->tv_sec = div_u64_by_inv(now, div_inv_64(1000000));
     __p->tv_usec = now - (__p->tv_sec * US_PER_SEC);
 
     return 0;

--- a/sys/evtimer/evtimer.c
+++ b/sys/evtimer/evtimer.c
@@ -124,8 +124,14 @@ static uint32_t _get_offset(xtimer_t *timer)
     }
     else {
         target_us -= now_us;
+
         /* add half of 125 so integer division rounds to nearest */
-        return div_u64_by_125((target_us >> 3) + 62);
+        target_us = (target_us >> 3) + 62;
+
+        /* a higher value would overflow the result type */
+        assert(target_us <= 536870911999LLU);
+
+        return (uint32_t)div_u64_by_inv(target_us, div_inv_64(125));
     }
 }
 

--- a/sys/evtimer/evtimer.c
+++ b/sys/evtimer/evtimer.c
@@ -131,7 +131,7 @@ static uint32_t _get_offset(xtimer_t *timer)
         /* a higher value would overflow the result type */
         assert(target_us <= 536870911999LLU);
 
-        return (uint32_t)div_u64_by_inv(target_us, div_inv_64(125));
+        return (uint32_t)div_64(target_us, 125);
     }
 }
 

--- a/sys/include/div.h
+++ b/sys/include/div.h
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2015 Kaspar Schleiser <kaspar@schleiser.de>
- * Copyright (C) 2016 Eistec AB
+ *               2016 Eistec AB
+ *               2018 Acutam Automation, LLC
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -16,35 +17,135 @@
  *
  * @file
  * @ingroup   sys
+ *
  * @author    Kaspar Schleiser <kaspar@schleiser.de>
  * @author    Joakim Nohlgård <joakim.nohlgard@eistec.se>
+ * @author    Matthew Blue <matthew.blue.neuro@gmail.com>
+ *
  * @{
  */
 
 #ifndef DIV_H
 #define DIV_H
 
-#include <assert.h>
 #include <stdint.h>
+
+#include "assert.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
 
 /**
- * @brief Approximation of (2**l)/d for d=15625, l=12, 32 bits
+ * @brief   Calculate 8-bit multiplicative inverse
+ *
+ * Result is calculated during compilation (requires const num). Bitshifted by
+ * 9 to give the most representation to the smallest interesting number (3)
+ *
+ * @param[in] num  reciprocal
+ *
+ * @return         result, bitshifted by 9
  */
-#define DIV_H_INV_15625_32    0x431bde83ul
+__attribute__((always_inline)) static inline uint8_t div_inv_8(
+                                             const uint8_t num)
+{
+    /* cannot be represented due to bit shift */
+    assert(num > 2);
+
+    const uint16_t numerator = (1 << 9);
+
+    if ((numerator % num) * 2 >= num) {
+        /* fraction is >= 0.5, so round up */
+        return (uint8_t)(numerator / num) + 1;
+    }
+    else {
+        return (uint8_t)(numerator / num);
+    }
+}
 
 /**
- * @brief Approximation of (2**l)/d for d=15625, l=12, 64 bits
+ * @brief   Calculate 16-bit multiplicative inverse
+ *
+ * Result is calculated during compilation (requires const num). Bitshifted by
+ * 17 to give the most representation to the smallest interesting number (3)
+ *
+ * @param[in] num  reciprocal
+ *
+ * @return         result, bitshifted by 17
  */
-#define DIV_H_INV_15625_64    0x431bde82d7b634dbull
+__attribute__((always_inline)) static inline uint16_t div_inv_16(
+                                             const uint16_t num)
+{
+    /* cannot be represented due to bit shift */
+    assert(num > 2);
+
+    const uint32_t numerator = (1UL << 17);
+
+    if ((numerator % num) * 2 >= num) {
+        /* fraction is >= 0.5, so round up */
+        return (uint16_t)(numerator / num) + 1;
+    }
+    else {
+        return (uint16_t)(numerator / num);
+    }
+}
 
 /**
- * @brief Required shifts for division by 15625, l above
+ * @brief   Calculate 32-bit multiplicative inverse
+ *
+ * Result is calculated during compilation (requires const num). Bitshifted by
+ * 33 to give the most representation to the smallest interesting number (3)
+ *
+ * @param[in] num  reciprocal
+ *
+ * @return         result, bitshifted by 33
  */
-#define DIV_H_INV_15625_SHIFT 12
+__attribute__((always_inline)) static inline uint32_t div_inv_32(
+                                             const uint32_t num)
+{
+    /* cannot be represented due to bit shift */
+    assert(num > 2);
+
+    const uint64_t numerator = (1ULL << 33);
+
+    if ((numerator % num) * 2 >= num) {
+        /* fraction is >= 0.5, so round up */
+        return (uint32_t)(numerator / num) + 1;
+    }
+    else {
+        return (uint32_t)(numerator / num);
+    }
+}
+
+/**
+ * @brief   Calculate 64-bit multiplicative inverse
+ *
+ * Result is calculated during compilation (requires const num). Bitshifted by
+ * 65 to give the most representation to the smallest interesting number (3)
+ *
+ * @param[in] num  reciprocal
+ *
+ * @return         result, bitshifted by 65
+ */
+__attribute__((always_inline)) static inline uint64_t div_inv_64(
+                                             const uint64_t num)
+{
+    /* cannot be represented due to bit shift */
+    assert(num > 2);
+
+    /* find the last bits without using 128-bit ints */
+    const uint64_t numerator = (1ULL << 63);
+    const uint64_t most_sig = (numerator / num) << 2;
+    const uint64_t least_sig = ((numerator % num) << 2) / num;
+
+    if ((((numerator % num) << 2) % num) * 2 >= num) {
+        /* fraction is >= 0.5, so round up */
+        return (most_sig + least_sig + 1);
+    }
+    else {
+        return (most_sig + least_sig);
+    }
+}
 
 /**
  * @internal
@@ -62,123 +163,76 @@ extern "C" {
 uint64_t _div_mulhi64(const uint64_t a, const uint64_t b);
 
 /**
- * @brief Integer divide val by 15625, 64 bit version
+ * @brief   Divide 8-bit number using an inverse
  *
- * @param[in]   val     dividend
- * @return      (val / 15625)
+ * @param[in] val  numerator
+ * @param[in] inv  multiplicative inverse of denominator (bitshifted by 9)
+ *
+ * @return         result
  */
-static inline uint64_t div_u64_by_15625(uint64_t val)
+static inline uint8_t div_u8_by_inv(const uint8_t val, const uint8_t inv)
 {
-    if (val > 16383999997ull) {
-        return (_div_mulhi64(DIV_H_INV_15625_64, val) >> DIV_H_INV_15625_SHIFT);
-    }
-    return (val * DIV_H_INV_15625_32) >> (DIV_H_INV_15625_SHIFT + 32);
+    uint16_t tmp;
+
+    tmp = (uint16_t)val * (uint16_t)inv;
+    tmp >>= 9;
+
+    return (uint8_t)tmp;
 }
 
 /**
- * @brief Integer divide val by 125
+ * @brief   Divide 16-bit number using an inverse
  *
- * This function can be used to convert uint64_t microsecond times (or
- * intervals) to miliseconds and store them in uint32_t variables, with up to
- * ~50 days worth of miliseconds ((2**32*1000) -1).
- * Use e.g.,  ms = div_u64_by_125(microseconds >> 3)
+ * @param[in] val  numerator
+ * @param[in] inv  multiplicative inverse of denominator (bitshifted by 17)
  *
- * @pre val <= 536870911999 ((2**32 * 125) -1)
- *
- * @param[in]   val     dividend
- * @return      (val / 125)
+ * @return         result
  */
-static inline uint32_t div_u64_by_125(uint64_t val)
+static inline uint16_t div_u16_by_inv(const uint16_t val, const uint16_t inv)
 {
-  /* a higher value would overflow the result type */
-  assert(val <= 536870911999LLU);
+    uint32_t tmp;
 
-  uint32_t hi = val >> 32;
-  uint32_t lo = val;
-  uint32_t r = (lo >> 16) + (hi << 16);
-  uint32_t res = r / 125;
-  r = ((r % 125) << 16) + (lo & 0xFFFF);
-  res = (res << 16) + r / 125;
-  return res;
+    tmp = (uint32_t)val * (uint32_t)inv;
+    tmp >>= 17;
+
+    return (uint16_t)tmp;
 }
 
 /**
- * @brief Integer divide val by 1000000
+ * @brief   Divide 32-bit number using an inverse
  *
- * @param[in]   val     dividend
- * @return      (val / 1000000)
+ * @param[in] val  numerator
+ * @param[in] inv  multiplicative inverse of denominator (bitshifted by 33)
+ *
+ * @return         result
  */
-static inline uint64_t div_u64_by_1000000(uint64_t val)
+static inline uint32_t div_u32_by_inv(const uint32_t val, const uint32_t inv)
 {
-    return div_u64_by_15625(val) >> 6;
+    uint64_t tmp;
+
+    tmp = (uint64_t)val * (uint64_t)inv;
+    tmp >>= 33;
+
+    return (uint32_t)tmp;
 }
 
 /**
- * @brief Divide val by (15625/512)
+ * @brief   Divide 64-bit number using an inverse
  *
- * This is used to quantize a 1MHz value to the closest 32768Hz value,
- * e.g., for timers.
+ * @param[in] val  numerator
+ * @param[in] inv  multiplicative inverse of denominator (bitshifted by 65)
  *
- * The algorithm uses the modular multiplicative inverse of 15625 to use only
- * multiplication and bit shifts to perform the division.
- *
- * The result will be equal to the mathematical expression: floor((val * 512) / 15625)
- *
- * @param[in]   val     dividend
- * @return      (val / (15625/512))
+ * @return         result
  */
-static inline uint32_t div_u32_by_15625div512(uint32_t val)
+static inline uint64_t div_u64_by_inv(const uint64_t val, const uint64_t inv)
 {
-    return ((uint64_t)(val) * DIV_H_INV_15625_32) >> (DIV_H_INV_15625_SHIFT + 32 - 9);
-}
-
-/**
- * @brief Divide val by (15625/512)
- *
- * This is used to quantize a 1MHz value to the closest 32768Hz value,
- * e.g., for timers.
- *
- * @param[in]   val     dividend
- * @return      (val / (15625/512))
- */
-static inline uint64_t div_u64_by_15625div512(uint64_t val)
-{
-    /*
-     * This saves around 1400 bytes of ROM on Cortex-M platforms (both ARMv6 and
-     * ARMv7) from avoiding linking against __aeabi_uldivmod and related helpers
-     */
-    if (val > 16383999997ull) {
-        /* this would overflow 2^64 in the multiplication that follows, need to
-         * use the long version */
-        return (_div_mulhi64(DIV_H_INV_15625_64, val) >> (DIV_H_INV_15625_SHIFT - 9));
-    }
-    return (val * DIV_H_INV_15625_32) >> (DIV_H_INV_15625_SHIFT + 32 - 9);
-}
-
-/**
- * @brief Integer divide val by 44488
- *
- * @param[in]   val     dividend
- * @return      (val / 44488)
- */
-static inline uint32_t div_u32_by_44488(uint32_t val)
-{
-    return ((uint64_t)val * 0xBC8F1391UL) >> (15 + 32);
-}
-
-/**
- * @brief Modulo 44488
- *
- * @param[in]   val     dividend
- * @return      (val % 44488)
- */
-static inline uint32_t div_u32_mod_44488(uint32_t val)
-{
-    return val - (div_u32_by_44488(val)*44488);
+    return (_div_mulhi64(val, inv) >> 1);
 }
 
 #ifdef __cplusplus
 }
 #endif
+
 /** @} */
+
 #endif /* DIV_H */

--- a/sys/include/div.h
+++ b/sys/include/div.h
@@ -45,8 +45,8 @@ extern "C" {
  *
  * @return         if 2*x > y then 1, else 0
  */
-__attribute__((always_inline)) static inline uint8_t _div_shcom(
-                                             const uint64_t x, const uint64_t y)
+__attribute__((always_inline)) __attribute__((optimize("merge-all-constants")))
+    static inline uint8_t _div_shcom(const uint64_t x, const uint64_t y)
 {
     if (x & (1ULL << 63)) {
         return 1;
@@ -67,8 +67,8 @@ __attribute__((always_inline)) static inline uint8_t _div_shcom(
  *
  * @return         difference
  */
-__attribute__((always_inline)) static inline uint64_t _div_shsub(
-                                             const uint64_t x, const uint64_t y)
+__attribute__((always_inline)) __attribute__((optimize("merge-all-constants")))
+    static inline uint64_t _div_shsub(const uint64_t x, const uint64_t y)
 {
     if (x & (1ULL << 63)) {
         uint64_t tmp;
@@ -95,8 +95,9 @@ __attribute__((always_inline)) static inline uint64_t _div_shsub(
  *
  * @return         result, bitshifted by 64
  */
-__attribute__((always_inline, optimize("unroll-all-loops"))) static inline
-               uint64_t _div_frac(const uint64_t num, const uint64_t den)
+__attribute__((always_inline))
+__attribute__((optimize("unroll-all-loops", "merge-all-constants")))
+    static inline uint64_t _div_frac(const uint64_t num, const uint64_t den)
 {
     uint64_t ans = 0, rem = num;
 
@@ -134,8 +135,8 @@ __attribute__((always_inline, optimize("unroll-all-loops"))) static inline
  *
  * @return         result, bitshifted by 16
  */
-__attribute__((always_inline)) static inline uint16_t div_frac_16(
-                               const uint16_t num, const uint16_t den)
+__attribute__((always_inline)) __attribute__((optimize("merge-all-constants")))
+    static inline uint16_t div_frac_16(const uint16_t num, const uint16_t den)
 {
     assert((den > 0) && (num < den));
 
@@ -162,8 +163,8 @@ __attribute__((always_inline)) static inline uint16_t div_frac_16(
  *
  * @return         result, bitshifted by 32
  */
-__attribute__((always_inline)) static inline uint32_t div_frac_32(
-                               const uint32_t num, const uint32_t den)
+__attribute__((always_inline)) __attribute__((optimize("merge-all-constants")))
+    static inline uint32_t div_frac_32(const uint32_t num, const uint32_t den)
 {
     assert((den > 0) && (num < den));
 
@@ -190,8 +191,8 @@ __attribute__((always_inline)) static inline uint32_t div_frac_32(
  *
  * @return         result, bitshifted by 64
  */
-__attribute__((always_inline)) static inline uint64_t div_frac_64(
-                               const uint64_t num, const uint64_t den)
+__attribute__((always_inline)) __attribute__((optimize("merge-all-constants")))
+    static inline uint64_t div_frac_64(const uint64_t num, const uint64_t den)
 {
     assert((den > 0) && (num < den));
 
@@ -269,8 +270,9 @@ static inline uint64_t div_mul_w_frac_64(const uint64_t val, const uint64_t frac
  *
  * @return          result
  */
-__attribute__((always_inline, optimize("unroll-all-loops"))) static inline
-               uint16_t div_16(const uint16_t num, const uint16_t den)
+__attribute__((always_inline))
+__attribute__((optimize("unroll-all-loops", "merge-all-constants")))
+    static inline uint16_t div_16(const uint16_t num, const uint16_t den)
 {
     uint8_t exp;
 
@@ -299,8 +301,9 @@ __attribute__((always_inline, optimize("unroll-all-loops"))) static inline
  *
  * @return          result
  */
-__attribute__((always_inline, optimize("unroll-all-loops"))) static inline
-               uint32_t div_32(const uint32_t num, const uint32_t den)
+__attribute__((always_inline))
+__attribute__((optimize("unroll-all-loops", "merge-all-constants")))
+    static inline uint32_t div_32(const uint32_t num, const uint32_t den)
 {
     uint8_t exp;
 
@@ -329,8 +332,9 @@ __attribute__((always_inline, optimize("unroll-all-loops"))) static inline
  *
  * @return          result
  */
-__attribute__((always_inline, optimize("unroll-all-loops"))) static inline
-               uint64_t div_64(const uint64_t num, const uint64_t den)
+__attribute__((always_inline))
+__attribute__((optimize("unroll-all-loops", "merge-all-constants")))
+    static inline uint64_t div_64(const uint64_t num, const uint64_t den)
 {
     uint8_t exp;
 

--- a/sys/include/div.h
+++ b/sys/include/div.h
@@ -172,12 +172,9 @@ uint64_t _div_mulhi64(const uint64_t a, const uint64_t b);
  */
 static inline uint8_t div_u8_by_inv(const uint8_t val, const uint8_t inv)
 {
-    uint16_t tmp;
+    const uint16_t tmp = (uint16_t)val * (uint16_t)inv;
 
-    tmp = (uint16_t)val * (uint16_t)inv;
-    tmp >>= 9;
-
-    return (uint8_t)tmp;
+    return (uint8_t)(tmp >> 9);
 }
 
 /**
@@ -190,12 +187,9 @@ static inline uint8_t div_u8_by_inv(const uint8_t val, const uint8_t inv)
  */
 static inline uint16_t div_u16_by_inv(const uint16_t val, const uint16_t inv)
 {
-    uint32_t tmp;
+    const uint32_t tmp = (uint32_t)val * (uint32_t)inv;
 
-    tmp = (uint32_t)val * (uint32_t)inv;
-    tmp >>= 17;
-
-    return (uint16_t)tmp;
+    return (uint16_t)(tmp >> 17);
 }
 
 /**
@@ -208,12 +202,9 @@ static inline uint16_t div_u16_by_inv(const uint16_t val, const uint16_t inv)
  */
 static inline uint32_t div_u32_by_inv(const uint32_t val, const uint32_t inv)
 {
-    uint64_t tmp;
+    const uint64_t tmp = (uint64_t)val * (uint64_t)inv;
 
-    tmp = (uint64_t)val * (uint64_t)inv;
-    tmp >>= 33;
-
-    return (uint32_t)tmp;
+    return (uint32_t)(tmp >> 33);
 }
 
 /**

--- a/sys/include/xtimer/tick_conversion.h
+++ b/sys/include/xtimer/tick_conversion.h
@@ -102,11 +102,11 @@ static inline uint64_t _xtimer_ticks_from_usec64(uint64_t usec) {
  * multiplying by the fraction (32768 / 1000000), we will instead use
  * (512 / 15625), which reduces the truncation caused by the integer widths */
 static inline uint32_t _xtimer_ticks_from_usec(uint32_t usec) {
-    return div_u32_by_inv(usec, div_inv_32(15625)) >> 9;
+    return div_u32_by_inv(usec, div_inv_32(15625)) << 9;
 }
 
 static inline uint64_t _xtimer_ticks_from_usec64(uint64_t usec) {
-    return div_u64_by_inv(usec, div_inv_64(15625)) >> 9;
+    return div_u64_by_inv(usec, div_inv_64(15625)) << 9;
 }
 
 static inline uint32_t _xtimer_usec_from_ticks(uint32_t ticks) {

--- a/sys/include/xtimer/tick_conversion.h
+++ b/sys/include/xtimer/tick_conversion.h
@@ -102,11 +102,13 @@ static inline uint64_t _xtimer_ticks_from_usec64(uint64_t usec) {
  * multiplying by the fraction (32768 / 1000000), we will instead use
  * (512 / 15625), which reduces the truncation caused by the integer widths */
 static inline uint32_t _xtimer_ticks_from_usec(uint32_t usec) {
-    return div_u32_by_inv(usec, div_inv_32(15625)) << 9;
+    /* bitshifts increase the accuracy */
+    return div_mul_w_frac_32(usec, div_frac_32((512 << 4), 15625)) >> 4;
 }
 
 static inline uint64_t _xtimer_ticks_from_usec64(uint64_t usec) {
-    return div_u64_by_inv(usec, div_inv_64(15625)) << 9;
+    /* bitshifts increase the accuracy */
+    return div_mul_w_frac_64(usec, div_frac_64((512 << 4), 15625)) >> 4;
 }
 
 static inline uint32_t _xtimer_usec_from_ticks(uint32_t ticks) {

--- a/sys/include/xtimer/tick_conversion.h
+++ b/sys/include/xtimer/tick_conversion.h
@@ -102,11 +102,11 @@ static inline uint64_t _xtimer_ticks_from_usec64(uint64_t usec) {
  * multiplying by the fraction (32768 / 1000000), we will instead use
  * (512 / 15625), which reduces the truncation caused by the integer widths */
 static inline uint32_t _xtimer_ticks_from_usec(uint32_t usec) {
-    return div_u32_by_15625div512(usec);
+    return div_u32_by_inv(usec, div_inv_32(15625)) >> 9;
 }
 
 static inline uint64_t _xtimer_ticks_from_usec64(uint64_t usec) {
-    return div_u64_by_15625div512(usec);
+    return div_u64_by_inv(usec, div_inv_64(15625)) >> 9;
 }
 
 static inline uint32_t _xtimer_usec_from_ticks(uint32_t ticks) {

--- a/sys/newlib_syscalls_default/syscalls.c
+++ b/sys/newlib_syscalls_default/syscalls.c
@@ -503,7 +503,7 @@ int _gettimeofday_r(struct _reent *r, struct timeval *restrict tp, void *restric
     (void) r;
     (void) tzp;
     uint64_t now = xtimer_now_usec64();
-    tp->tv_sec = div_u64_by_1000000(now);
+    tp->tv_sec = div_u64_by_inv(now, div_inv_64(1000000));
     tp->tv_usec = now - (tp->tv_sec * US_PER_SEC);
     return 0;
 }

--- a/sys/newlib_syscalls_default/syscalls.c
+++ b/sys/newlib_syscalls_default/syscalls.c
@@ -503,7 +503,7 @@ int _gettimeofday_r(struct _reent *r, struct timeval *restrict tp, void *restric
     (void) r;
     (void) tzp;
     uint64_t now = xtimer_now_usec64();
-    tp->tv_sec = div_u64_by_inv(now, div_inv_64(1000000));
+    tp->tv_sec = div_64(now, 1000000UL);
     tp->tv_usec = now - (tp->tv_sec * US_PER_SEC);
     return 0;
 }

--- a/sys/random/minstd.c
+++ b/sys/random/minstd.c
@@ -41,7 +41,7 @@ static uint32_t _seed = 1;
 
 int rand_minstd(void)
 {
-    uint32_t hi = div_u32_by_inv(_seed, div_inv_32(44488));
+    uint32_t hi = div_32(_seed, 44488);
     uint32_t lo = _seed - hi*44488;
     uint32_t test = (a * lo) - (r * hi);
 

--- a/sys/random/minstd.c
+++ b/sys/random/minstd.c
@@ -41,8 +41,8 @@ static uint32_t _seed = 1;
 
 int rand_minstd(void)
 {
-    uint32_t hi = div_u32_by_44488(_seed);
-    uint32_t lo = div_u32_mod_44488(_seed);
+    uint32_t hi = div_u32_by_inv(_seed, div_inv_32(44488));
+    uint32_t lo = _seed - hi*44488;
     uint32_t test = (a * lo) - (r * hi);
 
     if(test > 0) {

--- a/sys/xtimer/xtimer.c
+++ b/sys/xtimer/xtimer.c
@@ -186,7 +186,7 @@ void xtimer_now_timex(timex_t *out)
 {
     uint64_t now = xtimer_usec_from_ticks64(xtimer_now64());
 
-    out->seconds = div_u64_by_inv(now, div_inv_64(1000000));
+    out->seconds = div_64(now, 1000000UL);
     out->microseconds = now - (out->seconds * US_PER_SEC);
 }
 

--- a/sys/xtimer/xtimer.c
+++ b/sys/xtimer/xtimer.c
@@ -186,7 +186,7 @@ void xtimer_now_timex(timex_t *out)
 {
     uint64_t now = xtimer_usec_from_ticks64(xtimer_now64());
 
-    out->seconds = div_u64_by_1000000(now);
+    out->seconds = div_u64_by_inv(now, div_inv_64(1000000));
     out->microseconds = now - (out->seconds * US_PER_SEC);
 }
 

--- a/tests/unittests/tests-div/tests-div.c
+++ b/tests/unittests/tests-div/tests-div.c
@@ -74,14 +74,14 @@ static void test_div_u64_by_15625(void)
         DEBUG("Dividing %12"PRIu32" by 15625...\n", u32_test_values[i]);
         TEST_ASSERT_EQUAL_INT(
             (uint64_t)u32_test_values[i] / 15625,
-            div_u64_by_15625(u32_test_values[i]));
+            div_u64_by_inv(u32_test_values[i], div_inv_64(15625)));
     }
 
     for (unsigned i = 0; i < N_U64_VALS; i++) {
         DEBUG("Dividing %12"PRIu64" by 15625...\n", u64_test_values[i]);
         TEST_ASSERT_EQUAL_INT(
             (uint64_t)u64_test_values[i] / 15625,
-            div_u64_by_15625(u64_test_values[i]));
+            div_u64_by_inv(u64_test_values[i], div_inv_64(15625)));
     }
 }
 
@@ -91,7 +91,7 @@ static void test_div_u32_by_15625div512(void)
         DEBUG("Dividing %"PRIu32" by (15625/512)...\n", u32_test_values[i]);
         TEST_ASSERT_EQUAL_INT(
             (uint64_t)u32_test_values[i] * 512lu / 15625,
-            div_u32_by_15625div512(u32_test_values[i]));
+            div_u32_by_inv(u32_test_values[i], div_inv_32(15625)) >> 9);
     }
 }
 
@@ -101,14 +101,14 @@ static void test_div_u64_by_1000000(void)
         DEBUG("Dividing %"PRIu32" by 1000000...\n", u32_test_values[i]);
         TEST_ASSERT_EQUAL_INT(
             (uint64_t)u32_test_values[i] / 1000000lu,
-            div_u64_by_1000000(u32_test_values[i]));
+            div_u64_by_inv(u32_test_values[i], div_inv_64(1000000)));
     }
 
     for (unsigned i = 0; i < N_U64_VALS; i++) {
         DEBUG("Dividing %"PRIu64" by 1000000...\n", u64_test_values[i]);
         TEST_ASSERT_EQUAL_INT(
             u64_test_values[i] / 1000000lu,
-            div_u64_by_1000000(u64_test_values[i]));
+            div_u64_by_inv(u64_test_values[i], div_inv_64(1000000)));
     }
 }
 
@@ -118,14 +118,14 @@ static void test_div_u64_by_15625div512(void)
         DEBUG("Dividing %"PRIu32" by (15625/512)...\n", u32_test_values[i]);
         TEST_ASSERT_EQUAL_INT(
             (uint64_t)u32_test_values[i] * 512lu / 15625,
-            div_u64_by_15625div512(u32_test_values[i]));
+            div_u64_by_inv(u32_test_values[i], div_inv_64(15625)) >> 9);
     }
 
     for (unsigned i = 0; i < N_U64_VALS; i++) {
         DEBUG("Dividing %"PRIu64" by (15625/512)...\n", u64_test_values[i]);
         TEST_ASSERT_EQUAL_INT(
             u64_15625_512_expected_values[i],
-            div_u64_by_15625div512(u64_test_values[i]));
+            div_u64_by_inv(u64_test_values[i], div_inv_64(15625)) >> 9);
     }
 }
 

--- a/tests/unittests/tests-div/tests-div.c
+++ b/tests/unittests/tests-div/tests-div.c
@@ -91,7 +91,7 @@ static void test_div_u32_by_15625div512(void)
         DEBUG("Dividing %"PRIu32" by (15625/512)...\n", u32_test_values[i]);
         TEST_ASSERT_EQUAL_INT(
             (uint64_t)u32_test_values[i] * 512lu / 15625,
-            div_u32_by_inv(u32_test_values[i], div_inv_32(15625)) >> 9);
+            div_u32_by_inv(u32_test_values[i], div_inv_32(15625)) << 9);
     }
 }
 
@@ -118,14 +118,14 @@ static void test_div_u64_by_15625div512(void)
         DEBUG("Dividing %"PRIu32" by (15625/512)...\n", u32_test_values[i]);
         TEST_ASSERT_EQUAL_INT(
             (uint64_t)u32_test_values[i] * 512lu / 15625,
-            div_u64_by_inv(u32_test_values[i], div_inv_64(15625)) >> 9);
+            div_u64_by_inv(u32_test_values[i], div_inv_64(15625)) << 9);
     }
 
     for (unsigned i = 0; i < N_U64_VALS; i++) {
         DEBUG("Dividing %"PRIu64" by (15625/512)...\n", u64_test_values[i]);
         TEST_ASSERT_EQUAL_INT(
             u64_15625_512_expected_values[i],
-            div_u64_by_inv(u64_test_values[i], div_inv_64(15625)) >> 9);
+            div_u64_by_inv(u64_test_values[i], div_inv_64(15625)) << 9);
     }
 }
 

--- a/tests/unittests/tests-div/tests-div.c
+++ b/tests/unittests/tests-div/tests-div.c
@@ -74,14 +74,14 @@ static void test_div_u64_by_15625(void)
         DEBUG("Dividing %12"PRIu32" by 15625...\n", u32_test_values[i]);
         TEST_ASSERT_EQUAL_INT(
             (uint64_t)u32_test_values[i] / 15625,
-            div_u64_by_inv(u32_test_values[i], div_inv_64(15625)));
+            div_64(u32_test_values[i], 15625));
     }
 
     for (unsigned i = 0; i < N_U64_VALS; i++) {
         DEBUG("Dividing %12"PRIu64" by 15625...\n", u64_test_values[i]);
         TEST_ASSERT_EQUAL_INT(
             (uint64_t)u64_test_values[i] / 15625,
-            div_u64_by_inv(u64_test_values[i], div_inv_64(15625)));
+            div_64(u64_test_values[i], 15625));
     }
 }
 
@@ -91,24 +91,8 @@ static void test_div_u32_by_15625div512(void)
         DEBUG("Dividing %"PRIu32" by (15625/512)...\n", u32_test_values[i]);
         TEST_ASSERT_EQUAL_INT(
             (uint64_t)u32_test_values[i] * 512lu / 15625,
-            div_u32_by_inv(u32_test_values[i], div_inv_32(15625)) << 9);
-    }
-}
-
-static void test_div_u64_by_1000000(void)
-{
-    for (unsigned i = 0; i < N_U32_VALS; i++) {
-        DEBUG("Dividing %"PRIu32" by 1000000...\n", u32_test_values[i]);
-        TEST_ASSERT_EQUAL_INT(
-            (uint64_t)u32_test_values[i] / 1000000lu,
-            div_u64_by_inv(u32_test_values[i], div_inv_64(1000000)));
-    }
-
-    for (unsigned i = 0; i < N_U64_VALS; i++) {
-        DEBUG("Dividing %"PRIu64" by 1000000...\n", u64_test_values[i]);
-        TEST_ASSERT_EQUAL_INT(
-            u64_test_values[i] / 1000000lu,
-            div_u64_by_inv(u64_test_values[i], div_inv_64(1000000)));
+            div_mul_w_frac_32(u32_test_values[i],
+                              div_frac_32((512 << 4), 15625)) >> 4);
     }
 }
 
@@ -118,14 +102,33 @@ static void test_div_u64_by_15625div512(void)
         DEBUG("Dividing %"PRIu32" by (15625/512)...\n", u32_test_values[i]);
         TEST_ASSERT_EQUAL_INT(
             (uint64_t)u32_test_values[i] * 512lu / 15625,
-            div_u64_by_inv(u32_test_values[i], div_inv_64(15625)) << 9);
+            div_mul_w_frac_64(u32_test_values[i],
+                              div_frac_64((512 << 4), 15625)) >> 4);
     }
 
     for (unsigned i = 0; i < N_U64_VALS; i++) {
         DEBUG("Dividing %"PRIu64" by (15625/512)...\n", u64_test_values[i]);
         TEST_ASSERT_EQUAL_INT(
             u64_15625_512_expected_values[i],
-            div_u64_by_inv(u64_test_values[i], div_inv_64(15625)) << 9);
+            div_mul_w_frac_64(u64_test_values[i],
+                              div_frac_64((512 << 4), 15625)) >> 4);
+    }
+}
+
+static void test_div_u64_by_1000000(void)
+{
+    for (unsigned i = 0; i < N_U32_VALS; i++) {
+        DEBUG("Dividing %"PRIu32" by 1000000...\n", u32_test_values[i]);
+        TEST_ASSERT_EQUAL_INT(
+            (uint64_t)u32_test_values[i] / 1000000lu,
+            div_64(u32_test_values[i], 1000000UL));
+    }
+
+    for (unsigned i = 0; i < N_U64_VALS; i++) {
+        DEBUG("Dividing %"PRIu64" by 1000000...\n", u64_test_values[i]);
+        TEST_ASSERT_EQUAL_INT(
+            u64_test_values[i] / 1000000lu,
+            div_64(u64_test_values[i], 1000000UL));
     }
 }
 


### PR DESCRIPTION
This is a rewrite of sys/div to provide much simpler division by calculating the required magic numbers at compile time, rather than hard-coding them.

tests/unittests/tests-div is partially working, with a few rounding errors that I need to fix:
```
[liveuser@localhost-live unittests]$ make BOARD=mega-xplained term
/home/liveuser/Desktop/RIOT_div_magic/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "9600"
No handlers could be found for logger "root"
2018-06-03 17:59:59,585 - INFO # Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.
2018-06-03 18:00:01,363 - INFO # 

2018-06-03 18:00:01,453 - INFO # main(): This is RIOT! (Version: 2018.07-devel-462-g5e5275-localhost-live-RIOT_div_magic)
2018-06-03 18:00:01,454 - INFO # .Dividing            0 by 15625...
2018-06-03 18:00:01,488 - INFO # Dividing            1 by 15625...
2018-06-03 18:00:01,554 - INFO # Dividing           10 by 15625...
2018-06-03 18:00:01,554 - INFO # Dividing           32 by 15625...
2018-06-03 18:00:01,588 - INFO # Dividing        15625 by 15625...
2018-06-03 18:00:01,655 - INFO # Dividing        78125 by 15625...
2018-06-03 18:00:01,657 - INFO # Dividing        78126 by 15625...
2018-06-03 18:00:01,688 - INFO # Dividing        65535 by 15625...
2018-06-03 18:00:01,755 - INFO # Dividing        64512 by 15625...
2018-06-03 18:00:01,757 - INFO # Dividing   4294967295 by 15625...
2018-06-03 18:00:01,955 - INFO # Dividing Dividing Dividing Dividing Dividing Dividing Dividing Dividing Dividing Dividing Dividing Dividing Dividing Dividing .Dividing 0 by (15625/512)...
2018-06-03 18:00:01,957 - INFO # Dividing 1 by (15625/512)...
2018-06-03 18:00:01,989 - INFO # Dividing 10 by (15625/512)...
2018-06-03 18:00:02,055 - INFO # Dividing 32 by (15625/512)...
2018-06-03 18:00:02,055 - INFO # 
2018-06-03 18:00:02,154 - INFO # div_tests.test_div_u32_by_15625div512 (tests/unittests/tests-div/tests-div.c 94) exp 1 was 0
2018-06-03 18:00:02,157 - INFO # .Dividing 0 by (15625/512)...
2018-06-03 18:00:02,188 - INFO # Dividing 1 by (15625/512)...
2018-06-03 18:00:02,254 - INFO # Dividing 10 by (15625/512)...
2018-06-03 18:00:02,257 - INFO # Dividing 32 by (15625/512)...
2018-06-03 18:00:02,257 - INFO # 
2018-06-03 18:00:02,356 - INFO # div_tests.test_div_u64_by_15625div512 (tests/unittests/tests-div/tests-div.c 121) exp 1 was 0
2018-06-03 18:00:02,387 - INFO # .Dividing 0 by 1000000...
2018-06-03 18:00:02,390 - INFO # Dividing 1 by 1000000...
2018-06-03 18:00:02,454 - INFO # Dividing 10 by 1000000...
2018-06-03 18:00:02,454 - INFO # Dividing 32 by 1000000...
2018-06-03 18:00:02,488 - INFO # Dividing 15625 by 1000000...
2018-06-03 18:00:02,555 - INFO # Dividing 78125 by 1000000...
2018-06-03 18:00:02,556 - INFO # Dividing 78126 by 1000000...
2018-06-03 18:00:02,587 - INFO # Dividing 65535 by 1000000...
2018-06-03 18:00:02,653 - INFO # Dividing 64512 by 1000000...
2018-06-03 18:00:02,654 - INFO # Dividing 4294967295 by 1000000...
2018-06-03 18:00:02,688 - INFO # Dividing Dividing Dividing Dividing Dividing Dividing 
2018-06-03 18:00:02,789 - INFO # div_tests.test_div_u64_by_1000000 (tests/unittests/tests-div/tests-div.c 111) exp 16384 was 16383
2018-06-03 18:00:02,790 - INFO # 
2018-06-03 18:00:02,888 - INFO # run 4 failures 3
/exit
2018-06-03 18:00:06,520 - INFO # Exiting Pyterm
[liveuser@localhost-live unittests]$
```