### PR TITLE
core: Add THREAD_FLAG_IRQ_SERVICED

### DIFF
--- a/core/include/thread_flags.h
+++ b/core/include/thread_flags.h
@@ -62,7 +62,7 @@
 #include "sched.h"  /* for thread_t typedef */
 
 #ifdef __cplusplus
- extern "C" {
+extern "C" {
 #endif
 
 /**
@@ -96,13 +96,13 @@
  *          ...
  *      }
  */
-#define THREAD_FLAG_MSG_WAITING      (0x1<<15)
+#define THREAD_FLAG_MSG_WAITING     (1u << 15)
 /**
  * @brief Set by @ref xtimer_set_timeout_flag() when the timer expires
  *
  * @see xtimer_set_timeout_flag
  */
-#define THREAD_FLAG_TIMEOUT          (0x1<<14)
+#define THREAD_FLAG_TIMEOUT         (1u << 14)
 /** @} */
 
 /**

--- a/core/include/thread_flags.h
+++ b/core/include/thread_flags.h
@@ -40,7 +40,9 @@
  * of them, thread flags should be considered.
  *
  * Note that some flags (currently the three most significant bits) are used by
- * core functions and should not be set by the user. They can be waited for.
+ * core functions, system libraries, and device drivers and should not be set by
+ * a user application. These special flags can still be waited for to create
+ * event loops and wait conditions.
  *
  * This API is optional and must be enabled by adding "core_thread_flags" to USEMODULE.
  *
@@ -104,7 +106,7 @@ extern "C" {
  */
 #define THREAD_FLAG_TIMEOUT         (1u << 14)
 /**
- * @brief Set by some drivers for signalling from an ISR to an application thread
+ * @brief Set by some drivers for signaling from an ISR to an application thread
  *
  * Example usages include periph drivers waiting for data to be read or written
  * when using an IRQ driven or DMA driven method, and in network device drivers

--- a/core/include/thread_flags.h
+++ b/core/include/thread_flags.h
@@ -39,7 +39,7 @@
  * Usually, if it is only of interest that an event occurred, but not how many
  * of them, thread flags should be considered.
  *
- * Note that some flags (currently the three most significant bits) are used by
+ * Note that some flags (currently the four most significant bits) are used by
  * core functions, system libraries, and device drivers and should not be set by
  * a user application. These special flags can still be waited for to create
  * event loops and wait conditions.
@@ -113,6 +113,16 @@ extern "C" {
  * waiting for feedback from the hardware when trying to send a frame etc.
  */
 #define THREAD_FLAG_IRQ_SERVICED    (1u << 13)
+
+#ifndef THREAD_FLAG_EVENT
+/**
+ * @brief   Thread flag use to notify available events in an event queue
+ *
+ * @see @ref event_wait, @ref event_post, @ref event_loop
+ */
+#define THREAD_FLAG_EVENT           (1u << 12)
+#endif
+
 /** @} */
 
 /**

--- a/core/include/thread_flags.h
+++ b/core/include/thread_flags.h
@@ -103,6 +103,14 @@ extern "C" {
  * @see xtimer_set_timeout_flag
  */
 #define THREAD_FLAG_TIMEOUT         (1u << 14)
+/**
+ * @brief Set by some drivers for signalling from an ISR to an application thread
+ *
+ * Example usages include periph drivers waiting for data to be read or written
+ * when using an IRQ driven or DMA driven method, and in network device drivers
+ * waiting for feedback from the hardware when trying to send a frame etc.
+ */
+#define THREAD_FLAG_IRQ_SERVICED    (1u << 13)
 /** @} */
 
 /**

--- a/sys/include/event.h
+++ b/sys/include/event.h
@@ -99,13 +99,6 @@
 extern "C" {
 #endif
 
-#ifndef THREAD_FLAG_EVENT
-/**
- * @brief   Thread flag use to notify available events in an event queue
- */
-#define THREAD_FLAG_EVENT   (0x1)
-#endif
-
 /**
  * @brief   event_queue_t static initializer
  */


### PR DESCRIPTION
### Contribution description

Introduce a common thread flag which can be used as an alternative to the traditional mutex method where the user application locks a mutex and an interrupt handler unlocks it. The thread flags method may have a lower runtime overhead than using a mutex.

The Kinetis I2C driver in #9262 uses this for signalling when the transfer is complete. The kw41zrf driver in #7107 uses a thread flag for signalling, and will be updated to use this definition to avoid collisions with application specific thread flags.

### Issues/PRs references

#9262 #7107