### PR TITLE
drivers/at: make OK and ERROR replies configurable

### DIFF
--- a/drivers/at/at.c
+++ b/drivers/at/at.c
@@ -141,11 +141,17 @@ ssize_t at_send_cmd_get_lines(at_dev_t *dev, const char *command,
         }
         else if (res > 0) {
             bytes_left -= res;
-            if ((res == (2 + keep_eol)) && (strncmp(pos, "OK", 2) == 0)) {
+            size_t len_ok = sizeof(AT_RECV_OK) - 1;
+            size_t len_error = sizeof(AT_RECV_ERROR) - 1;
+            if (((size_t )res == (len_ok + keep_eol)) &&
+                (len_ok != 0) &&
+                (strncmp(pos, AT_RECV_OK, len_ok) == 0)) {
                 res = len - bytes_left;
                 break;
             }
-            else if ((res == (5 + keep_eol)) && (strncmp(pos, "ERROR", 5) == 0)) {
+            else if (((size_t )res == (len_error + keep_eol)) &&
+                     (len_error != 0) &&
+                     (strncmp(pos, AT_RECV_ERROR, len_error) == 0)) {
                 return -1;
             }
             else if (strncmp(pos, "+CME ERROR:", 11) == 0) {
@@ -204,8 +210,10 @@ int at_send_cmd_wait_ok(at_dev_t *dev, const char *command, uint32_t timeout)
     char resp_buf[64];
 
     res = at_send_cmd_get_resp(dev, command, resp_buf, sizeof(resp_buf), timeout);
+
     if (res > 0) {
-        if (strcmp(resp_buf, "OK") == 0) {
+        ssize_t len_ok = sizeof(AT_RECV_OK) - 1;
+        if ((len_ok != 0) && (strcmp(resp_buf, AT_RECV_OK) == 0)) {
             res = 0;
         }
         else {

--- a/drivers/include/at.h
+++ b/drivers/include/at.h
@@ -67,6 +67,16 @@ extern "C" {
 #define AT_RECV_EOL_2   "\n"
 #endif
 
+#ifndef AT_RECV_OK
+/** default OK reply of an AT device */
+#define AT_RECV_OK "OK"
+#endif
+
+#ifndef AT_RECV_ERROR
+/** default ERROR reply of an AT device */
+#define AT_RECV_ERROR "ERROR"
+#endif
+
 /**
  * @brief AT device structure
  */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR provides 2 new macro to the AT command parser. These macros allow to change the expected OK and ERROR replies of an AT module.

I have one that doesn't answer OK or ERROR as the driver expects by default but rather +OK and +ERR.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

#7084 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->