### PR TITLE
drivers/mkrwan: add initial implementation

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -437,6 +437,9 @@ ifneq (,$(filter stdio_ethos,$(USEMODULE)))
   USEMODULE += ethos
   USEMODULE += stdin
   USEMODULE += stdio_uart
+
+  # stdio_ethos doesn't work on boards providing stdio over USB
+  FEATURES_BLACKLIST += stdio_usb
 endif
 
 ifneq (,$(filter stdin,$(USEMODULE)))
@@ -642,6 +645,9 @@ ifneq (,$(filter arduino,$(USEMODULE)))
   FEATURES_OPTIONAL += periph_adc
   FEATURES_REQUIRED += periph_gpio
   USEMODULE += xtimer
+
+  # Arduino module doesn't work on boards providing stdio over USB
+  FEATURES_BLACKLIST += stdio_usb
 endif
 
 ifneq (,$(filter xtimer,$(USEMODULE)))
@@ -987,6 +993,11 @@ FEATURES_OPTIONAL += periph_pm
 
 # always select provided architecture features
 FEATURES_REQUIRED += $(filter arch_%,$(FEATURES_PROVIDED))
+
+ifneq (,$(filter auto_init,$(DISABLE_MODULE)))
+  # boards using stdio over USB require auto_init
+  FEATURES_BLACKLIST += stdio_usb
+endif
 
 # all periph features correspond to a periph submodule
 # FEATURES_USED is defined in Makefile.features

--- a/boards/arduino-mkrfox1200/doc.txt
+++ b/boards/arduino-mkrfox1200/doc.txt
@@ -16,19 +16,14 @@ powered by an Atmel SAMD21 microcontroller.
 
 ### Flash the board
 
-1. Put the board in bootloader mode by double tapping the reset button.<br/>
-   When the board is in bootloader mode, the user led (green) oscillates
-   smoothly.
-
-
-2. Use `BOARD=arduino-mkrfox1200` with the `make` command.<br/>
-   Example with `hello-world` application:
+Use `BOARD=arduino-mkrfox1200` with the `make` command.<br/>
+Example with `hello-world` application:
 ```
      make BOARD=arduino-mkrfox1200 -C examples/hello-world flash
 ```
 
 ### Accessing STDIO via UART
 
-To access the STDIO of RIOT, a FTDI to USB converter needs to be plugged to
-the RX/TX pins on the board.
+STDIO of RIOT is directly available over the USB port.
+
  */

--- a/boards/arduino-mkrwan1300/doc.txt
+++ b/boards/arduino-mkrwan1300/doc.txt
@@ -1,37 +1,28 @@
 /**
- * @defgroup    boards_arduino-mkrwan1300 Arduino MKR WAN 1300
- * @ingroup     boards
- * @brief       Support for the Arduino MKR WAN 1300 board.
- *
- * ### General information
- *
- * The [Arduino MKR WAN 1300](https://store.arduino.cc/mkr-wan-1300) board is
- * a learning and development board that provides LoRa connectivity and is
- * powered by an Atmel SAMD21 microcontroller.
- *
- * ### Pinout
- *
- * <img src="https://www.arduino.cc/en/uploads/Main/MKR1000_pinout.png"
- *      alt="Arduino MKR WAN 1300 pinout" style="height:800px;"/>
- *
- * ### Flash the board
- *
- * 1. Put the board in bootloader mode by double tapping the reset button.<br/>
- *    When the board is in bootloader mode, the user led (amber) oscillates
- *    smoothly.
- *
- *
- * 2. Use `BOARD=arduino-mkrwan1300` with the `make` command.<br/>
- *    Example with `hello-world` application:
- * ```
- *      make BOARD=arduino-mkrwan1300 -C examples/hello-world flash
- * ```
- *
- * @warning Unplug the board from the anti-static protective foam before
- *          starting to use it otherwise it may not work as expected.
- *
- * ### Accessing STDIO via UART
- *
- * To access the STDIO of RIOT, a FTDI to USB converted needs to be plugged to
- * the RX/TX pins on the board.
+@defgroup    boards_arduino-mkrwan1300 Arduino MKR WAN 1300
+@ingroup     boards
+@brief       Support for the Arduino MKR WAN 1300 board.
+
+### General information
+
+The [Arduino MKR WAN 1300](https://store.arduino.cc/mkr-wan-1300) board is
+a learning and development board that provides LoRa connectivity and is
+powered by an Atmel SAMD21 microcontroller.
+
+### Pinout
+
+<img src="https://www.arduino.cc/en/uploads/Main/MKR1000_pinout.png"
+     alt="Arduino MKR WAN 1300 pinout" style="height:800px;"/>
+
+### Flash the board
+
+Use `BOARD=arduino-mkrgsm1400` with the `make` command.<br/>
+Example with `hello-world` application:
+```
+     make BOARD=arduino-mkrgsm1400 -C examples/hello-world flash
+```
+
+### Accessing STDIO via UART
+
+STDIO of RIOT is directly available over the USB port.
  */

--- a/boards/common/arduino-mkr/Makefile
+++ b/boards/common/arduino-mkr/Makefile
@@ -1,3 +1,5 @@
 MODULE = boards_common_arduino-mkr
 
+DIRS = $(RIOTBOARD)/common/samd21-arduino-bootloader
+
 include $(RIOTBASE)/Makefile.base

--- a/boards/common/arduino-mkr/Makefile.dep
+++ b/boards/common/arduino-mkr/Makefile.dep
@@ -1,3 +1,6 @@
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
 endif
+
+# setup the samd21 arduino bootloader related dependencies
+include $(RIOTBOARD)/common/samd21-arduino-bootloader/Makefile.dep

--- a/boards/common/arduino-mkr/Makefile.features
+++ b/boards/common/arduino-mkr/Makefile.features
@@ -15,3 +15,4 @@ FEATURES_PROVIDED += periph_usbdev
 
 # Various other features (if any)
 FEATURES_PROVIDED += arduino
+FEATURES_PROVIDED += stdio_usb

--- a/boards/common/arduino-mkr/Makefile.include
+++ b/boards/common/arduino-mkr/Makefile.include
@@ -9,15 +9,9 @@ ifeq ($(PROGRAMMER),jlink)
   # in case J-Link is attached to SWD pins, use a plain CPU memory model
   export JLINK_DEVICE := $(MKR_JLINK_DEVICE)
   include $(RIOTMAKE)/tools/jlink.inc.mk
-else
-  # by default, we use BOSSA to flash this board and take into account the
-  # preinstalled Arduino bootloader. ROM_OFFSET skips the space taken by
-  # such bootloader.
-  ROM_OFFSET ?= 0x2000
-  include $(RIOTMAKE)/tools/bossa.inc.mk
 endif
 
-INCLUDES += -I$(RIOTBOARD)/common/arduino-mkr/include
+# Include all definitions for flashing with bossa other USB
+include $(RIOTBOARD)/common/samd21-arduino-bootloader/Makefile.include
 
-# setup the boards dependencies
-include $(RIOTBOARD)/$(BOARD)/Makefile.dep
+INCLUDES += -I$(RIOTBOARD)/common/arduino-mkr/include

--- a/boards/common/samd21-arduino-bootloader/Makefile
+++ b/boards/common/samd21-arduino-bootloader/Makefile
@@ -1,0 +1,3 @@
+MODULE = boards_common_samd21-arduino-bootloader
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/common/samd21-arduino-bootloader/Makefile.dep
+++ b/boards/common/samd21-arduino-bootloader/Makefile.dep
@@ -1,6 +1,7 @@
 # Force auto-initialization of usbus to get stdio feature other USB
 USEMODULE += auto_init_usbus
 USEMODULE += stdio_cdc_acm
+FEATURES_REQUIRED += stdio_usb
 
 # This boards requires support for Arduino bootloader.
 USEMODULE += arduino_bootloader

--- a/boards/common/samd21-arduino-bootloader/Makefile.dep
+++ b/boards/common/samd21-arduino-bootloader/Makefile.dep
@@ -1,0 +1,7 @@
+# Force auto-initialization of usbus to get stdio feature other USB
+USEMODULE += auto_init_usbus
+USEMODULE += stdio_cdc_acm
+
+# This boards requires support for Arduino bootloader.
+USEMODULE += arduino_bootloader
+USEMODULE += boards_common_samd21-arduino-bootloader

--- a/boards/common/samd21-arduino-bootloader/Makefile.include
+++ b/boards/common/samd21-arduino-bootloader/Makefile.include
@@ -1,0 +1,30 @@
+# setup the flash tool used
+# Bossa is the default programmer
+PROGRAMMER ?= bossa
+
+ifeq ($(PROGRAMMER),bossa)
+  # by default, we use BOSSA to flash this board and take into account the
+  # preinstalled Arduino bootloader. ROM_OFFSET skips the space taken by
+  # such bootloader.
+  ROM_OFFSET ?= 0x2000
+  BOSSA_ARDUINO_PREFLASH = yes
+  PREFLASH_DELAY = 1
+
+  ifneq (,$(filter reset flash flash-only, $(MAKECMDGOALS)))
+    # Add 2 seconds delay before opening terminal: this is required when opening
+    # the terminal right after flashing. In this case, the stdio over USB needs
+    # some time after reset before being ready.
+    TERM_DELAY = 2
+    TERMDEPS += term-delay
+  endif
+
+  include $(RIOTMAKE)/tools/bossa.inc.mk
+endif
+
+term-delay:
+	sleep $(TERM_DELAY)
+
+USB_VID ?= 1209
+USB_PID ?= 0001
+
+CFLAGS += -DUSB_CONFIG_VID=0x$(USB_VID) -DUSB_CONFIG_PID=0x$(USB_PID)

--- a/boards/common/samd21-arduino-bootloader/reset.c
+++ b/boards/common/samd21-arduino-bootloader/reset.c
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C)  2019 Inria
+ *                2019 Kees Bakker, SODAQ
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_common
+ * @{
+ * @file
+ * @brief       Board common implementations for managing an Arduino bootloader
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ * @author      Kees Bakker <kees@sodaq.com>
+ *
+ * @}
+ */
+
+#include "periph/pm.h"
+
+
+#define SAMD21_DOUBLE_TAP_ADDR              (0x20007FFCUL)
+#define SAMD21_DOUBLE_TAP_MAGIC_NUMBER      (0x07738135UL)
+
+void reset_in_application(void)
+{
+    pm_reboot();
+    while (1) {}
+}
+
+void reset_in_bootloader(void)
+{
+    /* The Arduino bootloader checks for a magic number in SRAM to remain in
+       bootloader mode.
+       See
+       https://github.com/arduino/ArduinoCore-samd/blob/master/bootloaders/zero/board_definitions_arduino_mkr1000.h#L38
+       and
+       https://github.com/arduino/ArduinoCore-samd/blob/master/bootloaders/zero/main.c#L94
+       for implementation details. */
+    uint32_t *reset_addr = (uint32_t *)SAMD21_DOUBLE_TAP_ADDR;
+    *reset_addr = (uint32_t)SAMD21_DOUBLE_TAP_MAGIC_NUMBER;
+
+    reset_in_application();
+}

--- a/boards/common/sodaq/Makefile
+++ b/boards/common/sodaq/Makefile
@@ -1,3 +1,5 @@
 MODULE = boards_common_sodaq
 
+DIRS = $(RIOTBOARD)/common/samd21-arduino-bootloader
+
 include $(RIOTBASE)/Makefile.base

--- a/boards/common/sodaq/Makefile.dep
+++ b/boards/common/sodaq/Makefile.dep
@@ -1,3 +1,6 @@
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
 endif
+
+# setup the samd21 arduino bootloader related dependencies
+include $(RIOTBOARD)/common/samd21-arduino-bootloader/Makefile.dep

--- a/boards/common/sodaq/Makefile.features
+++ b/boards/common/sodaq/Makefile.features
@@ -12,3 +12,4 @@ FEATURES_PROVIDED += periph_usbdev
 
 # Various other features (if any)
 FEATURES_PROVIDED += arduino
+FEATURES_PROVIDED += stdio_usb

--- a/boards/common/sodaq/Makefile.include
+++ b/boards/common/sodaq/Makefile.include
@@ -7,8 +7,5 @@ include $(RIOTMAKE)/tools/serial.inc.mk
 # Add board common includes
 INCLUDES += -I$(RIOTBOARD)/common/sodaq/include
 
-# setup the flash tool used
-# we use BOSSA to flash this board since there's an Arduino bootloader
-# preflashed on it. ROM_OFFSET skips the space taken by such bootloader.
-ROM_OFFSET ?= 0x2000
-include $(RIOTMAKE)/tools/bossa.inc.mk
+# Include all definitions for flashing with bossa other USB
+include $(RIOTBOARD)/common/samd21-arduino-bootloader/Makefile.include

--- a/boards/feather-m0/Makefile
+++ b/boards/feather-m0/Makefile
@@ -1,3 +1,5 @@
 MODULE = board
 
+DIRS = $(RIOTBOARD)/common/samd21-arduino-bootloader
+
 include $(RIOTBASE)/Makefile.base

--- a/boards/feather-m0/Makefile.dep
+++ b/boards/feather-m0/Makefile.dep
@@ -1,3 +1,6 @@
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
 endif
+
+# setup the samd21 arduino bootloader related dependencies
+include $(RIOTBOARD)/common/samd21-arduino-bootloader/Makefile.dep

--- a/boards/feather-m0/Makefile.features
+++ b/boards/feather-m0/Makefile.features
@@ -11,3 +11,6 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_usbdev
+
+# Various other features (if any)
+FEATURES_PROVIDED += stdio_usb

--- a/boards/feather-m0/Makefile.include
+++ b/boards/feather-m0/Makefile.include
@@ -9,13 +9,10 @@ ifeq ($(PROGRAMMER),jlink)
   # in case J-Link is attached to SWD pins, use a plain CPU memory model
   export JLINK_DEVICE := atsamd21
   include $(RIOTMAKE)/tools/jlink.inc.mk
-else
-  # by default, we use BOSSA to flash this board to take into account the
-  # pre-flashed Arduino bootloader. ROM_OFFSET skips the space taken by
-  # such bootloader.
-  ROM_OFFSET ?= 0x2000
-  include $(RIOTMAKE)/tools/bossa.inc.mk
 endif
+
+# Include all definitions for flashing with bossa other USB
+include $(RIOTBOARD)/common/samd21-arduino-bootloader/Makefile.include
 
 # setup the boards dependencies
 include $(RIOTBOARD)/$(BOARD)/Makefile.dep

--- a/boards/feather-m0/doc.txt
+++ b/boards/feather-m0/doc.txt
@@ -41,18 +41,13 @@ printf("Bat: %dV\n", vbat);
 
 ### Flash the board
 
-1. Put the board in bootloader mode by double tapping the reset button.<br/>
-   When the board is in bootloader mode, the user led (red) oscillates smoothly.
-
-
-2. Use `BOARD=feather-m0` with the `make` command.<br/>
-   Example with `hello-world` application:
+Use `BOARD=feather-m0` with the `make` command.<br/>
+Example with `hello-world` application:
 ```
      make BOARD=feather-m0 -C examples/hello-world flash
 ```
 
 ### Accessing STDIO via UART
 
-To access the STDIO of RIOT, a FTDI to USB converted needs to be plugged to
-the RX/TX pins on the board.
+STDIO of RIOT is directly available over the USB port.
  */

--- a/boards/sodaq-autonomo/doc.txt
+++ b/boards/sodaq-autonomo/doc.txt
@@ -93,15 +93,15 @@ Besides the SAMD21 the board has the following features:
 
 ## Flashing the device
 
-1. Put the board in bootloader mode by double tapping the reset button.<br/>
-   When the board is in bootloader mode, the user led (green) oscillates
-   smoothly.
-
-2. Use `BOARD=sodaq-autonomo` with the `make` command.<br/>
-   Example with `hello-world` application:
+Use `BOARD=sodaq-autonomo` with the `make` command.<br/>
+Example with `hello-world` application:
 ```
      make BOARD=sodaq-autonomo -C examples/hello-world flash
 ```
+
+## Accessing STDIO via UART
+
+STDIO of RIOT is directly available over the USB port.
 
 ## Supported Toolchains
 

--- a/boards/sodaq-explorer/doc.txt
+++ b/boards/sodaq-explorer/doc.txt
@@ -10,20 +10,14 @@ General information about this board can be found on the
 
 ### Flash the board
 
-1. Put the board in bootloader mode by double tapping the reset button.<br/>
-   When the board is in bootloader mode, the user led (blue) oscillates
-   smoothly.
-
-
-2. Use `BOARD=sodaq-explorer` with the `make` command.<br/>
-   Example with `hello-world` application:
+Use `BOARD=sodaq-explorer` with the `make` command.<br/>
+Example with `hello-world` application:
 ```
      make BOARD=sodaq-explorer -C examples/hello-world flash
 ```
 
 ### Accessing STDIO via UART
 
-To access the STDIO of RIOT, a FTDI to USB converter needs to be plugged to
-the RX/TX pins on the board.
+STDIO of RIOT is directly available over the USB port.
 
  */

--- a/boards/sodaq-one/Makefile
+++ b/boards/sodaq-one/Makefile
@@ -1,3 +1,5 @@
 MODULE = board
 
+DIRS = $(RIOTBOARD)/common/samd21-arduino-bootloader
+
 include $(RIOTBASE)/Makefile.base

--- a/boards/sodaq-one/doc.txt
+++ b/boards/sodaq-one/doc.txt
@@ -10,20 +10,14 @@
  *
  * ### Flash the board
  *
- * 1. Put the board in bootloader mode by double tapping the reset button.<br/>
- *    When the board is in bootloader mode, the user led (blue) oscillates
- *    smoothly.
- *
- *
- * 2. Use `BOARD=sodaq-one` with the `make` command.<br/>
- *    Example with `hello-world` application:
+ * Use `BOARD=sodaq-one` with the `make` command.<br/>
+ * Example with `hello-world` application:
  * ```
  *      make BOARD=sodaq-one -C examples/hello-world flash
  * ```
  *
  * ### Accessing STDIO via UART
  *
- * To access the STDIO of RIOT, a FTDI to USB converter needs to be plugged to
- * the RX/TX pins on the board.
+ * STDIO of RIOT is directly available over the USB port.
  *
  */

--- a/boards/sodaq-sara-aff/Makefile
+++ b/boards/sodaq-sara-aff/Makefile
@@ -1,3 +1,5 @@
 MODULE = board
 
+DIRS = $(RIOTBOARD)/common/samd21-arduino-bootloader
+
 include $(RIOTBASE)/Makefile.base

--- a/boards/sodaq-sara-aff/doc.txt
+++ b/boards/sodaq-sara-aff/doc.txt
@@ -13,20 +13,14 @@
  *
  * ### Flash the board
  *
- * 1. Put the board in bootloader mode by double tapping the reset button.<br/>
- *    When the board is in bootloader mode, the user led (blue) oscillates
- *    smoothly.
- *
- *
- * 2. Use `BOARD=sodaq-sara-aff` with the `make` command.<br/>
- *    Example with `hello-world` application:
+ * Use `BOARD=sodaq-sara-aff` with the `make` command.<br/>
+ * Example with `hello-world` application:
  * ```
  *      make BOARD=sodaq-sara-aff -C examples/hello-world flash
  * ```
  *
  * ### Accessing STDIO via UART
  *
- * To access the STDIO of RIOT, a FTDI to USB converter needs to be plugged to
- * the RX/TX pins on the board.
+ * STDIO of RIOT is directly available over the USB port.
  *
  */

--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -320,6 +320,12 @@ ifneq (,$(filter mag3110,$(USEMODULE)))
   FEATURES_REQUIRED += periph_i2c
 endif
 
+ifneq (,$(filter mkrwan,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_gpio
+  FEATURES_REQUIRED += periph_uart
+  USEMODULE += at
+endif
+
 ifneq (,$(filter mma7660,$(USEMODULE)))
   FEATURES_REQUIRED += periph_i2c
 endif

--- a/drivers/Makefile.include
+++ b/drivers/Makefile.include
@@ -186,6 +186,15 @@ ifneq (,$(filter mag3110,$(USEMODULE)))
   USEMODULE_INCLUDES += $(RIOTBASE)/drivers/mag3110/include
 endif
 
+ifneq (,$(filter mkrwan,$(USEMODULE)))
+  USEMODULE_INCLUDES += $(RIOTBASE)/drivers/mkrwan/include
+  # The AT reply of this module end with \r and no echo is sent
+  CFLAGS += -DAT_RECV_EOL_2=\"\"
+  CFLAGS += -DAT_SEND_ECHO=0
+  CFLAGS += -DAT_RECV_OK=\"+OK\"
+  CFLAGS += -DAT_RECV_ERROR=\"+ERR\"
+endif
+
 ifneq (,$(filter mma7660,$(USEMODULE)))
   USEMODULE_INCLUDES += $(RIOTBASE)/drivers/mma7660/include
 endif

--- a/drivers/include/mkrwan.h
+++ b/drivers/include/mkrwan.h
@@ -1,0 +1,372 @@
+/*
+ * Copyright (C) 2018 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    drivers_mkrwan MKRWAN LoRa radio transceiver
+ * @ingroup     drivers_netdev
+ * @brief       Device driver interface for the MKRWAN LoRa radio transceiver.
+ *
+ * @warning This driver was tested with version 1.1.9 of the firmware running on
+ * the transceiver.
+ *
+ * To update the firmware of the transceiver, the easiest is to flash the
+ * Arduino MKRWANFWUpdate_standalone example from https://github.com/arduino-libraries/MKRWAN/tree/master/examples/MKRWANFWUpdate_standalone
+ * on the board microcontroller.
+ * At startup, this firmware will automatically update the firmware running on
+ * transceiver.
+ *
+ * @{
+ *
+ * @file
+ * @brief       Device driver interface for the MKRWAN LoRa radio transceiver.
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ */
+
+#ifndef MKRWAN_H
+#define MKRWAN_H
+
+#include <inttypes.h>
+#include "net/loramac.h"
+#include "xtimer.h"
+
+#include "periph/gpio.h"
+#include "periph/uart.h"
+
+#include "at.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Size of temporary internal buffer
+ */
+#define MKRWAN_TMP_BUF_SIZE     (40U)
+
+/**
+ * @brief   Size of the internal buffer (must be a power of 2)
+ */
+#define MKRWAN_INT_BUF_SIZE     (256U)
+
+/**
+ * @brief   Command response timeout (2s)
+ */
+#define MKRWAN_TIMEOUT          (2 * US_PER_SEC)
+
+/**
+ * @brief   Command join timeout (60s)
+ */
+#define MKRWAN_JOIN_TIMEOUT     (60 * US_PER_SEC)
+
+/**
+ * @brief   Device initialization parameters
+ */
+typedef struct {
+    uart_t uart;                            /**< UART device that is used */
+    uint32_t baudrate;                      /**< UART baudrate */
+    gpio_t reset_pin;                       /**< Module reset pin */
+    gpio_t boot0_pin;                       /**< Module boot0 pin */
+} mkrwan_params_t;
+
+/**
+ * @brief   Device descriptor for the STM32 AT LoRa radio
+ */
+typedef struct {
+    mkrwan_params_t params;                 /**< Device initialization parameters */
+    at_dev_t at_dev;                        /**< AT command device */
+    char buf[MKRWAN_INT_BUF_SIZE];          /**< internal buffer */
+} mkrwan_t;
+
+/**
+ * @brief   Status and error return codes
+ */
+enum {
+    MKRWAN_OK = 0,                          /**< everything was fine */
+    MKRWAN_ERR,                             /**< generic error */
+};
+
+/**
+ * @brief   Setup the given device
+ *
+ * @param[out] dev          Initialized device descriptor of the device
+ * @param[in]  params       Initialization parameters
+ */
+void mkrwan_setup(mkrwan_t *dev, const mkrwan_params_t *params);
+
+/**
+ * @brief   Setup the given device
+ *
+ * @param[in] dev           Device descriptor of the device
+ *
+ * @return                  MKRWAN_OK on success
+ * @return                 -MKRWAN_ERR on error
+ */
+int mkrwan_init(mkrwan_t *dev);
+
+/**
+ * @brief   Reset the given device
+ *
+ * @param[in] dev           Device descriptor of the device
+ *
+ * @return                  MKRWAN_OK on success
+ * @return                 -MKRWAN_ERR on error
+ */
+int mkrwan_reset(mkrwan_t *dev);
+
+/**
+ * @brief   Get the version of the device
+ *
+ * @param[in] dev           Device descriptor of the device
+ * @param[out] version      String containing the version of the module
+ */
+void mkrwan_version(mkrwan_t *dev, char *version);
+
+/**
+ * @brief   Join a LoRaWAN network
+ *
+ * @param[in] dev           Device descriptor of the device
+ * @param[in] mode          Join procedure mode (either OTAA or ABP)
+ *
+ * @return                  MKRWAN_OK on success
+ * @return                 -MKRWAN_ERR on error
+ */
+int mkrwan_join(mkrwan_t *dev, uint8_t mode);
+
+/**
+ * @brief   Send data to a LoRaWAN network
+ *
+ * @param[in] dev           Device descriptor of the device
+ * @param[in] mode          Send mode (either confirmed or unconfirmed)
+ * @param[in] data          Data to send
+ * @param[in] len           Length of data to send
+ *
+ * @return                  MKRWAN_OK on success
+ * @return                 -MKRWAN_ERR on error
+ */
+int mkrwan_send(mkrwan_t *dev, uint8_t *data, uint8_t len, uint8_t mode);
+
+/**
+ * @brief   Set the device EUI
+ *
+ * @param[in] dev           Device descriptor of the device
+ * @param[in] eui           The device EUI
+ */
+void mkrwan_set_deveui(mkrwan_t *dev, uint8_t *eui);
+
+/**
+ * @brief   Get the device EUI
+ *
+ * @param[in] dev           Device descriptor of the device
+ * @param[out] eui          The device EUI
+ */
+void mkrwan_get_deveui(mkrwan_t *dev, uint8_t *eui);
+
+/**
+ * @brief   Set the application EUI
+ *
+ * @param[in] dev           Device descriptor of the device
+ * @param[in] eui           The application EUI
+ */
+void mkrwan_set_appeui(mkrwan_t *dev, uint8_t *eui);
+
+/**
+ * @brief   Set the application EUI
+ *
+ * @param[in] dev           Device descriptor of the device
+ * @param[out] eui          The application EUI
+ */
+void mkrwan_get_appeui(mkrwan_t *dev, uint8_t *eui);
+
+/**
+ * @brief   Set the application key
+ *
+ * @param[in] dev           Device descriptor of the device
+ * @param[in] key           The application key
+ */
+void mkrwan_set_appkey(mkrwan_t *dev, uint8_t *key);
+
+/**
+ * @brief   Get the application key
+ *
+ * @param[in] dev           Device descriptor of the device
+ * @param[in] key           The application key
+ */
+void mkrwan_get_appkey(mkrwan_t *dev, uint8_t *key);
+
+/**
+ * @brief   Set the device address
+ *
+ * @param[in] dev           Device descriptor of the device
+ * @param[in] addr          The device address
+ */
+void mkrwan_set_devaddr(mkrwan_t *dev, uint8_t *addr);
+
+/**
+ * @brief   Get the device address
+ *
+ * @param[in] dev           Device descriptor of the device
+ * @param[in] addr          The device address
+ */
+void mkrwan_get_devaddr(mkrwan_t *dev, uint8_t *addr);
+
+/**
+ * @brief   Set the application session key
+ *
+ * @param[in] dev           Device descriptor of the device
+ * @param[in] skey          The application session key
+ */
+void mkrwan_set_appskey(mkrwan_t *dev, uint8_t *skey);
+
+/**
+ * @brief   Get the application session key
+ *
+ * @param[in] dev           Device descriptor of the device
+ * @param[in] skey          The application session key
+ */
+void mkrwan_get_appskey(mkrwan_t *dev, uint8_t *skey);
+
+/**
+ * @brief   Set the network session key
+ *
+ * @param[in] dev           Device descriptor of the device
+ * @param[in] skey          The network session key
+ */
+void mkrwan_set_nwkskey(mkrwan_t *dev, uint8_t *skey);
+
+/**
+ * @brief   Get the network session key
+ *
+ * @param[in] dev           Device descriptor of the device
+ * @param[in] skey          The network session key
+ */
+void mkrwan_get_nwkskey(mkrwan_t *dev, uint8_t *skey);
+
+/**
+ * @brief   Set the device class
+ *
+ * @param[in] dev           Device descriptor of the device
+ * @param[in] class         Device class
+ *
+ * @return                  MKRWAN_OK on success
+ * @return                 -MKRWAN_ERR on error
+ */
+void mkrwan_set_class(mkrwan_t *dev, uint8_t class);
+
+/**
+ * @brief   Get the device class
+ *
+ * @param[in] dev           Device descriptor of the device
+ *
+ * @return                  the device class
+ */
+uint8_t mkrwan_get_class(mkrwan_t *dev);
+
+/**
+ * @brief   Enable/disable duty cycle
+ *
+ * @param[in] dev           Device descriptor of the device
+ * @param[in] enable        duty cycle is enabled or not
+ *
+ * @return                  MKRWAN_OK on success
+ * @return                 -MKRWAN_ERR on error
+ */
+void mkrwan_set_duty_cycle(mkrwan_t *dev, bool enable);
+
+/**
+ * @brief   Check if duty cycle is enabled/disabled
+ *
+ * @param[in] dev           Device descriptor of the device
+ *
+ * @return                  true duty cycle if is enabled, false otherwise
+ */
+bool mkrwan_get_duty_cycle(mkrwan_t *dev);
+
+/**
+ * @brief   Enable/disable the public network
+ *
+ * @param[in] dev           Device descriptor of the device
+ * @param[in] enable        network is enabled or not
+ *
+ * @return                  MKRWAN_OK on success
+ * @return                 -MKRWAN_ERR on error
+ */
+void mkrwan_set_public_network(mkrwan_t *dev, bool enable);
+
+/**
+ * @brief   Check if public network is enabled/disabled
+ *
+ * @param[in] dev           Device descriptor of the device
+ *
+ * @return                  true is public network is enabled, false otherwise
+ */
+bool mkrwan_get_public_network(mkrwan_t *dev);
+
+/**
+ * @brief   Set the datarate index
+ *
+ * @param[in] dev           Device descriptor of the device
+ * @param[in] dr            The datarate index
+ *
+ * @return                  MKRWAN_OK on success
+ * @return                 -MKRWAN_ERR on error
+ */
+void mkrwan_set_datarate(mkrwan_t *dev, loramac_dr_idx_t dr);
+
+/**
+ * @brief   Get the datarate index
+ *
+ * @param[in] dev           Device descriptor of the device
+ *
+ * @return                  the datarate index
+ */
+loramac_dr_idx_t mkrwan_get_datarate(mkrwan_t *dev);
+
+/**
+ * @brief   Set the adaptive datarate mode
+ *
+ * @param[in] dev           Device descriptor of the device
+ * @param[in] enable        Enable adaptive datarate
+ *
+ * @return                  MKRWAN_OK on success
+ * @return                 -MKRWAN_ERR on error
+ */
+void mkrwan_set_adr(mkrwan_t *dev, bool enable);
+
+/**
+ * @brief   Get the datarate index
+ *
+ * @param[in] dev           Device descriptor of the device
+ *
+ * @return                  the datarate index
+ */
+bool mkrwan_get_adr(mkrwan_t *dev);
+
+/**
+ * @brief   Sets the TX application port
+ *
+ * @param[in] dev           Device descriptor of the device
+ * @param[in] port          The TX application port
+ */
+void mkrwan_set_tx_port(mkrwan_t *dev, uint8_t port);
+
+/**
+ * @brief   Gets the TX application port
+ *
+ * @param[in] dev           Device descriptor of the device
+ *
+ * @return                  The TX application port
+ */
+uint8_t mkrwan_get_tx_port(mkrwan_t *dev);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MKRWAN_H */
+/** @} */

--- a/drivers/mkrwan/Makefile
+++ b/drivers/mkrwan/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/drivers/mkrwan/include/mkrwan_params.h
+++ b/drivers/mkrwan/include/mkrwan_params.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2018 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_mkrwan
+ *
+ * @{
+ * @file
+ * @brief       Default configuration for MKRWAN
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ */
+
+#ifndef MKRWAN_PARAMS_H
+#define MKRWAN_PARAMS_H
+
+#include "board.h"
+#include "mkrwan.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Set default configuration parameters for the MKRWAN
+ * @{
+ */
+#ifndef MKRWAN_PARAM_UART_DEV
+#define MKRWAN_PARAM_UART_DEV           UART_DEV(1)
+#endif
+#ifndef MKRWAN_PARAM_UART_BAUDRATE
+#define MKRWAN_PARAM_UART_BAUDRATE      (19200U)
+#endif
+#ifndef MKRWAN_PARAM_RESET_PIN
+#define MKRWAN_PARAM_RESET_PIN          GPIO_PIN(0,27) /* PA 27 */
+#endif
+#ifndef MKRWAN_PARAM_BOOT0_PIN
+#define MKRWAN_PARAM_BOOT0_PIN          GPIO_PIN(1,9) /* PB 9 */
+#endif
+
+#ifndef MKRWAN_PARAMS
+#define MKRWAN_PARAMS                   { .uart      = MKRWAN_PARAM_UART_DEV,      \
+                                          .baudrate  = MKRWAN_PARAM_UART_BAUDRATE, \
+                                          .reset_pin = MKRWAN_PARAM_RESET_PIN,     \
+                                          .boot0_pin = MKRWAN_PARAM_BOOT0_PIN }
+#endif
+/**@}*/
+
+/**
+ * @brief   Configure MKRWAN
+ */
+static const mkrwan_params_t mkrwan_params[] =
+{
+    MKRWAN_PARAMS
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MKRWAN_PARAMS_H */
+/** @} */

--- a/drivers/mkrwan/mkrwan.c
+++ b/drivers/mkrwan/mkrwan.c
@@ -1,0 +1,213 @@
+/*
+ * Copyright (C) 2018 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_mkrwan
+ * @{
+ *
+ * @file
+ * @brief       Device driver implementation for the  LoRa radio.
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ * @}
+ */
+
+#include <string.h>
+
+#include "at.h"
+#include "fmt.h"
+
+#include "net/loramac.h"
+
+#include "periph/gpio.h"
+
+#include "mkrwan.h"
+#include "mkrwan_params.h"
+
+#define ENABLE_DEBUG        (0)
+#include "debug.h"
+
+static char tmp_buf[MKRWAN_TMP_BUF_SIZE];
+
+void mkrwan_setup(mkrwan_t *dev, const mkrwan_params_t *params)
+{
+    assert(dev && (params->uart < UART_NUMOF));
+    dev->params = *params;
+}
+
+int mkrwan_init(mkrwan_t *dev)
+{
+    DEBUG("[mkrwan] Initializing UART %d at baudrate: %u\n",
+          dev->params.uart, (unsigned int)dev->params.baudrate);
+
+    DEBUG("[mkrwan] hardware reset of the module\n");
+    gpio_init(dev->params.boot0_pin, GPIO_OUT);
+    gpio_clear(dev->params.boot0_pin);
+
+    gpio_init(dev->params.reset_pin, GPIO_OUT);
+    gpio_set(dev->params.reset_pin);
+    xtimer_usleep(200 * US_PER_MS);
+    gpio_clear(dev->params.reset_pin);
+    xtimer_usleep(200 * US_PER_MS);
+    gpio_set(dev->params.reset_pin);
+
+    DEBUG("[mkrwan] initializing bus\n");
+
+    at_dev_init(&dev->at_dev,
+                dev->params.uart, dev->params.baudrate,
+                dev->buf, sizeof(dev->buf));
+
+    xtimer_usleep(200 * US_PER_MS);
+
+    if (at_send_cmd_wait_ok(&dev->at_dev, "AT", MKRWAN_TIMEOUT) < 0) {
+        DEBUG("[mkrwan] AT device not initialized correctly\n");
+        return -MKRWAN_ERR;
+    }
+
+    /* set default parameters */
+    mkrwan_set_tx_port(dev, LORAMAC_DEFAULT_TX_PORT);
+
+    DEBUG("[mkrwan] AT device initialized with success\n");
+
+    return MKRWAN_OK;
+}
+
+int mkrwan_reset(mkrwan_t *dev)
+{
+    DEBUG("[mkrwan] resetting device\n");
+
+    int res = at_send_cmd(&dev->at_dev, "AT+REBOOT", MKRWAN_TIMEOUT);
+    if (res < 0) {
+        return -MKRWAN_ERR;
+    }
+
+    return MKRWAN_OK;
+}
+
+void mkrwan_version(mkrwan_t *dev, char *version)
+{
+    at_send_cmd(&dev->at_dev, "AT+DEV?", MKRWAN_TIMEOUT);
+    at_readline(&dev->at_dev, tmp_buf, sizeof(tmp_buf), false, MKRWAN_TIMEOUT);
+    DEBUG("[mkrwan] version: %s-", &tmp_buf[4]);
+    size_t len_dev = strlen(&tmp_buf[4]);
+    memcpy(version, &tmp_buf[4], len_dev);
+    char *pos = &version[len_dev];
+    pos += fmt_str(pos, "-");
+    at_send_cmd(&dev->at_dev, "AT+VER?", MKRWAN_TIMEOUT);
+    at_readline(&dev->at_dev, tmp_buf, sizeof(tmp_buf), false, MKRWAN_TIMEOUT);
+    DEBUG("%s\n", &tmp_buf[4]);
+    size_t len_ver = strlen(&tmp_buf[4]);
+    memcpy(pos, &tmp_buf[4], len_ver);
+    pos += len_ver;
+    *pos = '\0';
+}
+
+int mkrwan_join(mkrwan_t *dev, uint8_t mode)
+{
+    DEBUG("[mkrwan] join to network using ");
+    switch (mode) {
+        case LORAMAC_JOIN_OTAA:
+            DEBUG("OTAA\n");
+            break;
+        case LORAMAC_JOIN_ABP:
+            DEBUG("ABP\n");
+            break;
+        default:
+            break;
+    }
+
+    char *pos = tmp_buf;
+    pos += fmt_str(pos, "AT+MODE=");
+    pos += fmt_u16_dec(pos, 1 - mode);
+    *pos = '\0';
+
+    DEBUG("[mkrwan] sending join command %s\n", tmp_buf);
+
+    int res = at_send_cmd_wait_ok(&dev->at_dev, tmp_buf, MKRWAN_TIMEOUT);
+
+    if (res < 0) {
+        DEBUG("[mkrwan] failed setting join mode\n");
+        return -MKRWAN_ERR;
+    }
+
+    res = at_send_cmd(&dev->at_dev, "AT+JOIN", MKRWAN_JOIN_TIMEOUT);
+    at_readline(&dev->at_dev, tmp_buf, sizeof(tmp_buf),
+                false, MKRWAN_JOIN_TIMEOUT);
+    DEBUG("[mkrwan] join response: %s\n", tmp_buf);
+    if (res < 0) {
+        DEBUG("[mkrwan] join error\n");
+        return -MKRWAN_ERR;
+    }
+
+    pos = tmp_buf;
+    pos += fmt_str(pos, "AT+NJS?");
+    *pos = '\0';
+    res = at_send_cmd_get_resp(&dev->at_dev, tmp_buf,
+                               tmp_buf, sizeof(tmp_buf),
+                               MKRWAN_TIMEOUT);
+    if (res < 0) {
+        DEBUG("[mkrwan] failed to get network status\n");
+        return -MKRWAN_ERR;
+    }
+
+    return MKRWAN_OK;
+}
+
+int mkrwan_send(mkrwan_t *dev, uint8_t *data, uint8_t len, uint8_t mode)
+{
+    DEBUG("[mkrwan] sending data\n");
+
+    int res;
+    DEBUG("[mkrwan] check if network is joined\n");
+
+    char *pos = tmp_buf;
+    pos += fmt_str(pos, "AT+NJS?");
+    *pos = '\0';
+    res = at_send_cmd_get_resp(&dev->at_dev, tmp_buf,
+                               tmp_buf, sizeof(tmp_buf),
+                               MKRWAN_TIMEOUT);
+    if (res < 0) {
+        DEBUG("[mkrwan] failed to get network status\n");
+        return -MKRWAN_ERR;
+    }
+
+    if (atoi(&tmp_buf[4]) != 1) {
+        DEBUG("[mkrwan] network is not joined!\n");
+        return -MKRWAN_ERR;
+    }
+
+    pos = tmp_buf;
+    if (mode == LORAMAC_TX_CNF) {
+        pos += fmt_str(pos, "AT+CTX ");
+    }
+    else {
+        pos += fmt_str(pos, "AT+UTX ");
+    }
+
+    pos += fmt_u16_dec(pos, len);
+    *pos = '\0';
+
+    DEBUG("[mkrwan] sending with command %s\n", tmp_buf);
+
+    res = at_send_cmd(&dev->at_dev, tmp_buf, MKRWAN_TIMEOUT);
+    if (res < 0) {
+        DEBUG("[mkrwan] send preparation failed!\n");
+        return -MKRWAN_ERR;
+    }
+
+    at_send_bytes(&dev->at_dev, (char *)data, len);
+
+    res = at_send_cmd_wait_ok(&dev->at_dev, "AT", MKRWAN_TIMEOUT);
+    if (res < 0) {
+        DEBUG("[mkrwan] failed to send data!\n");
+        return -MKRWAN_ERR;
+    }
+
+    return MKRWAN_OK;
+}

--- a/drivers/mkrwan/mkrwan_getset.c
+++ b/drivers/mkrwan/mkrwan_getset.c
@@ -1,0 +1,295 @@
+/*
+ * Copyright (C) 2018 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_mkrwan
+ * @{
+ *
+ * @file
+ * @brief       Device driver implementation for the MKRWAN LoRa radio.
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ * @}
+ */
+
+#include <string.h>
+
+#include "mkrwan.h"
+#include "xtimer.h"
+#include "fmt.h"
+
+#define ENABLE_DEBUG        (0)
+#include "debug.h"
+
+static const char *deveui_cmd       = "DEVEUI";
+static const char *appeui_cmd       = "APPEUI";
+static const char *appkey_cmd       = "APPKEY";
+static const char *devaddr_cmd      = "DEVADDR";
+static const char *appskey_cmd      = "APPSKEY";
+static const char *nwkskey_cmd      = "NWKSKEY";
+static const char *class_cmd        = "CLASS";
+static const char *dcycle_cmd       = "DUTYCYCLE";
+static const char *nwk_cmd          = "NWK";
+static const char *dr_cmd           = "DR";
+static const char *adr_cmd          = "ADR";
+static const char *port_cmd         = "PORT";
+
+static char tmp_buf[MKRWAN_TMP_BUF_SIZE];
+
+static void _set_array(mkrwan_t *dev, const char *cmd,
+                       uint8_t *array, size_t len)
+{
+    char *pos = tmp_buf;
+    pos += fmt_str(pos, "AT+");
+    pos += fmt_str(pos, cmd);
+    pos += fmt_str(pos, "=");
+    pos += fmt_bytes_hex(pos, array, len);
+    *pos = '\0';
+
+    DEBUG("[mkrwan] set array cmd: %s\n", tmp_buf);
+
+    at_send_cmd_wait_ok(&dev->at_dev, tmp_buf, MKRWAN_TIMEOUT);
+}
+
+static void _get_array(mkrwan_t *dev, const char *cmd,
+                       uint8_t *array)
+{
+    char *pos = tmp_buf;
+    pos += fmt_str(pos, "AT+");
+    pos += fmt_str(pos, cmd);
+    pos += fmt_str(pos, "?");
+    *pos = '\0';
+
+    DEBUG("[mkrwan] get array cmd: %s\n", tmp_buf);
+
+    at_send_cmd(&dev->at_dev, tmp_buf, MKRWAN_TIMEOUT);
+
+    at_readline(&dev->at_dev, tmp_buf, sizeof(tmp_buf),
+                false, MKRWAN_TIMEOUT);
+
+    DEBUG("[mkrwan] get array resp: %s\n", tmp_buf);
+
+    fmt_hex_bytes(array, &tmp_buf[4]);
+}
+
+static void _set_integer(mkrwan_t *dev, const char *cmd, uint8_t integer)
+{
+    char *pos = tmp_buf;
+    pos += fmt_str(pos, "AT+");
+    pos += fmt_str(pos, cmd);
+    pos += fmt_str(pos, "=");
+    pos += fmt_u16_dec(pos, integer);
+    *pos = '\0';
+
+    DEBUG("[mkrwan] set integer cmd: %s\n", tmp_buf);
+
+    at_send_cmd_wait_ok(&dev->at_dev, tmp_buf, MKRWAN_TIMEOUT);
+}
+
+static uint8_t _get_integer(mkrwan_t *dev, const char *cmd)
+{
+    char *pos = tmp_buf;
+    pos += fmt_str(pos, "AT+");
+    pos += fmt_str(pos, cmd);
+    pos += fmt_str(pos, "?");
+    *pos = '\0';
+
+    DEBUG("[mkrwan] get integer cmd: %s\n", tmp_buf);
+
+    at_send_cmd(&dev->at_dev, tmp_buf, MKRWAN_TIMEOUT);
+    at_readline(&dev->at_dev, tmp_buf, sizeof(tmp_buf),
+                false, MKRWAN_TIMEOUT);
+
+    DEBUG("[mkrwan] get integer resp: %s\n", tmp_buf);
+
+    return atoi(tmp_buf);
+}
+
+static void _set_bool(mkrwan_t *dev, const char *cmd, bool enable)
+{
+    _set_integer(dev, cmd, (uint8_t)enable);
+}
+
+static bool _get_bool(mkrwan_t *dev, const char *cmd)
+{
+    char *pos = tmp_buf;
+    pos += fmt_str(pos, "AT+");
+    pos += fmt_str(pos, cmd);
+    pos += fmt_str(pos, "?");
+    *pos = '\0';
+
+    DEBUG("[mkrwan] get bool cmd: %s\n", tmp_buf);
+
+    at_send_cmd_get_resp(&dev->at_dev, tmp_buf,
+                         tmp_buf, sizeof(tmp_buf), MKRWAN_JOIN_TIMEOUT);
+
+    DEBUG("[mkrwan] get bool resp: %s\n", tmp_buf);
+
+    return (bool)atoi(&tmp_buf[4]);
+}
+
+void mkrwan_set_deveui(mkrwan_t *dev, uint8_t *eui)
+{
+    _set_array(dev, deveui_cmd, eui, LORAMAC_DEVEUI_LEN);
+}
+
+void mkrwan_get_deveui(mkrwan_t *dev, uint8_t *eui)
+{
+    _get_array(dev, deveui_cmd, eui);
+}
+
+void mkrwan_set_appeui(mkrwan_t *dev, uint8_t *eui)
+{
+    _set_array(dev, appeui_cmd, eui, LORAMAC_APPEUI_LEN);
+}
+
+void mkrwan_get_appeui(mkrwan_t *dev, uint8_t *eui)
+{
+    _get_array(dev, appeui_cmd, eui);
+}
+
+void mkrwan_set_appkey(mkrwan_t *dev, uint8_t *key)
+{
+    _set_array(dev, appkey_cmd, key, LORAMAC_APPKEY_LEN);
+}
+
+void mkrwan_get_appkey(mkrwan_t *dev, uint8_t *key)
+{
+    _get_array(dev, appkey_cmd, key);
+}
+
+void mkrwan_set_devaddr(mkrwan_t *dev, uint8_t *addr)
+{
+    _set_array(dev, devaddr_cmd, addr, LORAMAC_DEVADDR_LEN);
+}
+
+void mkrwan_get_devaddr(mkrwan_t *dev, uint8_t *addr)
+{
+    _get_array(dev, devaddr_cmd, addr);
+}
+
+void mkrwan_set_appskey(mkrwan_t *dev, uint8_t *skey)
+{
+    _set_array(dev, appskey_cmd, skey, LORAMAC_APPSKEY_LEN);
+}
+
+void mkrwan_get_appskey(mkrwan_t *dev, uint8_t *skey)
+{
+    _get_array(dev, appskey_cmd, skey);
+}
+
+void mkrwan_set_nwkskey(mkrwan_t *dev, uint8_t *skey)
+{
+    _set_array(dev, nwkskey_cmd, skey, LORAMAC_NWKSKEY_LEN);
+}
+
+void mkrwan_get_nwkskey(mkrwan_t *dev, uint8_t *skey)
+{
+    _get_array(dev, nwkskey_cmd, skey);
+}
+
+void mkrwan_set_class(mkrwan_t *dev, uint8_t class)
+{
+    char *pos = tmp_buf;
+    pos += fmt_str(pos, "AT+");
+    pos += fmt_str(pos, class_cmd);
+    pos += fmt_str(pos, "=");
+    switch (class) {
+        case LORAMAC_CLASS_A:
+            *pos++ = 'A';
+            break;
+        case LORAMAC_CLASS_B:
+            *pos++ = 'B';
+            break;
+        case LORAMAC_CLASS_C:
+            *pos++ = 'C';
+            break;
+    }
+    *pos = '\0';
+
+    DEBUG("[mkrwan] set sleep cmd: %s\n", tmp_buf);
+
+    at_send_cmd_wait_ok(&dev->at_dev, tmp_buf, MKRWAN_TIMEOUT);
+}
+
+uint8_t mkrwan_get_class(mkrwan_t *dev)
+{
+    char *pos = tmp_buf;
+    pos += fmt_str(pos, "AT+");
+    pos += fmt_str(pos, class_cmd);
+    pos += fmt_str(pos, "?");
+    *pos = '\0';
+
+    int res = at_send_cmd_get_resp(&dev->at_dev, tmp_buf,
+                                   tmp_buf, sizeof(tmp_buf), MKRWAN_TIMEOUT);
+    if (res > 0) {
+        DEBUG("[mkrwan] get class resp: %s\n", tmp_buf);
+        if (strcmp(&tmp_buf[4], "A") == 0) {
+            return LORAMAC_CLASS_A;
+        }
+        else if (strcmp(&tmp_buf[4], "B") == 0) {
+            return LORAMAC_CLASS_B;
+        }
+        else {
+            return LORAMAC_CLASS_C;
+        }
+    }
+
+    return LORAMAC_CLASS_A;
+}
+
+void mkrwan_set_duty_cycle(mkrwan_t *dev, bool enable)
+{
+    _set_bool(dev, dcycle_cmd, enable);
+}
+
+bool mkrwan_get_duty_cycle(mkrwan_t *dev)
+{
+    return _get_bool(dev, dcycle_cmd);
+}
+
+void mkrwan_set_public_network(mkrwan_t *dev, bool enable)
+{
+    _set_bool(dev, nwk_cmd, enable);
+}
+
+bool mkrwan_get_public_network(mkrwan_t *dev)
+{
+    return _get_bool(dev, nwk_cmd);
+}
+
+void mkrwan_set_datarate(mkrwan_t *dev, loramac_dr_idx_t dr)
+{
+    _set_integer(dev, dr_cmd, dr);
+}
+
+loramac_dr_idx_t mkrwan_get_datarate(mkrwan_t *dev)
+{
+    return _get_integer(dev, dr_cmd);
+}
+
+void mkrwan_set_adr(mkrwan_t *dev, bool enable)
+{
+    _set_bool(dev, adr_cmd, enable);
+}
+
+bool mkrwan_get_adr(mkrwan_t *dev)
+{
+    return _get_bool(dev, adr_cmd);
+}
+
+void mkrwan_set_tx_port(mkrwan_t *dev, uint8_t port)
+{
+    _set_integer(dev, port_cmd, port);
+}
+
+uint8_t mkrwan_get_tx_port(mkrwan_t *dev)
+{
+    return _get_integer(dev, port_cmd);
+}

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -1,3 +1,4 @@
+PSEUDOMODULES += arduino_bootloader
 PSEUDOMODULES += at_urc
 PSEUDOMODULES += auto_init_gnrc_rpl
 PSEUDOMODULES += can_mbox

--- a/makefiles/tools/bossa.inc.mk
+++ b/makefiles/tools/bossa.inc.mk
@@ -13,9 +13,18 @@ ifneq (,$(BOSSA_ARDUINO_PREFLASH))
 
   PREFLASHER ?= stty
   PREFFLAGS  ?= $(STTY_FLAG) $(PROG_DEV) raw ispeed 1200 ospeed 1200 cs8 -cstopb ignpar eol 255 eof 255
-  FLASHDEPS += preflash
+  ifneq (,$(PREFLASH_DELAY))
+    FLASHDEPS += preflash-delay
+  else
+    FLASHDEPS += preflash
+  endif
 
+  RESETFFLASG ?= $(STTY_FLAG) $(PORT) raw ispeed 600 ospeed 600 cs8 -cstopb ignpar eol 255 eof 255
+  RESET ?= $(PREFLASHER) $(RESETFFLASG)
 endif
+
+preflash-delay: preflash
+	sleep $(PREFLASH_DELAY)
 
 # if we go with the default (BOSSA shipped with RIOT), we download and build
 # the tool if not already done

--- a/tests/driver_mkrwan/Makefile
+++ b/tests/driver_mkrwan/Makefile
@@ -1,0 +1,9 @@
+include ../Makefile.tests_common
+
+BOARD_BLACKLIST := msb-430 msb-430h telosb wsn430-v1_3b wsn430-v1_4 z1
+
+USEMODULE += mkrwan
+USEMODULE += shell
+USEMODULE += shell_commands
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/driver_mkrwan/README.md
+++ b/tests/driver_mkrwan/README.md
@@ -1,0 +1,55 @@
+# About
+
+This is a manual test application for testing the Arduino MKRWAN 1300 on-board
+LoRa radio.
+
+# Build and flash the application
+
+    make BOARD=arduino-mkrwan1300 -C tests/driver_mkrwan flash
+
+# Usage
+
+This test application provides a shell with basic commands to interact with
+the radio.
+
+Note: the Device EUI of the LoRa cannot be changed.
+
+* Read current version of the LoRa module:
+
+      > mkrwan version
+
+
+* Read the device EUI (invalid value given on purpose):
+
+      > mkrwan get deveui
+      device eui: 0000000000000000
+
+For an OTAA activation procedure:
+
+* Set the application EUI (invalid value given on purpose):
+
+      > mkrwan set appeui 0000000000000000
+
+* Set the application key:
+
+      > mkrwan set appkey 00000000000000000000000000000000
+
+* Join the network:
+
+      > mkrwan join otaa
+      Join procedure succeeded!
+
+* Send some data to the LoRaWAN network:
+
+      > mkrwan send ThisIsRIOT!
+      Data sent with success
+
+You can also play with LoRaWAN basic parameters:
+
+* Change the datarate to 5 (SF7BW125):
+
+      > mkrwan set dr 5
+
+* Turn off adaptive datarate:
+
+      > mkrwan set adr off

--- a/tests/driver_mkrwan/main.c
+++ b/tests/driver_mkrwan/main.c
@@ -1,0 +1,330 @@
+/*
+ * Copyright (C) 2018 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Test application for MKRWAN LoRa module driver
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <errno.h>
+
+#include "timex.h"
+#include "shell.h"
+#include "shell_commands.h"
+#include "fmt.h"
+
+#include "mkrwan_params.h"
+#include "mkrwan.h"
+
+static mkrwan_t mkrwan_dev;
+
+static uint8_t payload[MKRWAN_INT_BUF_SIZE];
+
+static void _print_mkrwan_usage(void)
+{
+    puts("Usage: mkrwan <get|set|join|tx|reset|version>");
+}
+
+static void _print_join_usage(void)
+{
+    puts("Usage: mkrwan join <otaa|abp>");
+}
+
+static void _print_tx_usage(void)
+{
+    puts("Usage: mkrwan tx <data> <uncnf|cnf> <port>");
+}
+
+static void _print_set_usage(void)
+{
+    puts("Usage: mkrwan set "
+         "<appeui|devaddr|appskey|nwkskey|class|public|duty_cycle|"
+         "dr|adr|port> <value>");
+}
+
+static void _print_get_usage(void)
+{
+    puts("Usage: mkrwan get "
+         "<deveui|appeui|devaddr|appskey|nwkskey|class|public|duty_cycle|"
+         "dr|adr|port>");
+}
+
+int mkrwan_cmd(int argc, char **argv)
+{
+    if (strcmp(argv[1], "get") == 0) {
+        if (argc != 3) {
+            _print_get_usage();
+            return 1;
+        }
+
+        if (strcmp(argv[2], "deveui") == 0) {
+            char buf[LORAMAC_DEVEUI_LEN * 2 + 1];
+            mkrwan_get_deveui(&mkrwan_dev, payload);
+            fmt_bytes_hex(buf, payload, LORAMAC_DEVEUI_LEN);
+            buf[LORAMAC_DEVEUI_LEN * 2] = '\0';
+            printf("device eui: %s\n", buf);
+        }
+        else if (strcmp(argv[2], "appeui") == 0) {
+            char buf[LORAMAC_APPEUI_LEN * 2 + 1];
+            mkrwan_get_appeui(&mkrwan_dev, payload);
+            fmt_bytes_hex(buf, payload, LORAMAC_APPEUI_LEN);
+            buf[LORAMAC_APPEUI_LEN * 2] = '\0';
+            printf("application eui: %s\n", buf);
+        }
+        else if (strcmp(argv[2], "appkey") == 0) {
+            char buf[LORAMAC_APPKEY_LEN * 2 + 1];
+            mkrwan_get_appkey(&mkrwan_dev, payload);
+            fmt_bytes_hex(buf, payload, LORAMAC_APPKEY_LEN);
+            buf[LORAMAC_APPKEY_LEN * 2] = '\0';
+            printf("application key: %s\n", buf);
+        }
+        else if (strcmp(argv[2], "devaddr") == 0) {
+            char buf[LORAMAC_DEVADDR_LEN * 2 + 1];
+            mkrwan_get_devaddr(&mkrwan_dev, payload);
+            fmt_bytes_hex(buf, payload, LORAMAC_DEVADDR_LEN);
+            buf[LORAMAC_DEVADDR_LEN * 2] = '\0';
+            printf("device address: %s\n", buf);
+        }
+        else if (strcmp(argv[2], "appskey") == 0) {
+            char buf[LORAMAC_APPSKEY_LEN * 2 + 1];
+            mkrwan_get_appskey(&mkrwan_dev, payload);
+            fmt_bytes_hex(buf, payload, LORAMAC_APPSKEY_LEN);
+            buf[LORAMAC_APPSKEY_LEN * 2] = '\0';
+            printf("application session key: %s\n", buf);
+        }
+        else if (strcmp(argv[2], "nwkskey") == 0) {
+            char buf[LORAMAC_NWKSKEY_LEN * 2 + 1];
+            mkrwan_get_nwkskey(&mkrwan_dev, payload);
+            fmt_bytes_hex(buf, payload, LORAMAC_NWKSKEY_LEN);
+            buf[LORAMAC_NWKSKEY_LEN * 2] = '\0';
+            printf("network session key: %s\n", buf);
+        }
+        else if (strcmp(argv[2], "public") == 0) {
+            bool enable = mkrwan_get_public_network(&mkrwan_dev);
+            printf("Public network: %s\n", enable ? "on": "off");
+        }
+        else if (strcmp(argv[2], "duty_cycle") == 0) {
+            bool enable = mkrwan_get_duty_cycle(&mkrwan_dev);
+            printf("Duty cycle: %s\n", enable ? "on": "off");
+        }
+        else if (strcmp(argv[2], "dr") == 0) {
+            uint8_t dr = mkrwan_get_datarate(&mkrwan_dev);
+            printf("Datarate: %d\n", dr);
+        }
+        else if (strcmp(argv[2], "adr") == 0) {
+            bool enable = mkrwan_get_adr(&mkrwan_dev);
+            printf("Adaptive datarate: %s\n", enable ? "on": "off");
+        }
+        else if (strcmp(argv[2], "port") == 0) {
+            uint8_t port = mkrwan_get_tx_port(&mkrwan_dev);
+            printf("Port: %d\n", port);
+        }
+        else {
+            _print_get_usage();
+            return 1;
+        }
+    }
+    else if (strcmp(argv[1], "set") == 0) {
+        if (argc != 4) {
+            _print_set_usage();
+            return 1;
+        }
+
+        if (strcmp(argv[2], "deveui") == 0) {
+            fmt_hex_bytes(payload, argv[3]);
+            mkrwan_set_deveui(&mkrwan_dev, payload);
+        }
+        else if (strcmp(argv[2], "appeui") == 0) {
+            fmt_hex_bytes(payload, argv[3]);
+            mkrwan_set_appeui(&mkrwan_dev, payload);
+        }
+        else if (strcmp(argv[2], "appkey") == 0) {
+            fmt_hex_bytes(payload, argv[3]);
+            mkrwan_set_appkey(&mkrwan_dev, payload);
+        }
+        else if (strcmp(argv[2], "devaddr") == 0) {
+            fmt_hex_bytes(payload, argv[3]);
+            mkrwan_set_devaddr(&mkrwan_dev, payload);
+        }
+        else if (strcmp(argv[2], "appskey") == 0) {
+            fmt_hex_bytes(payload, argv[3]);
+            mkrwan_set_appskey(&mkrwan_dev, payload);
+        }
+        else if (strcmp(argv[2], "nwkskey") == 0) {
+            fmt_hex_bytes(payload, argv[3]);
+            mkrwan_set_nwkskey(&mkrwan_dev, payload);
+        }
+        else if (strcmp(argv[2], "class") == 0) {
+            uint8_t class;
+            if (strcmp(argv[3], "A") == 0) {
+                class = LORAMAC_CLASS_A;
+            }
+            else if (strcmp(argv[3], "B") == 0) {
+                class = LORAMAC_CLASS_B;
+            }
+            else if (strcmp(argv[3], "C") == 0) {
+                class = LORAMAC_CLASS_C;
+            }
+            else {
+                printf("Invalid class '%s'\n", argv[3]);
+                return 1;
+            }
+
+            mkrwan_set_class(&mkrwan_dev, class);
+        }
+        else if (strcmp(argv[2], "public") == 0) {
+            mkrwan_set_public_network(&mkrwan_dev, strcmp(argv[3], "on") == 0);
+        }
+        else if (strcmp(argv[2], "duty_cycle") == 0) {
+            mkrwan_set_duty_cycle(&mkrwan_dev, strcmp(argv[3], "on") == 0);
+        }
+        else if (strcmp(argv[2], "dr") == 0) {
+            mkrwan_set_datarate(&mkrwan_dev, atoi(argv[3]));
+        }
+        else if (strcmp(argv[2], "adr") == 0) {
+            mkrwan_set_adr(&mkrwan_dev, (bool)atoi(argv[3]));
+        }
+        else if (strcmp(argv[2], "port") == 0) {
+            mkrwan_set_tx_port(&mkrwan_dev, atoi(argv[3]));
+        }
+        else {
+            _print_set_usage();
+            return 1;
+        }
+    }
+    else if (strcmp(argv[1], "join") == 0) {
+        if (argc != 3) {
+            _print_join_usage();
+            return 1;
+        }
+
+        uint8_t mode;
+        if (strcmp(argv[2], "otaa") == 0) {
+            mode = LORAMAC_JOIN_OTAA;
+        }
+        else {
+            mode = LORAMAC_JOIN_ABP;
+        }
+        if (mkrwan_join(&mkrwan_dev, mode) != MKRWAN_OK) {
+            puts("Join procedure failed!");
+        }
+        else {
+            puts("Join procedure succeeded!");
+        }
+    }
+    else if (strcmp(argv[1], "tx") == 0) {
+        if ((argc < 3) || (argc > 5)) {
+            _print_tx_usage();
+            return 1;
+        }
+
+        uint8_t mode = LORAMAC_DEFAULT_TX_MODE;
+
+        if (argc > 3) {
+            if (strcmp(argv[3], "cnf") == 0) {
+                mode = LORAMAC_TX_CNF;
+            }
+            else if (strcmp(argv[3], "uncnf") == 0) {
+                mode = LORAMAC_TX_UNCNF;
+            }
+            else {
+                _print_tx_usage();
+                return 1;
+            }
+        }
+
+        if (argc > 4) {
+            uint8_t port = atoi(argv[4]);
+            mkrwan_set_tx_port(&mkrwan_dev, port);
+        }
+
+        if (mkrwan_send(&mkrwan_dev, (uint8_t*)argv[2], strlen(argv[2]),
+                        mode) != MKRWAN_OK) {
+            puts("Send failed!");
+        }
+        else {
+            puts("Data sent with success");
+        }
+    }
+    else if (strcmp(argv[1], "reset") == 0) {
+        if (argc != 2) {
+            _print_mkrwan_usage();
+            return 1;
+        }
+
+        char buf[MKRWAN_INT_BUF_SIZE];
+        mkrwan_version(&mkrwan_dev, buf);
+        printf("Version: %s\n", buf);
+    }
+    else if (strcmp(argv[1], "version") == 0) {
+        if (argc != 2) {
+            _print_mkrwan_usage();
+            return 1;
+        }
+
+        char buf[MKRWAN_INT_BUF_SIZE];
+        mkrwan_version(&mkrwan_dev, buf);
+        printf("Version: %s\n", buf);
+    }
+    else {
+        _print_mkrwan_usage();
+        return 1;
+    }
+
+    return 0;
+}
+
+int mkrwan_at_cmd(int argc, char **argv)
+{
+    if (argc < 2) {
+        printf("Usage: %s <at command>\n", argv[0]);
+        return 1;
+    }
+
+    char buf[MKRWAN_INT_BUF_SIZE];
+    at_send_cmd_get_resp(&mkrwan_dev.at_dev, argv[1],
+                         buf, sizeof(buf), MKRWAN_TIMEOUT);
+
+    printf("Response: %s\n", buf);
+
+    return 0;
+}
+
+static const shell_command_t shell_commands[] = {
+    { "mkrwan",     "Control the mkrwan driver",    mkrwan_cmd },
+    { "at",         "Send an AT command",        mkrwan_at_cmd },
+    { NULL, NULL, NULL }
+};
+
+int main(void)
+{
+    puts("MKRWAN device driver test");
+
+    mkrwan_setup(&mkrwan_dev, &mkrwan_params[0]);
+    if (mkrwan_init(&mkrwan_dev) != MKRWAN_OK) {
+        puts("MKRWAN initialization failed");
+        return -1;
+    }
+
+    /* start the shell */
+    puts("Initialization OK, starting shell now");
+
+    char line_buf[SHELL_DEFAULT_BUFSIZE];
+    shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
+
+    return 0;
+}

--- a/tests/gnrc_ipv6_ext/Makefile
+++ b/tests/gnrc_ipv6_ext/Makefile
@@ -1,3 +1,4 @@
+BOARD ?= samr21-xpro
 DEVELHELP := 1
 # name of your application
 include ../Makefile.tests_common

--- a/tests/gnrc_ipv6_ext_frag/Makefile
+++ b/tests/gnrc_ipv6_ext_frag/Makefile
@@ -1,3 +1,4 @@
+BOARD ?= samr21-xpro
 DEVELHELP := 1
 # name of your application
 include ../Makefile.tests_common

--- a/tests/gnrc_rpl_srh/Makefile
+++ b/tests/gnrc_rpl_srh/Makefile
@@ -1,3 +1,4 @@
+BOARD ?= samr21-xpro
 DEVELHELP := 1
 # name of your application
 include ../Makefile.tests_common

--- a/tests/gnrc_sock_dns/Makefile
+++ b/tests/gnrc_sock_dns/Makefile
@@ -1,3 +1,5 @@
+BOARD ?= samr21-xpro
+
 include ../Makefile.tests_common
 
 RIOTBASE ?= $(CURDIR)/../..

--- a/tests/gnrc_tcp/Makefile
+++ b/tests/gnrc_tcp/Makefile
@@ -1,3 +1,5 @@
+BOARD ?= samr21-xpro
+
 include ../Makefile.tests_common
 
 # Basic Configuration


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR provides an initial implementation for the LoRa module available on the arduino-mkrwan1300 board. This module is controlled using AT commands so the driver is based on the generic AT command parser available in RIOT.

This PR also provides a basic test application for configuring the module, joining a network and sending data to the network. Reception of messages from the network is not supported in the current state.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

PR based on #8354 and ~#9288~

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->