### PR TITLE
tools/ethos: adapt start_network.sh for macOS

### DIFF
--- a/dist/tools/ethos/start_network.sh
+++ b/dist/tools/ethos/start_network.sh
@@ -1,6 +1,18 @@
 #!/bin/sh
 
-ETHOS_DIR="$(dirname $(readlink -f $0))"
+ETHOS_DIR="$(cd $(dirname $0); pwd)"
+ETHOS="${ETHOS_DIR}/ethos"
+[ ! -f ${ETHOS} ] && {
+    echo "missing binary (${ETHOS})"
+    exit 1
+}
+
+UHCPD_DIR="$(cd ${ETHOS_DIR}; cd ../uhcpd; pwd)"
+UHCPD="${UHCPD_DIR}/bin/uhcpd"
+[ ! -f ${UHCPD} ] && {
+    echo "missing binary (${UHCPD})"
+    exit 1
+}
 
 create_tap() {
     ip tuntap add ${TAP} mode tap user ${USER}
@@ -33,7 +45,6 @@ PORT=$1
 TAP=$2
 PREFIX=$3
 BAUDRATE=115200
-UHCPD="$(readlink -f "${ETHOS_DIR}/../uhcpd/bin")/uhcpd"
 
 [ -z "${PORT}" -o -z "${TAP}" -o -z "${PREFIX}" ] && {
     echo "usage: $0 <serial-port> <tap-device> <prefix> [baudrate]"


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This adapts the `start_network.sh` script to run on macOS by using only standard tools, and avoiding GNU tools such as `readlink`. Though ethos still needs to be fixed for OSX, anyways, see #6718.


### Issues/PRs references

- #4764 
- #6718
