### PR TITLE
tools: allow static checks to be run from any directory

### DIFF
--- a/dist/tools/coccinelle/check.sh
+++ b/dist/tools/coccinelle/check.sh
@@ -6,7 +6,10 @@
 # General Public License v2.1. See the file LICENSE in the top level
 # directory for more details.
 
-: "${RIOTTOOLS:=${PWD}/dist/tools}"
+: "${RIOTBASE:=$(cd $(dirname $0)/../../../; pwd)}"
+cd $RIOTBASE
+
+: "${RIOTTOOLS:=${RIOTBASE}/dist/tools}"
 . "${RIOTTOOLS}"/ci/changed_files.sh
 
 EXIT_CODE=0

--- a/dist/tools/cppcheck/check.sh
+++ b/dist/tools/cppcheck/check.sh
@@ -8,7 +8,10 @@
 # General Public License v2.1. See the file LICENSE in the top level
 # directory for more details.
 
-: "${RIOTTOOLS:=${PWD}/dist/tools}"
+: "${RIOTBASE:=$(cd $(dirname $0)/../../../; pwd)}"
+cd $RIOTBASE
+
+: "${RIOTTOOLS:=${RIOTBASE}/dist/tools}"
 . "${RIOTTOOLS}"/ci/changed_files.sh
 
 # Don't show warnings about unusedStructMembers by default

--- a/dist/tools/externc/check.sh
+++ b/dist/tools/externc/check.sh
@@ -8,7 +8,10 @@
 # General Public License v2.1. See the file LICENSE in the top level
 # directory for more details.
 
-: "${RIOTTOOLS:=${PWD}/dist/tools}"
+: "${RIOTBASE:=$(cd $(dirname $0)/../../../; pwd)}"
+cd $RIOTBASE
+
+: "${RIOTTOOLS:=${RIOTBASE}/dist/tools}"
 . "${RIOTTOOLS}"/ci/changed_files.sh
 
 # prepare

--- a/dist/tools/flake8/check.sh
+++ b/dist/tools/flake8/check.sh
@@ -17,7 +17,10 @@ else
     CRESET=
 fi
 
-: "${RIOTTOOLS:=${PWD}/dist/tools}"
+: "${RIOTBASE:=$(cd $(dirname $0)/../../../; pwd)}"
+cd $RIOTBASE
+
+: "${RIOTTOOLS:=${RIOTBASE}/dist/tools}"
 . "${RIOTTOOLS}"/ci/changed_files.sh
 
 FILES=$(FILEREGEX='(?=*.py$|pyterm$)' changed_files)

--- a/dist/tools/headerguards/check.sh
+++ b/dist/tools/headerguards/check.sh
@@ -6,7 +6,10 @@
 # General Public License v2.1. See the file LICENSE in the top level
 # directory for more details.
 
-: "${RIOTTOOLS:=${PWD}/dist/tools}"
+: "${RIOTBASE:=$(cd $(dirname $0)/../../../; pwd)}"
+cd $RIOTBASE
+
+: "${RIOTTOOLS:=${RIOTBASE}/dist/tools}"
 . "${RIOTTOOLS}"/ci/changed_files.sh
 
 EXIT_CODE=0

--- a/dist/tools/licenses/check.sh
+++ b/dist/tools/licenses/check.sh
@@ -7,7 +7,10 @@
 # General Public License v2.1. See the file LICENSE in the top level
 # directory for more details.
 
-: "${RIOTTOOLS:=${PWD}/dist/tools}"
+: "${RIOTBASE:=$(cd $(dirname $0)/../../../; pwd)}"
+cd $RIOTBASE
+
+: "${RIOTTOOLS:=${RIOTBASE}/dist/tools}"
 . "${RIOTTOOLS}"/ci/changed_files.sh
 
 # customizable

--- a/dist/tools/pr_check/pr_check.sh
+++ b/dist/tools/pr_check/pr_check.sh
@@ -7,9 +7,13 @@
 # directory for more details.
 #
 
-EXIT_CODE=0
-: "${RIOTTOOLS:=${PWD}/dist/tools}"
+: "${RIOTBASE:=$(cd $(dirname $0)/../../../; pwd)}"
+cd $RIOTBASE
+
+: "${RIOTTOOLS:=${RIOTBASE}/dist/tools}"
 . "${RIOTTOOLS}"/pr_check/check_labels.sh
+
+EXIT_CODE=0
 
 if tput colors &> /dev/null && [ $(tput colors) -ge 8 ]; then
     CERROR="\e[1;31m"


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

most static check script assume to be run from `RIOTBASE`, this PR changes this and allows
to execute the scripts from any (sub)directory.


### Issues/PRs references

