### PR TITLE
tests/pkg_semtech_loramac: improve README

### DIFF
--- a/tests/pkg_semtech-loramac/README.md
+++ b/tests/pkg_semtech-loramac/README.md
@@ -88,6 +88,9 @@ is activated by default.
 ```
 ### Joining with Activation By Personalization
 
+OTAA is always prefered in real world scenarios.
+However, ABP can be practical for testing or workshops.
+
 * Set your Device Address, Network Session Key , Application Session Key:
 ```
     > loramac set devaddr AAAAAAAA
@@ -99,6 +102,10 @@ is activated by default.
     > loramac join abp
     Join procedure succeeded!
 ```
+Saving frame counters in flash memory is not (yet) supported.
+Before sending data, it's necessary to clear frame counters in
+Network Server! Otherwise uplink messages won't work.
+
 **NOTE**:
 If using TTN with ABP make sure to set the correct datarate for RX2.
 Otherwise confirmed and downlink messages won't work.

--- a/tests/pkg_semtech-loramac/README.md
+++ b/tests/pkg_semtech-loramac/README.md
@@ -1,6 +1,6 @@
-## Semtech LoRaMAC package test application
+# Semtech LoRaMAC package test application
 
-### About
+## About
 
 This is a test application for the Semtech LoRaMAC package. This package
 provides the MAC primitives for sending and receiving data to/from a
@@ -14,7 +14,7 @@ This application can only be used with Semtech
 [SX1272](http://www.semtech.com/images/datasheet/sx1272.pdf) or
 [SX1276](http://www.semtech.com/images/datasheet/sx1276.pdf) radio devices.
 
-### Application configuration
+## Application configuration
 
 Before building the application and joining a LoRaWAN network, you need an
 account on a LoRaWAN backend provider. Then create a LoRaWAN application and
@@ -37,7 +37,7 @@ The Air Activation)
 Once you have this information, either edit the `Makefile` accordingly or
 use the `set`/`get` commands in test application shell.
 
-### Building the application
+## Building the application
 
 The default parameters for the Semtech SX1272/SX1276 radios works as-is with
 STM32 Nucleo-64 boards and MBED LoRa shields
@@ -67,25 +67,48 @@ for US915 region.
 The default region is `EU868`.
 
 
-### Using the shell
-
+## Using the shell
 This application provides the `loramac` command for configuring the MAC,
 joining a network and sending/receiving data to/from a LoRaWAN network.
 `join` and `tx` subcommands are blocking until the MAC is done.
 
-* Set your device EUI, application EUI, application key. Example for OTAA
-  activation:
+### Joining with Over The Air Activation
+
+* Set your device EUI, application EUI, application key:
 ```
     > loramac set deveui AAAAAAAAAAAAAAAA
     > loramac set appeui BBBBBBBBBBBBBBBB
     > loramac set appkey CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
 ```
-
 * Join a network using the OTAA procedure:
 ```
     > loramac join otaa
     Join procedure succeeded!
 ```
+### Joining with Activation By Personalization
+
+* Set your Device Address, Network Session Key , Application Session Key:
+```
+    > loramac set devaddr AAAAAAAA
+    > loramac set nwkskey BBBBBBBBBBBBBBBBBBBBBBBBBBBBBBBB
+    > loramac set appskey CCCCCCCCCCCCCCCCCCCCCCCCCCCCCCCC
+```
+* Join a network using the ABP procedure:
+```
+    > loramac join abp
+    Join procedure succeeded!
+```
+**NOTE**:
+If using TTN with ABP make sure to set the correct datarate for RX2.
+Otherwise confirmed and downlink messages won't work.
+The datarate for RX2 should be DR3 (SF9BW125) as seen in
+[TTN LoRaWAN Frequencies Overview](https://www.thethingsnetwork.org/docs/lorawan/frequency-plans.html):
+```
+    > loramac set rx2_dr 3
+```
+
+### Sending and receiving data
+
 * Send confirmable data on port 2 (cnf and port are optional):
 ```
     > loramac tx This\ is\ RIOT! cnf 2
@@ -94,6 +117,8 @@ joining a network and sending/receiving data to/from a LoRaWAN network.
 ```
     > loramac tx This\ is\ RIOT! uncnf 10
 ```
+
+### Other shell commands
 * Switch the default datarate index (from 0 to 16). 5 is for SF7, BW125:
 ```
     > loramac set dr 5
@@ -101,6 +126,10 @@ joining a network and sending/receiving data to/from a LoRaWAN network.
 * Switch to adaptive data rate:
 ```
     > loramac set adr on
+```
+* Perform a Link Check command (will be triggered in the next transmission):
+```
+    > loramac link_check
 ```
 The list of available commands:
 ```
@@ -115,7 +144,7 @@ The list of available commands:
 On the TTN web console, you can follow the activation and the data
 sent/received to/from a node.
 
-### Playing with MQTT to send/receive data to/from a LoRa node
+## Playing with MQTT to send/receive data to/from a LoRa node
 
 TheThingsNetwork API also provide a MQTT broker to send/receive data.
 See the

--- a/tests/pkg_semtech-loramac/README.md
+++ b/tests/pkg_semtech-loramac/README.md
@@ -70,7 +70,8 @@ The default region is `EU868`.
 ## Using the shell
 This application provides the `loramac` command for configuring the MAC,
 joining a network and sending/receiving data to/from a LoRaWAN network.
-`join` and `tx` subcommands are blocking until the MAC is done.
+`join` and `tx` subcommands are blocking until the MAC is done. Class A
+is activated by default.
 
 ### Joining with Over The Air Activation
 
@@ -116,6 +117,12 @@ The datarate for RX2 should be DR3 (SF9BW125) as seen in
 * Send unconfirmable data on port 10:
 ```
     > loramac tx This\ is\ RIOT! uncnf 10
+```
+When using Class A (default mode) downlink messages will be received in
+the next uplink:
+```
+    > loramac tx hello
+      Data received: RIOT, port: 1
 ```
 
 ### Other shell commands


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR improves the README of semtech loramac test.
* Add OTAA and ABP sections in `Using the shell` section
* Add RX2 datarate for receiving downlink and confirmed messages when using ABP mode and The Things Network backend.
* Add `sending and receiving data` and `other shell commands` sections
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references
None so far
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->