### PR TITLE
cpu/lpc2387: Various fixes for GPIO driver

### DIFF
--- a/cpu/lpc2387/include/periph_cpu.h
+++ b/cpu/lpc2387/include/periph_cpu.h
@@ -39,12 +39,22 @@ extern "C" {
  * @brief Fast GPIO register definition struct
  */
 typedef struct {
-    __IO uint32_t DIR;      /**< he */
-    uint32_t _reserved[3];  /**< really */
-    __IO uint32_t MASK;     /**< wants */
-    __IO uint32_t PIN;      /**< to */
-    __IO uint32_t SET;      /**< know */
-    __IO uint32_t CLR;      /**< everything */
+    /** @brief Direction: Output if corresponding bit is set, otherwise input */
+    __IO uint32_t DIR;
+    /** @brief 12 bytes of reseved memory we don't need to access */
+    uint32_t _reserved[3];
+    /** @brief Set bits to ignore corresponding bits when accessing `PIN`, `SET`
+     *         or `CLR` register of this port
+     */
+    __IO uint32_t MASK;
+    /** @brief The current state of each pin of this port is accessible here
+     *         (regardless of direction): If bit is set input is high
+     */
+    __IO uint32_t PIN;
+    /** @brief Output pins are set to high by setting the corresponding bit */
+    __IO uint32_t SET;
+    /** @brief Output pins are set to low by setting the corresponding bit */
+    __IO uint32_t CLR;
 } FIO_PORT_t;
 
 #define FIO_PORTS   ((FIO_PORT_t*)FIO_BASE_ADDR)
@@ -54,7 +64,7 @@ typedef struct {
 int gpio_init_mux(unsigned pin, unsigned mux);
 void gpio_init_states(void);
 
-#define GPIO_PIN(port, pin) (port*32 + pin)
+#define GPIO_PIN(port, pin) (port<<5 | pin)
 
 #ifndef DOXYGEN
 #define HAVE_GPIO_FLANK_T


### PR DESCRIPTION
- Fixed documentation
- Use bitwise operation instead of multiplication and addition in `GPIO_PIN()`
- Allow GPIOs to be configured as input via `gpio_init()`
- Fixed bugs in `gpio_init_mux`:
    - `0x01 << ((pin & 31) * 2)` was used before to generate the bitmask, but this would shift by 62 to the left. Correct is `0x01 << ((pin & 15) * 2)` (See [datasheet](https://www.nxp.com/docs/en/user-guide/UM10211.pdf) at pages 156ff)
    - Only one of the two bits was cleared previously
- Changed strategy to access GPIO pins:
    - Previous strategy:
        - Set all bits in FIOMASK except the one for the pin to control to disable access to them
        - Set/clear/read all pins in the target GPIO port (but access to all but the target pin is ignored because of the applied FIOMASK)
    - New strategy:
        - Set/clear/read only the target pin
    - Advantages:
        - Only one access to a GPIO register instead of two
        - Proven approach: Access to GPIOs on lpc2387 is mostly done by accessing the GPIO registers directy (e.g. see the sht11 driver). Those accesses never touch the FIOMASK register
        - No unwanted side effects: Disabling all but one pin in a GPIO port without undoing that seems not to be a good idea