### PR TITLE
gnrc_ipv6_nib: use router instead of netif for router timeout context

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/nib/nib.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib.c
@@ -606,7 +606,7 @@ static void _handle_rtr_adv(gnrc_netif_t *netif, const ipv6_hdr_t *ipv6,
 
         dr = _nib_drl_add(&ipv6->src, netif->pid);
         if (dr != NULL) {
-            _evtimer_add(netif, GNRC_IPV6_NIB_RTR_TIMEOUT, &dr->rtr_timeout,
+            _evtimer_add(dr, GNRC_IPV6_NIB_RTR_TIMEOUT, &dr->rtr_timeout,
                          rtr_ltime * MS_PER_SEC);
         }
         else {


### PR DESCRIPTION
### Contribution description
`GNRC_IPV6_NIB_RTR_TIMEOUT` [expects a default router entry][doc] as
context, so using the `netif` here is clearly wrong. This causes the
hardfault described in #9297.

[doc]: http://doc.riot-os.org/group__net__gnrc__ipv6__nib.html#ga1c7e892ef6533f699c4e64737c2847c2

### Issues/PRs references
Fixes #9297