### PR TITLE
core/byteorder: add uint16 from/to buffer funcs

### DIFF
--- a/core/include/byteorder.h
+++ b/core/include/byteorder.h
@@ -225,6 +225,31 @@ static inline uint32_t byteorder_swapl(uint32_t v);
 static inline uint64_t byteorder_swapll(uint64_t v);
 
 /**
+ * @brief           Read a little endian encoded unsigned integer from a buffer
+ *                  into host byte order encoded variable, 16-bit
+ *
+ * @note            This function is agnostic to the alignment of the target
+ *                  value in the given buffer
+ *
+ * @param[in] buf   position in a buffer holding the target value
+ *
+ * @return          16-bit unsigned integer in host byte order
+ */
+static inline uint16_t byteorder_lebuftohs(const uint8_t *buf);
+
+/**
+ * @brief           Write a host byte order encoded unsigned integer as little
+ *                  endian encoded value into a buffer, 16-bit
+ *
+ * @note            This function is alignment agnostic and works with any given
+ *                  memory location of the buffer
+ *
+ * @param[out] buf  target buffer, must be able to accept 2 bytes
+ * @param[in]  val  value written to the buffer, in host byte order
+ */
+static inline void byteorder_htolebufs(uint8_t *buf, uint16_t val);
+
+/**
  * @brief          Convert from host byte order to network byte order, 16 bit.
  * @see            byteorder_htons()
  * @param[in]      v   The integer to convert.
@@ -416,6 +441,26 @@ static inline uint64_t ntohll(uint64_t v)
 {
     network_uint64_t input = { v };
     return byteorder_ntohll(input);
+}
+
+static inline uint16_t byteorder_lebuftohs(const uint8_t *buf)
+{
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+    return (uint16_t)((buf[0] << 8) | buf[1]);
+#else
+    return (uint16_t)((buf[1] << 8) | buf[0]);
+#endif
+}
+
+static inline void byteorder_htolebufs(uint8_t *buf, uint16_t val)
+{
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+    buf[0] = (uint8_t)(val >> 8);
+    buf[1] = (uint8_t)(val & 0xff);
+#else
+    buf[0] = (uint8_t)(val & 0xff);
+    buf[1] = (uint8_t)(val >> 8);
+#endif
 }
 
 #ifdef __cplusplus


### PR DESCRIPTION
### Contribution description
A typical use case when implementing network protocols or similar is to read/write integers from/to buffers while casting them between host and le/be byte orders. The problem here is, that the values in the target buffers are not aligned, so a simple casting of multiple byte values does lead to hard-faults on some platforms (e.g. cortex-m0). 

This PR adds two byteorder functions that can read/write `uint16_t` vars from/to buffers with any alignment. So far I added only two functions for writing/reading little endian values. I think it makes most sense to add be and/or other bit width functions on demand later.

I found that I copied these function to multiple modules, so having them in one central place make probably the most sense, right?!

### Issues/PRs references
none