### PR TITLE
gnrc_netreg: Further specify gnrc_netreg_register() precondition

### DIFF
--- a/sys/include/net/gnrc/netreg.h
+++ b/sys/include/net/gnrc/netreg.h
@@ -305,7 +305,9 @@ static inline void gnrc_netreg_entry_init_cb(gnrc_netreg_entry_t *entry,
  * @warning Call gnrc_netreg_unregister() *before* you leave the context you
  *          allocated @p entry in. Otherwise it might get overwritten.
  *
- * @pre The calling thread must provide a message queue.
+ * @pre The calling thread must provide a [message queue](@ref msg_init_queue)
+ *      when using @ref GNRC_NETREG_TYPE_DEFAULT for gnrc_netreg_entry_t::type
+ *      of @p entry.
  *
  * @return  0 on success
  * @return  -EINVAL if @p type was < GNRC_NETTYPE_UNDEF or >= GNRC_NETTYPE_NUMOF


### PR DESCRIPTION
### Contribution description
While browsing through the rendered doc, I found the precondition of
`gnrc_netreg_register()` somewhat lacking. What is a "message queue"?
`gnrc_netreg_entry_t`s have types. Does this apply for all types?
This specifies the requirement more: The calling thread **only** needs
a message queue (also provides a link to `msg_init_queue()` now for
further information), if the provided `gnrc_netreg_entry_t` is of type
`GNRC_NETREG_TYPE_DEFAULT` (i.e. thread-wise IPC).

### Issues/PRs references
None