### PR TITLE
gnrc_netif: increase number of maximum IPv6 groups

### DIFF
--- a/sys/include/net/gnrc/netif/conf.h
+++ b/sys/include/net/gnrc/netif/conf.h
@@ -74,7 +74,7 @@ extern "C" {
  *          @ref GNRC_NETIF_IPV6_GROUPS_NUMOF is also large enough to fit the
  *          addresses' solicited nodes multicast addresses.
  *
- * Default: 2 (link-local + corresponding global address)
+ * Default: 2 (1 link-local + 1 global address)
  */
 #ifndef GNRC_NETIF_IPV6_ADDRS_NUMOF
 #define GNRC_NETIF_IPV6_ADDRS_NUMOF    (2)
@@ -83,11 +83,13 @@ extern "C" {
 /**
  * @brief   Maximum number of multicast groups per interface
  *
- * Default: 2 (all-nodes + solicited-nodes of link-local and global unicast
+ * Default: 3 (all-nodes + solicited-nodes of link-local and global unicast
  * address) + @ref GNRC_NETIF_RPL_ADDR + @ref GNRC_NETIF_IPV6_RTR_ADDR
  */
 #ifndef GNRC_NETIF_IPV6_GROUPS_NUMOF
-#define GNRC_NETIF_IPV6_GROUPS_NUMOF   (2 + GNRC_NETIF_RPL_ADDR + GNRC_NETIF_IPV6_RTR_ADDR)
+#define GNRC_NETIF_IPV6_GROUPS_NUMOF   (GNRC_NETIF_IPV6_ADDRS_NUMOF + \
+                                        GNRC_NETIF_RPL_ADDR + \
+                                        GNRC_NETIF_IPV6_RTR_ADDR + 1)
 #endif
 
 /**


### PR DESCRIPTION
### Contribution description
Apparently, just returning an error when there isn't enough space for a node's solicited nodes multicast address wasn't enough. Now instead of people wondering why their node isn't reachable (due to not working neighbor discovery) they are agonizing over the error message (even though it is [clearly documented](https://doc.riot-os.org/group__net__gnrc__netif.html#gaf96707a5e322b5fa8458fba45de01837)). So fine, let's spend these extra 16 byte RAM to get this out of the way ;-)

### Issues/PRs references
None