### PR TITLE
drivers/servo: add periph_pwm as dependency

### DIFF
--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -298,6 +298,10 @@ ifneq (,$(filter sdcard_spi,$(USEMODULE)))
   USEMODULE += xtimer
 endif
 
+ifneq (,$(filter servo,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_pwm
+endif
+
 ifneq (,$(filter sht11,$(USEMODULE)))
   USEMODULE += xtimer
 endif

--- a/tests/driver_servo/Makefile
+++ b/tests/driver_servo/Makefile
@@ -1,7 +1,5 @@
 include ../Makefile.tests_common
 
-FEATURES_REQUIRED = periph_pwm
-
 USEMODULE += xtimer
 USEMODULE += servo
 


### PR DESCRIPTION
### Contribution description
The `servo` driver depends on the `periph_pwm` module, so this should be modeled globally in `drivers/Makefile.dep` instead of having to include the `periph_pwm` module manually every time the `servo` module is used. This PR fixes this.

### Issues/PRs references
none