### PR TITLE
tests: test for prio inversion using msg_send_recv

### DIFF
--- a/tests/thread_priority_inversion_msg/Makefile
+++ b/tests/thread_priority_inversion_msg/Makefile
@@ -1,0 +1,10 @@
+include ../Makefile.tests_common
+
+BOARD_INSUFFICIENT_MEMORY := nucleo32-f031 nucleo32-f042
+
+USEMODULE += xtimer
+
+test:
+	tests/01-run.py
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/thread_priority_inversion_msg/README.md
+++ b/tests/thread_priority_inversion_msg/README.md
@@ -1,0 +1,44 @@
+NOTE
+====
+THIS TEST WILL FAIL WHEN RUNNING RIOT USING THE DEFAULT CORE/KERNEL CONFIGURATION!
+
+TODO: merge the `core_priority_inheritance` module to enable priority
+      inheritance and with this successfully pass this test.
+
+Expected result
+===============
+When successful, you will see the 3 configured threads printing 6 different
+events in a defined order. If the test passes, the output should look like this:
+
+```
+main(): This is RIOT! (Version: xxx)
+Test for showing priority inversion when using msg_send_receive
+
+If this tests succeeds, you should see 6 events appearing in order.
+The expected output should look like this:
+Event  1:      t3 - waiting for incoming message
+Event  2:      t2 - starting infinite loop, potentially starving others
+Event  3:      t1 - sending msg to t3 (msg_send_receive)
+Event  4:      t3 - received message
+Event  5:      t3 - sending reply
+Event  6:      t1 - received reply
+
+TEST OUTPUT:
+Event  1:      t3 - waiting for incoming message
+Event  2:      t2 - starting infinite loop, potentially starving others
+Event  3:      t1 - sending msg to t3 (msg_send_receive)
+Event  4:      t3 - received message
+Event  5:      t3 - sending reply
+Event  6:      t1 - received reply
+
+   *** result: SUCCESS ***
+```
+
+Background
+==========
+Priority inversion is a known problem in real-time systems, leading in certain
+constellations to lower priority threads indirectly blocking higher priority
+threads. This test constructs a simple scenario, where a high priority thread
+(`t1`) is trying to `send_receive` a message to a low priority thread (`t3`),
+but never gets a reply as a medium priority thread (`t2`) is never letting `t3`
+to be scheduled.

--- a/tests/thread_priority_inversion_msg/main.c
+++ b/tests/thread_priority_inversion_msg/main.c
@@ -1,0 +1,143 @@
+/*
+ * Copyright (C) 2017 Technische Universität Berlin
+ *               2017,2018 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Test application for testing priority inheritance when using
+ *              nested msg_send_receive calls
+ *
+ * @author      Thomas Geithner <thomas.geithner@dai-labor.de>
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @}
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdint.h>
+
+#include "thread.h"
+#include "msg.h"
+#include "xtimer.h"
+
+#define TICK_LEN            (50UL * US_PER_MS)
+#define EXPECTED_RESULT     (-3)
+
+#define T_NUMOF             (3U)
+#define MSG_TYPE            (0xabcd)
+
+static char _stacks[T_NUMOF][THREAD_STACKSIZE_MAIN];
+static kernel_pid_t _pids[T_NUMOF];
+static const char *_names[] = { "t1", "t2", "t3" };
+
+static int _result = 0;
+static int _res_addsub = 1;
+
+static inline void delay(unsigned ticks)
+{
+    xtimer_usleep(ticks * TICK_LEN);
+}
+
+static inline void event(int num, const char *t_name, const char *msg)
+{
+    /* record event */
+    _result += (_res_addsub * num);
+    _res_addsub *= -1;
+
+    printf("Event %2i: %7s - %s\n", num, t_name, msg);
+}
+
+static void *t1(void *arg)
+{
+    (void)arg;
+    msg_t m;
+    msg_t rply;
+
+    m.type = MSG_TYPE;
+    m.content.value = (uint32_t)'M';
+
+    delay(2);
+
+    event(3, "t1", "sending msg to t3 (msg_send_receive)");
+    msg_send_receive(&m, &rply, _pids[2]);
+    event(6, "t1", "received reply");
+
+    return NULL;
+}
+
+static void *t2(void *arg)
+{
+    (void)arg;
+
+    delay(1);
+
+    event(2, "t2", "starting infinite loop, potentially starving others");
+    while (1) {
+        thread_yield_higher();
+    }
+
+    return NULL;
+}
+
+static void *t3(void *arg)
+{
+    (void)arg;
+    msg_t m;
+    msg_t rply;
+
+    rply.type = MSG_TYPE;
+    rply.content.value = (uint32_t)'m';
+
+    event(1, "t3", "waiting for incoming message");
+    msg_receive(&m);
+    event(4, "t3", "received message");
+
+    event(5, "t3", "sending reply");
+    msg_reply(&m, &rply);
+
+    return NULL;
+}
+
+static thread_task_func_t _handlers[] = { t1, t2, t3 };
+
+int main(void)
+{
+    puts("Test for showing priority inversion when using msg_send_receive\n");
+    puts("If this tests succeeds, you should see 6 events appearing in order.\n"
+         "The expected output should look like this:\n"
+         "Event  1:      t3 - waiting for incoming message\n"
+         "Event  2:      t2 - starting infinite loop, potentially starving others\n"
+         "Event  3:      t1 - sending msg to t3 (msg_send_receive)\n"
+         "Event  4:      t3 - received message\n"
+         "Event  5:      t3 - sending reply\n"
+         "Event  6:      t1 - received reply\n");
+    puts("TEST OUTPUT:");
+
+    /* create threads */
+    for (unsigned i = 0; i < T_NUMOF; i++) {
+        _pids[i] = thread_create(_stacks[i], sizeof(_stacks[i]),
+                                 (THREAD_PRIORITY_MAIN + 1 + i),
+                                 THREAD_CREATE_WOUT_YIELD,
+                                 _handlers[i], NULL,
+                                 _names[i]);
+    }
+
+    delay(3);
+
+    if (_result == EXPECTED_RESULT) {
+        puts("\n[SUCCESS]");
+    }
+    else {
+        puts("\n[FAILED]");
+    }
+
+    return 0;
+}

--- a/tests/thread_priority_inversion_msg/tests/01-run.py
+++ b/tests/thread_priority_inversion_msg/tests/01-run.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2018 Hauke Petersen <hauke.petersen@fu-berlin.de>
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import os
+import sys
+
+
+def testfunc(child):
+    rt = child.expect([r"\[SUCCESS\]",r"\[FAILED\]"])
+    if rt == 1:
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    sys.path.append(os.path.join(os.environ['RIOTTOOLS'], 'testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc))


### PR DESCRIPTION
### Contribution description
#7445 also introduces priority inheritance for `msg_send_receive` calls. This PR adds a test showcasing priority inversion for `msg_send_receive`, cutting it from #7445 for simpler reviewing...

### Issues/PRs references
Cut out from #7445 and similar to #7444