### PR TITLE
sys/xtimer: multiple hardware timer support

### DIFF
--- a/sys/Makefile
+++ b/sys/Makefile
@@ -71,7 +71,7 @@ ifneq (,$(filter log_%,$(USEMODULE)))
   DIRS += log
 endif
 ifneq (,$(filter xtimer,$(USEMODULE)))
-  DIRS += xtimer
+  DIRS += xtimer xtimer/devs
 endif
 ifneq (,$(filter cpp11-compat,$(USEMODULE)))
   DIRS += cpp11-compat

--- a/sys/Makefile.include
+++ b/sys/Makefile.include
@@ -43,6 +43,10 @@ ifneq (,$(filter vfs,$(USEMODULE)))
   USEMODULE_INCLUDES += $(RIOTBASE)/sys/posix/include
 endif
 
+ifneq (,$(filter xtimer,$(USEMODULE)))
+  USEMODULE_INCLUDES += $(RIOTBASE)/sys/xtimer/include
+endif
+
 ifneq (,$(filter cpp11-compat,$(USEMODULE)))
   USEMODULE_INCLUDES += $(RIOTBASE)/sys/cpp11-compat/include
   # make sure cppsupport.o is linked explicitly because __dso_handle is not

--- a/sys/include/xtimer.h
+++ b/sys/include/xtimer.h
@@ -470,30 +470,6 @@ int xtimer_mutex_lock_timeout(mutex_t *mutex, uint64_t us);
  */
 void xtimer_set_timeout_flag(xtimer_t *t, uint32_t timeout);
 
-/**
- * @brief xtimer backoff value
- *
- * All timers that are less than XTIMER_BACKOFF microseconds in the future will
- * just spin.
- *
- * This is supposed to be defined per-device in e.g., periph_conf.h.
- */
-#ifndef XTIMER_BACKOFF
-#define XTIMER_BACKOFF 30
-#endif
-
-#ifndef XTIMER_ISR_BACKOFF
-/**
- * @brief   xtimer IRQ backoff time, in hardware ticks
- *
- * When scheduling the next IRQ, if it is less than the backoff time
- * in the future, just spin.
- *
- * This is supposed to be defined per-device in e.g., periph_conf.h.
- */
-#define XTIMER_ISR_BACKOFF 20
-#endif
-
 #ifndef XTIMER_PERIODIC_SPIN
 /**
  * @brief   xtimer_periodic_wakeup spin cutoff

--- a/sys/include/xtimer.h
+++ b/sys/include/xtimer.h
@@ -34,7 +34,6 @@
 #include "msg.h"
 #include "mutex.h"
 
-#include "board.h"
 #include "periph_conf.h"
 
 #ifdef __cplusplus
@@ -483,29 +482,6 @@ void xtimer_set_timeout_flag(xtimer_t *t, uint32_t timeout);
 #define XTIMER_BACKOFF 30
 #endif
 
-/**
- * @brief xtimer overhead value, in hardware ticks
- *
- * This value specifies the time a timer will be late if uncorrected, e.g.,
- * the system-specific xtimer execution time from timer ISR to executing
- * a timer's callback's first instruction.
- *
- * E.g., with XTIMER_OVERHEAD == 0
- * start=xtimer_now();
- * xtimer_set(&timer, X);
- * (in callback:)
- * overhead=xtimer_now()-start-X;
- *
- * xtimer automatically substracts XTIMER_OVERHEAD from a timer's target time,
- * but when the timer triggers, xtimer will spin-lock until a timer's target
- * time is reached, so timers will never trigger early.
- *
- * This is supposed to be defined per-device in e.g., periph_conf.h.
- */
-#ifndef XTIMER_OVERHEAD
-#define XTIMER_OVERHEAD 20
-#endif
-
 #ifndef XTIMER_ISR_BACKOFF
 /**
  * @brief   xtimer IRQ backoff time, in hardware ticks
@@ -541,104 +517,12 @@ void xtimer_set_timeout_flag(xtimer_t *t, uint32_t timeout);
 #define XTIMER_PERIODIC_RELATIVE (512)
 #endif
 
-/*
- * Default xtimer configuration
- */
-#ifndef XTIMER_DEV
-/**
- * @brief Underlying hardware timer device to assign to xtimer
- */
-#define XTIMER_DEV TIMER_DEV(0)
-/**
- * @brief Underlying hardware timer channel to assign to xtimer
- */
-#define XTIMER_CHAN (0)
-
-#if (TIMER_0_MAX_VALUE) == 0xfffffful
-#define XTIMER_WIDTH (24)
-#elif (TIMER_0_MAX_VALUE) == 0xffff
-#define XTIMER_WIDTH (16)
-#endif
-
-#endif
-
-#ifndef XTIMER_WIDTH
-/**
- * @brief xtimer timer width
- *
- * This value specifies the width (in bits) of the hardware timer used by xtimer.
- * Default is 32.
- */
-#define XTIMER_WIDTH (32)
-#endif
-
-#if (XTIMER_WIDTH != 32) || DOXYGEN
-/**
- * @brief xtimer timer mask
- *
- * This value specifies the mask relative to 0xffffffff that the used timer
- * counts to, e.g., 0xffffffff & ~TIMER_MAXVALUE.
- *
- * For a 16bit timer, the mask would be 0xFFFF0000, for a 24bit timer, the mask
- * would be 0xFF000000.
- */
-#define XTIMER_MASK ((0xffffffff >> XTIMER_WIDTH) << XTIMER_WIDTH)
-#else
-#define XTIMER_MASK (0)
-#endif
-
 /**
  * @brief  Base frequency of xtimer is 1 MHz
  */
 #define XTIMER_HZ_BASE (1000000ul)
 
-#ifndef XTIMER_HZ
-/**
- * @brief  Frequency of the underlying hardware timer
- */
-#define XTIMER_HZ XTIMER_HZ_BASE
-#endif
-
-#ifndef XTIMER_SHIFT
-#if (XTIMER_HZ == 32768ul)
-/* No shift necessary, the conversion is not a power of two and is handled by
- * functions in tick_conversion.h */
-#define XTIMER_SHIFT (0)
-#elif (XTIMER_HZ == XTIMER_HZ_BASE)
-/**
- * @brief   xtimer prescaler value
- *
- * If the underlying hardware timer is running at a power of two multiple of
- * 15625, XTIMER_SHIFT can be used to adjust the difference.
- *
- * For a 1 MHz hardware timer, set XTIMER_SHIFT to 0.
- * For a 2 MHz or 500 kHz, set XTIMER_SHIFT to 1.
- * For a 4 MHz or 250 kHz, set XTIMER_SHIFT to 2.
- * For a 8 MHz or 125 kHz, set XTIMER_SHIFT to 3.
- * For a 16 MHz or 62.5 kHz, set XTIMER_SHIFT to 4.
- * and for 32 MHz, set XTIMER_SHIFT to 5.
- *
- * The direction of the shift is handled by the macros in tick_conversion.h
- */
-#define XTIMER_SHIFT (0)
-#elif (XTIMER_HZ >> 1 == XTIMER_HZ_BASE) || (XTIMER_HZ << 1 == XTIMER_HZ_BASE)
-#define XTIMER_SHIFT (1)
-#elif (XTIMER_HZ >> 2 == XTIMER_HZ_BASE) || (XTIMER_HZ << 2 == XTIMER_HZ_BASE)
-#define XTIMER_SHIFT (2)
-#elif (XTIMER_HZ >> 3 == XTIMER_HZ_BASE) || (XTIMER_HZ << 3 == XTIMER_HZ_BASE)
-#define XTIMER_SHIFT (3)
-#elif (XTIMER_HZ >> 4 == XTIMER_HZ_BASE) || (XTIMER_HZ << 4 == XTIMER_HZ_BASE)
-#define XTIMER_SHIFT (4)
-#elif (XTIMER_HZ >> 5 == XTIMER_HZ_BASE) || (XTIMER_HZ << 5 == XTIMER_HZ_BASE)
-#define XTIMER_SHIFT (5)
-#elif (XTIMER_HZ >> 6 == XTIMER_HZ_BASE) || (XTIMER_HZ << 6 == XTIMER_HZ_BASE)
-#define XTIMER_SHIFT (6)
-#else
-#error "XTIMER_SHIFT cannot be derived for given XTIMER_HZ, verify settings!"
-#endif
-#else
-#error "XTIMER_SHIFT is set relative to XTIMER_HZ, no manual define required!"
-#endif
+#include "xtimer/hal.h"
 
 #include "xtimer/tick_conversion.h"
 

--- a/sys/include/xtimer/hal.h
+++ b/sys/include/xtimer/hal.h
@@ -26,23 +26,33 @@
 extern "C" {
 #endif
 
+/**
+ * @brief   xtimer low-level paramters for timer
+ */
 typedef struct xtimer_llparams_timer {
-    uint8_t devid;
-    uint8_t chan;
+    uint8_t devid;    /**< device timer number */
+    uint8_t chan;     /**< device channel number */
 } xtimer_llparams_timer_t;
 
+/**
+ * @brief   xtimer hal parameters
+ */
 typedef struct xtimer_params {
-    uint32_t hz;
-    void *ll;
-    uint8_t width;
-    uint8_t backoff;
-    uint8_t backoff_isr;
-    uint8_t overhead;
+    uint32_t hz;             /**< device frequency */
+    uint32_t backoff;        /**< backoff time in microseconds */
+    uint32_t backoff_isr;    /**< ISR backoff time in microseconds */
+    void *ll;                /**< low-level device parameters */
+    uint8_t width;           /**< number of bits in device counter */
+    uint8_t overhead;        /**< overhead time in ticks */
+    uint8_t flags;           /**< configuration flags */
 } xtimer_params_t;
 
+/**
+ * @brief   xtimer hal device descriptor
+ */
 typedef struct xtimer_hal {
-    xtimer_params_t *params;
-    void *ll;
+    xtimer_params_t *params;    /**< device parameters */
+    void *ll;                   /**< low-level device descriptor details */
 } xtimer_hal_t;
 
 /**
@@ -50,17 +60,63 @@ typedef struct xtimer_hal {
  */
 typedef void (*xtimer_hal_cb_t)(void *);
 
+/**
+ * @brief   Initialize a low-level timer (callback typedef)
+ *
+ * Some drivers utilize the callback when initializing, and others utilize it
+ * when setting the alarm.
+ *
+ * @param[in] dev       device descriptor of timer to initialize
+ * @param[in] cb        callback to be executed when alarm sounds
+ * @param[in] arg       argument for callback
+ *
+ * @return    >=0 when successful, <0 on failure
+ */
 typedef int (*xtimer_driver_init_t)(xtimer_hal_t *dev, xtimer_hal_cb_t cb, void *arg);
 
+/**
+ * @brief   Set an alarm for a low-level timer (callback typedef)
+ *
+ * Some drivers utilize the callback when initializing, and others utilize it
+ * when setting the alarm.
+ *
+ * @param[in] dev       device descriptor of timer to set alarm for
+ * @param[in] target    target time, in ticks
+ * @param[in] cb        callback to be executed when alarm sounds
+ * @param[in] arg       argument for callback
+ */
 typedef void (*xtimer_driver_set_t)(xtimer_hal_t *dev, uint32_t target,
                                     xtimer_hal_cb_t cb, void *arg);
 
+/**
+ * @brief   Get current time from low-level timer (callback typedef)
+ *
+ * @param[in] dev    device descriptor of timer to get time from
+ *
+ * @return    current time of that timer in ticks
+ */
 typedef uint32_t (*xtimer_driver_now_t)(xtimer_hal_t *dev);
 
+/**
+ * @brief   Start a low-level timer (callback typedef)
+ *
+ * @param[in] dev    device descriptor of timer to start
+ */
 typedef void (*xtimer_driver_start_t)(xtimer_hal_t *dev);
 
+/**
+ * @brief   Stop a low-level timer (callback typedef)
+ *
+ * This is expected to prevent the stopped timer from blocking power
+ * management modes
+ *
+ * @param[in] dev    device descriptor of timer to stop
+ */
 typedef void (*xtimer_driver_stop_t)(xtimer_hal_t *dev);
 
+/**
+ * @brief   xtimer low-level driver entry
+ */
 typedef struct xtimer_driver {
     xtimer_driver_init_t init;
     xtimer_driver_set_t set;

--- a/sys/include/xtimer/hal.h
+++ b/sys/include/xtimer/hal.h
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2018 Acutam Automation, LLC
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup   sys_xtimer
+
+ * @{
+ * @file
+ * @brief   xtimer hardware abstraction layer
+ *
+ * @author  Matthew Blue <matthew.blue.neuro@gmail.com>
+ */
+#ifndef XTIMER_HAL_H
+#define XTIMER_HAL_H
+
+#ifndef XTIMER_H
+#error "Do not include this file directly! Use xtimer.h instead"
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct xtimer_llparams_timer {
+    uint8_t devid;
+    uint8_t chan;
+} xtimer_llparams_timer_t;
+
+typedef struct xtimer_params {
+    uint32_t hz;
+    void *ll;
+    uint8_t width;
+    uint8_t backoff;
+    uint8_t backoff_isr;
+    uint8_t overhead;
+} xtimer_params_t;
+
+typedef struct xtimer_hal {
+    xtimer_params_t *params;
+    void *ll;
+} xtimer_hal_t;
+
+/**
+ * @brief   xtimer hal callback
+ */
+typedef void (*xtimer_hal_cb_t)(void *);
+
+typedef int (*xtimer_driver_init_t)(xtimer_hal_t *dev, xtimer_hal_cb_t cb, void *arg);
+
+typedef void (*xtimer_driver_set_t)(xtimer_hal_t *dev, uint32_t target,
+                                    xtimer_hal_cb_t cb, void *arg);
+
+typedef uint32_t (*xtimer_driver_now_t)(xtimer_hal_t *dev);
+
+typedef void (*xtimer_driver_start_t)(xtimer_hal_t *dev);
+
+typedef void (*xtimer_driver_stop_t)(xtimer_hal_t *dev);
+
+typedef struct xtimer_driver {
+    xtimer_driver_init_t init;
+    xtimer_driver_set_t set;
+    xtimer_driver_now_t now;
+    xtimer_driver_start_t start;
+    xtimer_driver_stop_t stop;
+} xtimer_driver_t;
+
+/**
+ * @brief drop bits of a value that don't fit into the low-level timer.
+ */
+static inline uint32_t _xtimer_lltimer_mask(const uint8_t width, uint32_t val)
+{
+    if (width >= 32) {
+        return val;
+    }
+
+    return val & (((uint32_t)(-1) << width) >> width);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */
+#endif /* XTIMER_HAL_H */

--- a/sys/include/xtimer/implementation.h
+++ b/sys/include/xtimer/implementation.h
@@ -27,7 +27,7 @@
 #error "Do not include this file directly! Use xtimer.h instead"
 #endif
 
-#include "periph/timer.h"
+#include "xtimer/hal.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -41,24 +41,6 @@ extern volatile uint32_t _xtimer_high_cnt;
  * @brief IPC message type for xtimer msg callback
  */
 #define MSG_XTIMER 12345
-
-/**
- * @brief returns the (masked) low-level timer counter value.
- */
-static inline uint32_t _xtimer_lltimer_now(void)
-{
-    return timer_read(XTIMER_DEV);
-}
-
-/**
- * @brief drop bits of a value that don't fit into the low-level timer.
- */
-static inline uint32_t _xtimer_lltimer_mask(uint32_t val)
-{
-    /* cppcheck-suppress shiftTooManyBits
-     * (reason: cppcheck bug. `XTIMER_MASK` is zero when `XTIMER_WIDTH` is 32) */
-    return val & ~XTIMER_MASK;
-}
 
 /**
  * @{

--- a/sys/xtimer/devs/rtc_hal.c
+++ b/sys/xtimer/devs/rtc_hal.c
@@ -37,7 +37,7 @@ static void _dev_set(xtimer_hal_t *dev, uint32_t target,
 {
     struct tm time;
 
-    gmtime_r(_xtimer_lltimer_mask(dev->params.width, target), &time);
+    gmtime_r(_xtimer_lltimer_mask(dev->params->width, target), &time);
 
     rtc_set_alarm(&time, cb, arg);
 }

--- a/sys/xtimer/devs/rtc_hal.c
+++ b/sys/xtimer/devs/rtc_hal.c
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2018 Acutam Automation, LLC
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup   sys_xtimer
+ * @{
+ *
+ * @file
+ * @brief   xtimer hardware abstraction for periph/rtc
+ *
+ * @author  Matthew Blue <matthew.blue.neuro@gmail.com>
+ *
+ * @}
+ */
+
+#include <time.h>
+
+#include "xtimer.h"
+
+#include "periph/rtc.h"
+
+static int _dev_init(xtimer_hal_t *dev, xtimer_hal_cb_t cb, void *arg)
+{
+    /* don't rtc_init here, since it is done in drivers/periph_common */
+    (void)info;
+    (void)cb;
+    (void)arg;
+}
+
+static void _dev_set(xtimer_hal_t *dev, uint32_t target,
+                     xtimer_hal_cb_t cb, void *arg)
+{
+    struct tm time;
+
+    gmtime_r(_xtimer_lltimer_mask(dev->params.width, target), &time);
+
+    rtc_set_alarm(&time, cb, arg);
+}
+
+static uint32_t _dev_now(xtimer_hal_t *dev)
+{
+    (void)dev;
+
+    struct tm time;
+
+    rtc_get_time(&time);
+
+    return (uint32_t)mktime(&time);
+}
+
+static void _dev_start(xtimer_hal_t *dev)
+{
+    (void)dev;
+
+    rtc_poweron();
+}
+
+static void _dev_stop(xtimer_hal_t *dev)
+{
+    (void)dev;
+
+    rtc_poweroff();
+}
+
+const xtimer_driver_t xtimer_driver_rtc = {
+    .init = _dev_init,
+    .set = _dev_set,
+    .now = _dev_now,
+    .start = _dev_start,
+    .stop = _dev_stop,
+};

--- a/sys/xtimer/devs/rtt_hal.c
+++ b/sys/xtimer/devs/rtt_hal.c
@@ -34,7 +34,7 @@ static int _dev_init(xtimer_hal_t *dev, xtimer_hal_cb_t cb, void *arg)
 static void _dev_set(xtimer_hal_t *dev, uint32_t target,
                      xtimer_hal_cb_t cb, void *arg)
 {
-    rtt_set_alarm(_xtimer_lltimer_mask(dev->params.width, target), cb, arg);
+    rtt_set_alarm(_xtimer_lltimer_mask(dev->params->width, target), cb, arg);
 }
 
 static uint32_t _dev_now(xtimer_hal_t *dev)

--- a/sys/xtimer/devs/rtt_hal.c
+++ b/sys/xtimer/devs/rtt_hal.c
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2018 Acutam Automation, LLC
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup   sys_xtimer
+ * @{
+ *
+ * @file
+ * @brief   xtimer hardware abstraction for periph/rtt
+ *
+ * @author  Matthew Blue <matthew.blue.neuro@gmail.com>
+ *
+ * @}
+ */
+
+#include "xtimer.h"
+
+#include "periph/rtt.h"
+
+static int _dev_init(xtimer_hal_t *dev, xtimer_hal_cb_t cb, void *arg)
+{
+    (void)dev;
+
+    rtt_init();
+
+    rtt_set_overflow_cb(cb, *arg);
+}
+
+static void _dev_set(xtimer_hal_t *dev, uint32_t target,
+                     xtimer_hal_cb_t cb, void *arg)
+{
+    rtt_set_alarm(_xtimer_lltimer_mask(dev->params.width, target), cb, arg);
+}
+
+static uint32_t _dev_now(xtimer_hal_t *dev)
+{
+    (void)dev;
+
+    return rtt_get_counter;
+}
+
+static void _dev_start(xtimer_hal_t *dev)
+{
+    (void)dev;
+
+    rtt_poweron();
+}
+
+static void _dev_stop(xtimer_hal_t *dev)
+{
+    (void)dev;
+
+    rtt_poweroff();
+}
+
+const xtimer_driver_t xtimer_driver_rtt = {
+    .init = _dev_init,
+    .set = _dev_set,
+    .now = _dev_now,
+    .start = _dev_start,
+    .stop = _dev_stop,
+};

--- a/sys/xtimer/devs/timer_hal.c
+++ b/sys/xtimer/devs/timer_hal.c
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2018 Acutam Automation, LLC
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup   sys_xtimer
+ * @{
+ *
+ * @file
+ * @brief   xtimer hardware abstraction for periph/timer
+ *
+ * @author  Matthew Blue <matthew.blue.neuro@gmail.com>
+ *
+ * @}
+ */
+
+#include "xtimer.h"
+
+#include "periph/timer.h"
+
+/* access to low-level through generic layer */
+#define LLDEV       (*(xtimer_lldev_timer_t *)(dev->ll))
+#define LLPARAMS    (*(xtimer_llparams_timer_t *)(dev->params.ll))
+
+static int _dev_init(xtimer_hal_t *dev, xtimer_hal_cb_t cb, void *arg)
+{
+    timer_init(LLPARAMS.devid, dev->params.hz, cb, *arg);
+
+    timer_set_absolute(LLPARAMS.devid, LLPARAMS.chan,
+                       _xtimer_lltimer_mask(dev->params.width, (uint32_t)(-1)));
+}
+
+static void _dev_set(xtimer_hal_t *dev, uint32_t target,
+                     xtimer_hal_cb_t cb, void *arg)
+{
+    /* callbacks are set in init for this device */
+    (void)cb;
+    (void)arg;
+
+    timer_set_absolute(LLPARAMS.devid, LLPARAMS.chan,
+                       _xtimer_lltimer_mask(dev->params.width, target));
+}
+
+static uint32_t _dev_now(xtimer_hal_t *dev)
+{
+    return timer_read(LLPARAMS.devid);
+}
+
+static void _dev_start(xtimer_hal_t *dev)
+{
+    timer_start(LLPARAMS.devid);
+}
+
+static void _dev_stop(xtimer_hal_t *dev)
+{
+    timer_stop(LLPARAMS.devid);
+}
+
+const xtimer_driver_t xtimer_driver_timer = {
+    .init = _dev_init,
+    .set = _dev_set,
+    .now = _dev_now,
+    .start = _dev_start,
+    .stop = _dev_stop,
+};

--- a/sys/xtimer/devs/timer_hal.c
+++ b/sys/xtimer/devs/timer_hal.c
@@ -24,14 +24,14 @@
 
 /* access to low-level through generic layer */
 #define LLDEV       (*(xtimer_lldev_timer_t *)(dev->ll))
-#define LLPARAMS    (*(xtimer_llparams_timer_t *)(dev->params.ll))
+#define LLPARAMS    (*(xtimer_llparams_timer_t *)(dev->params->ll))
 
 static int _dev_init(xtimer_hal_t *dev, xtimer_hal_cb_t cb, void *arg)
 {
-    timer_init(LLPARAMS.devid, dev->params.hz, cb, *arg);
+    timer_init(LLPARAMS.devid, dev->params->hz, cb, *arg);
 
     timer_set_absolute(LLPARAMS.devid, LLPARAMS.chan,
-                       _xtimer_lltimer_mask(dev->params.width, (uint32_t)(-1)));
+        _xtimer_lltimer_mask(dev->params->width, (uint32_t)(-1)));
 }
 
 static void _dev_set(xtimer_hal_t *dev, uint32_t target,
@@ -42,7 +42,7 @@ static void _dev_set(xtimer_hal_t *dev, uint32_t target,
     (void)arg;
 
     timer_set_absolute(LLPARAMS.devid, LLPARAMS.chan,
-                       _xtimer_lltimer_mask(dev->params.width, target));
+                       _xtimer_lltimer_mask(dev->params->width, target));
 }
 
 static uint32_t _dev_now(xtimer_hal_t *dev)

--- a/sys/xtimer/include/xtimer_params.h
+++ b/sys/xtimer/include/xtimer_params.h
@@ -1,0 +1,160 @@
+/*
+ * Copyright (C) 2015 Kaspar Schleiser <kaspar@schleiser.de>
+ *               2016 Eistec AB
+ *               2018 Acutam Automation, LLC
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup   sys_xtimer
+ * @{
+ *
+ * @file
+ * @brief   xtimer hardware access layer default configuration
+ *
+ * @author  Kaspar Schleiser <kaspar@schleiser.de>
+ * @author  Joakim Nohlgård <joakim.nohlgard@eistec.se>
+ * @author  Matthew Blue <matthew.blue.neuro@gmail.com>
+ *
+ * @}
+ */
+
+#ifndef XTIMER_PARAMS_H
+#define XTIMER_PARAMS_H
+
+#include "board.h"
+#include "xtimer.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef XTIMER_DEV
+/**
+ * @brief Default low-level hardware timer device
+ */
+#define XTIMER_DEV TIMER_DEV(0)
+/**
+ * @brief Default low-level hardware timer channel
+ */
+#define XTIMER_CHAN (0)
+
+#if (TIMER_0_MAX_VALUE) == 0xfffffful
+#define XTIMER_WIDTH (24)
+#elif (TIMER_0_MAX_VALUE) == 0xffff
+#define XTIMER_WIDTH (16)
+#endif /* TIMER_0_MAX_VALUE */
+#endif /* XTIMER_DEV */
+
+#ifndef XTIMER_WIDTH
+/**
+ * @brief xtimer default timer width
+ *
+ * This value specifies the width (in bits) of the default hardware timer.
+ * Default is 32.
+ */
+#define XTIMER_WIDTH (32)
+#endif
+
+#ifndef XTIMER_HZ
+/**
+ * @brief  Frequency of the default hardware timer
+ */
+#define XTIMER_HZ XTIMER_HZ_BASE
+#endif
+
+/**
+ * @brief xtimer backoff value in ticks for default hardware timer
+ *
+ * All timers that are less than the backoff in ticks will fall back to
+ * a faster timer. If there is no faster timer, xtimer will just spin.
+ */
+#ifndef XTIMER_BACKOFF
+#define XTIMER_BACKOFF 30
+#endif
+
+#ifndef XTIMER_ISR_BACKOFF
+/**
+ * @brief   xtimer IRQ backoff time in ticks for default hardware timer
+ *
+ * When scheduling the next IRQ, if it is less than the backoff time in ticks
+ * in the future, fall back to a faster timer. If there is no faster timer,
+ * then just spin.
+ */
+#define XTIMER_ISR_BACKOFF 20
+#endif
+
+/**
+ * @brief xtimer overhead value in ticks for default hardware timer
+ *
+ * This value specifies the time a timer will be late if uncorrected, e.g.,
+ * the system-specific xtimer execution time from timer ISR to executing
+ * a timer's callback's first instruction.
+ *
+ * E.g., with XTIMER_OVERHEAD == 0
+ * start=xtimer_now();
+ * xtimer_set(&timer, X);
+ * (in callback:)
+ * overhead=xtimer_now()-start-X;
+ *
+ * xtimer automatically substracts XTIMER_OVERHEAD from a timer's target time,
+ * but when the timer triggers, xtimer will spin-lock until a timer's target
+ * time is reached, so timers will never trigger early.
+ */
+#ifndef XTIMER_OVERHEAD
+#define XTIMER_OVERHEAD 20
+#endif
+
+/**
+ * @name    Default low-level parameter struct for xtimer hal
+ * @{
+ */
+#ifndef XTIMER_LLPARAMS_TIMER
+#define XTIMER_LLPARAMS_TIMER    { .devid = XTIMER_DEV, \
+                                   .chan  = XTIMER_CHAN }
+#endif
+
+static const xtimer_llparams_timer_t xtimer_llparams_timer0
+                                     = XTIMER_LLPARAMS_TIMER;
+/** @} */
+
+/**
+ * @name    Default parameter struct for xtimer hal
+ * @{
+ */
+#ifndef XTIMER_PARAMS
+#define XTIMER_PARAMS    { .hz          = XTIMER_HZ ,                      \
+                           .ll          = (void *)&xtimer_llparams_timer0, \
+                           .width       = XTIMER_WIDTH,                    \
+                           .backoff     = XTIMER_BACKOFF,                  \
+                           .backoff_isr = XTIMER_ISR_BACKOFF,              \
+                           .overhead    = XTIMER_OVERHEAD }
+#endif
+
+static const xtimer_params_t xtimer_params[] =
+{
+    XTIMER_PARAMS
+};
+/** @} */
+
+/**
+ * @name    Default driver list for xtimer hal
+ * @{
+ */
+extern xtimer_driver_t xtimer_driver_timer;
+
+static const xtimer_driver_t *xtimer_drivers[] =
+{
+    &xtimer_driver_timer
+};
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* XTIMER_PARAMS_H */
+/** @} */

--- a/sys/xtimer/include/xtimer_params.h
+++ b/sys/xtimer/include/xtimer_params.h
@@ -67,9 +67,9 @@ extern "C" {
 #endif
 
 /**
- * @brief xtimer backoff value in ticks for default hardware timer
+ * @brief xtimer backoff value in microseconds for default hardware timer
  *
- * All timers that are less than the backoff in ticks will fall back to
+ * All timers that are less than the backoff in microseconds will fall back to
  * a faster timer. If there is no faster timer, xtimer will just spin.
  */
 #ifndef XTIMER_BACKOFF
@@ -78,11 +78,11 @@ extern "C" {
 
 #ifndef XTIMER_ISR_BACKOFF
 /**
- * @brief   xtimer IRQ backoff time in ticks for default hardware timer
+ * @brief   xtimer IRQ backoff time in microseconds for default hardware timer
  *
- * When scheduling the next IRQ, if it is less than the backoff time in ticks
- * in the future, fall back to a faster timer. If there is no faster timer,
- * then just spin.
+ * When scheduling the next IRQ, if it is less than the backoff time in
+ * microseconds in the future, fall back to a faster timer. If there is no
+ * faster timer, then just spin.
  */
 #define XTIMER_ISR_BACKOFF 20
 #endif
@@ -127,11 +127,12 @@ static const xtimer_llparams_timer_t xtimer_llparams_timer0
  */
 #ifndef XTIMER_PARAMS
 #define XTIMER_PARAMS    { .hz          = XTIMER_HZ ,                      \
-                           .ll          = (void *)&xtimer_llparams_timer0, \
-                           .width       = XTIMER_WIDTH,                    \
                            .backoff     = XTIMER_BACKOFF,                  \
                            .backoff_isr = XTIMER_ISR_BACKOFF,              \
-                           .overhead    = XTIMER_OVERHEAD }
+                           .ll          = (void *)&xtimer_llparams_timer0, \
+                           .width       = XTIMER_WIDTH,                    \
+                           .overhead    = XTIMER_OVERHEAD,                 \
+                           .flags       = XTIMER_FLAGS }
 #endif
 
 static const xtimer_params_t xtimer_params[] =

--- a/sys/xtimer/xtimer_hal.c
+++ b/sys/xtimer/xtimer_hal.c
@@ -1,0 +1,177 @@
+/**
+ * Copyright (C) 2018 Acutam Automation, LLC
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup    xtimer
+ *
+ * @{
+ *
+ * @file
+ * @brief      xtimer hardware abstraction layer
+ *
+ * @author     Matthew Blue <matthew.blue.neuro@gmail.com>
+ *
+ * @}
+ */
+
+/* WARNING! enabling this will have side effects and can lead to timer underflows. */
+#define ENABLE_DEBUG 0
+#include "debug.h"
+
+static void _periph_timer_callback(void *arg, int chan)
+{
+    (void)arg;
+    (void)chan;
+    _timer_callback();
+}
+
+static void _shoot(xtimer_t *timer)
+{
+    timer->callback(timer->arg);
+}
+
+static inline void _lltimer_set(uint32_t target)
+{
+    if (_in_handler) {
+        return;
+    }
+    DEBUG("_lltimer_set(): setting %" PRIu32 "\n", _xtimer_lltimer_mask(target));
+    timer_set_absolute(XTIMER_DEV, XTIMER_CHAN, _xtimer_lltimer_mask(target));
+}
+
+/**
+ * @brief handle low-level timer overflow, advance to next short timer period
+ */
+static void _next_period(void)
+{
+#if XTIMER_MASK
+    /* advance <32bit mask register */
+    _xtimer_high_cnt += ~XTIMER_MASK + 1;
+    if (_xtimer_high_cnt == 0) {
+        /* high_cnt overflowed, so advance >32bit counter */
+        _long_cnt++;
+    }
+#else
+    /* advance >32bit counter */
+    _long_cnt++;
+#endif
+
+    /* swap overflow list to current timer list */
+    timer_list_head = overflow_list_head;
+    overflow_list_head = NULL;
+
+    _select_long_timers();
+}
+
+/**
+ * @brief main xtimer callback function
+ */
+static void _timer_callback(void)
+{
+    uint32_t next_target;
+    uint32_t reference;
+
+    _in_handler = 1;
+
+    DEBUG("_timer_callback() now=%" PRIu32 " (%" PRIu32 ")pleft=%" PRIu32 "\n",
+          xtimer_now().ticks32, _xtimer_lltimer_mask(xtimer_now().ticks32),
+          _xtimer_lltimer_mask(0xffffffff - xtimer_now().ticks32));
+
+    if (!timer_list_head) {
+        DEBUG("_timer_callback(): tick\n");
+        /* there's no timer for this timer period,
+         * so this was a timer overflow callback.
+         *
+         * In this case, we advance to the next timer period.
+         */
+        _next_period();
+
+        reference = 0;
+
+        /* make sure the timer counter also arrived
+         * in the next timer period */
+        while (_xtimer_lltimer_now() == _xtimer_lltimer_mask(0xFFFFFFFF)) {}
+    }
+    else {
+        /* we ended up in _timer_callback and there is
+         * a timer waiting.
+         */
+        /* set our period reference to the current time. */
+        reference = _xtimer_lltimer_now();
+    }
+
+overflow:
+    /* check if next timers are close to expiring */
+    while (timer_list_head && (_time_left(_xtimer_lltimer_mask(timer_list_head->target), reference) < XTIMER_ISR_BACKOFF)) {
+        /* make sure we don't fire too early */
+        while (_time_left(_xtimer_lltimer_mask(timer_list_head->target), reference)) {}
+
+        /* pick first timer in list */
+        xtimer_t *timer = timer_list_head;
+
+        /* advance list */
+        timer_list_head = timer->next;
+
+        /* make sure timer is recognized as being already fired */
+        timer->target = 0;
+        timer->long_target = 0;
+
+        /* fire timer */
+        _shoot(timer);
+    }
+
+    /* possibly executing all callbacks took enough
+     * time to overflow.  In that case we advance to
+     * next timer period and check again for expired
+     * timers.*/
+    if (reference > _xtimer_lltimer_now()) {
+        DEBUG("_timer_callback: overflowed while executing callbacks. %i\n",
+              timer_list_head != NULL);
+        _next_period();
+        reference = 0;
+        goto overflow;
+    }
+
+    if (timer_list_head) {
+        /* schedule callback on next timer target time */
+        next_target = timer_list_head->target - XTIMER_OVERHEAD;
+
+        /* make sure we're not setting a time in the past */
+        if (next_target < (_xtimer_lltimer_now() + XTIMER_ISR_BACKOFF)) {
+            goto overflow;
+        }
+    }
+    else {
+        /* there's no timer planned for this timer period */
+        /* schedule callback on next overflow */
+        next_target = _xtimer_lltimer_mask(0xFFFFFFFF);
+        uint32_t now = _xtimer_lltimer_now();
+
+        /* check for overflow again */
+        if (now < reference) {
+            _next_period();
+            reference = 0;
+            goto overflow;
+        }
+        else {
+            /* check if the end of this period is very soon */
+            if (_xtimer_lltimer_mask(now + XTIMER_ISR_BACKOFF) < now) {
+                /* spin until next period, then advance */
+                while (_xtimer_lltimer_now() >= now) {}
+                _next_period();
+                reference = 0;
+                goto overflow;
+            }
+        }
+    }
+
+    _in_handler = 0;
+
+    /* set low level timer */
+    _lltimer_set(next_target);
+}


### PR DESCRIPTION
### Contribution description
This is a very WIP PR to add support for multiple hardware timers to xtimer. A hardware abstraction layer interfaces xtimer to the low-level timers, allowing easy addition and maintenance of low-level timers. Configuration should be reverse-compatible with the old configuration (requiring no alterations to board.h), but multiple timers can be added by creating an xtimer_params.h file, in the style of how the drivers work. I intend to have periph/timer, periph/rtt, and periph/rtc support added. It may also be possible to add support for drivers/ds1307 and similar discrete RTC modules, but I do not have one of these lying around.

One of my primary reasons for adding this is to create better support for sleep modes in xtimer. Consider the following example atmega1284p setup:
- system clock 8MHz
- RTC crystal 32kHz
- timer1 set to count system clock at 1MHz
- timer3 set to count system clock at 125kHz (prescale by 1/64)
- timer2 set to count RTC crystal at 32 Hz

If the xtimer_sleep time is very short, then the 1MHz timer is used. If it is medium, then the 125kHz timer is used. If it is long then the 32 Hz timer is used. Here is the current used in different power modes (according to the datasheet at 3.3V):
- System is active at 8MHz (figure 30-348): 4.5 mA
- System is idle when using 1MHz timer. Switch to idle mode, reduce system clock to 1MHz, and disable timer prescaling (figure 30-353). 200uA
- System is idle when using 125kHz timer. Switch to idle mode, reduce system clock to 125kHz, and disable timer prescaling (figure 30-354). 60uA (better if more aggressive prescaling, but there isn't a figure for that)
- System is idle when using 32 Hz timer. Switch to power-save mode, which turns off the system clock (figure 30-357). <1uA (slightly higher due to periodic wakes to handle overflow events)

### Current state
```sys/include/xtimer/hal.h``` is incomplete
```sys/xtimer/xtimer_hal.c``` is messy and does not reflect intended change
```sys/xtimer/xtimer.c``` and ```sys/xtimer/xtimer_core.c``` haven't been altered yet
xtimer headers may require some further alterations.
Nothing has been tested yet.

Posted mainly for discussion.

### Issues/PRs references
This affects discussion of div / frac requirements in #9280 and #9283