### PR TITLE
tests/periph_i2c: python interface for shell

### DIFF
--- a/tests/periph_i2c/tests/periph_i2c_if.py
+++ b/tests/periph_i2c/tests/periph_i2c_if.py
@@ -1,0 +1,111 @@
+import test_shell_if
+import serial.tools.list_ports
+import logging
+
+
+class PeriphI2CIf(test_shell_if.TestShellIf):
+
+    def __init__(self, port=None, baud=115200):
+
+        if (port is None):
+            self.autoconnect()
+        else:
+            self.connect(port, baud)
+
+    def autoconnect(self):
+        found_connection = False
+        comlist = serial.tools.list_ports.comports()
+        connected = []
+        logging.debug("Autoconnecting")
+        for element in comlist:
+            connected.append(element.device)
+        for port in connected:
+            logging.debug("Port: " + port)
+            self.connect(port)
+            ret = self.get_id().data
+            if (isinstance(ret, list)):
+                if (len(ret) is 1):
+                    if (isinstance(ret[0], str)):
+                        logging.debug("ID: %s" % ret[0])
+                        if ('periph_i2c' in ret[0]):
+                            logging.debug("Found connection")
+                            found_connection = True
+                            break
+            self.disconnect()
+        return found_connection
+
+    def assign_dev(self, dev_num):
+        return self.send_cmd('i2c_assign_dev %d' % (dev_num))
+
+    def acquire(self):
+        return self.send_cmd('i2c_acquire')
+
+    def release(self):
+        return self.send_cmd('i2c_release')
+
+    def read_reg(self, addr, reg, flag=None):
+        if (flag is None):
+            return self.send_cmd('i2c_read_reg %d %d' % (addr, reg))
+        else:
+            return self.send_cmd('i2c_read_reg %d %d %d' % (addr, reg, flag))
+
+    def read_regs(self, addr, reg, len, flag=None):
+        if (flag is None):
+            return self.send_cmd('i2c_read_regs %d %d %d' % (addr, reg, len))
+        else:
+            return self.send_cmd('i2c_read_regs \
+            %d %d %d %d' % (addr, reg, len, flag))
+
+    def read_byte(self, addr, flag=None):
+        if (flag is None):
+            return self.send_cmd('i2c_read_byte %d' % (addr))
+        else:
+            return self.send_cmd('i2c_read_byte %d %d' % (addr, flag))
+
+    def read_bytes(self, addr, len, flag=None):
+        if (flag is None):
+            return self.send_cmd('i2c_read_bytes %d %d' % (addr, len))
+        else:
+            return self.send_cmd('i2c_read_bytes %d %d %d' % (addr, len, flag))
+
+    def write_reg(self, addr, reg, data, flag=None):
+        if (flag is None):
+            return self.send_cmd('i2c_write_reg %d %d %d' % (addr, reg, data))
+        else:
+            return self.send_cmd('i2c_write_reg \
+            %d %d %d %d' % (addr, reg, data, flag))
+
+    def write_regs(self, addr, reg, data, flag=None):
+        str = ''
+        for val in data:
+            str += ' %d' % (val)
+        if (flag is None):
+            return self.send_cmd('i2c_write_regs %d %d 0' % (addr, reg) + str)
+        else:
+            return self.send_cmd('i2c_write_regs \
+            %d %d %d' % (addr, reg, flag) + str)
+
+    def write_byte(self, addr, data, flag=None):
+        if (flag is None):
+            return self.send_cmd('i2c_write_byte %d %d' % (addr, data))
+        else:
+            return self.send_cmd('i2c_write_byte \
+            %d %d %d' % (addr, flag, data))
+
+    def write_bytes(self, addr, data, flag=None):
+        str = ''
+        for val in data:
+            str += ' %d' % (val)
+        if (flag is None):
+            return self.send_cmd('i2c_write_bytes %d 0' % (addr) + str)
+        else:
+            return self.send_cmd('i2c_write_bytes %d %d' % (addr, flag) + str)
+
+    def get_devs(self):
+        return self.send_cmd('i2c_get_devs')
+
+    def get_speed(self):
+        return self.send_cmd('i2c_get_speed')
+
+    def get_id(self):
+        return self.send_cmd('i2c_get_id')

--- a/tests/periph_i2c/tests/test_shell_if.py
+++ b/tests/periph_i2c/tests/test_shell_if.py
@@ -1,0 +1,78 @@
+import serial
+import logging
+
+
+class TestShellParams:
+    cmd = ''
+    result = ''
+    msg = ''
+    data = ''
+
+
+class TestShellIf:
+    __COMMAND = 'Command: '
+    __SUCCESS = 'Success: '
+    __ERROR = 'Error: '
+    __TIMEOUT = 'Timeout: '
+    __RESULT_SUCCESS = 'Success'
+    __RESULT_ERROR = 'Error'
+    __RESULT_TIMEOUT = 'Timeout'
+
+    def __init__(self, port='/dev/ttyACM0', baud=115200):
+
+        self.connect(port, baud)
+
+    def connect(self, port, baud=115200, timeout=1):
+        logging.debug("Connecting to " + port)
+        self.__dev = serial.Serial(port, baud, timeout=timeout)
+        if(self.__dev.isOpen() is False):
+            self.__dev.open()
+
+    def disconnect(self):
+        logging.debug("Disconnecting")
+        if (isinstance(self.__dev, serial.Serial)):
+            if (self.__dev.isOpen()):
+                self.__dev.close()
+
+    def send_cmd(self, send_cmd):
+        cmd_info = TestShellParams()
+        logging.debug("Sending: " + send_cmd)
+        self.__dev.write(send_cmd + '\n')
+        response = 'no_exit'
+        while (response != ''):
+            response = self.__dev.readline()
+            logging.debug("Response: " + response.replace('\n', ''))
+            if (self.__COMMAND in response):
+                cmd_info.msg = response.replace(self.__COMMAND, '')
+                cmd_info.cmd = cmd_info.msg.replace('\n', '')
+
+            if (self.__SUCCESS in response):
+                cmd_info.msg = response.replace(self.__SUCCESS, '')
+                cmd_info.msg = cmd_info.msg.replace('\n', '')
+                if ('[' in cmd_info.msg) and (']' in cmd_info.msg):
+                    data = cmd_info.msg
+                    data = data[data.find("[")+1:data.find("]")]
+                    data = data.split(', ')
+                    cmd_info.data = list()
+                    for value in data:
+                        try:
+                            cmd_info.data.append(int(value, 0))
+                        except ValueError:
+                            cmd_info.data.append(value)
+                    logging.debug(cmd_info.data)
+                cmd_info.result = self.__RESULT_SUCCESS
+                break
+
+            if (self.__ERROR in response):
+                cmd_info.msg = response.replace(self.__ERROR, '')
+                cmd_info.msg = cmd_info.msg.replace('\n', '')
+                cmd_info.result = self.__RESULT_ERROR
+                break
+
+        if (response == ''):
+            cmd_info.result = self.__RESULT_TIMEOUT
+            logging.debug(self.__RESULT_TIMEOUT)
+        return cmd_info
+
+    def __del__(self):
+        self.disconnect()


### PR DESCRIPTION
### Contribution description
This is a python interface for the shell commands of the periph_i2c test.  It should make it easier to program tests that use the shell.  Eventually the test_shell_if.py can be move out and reused for other periphs.  This is part of the I2C embargo.

### Issues/PRs references
See #6577
Depends on #9168