### PR TITLE
bmx280 test: use constants for bmx280_init return values 

### DIFF
--- a/tests/driver_bmx280/main.c
+++ b/tests/driver_bmx280/main.c
@@ -47,6 +47,11 @@ int main(void)
         return 1;
     }
 
+    if (result == BMX280_ERR_NOCAL) {
+        puts("[Error] Could not read calibration data");
+        return 1;
+    }
+
     printf("Initialization successful\n\n");
 
     printf("+------------Calibration Data------------+\n");

--- a/tests/driver_bmx280/main.c
+++ b/tests/driver_bmx280/main.c
@@ -37,12 +37,12 @@ int main(void)
 
     printf("+------------Initializing------------+\n");
     result = bmx280_init(&dev, &bmx280_params[0]);
-    if (result == -1) {
+    if (result == BMX280_ERR_I2C) {
         puts("[Error] The given i2c is not enabled");
         return 1;
     }
 
-    if (result == -2) {
+    if (result == BMX280_ERR_NODEV) {
         printf("[Error] The sensor did not answer correctly at address 0x%02X\n", bmx280_params[0].i2c_addr);
         return 1;
     }


### PR DESCRIPTION
### Contribution description

The bmx280 test didn't use the constants defined in `bmx280.h` for the `bmx280_init` return values and instead hardcoded them. I adjusted this accordingly. Besides it didn't check for the `BMX280_ERR_NOCAL` error, I also fixed that.