### PR TITLE
cortexm: Remove -fno-builtin from CFLAGS

### DIFF
--- a/makefiles/arch/cortexm.inc.mk
+++ b/makefiles/arch/cortexm.inc.mk
@@ -15,7 +15,7 @@ ifneq (,$(filter cortex-m0%,$(CPU_ARCH)))
 endif
 endif
 
-export CFLAGS_LINK  = -ffunction-sections -fdata-sections -fno-builtin -fshort-enums
+export CFLAGS_LINK  = -ffunction-sections -fdata-sections -fshort-enums
 export CFLAGS_DBG  ?= -ggdb -g3
 export CFLAGS_OPT  ?= -Os
 

--- a/tests/gnrc_netif/main.c
+++ b/tests/gnrc_netif/main.c
@@ -1043,7 +1043,7 @@ static void test_netif_iter(void)
 
 static void test_netif_get_name(void)
 {
-    char exp_name[NETIF_NAMELENMAX];
+    char exp_name[NETIF_NAMELENMAX + 1];
     char name[NETIF_NAMELENMAX];
     int res;
     netif_t netif = netif_iter(NETIF_INVALID);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Remove `-fno-builtin` from CFLAGS for Cortex-M targets. This allows the optimizer to optimize calls to printf, memcpy etc. printf is sometimes optimized into a call to puts or putchar. Loops may be optimized into calls to memcpy, memset and so on.

Testing: Unit tests pass on frdm-kw41z with this applied, examples/default works.
ROM usage for .text was reduced by 8 to 108 bytes for examples/default on the Cortex-M boards. 

### Issues/PRs references

#4881 