### PR TITLE
drivers: add MH-Z19 CO2 sensor driver

### DIFF
--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -226,6 +226,11 @@ ifneq (,$(filter mag3110,$(USEMODULE)))
   FEATURES_REQUIRED += periph_i2c
 endif
 
+ifneq (,$(filter mhz19,$(USEMODULE)))
+  USEMODULE += xtimer
+  FEATURES_REQUIRED += periph_gpio
+endif
+
 ifneq (,$(filter mma8x5x,$(USEMODULE)))
   FEATURES_REQUIRED += periph_i2c
 endif

--- a/drivers/Makefile.include
+++ b/drivers/Makefile.include
@@ -158,6 +158,10 @@ ifneq (,$(filter mag3110,$(USEMODULE)))
   USEMODULE_INCLUDES += $(RIOTBASE)/drivers/mag3110/include
 endif
 
+ifneq (,$(filter mhz19,$(USEMODULE)))
+  USEMODULE_INCLUDES += $(RIOTBASE)/drivers/mhz19/include
+endif
+
 ifneq (,$(filter mma8x5x,$(USEMODULE)))
   USEMODULE_INCLUDES += $(RIOTBASE)/drivers/mma8x5x/include
 endif

--- a/drivers/mhz19/Makefile
+++ b/drivers/mhz19/Makefile
@@ -1,0 +1,2 @@
+MODULE = mhz19
+include $(RIOTBASE)/Makefile.base

--- a/drivers/mhz19/include/mhz19.h
+++ b/drivers/mhz19/include/mhz19.h
@@ -1,0 +1,79 @@
+/*
+ * Copyright (C) 2018 Beduino Master Projekt - University of Bremen
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    drivers_mhz19 MH-Z19 CO2 sensor driver
+ * @ingroup     drivers_sensors
+ * @{
+ *
+ * @file
+ * @brief       Device driver implementation for the Zhengzhou Winsen Electronics Technology MH-Z19 CO2 sensor
+ *
+ * @author      Christian Manal <manal@uni-bremen.de>
+ */
+
+#ifndef MHZ19_H
+#define MHZ19_H
+
+#include <stdint.h>
+#include "periph/gpio.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name mhz19 status return codes
+ * @{
+ */
+#define MHZ19_OK      (0)
+#define MHZ19_ERROR  (-1)
+/** @} */
+
+/**
+ * @brief  Device descriptor for a mhz19 driver
+ */
+typedef struct {
+    gpio_t pin;   /**< Pin the sensor is connected to */
+} mhz19_t;
+
+/**
+ * @brief  Device initialization parameters
+ */
+typedef struct {
+    gpio_t pin;   /**< Pin the sensor is connected to */
+} mhz19_params_t;
+
+/**
+ * @brief  Initialize a mhz19 device
+ *
+ * @param[out] dev        device descriptor
+ * @param[in]  params     mhz19 initialization struct
+ *
+ * @return                0 on success
+ * @return               -1 on error
+ */
+int mhz19_init(mhz19_t *dev, mhz19_params_t *params);
+
+
+/**
+ * @brief  Get a measurement
+ *
+ * @param[in] dev         device descriptor
+ *
+ * @return                >=0 ppm of CO2 in the air (max 2000)
+ * @return                <0 on error
+ */
+int16_t mhz19_get_ppm(mhz19_t *dev);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MHZ19_H */
+/** @} */

--- a/drivers/mhz19/include/mhz19_params.h
+++ b/drivers/mhz19/include/mhz19_params.h
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2018 Beduino Master Projekt - University of Bremen
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_mhz19
+ *
+ * @{
+ * @file
+ * @brief       Default configuration for MH-Z19 CO2 sensor
+ *
+ * @author      Christian Manal <manal@uni-bremen.de>
+ */
+
+#ifndef MHZ19_PARAMS_H
+#define MHZ19_PARAMS_H
+
+#include "mhz19.h"
+#include "saul_reg.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief  Set default configuration parameters for the mhz19
+ * @{
+ */
+#ifndef MHZ19_PARAM_PIN
+#define MHZ19_PARAM_PIN (GPIO_PIN(0, 0))
+#endif
+
+#define MHZ19_PARAMS_DEFAULT { .pin = MHZ19_PARAM_PIN }
+
+#ifndef MHZ19_SAUL_INFO
+#define MHZ19_SAUL_INFO { .name = "mh-z19" }
+#endif
+
+/** @} */
+
+
+/**
+ * @brief  Configure mhz19
+ */
+static const mhz19_params_t mhz19_params[] =
+{
+#ifdef MHZ19_PARAMS_BOARD
+    MHZ19_PARAMS_BOARD
+#else
+    MHZ19_PARAMS_DEFAULT
+#endif
+};
+
+/**
+ * @brief  Configure mhz19 SAUL registry entries
+ */
+static const saul_reg_info_t mhz19_saul_reg_info[] =
+{
+    MHZ19_SAUL_INFO
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MHZ19_PARAMS_H */
+/** @} */

--- a/drivers/mhz19/mhz19_saul.c
+++ b/drivers/mhz19/mhz19_saul.c
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2018 Beduino Master Projekt - University of Bremen
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_mhz19
+ * @{
+ *
+ * @file
+ * @brief       SAUL adaption for the Zhengzhou Winsen Electronics Technology MH-Z19 CO2 sensor
+ *
+ * @author      Christian Manal <manal@uni-bremen.de>
+ *
+ * @}
+ */
+
+#include "mhz19.h"
+#include "saul.h"
+
+static int read_co2_ppm(const void *dev, phydat_t *res)
+{
+    mhz19_t *d = (mhz19_t *)dev;
+    int16_t val = mhz19_get_ppm(d);
+
+    if (val < 0) {
+        return -ECANCELED;
+    }
+
+    res->val[0] = val;
+    res->unit = UNIT_PPM;
+    res->scale = 0;
+    return 1;
+}
+
+const saul_driver_t mhz19_co2_saul_driver = {
+    .read = read_co2_ppm,
+    .write = saul_notsup,
+    .type = SAUL_SENSE_CO2,
+};

--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -414,6 +414,10 @@ auto_init_mpu9150();
     extern void auto_init_si114x(void);
     auto_init_si114x();
 #endif
+#ifdef MODULE_MHZ19
+    extern void auto_init_mhz19(void);
+    auto_init_mhz19();
+#endif
 
 #endif /* MODULE_AUTO_INIT_SAUL */
 

--- a/sys/auto_init/saul/auto_init_mhz19.c
+++ b/sys/auto_init/saul/auto_init_mhz19.c
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2018 Beduino Master Projekt - University of Bremen
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     auto_init_saul
+ * @{
+ *
+ * @file
+ * @brief       Auto initialization of mhz19 driver.
+ *
+ * @author      Christian Manal <manal@uni-bremen.de>
+ *
+ * @}
+ */
+
+#ifdef MODULE_MHZ19
+
+#include "log.h"
+#include "saul_reg.h"
+
+#include "mhz19.h"
+#include "mhz19_params.h"
+
+/**
+ * @brief  Define the number of configured sensors
+ */
+#define MHZ19_NUMOF (sizeof(mhz19_params) / sizeof(mhz19_params[0]))
+
+/**
+ * @brief  Allocate memory for device descriptors
+ */
+static mhz19_t mhz19_devs[MHZ19_NUMOF];
+
+/**
+ * @brief  Allocate memory for SAUL registry entries
+ */
+static saul_reg_t saul_entries[MHZ19_NUMOF];
+
+/**
+ * @brief  Reference the driver structs.
+ * @{
+ */
+extern const saul_driver_t mhz19_co2_saul_driver;
+/** @} */
+
+void auto_init_mhz19(void)
+{
+    for (unsigned i = 0; i < MHZ19_NUMOF; i++) {
+        const mhz19_params_t *p = &mhz19_params[0];
+
+        LOG_DEBUG("[auto_init_saul] initializing mhz19 #%u\n", i);
+
+        if (mhz19_init(&mhz19_devs[i], (mhz19_params_t *)p) != MHZ19_OK) {
+            LOG_DEBUG("[auto_init_saul] error initializing mhz19 #%u\n", i);
+            return;
+        }
+
+        saul_entries[i].dev = &mhz19_devs[i];
+        saul_entries[i].name = mhz19_saul_reg_info[i].name;
+        saul_entries[i].driver = &mhz19_co2_saul_driver;
+
+        saul_reg_add(&(saul_entries[i]));
+    }
+}
+
+#endif /* MODULE_MHZ19 */

--- a/tests/driver_mhz19/Makefile
+++ b/tests/driver_mhz19/Makefile
@@ -1,0 +1,5 @@
+include ../Makefile.tests_common
+
+USEMODULE += mhz19
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/driver_mhz19/README.md
+++ b/tests/driver_mhz19/README.md
@@ -1,0 +1,25 @@
+## About
+This is a test application for the MH-Z19 CO2 sensor, which measured
+the parts per million CO2 content in the air up to 2000ppm.
+
+## Usage
+The application initializes the device and goes into an infinite loop of
+measurements. One measurement can take up to sligtly more than 2 seconds,
+as the sensor outputs its measurements via pulse width modulation,
+with pulses of 1004ms +-5%, so if a measurement is started just after
+the start of a cycle, it takes the time of two cycles for an accurate
+measurement (see the [datasheet][1] for more information).
+
+After initialization, the application will take and display measurements
+every two seconds.
+
+## Overruling default parameters
+The default pin for an MH-Z19 device is `GPIO_PIN(0, 0)`. If you want
+to use another pin, build this application as follows:
+
+    export CFLAGS='-DMHZ19_PARAM_PIN=\(GPIO_PIN\(1,2\)\)'
+    make -C tests/driver_mhz19 BOARD=...
+
+
+For more information see the datasheet:
+[1]: http://www.winsen-sensor.com/d/files/PDF/Infrared%20Gas%20Sensor/NDIR%20CO2%20SENSOR/MH-Z19%20CO2%20Ver1.0.pdf

--- a/tests/driver_mhz19/main.c
+++ b/tests/driver_mhz19/main.c
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2018 Beduino Master Projekt - University of Bremen
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Test application for the MH-Z19 CO2 sensor.
+ *
+ * @author      Christian Manal <manal@uni-bremen.de>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include <inttypes.h>
+
+#include "mhz19.h"
+#include "mhz19_params.h"
+#include "xtimer.h"
+
+int main(void)
+{
+    mhz19_t dev;
+
+    printf("MH-Z19 test application\n");
+
+    printf("------- Initialization -------\n");
+    if (mhz19_init(&dev, (mhz19_params_t *)&mhz19_params[0]) != MHZ19_OK) {
+        printf("[Error] Initialization failed\n");
+        return 1;
+    }
+    printf("[Ok] Initialization successfull\n\n");
+
+
+    printf("------- Starting measurements -------\n");
+    while (1) {
+        int16_t ppm = mhz19_get_ppm(&dev);
+
+        if (ppm < 0) {
+            printf("[Error] Measurement timed out\n");
+        } else if (ppm > 2000) {
+            printf("[Error] Measurement above the range of the sensor (%dppm)\n", (int)ppm);
+        } else {
+            printf("[Ok] Measured %dppm of CO2\n", (int)ppm);
+        }
+
+        xtimer_sleep(2);
+    }
+}


### PR DESCRIPTION
### Contribution description

This commit adds a driver for the MH-Z19 CO2 sensor. Specifically the PWM interface (since it also has an UART). The PWM is interpreted by measuring the durations of high and low levels of a pulse and calculating the result according to a formular from the datasheet. It measures CO2 in parts per million up to 2000ppm.

See `tests/driver_mhz19/README.md` for further info and a link to the datasheet.