### PR TITLE
native: Enforce strncpy usage in tap device setup

### DIFF
--- a/cpu/native/netdev_tap/netdev_tap.c
+++ b/cpu/native/netdev_tap/netdev_tap.c
@@ -300,7 +300,7 @@ static int _send(netdev_t *netdev, const iolist_t *iolist)
 
 void netdev_tap_setup(netdev_tap_t *dev, const netdev_tap_params_t *params) {
     dev->netdev.driver = &netdev_driver_tap;
-    strncpy(dev->tap_name, *(params->tap_name), IFNAMSIZ);
+    strncpy(dev->tap_name, *(params->tap_name), IFNAMSIZ - sizeof('\0'));
 }
 
 static void _tap_isr(int fd, void *arg) {


### PR DESCRIPTION
Hi Everyone,

I noticed that network based examples failed to build under native then built with -O2 or -O3.
This small PR should fix this.