### PR TITLE
drivers/saul :sys/phydat: add definitions for TVOC sensor type and PPB unit

### DIFF
--- a/drivers/include/saul.h
+++ b/drivers/include/saul.h
@@ -95,6 +95,7 @@ enum {
     SAUL_SENSE_COUNT    = 0x8d,     /**< sensor: pulse counter */
     SAUL_SENSE_DISTANCE = 0x8e,     /**< sensor: distance */
     SAUL_SENSE_CO2      = 0x8f,     /**< sensor: CO2 Gas */
+    SAUL_SENSE_TVOC     = 0x90,     /**< sensor: TVOC Gas */
     SAUL_CLASS_ANY      = 0xff      /**< any device - wildcard */
     /* extend this list as needed... */
 };

--- a/drivers/saul/saul_str.c
+++ b/drivers/saul/saul_str.c
@@ -52,6 +52,7 @@ const char *saul_class_to_str(const uint8_t class_id)
         case SAUL_SENSE_COUNT:     return "SENSE_PULSE_COUNT";
         case SAUL_SENSE_DISTANCE:  return "SENSE_DISTANCE";
         case SAUL_SENSE_CO2:       return "SENSE_CO2";
+        case SAUL_SENSE_TVOC:      return "SENSE_TVOC";
         case SAUL_CLASS_ANY:       return "CLASS_ANY";
         default:                   return "CLASS_UNKNOWN";
     }

--- a/sys/include/phydat.h
+++ b/sys/include/phydat.h
@@ -104,6 +104,7 @@ enum {
     UNIT_PERCENT,   /**< out of 100 */
     UNIT_PERMILL,   /**< out of 1000 */
     UNIT_PPM,       /**< part per million */
+    UNIT_PPB,       /**< part per billion */
     /* aggregate values */
     UNIT_TIME,      /**< the three dimensions contain sec, min, and hours */
     UNIT_DATE       /**< the 3 dimensions contain days, months and years */

--- a/sys/phydat/phydat_str.c
+++ b/sys/phydat/phydat_str.c
@@ -95,6 +95,7 @@ const char *phydat_unit_to_str(uint8_t unit)
         case UNIT_BAR:      return "Bar";
         case UNIT_PA:       return "Pa";
         case UNIT_PPM:      return "ppm";
+        case UNIT_PPB:      return "ppb";
         case UNIT_CD:       return "cd";
         case UNIT_PERCENT:  return "%";
         default:            return "";


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR adds support for TVOC (total volatile organic compounds) sensor types and PPB (part per billion).

This is required for a driver I wrote for the [CCS811 gas sensor](https://ams.com/ccs811). This is not PRed because of the I2C embargo but I'll do that when this work is done.

The branch of the driver is [here](https://github.com/aabadie/RIOT/tree/pr/driver/ccs811).

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->