### PR TITLE
gnrc_netif: Add support for internal event loop

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -148,6 +148,11 @@ ifneq (,$(filter gnrc_netif,$(USEMODULE)))
   USEMODULE += fmt
 endif
 
+ifneq (,$(filter gnrc_netif_events,$(USEMODULE)))
+  USEMODULE += core_thread_flags
+  USEMODULE += event
+endif
+
 ifneq (,$(filter ieee802154 nrfmin,$(USEMODULE)))
   ifneq (,$(filter gnrc_ipv6, $(USEMODULE)))
     USEMODULE += gnrc_sixlowpan

--- a/examples/gnrc_networking/Makefile
+++ b/examples/gnrc_networking/Makefile
@@ -39,6 +39,7 @@ USEMODULE += ps
 USEMODULE += netstats_l2
 USEMODULE += netstats_ipv6
 USEMODULE += netstats_rpl
+USEMODULE += gnrc_netif_events
 
 # Comment this out to disable code in RIOT that does safety checking
 # which is not needed in a production environment but helps in the

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -23,6 +23,7 @@ PSEUDOMODULES += gnrc_netdev_default
 PSEUDOMODULES += gnrc_neterr
 PSEUDOMODULES += gnrc_netapi_callbacks
 PSEUDOMODULES += gnrc_netapi_mbox
+PSEUDOMODULES += gnrc_netif_events
 PSEUDOMODULES += gnrc_pktbuf_cmd
 PSEUDOMODULES += gnrc_sixlowpan_border_router_default
 PSEUDOMODULES += gnrc_sixlowpan_default

--- a/sys/include/net/gnrc/netif.h
+++ b/sys/include/net/gnrc/netif.h
@@ -84,15 +84,15 @@ typedef struct {
      */
     event_queue_t evq;
     /**
-     * @brief   Pointer to event instance table
+     * @brief   Pointer to ISR event
      *
-     * This pointer gives a way to allocate events on the stack of each
+     * This pointer gives a way to allocate ISR events on the stack of each
      * gnrc_netif thread, instead of having a single global instance which will
      * not work if the system has more than one network interface.
      * The _event_cb function of gnrc_netif.c uses this pointer to be able to
      * post events from interrupt context.
      */
-    void *events;
+    void *event_isr; /* void * to keep implementation details private to gnrc_netif.c */
 #endif /* MODULE_GNRC_NETIF_EVENTS */
 #if (GNRC_NETIF_L2ADDR_MAXLEN > 0)
     /**

--- a/sys/include/net/gnrc/netif.h
+++ b/sys/include/net/gnrc/netif.h
@@ -30,6 +30,9 @@
 
 #include "kernel_types.h"
 #include "msg.h"
+#ifdef MODULE_GNRC_NETIF_EVENTS
+#include "event.h"
+#endif /* MODULE_GNRC_NETIF_EVENTS */
 #include "net/ipv6/addr.h"
 #include "net/gnrc/netapi.h"
 #include "net/gnrc/pkt.h"
@@ -75,6 +78,22 @@ typedef struct {
      * @see net_gnrc_netif_flags
      */
     uint32_t flags;
+#if defined(MODULE_GNRC_NETIF_EVENTS) || DOXYGEN
+    /**
+     * @brief   Event queue for asynchronous events
+     */
+    event_queue_t evq;
+    /**
+     * @brief   Pointer to event instance table
+     *
+     * This pointer gives a way to allocate events on the stack of each
+     * gnrc_netif thread, instead of having a single global instance which will
+     * not work if the system has more than one network interface.
+     * The _event_cb function of gnrc_netif.c uses this pointer to be able to
+     * post events from interrupt context.
+     */
+    void *events;
+#endif /* MODULE_GNRC_NETIF_EVENTS */
 #if (GNRC_NETIF_L2ADDR_MAXLEN > 0)
     /**
      * @brief   The link-layer address currently used as the source address

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -1417,6 +1417,8 @@ static void *_gnrc_netif_thread(void *args)
 
     while (1) {
         msg_t msg;
+        /* msg will be filled by _process_events_await_msg.
+         * The function will not return until a message has been received. */
         _process_events_await_msg(netif, &msg);
 
         /* dispatch netdev, MAC and gnrc_netapi messages */

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -48,10 +48,6 @@ typedef struct {
     event_t super;
     netdev_t *dev;
 } event_netdev_t;
-
-typedef struct {
-    event_netdev_t isr;
-} gnrc_netif_events_t;
 #endif /* MODULE_GNRC_NETIF_EVENTS */
 
 static gnrc_netif_t _netifs[GNRC_NETIF_NUMOF];
@@ -1337,13 +1333,11 @@ static void *_gnrc_netif_thread(void *args)
     dev = netif->dev;
     netif->pid = sched_active_pid;
 #ifdef MODULE_GNRC_NETIF_EVENTS
-    gnrc_netif_events_t event_table = {
-        .isr = {
-            .super = { .handler = _event_handler_isr, },
-            .dev = dev,
-        },
+    event_netdev_t ev_isr = {
+        .super = { .handler = _event_handler_isr, },
+        .dev = dev,
     };
-    netif->events = &event_table;
+    netif->event_isr = &ev_isr;
     /* set up the event queue */
     event_queue_init(&netif->evq);
 #endif /* MODULE_GNRC_NETIF_EVENTS */
@@ -1486,8 +1480,8 @@ static void _event_cb(netdev_t *dev, netdev_event_t event)
 
     if (event == NETDEV_EVENT_ISR) {
 #ifdef MODULE_GNRC_NETIF_EVENTS
-        gnrc_netif_events_t *etp = netif->events;
-        event_post(&netif->evq, &etp->isr.super);
+        event_netdev_t *etp = netif->event_isr;
+        event_post(&netif->evq, &etp->super);
 #else /* MODULE_GNRC_NETIF_EVENTS */
         msg_t msg = { .type = NETDEV_MSG_TYPE_EVENT,
                       .content = { .ptr = netif } };

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -1357,6 +1357,7 @@ static void _process_events_await_msg(gnrc_netif_t *netif, msg_t *msg)
         thread_flags_wait_any(THREAD_FLAG_MSG_WAITING | THREAD_FLAG_EVENT);
     }
 #else /* MODULE_GNRC_NETIF_EVENTS */
+    (void) netif;
     /* Only messages used for event handling */
     DEBUG("gnrc_netif: waiting for incoming messages\n");
     msg_receive(msg);


### PR DESCRIPTION
### Contribution description

Enabled by the `gnrc_netif_events` pseudo module. Using an internal event loop eliminates the risk of lost interrupts and lets ISR events always be handled before any send/receive requests from other threads are processed.
The events in the event loop is also a potential hook for MAC layers and other link layer modules which may need a way to inject and process events before any external IPC messages are handled.

### Issues/PRs references

