### PR TITLE
tlsf: add custom walker to get total free / used sizes

### DIFF
--- a/pkg/tlsf/contrib/include/tlsf-malloc.h
+++ b/pkg/tlsf/contrib/include/tlsf-malloc.h
@@ -44,6 +44,28 @@ extern "C" {
 #endif
 
 /**
+ * @brief Struct to hold the total sizes of free and used blocks
+ * Used for @ref tlsf_size_walker()
+ */
+typedef struct {
+    unsigned free;          /**< total free size */
+    unsigned used;          /**< total used size */
+} tlsf_size_container_t;
+
+/**
+ * Walk the memory pool to print all block sizes and to calculate
+ * the total amount of free and used block sizes.
+ *
+ * @note This function is passed to tlsf_walk_pool()
+ *
+ * @param   ptr        Pointer to the current block.
+ * @param   size       Size of the current block at @p ptr.
+ * @param   used       Shows whether the current block is used or free.
+ * @param   user       Custom data expected to be of type ``pointer to tlsf_size_container_t``
+ */
+void tlsf_size_walker(void* ptr, size_t size, int used, void* user);
+
+/**
  * Add an area of memory to the global allocator pool.
  *
  * The first time this function is called, it will automatically perform a

--- a/pkg/tlsf/contrib/tlsf-malloc.c
+++ b/pkg/tlsf/contrib/tlsf-malloc.c
@@ -63,6 +63,18 @@ tlsf_t *_tlsf_get_global_control(void)
     return gheap;
 }
 
+void tlsf_size_walker(void* ptr, size_t size, int used, void* user)
+{
+    printf("\t%p %s size: %u (%p)\n", ptr, used ? "used" : "free", (unsigned int)size, ptr);
+
+    if (used) {
+        ((tlsf_size_container_t *)user)->used += (unsigned int)size;
+    }
+    else {
+        ((tlsf_size_container_t *)user)->free += (unsigned int)size;
+    }
+}
+
 /**
  * Allocate a block of size "bytes"
  */

--- a/sys/ps/ps.c
+++ b/sys/ps/ps.c
@@ -147,7 +147,10 @@ void ps(void)
            overall_stacksz, overall_used);
 #   ifdef MODULE_TLSF_MALLOC
     puts("\nHeap usage:");
-    tlsf_walk_pool(tlsf_get_pool(_tlsf_get_global_control()), NULL, NULL);
+    tlsf_size_container_t sizes = { .free = 0, .used = 0 };
+    tlsf_walk_pool(tlsf_get_pool(_tlsf_get_global_control()), tlsf_size_walker, &sizes);
+    printf("\tTotal free size: %u\n", sizes.free);
+    printf("\tTotal used size: %u\n", sizes.used);
 #   endif
 #endif
 }


### PR DESCRIPTION
### Contribution description
This PR provides a custom walker for TLSF to
1. print the sizes in dec, not hex
2. calculate the total free / used block sizes and print them at the `ps` call.


### Issues/PRs references
none