### PR TITLE
gnrc_netif: Add bootstrap function for device setup

### DIFF
--- a/sys/include/net/gnrc/netif.h
+++ b/sys/include/net/gnrc/netif.h
@@ -71,7 +71,6 @@ typedef thread_task_func_t gnrc_netif_bootstrap_t;
 typedef struct {
     const gnrc_netif_ops_t *ops;            /**< Operations of the network interface */
     netdev_t *dev;                          /**< Network device of the network interface */
-    netdev_t *hwdev;                        /**< Hardware layer of the network device */
     rmutex_t mutex;                         /**< Mutex of the interface */
 #if defined(MODULE_GNRC_IPV6) || DOXYGEN
     gnrc_netif_ipv6_t ipv6;                 /**< IPv6 component */
@@ -489,13 +488,6 @@ char *gnrc_netif_addr_to_str(const uint8_t *addr, size_t addr_len, char *out);
  * @return  0, on failure.
  */
 size_t gnrc_netif_addr_from_str(const char *str, uint8_t *out);
-
-/**
- * @brief   gnrc netif thread event handler.
- *
- * @param[in] args   The network interface
- */
-void *gnrc_netif_thread(void *args);
 
 #ifdef __cplusplus
 }

--- a/sys/include/net/gnrc/netif.h
+++ b/sys/include/net/gnrc/netif.h
@@ -496,6 +496,7 @@ size_t gnrc_netif_addr_from_str(const char *str, uint8_t *out);
  * @param[in] args   The network interface
  */
 void *gnrc_netif_thread(void *args);
+
 #ifdef __cplusplus
 }
 #endif

--- a/sys/include/net/gnrc/netif/internal.h
+++ b/sys/include/net/gnrc/netif/internal.h
@@ -415,6 +415,13 @@ static inline bool gnrc_netif_is_6lbr(const gnrc_netif_t *netif)
 #define gnrc_netif_is_6lbr(netif)               (false)
 #endif
 
+/**
+ * @brief   gnrc netif thread event handler.
+ *
+ * @param[in] args   The network interface
+ */
+void *gnrc_netif_thread(void *args);
+
 #ifdef __cplusplus
 }
 #endif

--- a/sys/net/gnrc/link_layer/gomach/gomach.c
+++ b/sys/net/gnrc/link_layer/gomach/gomach.c
@@ -81,8 +81,6 @@ gnrc_netif_t *gnrc_netif_gomach_create(char *stack, int stacksize,
 
 static void *_bootstrap(void *args)
 {
-    gnrc_netif_t *netif = args;
-    netif->hwdev = netif->dev;
     return gnrc_netif_thread(args);
 }
 
@@ -90,7 +88,7 @@ static gnrc_pktsnip_t *_recv(gnrc_netif_t *netif)
 {
     netdev_t *dev = netif->dev;
     netdev_ieee802154_rx_info_t rx_info;
-    netdev_ieee802154_t *state = (netdev_ieee802154_t *)netif->hwdev;
+    netdev_ieee802154_t *state = (netdev_ieee802154_t *)netif->dev;
     gnrc_pktsnip_t *pkt = NULL;
     int bytes_expected = dev->driver->recv(dev, NULL, 0, NULL);
 
@@ -541,7 +539,7 @@ static void gomach_t2k_trans_in_cp(gnrc_netif_t *netif)
     /* If we are retransmitting the packet, use the same sequence number for the
      * packet to avoid duplicate packet reception at the receiver side. */
     if ((netif->mac.tx.no_ack_counter > 0) || (netif->mac.tx.tx_busy_count > 0)) {
-        netdev_ieee802154_t *device_state = (netdev_ieee802154_t *)netif->hwdev;
+        netdev_ieee802154_t *device_state = (netdev_ieee802154_t *)netif->dev;
         device_state->seq = netif->mac.tx.tx_seq;
     }
 
@@ -634,7 +632,7 @@ static bool _cp_tx_busy(gnrc_netif_t *netif)
         /* Store the TX sequence number for this packet. Always use the same
          * sequence number for sending the same packet, to avoid duplicated
          * packet reception at the receiver. */
-        netdev_ieee802154_t *device_state = (netdev_ieee802154_t *)netif->hwdev;
+        netdev_ieee802154_t *device_state = (netdev_ieee802154_t *)netif->dev;
         netif->mac.tx.tx_seq = device_state->seq - 1;
 
         netif->mac.tx.t2k_state = GNRC_GOMACH_T2K_TRANS_IN_CP;
@@ -652,7 +650,7 @@ static void _cp_tx_default(gnrc_netif_t *netif)
 
     /* This packet will be retried. Store the TX sequence number for this packet.
      * Always use the same sequence number for sending the same packet. */
-    netdev_ieee802154_t *device_state = (netdev_ieee802154_t *)netif->hwdev;
+    netdev_ieee802154_t *device_state = (netdev_ieee802154_t *)netif->dev;
     netif->mac.tx.tx_seq = device_state->seq - 1;
 
     /* If no_ack_counter reaches the threshold, regarded as phase-lock failed. So
@@ -675,7 +673,7 @@ static void gomach_t2k_wait_cp_txfeedback(gnrc_netif_t *netif)
         /* No TX-ISR, go to sleep. */
         netif->mac.tx.no_ack_counter++;
 
-        netdev_ieee802154_t *device_state = (netdev_ieee802154_t *)netif->hwdev;
+        netdev_ieee802154_t *device_state = (netdev_ieee802154_t *)netif->dev;
         netif->mac.tx.tx_seq = device_state->seq - 1;
 
         /* Here, we don't queue the packet again, but keep it in tx.packet. */
@@ -805,7 +803,7 @@ static void gomach_t2k_trans_in_slots(gnrc_netif_t *netif)
 {
     /* If this packet is being retransmitted, use the same recorded MAC sequence number. */
     if (netif->mac.tx.no_ack_counter > 0) {
-        netdev_ieee802154_t *device_state = (netdev_ieee802154_t *)netif->hwdev;
+        netdev_ieee802154_t *device_state = (netdev_ieee802154_t *)netif->dev;
         device_state->seq = netif->mac.tx.tx_seq;
     }
 
@@ -873,7 +871,7 @@ static void _t2k_wait_vtdma_tx_default(gnrc_netif_t *netif)
      *  the following cycle. */
     netif->mac.tx.no_ack_counter = 1;
 
-    netdev_ieee802154_t *device_state = (netdev_ieee802154_t *)netif->hwdev;
+    netdev_ieee802154_t *device_state = (netdev_ieee802154_t *)netif->dev;
     netif->mac.tx.tx_seq = device_state->seq - 1;
 
     /* Do not release the packet here, continue sending the same packet. ***/
@@ -897,7 +895,7 @@ static void gomach_t2k_wait_vtdma_transfeedback(gnrc_netif_t *netif)
         /* No TX-ISR, go to sleep. */
         netif->mac.tx.no_ack_counter++;
 
-        netdev_ieee802154_t *device_state = (netdev_ieee802154_t *)netif->hwdev;
+        netdev_ieee802154_t *device_state = (netdev_ieee802154_t *)netif->dev;
         netif->mac.tx.tx_seq = device_state->seq - 1;
 
         /* Here, we don't queue the packet again, but keep it in tx.packet. */
@@ -1258,7 +1256,7 @@ static void gomach_t2u_send_data(gnrc_netif_t *netif)
 {
     /* If we are retrying to send the data, reload its original MAC sequence. */
     if (netif->mac.tx.no_ack_counter > 0) {
-        netdev_ieee802154_t *device_state = (netdev_ieee802154_t *)netif->hwdev;
+        netdev_ieee802154_t *device_state = (netdev_ieee802154_t *)netif->dev;
         device_state->seq = netif->mac.tx.tx_seq;
     }
 
@@ -1333,7 +1331,7 @@ static void _t2u_data_tx_fail(gnrc_netif_t *netif)
     else {
         /* Record the MAC sequence of the data, retry t2u in next cycle. */
         netif->mac.tx.no_ack_counter = GNRC_GOMACH_REPHASELOCK_THRESHOLD;
-        netdev_ieee802154_t *device_state = (netdev_ieee802154_t *)netif->hwdev;
+        netdev_ieee802154_t *device_state = (netdev_ieee802154_t *)netif->dev;
         netif->mac.tx.tx_seq = device_state->seq - 1;
 
         LOG_DEBUG("[GOMACH] t2u send data failed on channel %d.\n",
@@ -1352,7 +1350,7 @@ static void gomach_t2u_wait_tx_feedback(gnrc_netif_t *netif)
         netif->mac.tx.t2u_retry_counter++;
 
         netif->mac.tx.no_ack_counter = GNRC_GOMACH_REPHASELOCK_THRESHOLD;
-        netdev_ieee802154_t *device_state = (netdev_ieee802154_t *)netif->hwdev;
+        netdev_ieee802154_t *device_state = (netdev_ieee802154_t *)netif->dev;
         netif->mac.tx.tx_seq = device_state->seq - 1;
 
         gnrc_gomach_set_quit_cycle(netif, true);
@@ -2178,7 +2176,7 @@ static void _gomach_init(gnrc_netif_t *netif)
     netif->mac.rx.check_dup_pkt.queue_head = 0;
     netif->mac.tx.last_tx_neighbor_id = 0;
 
-    netdev_ieee802154_t *device_state = (netdev_ieee802154_t *)netif->hwdev;
+    netdev_ieee802154_t *device_state = (netdev_ieee802154_t *)netif->dev;
     device_state->seq = netif->l2addr[netif->l2addr_len - 1];
 
     /* Initialize GoMacH's duplicate-check scheme. */

--- a/sys/net/gnrc/link_layer/lwmac/lwmac.c
+++ b/sys/net/gnrc/link_layer/lwmac/lwmac.c
@@ -86,8 +86,6 @@ gnrc_netif_t *gnrc_netif_lwmac_create(char *stack, int stacksize,
 
 static void *_bootstrap(void *args)
 {
-    gnrc_netif_t *netif = args;
-    netif->hwdev = netif->dev;
     return gnrc_netif_thread(args);
 }
 
@@ -122,7 +120,7 @@ static gnrc_pktsnip_t *_recv(gnrc_netif_t *netif)
 {
     netdev_t *dev = netif->dev;
     netdev_ieee802154_rx_info_t rx_info;
-    netdev_ieee802154_t *state = (netdev_ieee802154_t *)netif->hwdev;
+    netdev_ieee802154_t *state = (netdev_ieee802154_t *)netif->dev;
     gnrc_pktsnip_t *pkt = NULL;
     int bytes_expected = dev->driver->recv(dev, NULL, 0, NULL);
 

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -1258,9 +1258,9 @@ void *gnrc_netif_thread(void *args)
     netif->pid = sched_active_pid;
     /* setup the link-layer's message queue */
     msg_init_queue(msg_queue, _NETIF_NETAPI_MSG_QUEUE_SIZE);
-    dev->context = netif;
     /* register the event callback with the device driver */
     dev->event_callback = _event_cb;
+    dev->context = netif;
     /* initialize low-level driver */
     dev->driver->init(dev);
     _configure_netdev(dev);

--- a/sys/net/gnrc/netif/gnrc_netif_ieee802154.c
+++ b/sys/net/gnrc/netif/gnrc_netif_ieee802154.c
@@ -52,6 +52,8 @@ gnrc_netif_t *gnrc_netif_ieee802154_create(char *stack, int stacksize,
 
 static void *_bootstrap(void *args)
 {
+    gnrc_netif_t *netif = args;
+    netif->hwdev = netif->dev;
     return gnrc_netif_thread(args);
 }
 
@@ -86,7 +88,7 @@ static gnrc_pktsnip_t *_recv(gnrc_netif_t *netif)
 {
     netdev_t *dev = netif->dev;
     netdev_ieee802154_rx_info_t rx_info;
-    netdev_ieee802154_t *state = (netdev_ieee802154_t *)netif->dev;
+    netdev_ieee802154_t *state = (netdev_ieee802154_t *)netif->hwdev;
     gnrc_pktsnip_t *pkt = NULL;
     int bytes_expected = dev->driver->recv(dev, NULL, 0, NULL);
 
@@ -174,7 +176,7 @@ static gnrc_pktsnip_t *_recv(gnrc_netif_t *netif)
 static int _send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
 {
     netdev_t *dev = netif->dev;
-    netdev_ieee802154_t *state = (netdev_ieee802154_t *)netif->dev;
+    netdev_ieee802154_t *state = (netdev_ieee802154_t *)netif->hwdev;
     gnrc_netif_hdr_t *netif_hdr;
     const uint8_t *src, *dst = NULL;
     int res = 0;

--- a/sys/net/gnrc/netif/gnrc_netif_ieee802154.c
+++ b/sys/net/gnrc/netif/gnrc_netif_ieee802154.c
@@ -15,6 +15,7 @@
 
 #include "net/gnrc.h"
 #include "net/gnrc/netif/ieee802154.h"
+#include "net/gnrc/netif/internal.h"
 #include "net/netdev/ieee802154.h"
 
 #ifdef MODULE_GNRC_IPV6
@@ -29,6 +30,7 @@
 #endif
 
 #ifdef MODULE_NETDEV_IEEE802154
+static void *_bootstrap(void *args);
 static int _send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt);
 static gnrc_pktsnip_t *_recv(gnrc_netif_t *netif);
 
@@ -44,7 +46,13 @@ gnrc_netif_t *gnrc_netif_ieee802154_create(char *stack, int stacksize,
                                            netdev_t *dev)
 {
     return gnrc_netif_create(stack, stacksize, priority, name, dev,
+                             _bootstrap,
                              &ieee802154_ops);
+}
+
+static void *_bootstrap(void *args)
+{
+    return gnrc_netif_thread(args);
 }
 
 static gnrc_pktsnip_t *_make_netif_hdr(uint8_t *mhr)

--- a/sys/net/gnrc/netif/gnrc_netif_ieee802154.c
+++ b/sys/net/gnrc/netif/gnrc_netif_ieee802154.c
@@ -52,8 +52,6 @@ gnrc_netif_t *gnrc_netif_ieee802154_create(char *stack, int stacksize,
 
 static void *_bootstrap(void *args)
 {
-    gnrc_netif_t *netif = args;
-    netif->hwdev = netif->dev;
     return gnrc_netif_thread(args);
 }
 
@@ -88,7 +86,7 @@ static gnrc_pktsnip_t *_recv(gnrc_netif_t *netif)
 {
     netdev_t *dev = netif->dev;
     netdev_ieee802154_rx_info_t rx_info;
-    netdev_ieee802154_t *state = (netdev_ieee802154_t *)netif->hwdev;
+    netdev_ieee802154_t *state = (netdev_ieee802154_t *)netif->dev;
     gnrc_pktsnip_t *pkt = NULL;
     int bytes_expected = dev->driver->recv(dev, NULL, 0, NULL);
 
@@ -176,7 +174,7 @@ static gnrc_pktsnip_t *_recv(gnrc_netif_t *netif)
 static int _send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
 {
     netdev_t *dev = netif->dev;
-    netdev_ieee802154_t *state = (netdev_ieee802154_t *)netif->hwdev;
+    netdev_ieee802154_t *state = (netdev_ieee802154_t *)netif->dev;
     gnrc_netif_hdr_t *netif_hdr;
     const uint8_t *src, *dst = NULL;
     int res = 0;

--- a/sys/net/gnrc/netif/gnrc_netif_raw.c
+++ b/sys/net/gnrc/netif/gnrc_netif_raw.c
@@ -24,6 +24,7 @@
 #define IP_VERSION6     (0x60U)
 
 
+static void *_bootstrap(void *args);
 static int _send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt);
 static gnrc_pktsnip_t *_recv(gnrc_netif_t *netif);
 
@@ -39,13 +40,18 @@ gnrc_netif_t *gnrc_netif_raw_create(char *stack, int stacksize,
                                     netdev_t *dev)
 {
     return gnrc_netif_create(stack, stacksize, priority, name, dev,
-                             gnrc_netif_thread,
+                             _bootstrap,
                              &raw_ops);
 }
 
 static inline uint8_t _get_version(uint8_t *data)
 {
     return (data[0] & IP_VERSION_MASK);
+}
+
+static void *_bootstrap(void *args)
+{
+    return gnrc_netif_thread(args);
 }
 
 static gnrc_pktsnip_t *_recv(gnrc_netif_t *netif)

--- a/sys/net/gnrc/netif/gnrc_netif_raw.c
+++ b/sys/net/gnrc/netif/gnrc_netif_raw.c
@@ -39,6 +39,7 @@ gnrc_netif_t *gnrc_netif_raw_create(char *stack, int stacksize,
                                     netdev_t *dev)
 {
     return gnrc_netif_create(stack, stacksize, priority, name, dev,
+                             gnrc_netif_thread,
                              &raw_ops);
 }
 

--- a/sys/net/gnrc/netif/gnrc_netif_raw.c
+++ b/sys/net/gnrc/netif/gnrc_netif_raw.c
@@ -15,6 +15,7 @@
 
 #include "net/gnrc/pktbuf.h"
 #include "net/gnrc/netif/raw.h"
+#include "net/gnrc/netif/internal.h"
 
 #define ENABLE_DEBUG    (0)
 #include "debug.h"


### PR DESCRIPTION
### Contribution description
This adds a bootstrap function to the gnrc_netif initialization. This bootstrap function can be used to initialize a layered netdev structure. This way the required structures can be kept on the stack of the netif thread while keeping the total structure somewhat dynamic.

For now the bootstrap functions are empty. They are used as soon as there are separate netdev layers that require them.

### Issues/PRs references

next step of #8198