### PR TITLE
netdev: Rework netdev_eth to layered structure

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -60,6 +60,10 @@ ifneq (,$(filter netdev_ieee802154,$(USEMODULE)))
   USEMODULE += ieee802154
 endif
 
+ifneq (,$(filter netdev_eth,$(USEMODULE)))
+  USEMODULE += netdev_layer
+endif
+
 ifneq (,$(filter gnrc_uhcpc,$(USEMODULE)))
   USEMODULE += uhcpc
   USEMODULE += gnrc_sock_udp

--- a/cpu/native/netdev_tap/netdev_tap.c
+++ b/cpu/native/netdev_tap/netdev_tap.c
@@ -108,7 +108,7 @@ static inline void _isr(netdev_t *netdev)
 
 static int _get(netdev_t *dev, netopt_t opt, void *value, size_t max_len)
 {
-    int res = 0;
+    int res = -ENOTSUP;
 
     switch (opt) {
         case NETOPT_ADDRESS:
@@ -125,7 +125,6 @@ static int _get(netdev_t *dev, netopt_t opt, void *value, size_t max_len)
             res = sizeof(bool);
             break;
         default:
-            res = netdev_eth_get(dev, opt, value, max_len);
             break;
     }
 
@@ -135,7 +134,7 @@ static int _get(netdev_t *dev, netopt_t opt, void *value, size_t max_len)
 static int _set(netdev_t *dev, netopt_t opt, const void *value, size_t value_len)
 {
     (void)value_len;
-    int res = 0;
+    int res = -ENOTSUP;
 
     switch (opt) {
         case NETOPT_ADDRESS:
@@ -148,7 +147,6 @@ static int _set(netdev_t *dev, netopt_t opt, const void *value, size_t value_len
             res = sizeof(netopt_enable_t);
             break;
         default:
-            res = netdev_eth_set(dev, opt, value, value_len);
             break;
     }
 

--- a/drivers/enc28j60/enc28j60.c
+++ b/drivers/enc28j60/enc28j60.c
@@ -447,13 +447,16 @@ static void nd_isr(netdev_t *netdev)
 
 static int nd_get(netdev_t *netdev, netopt_t opt, void *value, size_t max_len)
 {
+    (void)max_len;
     enc28j60_t *dev = (enc28j60_t *)netdev;
+    int res = -ENOTSUP;
 
     switch (opt) {
         case NETOPT_ADDRESS:
             assert(max_len >= ETHERNET_ADDR_LEN);
             mac_get(dev, (uint8_t *)value);
-            return ETHERNET_ADDR_LEN;
+            res = ETHERNET_ADDR_LEN;
+            break;
         case NETOPT_LINK_CONNECTED:
             if (cmd_r_phy(dev, REG_PHY_PHSTAT2) & PHSTAT2_LSTAT) {
                 *((netopt_enable_t *)value) = NETOPT_ENABLE;
@@ -461,24 +464,29 @@ static int nd_get(netdev_t *netdev, netopt_t opt, void *value, size_t max_len)
             else {
                 *((netopt_enable_t *)value) = NETOPT_DISABLE;
             }
-            return sizeof(netopt_enable_t);
+            res = sizeof(netopt_enable_t);
         default:
-            return netdev_eth_get(netdev, opt, value, max_len);
+            break;
     }
+    return res;
 }
 
 static int nd_set(netdev_t *netdev, netopt_t opt, const void *value, size_t value_len)
 {
+    (void)value_len;
     enc28j60_t *dev = (enc28j60_t *)netdev;
+    int res = -ENOTSUP;
 
     switch (opt) {
         case NETOPT_ADDRESS:
             assert(value_len == ETHERNET_ADDR_LEN);
             mac_set(dev, (uint8_t *)value);
-            return ETHERNET_ADDR_LEN;
+            res = ETHERNET_ADDR_LEN;
+            break;
         default:
-            return netdev_eth_set(netdev, opt, value, value_len);
+            break;
     }
+    return res;
 }
 
 static const netdev_driver_t netdev_driver_enc28j60 = {

--- a/drivers/enc28j60/enc28j60.c
+++ b/drivers/enc28j60/enc28j60.c
@@ -447,7 +447,6 @@ static void nd_isr(netdev_t *netdev)
 
 static int nd_get(netdev_t *netdev, netopt_t opt, void *value, size_t max_len)
 {
-    (void)max_len;
     enc28j60_t *dev = (enc28j60_t *)netdev;
     int res = -ENOTSUP;
 
@@ -473,7 +472,6 @@ static int nd_get(netdev_t *netdev, netopt_t opt, void *value, size_t max_len)
 
 static int nd_set(netdev_t *netdev, netopt_t opt, const void *value, size_t value_len)
 {
-    (void)value_len;
     enc28j60_t *dev = (enc28j60_t *)netdev;
     int res = -ENOTSUP;
 

--- a/drivers/encx24j600/encx24j600.c
+++ b/drivers/encx24j600/encx24j600.c
@@ -69,6 +69,7 @@ static int _recv(netdev_t *netdev, void *buf, size_t len, void *info);
 static int _init(netdev_t *dev);
 static void _isr(netdev_t *dev);
 static int _get(netdev_t *dev, netopt_t opt, void *value, size_t max_len);
+static int _set(netdev_t *dev, netopt_t opt, const void *value, size_t value_len);
 
 static const netdev_driver_t netdev_driver_encx24j600 = {
     .send = _send,
@@ -76,7 +77,7 @@ static const netdev_driver_t netdev_driver_encx24j600 = {
     .init = _init,
     .isr = _isr,
     .get = _get,
-    .set = netdev_eth_set,
+    .set = _set,
 };
 
 static inline void lock(encx24j600_t *dev) {
@@ -389,7 +390,7 @@ static int _recv(netdev_t *netdev, void *buf, size_t len, void *info)
 
 static int _get(netdev_t *dev, netopt_t opt, void *value, size_t max_len)
 {
-    int res = 0;
+    int res = -ENOTSUP;
 
     switch (opt) {
         case NETOPT_ADDRESS:
@@ -408,11 +409,20 @@ static int _get(netdev_t *dev, netopt_t opt, void *value, size_t max_len)
             else {
                 *((netopt_enable_t *)value) = NETOPT_DISABLE;
             }
-            return sizeof(netopt_enable_t);
+            res = sizeof(netopt_enable_t);
+            break;
         default:
-            res = netdev_eth_get(dev, opt, value, max_len);
             break;
     }
 
     return res;
+}
+
+static int _set(netdev_t *dev, netopt_t opt, const void *value, size_t value_len)
+{
+    (void)dev;
+    (void)opt;
+    (void)value;
+    (void)value_len;
+    return -ENOTSUP;
 }

--- a/drivers/ethos/ethos.c
+++ b/drivers/ethos/ethos.c
@@ -320,7 +320,7 @@ static int _recv(netdev_t *netdev, void *buf, size_t len, void* info)
 
 static int _get(netdev_t *dev, netopt_t opt, void *value, size_t max_len)
 {
-    int res = 0;
+    int res = -ENOTSUP;
 
     switch (opt) {
         case NETOPT_ADDRESS:
@@ -333,11 +333,19 @@ static int _get(netdev_t *dev, netopt_t opt, void *value, size_t max_len)
             }
             break;
         default:
-            res = netdev_eth_get(dev, opt, value, max_len);
             break;
     }
 
     return res;
+}
+
+static int _set(netdev_t *dev, netopt_t opt, const void *value, size_t value_len)
+{
+    (void)dev;
+    (void)opt;
+    (void)value;
+    (void)value_len;
+    return -ENOTSUP;
 }
 
 /* netdev interface */
@@ -347,5 +355,5 @@ static const netdev_driver_t netdev_driver_ethos = {
     .init = _init,
     .isr = _isr,
     .get = _get,
-    .set = netdev_eth_set
+    .set = _set
 };

--- a/drivers/include/net/netdev/eth.h
+++ b/drivers/include/net/netdev/eth.h
@@ -29,34 +29,23 @@ extern "C" {
 #endif
 
 /**
- * @brief   Fallback function for netdev ethernet devices' _get function
- *
- * Supposed to be used by netdev drivers as default case.
- *
- * @warning Driver *MUST* implement NETOPT_ADDRESS case!
- *
- * @param[in]   dev     network device descriptor
- * @param[in]   opt     option type
- * @param[out]  value   pointer to store the option's value in
- * @param[in]   max_len maximal amount of byte that fit into @p value
- *
- * @return              number of bytes written to @p value
- * @return              <0 on error
+ * @brief   Layer descriptor for ethernet netdev layer
  */
-int netdev_eth_get(netdev_t *dev, netopt_t opt, void *value, size_t max_len);
+typedef struct {
+    netdev_t netdev;    /**< Netdev layer parent struct. */
+    uint8_t type;       /**< Device type, used to determine multicast detection. */
+    netdev_t *hwdev;    /**< Pointer to the hardware driver struct. */
+} netdev_eth_t;
 
 /**
- * @brief   Fallback function for netdev ethernet devices' _set function
+ * @brief   Add a ethernet netdev layer to the top of the netdev stack
  *
- * @param[in] dev       network device descriptor
- * @param[in] opt       option type
- * @param[in] value     value to set
- * @param[in] value_len the length of @p value
+ * @param[in] head    Top netdev device of the stack.
+ * @param[in] layer   New ethernet layer to push to the top of the stack.
  *
- * @return              number of bytes used from @p value
- * @return              <0 on error
+ * @return  The new top of the netdev stack.
  */
-int netdev_eth_set(netdev_t *dev, netopt_t opt, const void *value, size_t value_len);
+netdev_t *netdev_eth_add(netdev_t *head, netdev_eth_t *layer);
 
 #ifdef __cplusplus
 }

--- a/drivers/netdev_eth/netdev_eth.c
+++ b/drivers/netdev_eth/netdev_eth.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2015 Kaspar Schleiser <kaspar@schleiser.de>
+ *               2017 Koen Zandberg <koen@bergzand.net>
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -14,36 +15,61 @@
  * @brief       Common code for netdev ethernet drivers
  *
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ * @author      Koen Zandberg <koen@bergzand.net>
  *
  * @}
  */
 
 #include <assert.h>
 #include <errno.h>
-
 #include "net/netdev.h"
+#include "net/netdev/eth.h"
+#include "net/netdev/layer.h"
 #include "net/eui64.h"
 #include "net/ethernet.h"
 
-#define ENABLE_DEBUG (0)
+#define ENABLE_DEBUG    (0)
 #include "debug.h"
 
-static int _get_iid(netdev_t *netdev, eui64_t *value, size_t max_len)
+static int _get(netdev_t *dev, netopt_t opt, void *value, size_t max_len);
+static int _set(netdev_t *dev, netopt_t opt, const void *value, size_t value_len);
+
+const netdev_driver_t eth_layer = {
+    .send = netdev_send_pass,
+    .recv = netdev_recv_pass,
+    .init = netdev_init_pass,
+    .isr = netdev_isr_pass,
+    .get = _get,
+    .set = _set,
+};
+
+netdev_t *netdev_eth_add(netdev_t *head, netdev_eth_t *dev_eth) {
+    dev_eth->netdev.driver = &eth_layer;
+    head->event_callback = netdev_event_cb_pass;
+    dev_eth->hwdev = head;
+    return netdev_add_layer(head, (netdev_t *)dev_eth);
+}
+
+static int _get_iid(netdev_eth_t *dev_eth, eui64_t *value, size_t max_len)
 {
+    DEBUG("netdev_eth: IID called\n");
     if (max_len < sizeof(eui64_t)) {
         return -EOVERFLOW;
     }
 
     uint8_t addr[ETHERNET_ADDR_LEN];
-    netdev->driver->get(netdev, NETOPT_ADDRESS, addr, ETHERNET_ADDR_LEN);
+    dev_eth->netdev.lower->driver->get(dev_eth->netdev.lower,
+                                       NETOPT_ADDRESS,
+                                       addr, ETHERNET_ADDR_LEN);
     ethernet_get_iid(value, addr);
-
     return sizeof(eui64_t);
 }
 
-int netdev_eth_get(netdev_t *dev, netopt_t opt, void *value, size_t max_len)
+int _get(netdev_t *dev, netopt_t opt, void *value, size_t max_len)
 {
-    int res = 0;
+    DEBUG("netdev_layer_eth: Get called: %d\n", opt);
+    netdev_eth_t *dev_eth = (netdev_eth_t *)dev;
+    int res = -ENOTSUP;
 
     switch (opt) {
         case NETOPT_DEVICE_TYPE:
@@ -77,13 +103,14 @@ int netdev_eth_get(netdev_t *dev, netopt_t opt, void *value, size_t max_len)
             }
         case NETOPT_IPV6_IID:
             {
-                return _get_iid(dev, value, max_len);
+                res = _get_iid(dev_eth, value, max_len);
+                break;
             }
 #ifdef MODULE_NETSTATS_L2
         case NETOPT_STATS:
             {
                 assert(max_len >= sizeof(uintptr_t));
-                *((netstats_t**)value) = &dev->stats;
+                *((netstats_t**)value) = &dev_eth->hwdev->stats;
                 res = sizeof(uintptr_t);
                 break;
             }
@@ -92,44 +119,47 @@ int netdev_eth_get(netdev_t *dev, netopt_t opt, void *value, size_t max_len)
         case NETOPT_L2FILTER:
             {
                 assert(max_len >= sizeof(l2filter_t **));
-                *((l2filter_t **)value) = dev->filter;
+                *((l2filter_t **)value) = dev_eth->hwdev->filter;
                 res = sizeof(l2filter_t **);
                 break;
             }
 #endif
         default:
-            {
-                res = -ENOTSUP;
-                break;
-            }
+            break;
     }
-
+    if (res == -ENOTSUP) {
+        DEBUG("netdev_layer_eth: Passing get to device\n");
+        res = dev_eth->netdev.lower->driver->get(dev_eth->netdev.lower,
+                                                 opt, value, max_len);
+    }
+    DEBUG("netdev_layer_eth: Get returned %d\n", res);
     return res;
 }
 
-int netdev_eth_set(netdev_t *dev, netopt_t opt, const void *value, size_t value_len)
+int _set(netdev_t *dev, netopt_t opt, const void *value, size_t value_len)
 {
-#ifndef MODULE_L2FILTER
-    (void)dev;
-#endif
-    (void)value;
-    (void)value_len;
-
-    int res = 0;
+    DEBUG("netdev_eth: Set called\n");
+    netdev_eth_t *dev_eth = (netdev_eth_t *)dev;
+    int res = -ENOTSUP;
 
     switch (opt) {
 
 #ifdef MODULE_L2FILTER
         case NETOPT_L2FILTER:
-            res = l2filter_add(dev->filter, value, value_len);
+            res = l2filter_add(dev_eth->hwdev->filter,
+                               value, value_len);
             break;
         case NETOPT_L2FILTER_RM:
-            res = l2filter_rm(dev->filter, value, value_len);
+            res = l2filter_rm(dev_eth->hwdev->filter,
+                              value, value_len);
             break;
 #endif
         default:
-            res = -ENOTSUP;
             break;
+    }
+    if (res == -ENOTSUP) {
+        res = dev_eth->netdev.lower->driver->set(dev_eth->netdev.lower,
+                                                 opt, value, value_len);
     }
 
     return res;

--- a/drivers/w5100/w5100.c
+++ b/drivers/w5100/w5100.c
@@ -298,8 +298,9 @@ static void isr(netdev_t *netdev)
 
 static int get(netdev_t *netdev, netopt_t opt, void *value, size_t max_len)
 {
+    (void)max_len;
     w5100_t *dev = (w5100_t *)netdev;
-    int res = 0;
+    int res = -ENOTSUP;
 
     switch (opt) {
         case NETOPT_ADDRESS:
@@ -310,11 +311,19 @@ static int get(netdev_t *netdev, netopt_t opt, void *value, size_t max_len)
             res = ETHERNET_ADDR_LEN;
             break;
         default:
-            res = netdev_eth_get(netdev, opt, value, max_len);
             break;
     }
 
     return res;
+}
+
+static int set(netdev *dev, netopt_t opt, const void *value, size_t value_len)
+{
+    (void)dev;
+    (void)opt;
+    (void)value;
+    (void)value_len;
+    return -ENOTSUP;
 }
 
 static const netdev_driver_t netdev_driver_w5100 = {
@@ -323,5 +332,5 @@ static const netdev_driver_t netdev_driver_w5100 = {
     .init = init,
     .isr = isr,
     .get = get,
-    .set = netdev_eth_set,
+    .set = set,
 };

--- a/pkg/lwip/contrib/lwip.c
+++ b/pkg/lwip/contrib/lwip.c
@@ -19,6 +19,7 @@
 #include "netif/lowpan6.h"
 
 #ifdef MODULE_NETDEV_TAP
+#include "net/netdev/eth.h"
 #include "netdev_tap.h"
 #include "netdev_tap_params.h"
 #endif
@@ -55,6 +56,7 @@ static struct netif netif[LWIP_NETIF_NUMOF];
 #endif
 
 #ifdef MODULE_NETDEV_TAP
+static netdev_eth_t eth_layer[LWIP_NETIF_NUMOF];
 static netdev_tap_t netdev_taps[LWIP_NETIF_NUMOF];
 #endif
 
@@ -73,7 +75,8 @@ void lwip_bootstrap(void)
 #ifdef MODULE_NETDEV_TAP
     for (unsigned i = 0; i < LWIP_NETIF_NUMOF; i++) {
         netdev_tap_setup(&netdev_taps[i], &netdev_tap_params[i]);
-        if (netif_add(&netif[i], &netdev_taps[i], lwip_netdev_init,
+        netdev_eth_add((netdev_t*)&netdev_taps[i], &eth_layer[i]);
+        if (netif_add(&netif[i], &eth_layer[i], lwip_netdev_init,
                       tcpip_input) == NULL) {
             DEBUG("Could not add netdev_tap device\n");
             return;

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -39,11 +39,11 @@
 static gnrc_netif_t _netifs[GNRC_NETIF_NUMOF];
 
 static void _update_l2addr_from_dev(gnrc_netif_t *netif);
-static void *_gnrc_netif_thread(void *args);
 static void _event_cb(netdev_t *dev, netdev_event_t event);
 
 gnrc_netif_t *gnrc_netif_create(char *stack, int stacksize, char priority,
                                 const char *name, netdev_t *netdev,
+                                gnrc_netif_bootstrap_t bootstrap,
                                 const gnrc_netif_ops_t *ops)
 {
     gnrc_netif_t *netif = NULL;
@@ -63,7 +63,7 @@ gnrc_netif_t *gnrc_netif_create(char *stack, int stacksize, char priority,
     assert(netif->dev == NULL);
     netif->dev = netdev;
     res = thread_create(stack, stacksize, priority, THREAD_CREATE_STACKTEST,
-                        _gnrc_netif_thread, (void *)netif, name);
+                        bootstrap, (void *)netif, name);
     (void)res;
     assert(res > 0);
     return netif;
@@ -1220,7 +1220,7 @@ static void _init_from_device(gnrc_netif_t *netif)
     _update_l2addr_from_dev(netif);
 }
 
-static void *_gnrc_netif_thread(void *args)
+void *gnrc_netif_thread(void *args)
 {
     gnrc_netapi_opt_t *opt;
     gnrc_netif_t *netif;
@@ -1236,9 +1236,9 @@ static void *_gnrc_netif_thread(void *args)
     netif->pid = sched_active_pid;
     /* setup the link-layer's message queue */
     msg_init_queue(msg_queue, _NETIF_NETAPI_MSG_QUEUE_SIZE);
+    dev->context = netif;
     /* register the event callback with the device driver */
     dev->event_callback = _event_cb;
-    dev->context = netif;
     /* initialize low-level driver */
     dev->driver->init(dev);
     _init_from_device(netif);

--- a/sys/net/gnrc/netif/gnrc_netif_ethernet.c
+++ b/sys/net/gnrc/netif/gnrc_netif_ethernet.c
@@ -78,6 +78,13 @@ static inline void _addr_set_multicast(uint8_t *dst, gnrc_pktsnip_t *payload)
 
 static void *_bootstrap(void *args)
 {
+    gnrc_netif_t *netif = args;
+    netdev_eth_t eth_layer;
+
+    gnrc_netif_acquire(netif);
+    /* Add netdev ethernet layer to the stack */
+    netif->dev = netdev_eth_add(netif->dev, &eth_layer);
+    gnrc_netif_release(netif);
     return gnrc_netif_thread(args);
 }
 

--- a/sys/net/gnrc/netif/gnrc_netif_ieee802154.c
+++ b/sys/net/gnrc/netif/gnrc_netif_ieee802154.c
@@ -52,6 +52,8 @@ gnrc_netif_t *gnrc_netif_ieee802154_create(char *stack, int stacksize,
 
 static void *_bootstrap(void *args)
 {
+    gnrc_netif_t *netif = args;
+    netif->hwdev = netif->dev;
     return gnrc_netif_thread(args);
 }
 
@@ -86,7 +88,7 @@ static gnrc_pktsnip_t *_recv(gnrc_netif_t *netif)
 {
     netdev_t *dev = netif->dev;
     netdev_ieee802154_rx_info_t rx_info;
-    netdev_ieee802154_t *state = (netdev_ieee802154_t *)netif->dev;
+    netdev_ieee802154_t *state = (netdev_ieee802154_t *)netif->hwdev;
     gnrc_pktsnip_t *pkt = NULL;
     int bytes_expected = dev->driver->recv(dev, NULL, 0, NULL);
 
@@ -174,7 +176,7 @@ static gnrc_pktsnip_t *_recv(gnrc_netif_t *netif)
 static int _send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
 {
     netdev_t *dev = netif->dev;
-    netdev_ieee802154_t *state = (netdev_ieee802154_t *)netif->dev;
+    netdev_ieee802154_t *state = (netdev_ieee802154_t *)netif->hwdev;
     gnrc_netif_hdr_t *netif_hdr;
     const uint8_t *src, *dst = NULL;
     int res = 0;

--- a/sys/net/gnrc/netif/gnrc_netif_ieee802154.c
+++ b/sys/net/gnrc/netif/gnrc_netif_ieee802154.c
@@ -15,6 +15,7 @@
 
 #include "net/gnrc.h"
 #include "net/gnrc/netif/ieee802154.h"
+#include "net/gnrc/netif/internal.h"
 #include "net/netdev/ieee802154.h"
 
 #ifdef MODULE_GNRC_IPV6
@@ -29,6 +30,7 @@
 #endif
 
 #ifdef MODULE_NETDEV_IEEE802154
+static void *_bootstrap(void *args);
 static int _send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt);
 static gnrc_pktsnip_t *_recv(gnrc_netif_t *netif);
 
@@ -44,7 +46,13 @@ gnrc_netif_t *gnrc_netif_ieee802154_create(char *stack, int stacksize,
                                            netdev_t *dev)
 {
     return gnrc_netif_create(stack, stacksize, priority, name, dev,
+                             _bootstrap,
                              &ieee802154_ops);
+}
+
+static void *_bootstrap(void *args)
+{
+    return gnrc_netif_thread(args);
 }
 
 static gnrc_pktsnip_t *_make_netif_hdr(uint8_t *mhr)

--- a/sys/net/gnrc/netif/gnrc_netif_raw.c
+++ b/sys/net/gnrc/netif/gnrc_netif_raw.c
@@ -39,6 +39,7 @@ gnrc_netif_t *gnrc_netif_raw_create(char *stack, int stacksize,
                                     netdev_t *dev)
 {
     return gnrc_netif_create(stack, stacksize, priority, name, dev,
+                             gnrc_netif_thread,
                              &raw_ops);
 }
 


### PR DESCRIPTION
### Contribution description

This PR changes the netdev_eth module to a layered structure. The change here is that the netdev_driver_t functions of the netdev_eth struct are called first, and the functions of the hardware driver are called next.

The hardware drivers are adapted to not call the netdev_eth get and set functions anymore.

The `hwdev` struct member in the `netdev_eth_t` is only required to handle the L2 network stats and can be removed as soon as the stats are moved to a separate layer.

@miri64 Could it be that I'm also breaking the other (non-gnrc) network stacks here?

### Issues/PRs references

Depends on #9329 