### PR TITLE
examples: add systick scheduling example

### DIFF
--- a/examples/systick/Makefile
+++ b/examples/systick/Makefile
@@ -1,0 +1,11 @@
+BOARD ?= nucleo-f446re
+
+APPLICATION = systick
+
+USEMODULE += xtimer
+USEMODULE += ps
+
+DEVELHELP ?= 1
+
+RIOTBASE ?= $(CURDIR)/../..
+include $(RIOTBASE)/Makefile.include

--- a/examples/systick/README.md
+++ b/examples/systick/README.md
@@ -1,0 +1,96 @@
+examples/systick
+================
+
+This application runs 4 threads (tasks) using systick hardware timer for preemption
+* thread 'test0' every second
+* thread 'test1' every 2 seconds
+* thread 'test2' every 3 seconds
+* thread 'test3' never yield
+
+With no-preempt scheduling (classic RIOT way of life), thread 'test3' would block infinitely.
+With systick timer, isr_systick() launch thread_yield() every X ticks to schedule.
+
+Usage
+=====
+
+Build, flash and start the application:
+```
+export BOARD=your_board
+make
+make flash
+make term
+```
+
+Example output
+==============
+
+```
+main(): This is RIOT! (Version: 2018.04-devel-373-g4647c-gdo-sfl-laptop-systick_example)
+SUCCESS !
+test0 - 1 seconds
+test1 - 2 seconds
+test2 - 3 seconds
+test3 - Forever
+test3 - Forever
+test3 - Forever
+test3 - Forever
+test3 - Forever
+test3 - Forever
+test3 - Forever
+test3 - Forever
+test0 - 1 seconds
+test3 - Forever
+test3 - Forever
+test3 - Forever
+test3 - Forever
+test3 - Forever
+test3 - Forever
+test3 - Forever
+test3 - Forever
+test0 - 1 seconds
+test1 - 2 seconds
+test3 - Forever
+test3 - Forever
+test3 - Forever
+test3 - Forever
+test3 - Forever
+test3 - Forever
+test3 - Forever
+test3 - Forever
+test0 - 1 seconds
+test2 - 3 seconds
+test3 - Forever
+test3 - Forever
+test3 - Forever
+test3 - Forever
+test3 - Forever
+test3 - Forever
+test3 - Forever
+test3 - Forever
+test0 - 1 seconds
+test1 - 2 seconds
+test3 - Forever
+test3 - Forever
+test3 - Forever
+test3 - Forever
+test3 - Forever
+test3 - Forever
+test3 - Forever
+test3 - Forever
+test0 - 1 seconds
+Received: p
+*** RIOT kernel panic:
+Debug panic to display threads
+
+        pid | name                 | state    Q | pri | stack  ( used) | base addr  | current
+          - | isr_stack            | -        - |   - |    512 (  140) | 0x20000000 | 0x200001c8
+          1 | idle                 | pending  Q |  15 |    256 (  120) | 0x200003bc | 0x20000444
+          2 | main                 | running  Q |   7 |   1536 (  528) | 0x200004bc | 0x200008ac
+          3 | test0                | bl mutex _ |   8 |   1024 ( 1020) | 0x2000135c | 0x20001694
+          4 | test1                | bl mutex _ |   9 |   1024 ( 1020) | 0x2000175c | 0x20001a94
+          5 | test2                | bl mutex _ |  10 |   1024 ( 1020) | 0x20000b5c | 0x20000e94
+          6 | test3                | pending  Q |  11 |   1024 ( 1020) | 0x20000f5c | 0x200012dc
+            | SUM                  |            |     |   6400 ( 4868)
+
+*** halted.
+```

--- a/examples/systick/main.c
+++ b/examples/systick/main.c
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2017 Gilles DOFFE <gdoffe@gmail.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup examples
+ * @{
+ *
+ * @file
+ * @brief       Example of systick handler
+ *
+ * This example uses hardware systick to perform preemption
+ *
+ * @author      Gilles DOFFE <gdoffe@gmail.com>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+
+#include "xtimer.h"
+#include "thread.h"
+
+/* 1 second */
+#define THREAD_PERIOD_INTERVAL (1000U * US_PER_MS)
+
+char test0_thread_stack[THREAD_STACKSIZE_DEFAULT];
+char test1_thread_stack[THREAD_STACKSIZE_DEFAULT];
+char test2_thread_stack[THREAD_STACKSIZE_DEFAULT];
+char test3_thread_stack[THREAD_STACKSIZE_DEFAULT];
+
+/*** Thread functions ***/
+
+/* test_task launched every X seconds */
+void* test_task(void* arg) {
+    uint32_t seconds = (uint32_t)arg;
+    thread_t *active_thread = (thread_t *)sched_active_thread;
+
+    for (;;) {
+        xtimer_ticks32_t loop_start_time = xtimer_now();
+        printf("%s - %"PRIu32" seconds\n", active_thread->name, seconds);
+        xtimer_periodic_wakeup(&loop_start_time, seconds * THREAD_PERIOD_INTERVAL);
+    }
+
+    return NULL;
+}
+
+/* test3_task launched and blocking forever (that's what he believes ;) */
+void* test3_task(void* arg) {
+    (void)arg;
+    for (;;) {
+        puts("test3 - Forever");
+        for (uint64_t i = 0; i < (3*XTIMER_HZ_BASE); i++);
+    }
+
+    return NULL;
+}
+
+/*** Handlers ***/
+
+/* Systick IRQ handler */
+void isr_systick(void)  {
+    thread_yield();
+}
+
+/*** Main ***/
+
+int main(void)  {
+
+/* Tested only on Cortex M */
+#if defined(MODULE_CORTEXM_COMMON)
+    /* Configure systick clock to 1 ms */
+    uint32_t error = SysTick_Config((CLOCK_CORECLOCK / 1000));
+
+    if (error != 0)
+        puts("ERROR !");
+    else
+        puts("SUCCESS !");
+#else
+#error "Error: arch not supported/tested. If you want to support another architecture, please update this example."
+#endif /* __CORTEX_M */
+
+    /* Do not set a priority value lower than THREAD_PRIORITY_MAIN or other threads will never be created... */
+    /* Note : Lower is the priority value, higher is the priority */
+    /* Note : Setting same priority for two or more threads do garanty scheduling order */
+    thread_create(test0_thread_stack, sizeof(test0_thread_stack),
+                  THREAD_PRIORITY_MAIN + 1, 0,
+                  test_task, (void *) 1, "test0");
+    thread_create(test1_thread_stack, sizeof(test1_thread_stack),
+                  THREAD_PRIORITY_MAIN + 2, 0,
+                  test_task, (void *) 2, "test1");
+    thread_create(test2_thread_stack, sizeof(test2_thread_stack),
+                  THREAD_PRIORITY_MAIN + 3, 0,
+                  test_task, (void *) 3, "test2");
+    thread_create(test3_thread_stack, sizeof(test3_thread_stack),
+                  THREAD_PRIORITY_MAIN + 4, 0,
+                  test3_task, NULL, "test3");
+
+    for (;;) {
+        char c = getchar();
+        printf("Received: %c\n", c);
+        if (c == 'p')
+            core_panic(PANIC_UNDEFINED, "Debug panic to display threads");
+    }
+
+    return 0;
+}


### PR DESCRIPTION
Configure systick hardware timer to schedule tasks.
It calls thread_yield() inside isr_systick() to preempt tasks.

### Contribution description

A running thread must yield to give hand to an other thread (tickless scheduling).
But sometimes, it is needed to switch threads strictly, according to a period.
On STM32, there is a dedicated timer to do that : the systick timer.

On other architecture, on systick timer lack,  a classic timer coul be used.

This example aims to show how to turn RIOT into a tick based preemptive scheduler on STM32.