### PR TITLE
nrf52/i2c: adapt to new I2C API

### DIFF
--- a/boards/common/nrf52xxxdk/include/periph_conf.h
+++ b/boards/common/nrf52xxxdk/include/periph_conf.h
@@ -100,11 +100,11 @@ static const spi_conf_t spi_config[] = {
 static const i2c_conf_t i2c_config[] = {
     {
         .dev = NRF_TWIM1,
-        .scl = 28,
-        .sda = 29
+        .scl = 27,
+        .sda = 26,
+        .speed = I2C_SPEED_NORMAL
     }
 };
-
 #define I2C_NUMOF           (sizeof(i2c_config) / sizeof(i2c_config[0]))
 /** @} */
 

--- a/cpu/nrf52/include/periph_cpu.h
+++ b/cpu/nrf52/include/periph_cpu.h
@@ -96,7 +96,17 @@ typedef struct {
     NRF_TWIM_Type *dev;         /**< TWIM hardware device */
     uint8_t scl;                /**< SCL pin */
     uint8_t sda;                /**< SDA pin */
+    i2c_speed_t speed;          /**< Bus speed */
 } i2c_conf_t;
+/** @} */
+
+/**
+ * @name   Use shared I2C functions
+ * @{
+ */
+#define PERIPH_I2C_NEED_READ_REG
+#define PERIPH_I2C_NEED_WRITE_REG
+/** @} */
 
 #ifdef __cplusplus
 }

--- a/cpu/nrf52/periph/i2c.c
+++ b/cpu/nrf52/periph/i2c.c
@@ -1,6 +1,7 @@
 /*
  * Copyright (C) 2017 HAW Hamburg
  *               2018 Freie Universität Berlin
+ *               2018 Mesotic SAS
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -16,11 +17,13 @@
  *
  * @author      Dimitri Nahm <dimitri.nahm@haw-hamburg.de>
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author      Dylan Laduranty <dylan.laduranty@mesotic.com>
  *
  * @}
  */
 
 #include <string.h>
+#include <errno.h>
 
 #include "cpu.h"
 #include "mutex.h"
@@ -37,175 +40,98 @@
 #define INVALID_SPEED_MASK  (0xff)
 
 /**
- * @brief   Initialized bus locks (we have a maximum of two devices...)
+ * @brief   Initialized dev locks (we have a maximum of two devices...)
  */
-static mutex_t locks[] = {
-    MUTEX_INIT,
-    MUTEX_INIT
-};
+static mutex_t locks[I2C_NUMOF];
 
-static inline NRF_TWIM_Type *dev(i2c_t bus)
+static inline NRF_TWIM_Type *bus(i2c_t dev)
 {
-    return i2c_config[bus].dev;
+    (void) dev;
+    return i2c_config[0].dev;
 }
 
-static int finish(i2c_t bus, int len)
+static int finish(i2c_t dev)
 {
     DEBUG("[i2c] waiting for STOPPED or ERROR event\n");
-
-    while ((!(dev(bus)->EVENTS_STOPPED)) && (!(dev(bus)->EVENTS_ERROR))) {
+    while ((!(bus(dev)->EVENTS_STOPPED)) && (!(bus(dev)->EVENTS_ERROR))) {
         nrf52_sleep();
     }
 
-    if ((dev(bus)->EVENTS_STOPPED)) {
-        dev(bus)->EVENTS_STOPPED = 0;
+    if ((bus(dev)->EVENTS_STOPPED)) {
+        bus(dev)->EVENTS_STOPPED = 0;
         DEBUG("[i2c] finish: stop event occurred\n");
     }
 
-    if (dev(bus)->EVENTS_ERROR) {
-        dev(bus)->EVENTS_ERROR = 0;
-        if (dev(bus)->ERRORSRC & TWIM_ERRORSRC_ANACK_Msk) {
-            dev(bus)->ERRORSRC = TWIM_ERRORSRC_ANACK_Msk;
+    if (bus(dev)->EVENTS_ERROR) {
+        bus(dev)->EVENTS_ERROR = 0;
+        if (bus(dev)->ERRORSRC & TWIM_ERRORSRC_ANACK_Msk) {
+            bus(dev)->ERRORSRC = TWIM_ERRORSRC_ANACK_Msk;
             DEBUG("[i2c] check_error: NACK on address byte\n");
-            return -1;
+            return -ENXIO;
         }
-        if (dev(bus)->ERRORSRC & TWIM_ERRORSRC_DNACK_Msk) {
-            dev(bus)->ERRORSRC = TWIM_ERRORSRC_DNACK_Msk;
+        if (bus(dev)->ERRORSRC & TWIM_ERRORSRC_DNACK_Msk) {
+            bus(dev)->ERRORSRC = TWIM_ERRORSRC_DNACK_Msk;
             DEBUG("[i2c] check_error: NACK on data byte\n");
-            return -1;
+            return -EIO;
         }
     }
 
-    return len;
+    return 0;
 }
 
-int i2c_init_master(i2c_t bus, i2c_speed_t speed)
+void i2c_init(i2c_t dev)
 {
-    if (bus >= I2C_NUMOF) {
-        return -1;
-    }
-    if (speed & INVALID_SPEED_MASK) {
-        return -2;
-    }
+    assert(dev < I2C_NUMOF);
 
+    /* Initialize mutex */
+    mutex_init(&locks[dev]);
     /* disable device during initialization, will be enabled when acquire is
      * called */
-    dev(bus)->ENABLE = TWIM_ENABLE_ENABLE_Disabled;
-
+    bus(dev)->ENABLE = TWIM_ENABLE_ENABLE_Disabled;
     /* configure pins */
-    gpio_init(i2c_config[bus].scl, GPIO_IN_PU);
-    gpio_init(i2c_config[bus].sda, GPIO_IN_PU);
-    dev(bus)->PSEL.SCL = i2c_config[bus].scl;
-    dev(bus)->PSEL.SDA = i2c_config[bus].sda;
-
-    /* configure bus clock speed */
-    dev(bus)->FREQUENCY = speed;
+    gpio_init(i2c_config[dev].scl, GPIO_IN_PU);
+    gpio_init(i2c_config[dev].sda, GPIO_IN_PU);
+    bus(dev)->PSEL.SCL = i2c_config[dev].scl;
+    bus(dev)->PSEL.SDA = i2c_config[dev].sda;
+    /* configure dev clock speed */
+    bus(dev)->FREQUENCY = i2c_config[dev].speed;
 
     /* re-enable the device. We expect that the device was being acquired before
      * the i2c_init_master() function is called, so it should be enabled when
      * exiting this function. */
-    dev(bus)->ENABLE = TWIM_ENABLE_ENABLE_Enabled;
+    bus(dev)->ENABLE = TWIM_ENABLE_ENABLE_Enabled;
+}
 
+int i2c_acquire(i2c_t dev)
+{
+    assert(dev < I2C_NUMOF);
+
+    mutex_lock(&locks[dev]);
+    bus(dev)->ENABLE = TWIM_ENABLE_ENABLE_Enabled;
+
+    DEBUG("[i2c] acquired dev %i\n", (int)dev);
     return 0;
 }
 
-int i2c_acquire(i2c_t bus)
+int i2c_release(i2c_t dev)
 {
-    assert(bus < I2C_NUMOF);
+    assert(dev < I2C_NUMOF);
 
-    mutex_lock(&locks[bus]);
-    dev(bus)->ENABLE = TWIM_ENABLE_ENABLE_Enabled;
+    bus(dev)->ENABLE = TWIM_ENABLE_ENABLE_Disabled;
+    mutex_unlock(&locks[dev]);
 
-    DEBUG("[i2c] acquired bus %i\n", (int)bus);
+    DEBUG("[i2c] released dev %i\n", (int)dev);
     return 0;
 }
 
-int i2c_release(i2c_t bus)
+int i2c_write_regs(i2c_t dev, uint16_t addr, uint16_t reg,
+                   const void *data, size_t len, uint8_t flags)
 {
-    assert(bus < I2C_NUMOF);
+    assert((dev < I2C_NUMOF) && data && (len > 0) && (len < 255));
 
-    dev(bus)->ENABLE = TWIM_ENABLE_ENABLE_Disabled;
-    mutex_unlock(&locks[bus]);
-
-    DEBUG("[i2c] released bus %i\n", (int)bus);
-    return 0;
-}
-
-int i2c_read_byte(i2c_t bus, uint8_t addr, void *data)
-{
-    return i2c_read_bytes(bus, addr, data, 1);
-}
-
-int i2c_read_bytes(i2c_t bus, uint8_t addr, void *data, int len)
-{
-    assert((bus < I2C_NUMOF) && data && (len > 0) && (len < 256));
-
-    DEBUG("[i2c] read_bytes: %i bytes from addr 0x%02x\n", (int)len, (int)addr);
-
-    dev(bus)->ADDRESS = addr;
-    dev(bus)->RXD.PTR = (uint32_t)data;
-    dev(bus)->RXD.MAXCNT = (uint8_t)len;
-    dev(bus)->SHORTS =  TWIM_SHORTS_LASTRX_STOP_Msk;
-    dev(bus)->TASKS_STARTRX = 1;
-
-    return finish(bus, len);
-}
-
-int i2c_read_reg(i2c_t bus, uint8_t addr, uint8_t reg, void *data)
-{
-    return i2c_read_regs(bus, addr, reg, data, 1);
-}
-
-int i2c_read_regs(i2c_t bus, uint8_t addr, uint8_t reg,
-                  void *data, int len)
-{
-    assert((bus < I2C_NUMOF) && data && (len > 0) && (len < 256));
-
-    DEBUG("[i2c] read_regs: %i byte(s) from reg 0x%02x at addr 0x%02x\n",
-           (int)len, (int)reg, (int)addr);
-
-    dev(bus)->ADDRESS = addr;
-    dev(bus)->TXD.PTR = (uint32_t)&reg;
-    dev(bus)->TXD.MAXCNT = 1;
-    dev(bus)->RXD.PTR = (uint32_t)data;
-    dev(bus)->RXD.MAXCNT = (uint8_t)len;
-    dev(bus)->SHORTS = (TWIM_SHORTS_LASTTX_STARTRX_Msk |
-                        TWIM_SHORTS_LASTRX_STOP_Msk);
-    dev(bus)->TASKS_STARTTX = 1;
-
-    return finish(bus, len);
-}
-
-int i2c_write_byte(i2c_t bus, uint8_t addr, uint8_t data)
-{
-    return i2c_write_bytes(bus, addr, &data, 1);
-}
-
-int i2c_write_bytes(i2c_t bus, uint8_t addr, const void *data, int len)
-{
-    assert((bus < I2C_NUMOF) && data && (len > 0) && (len < 256));
-
-    DEBUG("[i2c] write_bytes: %i byte(s) to addr 0x%02x\n", (int)len, (int)addr);
-
-    dev(bus)->ADDRESS = addr;
-    dev(bus)->TXD.PTR = (uint32_t)data;
-    dev(bus)->TXD.MAXCNT = (uint8_t)len;
-    dev(bus)->SHORTS = TWIM_SHORTS_LASTTX_STOP_Msk;
-    dev(bus)->TASKS_STARTTX = 1;
-
-    return finish(bus, len);
-}
-
-int i2c_write_reg(i2c_t bus, uint8_t addr, uint8_t reg, uint8_t data)
-{
-    return i2c_write_regs(bus, addr, reg, &data, 1);
-}
-
-int i2c_write_regs(i2c_t bus, uint8_t addr, uint8_t reg,
-                   const void *data, int len)
-{
-    assert((bus < I2C_NUMOF) && data && (len > 0) && (len < 255));
-
+    if (flags & (I2C_NOSTART | I2C_REG16 | I2C_ADDR10)) {
+        return -EOPNOTSUPP;
+    }
     /* the nrf52's TWI device does not support to do two consecutive transfers
      * without a repeated start condition in between. So we have to put all data
      * to be transfered into a temporary buffer
@@ -215,5 +141,74 @@ int i2c_write_regs(i2c_t bus, uint8_t addr, uint8_t reg,
     uint8_t buf_tmp[len + 1];
     buf_tmp[0] = reg;
     memcpy(&buf_tmp[1], data, len);
-    return i2c_write_bytes(bus, addr, buf_tmp, (len + 1)) - 1;
+    return i2c_write_bytes(dev, addr, buf_tmp, (len + 1), flags);
+}
+
+int i2c_read_bytes(i2c_t dev, uint16_t addr, void *data, size_t len,
+                   uint8_t flags)
+{
+    assert((dev < I2C_NUMOF) && data && (len > 0) && (len < 256));
+
+    if (flags & (I2C_NOSTART | I2C_REG16 | I2C_ADDR10)) {
+        return -EOPNOTSUPP;
+    }
+    DEBUG("[i2c] read_bytes: %i bytes from addr 0x%02x\n", (int)len, (int)addr);
+
+    bus(dev)->ADDRESS = addr;
+    bus(dev)->RXD.PTR = (uint32_t)data;
+    bus(dev)->RXD.MAXCNT = (uint8_t)len;
+
+    if (!(flags & I2C_NOSTOP)) {
+        bus(dev)->SHORTS = TWIM_SHORTS_LASTRX_STOP_Msk;
+    }
+    /* Start transmission */
+    bus(dev)->TASKS_STARTRX = 1;
+
+    return finish(dev);
+}
+
+int i2c_read_regs(i2c_t dev, uint16_t addr, uint16_t reg,
+                  void *data, size_t len, uint8_t flags)
+{
+    assert((dev < I2C_NUMOF) && data && (len > 0) && (len < 256));
+
+    if (flags & (I2C_NOSTART | I2C_REG16 | I2C_ADDR10)) {
+        return -EOPNOTSUPP;
+    }
+    DEBUG("[i2c] read_regs: %i byte(s) from reg 0x%02x at addr 0x%02x\n",
+           (int)len, (int)reg, (int)addr);
+
+    bus(dev)->ADDRESS = addr;
+    bus(dev)->TXD.PTR = (uint32_t)&reg;
+    bus(dev)->TXD.MAXCNT = 1;
+    bus(dev)->RXD.PTR = (uint32_t)data;
+    bus(dev)->RXD.MAXCNT = (uint8_t)len;
+    bus(dev)->SHORTS = (TWIM_SHORTS_LASTTX_STARTRX_Msk);
+    if (!(flags & I2C_NOSTOP)) {
+        bus(dev)->SHORTS |=  TWIM_SHORTS_LASTRX_STOP_Msk;
+    }
+    bus(dev)->TASKS_STARTTX = 1;
+
+    return finish(dev);
+}
+
+int i2c_write_bytes(i2c_t dev, uint16_t addr, const void *data, size_t len,
+                    uint8_t flags)
+{
+    assert((dev < I2C_NUMOF) && data && (len > 0) && (len < 256));
+
+    if (flags & (I2C_NOSTART | I2C_REG16 | I2C_ADDR10)) {
+        return -EOPNOTSUPP;
+    }
+    DEBUG("[i2c] write_bytes: %i byte(s) to addr 0x%02x\n", (int)len, (int)addr);
+
+    bus(dev)->ADDRESS = addr;
+    bus(dev)->TXD.PTR = (uint32_t)data;
+    bus(dev)->TXD.MAXCNT = (uint8_t)len;
+    if (!(flags & I2C_NOSTOP)) {
+        bus(dev)->SHORTS = TWIM_SHORTS_LASTTX_STOP_Msk;
+    }
+    bus(dev)->TASKS_STARTTX = 1;
+
+    return finish(dev);
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->
This PR adapts NRF52 I2C driver to the new API.
it has been tested with ADXL345 and nrf52dk board.

### Issues/PRs references
#6577 
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->