### PR TITLE
netdev: Add netopt to retrieve netdev_ieee802154_t

### DIFF
--- a/drivers/netdev_ieee802154/netdev_ieee802154.c
+++ b/drivers/netdev_ieee802154/netdev_ieee802154.c
@@ -136,6 +136,11 @@ int netdev_ieee802154_get(netdev_ieee802154_t *dev, netopt_t opt, void *value,
             res = sizeof(l2filter_t **);
             break;
 #endif
+        case NETOPT_NETDEV802154_PTR:
+            assert(max_len >= sizeof(netdev_ieee802154_t**));
+            *((netdev_ieee802154_t **)value) = dev;
+            res = sizeof(netdev_ieee802154_t**);
+            break;
         default:
             break;
     }

--- a/sys/include/net/netopt.h
+++ b/sys/include/net/netopt.h
@@ -554,6 +554,14 @@ typedef enum {
      */
     NETOPT_PHY_BUSY,
 
+    /**
+     * @brief   (@ref netdev_ieee802154_t) ieee802154 netdev struct
+     *
+     * Internal get function for gnrc to retrieve the @ref netdev_ieee802154_t
+     * struct.
+     */
+    NETOPT_NETDEV802154_PTR,
+
     /* add more options if needed */
 
     /**

--- a/sys/net/crosslayer/netopt/netopt.c
+++ b/sys/net/crosslayer/netopt/netopt.c
@@ -92,6 +92,7 @@ static const char *_netopt_strmap[] = {
     [NETOPT_BLE_CTX]               = "NETOPT_BLE_CTX",
     [NETOPT_CHECKSUM]              = "NETOPT_CHECKSUM",
     [NETOPT_PHY_BUSY]              = "NETOPT_PHY_BUSY",
+    [NETOPT_NETDEV802154_PTR]      = "NETOPT_NETDEV802154_PTR",
     [NETOPT_NUMOF]                 = "NETOPT_NUMOF",
 };
 

--- a/sys/net/gnrc/netif/gnrc_netif_ieee802154.c
+++ b/sys/net/gnrc/netif/gnrc_netif_ieee802154.c
@@ -78,7 +78,9 @@ static gnrc_pktsnip_t *_recv(gnrc_netif_t *netif)
 {
     netdev_t *dev = netif->dev;
     netdev_ieee802154_rx_info_t rx_info;
-    netdev_ieee802154_t *state = (netdev_ieee802154_t *)netif->dev;
+    netdev_ieee802154_t *state = NULL;
+    netif->dev->driver->get(netif->dev, NETOPT_NETDEV802154_PTR, &state,
+                    sizeof(netdev_ieee802154_t**));
     gnrc_pktsnip_t *pkt = NULL;
     int bytes_expected = dev->driver->recv(dev, NULL, 0, NULL);
 
@@ -166,7 +168,9 @@ static gnrc_pktsnip_t *_recv(gnrc_netif_t *netif)
 static int _send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
 {
     netdev_t *dev = netif->dev;
-    netdev_ieee802154_t *state = (netdev_ieee802154_t *)netif->dev;
+    netdev_ieee802154_t *state = NULL;
+    netif->dev->driver->get(netif->dev, NETOPT_NETDEV802154_PTR, &state,
+                    sizeof(netdev_ieee802154_t**));
     gnrc_netif_hdr_t *netif_hdr;
     const uint8_t *src, *dst = NULL;
     int res = 0;


### PR DESCRIPTION
### Contribution description

This PR adds a get operation to retrieve the `netdev_ieee802154_t` from a radio. This because the struct contains essential information required for constructing an ieee802154 frame.

### Issues/PRs references

required to save a new struct member in #9329 