### PR TITLE
drivers*: add drivers with saul support in the doxygen drivers_saul group

### DIFF
--- a/drivers/include/adcxx1c.h
+++ b/drivers/include/adcxx1c.h
@@ -9,9 +9,12 @@
 /**
  * @defgroup   drivers_adcxx1c ADCXX1C ADC device driver
  * @ingroup    drivers_sensors
+ * @ingroup    drivers_saul
  * @brief      I2C Analog-to-Digital Converter device driver
  *
- *             This driver works with adc081c, adc101c and adc121c versions.
+ * This driver works with adc081c, adc101c and adc121c versions.
+ *
+ * This driver provides @ref drivers_saul capabilities.
  * @{
  *
  * @file

--- a/drivers/include/ads101x.h
+++ b/drivers/include/ads101x.h
@@ -10,9 +10,12 @@
 /**
  * @defgroup   drivers_ads101x ADS101x/111x ADC device driver
  * @ingroup    drivers_sensors
+ * @ingroup    drivers_saul
  * @brief      I2C Analog-to-Digital Converter device driver
  *
- *             This driver works with ADS1013-5 and ADS1113-5.
+ * This driver works with ADS1013-5 and ADS1113-5.
+ *
+ * This driver provides @ref drivers_saul capabilities.
  * @{
  *
  * @file

--- a/drivers/include/adxl345.h
+++ b/drivers/include/adxl345.h
@@ -9,7 +9,10 @@
 /**
  * @defgroup    drivers_adxl345 ADXL345 3-Axis accelerometer
  * @ingroup     drivers_sensors
+ * @ingroup     drivers_saul
  * @brief       Device driver interface for the ADXL345
+ *
+ * This driver provides @ref drivers_saul capabilities.
  * @{
  *
  * @file

--- a/drivers/include/bmp180.h
+++ b/drivers/include/bmp180.h
@@ -9,7 +9,10 @@
 /**
  * @defgroup    drivers_bmp180 BMP180 temperature and pressure sensor
  * @ingroup     drivers_sensors
- * @brief       Device driver interface for the BMP180 sensor.
+ * @ingroup     drivers_saul
+ * @brief       Device driver interface for the BMP180 sensor
+ *
+ * This driver provides @ref drivers_saul capabilities.
  * @{
  *
  * @file

--- a/drivers/include/bmx055.h
+++ b/drivers/include/bmx055.h
@@ -9,7 +9,10 @@
 /**
  * @defgroup    drivers_bmx055 BMX055 9-axis sensor
  * @ingroup     drivers_sensors
+ * @ingroup     drivers_saul
  * @brief       Device driver for the Bosch BMX055 9-axis sensor
+ *
+ * This driver provides @ref drivers_saul capabilities.
  * @{
  *
  * @file

--- a/drivers/include/bmx280.h
+++ b/drivers/include/bmx280.h
@@ -10,6 +10,7 @@
 /**
  * @defgroup    drivers_bmx280 BMP280/BME280 temperature, pressure and humidity sensor
  * @ingroup     drivers_sensors
+ * @ingroup     drivers_saul
  * @brief       Device driver interface for the Bosch BMP280 and BME280 sensors.
  *
  * BMP280 and BME280 measure temperature in centi °C and pressure in Pa. BME280
@@ -19,6 +20,7 @@
  * * [BMP280](https://ae-bst.resource.bosch.com/media/_tech/media/datasheets/BST-BMP280-DS001-18.pdf)
  * * [BME280](https://ae-bst.resource.bosch.com/media/_tech/media/datasheets/BST-BME280_DS001-11.pdf)
  *
+ * This driver provides @ref drivers_saul capabilities.
  * @{
  * @file
  * @brief       Device driver interface for the BMX280 sensors (BMP280 and BME280).

--- a/drivers/include/dht.h
+++ b/drivers/include/dht.h
@@ -11,8 +11,11 @@
 /**
  * @defgroup    drivers_dht DHT Family of Humidity and Temperature Sensors
  * @ingroup     drivers_sensors
+ * @ingroup     drivers_saul
  * @brief       Device driver for the DHT Family of humidity
  *              and temperature sensors
+ *
+ * This driver provides @ref drivers_saul capabilities.
  *
  * @{
  *

--- a/drivers/include/fxos8700.h
+++ b/drivers/include/fxos8700.h
@@ -9,11 +9,13 @@
 /**
  * @defgroup    drivers_fxos8700 FXOS8700 3-axis accelerometer/magnetometer
  * @ingroup     drivers_sensors
+ * @ingroup     drivers_saul
  * @brief       Driver for the FXOS8700 3-axis accelerometer/magnetometer
  *
  * The connection between the MCU and the FXOS8700 is based on the
  * I2C-interface.
  *
+ * This driver provides @ref drivers_saul capabilities.
  * @{
  *
  * @file

--- a/drivers/include/grove_ledbar.h
+++ b/drivers/include/grove_ledbar.h
@@ -9,7 +9,10 @@
 /**
  * @defgroup    drivers_grove_ledbar Grove ledbar
  * @ingroup     drivers_actuators
+ * @ingroup     drivers_saul
  * @brief       Driver for the Grove ledbar
+ *
+ * This driver provides @ref drivers_saul capabilities.
  *
  * @{
  * @file

--- a/drivers/include/hdc1000.h
+++ b/drivers/include/hdc1000.h
@@ -10,6 +10,7 @@
 /**
  * @defgroup    drivers_hdc1000 HDC1000 Humidity and Temperature Sensor
  * @ingroup     drivers_sensors
+ * @ingroup     drivers_saul
  * @brief       Driver for the TI HDC1000 Humidity and Temperature Sensor
  *
  * The driver will initialize the sensor for best resolution (14 bit). Currently
@@ -25,6 +26,8 @@
  *
  * @note        The driver does currently not support using the devices heating
  *              unit.
+ *
+ * This driver provides @ref drivers_saul capabilities.
  *
  * @{
  *

--- a/drivers/include/hts221.h
+++ b/drivers/include/hts221.h
@@ -9,7 +9,10 @@
 /**
  * @defgroup    drivers_hts221 ST HTS221 digital Humidity Sensor
  * @ingroup     drivers_sensors
+ * @ingroup     drivers_saul
  * @brief       Driver for the ST HTS221 digital Humidity Sensor
+ *
+ * This driver provides @ref drivers_saul capabilities.
  *
  * @{
  * @file

--- a/drivers/include/io1_xplained.h
+++ b/drivers/include/io1_xplained.h
@@ -9,6 +9,7 @@
 /**
  * @defgroup    drivers_io1_xplained Atmel IO1 Xplained Extension board
  * @ingroup     drivers_sensors
+ * @ingroup     drivers_saul
  * @brief       Device driver interface for the Atmel IO1 Xplained extension.
  *
  * This board contains several sensors and actuators:
@@ -27,6 +28,7 @@
  * (http://www.atmel.com/images/atmel-42078-io1-xplained-pro_user-guide.pdf)
  * for more information
  *
+ * This driver provides @ref drivers_saul capabilities.
  * @{
  *
  * @file

--- a/drivers/include/isl29020.h
+++ b/drivers/include/isl29020.h
@@ -9,7 +9,10 @@
 /**
  * @defgroup    drivers_isl29020 ISL29020 light sensor
  * @ingroup     drivers_sensors
+ * @ingroup     drivers_saul
  * @brief       Device driver for the ISL29020 light sensor
+ *
+ * This driver provides @ref drivers_saul capabilities.
  * @{
  *
  * @file

--- a/drivers/include/jc42.h
+++ b/drivers/include/jc42.h
@@ -9,6 +9,7 @@
 /**
  * @defgroup    drivers_jc42 JC42 compliant temperature sensor driver
  * @ingroup     drivers_sensors
+ * @ingroup     drivers_saul
  *
  * @brief       JC42 compliant temperature sensor driver
  *
@@ -20,6 +21,7 @@
  * temperature from these sensors. The sensors support a alarm wire, but this
  * is not supported by this driver.
  *
+ * This driver provides @ref drivers_saul capabilities.
  * @{
  *
  * @file

--- a/drivers/include/l3g4200d.h
+++ b/drivers/include/l3g4200d.h
@@ -9,13 +9,17 @@
 /**
  * @defgroup    drivers_l3g4200d L3G4200D gyroscope
  * @ingroup     drivers_sensors
+ * @ingroup     drivers_saul
  * @brief       Device driver for the L3G4200D gyroscope
+ *
+ * This driver provides @ref drivers_saul capabilities.
+ *
+ * @note The current state of the driver only implements a very basic polling mode.
+ *
  * @{
  *
  * @file
  * @brief       Device driver interface for the L3G4200D gyroscope
- *
- * @note The current state of the driver only implements a very basic polling mode.
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */

--- a/drivers/include/lis2dh12.h
+++ b/drivers/include/lis2dh12.h
@@ -9,6 +9,7 @@
 /**
  * @defgroup    drivers_lis2dh12 LIS2DH12 Accelerometer
  * @ingroup     drivers_sensors
+ * @ingroup     drivers_saul
  * @brief       Driver for the STM LIS2DH12 accelerometer
  *
  * This device driver provides a minimal interface to LIS2DH12 devices. As of
@@ -22,6 +23,8 @@
  * via SPI. The driver is however written in a way, that adding I2C interface
  * support is quite simple, as all bus related functions (acquire, release,
  * read, write) are cleanly separated in the code.
+ *
+ * This driver provides @ref drivers_saul capabilities.
  *
  * @{
  * @file

--- a/drivers/include/lis3dh.h
+++ b/drivers/include/lis3dh.h
@@ -9,7 +9,10 @@
 /**
  * @defgroup    drivers_lis3dh LIS3DH accelerometer
  * @ingroup     drivers_sensors
+ * @ingroup     drivers_saul
  * @brief       Device driver for the LIS3DH accelerometer
+ *
+ * This driver provides @ref drivers_saul capabilities.
  * @{
  *
  * @file

--- a/drivers/include/lis3mdl.h
+++ b/drivers/include/lis3mdl.h
@@ -9,7 +9,10 @@
 /**
  * @defgroup    drivers_lis3mdl LIS3MDL 3-axis magnetometer
  * @ingroup     drivers_sensors
+ * @ingroup     drivers_saul
  * @brief       Device driver for the LIS3MDL 3-axis magnetometer
+ *
+ * This driver provides @ref drivers_saul capabilities.
  * @{
  *
  * @file

--- a/drivers/include/lps331ap.h
+++ b/drivers/include/lps331ap.h
@@ -9,7 +9,10 @@
 /**
  * @defgroup    drivers_lps331ap LPS331AP Pressure Sensor Driver
  * @ingroup     drivers_sensors
+ * @ingroup     drivers_saul
  * @brief       Device driver for the LPS331AP pressure sensor
+ *
+ * This driver provides @ref drivers_saul capabilities.
  * @{
  *
  * @file

--- a/drivers/include/lsm303dlhc.h
+++ b/drivers/include/lsm303dlhc.h
@@ -9,7 +9,10 @@
 /**
  * @defgroup    drivers_lsm303dlhc LSM303DLHC 3D accelerometer/magnetometer
  * @ingroup     drivers_sensors
+ * @ingroup     drivers_saul
  * @brief       Device driver for the LSM303DLHC 3D accelerometer/magnetometer
+ *
+ * This driver provides @ref drivers_saul capabilities.
  * @{
  *
  * @file

--- a/drivers/include/lsm6dsl.h
+++ b/drivers/include/lsm6dsl.h
@@ -10,8 +10,10 @@
 /**
  * @defgroup    drivers_lsm6dsl LSM6DSL 3D accelerometer/gyroscope
  * @ingroup     drivers_sensors
+ * @ingroup     drivers_saul
  * @brief       Device driver for the LSM6DSL 3D accelerometer/gyroscope
  *
+ * This driver provides @ref drivers_saul capabilities.
  * @{
  *
  * @file

--- a/drivers/include/mag3110.h
+++ b/drivers/include/mag3110.h
@@ -10,16 +10,19 @@
 /**
  * @defgroup    drivers_mag3110 MAG3110 3-Axis Digital Magnetometer
  * @ingroup     drivers_sensors
+ * @ingroup     drivers_saul
  * @brief       Driver for the Freescale MAG3110 magnetometer.
- *              After initialization and set activ the magnetometer
- *              will make measurements at periodic times.
- *              The output rate and over sample ratio
- *              can be determined by magnetometer initialization.
- *              The measured values of magnetic field strength and
- *              die temperature have uncalibrated offsets.
- *              To get correct measurement values, the individual
- *              offsets must be measured and set accordingly.
  *
+ * After initialization and set activ the magnetometer will make measurements
+ * at periodic times.
+ * The output rate and over sample ratio can be determined by magnetometer
+ * initialization.
+ * The measured values of magnetic field strength and die temperature have
+ * uncalibrated offsets.
+ * To get correct measurement values, the individual offsets must be measured
+ * and set accordingly.
+ *
+ * This driver provides @ref drivers_saul capabilities.
  * @{
  *
  * @file

--- a/drivers/include/mma8x5x.h
+++ b/drivers/include/mma8x5x.h
@@ -10,14 +10,17 @@
 /**
  * @defgroup    drivers_mma8x5x MMA8x5x Accelerometer
  * @ingroup     drivers_sensors
+ * @ingroup     drivers_saul
  * @brief       Driver for the Freescale MMA8x5x 3-Axis accelerometer.
- *              The driver will initialize the accelerometer for best
- *              resolution. After the initialization the accelerometer will make
- *              measurements at periodic times. The measurements period and
- *              scale range can be determined by accelerometer initialization.
- *              This driver only implements basic functionality (i.e. no support
- *              for external interrupt pins).
  *
+ * The driver will initialize the accelerometer for best resolution. After the
+ * initialization the accelerometer will make measurements at periodic times.
+ * The measurements period and scale range can be determined by accelerometer
+ * initialization.
+ * This driver only implements basic functionality (i.e. no support
+ * for external interrupt pins).
+ *
+ * This driver provides @ref drivers_saul capabilities.
  * @{
  *
  * @file

--- a/drivers/include/mpl3115a2.h
+++ b/drivers/include/mpl3115a2.h
@@ -10,6 +10,7 @@
 /**
  * @defgroup    drivers_mpl3115a2 MPL3115A2 Pressure Sensor
  * @ingroup     drivers_sensors
+ * @ingroup     drivers_saul
  * @brief       Driver for the Freescale MPL3115A2 pressure sensor.
  *
  * The driver will initialize the sensor for pressure measurement. The
@@ -17,6 +18,7 @@
  * the sensor can be set active to run periodic measurements. The oversample
  * ratio can be configured during sensor initialization.
  *
+ * This driver provides @ref drivers_saul capabilities.
  * @{
  *
  * @file

--- a/drivers/include/mpu9150.h
+++ b/drivers/include/mpu9150.h
@@ -9,7 +9,10 @@
 /**
  * @defgroup    drivers_mpu9150 MPU-9150 accelerometer/magnetometer/gyroscope
  * @ingroup     drivers_sensors
+ * @ingroup     drivers_saul
  * @brief       Device driver interface for the MPU-9150
+ *
+ * This driver provides @ref drivers_saul capabilities.
  * @{
  *
  * @file

--- a/drivers/include/pulse_counter.h
+++ b/drivers/include/pulse_counter.h
@@ -9,9 +9,11 @@
 /**
  * @defgroup    drivers_pulse_counter Pulse counter
  * @ingroup     drivers_sensors
+ * @ingroup     drivers_saul
  *
  * @brief       GPIO based pulse counting driver
  *
+ * This driver provides @ref drivers_saul capabilities.
  * @{
  *
  * @file

--- a/drivers/include/si114x.h
+++ b/drivers/include/si114x.h
@@ -9,7 +9,10 @@
 /**
  * @defgroup    drivers_si114x Si1145/6/7 UV/Ambient light/Proximity sensors
  * @ingroup     drivers_sensors
+ * @ingroup     drivers_saul
  * @brief       Device driver for the Si1145/6/7 sensors family
+ *
+ * This driver provides @ref drivers_saul capabilities.
  * @{
  *
  * @file

--- a/drivers/include/si70xx.h
+++ b/drivers/include/si70xx.h
@@ -9,7 +9,10 @@
 /**
  * @defgroup    drivers_si70xx Si7006/13/20/21 temperature and humidity sensors
  * @ingroup     drivers_sensors
- * @brief       Driver for the Si7006/13/20/21 temperature and humidity sensor.
+ * @ingroup     drivers_saul
+ * @brief       Driver for the Si7006/13/20/21 temperature and humidity sensor
+ *
+ * This driver provides @ref drivers_saul capabilities.
  * @{
  *
  * @file

--- a/drivers/include/tcs37727.h
+++ b/drivers/include/tcs37727.h
@@ -10,9 +10,10 @@
 /**
  * @defgroup    drivers_tcs37727 TCS37727 RGB Light Sensor
  * @ingroup     drivers_sensors
+ * @ingroup     drivers_saul
  * @brief       Driver for the AMS TCS37727 Color Light-To-Digital Converter
  *
- *
+ * This driver provides @ref drivers_saul capabilities.
  * @{
  *
  * @file

--- a/drivers/include/tmp006.h
+++ b/drivers/include/tmp006.h
@@ -10,6 +10,7 @@
 /**
  * @defgroup    drivers_tmp006 TI TMP006 Infrared Thermopile Sensor
  * @ingroup     drivers_sensors
+ * @ingroup     drivers_saul
  * @brief       Driver for the Texas Instruments TMP006 sensor.
  *
  * The TI TMP006 (Infrared Thermopile Contactless Temperature Sensor) measures
@@ -65,6 +66,7 @@
  *
  * The calculation and constants are wrapped from TI TMP006 User's Guide SBOU107.
  *
+ * This driver provides @ref drivers_saul capabilities.
  * @{
  *
  * @file

--- a/drivers/include/tsl2561.h
+++ b/drivers/include/tsl2561.h
@@ -9,7 +9,10 @@
 /**
  * @defgroup    drivers_tsl2561 TSL2561 illuminance sensor
  * @ingroup     drivers_sensors
+ * @ingroup     drivers_saul
  * @brief       Device driver interface for the illuminance TSL2561 sensor
+ *
+ * This driver provides @ref drivers_saul capabilities.
  * @{
  *
  * @file

--- a/drivers/include/veml6070.h
+++ b/drivers/include/veml6070.h
@@ -9,7 +9,10 @@
 /**
  * @defgroup    drivers_veml6070 VEML6070 UV sensor
  * @ingroup     drivers_sensors
+ * @ingroup     drivers_saul
  * @brief       Device driver interface for the VEML6070 UV sensor
+ *
+ * This driver provides @ref drivers_saul capabilities.
  * @{
  *
  * @file


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


This PR is a follow-up of #9328 that put a doxygen dependency of drivers with saul support to the drivers_saul group.
This way all drivers with SAUL support can be reached directly when browsing the SAUL module documentation.

### Issues/PRs references

follow-up of #9328

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->