### PR TITLE
atmega_common/gpio.c Fixes GPIO_LOW interrupt

### DIFF
--- a/cpu/atmega_common/periph/gpio.c
+++ b/cpu/atmega_common/periph/gpio.c
@@ -174,10 +174,12 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
 
     /* apply flank to interrupt number int_num */
     if (int_num < 4) {
+        EICRA &= ~(0x3 << (int_num * 2));
         EICRA |= (flank << (int_num * 2));
     }
 #if defined(EICRB)
     else {
+        EICRB &= ~(0x3 << ((int_num % 4) * 2));
         EICRB |= (flank << ((int_num % 4) * 2));
     }
 #endif


### PR DESCRIPTION
fixes the GPIO_LOW interrupt on the atmega platform.

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR fixes a bug in the atmega_common gpio.c file. In order to set a GPIO_LOW interrupt, EICRA will need to set some bits to zero. The originial code did this by just shifting the `flank` variable. But 0 variables can not be shifted. Therefore the interrupts were not set correctly. Its fixed by checking first if GPIO_LOW is supposed to be set and then using `EICRA &= ~(0x3 << (int_num * 2));` to set the GPIO_LOW interrupt correctly.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->