### PR TITLE
fmt: Add fmt_strnlen function

### DIFF
--- a/sys/fmt/fmt.c
+++ b/sys/fmt/fmt.c
@@ -83,6 +83,15 @@ size_t fmt_strlen(const char *str)
     return (tmp - str);
 }
 
+size_t fmt_strnlen(const char *str, size_t maxlen)
+{
+    const char *tmp = str;
+    while(*tmp && maxlen--) {
+        tmp++;
+    }
+    return (tmp - str);
+}
+
 size_t fmt_str(char *out, const char *str)
 {
     int len = 0;

--- a/sys/include/fmt.h
+++ b/sys/include/fmt.h
@@ -295,6 +295,17 @@ size_t fmt_float(char *out, float f, unsigned precision);
 size_t fmt_strlen(const char *str);
 
 /**
+ * @brief Count at most @p maxlen characters until '\0' (exclusive) in @p str
+ *
+ * @param[in]   str     Pointer to string
+ * @param[in]   maxlen  Maximum number of chars to count
+ *
+ * @return      nr of characters in string @p str points to, or @p maxlen if no
+ *              null terminator is found within @p maxlen chars
+ */
+size_t fmt_strnlen(const char *str, size_t maxlen);
+
+/**
  * @brief Copy null-terminated string (excluding terminating \0)
  *
  * If @p out is NULL, will only return the number of bytes that would have

--- a/tests/unittests/tests-fmt/tests-fmt.c
+++ b/tests/unittests/tests-fmt/tests-fmt.c
@@ -704,6 +704,17 @@ static void test_fmt_strlen(void)
     TEST_ASSERT_EQUAL_INT(21, fmt_strlen(long_str));
 }
 
+static void test_fmt_strnlen(void)
+{
+    const char *empty_str = "";
+    const char *short_str = "short";
+    const char *long_str = "this is a long string";
+
+    TEST_ASSERT_EQUAL_INT(0, fmt_strnlen(empty_str, 16));
+    TEST_ASSERT_EQUAL_INT(5, fmt_strnlen(short_str, 16));
+    TEST_ASSERT_EQUAL_INT(16, fmt_strnlen(long_str, 16));
+}
+
 static void test_fmt_str(void)
 {
     const char *string1 = "string1";
@@ -778,6 +789,7 @@ Test *tests_fmt_tests(void)
         new_TestFixture(test_fmt_s16_dfp),
         new_TestFixture(test_fmt_s32_dfp),
         new_TestFixture(test_fmt_strlen),
+        new_TestFixture(test_fmt_strnlen),
         new_TestFixture(test_fmt_str),
         new_TestFixture(test_scn_u32_dec),
         new_TestFixture(test_fmt_lpad),


### PR DESCRIPTION
### Contribution description

Add an `fmt_strnlen` function, equivalent to the POSIX `strnlen` function. PR includes a test for the new function.

### Issues/PRs references

None