### PR TITLE
tests: add runtime benchmark for selected core functions

### DIFF
--- a/sys/benchmark/benchmark.c
+++ b/sys/benchmark/benchmark.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Freie Universität Berlin
+ * Copyright (C) 2017,2018 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser General
  * Public License v2.1. See the file LICENSE in the top level directory for more
@@ -27,6 +27,10 @@ void benchmark_print_time(uint32_t time, unsigned long runs, const char *name)
     uint32_t full = (time / runs);
     uint32_t div  = (time - (full * runs)) / (runs / 1000);
 
-    printf("%11s: %9" PRIu32 "us  ---  %2" PRIu32 ".%03" PRIu32 "us per call\n",
-           name, time, full, div);
+    uint32_t per_sec = (uint32_t)(((uint64_t)1000000UL * runs) / time);
+
+    printf("%25s: %9" PRIu32 "us"
+           "  ---  %2" PRIu32 ".%03" PRIu32 "us per call"
+           "  ---  %9" PRIu32 " calls per sec\n",
+           name, time, full, div, per_sec);
 }

--- a/sys/include/benchmark.h
+++ b/sys/include/benchmark.h
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Freie Universität Berlin
+ * Copyright (C) 2017,2018 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -23,6 +23,7 @@
 
 #include <stdint.h>
 
+#include "irq.h"
 #include "xtimer.h"
 
 #ifdef __cplusplus

--- a/tests/bench_runtime_coreapis/Makefile
+++ b/tests/bench_runtime_coreapis/Makefile
@@ -1,0 +1,16 @@
+include ../Makefile.tests_common
+
+# we use thread flags in this benchmark by default, disable on demand
+USEMODULE += core_thread_flags
+USEMODULE += benchmark
+
+# no need to build this test for all targets, so just build for some selected
+# boards
+BOARD_WHITELIST += native nrf52dk samr21-xpro z1 arduino-mega2560
+
+TEST_ON_CI_WHITELIST += all
+
+include $(RIOTBASE)/Makefile.include
+
+test:
+	tests/01-run.py

--- a/tests/bench_runtime_coreapis/README.md
+++ b/tests/bench_runtime_coreapis/README.md
@@ -1,0 +1,7 @@
+# Measure Runtime of Selected Core API functions
+
+This benchmark application measures the runtime of selected core API functions.
+Its purpose is to provide a baseline to assess the impacts when doing changes to
+core code.
+
+This application is not complete, simply add additional runs if needed.

--- a/tests/bench_runtime_coreapis/main.c
+++ b/tests/bench_runtime_coreapis/main.c
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2018 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Measure runtime of select core API functions
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+
+#include "mutex.h"
+#include "benchmark.h"
+#include "thread.h"
+#include "thread_flags.h"
+
+#ifndef BENCH_RUNS
+#define BENCH_RUNS          (1000UL * 1000UL)
+#endif
+
+static mutex_t _lock;
+static thread_t *t;
+static kernel_pid_t pid;
+static thread_flags_t _flag = 0x0001;
+static msg_t _msg;
+
+static void _mutex_lockunlock(void)
+{
+    mutex_lock(&_lock);
+    mutex_unlock(&_lock);
+}
+
+static void _flag_waitany(void)
+{
+    thread_flags_set(t, _flag);
+    thread_flags_wait_any(_flag);
+}
+
+static void _flag_waitall(void)
+{
+    thread_flags_set(t, _flag);
+    thread_flags_wait_all(_flag);
+}
+
+static void _flag_waitone(void)
+{
+    thread_flags_set(t, _flag);
+    thread_flags_wait_all(_flag);
+}
+
+int main(void)
+{
+    puts("Runtime of Selected Core API functions\n");
+
+    t = (thread_t *)sched_active_thread;
+    pid = thread_getpid();
+
+    BENCHMARK_FUNC("nop loop", BENCH_RUNS, __asm__ volatile("nop"));
+    puts("");
+    BENCHMARK_FUNC("mutex_init()", BENCH_RUNS, mutex_init(&_lock));
+    BENCHMARK_FUNC("mutex lock/unlock", BENCH_RUNS, _mutex_lockunlock());
+    puts("");
+    BENCHMARK_FUNC("thread_flags_set()", BENCH_RUNS, thread_flags_set(t, _flag));
+    BENCHMARK_FUNC("thread_flags_clear()", BENCH_RUNS, thread_flags_clear(_flag));
+    BENCHMARK_FUNC("thread flags set/wait any", BENCH_RUNS, _flag_waitany());
+    BENCHMARK_FUNC("thread flags set/wait all", BENCH_RUNS, _flag_waitall());
+    BENCHMARK_FUNC("thread flags set/wait one", BENCH_RUNS, _flag_waitone());
+    puts("");
+    BENCHMARK_FUNC("msg_try_receive()", BENCH_RUNS, msg_try_receive(&_msg));
+    BENCHMARK_FUNC("msg_avail()", BENCH_RUNS, msg_avail());
+
+    puts("\n[SUCCESS]");
+    return 0;
+}

--- a/tests/bench_runtime_coreapis/tests/01-run.py
+++ b/tests/bench_runtime_coreapis/tests/01-run.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2018 Freie Universität Berlin
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import os
+import sys
+
+
+def testfunc(child):
+    child.expect_exact('[SUCCESS]')
+
+
+if __name__ == "__main__":
+    sys.path.append(os.path.join(os.environ['RIOTTOOLS'], 'testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc))


### PR DESCRIPTION
### Contribution description
This PR adds a new benchmark application, which measures the runtime some selected core API functions. The selection of the function is more or less arbitrary for now, and other functions can simply be added at anytime. The current list of functions is selected for this application to be useful analyzing the impact of the changes from #7445. More 'advanced' functions that also trigger context switches can further be analyzed with the benchmarks presented in #7786.

### Issues/PRs references
more benchmarks in #7786
this PR is needed for testing #7445