### PR TITLE
gnrc_sixlowpan_frag: expose (parts of) reassembly buffer

### DIFF
--- a/sys/include/net/gnrc/sixlowpan/frag.h
+++ b/sys/include/net/gnrc/sixlowpan/frag.h
@@ -31,6 +31,7 @@
 #include "byteorder.h"
 #include "kernel_types.h"
 #include "net/gnrc/pkt.h"
+#include "net/ieee802154.h"
 #include "net/sixlowpan.h"
 
 #ifdef __cplusplus
@@ -41,6 +42,32 @@ extern "C" {
  * @brief   Message type for passing one 6LoWPAN fragment down the network stack
  */
 #define GNRC_SIXLOWPAN_MSG_FRAG_SND    (0x0225)
+
+/**
+ * @brief   An entry in the 6LoWPAN reassembly buffer.
+ *
+ * A recipient of a fragment SHALL use
+ *
+ * 1. the source address,
+ * 2. the destination address,
+ * 3. the datagram size (gnrc_pktsnip_t::size of rbuf_t::pkt), and
+ * 4. the datagram tag
+ *
+ * to identify all fragments that belong to the given datagram.
+ *
+ * @see [RFC 4944, section 5.3](https://tools.ietf.org/html/rfc4944#section-5.3)
+ */
+typedef struct {
+    /**
+     * @brief   The reassembled packet in the packet buffer
+     */
+    gnrc_pktsnip_t *pkt;
+    uint8_t src[IEEE802154_LONG_ADDRESS_LEN];   /**< source address */
+    uint8_t dst[IEEE802154_LONG_ADDRESS_LEN];   /**< destination address */
+    uint8_t src_len;                            /**< length of gnrc_sixlowpan_rbuf_t::src */
+    uint8_t dst_len;                            /**< length of gnrc_sixlowpan_rbuf_t::dst */
+    uint16_t tag;                               /**< the datagram's tag */
+} gnrc_sixlowpan_rbuf_t;
 
 /**
  * @brief   Definition of 6LoWPAN fragmentation type.

--- a/sys/net/gnrc/network_layer/sixlowpan/frag/rbuf.h
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/rbuf.h
@@ -30,7 +30,6 @@
 extern "C" {
 #endif
 
-#define RBUF_L2ADDR_MAX_LEN (8U)               /**< maximum length for link-layer addresses */
 #define RBUF_SIZE           (4U)               /**< size of the reassembly buffer */
 #define RBUF_TIMEOUT        (3U * US_PER_SEC) /**< timeout for reassembly in microseconds */
 
@@ -53,33 +52,19 @@ typedef struct rbuf_int {
 } rbuf_int_t;
 
 /**
- * @brief   An entry in the 6LoWPAN reassembly buffer.
+ * @brief   Internal representation of the 6LoWPAN reassembly buffer.
  *
- * @details A receipient of a fragment SHALL use
- *
- * 1. the source address,
- * 2. the destination address,
- * 3. the datagram size (gnrc_pktsnip_t::size of rbuf_t::pkt), and
- * 4. the datagram tag
- *
- * to identify all fragments that belong to the given datagram.
- *
- * @see <a href="https://tools.ietf.org/html/rfc4944#section-5.3">
- *          RFC 4944, section 5.3
- *      </a>
+ * Additional members help with correct reassembly of the buffer.
  *
  * @internal
+ *
+ * @extends gnrc_sixlowpan_rbuf_t
  */
 typedef struct {
+    gnrc_sixlowpan_rbuf_t super;        /**< exposed part of the reassembly buffer */
     rbuf_int_t *ints;                   /**< intervals of the fragment */
-    gnrc_pktsnip_t *pkt;                /**< the reassembled packet in packet buffer */
     uint32_t arrival;                   /**< time in microseconds of arrival of
                                          *   last received fragment */
-    uint8_t src[RBUF_L2ADDR_MAX_LEN];   /**< source address */
-    uint8_t dst[RBUF_L2ADDR_MAX_LEN];   /**< destination address */
-    uint8_t src_len;                    /**< length of source address */
-    uint8_t dst_len;                    /**< length of destination address */
-    uint16_t tag;                       /**< the datagram's tag */
     uint16_t cur_size;                  /**< the datagram's current size */
 } rbuf_t;
 


### PR DESCRIPTION
### Contribution description
This exposes the parts of the reassembly buffer to be usable as context
as proposed in #8511.

I only exposed *parts of* for two reasons:

1. I don't need to expose further types (like `rbuf_int_t`), that are
   not of interest outside of fragmentation.
2. This allows for an easy future extension for the virtual reassembly
   buffer as proposed in [[1]].

This makes this change a little bit more involved, because instead of
just renaming the type, I also need to add the usage of the `super`
member, but I think in the end this little preparation work will be
beneficial in the future.

[1]: https://tools.ietf.org/html/draft-watteyne-6lo-minimal-fragment-01#section-3

### Issues/PRs references
Moves GNRC's 6Lo implementation more towards #8511.