### PR TITLE
gnrc_sixlowpan: fix order of gnrc_sixlowpan_msg_frag_t

### DIFF
--- a/sys/include/net/gnrc/sixlowpan/frag.h
+++ b/sys/include/net/gnrc/sixlowpan/frag.h
@@ -46,11 +46,11 @@ extern "C" {
  * @brief   Definition of 6LoWPAN fragmentation type.
  */
 typedef struct {
-    kernel_pid_t pid;       /**< PID of the interface */
     gnrc_pktsnip_t *pkt;    /**< Pointer to the IPv6 packet to be fragmented */
     size_t datagram_size;   /**< Length of just the IPv6 packet to be fragmented */
     uint16_t offset;        /**< Offset of the Nth fragment from the beginning of the
                              *   payload datagram */
+    kernel_pid_t pid;       /**< PID of the interface */
 } gnrc_sixlowpan_msg_frag_t;
 
 /**

--- a/sys/net/gnrc/network_layer/sixlowpan/gnrc_sixlowpan.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/gnrc_sixlowpan.c
@@ -35,7 +35,7 @@
 static kernel_pid_t _pid = KERNEL_PID_UNDEF;
 
 #ifdef MODULE_GNRC_SIXLOWPAN_FRAG
-static gnrc_sixlowpan_msg_frag_t fragment_msg = {KERNEL_PID_UNDEF, NULL, 0, 0};
+static gnrc_sixlowpan_msg_frag_t fragment_msg = {NULL, 0, 0, KERNEL_PID_UNDEF};
 #endif
 
 #if ENABLE_DEBUG


### PR DESCRIPTION
### Contribution description
While working on #9352 I noticed that the order of members in the
`gnrc_sixlowpan_msg_frag_t` struct costs us 4 bytes in RAM due to byte
alignment. This PR fixes the order of members, so they are the most
packed.

### Issues/PRs references
None