### PR TITLE
core: add more stacksize defines

### DIFF
--- a/core/include/thread.h
+++ b/core/include/thread.h
@@ -262,6 +262,34 @@ struct _thread {
 #endif
 
 /**
+ * @brief Large stack size
+ */
+#ifndef THREAD_STACKSIZE_LARGE
+#define THREAD_STACKSIZE_LARGE (THREAD_STACKSIZE_MEDIUM * 2)
+#endif
+
+/**
+ * @brief Medium stack size
+ */
+#ifndef THREAD_STACKSIZE_MEDIUM
+#define THREAD_STACKSIZE_MEDIUM THREAD_STACKSIZE_DEFAULT
+#endif
+
+/**
+ * @brief Small stack size
+ */
+#ifndef THREAD_STACKSIZE_SMALL
+#define THREAD_STACKSIZE_SMALL (THREAD_STACKSIZE_MEDIUM / 2)
+#endif
+
+/**
+ * @brief Tiny stack size
+ */
+#ifndef THREAD_STACKSIZE_TINY
+#define THREAD_STACKSIZE_TINY (THREAD_STACKSIZE_MEDIUM / 4)
+#endif
+
+/**
  * @brief Minimum stack size
  */
 #ifndef THREAD_STACKSIZE_MINIMUM


### PR DESCRIPTION
### Contribution description

This PR adds more stacksize defines: tiny, small, medium, large being 1/4, 1/2, 1 and 2 times of the default size.

They can be combined, see @miri64's suggestion here: https://github.com/RIOT-OS/RIOT/issues/1976#issuecomment-62331232.

### Issues/PRs references

Fixes #1976.

See #6273, #6669.