### PR TITLE
 make: Clean up WERROR handling 

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -129,13 +129,13 @@ endif
 WERROR ?= 1
 export WERROR
 ifeq ($(WERROR),1)
-  CFLAGS += -Wall -Werror -Wextra
+  CFLAGS += -Werror
 endif
 
 WPEDANTIC ?= 0
 export WPEDANTIC
 ifeq ($(WPEDANTIC),1)
-    CFLAGS += -Wpedantic -pedantic-errors
+  CFLAGS += -Wpedantic
 endif
 
 # remove this once codebase is adapted

--- a/makefiles/cflags.inc.mk
+++ b/makefiles/cflags.inc.mk
@@ -57,8 +57,8 @@ endif
 # Forbid common symbols to prevent accidental aliasing.
 CFLAGS += -fno-common
 
-# Enable all default warnings
-CFLAGS += -Wall
+# Enable all default warnings and all extra warnings
+CFLAGS += -Wall -Wextra
 
 # Warn if a user-supplied include directory does not exist.
 CFLAGS += -Wmissing-include-dirs


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Clean up of the WERROR handling in Makefile.include to let the WERROR variable only control the actual -Werror compiler flag. All other warning related flags are set regardless of WERROR=1 or not.

### Issues/PRs references
