### PR TITLE
makefiles/cflags.inc.mk: Use a template for CFLAGS testing

### DIFF
--- a/makefiles/cflags.inc.mk
+++ b/makefiles/cflags.inc.mk
@@ -40,9 +40,6 @@ ifeq ($(shell $(CC) -Wstrict-prototypes -Werror=strict-prototypes -Wold-style-de
   # duplicated parameters don't hurt
   CFLAGS += -Wstrict-prototypes -Wold-style-definition
   CXXUWFLAGS += -Wstrict-prototypes -Wold-style-definition
-  ifeq ($(WERROR),1)
-    CFLAGS += -Werror=strict-prototypes -Werror=old-style-definition
-  endif
 endif
 
 # Unwanted flags for c++

--- a/makefiles/cflags.inc.mk
+++ b/makefiles/cflags.inc.mk
@@ -39,11 +39,11 @@ endif
 ifeq ($(shell $(CC) -Wstrict-prototypes -Werror=strict-prototypes -Wold-style-definition -Werror=old-style-definition -E - 2>/dev/null >/dev/null </dev/null ; echo $$?),0)
   # duplicated parameters don't hurt
   CFLAGS += -Wstrict-prototypes -Wold-style-definition
-  CXXUWFLAGS += -Wstrict-prototypes -Wold-style-definition
 endif
 
 # Unwanted flags for c++
 CXXUWFLAGS += -std=%
+CXXUWFLAGS += -Wstrict-prototypes -Wold-style-definition
 
 ifeq ($(LTO),1)
   $(warning Building with Link-Time-Optimizations is currently an experimental feature. Expect broken binaries.)

--- a/makefiles/cflags.inc.mk
+++ b/makefiles/cflags.inc.mk
@@ -25,21 +25,23 @@ ifeq ($(shell $(CC) -fno-delete-null-pointer-checks -E - 2>/dev/null >/dev/null 
   endif
 endif
 
+# Template for testing a compiler flag and adding it to CFLAGS (errors usually
+# happens when using older toolchains which do not support the given flags)
+define cflags_test_and_add
+  ifeq ($(shell $(CC) $(1) -E - 2>/dev/null >/dev/null </dev/null ; echo $$?),0)
+    CFLAGS += $(1)
+  endif
+endef
 # Use colored compiler output if the compiler supports this and if this is not
 # disabled by the user
 ifeq ($(CC_NOCOLOR),0)
-  ifeq ($(shell $(CC) -fdiagnostics-color -E - 2>/dev/null >/dev/null </dev/null ; echo $$?),0)
-    CFLAGS += -fdiagnostics-color
-  endif
+  $(eval $(call cflags_test_and_add,-fdiagnostics-color))
 endif
 
 # Fast-out on old style function definitions.
 # They cause unreadable error compiler errors on missing semicolons.
 # Worse yet they hide errors by accepting wildcard argument types.
-ifeq ($(shell $(CC) -Wstrict-prototypes -Werror=strict-prototypes -Wold-style-definition -Werror=old-style-definition -E - 2>/dev/null >/dev/null </dev/null ; echo $$?),0)
-  # duplicated parameters don't hurt
-  CFLAGS += -Wstrict-prototypes -Wold-style-definition
-endif
+$(foreach flag,-Wstrict-prototypes -Wold-style-definition,$(eval $(call cflags_test_and_add,$(flag))))
 
 # Unwanted flags for c++
 CXXUWFLAGS += -std=%


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Using a makefile template reduces the code duplication in cflags.inc.mk

### Issues/PRs references

depends on ~#9357~