### PR TITLE
make: Makefile.include: Remove -Wno-implicit-fallthrough

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -141,10 +141,6 @@ ifeq ($(WPEDANTIC),1)
   CFLAGS += -Wpedantic
 endif
 
-# remove this once codebase is adapted
-CFLAGS += -Wno-implicit-fallthrough
-CXXFLAGS += -Wno-implicit-fallthrough
-
 ifneq (10,$(if $(RIOT_VERSION),1,0)$(if $(__RIOTBUILD_FLAG),1,0))
 
 # Provide a shallow sanity check. You cannot call `make` in a module directory.

--- a/Makefile.include
+++ b/Makefile.include
@@ -248,6 +248,16 @@ include $(RIOTCPU)/$(CPU)/Makefile.include
 # Import all toolchain settings
 include $(RIOTMAKE)/toolchain/$(TOOLCHAIN).inc.mk
 
+# Tell ccache to pass the original file to the compiler, instead of passing the
+# preprocessed code. Without this setting, the compilation will fail with
+# -Wimplicit-fallthrough warnings even when the fall through case is properly
+# commented because the preprocessor has stripped the comments from the code.
+# This also fixes some other false warnings when compiling with LLVM/Clang.
+# The environment variable only affects builds with ccache (e.g. on CI/Murdock).
+# Non cached builds are not affected in any way.
+# For more information, see http://petereisentraut.blogspot.com/2011/09/ccache-and-clang-part-2.html
+export CCACHE_CPP2=yes
+
 # get number of interfaces straight before resolving dependencies
 GNRC_NETIF_NUMOF ?= 1
 

--- a/drivers/sht1x/sht1x_saul.c
+++ b/drivers/sht1x/sht1x_saul.c
@@ -41,6 +41,7 @@ static int read(const sht1x_dev_t *dev, int16_t *temp, int16_t *hum)
                 continue;
             case -ECANCELED:
                 puts("[sht1x] Measurement times out");
+                /* falls through */
             default:
                 /* Other failure, cannot recover so giving up */
                 return -1;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

These flags should hopefully not be necessary now.

### Issues/PRs references

Introduced in #8603, #8617