### PR TITLE
core/pthread: make them compilable with g++

### DIFF
--- a/core/include/native_sched.h
+++ b/core/include/native_sched.h
@@ -48,6 +48,14 @@ inline int sched_yield(void)
     puts("[ERROR] sched_yield called (defined in sched.h)\n");
     return 0;
 }
+#else
+/**
+ * @brief Compilation with g++ may require the declaration of this function.
+ *
+ * If implementation of this function is required, it can be realized in
+ * thread_arch.c.
+ */
+extern int sched_yield(void);
 #endif /* BOARD_NATIVE */
 
 #ifdef __cplusplus

--- a/sys/posix/pthread/include/pthread_spin.h
+++ b/sys/posix/pthread/include/pthread_spin.h
@@ -20,10 +20,11 @@
 #ifndef PTHREAD_SPIN_H
 #define PTHREAD_SPIN_H
 
-#include <stdatomic.h>
-
 #ifdef __cplusplus
-extern "C" {
+#include <atomic>
+using std::atomic_flag;
+#else
+#include <stdatomic.h>
 #endif
 
 /**
@@ -35,6 +36,10 @@ extern "C" {
 typedef struct {
     atomic_flag flag; /**< Current lock state */
 } pthread_spinlock_t;
+
+#ifdef __cplusplus
+extern "C" {
+#endif
 
 /**
  * @brief           Intializes a spinlock.


### PR DESCRIPTION
If ```pthread``` is used in source files that have to be compiled with g++, ```atomic``` has to be included instead of ```stdatomic.h``` in ```pthread_spin.h```. 

The compilation with g++ may also require the declaration of function  ```sched_yield```. This should be declared not only for the native architecture, but in any case. It can then be implemented in ```thread_arch.c``` if necessary.