### PR TITLE
core: add architecture dependent thread information

### DIFF
--- a/core/include/thread.h
+++ b/core/include/thread.h
@@ -209,7 +209,10 @@ struct _thread {
     const char *name;               /**< thread's name                  */
     int stack_size;                 /**< thread's stack size            */
 #endif
-};
+#ifdef HAVE_THREAD_ARCH_EXT_T 
+    thread_arch_ext_t arch;         /**< architecture dependent exten- 
+                                         sions                          */ 
+#endif };
 
 /**
  * @def THREAD_STACKSIZE_DEFAULT

--- a/core/include/thread.h
+++ b/core/include/thread.h
@@ -209,10 +209,10 @@ struct _thread {
     const char *name;               /**< thread's name                  */
     int stack_size;                 /**< thread's stack size            */
 #endif
-#ifdef HAVE_THREAD_ARCH_EXT_T 
-    thread_arch_ext_t arch;         /**< architecture dependent exten- 
-                                         sions                          */ 
-#endif };
+#ifdef HAVE_THREAD_ARCH_T
+    thread_arch_t arch;             /**< architecture dependent part    */
+#endif
+};
 
 /**
  * @def THREAD_STACKSIZE_DEFAULT


### PR DESCRIPTION
By adding a member of type ```thread_arch_t``` to the ```thread_t``` structure, depending on the existence of definition ```HAVE_THREAD_ARCH_T```, it is possible to add architecture-dependent information to the thread control block that are required to restore the context. This could be used for example for references to the co-processor save area.

Since ```thread.h``` includes ```$(ROITCPU)/include/cpu_conf.h```, the architecture dependent definition of additional context information can be placed there. For example, the following code add additional members to the thread context as required for the EPS32 architecture.
```
/**
 * @brief   Architecture depended part of thread control block for ESP32 CPU
 */
#define HAVE_THREAD_ARCH_T
typedef struct {
    uint32_t* saved_int_level;    /**< pointer to saved interrupt level */
    uint32_t* cp_save_area;       /**< pointer to co-processor save area */
} thread_arch_t;
```
This PR is related to issue #9359