### PR TITLE
boards: slstk3402a: add uart modes

### DIFF
--- a/boards/slstk3402a/include/periph_conf.h
+++ b/boards/slstk3402a/include/periph_conf.h
@@ -167,6 +167,9 @@ static const uart_conf_t uart_config[] = {
         .tx_pin = GPIO_PIN(PA, 0),
         .loc = USART_ROUTELOC0_RXLOC_LOC0 |
                USART_ROUTELOC0_TXLOC_LOC0,
+#if EFM32_UART_MODES
+        .mode = UART_MODE_8N1,
+#endif
         .cmu = cmuClock_USART0,
         .irq = USART0_RX_IRQn
     },
@@ -176,6 +179,9 @@ static const uart_conf_t uart_config[] = {
         .tx_pin = GPIO_PIN(PD, 10),
         .loc = LEUART_ROUTELOC0_RXLOC_LOC18 |
                LEUART_ROUTELOC0_TXLOC_LOC18,
+#if EFM32_UART_MODES
+        .mode = UART_MODE_8N1,
+#endif
         .cmu = cmuClock_LEUART0,
         .irq = LEUART0_IRQn
     }


### PR DESCRIPTION
### Contribution description

SLSTK3402a is missing non-standard UART modes, which was added with #9127 for the other boards.

### Issues/PRs references

#9127