### PR TITLE
tests: cpu_efm32_features: add test application

### DIFF
--- a/tests/cpu_efm32_features/Makefile
+++ b/tests/cpu_efm32_features/Makefile
@@ -1,0 +1,16 @@
+include ../Makefile.tests_common
+
+BOARD = sltb001a
+
+BOARD_WHITELIST := ikea-tradfri \
+                   slstk3401a \
+                   slstk3402a \
+                   sltb001a \
+                   slwstk6000b \
+                   stk3600 \
+                   stk3700
+
+# see cpu/efm32/efm32-features.mk for the supported flags
+EFM32_UART_MODES = 1
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/cpu_efm32_features/README.md
+++ b/tests/cpu_efm32_features/README.md
@@ -1,0 +1,9 @@
+# EFM32 CPU Features
+
+## Introduction
+The EFM32 support several features that can be toggled compile-time.
+
+This test will ensure that RIOT-OS will compile whenever these features are toggled.
+
+## Expected result
+The test application compiles for EFM32-based boards.

--- a/tests/cpu_efm32_features/main.c
+++ b/tests/cpu_efm32_features/main.c
@@ -1,0 +1,42 @@
+/*
+ * Copyright (C) 2018 Bas Stottelaar <basstottelaar@gmail.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Test application for EFM32 specific features.
+ *
+ * @author      Bas Stottelaar <basstottelaar@gmail.com>
+ *
+ * @}
+ */
+
+#include "periph/uart.h"
+
+int main(void)
+{
+    /* test if uart_config[i].mode is set to a know value */
+    for (unsigned i = 0; i < UART_NUMOF; i++) {
+        printf("UART %u mode: ", i);
+
+        switch (uart_config[i].mode) {
+            case UART_MODE_8N1:
+                puts("8N1");
+                break;
+            case UART_MODE_8E1:
+                puts("8E1");
+                break;
+            default:
+                puts("unknown");
+        }
+    }
+
+    return 0;
+}


### PR DESCRIPTION
### Contribution description

With #9127, I have added support for non-standard UART modes, enabled using a flag. This application adds support for testing this feature (and future features I have planned), so that we can assert that RIOT still compiles. 

Without this test application, there is no automatic way to assert this. 

### Issues/PRs references

#9127