### PR TITLE
cpu/msp430fxyz: Fixed input sanitizing in GPIO_PIN

### DIFF
--- a/cpu/msp430fxyz/include/periph_cpu.h
+++ b/cpu/msp430fxyz/include/periph_cpu.h
@@ -45,7 +45,7 @@ typedef uint16_t gpio_t;
  * @brief   Mandatory function for defining a GPIO pins
  * @{
  */
-#define GPIO_PIN(x, y)      ((gpio_t)(((x & 0xff) << 8) | (1 << (y & 0xff))))
+#define GPIO_PIN(x, y)      ((gpio_t)(((x & 0xff) << 8) | (1 << (y & 0x07))))
 
 /**
  * @brief   No support for HW chip select...


### PR DESCRIPTION
In `cpu/msp430fxyz/include/periph_cpu.h` the type `gpio_t` is defined as:

``` C
typedef uint16_t gpio_t;
```

The old version of the macro is:

``` C
#define GPIO_PIN(x, y)      ((gpio_t)(((x & 0xff) << 8) | (1 << (y & 0xff))))
```

Both `x` and `y` are sanitized by using bit-wise and. But the `y` sanitizing is not correct:
1 can be shifted at most 15 times to the left in an `uint16_t`. But the upper 8 bits are determined by the port `x`, so only the lower 8 bit should be determined by `y`. Thus, the correct bitmask is `0x07` to sanitize `y`.

Update: My original patch and statement was strictly wrong. It should be fixed now.