### PR TITLE
pic32: Add SPI Support

### DIFF
--- a/boards/pic32-clicker/Makefile.features
+++ b/boards/pic32-clicker/Makefile.features
@@ -1,5 +1,6 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_gpio
+FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 

--- a/boards/pic32-clicker/clicker.c
+++ b/boards/pic32-clicker/clicker.c
@@ -32,10 +32,6 @@ void board_init(void)
     uart_init(DEBUG_VIA_UART, DEBUG_UART_BAUD, NULL, 0);
 #endif
 
-    /* Initialise all SPI modules */
-    for (unsigned i = 1; i <= SPI_NUMOF; i++)
-        spi_init(SPI_DEV(i));
-
     /* Turn off all LED's */
     gpio_init(LED1_PIN, GPIO_OUT);
     gpio_init(LED2_PIN, GPIO_OUT);

--- a/boards/pic32-clicker/clicker.c
+++ b/boards/pic32-clicker/clicker.c
@@ -10,6 +10,7 @@
 #include <stdio.h>
 #include <stdint.h>
 #include "periph/gpio.h"
+#include "periph/spi.h"
 #include "periph/uart.h"
 #include "bitarithm.h"
 #include "board.h"
@@ -30,6 +31,10 @@ void board_init(void)
 #ifdef DEBUG_VIA_UART
     uart_init(DEBUG_VIA_UART, DEBUG_UART_BAUD, NULL, 0);
 #endif
+
+    /* Initialise all SPI modules */
+    for (unsigned i = 1; i <= SPI_NUMOF; i++)
+        spi_init(SPI_DEV(i));
 
     /* Turn off all LED's */
     gpio_init(LED1_PIN, GPIO_OUT);

--- a/boards/pic32-clicker/include/periph_conf.h
+++ b/boards/pic32-clicker/include/periph_conf.h
@@ -1,6 +1,7 @@
 /*
  * Copyright(C) 2016,2017, Imagination Technologies Limited and/or its
  *                 affiliated group companies.
+ *              2017 Francois Berder <fberder@outlook.fr>
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -18,12 +19,14 @@
  * @brief       peripheral configuration for the MikroE PIC32 Clicker
  *
  * @author      Neil Jones <Neil.Jones@imgtec.com>
+ * @author      Francois Berder <fberder@outlook.fr>
  */
 
 #ifndef PERIPH_CONF_H
 #define PERIPH_CONF_H
 
 #include "periph_cpu.h"
+#include "vendor/p32mx470f512h.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -57,6 +60,48 @@ extern "C" {
 #define UART_NUMOF          (4)
 #define DEBUG_VIA_UART      (3)
 #define DEBUG_UART_BAUD     (9600)
+/** @} */
+
+
+/**
+ * @name    SPI device configuration
+ *
+ * @{
+ */
+
+static const spi_conf_t spi_config[] = {
+    {}, /* No SPI0 on PIC32 */
+
+    {   /*
+         * SPI 1 (Mikrobus)
+         *      MOSI -> RD4
+         *      MISO -> RD3
+         *      SCK  -> RD2
+         */
+        .mosi_pin = GPIO_PIN(PORT_D, 4),
+        .mosi_reg = (volatile uint32_t*)&RPD4R,
+        .mosi_af  = 0b1000,
+        .miso_pin = GPIO_PIN(PORT_D, 3),
+        .miso_reg = (volatile uint32_t*)&SDI1R,
+        .miso_af  = 0b0000
+    },
+
+    {   /*
+         * SPI 2 (6LoWPAN radio)
+         *      MOSI -> RG8
+         *      MISO -> RG7
+         *      SCK  -> RG6
+         */
+        .mosi_pin = GPIO_PIN(PORT_G, 8),
+        .mosi_reg = (volatile uint32_t*)&RPG8R,
+        .mosi_af  = 0b0110,
+        .miso_pin = GPIO_PIN(PORT_G, 7),
+        .miso_reg = (volatile uint32_t*)&SDI2R,
+        .miso_af  = 0b0001
+    }
+};
+
+#define SPI_NUMOF           (2)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/pic32-clicker/include/periph_conf.h
+++ b/boards/pic32-clicker/include/periph_conf.h
@@ -70,7 +70,15 @@ extern "C" {
  */
 
 static const spi_conf_t spi_config[] = {
-    {}, /* No SPI0 on PIC32 */
+    {
+        /* No SPI0 on PIC32 */
+        .mosi_pin = 0,
+        .mosi_reg = (volatile uint32_t*)0,
+        .mosi_af  = 0,
+        .miso_pin = 0,
+        .miso_reg = (volatile uint32_t*)0,
+        .miso_af  = 0,
+    },
 
     {   /*
          * SPI 1 (Mikrobus)
@@ -80,10 +88,10 @@ static const spi_conf_t spi_config[] = {
          */
         .mosi_pin = GPIO_PIN(PORT_D, 4),
         .mosi_reg = (volatile uint32_t*)&RPD4R,
-        .mosi_af  = 0b1000,
+        .mosi_af  = 0x8, /* 0b1000 */
         .miso_pin = GPIO_PIN(PORT_D, 3),
         .miso_reg = (volatile uint32_t*)&SDI1R,
-        .miso_af  = 0b0000
+        .miso_af  = 0x0, /* 0b0000 */
     },
 
     {   /*
@@ -94,10 +102,10 @@ static const spi_conf_t spi_config[] = {
          */
         .mosi_pin = GPIO_PIN(PORT_G, 8),
         .mosi_reg = (volatile uint32_t*)&RPG8R,
-        .mosi_af  = 0b0110,
+        .mosi_af  = 0x6, /* 0b0110 */
         .miso_pin = GPIO_PIN(PORT_G, 7),
         .miso_reg = (volatile uint32_t*)&SDI2R,
-        .miso_af  = 0b0001
+        .miso_af  = 0x1 /* 0b0001 */
     }
 };
 

--- a/boards/pic32-wifire/Makefile.features
+++ b/boards/pic32-wifire/Makefile.features
@@ -1,5 +1,6 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_gpio
+FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 

--- a/boards/pic32-wifire/include/periph_conf.h
+++ b/boards/pic32-wifire/include/periph_conf.h
@@ -1,6 +1,7 @@
 /*
  * Copyright(C) 2016,2017, Imagination Technologies Limited and/or its
  *                 affiliated group companies.
+ *              2017 Francois Berder <fberder@outlook.fr>
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -18,11 +19,13 @@
  * @brief       peripheral configuration for the Digilent PIC32 WiFire
  *
  * @author       Neil Jones <Neil.Jones@imgtec.com>
+ * @author       Francois Berder <fberder@outlook.fr>
  */
 #ifndef PERIPH_CONF_H
 #define PERIPH_CONF_H
 
 #include "periph_cpu.h"
+#include "vendor/p32mz2048efg100.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -54,6 +57,75 @@ extern "C" {
 #define UART_NUMOF          (6)
 #define DEBUG_VIA_UART      (4)
 #define DEBUG_UART_BAUD     (9600)
+/** @} */
+
+/**
+ * @name    SPI device configuration
+ *
+ * @{
+ */
+
+static const spi_conf_t spi_config[] = {
+    {}, /* No SPI0 on PIC32 */
+
+    {   /*
+         * SPI 1 (J10 connector)
+         *      MOSI -> RE5
+         *      MISO -> RD2
+         *      SCK  -> RD1
+         */
+        .mosi_pin = GPIO_PIN(PORT_E, 5),
+        .mosi_reg = (volatile uint32_t*)&RPE5R,
+        .mosi_af  = 0b0101,
+        .miso_pin = GPIO_PIN(PORT_D, 2),
+        .miso_reg = (volatile uint32_t*)&SDI1R,
+        .miso_af  = 0b000
+    },
+
+    {   /*
+         * SPI 2 (J9 connector)
+         *      MOSI -> RF0
+         *      MISO -> RD11
+         *      SCK  -> RG6
+         */
+        .mosi_pin = GPIO_PIN(PORT_F, 0),
+        .mosi_reg = (volatile uint32_t*)&RPF0R,
+        .mosi_af  = 0b0110,
+        .miso_pin = GPIO_PIN(PORT_D, 11),
+        .miso_reg = (volatile uint32_t*)&SDI2R,
+        .miso_af  = 0b0011,
+    },
+
+    {   /*
+         * SPI 3 (microSD card)
+         *   MOSI -> RC4
+         *   MISO -> RB10
+         *   SCK  -> RB14
+         */
+        .mosi_pin = GPIO_PIN(PORT_C, 4),
+        .mosi_reg = (volatile uint32_t*)&RPC4R,
+        .mosi_af  = 0b0111,
+        .miso_pin = GPIO_PIN(PORT_B, 10),
+        .miso_reg = (volatile uint32_t*)&SDI3R,
+        .miso_af  = 0b0110,
+    },
+
+    {   /*
+         * SPI 4 (MRF24WG0MA - wifi module)
+         *   MOSI -> RG0
+         *   MISO -> RF5
+         *   SCK  -> RD10
+         */
+        .mosi_pin = GPIO_PIN(PORT_G, 0),
+        .mosi_reg = (volatile uint32_t*)&RPG0R,
+        .mosi_af  = 0b1000,
+        .miso_pin = GPIO_PIN(PORT_F, 5),
+        .miso_reg = (volatile uint32_t*)&SDI4R,
+        .miso_af  = 0b0010,
+    },
+};
+
+#define SPI_NUMOF           (2)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/pic32-wifire/include/periph_conf.h
+++ b/boards/pic32-wifire/include/periph_conf.h
@@ -66,8 +66,15 @@ extern "C" {
  */
 
 static const spi_conf_t spi_config[] = {
-    {}, /* No SPI0 on PIC32 */
-
+    {
+        /* No SPI0 on PIC32 */
+        .mosi_pin = 0,
+        .mosi_reg = (volatile uint32_t*)0,
+        .mosi_af  = 0,
+        .miso_pin = 0,
+        .miso_reg = (volatile uint32_t*)0,
+        .miso_af  = 0,
+    },
     {   /*
          * SPI 1 (J10 connector)
          *      MOSI -> RE5
@@ -76,10 +83,10 @@ static const spi_conf_t spi_config[] = {
          */
         .mosi_pin = GPIO_PIN(PORT_E, 5),
         .mosi_reg = (volatile uint32_t*)&RPE5R,
-        .mosi_af  = 0b0101,
+        .mosi_af  = 0x5, /* 0b0101 */
         .miso_pin = GPIO_PIN(PORT_D, 2),
         .miso_reg = (volatile uint32_t*)&SDI1R,
-        .miso_af  = 0b000
+        .miso_af  = 0x0 /* 0b000 */
     },
 
     {   /*
@@ -90,10 +97,10 @@ static const spi_conf_t spi_config[] = {
          */
         .mosi_pin = GPIO_PIN(PORT_F, 0),
         .mosi_reg = (volatile uint32_t*)&RPF0R,
-        .mosi_af  = 0b0110,
+        .mosi_af  = 0x6, /* 0b0110 */
         .miso_pin = GPIO_PIN(PORT_D, 11),
         .miso_reg = (volatile uint32_t*)&SDI2R,
-        .miso_af  = 0b0011,
+        .miso_af  = 0x3, /* 0b0011 */
     },
 
     {   /*
@@ -104,10 +111,10 @@ static const spi_conf_t spi_config[] = {
          */
         .mosi_pin = GPIO_PIN(PORT_C, 4),
         .mosi_reg = (volatile uint32_t*)&RPC4R,
-        .mosi_af  = 0b0111,
+        .mosi_af  = 0x7, /* 0b0111 */
         .miso_pin = GPIO_PIN(PORT_B, 10),
         .miso_reg = (volatile uint32_t*)&SDI3R,
-        .miso_af  = 0b0110,
+        .miso_af  = 0x6, /* 0b0110 */
     },
 
     {   /*
@@ -118,14 +125,14 @@ static const spi_conf_t spi_config[] = {
          */
         .mosi_pin = GPIO_PIN(PORT_G, 0),
         .mosi_reg = (volatile uint32_t*)&RPG0R,
-        .mosi_af  = 0b1000,
+        .mosi_af  = 0x8, /* 0b1000 */
         .miso_pin = GPIO_PIN(PORT_F, 5),
         .miso_reg = (volatile uint32_t*)&SDI4R,
-        .miso_af  = 0b0010,
+        .miso_af  = 0x2, /* 0b0010 */
     },
 };
 
-#define SPI_NUMOF           (2)
+#define SPI_NUMOF           (4)
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/pic32-wifire/wifire.c
+++ b/boards/pic32-wifire/wifire.c
@@ -12,6 +12,7 @@
 #include <stdint.h>
 #include "periph/gpio.h"
 #include "periph/hwrng.h"
+#include "periph/spi.h"
 #include "periph/uart.h"
 #include "bitarithm.h"
 #include "board.h"
@@ -32,6 +33,10 @@ void board_init(void)
 #ifdef DEBUG_VIA_UART
     uart_init(DEBUG_VIA_UART, DEBUG_UART_BAUD, NULL, 0);
 #endif
+
+    /* Initialise all SPI modules */
+    for (unsigned i = 1; i <= SPI_NUMOF; i++)
+        spi_init(SPI_DEV(i));
 
     /* Turn off all LED's */
     gpio_init(LED1_PIN, GPIO_OUT);

--- a/boards/pic32-wifire/wifire.c
+++ b/boards/pic32-wifire/wifire.c
@@ -34,10 +34,6 @@ void board_init(void)
     uart_init(DEBUG_VIA_UART, DEBUG_UART_BAUD, NULL, 0);
 #endif
 
-    /* Initialise all SPI modules */
-    for (unsigned i = 1; i <= SPI_NUMOF; i++)
-        spi_init(SPI_DEV(i));
-
     /* Turn off all LED's */
     gpio_init(LED1_PIN, GPIO_OUT);
     gpio_init(LED2_PIN, GPIO_OUT);

--- a/cpu/mips_pic32_common/Makefile.features
+++ b/cpu/mips_pic32_common/Makefile.features
@@ -1,3 +1,4 @@
 FEATURES_PROVIDED += periph_cpuid
+FEATURES_PROVIDED += periph_spi
 
 -include $(RIOTCPU)/mips32r2_common/Makefile.features

--- a/cpu/mips_pic32_common/include/periph_cpu_common.h
+++ b/cpu/mips_pic32_common/include/periph_cpu_common.h
@@ -22,6 +22,8 @@
 #ifndef PERIPH_CPU_COMMON_H
 #define PERIPH_CPU_COMMON_H
 
+#include <stdint.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -60,6 +62,42 @@ enum {
  * @brief   Prevent shared timer functions from being used
  */
 #define PERIPH_TIMER_PROVIDES_SET
+
+/**
+ * @brief   Use some common SPI functions
+ * @{
+ */
+#define PERIPH_SPI_NEEDS_INIT_CS
+#define PERIPH_SPI_NEEDS_TRANSFER_BYTE
+#define PERIPH_SPI_NEEDS_TRANSFER_REG
+#define PERIPH_SPI_NEEDS_TRANSFER_REGS
+/** @} */
+
+/**
+ * @brief   Override SPI clock speed values
+ * @{
+ */
+#define HAVE_SPI_CLK_T
+typedef enum {
+    SPI_CLK_100KHZ =   100000U, /**< drive the SPI bus with 100KHz */
+    SPI_CLK_400KHZ =   400000U, /**< drive the SPI bus with 400KHz */
+    SPI_CLK_1MHZ   =  1000000U, /**< drive the SPI bus with 1MHz */
+    SPI_CLK_5MHZ   =  5000000U, /**< drive the SPI bus with 5MHz */
+    SPI_CLK_10MHZ  = 10000000U  /**< drive the SPI bus with 10MHz */
+} spi_clk_t;
+/** @} */
+
+/**
+ * @brief   SPI device configuration
+ */
+typedef struct {
+    volatile uint32_t *mosi_reg;    /**< Output pin mux register address */
+    volatile uint32_t *miso_reg;    /**< MISO pin mux register address */
+    uint8_t mosi_af;                /**< Specify function of output pin */
+    uint8_t miso_af;                /**< Specify input pin for MISO */
+    gpio_t mosi_pin;                /**< GPIO pin for MOSI */
+    gpio_t miso_pin;                /**< GPIO pin for MISO */
+} spi_conf_t;
 
 #ifdef __cplusplus
 }

--- a/cpu/mips_pic32_common/include/periph_cpu_common.h
+++ b/cpu/mips_pic32_common/include/periph_cpu_common.h
@@ -90,13 +90,15 @@ typedef enum {
 /**
  * @brief   SPI device configuration
  */
+typedef unsigned int gpio_t;
+
 typedef struct {
-    volatile uint32_t *mosi_reg;    /**< Output pin mux register address */
-    volatile uint32_t *miso_reg;    /**< MISO pin mux register address */
-    uint8_t mosi_af;                /**< Specify function of output pin */
-    uint8_t miso_af;                /**< Specify input pin for MISO */
     gpio_t mosi_pin;                /**< GPIO pin for MOSI */
+    volatile uint32_t *mosi_reg;    /**< Output pin mux register address */
+    uint8_t mosi_af;                /**< Specify function of output pin */
     gpio_t miso_pin;                /**< GPIO pin for MISO */
+    volatile uint32_t *miso_reg;    /**< MISO pin mux register address */
+    uint8_t miso_af;                /**< Specify input pin for MISO */
 } spi_conf_t;
 
 #ifdef __cplusplus

--- a/cpu/mips_pic32_common/periph/spi.c
+++ b/cpu/mips_pic32_common/periph/spi.c
@@ -1,0 +1,144 @@
+/*
+ * Copyright(C) 2017 Francois Berder <fberder@outlook.fr>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ *
+ */
+
+#include "assert.h"
+#include "board.h"
+#include "mutex.h"
+#include "periph/gpio.h"
+#include "periph/spi.h"
+
+#define SPIxCON(U)          ((U).regs[0x00 / 4])
+#define SPIxCONCLR(U)       ((U).regs[0x04 / 4])
+#define SPIxCONSET(U)       ((U).regs[0x08 / 4])
+#define SPIxSTAT(U)         ((U).regs[0x10 / 4])
+#define SPIxSTATCLR(U)      ((U).regs[0x14 / 4])
+#define SPIxBUF(U)          ((U).regs[0x20 / 4])
+#define SPIxBRG(U)          ((U).regs[0x30 / 4])
+#define SPIxCON2(U)         ((U).regs[0x40 / 4])
+#define SPI_REGS_SPACING    (_SPI2_BASE_ADDRESS - _SPI1_BASE_ADDRESS)
+
+/* PERIPHERAL_CLOCK must be defined in board file */
+
+
+typedef struct PIC32_SPI_tag {
+    volatile uint32_t   *regs;
+} PIC32_SPI_T;
+
+static PIC32_SPI_T pic_spi[SPI_NUMOF + 1];
+static mutex_t locks[SPI_NUMOF + 1];
+
+void spi_init(spi_t bus)
+{
+    assert(bus != 0 && bus <= SPI_NUMOF);
+
+    mutex_init(&locks[bus]);
+
+    PMD5SET = _PMD5_SPI1MD_MASK << (bus - 1);
+    spi_init_pins(bus);
+}
+
+void spi_init_pins(spi_t bus)
+{
+    assert(bus != 0 && bus <= SPI_NUMOF);
+
+    gpio_init(spi_config[bus].mosi_pin, GPIO_OUT);
+    gpio_init(spi_config[bus].miso_pin, GPIO_IN);
+    *(spi_config[bus].mosi_reg) = spi_config[bus].mosi_af;
+    *(spi_config[bus].miso_reg) = spi_config[bus].miso_af;
+}
+
+int spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t clk)
+{
+    volatile int rdata __attribute__((unused));
+
+    assert(bus != 0 && bus <= SPI_NUMOF);
+
+    pic_spi[bus].regs = (volatile uint32_t *)(_SPI1_BASE_ADDRESS + (bus - 1) * SPI_REGS_SPACING);
+
+    mutex_lock(&locks[bus]);
+
+    PMD5CLR = _PMD5_SPI1MD_MASK << (bus - 1);
+
+    SPIxCON(pic_spi[bus]) = 0;
+    SPIxCON2(pic_spi[bus]) = 0;
+
+    /* Clear receive FIFO */
+    rdata = SPIxBUF(pic_spi[bus]);
+
+    switch (mode) {
+        case SPI_MODE_0:
+            SPIxCONCLR(pic_spi[bus]) = (_SPI1CON_CKP_MASK | _SPI1CON_CKE_MASK);
+            break;
+        case SPI_MODE_1:
+            SPIxCONCLR(pic_spi[bus]) = _SPI1CON_CKP_MASK;
+            SPIxCONSET(pic_spi[bus]) = _SPI1CON_CKE_MASK;
+            break;
+        case SPI_MODE_2:
+            SPIxCONCLR(pic_spi[bus]) = _SPI1CON_CKE_MASK;
+            SPIxCONSET(pic_spi[bus]) = _SPI1CON_CKP_MASK;
+            break;
+        case SPI_MODE_3:
+            SPIxCONSET(pic_spi[bus]) = (_SPI1CON_CKP_MASK | _SPI1CON_CKE_MASK);
+            break;
+        default:
+            return SPI_NOMODE;
+    }
+
+    SPIxBRG(pic_spi[bus]) = (PERIPHERAL_CLOCK / (2 * clk)) - 1;
+    SPIxSTATCLR(pic_spi[bus]) = _SPI1STAT_SPIROV_MASK;
+    SPIxCONSET(pic_spi[bus]) = (_SPI1CON_ON_MASK | _SPI1CON_MSTEN_MASK);
+
+    return SPI_OK;
+}
+
+void spi_release(spi_t bus)
+{
+    assert(bus != 0 && bus <= SPI_NUMOF);
+
+    /* SPI module must be turned off before powering it down */
+    SPIxCON(pic_spi[bus]) = 0;
+
+    PMD5SET = _PMD5_SPI1MD_MASK << (bus - 1);
+
+    mutex_unlock(&locks[bus]);
+}
+
+void spi_transfer_bytes(spi_t bus, spi_cs_t cs, bool cont,
+                        const void *out, void *in, size_t len)
+{
+    const uint8_t *out_buffer = (const uint8_t*)out;
+    uint8_t *in_buffer = (uint8_t*)in;
+
+    assert(bus != 0 && bus <= SPI_NUMOF);
+
+    if (cs != SPI_CS_UNDEF)
+        gpio_clear((gpio_t)cs);
+
+    while (len--) {
+        uint8_t rdata;
+
+        if (out_buffer) {
+            SPIxBUF(pic_spi[bus]) = *out_buffer++;
+
+            /* Wait until TX FIFO is empty */
+            while (!(SPIxSTAT(pic_spi[bus]) & _SPI1STAT_SPITBE_MASK)) {}
+        }
+
+        /* Wait until RX FIFO is not empty */
+        while (!(SPIxSTAT(pic_spi[bus]) & _SPI1STAT_SPIRBF_MASK)) {}
+
+        rdata = SPIxBUF(pic_spi[bus]);
+
+        if (in_buffer)
+            *in_buffer++ = rdata;
+    }
+
+    if (!cont && cs != SPI_CS_UNDEF)
+        gpio_set((gpio_t)cs);
+}


### PR DESCRIPTION
This is a re-open of #7383 with a couple of fixes + rebase.

This PR adds SPI support for PIC32 devices and has been tested on wifire and clicker.

Depends on #9433 