### PR TITLE
uncrustify: special function ISR

### DIFF
--- a/uncrustify-riot.cfg
+++ b/uncrustify-riot.cfg
@@ -74,3 +74,9 @@ align_on_tabstop       = TRUE      # align on tabstops
 align_enum_equ_span    = 4         # '=' in enum definition
 align_struct_init_span = 0         # align stuff in a structure init '= { }'
 align_right_cmt_span   = 3         #
+
+#
+# Special cases
+#
+
+set PROTO_WRAP ISR   # Wrap ISR macros like functions


### PR DESCRIPTION
This PR sets uncrustify to handle AVR ISR macro like functions and wrap them.

Uncrustify would change them from wrapped to unwrapped like this.

```
ISR(TIMER_1_ISRC, ISR_BLOCK){
    _isr(1, 2);
}
```

With this PR the ISR stay or will be changed to be formatted as follows 
```
ISR(TIMER_1_ISRC, ISR_BLOCK)
{
    _isr(1, 2);
}
```