### PR TITLE
drivers/pulse_counter: make gpio_mode configurable

### DIFF
--- a/drivers/pulse_counter/pulse_counter.c
+++ b/drivers/pulse_counter/pulse_counter.c
@@ -38,7 +38,15 @@ static void pulse_counter_trigger(void *arg)
 /* Initialize pulse counter */
 int pulse_counter_init(pulse_counter_t *dev, const pulse_counter_params_t *params)
 {
-    if (gpio_init_int(params->gpio, GPIO_IN_PU, params->gpio_flank, pulse_counter_trigger, dev)) {
+    gpio_mode_t gpio_mode;
+    if (params->gpio_flank == GPIO_FALLING) {
+        gpio_mode = GPIO_IN_PU;
+    }
+    else {
+        gpio_mode = GPIO_IN_PD;
+    }
+
+    if (gpio_init_int(params->gpio, gpio_mode, params->gpio_flank, pulse_counter_trigger, dev)) {
         return -1;
     }
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

This PR has a simple fix to make gpio_mode configurable.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->



<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->