### PR TITLE
sock_udp: allow creation with ephemeral ports

### DIFF
--- a/pkg/emb6/contrib/sock/udp/emb6_sock_udp.c
+++ b/pkg/emb6/contrib/sock/udp/emb6_sock_udp.c
@@ -84,7 +84,7 @@ int sock_udp_create(sock_udp_t *sock, const sock_udp_ep_t *local,
 
     (void)flags;
     assert((sock != NULL));
-    assert((local == NULL) || (local->port != 0));
+    assert((local == NULL));
     assert((remote == NULL) || (remote->port != 0));
     if (sock->sock.input_callback != NULL) {
         sock_udp_close(sock);

--- a/pkg/lwip/contrib/sock/udp/lwip_sock_udp.c
+++ b/pkg/lwip/contrib/sock/udp/lwip_sock_udp.c
@@ -29,7 +29,7 @@ int sock_udp_create(sock_udp_t *sock, const sock_udp_ep_t *local,
                     const sock_udp_ep_t *remote, uint16_t flags)
 {
     assert(sock != NULL);
-    assert(local == NULL || local->port != 0);
+    assert(local == NULL);
     assert(remote == NULL || remote->port != 0);
 
     int res;

--- a/sys/include/net/sock/udp.h
+++ b/sys/include/net/sock/udp.h
@@ -293,17 +293,18 @@ typedef struct sock_udp sock_udp_t;
  * @brief   Creates a new UDP sock object
  *
  * @pre `(sock != NULL)`
- * @pre `(local == NULL) || (local->port != 0)`
+ * @pre `(local == NULL)`
  * @pre `(remote == NULL) || (remote->port != 0)`
  *
  * @param[out] sock     The resulting sock object.
  * @param[in] local     Local end point for the sock object.
  *                      May be NULL.
- *                      sock_udp_ep_t::port must not be 0 if `local != NULL`.
  *                      sock_udp_ep_t::netif must either be
  *                      @ref SOCK_ADDR_ANY_NETIF or equal to
  *                      sock_udp_ep_t::netif of @p remote if `remote != NULL`.
  *                      If NULL @ref sock_udp_send() may bind implicitly.
+ *                      sock_udp_ep_t::port may also be 0 to bind the `sock` to
+ *                      an ephemeral port.
  * @param[in] remote    Remote end point for the sock object.
  *                      May be `NULL` but then the `remote` parameter of
  *                      @ref sock_udp_send() may not be `NULL` or it will
@@ -318,7 +319,8 @@ typedef struct sock_udp sock_udp_t;
  *
  * @return  0 on success.
  * @return  -EADDRINUSE, if `local != NULL` and @p local is already used
- *         elsewhere
+ *          elsewhere or if `local->port == 0` but the pool of ephemeral ports
+ *          is depleted
  * @return  -EAFNOSUPPORT, if `local != NULL` or `remote != NULL` and
  *          sock_udp_ep_t::family of @p local or @p remote is not supported.
  * @return  -EINVAL, if sock_udp_ep_t::addr of @p remote is an invalid address.

--- a/sys/include/net/sock/udp.h
+++ b/sys/include/net/sock/udp.h
@@ -421,6 +421,8 @@ ssize_t sock_udp_recv(sock_udp_t *sock, void *data, size_t max_len,
  *                      sock_udp_ep_t::port may not be 0.
  *
  * @return  The number of bytes sent on success.
+ * @return  -EADDRINUSE, if `sock` has no local end-point or was `NULL` and the
+ *          pool of available ephemeral ports is depleted.
  * @return  -EAFNOSUPPORT, if `remote != NULL` and sock_udp_ep_t::family of
  *          @p remote is != AF_UNSPEC and not supported.
  * @return  -EHOSTUNREACH, if @p remote or remote end point of @p sock is not

--- a/sys/net/gnrc/sock/udp/gnrc_sock_udp.c
+++ b/sys/net/gnrc/sock/udp/gnrc_sock_udp.c
@@ -256,7 +256,7 @@ ssize_t sock_udp_send(sock_udp_t *sock, const void *data, size_t len,
         /* no sock or sock currently unbound */
         memset(&local, 0, sizeof(local));
         if ((src_port = _get_dyn_port(sock)) == GNRC_SOCK_DYN_PORTRANGE_ERR) {
-            return -EINVAL;
+            return -EADDRINUSE;
         }
         /* cppcheck-suppress nullPointer
          * (reason: sock *can* be NULL at this place, cppcheck is weird here as

--- a/sys/net/gnrc/sock/udp/gnrc_sock_udp.c
+++ b/sys/net/gnrc/sock/udp/gnrc_sock_udp.c
@@ -87,7 +87,7 @@ int sock_udp_create(sock_udp_t *sock, const sock_udp_ep_t *local,
                     const sock_udp_ep_t *remote, uint16_t flags)
 {
     assert(sock);
-    assert(local == NULL || local->port != 0);
+    assert(local == NULL);
     assert(remote == NULL || remote->port != 0);
     if ((local != NULL) && (remote != NULL) &&
         (local->netif != SOCK_ADDR_ANY_NETIF) &&
@@ -97,6 +97,12 @@ int sock_udp_create(sock_udp_t *sock, const sock_udp_ep_t *local,
     }
     memset(&sock->local, 0, sizeof(sock_udp_ep_t));
     if (local != NULL) {
+        if (local->port == 0U) {
+            local->port = _get_dyn_port(sock);
+            if (local->port == GNRC_SOCK_DYN_PORTRANGE_ERR) {
+                return -EADDRINUSE;
+            }
+        }
 #ifdef MODULE_GNRC_SOCK_CHECK_REUSE
         if (!(flags & SOCK_FLAGS_REUSE_EP)) {
             for (sock_udp_t *ptr = _udp_socks; ptr != NULL;

--- a/sys/net/gnrc/sock/udp/gnrc_sock_udp.c
+++ b/sys/net/gnrc/sock/udp/gnrc_sock_udp.c
@@ -97,14 +97,13 @@ int sock_udp_create(sock_udp_t *sock, const sock_udp_ep_t *local,
     }
     memset(&sock->local, 0, sizeof(sock_udp_ep_t));
     if (local != NULL) {
-        if (local->port == 0U) {
-            local->port = _get_dyn_port(sock);
-            if (local->port == GNRC_SOCK_DYN_PORTRANGE_ERR) {
-                return -EADDRINUSE;
-            }
+        uint16_t port = local->port;
+
+        if (gnrc_af_not_supported(local->family)) {
+            return -EAFNOSUPPORT;
         }
 #ifdef MODULE_GNRC_SOCK_CHECK_REUSE
-        if (!(flags & SOCK_FLAGS_REUSE_EP)) {
+        if ((port != 0) && !(flags & SOCK_FLAGS_REUSE_EP)) {
             for (sock_udp_t *ptr = _udp_socks; ptr != NULL;
                  ptr = (sock_udp_t *)ptr->reg.next) {
                 if (memcmp(&ptr->local, local, sizeof(sock_udp_ep_t)) == 0) {
@@ -116,10 +115,14 @@ int sock_udp_create(sock_udp_t *sock, const sock_udp_ep_t *local,
         sock->reg.next = (gnrc_sock_reg_t *)_udp_socks;
         _udp_socks = sock;
 #endif
-        if (gnrc_af_not_supported(local->family)) {
-            return -EAFNOSUPPORT;
+        if (port == 0U) {
+            port = _get_dyn_port(sock);
+            if (port == GNRC_SOCK_DYN_PORTRANGE_ERR) {
+                return -EADDRINUSE;
+            }
         }
         memcpy(&sock->local, local, sizeof(sock_udp_ep_t));
+        sock->local.port = port;
     }
     memset(&sock->remote, 0, sizeof(sock_udp_ep_t));
     if (remote != NULL) {


### PR DESCRIPTION
### Contribution description
This change allows the port for local endpoint to be zero 0. If this is the case the `sock_udp_create()` function binds the object to an ephemeral port.

This also provides the port for GNRC, lwIP, and emb6. Since GNRC doesn't support ephemeral ports natively (something like a UDP end-point isn't modeled in `netapi`) the port for this is a little bit more involved, but still a 5 liner. lwIP and emb6 handle this situation already internally, so only the assert needed changing.

This also piggy-backs a change for the return value of `sock_udp_send()` since the return value for when no ephemeral ports are available anymore shouldn't be `-EINVAL` (the input wasn't invalid, but some internal state isn't able to deliver).

### Issues/PRs references
Fixes #9376