### PR TITLE
pkgs/cmake: fix CFLAGS given two times

### DIFF
--- a/pkg/ccn-lite/Makefile
+++ b/pkg/ccn-lite/Makefile
@@ -5,7 +5,7 @@ PKG_LICENSE=ISC
 
 .PHONY: all
 
-export RIOT_CFLAGS = $(CFLAGS) $(INCLUDES)
+RIOT_CFLAGS = $(INCLUDES)
 
 TOOLCHAIN_FILE=$(PKG_BUILDDIR)/xcompile-toolchain.cmake
 

--- a/pkg/jerryscript/Makefile.jerryscript
+++ b/pkg/jerryscript/Makefile.jerryscript
@@ -4,8 +4,6 @@ JERRYHEAP  ?= 16
 
 EXT_CFLAGS :=-D__TARGET_RIOT
 
-EXT_CFLAGS += $(CFLAGS)
-
 .PHONY: libjerry riot-jerry flash clean
 
 # all: libjerry riot-jerry


### PR DESCRIPTION
### Contribution description

This PR prevents CFLAGS from being provided twice to cmake object compilation.
It is reqiured to allow providing `nano.specs` in `CFLAGS`

It is a split of https://github.com/RIOT-OS/RIOT/pull/9216. I reused @smlng commits and addressed https://github.com/RIOT-OS/RIOT/pull/9216#discussion_r195118323

### Testing

I compiled with `VERBOSE=1 make -C examples/ccn-lite-relay`

I extracted the first different line when building `examples/ccn-lite-relay` and split in lines and we can see that the removed lines with, for example, `riotbuild.h` which is not provided twice now.

``` diff
diff -u out_master_1 out_pr_1
--- out_master_1        2018-06-20 16:01:10.642462658 +0200
+++ out_pr_1    2018-06-20 16:01:54.938633694 +0200
@@ -17,13 +17,6 @@
 -fno-common -Wall -Wmissing-include-dirs -include
 '/home/harter/work/git/RIOT/examples/ccn-lite-relay/bin/native/riotbuild/riotbuild.h'
 -Wextra -Wall -Werror -std=c99 -g
--Wall -Werror -Wextra
--Wno-implicit-fallthrough -Wall -Wextra -pedantic -std=gnu99 -m32
--fstack-protector-all -ffunction-sections -fdata-sections
--fno-delete-null-pointer-checks -fdiagnostics-color -Wstrict-prototypes
--Wold-style-definition -Werror=strict-prototypes -Werror=old-style-definition
--fno-common -Wall -Wmissing-include-dirs -include
-'/home/harter/work/git/RIOT/examples/ccn-lite-relay/bin/native/riotbuild/riotbuild.h'
 -I/home/harter/work/git/RIOT/core/include
 -I/home/harter/work/git/RIOT/drivers/include
 -I/home/harter/work/git/RIOT/sys/include
```

And the same for `examples/javascript`

``` diff
diff -u javascript_*                                                                                                                                                                                                                                       
--- javascript_master   2018-06-20 16:19:43.544641209 +0200
+++ javascript_pr       2018-06-20 16:19:45.748654264 +0200
@@ -25,14 +25,5 @@
 '/home/harter/work/git/RIOT/examples/javascript/bin/native/riotbuild/riotbuild.h'
 -I/home/harter/work/git/RIOT/examples/javascript/bin/native/js/
 -Wno-implicit-fallthrough  -D__TARGET_RIOT
--Wall -Werror -Wextra
--Wno-implicit-fallthrough -Wall -Wextra -pedantic -std=gnu99 -m32
--fstack-protector-all -ffunction-sections -fdata-sections
--fno-delete-null-pointer-checks -fdiagnostics-color -Wstrict-prototypes
--Wold-style-definition -Werror=strict-prototypes -Werror=old-style-definition
--fno-common -Wall -Wmissing-include-dirs -include
-'/home/harter/work/git/RIOT/examples/javascript/bin/native/riotbuild/riotbuild.h'
--I/home/harter/work/git/RIOT/examples/javascript/bin/native/js/
--Wno-implicit-fallthrough
 -o CMakeFiles/jerry-core.dir/api/jerry-debugger.c.obj
 -c /home/harter/work/git/RIOT/examples/javascript/bin/pkg/native/jerryscript/jerry-core/api/jerry-debugger.c
```

### Issues/PRs references

Split from https://github.com/RIOT-OS/RIOT/pull/9216 or https://github.com/RIOT-OS/RIOT/pull/9281

Fixes https://github.com/RIOT-OS/RIOT/issues/9254