### PR TITLE
newlib.mk: replace the error by a warning on nano header not found

### DIFF
--- a/makefiles/libc/newlib.mk
+++ b/makefiles/libc/newlib.mk
@@ -78,7 +78,7 @@ ifeq (1,$(USE_NEWLIB_NANO))
   # newlib-nano overrides newlib.h and its include dir should therefore go before
   # the regular system include dirs.
   ifeq (,$(wildcard $(NEWLIB_NANO_INCLUDE_DIR)))
-    # HACK until this is really fixed. It keeps the old build system behaviour
+    # TODO: HACK until this is really fixed. It keeps the old build system behaviour
     # but removes the error on non existing directory
     $(warning $(lastword $(MAKEFILE_LIST)) could not correctly find include path to newlib-nano headers.)
     $(warning It was set to $(NEWLIB_NANO_INCLUDE_DIR) which does not exist on your system.)

--- a/makefiles/libc/newlib.mk
+++ b/makefiles/libc/newlib.mk
@@ -77,7 +77,15 @@ ifeq (1,$(USE_NEWLIB_NANO))
                                                     $(NEWLIB_INCLUDE_DIR)nano))
   # newlib-nano overrides newlib.h and its include dir should therefore go before
   # the regular system include dirs.
-  INCLUDES := -isystem $(NEWLIB_NANO_INCLUDE_DIR) $(INCLUDES)
+  ifeq (0,$(words $(wildcard $(NEWLIB_NANO_INCLUDE_DIR))))
+    # HACK until this is really fixed. It keeps the old build system behaviour
+    # but removes the error on non existing directory
+    $(warning $(lastword $(MAKEFILE_LIST)) could not correctly find include path to newlib-nano headers.)
+    $(warning It was set to $(NEWLIB_NANO_INCLUDE_DIR) which does not exist on your system.)
+    $(warning The non newlib-nano newlib.h may be used)
+  else
+    INCLUDES := -isystem $(NEWLIB_NANO_INCLUDE_DIR) $(INCLUDES)
+  endif
 endif
 
 # Newlib includes should go before GCC includes. This is especially important

--- a/makefiles/libc/newlib.mk
+++ b/makefiles/libc/newlib.mk
@@ -77,7 +77,7 @@ ifeq (1,$(USE_NEWLIB_NANO))
                                                     $(NEWLIB_INCLUDE_DIR)nano))
   # newlib-nano overrides newlib.h and its include dir should therefore go before
   # the regular system include dirs.
-  ifeq (0,$(words $(wildcard $(NEWLIB_NANO_INCLUDE_DIR))))
+  ifeq (,$(wildcard $(NEWLIB_NANO_INCLUDE_DIR)))
     # HACK until this is really fixed. It keeps the old build system behaviour
     # but removes the error on non existing directory
     $(warning $(lastword $(MAKEFILE_LIST)) could not correctly find include path to newlib-nano headers.)

--- a/makefiles/libc/newlib.mk
+++ b/makefiles/libc/newlib.mk
@@ -81,7 +81,7 @@ ifeq (1,$(USE_NEWLIB_NANO))
     # TODO: HACK until this is really fixed. It keeps the old build system behaviour
     # but removes the error on non existing directory
     $(warning $(lastword $(MAKEFILE_LIST)) could not correctly find include path to newlib-nano headers.)
-    $(warning It was set to $(NEWLIB_NANO_INCLUDE_DIR) which does not exist on your system.)
+    $(warning It was set to "$(NEWLIB_NANO_INCLUDE_DIR)" which does not exist on your system.)
     $(warning The non newlib-nano newlib.h may be used)
   else
     INCLUDES := -isystem $(NEWLIB_NANO_INCLUDE_DIR) $(INCLUDES)

--- a/makefiles/libc/newlib.mk
+++ b/makefiles/libc/newlib.mk
@@ -82,7 +82,7 @@ ifeq (1,$(USE_NEWLIB_NANO))
     # but removes the error on non existing directory
     $(warning $(lastword $(MAKEFILE_LIST)) could not correctly find include path to newlib-nano headers.)
     $(warning It was set to "$(NEWLIB_NANO_INCLUDE_DIR)" which does not exist on your system.)
-    $(warning The non newlib-nano newlib.h may be used)
+    $(warning The regular non-nano newlib.h configuration header may be used instead, with unknown side effects.)
   else
     INCLUDES := -isystem $(NEWLIB_NANO_INCLUDE_DIR) $(INCLUDES)
   endif


### PR DESCRIPTION
### Contribution description

Because of https://github.com/RIOT-OS/RIOT/pull/9243, failing to find the proper newlib-nano include directory triggered an error as the given newlib-nano include directory does not exist.

This PR does:

 * only add the NEWLIB_NANO_INCLUDE_DIR to INCLUDES if it exists
 * show a warning if the directory does not exist but still keeps going
   as it was the previous behavior.


### Warning

It does not solve any issue with `newlib-nano/newlib.h` not being included but just prints a warning and keeps building without nano headers as it was the behavior before #9243

### Issues/PRs references

Mentionned in:
* https://github.com/RIOT-OS/RIOT/issues/9381
* https://github.com/RIOT-OS/RIOT/pull/9216
* https://github.com/RIOT-OS/RIOT/pull/9243 post merge feedback