### PR TITLE
drivers/hdc1000: change renew_interval to a parameter

### DIFF
--- a/drivers/hdc1000/hdc1000.c
+++ b/drivers/hdc1000/hdc1000.c
@@ -31,10 +31,6 @@
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
 
-#ifndef HDC1000_RENEW_INTERVAL
-#define HDC1000_RENEW_INTERVAL     (1000000ul)
-#endif
-
 static int16_t temp_cached, hum_cached;
 static uint32_t last_read_time;
 
@@ -144,7 +140,7 @@ int hdc1000_read_cached(const hdc1000_t *dev, int16_t *temp, int16_t *hum)
     uint32_t now = xtimer_now_usec();
 
     /* check if readings are outdated */
-    if (now - last_read_time > HDC1000_RENEW_INTERVAL) {
+    if (now - last_read_time > dev->p.renew_interval) {
         /* update last_read_time */
         if (hdc1000_read(dev, &temp_cached, &hum_cached) != HDC1000_OK) {
             return HDC1000_BUSERR;

--- a/drivers/hdc1000/include/hdc1000_params.h
+++ b/drivers/hdc1000/include/hdc1000_params.h
@@ -32,22 +32,26 @@ extern "C" {
  * @{
  */
 #ifndef HDC1000_PARAM_I2C
-#define HDC1000_PARAM_I2C           I2C_DEV(0)
+#define HDC1000_PARAM_I2C            I2C_DEV(0)
 #endif
 #ifndef HDC1000_PARAM_ADDR
-#define HDC1000_PARAM_ADDR          (HDC1000_I2C_ADDRESS)
+#define HDC1000_PARAM_ADDR           (HDC1000_I2C_ADDRESS)
 #endif
 #ifndef HDC1000_PARAM_RES
-#define HDC1000_PARAM_RES           HDC1000_14BIT
+#define HDC1000_PARAM_RES            HDC1000_14BIT
+#endif
+#ifndef HDC1000_PARAM_RENEW_INTERVAL
+#define HDC1000_PARAM_RENEW_INTERVAL (1000000ul)
 #endif
 
 #ifndef HDC1000_PARAMS
-#define HDC1000_PARAMS              { .i2c  = HDC1000_PARAM_I2C,  \
-                                      .addr = HDC1000_PARAM_ADDR, \
-                                      .res  = HDC1000_PARAM_RES }
+#define HDC1000_PARAMS               { .i2c  = HDC1000_PARAM_I2C,  \
+                                       .addr = HDC1000_PARAM_ADDR, \
+                                       .res  = HDC1000_PARAM_RES, \
+                                       .renew_interval = HDC1000_PARAM_RENEW_INTERVAL }
 #endif
 #ifndef HDC1000_SAUL_INFO
-#define HDC1000_SAUL_INFO           { .name = "hdc1000" }
+#define HDC1000_SAUL_INFO            { .name = "hdc1000" }
 #endif
 /**@}*/
 

--- a/drivers/include/hdc1000.h
+++ b/drivers/include/hdc1000.h
@@ -88,9 +88,10 @@ typedef enum {
  * @brief   Parameters needed for device initialization
  */
 typedef struct {
-    i2c_t i2c;              /**< bus the device is connected to */
-    uint8_t addr;           /**< address on that bus */
-    hdc1000_res_t res;      /**< resolution used for sampling temp and hum */
+    i2c_t i2c;               /**< bus the device is connected to */
+    uint8_t addr;            /**< address on that bus */
+    hdc1000_res_t res;       /**< resolution used for sampling temp and hum */
+    uint32_t renew_interval; /**< interval for cache renewal */
 } hdc1000_params_t;
 
 /**


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->
### Contributions
This PR changes HDC1000_RENEW_INTERVAL to HDC1000_PARAM_RENEW_INTERVAL, as a parameter. This is for consistency with FXOS8700 driver in #8978. 

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references
#8978 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->