### PR TITLE
gnrc_rpl: remove events from the queue before memset()

### DIFF
--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_dodag.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_dodag.c
@@ -116,6 +116,8 @@ bool gnrc_rpl_instance_remove(gnrc_rpl_instance_t *inst)
 #endif
     gnrc_rpl_dodag_remove_all_parents(dodag);
     trickle_stop(&dodag->trickle);
+    evtimer_del(&gnrc_rpl_evtimer, (evtimer_event_t *)&dodag->dao_event);
+    evtimer_del(&gnrc_rpl_evtimer, (evtimer_event_t *)&inst->cleanup_event);
     memset(inst, 0, sizeof(gnrc_rpl_instance_t));
     return true;
 }


### PR DESCRIPTION
### Contribution description
On dodag cleanup, events are not cleared from the event queue. This may lead to issues when a DAO event is scheduled, but the dodag is not around anymore.

### Issues/PRs references
none