### PR TITLE
c25519: Initial support for the c25519 package

### DIFF
--- a/pkg/c25519/Makefile
+++ b/pkg/c25519/Makefile
@@ -1,0 +1,36 @@
+PKG_NAME    = c25519
+PKG_URL     = https://www.dlbeer.co.nz/downloads
+PKG_VERSION = 2017-10-05
+PKG_EXT     = zip
+PKG_LICENSE = PD
+PKG_SHA512  = dbfb4285837ab2ea3d99c448b22877cc7a139ccbaebb1de367e2bec1fd562fe629b389d86603915448078b8fd7e631c8fc9a7d126eb889a1ba0c17611369b190
+
+PKG_BUILDDIR ?= $(PKGDIRBASE)/$(PKG_NAME)
+PKG_ZIPFILE = $(PKGDIRBASE)/$(PKG_NAME)-$(PKG_VERSION).$(PKG_EXT)
+
+ifneq ($(RIOTBASE),)
+include $(RIOTBASE)/Makefile.base
+endif
+
+.PHONY: all clean distclean
+
+prepare: $(PKG_BUILDDIR)/
+
+all: $(PKG_BUILDDIR)/
+	"$(MAKE)" -C $(PKG_BUILDDIR)/src -f $(CURDIR)/Makefile.c25519
+
+$(PKG_BUILDDIR)/: $(PKGDIRBASE)/$(PKG_NAME)-$(PKG_VERSION).$(PKG_EXT)
+	test "$(PKG_SHA512)  $(PKG_ZIPFILE)" =  "$$(sha512sum "${PKG_ZIPFILE}")"
+	$(Q)$(UNZIP_HERE) -D -d $(PKGDIRBASE) $<
+
+$(PKG_ZIPFILE):
+	mkdir -p $(PKGDIRBASE)
+	$(Q)$(DOWNLOAD_TO_FILE) $@ $(PKG_URL)/$(PKG_NAME)-$(PKG_VERSION).$(PKG_EXT)
+
+clean::
+	# Reset package to checkout state.
+	rm -rf $(PKG_BUILDDIR)
+
+distclean::
+	rm -rf $(PKG_BUILDDIR) $(PKGDIRBASE)/$(PKG_NAME)-$(PKG_VERSION).$(PKG_EXT)
+	rm -rf $(PKG_SHAFILE)

--- a/pkg/c25519/Makefile.c25519
+++ b/pkg/c25519/Makefile.c25519
@@ -1,0 +1,11 @@
+MODULE := c25519
+
+SRC += c25519.c
+SRC += ed25519.c
+SRC += edsign.c
+SRC += f25519.c
+SRC += fprime.c
+SRC += morph25519.c
+SRC += sha512.c
+
+include $(RIOTBASE)/Makefile.base

--- a/pkg/c25519/Makefile.include
+++ b/pkg/c25519/Makefile.include
@@ -1,0 +1,1 @@
+INCLUDES += -I$(PKGDIRBASE)/c25519/src

--- a/pkg/c25519/doc.txt
+++ b/pkg/c25519/doc.txt
@@ -1,0 +1,36 @@
+/**
+ * @defgroup pkg_c25519 C25519 cryptographic library
+ * @ingroup  pkg
+ * @ingroup  sys
+ * @brief    Curve25519 and Ed25519 for low-memory systems
+ *
+ * This package contains portable public-domain implementations of Daniel J.
+ * Bernstein's Curve255191 Diffie-Hellman function, and of the Ed25519
+ * signature system. The memory consumption is low enough that they could be
+ * reasonably considered for most microcontroller applications. In particular,
+ * Curve25519 scalar multiplication uses less than half a kB of peak stack
+ * usage.
+ *
+ * ## Requirements
+ *
+ * C25519 requires around 1K of stack, so beware that you're allocating at
+ * least `THREAD_STACKSIZE_DEFAULT + 1K` bytes.
+ *
+ * You can do it easily by adding:
+ *
+ * ```makefile
+ * CFLAGS += '-DTHREAD_STACKSIZE_MAIN=(THREAD_STACKSIZE_DEFAULT + 1024)'
+ * ```
+ *
+ * to your makefile.
+ *
+ * ## Usage
+ *
+ * Just add it as a package in your application:
+ *
+ * ```makefile
+ * USEPKG += c25519
+ * ```
+ *
+ * @see      https://www.dlbeer.co.nz/oss/c25519.html
+ */

--- a/tests/pkg_c25519/Makefile
+++ b/tests/pkg_c25519/Makefile
@@ -1,0 +1,25 @@
+include ../Makefile.tests_common
+
+USEMODULE += embunit
+USEMODULE += random
+USEPKG += c25519
+
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-nano arduino-uno
+
+TEST_ON_CI_WHITELIST += all
+
+include $(RIOTBASE)/Makefile.include
+
+# c25519 takes up to 1.5K in stack, almost independent of the platform
+ifneq (,$(filter cortex-%,$(CPU_ARCH)))
+  CFLAGS += -DTHREAD_STACKSIZE_MAIN=\(THREAD_STACKSIZE_DEFAULT+THREAD_EXTRA_STACKSIZE_PRINTF\)
+else
+ifneq (,$(filter atmega_common,$(USEMODULE)))
+  CFLAGS += -DTHREAD_STACKSIZE_MAIN=\(5*THREAD_STACKSIZE_DEFAULT+THREAD_EXTRA_STACKSIZE_PRINTF\)
+else
+  CFLAGS += -DTHREAD_STACKSIZE_MAIN=\(3*THREAD_STACKSIZE_DEFAULT+THREAD_EXTRA_STACKSIZE_PRINTF\)
+endif
+endif
+
+test:
+	tests/01-run.py

--- a/tests/pkg_c25519/main.c
+++ b/tests/pkg_c25519/main.c
@@ -1,0 +1,87 @@
+/*
+ * Copyright (C) 2018 Freie Universität Berlin
+ * Copyright (C) 2018 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Tests c25519 package
+ *
+ * @author      Koen Zandberg <koen@bergzand.net>
+ *
+ * @}
+ */
+
+#include <string.h>
+
+#include "edsign.h"
+#include "ed25519.h"
+#include "embUnit.h"
+#include "random.h"
+
+static uint8_t message[] = "0123456789abcdef";
+
+static uint8_t sign_sk[EDSIGN_SECRET_KEY_SIZE];
+static uint8_t sign_pk[EDSIGN_PUBLIC_KEY_SIZE];
+static uint8_t signature[EDSIGN_SIGNATURE_SIZE];
+
+static void setUp(void)
+{
+    /* Initialize */
+    random_init(0);
+}
+
+static void test_c25519_signverify(void)
+{
+    int res;
+    /* Creating keypair ... */
+    random_bytes(sign_sk, sizeof(sign_sk));
+    ed25519_prepare(sign_sk);
+    edsign_sec_to_pub(sign_pk, sign_sk);
+
+    /* Sign */
+    edsign_sign(signature, sign_pk, sign_sk, message, sizeof(message));
+
+    /* Verifying... */
+    res = edsign_verify(signature, sign_pk, message, sizeof(message));
+    TEST_ASSERT(res);
+}
+
+static void test_c25519_verifynegative(void)
+{
+    int res;
+
+    /* changing message */
+    message[0] = 'A';
+
+    /* Verifying... */
+    res = edsign_verify(signature, sign_pk, message, sizeof(message));
+    TEST_ASSERT_EQUAL_INT(0, res);
+}
+
+Test *tests_c25519(void)
+{
+    EMB_UNIT_TESTFIXTURES(fixtures) {
+        new_TestFixture(test_c25519_signverify),
+        new_TestFixture(test_c25519_verifynegative)
+    };
+
+    EMB_UNIT_TESTCALLER(c25519_tests, setUp, NULL, fixtures);
+    return (Test*)&c25519_tests;
+}
+
+int main(void)
+{
+    TESTS_START();
+    TESTS_RUN(tests_c25519());
+    TESTS_END();
+
+    return 0;
+}

--- a/tests/pkg_c25519/tests/01-run.py
+++ b/tests/pkg_c25519/tests/01-run.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2016 Kaspar Schleiser <kaspar@schleiser.de>
+# Copyright (C) 2016 Takuo Yonezawa <Yonezawa-T2@mail.dnp.co.jp>
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import os
+import sys
+
+
+def testfunc(child):
+    child.expect(r"OK \(2 tests\)")
+
+
+if __name__ == "__main__":
+    sys.path.append(os.path.join(os.environ['RIOTBASE'],
+                                 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc))


### PR DESCRIPTION
[c25519] is a library optimized for embedded applications handling ed25519
signing and x25519 crypto. It uses significantly less memory and flash
compared to TweetNaCl and is significantly faster when used on a
samr21-xpro

Around below 1.5K of stack size required (~1282B on the arduino-mega2560, 1444B on a samr21-xpro), which is significantly less than TweetNaCl or HaCl
    
[c25519]: https://www.dlbeer.co.nz/oss/c25519.html

### Issues/PRs references

None