### PR TITLE
shell_commands: add command for packet buffer stats

### DIFF
--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -21,6 +21,7 @@ PSEUDOMODULES += gnrc_netdev_default
 PSEUDOMODULES += gnrc_neterr
 PSEUDOMODULES += gnrc_netapi_callbacks
 PSEUDOMODULES += gnrc_netapi_mbox
+PSEUDOMODULES += gnrc_pktbuf_cmd
 PSEUDOMODULES += gnrc_sixlowpan_border_router_default
 PSEUDOMODULES += gnrc_sixlowpan_default
 PSEUDOMODULES += gnrc_sixlowpan_iphc_nhc

--- a/sys/shell/commands/Makefile
+++ b/sys/shell/commands/Makefile
@@ -40,6 +40,9 @@ ifneq (,$(filter xtimer,$(USEMODULE)))
   SRC += sc_icmpv6_echo.c
 endif
 endif
+ifneq (,$(filter gnrc_pktbuf_cmd,$(USEMODULE)))
+    SRC += sc_gnrc_pktbuf.c
+endif
 ifneq (,$(filter gnrc_rpl,$(USEMODULE)))
     SRC += sc_gnrc_rpl.c
 endif

--- a/sys/shell/commands/sc_gnrc_pktbuf.c
+++ b/sys/shell/commands/sc_gnrc_pktbuf.c
@@ -1,0 +1,26 @@
+/*
+ * Copyright (C) 2017 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ *
+ * @file
+ * @author  Martine Lenders <m.lenders@fu-berlin.de>
+ */
+
+#include "net/gnrc/pktbuf.h"
+
+int _gnrc_pktbuf_cmd(int argc, char **argv)
+{
+    (void)argc;
+    (void)argv;
+    gnrc_pktbuf_stats();
+    return 0;
+}
+
+/** @} */

--- a/sys/shell/commands/shell_commands.c
+++ b/sys/shell/commands/shell_commands.c
@@ -108,6 +108,10 @@ extern int _whitelist(int argc, char **argv);
 extern int _blacklist(int argc, char **argv);
 #endif
 
+#ifdef MODULE_GNRC_PKTBUF_CMD
+extern int _gnrc_pktbuf_cmd(int argc, char **argv);
+#endif
+
 #ifdef MODULE_GNRC_RPL
 extern int _gnrc_rpl(int argc, char **argv);
 #endif
@@ -198,6 +202,9 @@ const shell_command_t _shell_command_list[] = {
 #endif
 #ifdef MODULE_GNRC_IPV6_BLACKLIST
     {"blacklist", "blacklists an address for receival ('blacklist [add|del|help]')", _blacklist },
+#endif
+#ifdef MODULE_GNRC_PKTBUF_CMD
+    {"pktbuf", "prints internal stats of the packet buffer", _gnrc_pktbuf_cmd },
 #endif
 #ifdef MODULE_GNRC_RPL
     {"rpl", "rpl configuration tool ('rpl help' for more information)", _gnrc_rpl },


### PR DESCRIPTION
### Contribution description
I'm using something like this command for a while now for debugging
GNRC. Usually, I just patch it into the application I'm using it with,
but I think there is a benefit to also provide it to RIOT upstream
properly.

### Issues/PRs references
None