### PR TITLE
drivers/isl29125: apply unified params definition scheme and new i2c API

### DIFF
--- a/drivers/include/isl29125.h
+++ b/drivers/include/isl29125.h
@@ -100,13 +100,21 @@ typedef enum {
 } isl29125_resolution_t;
 
 /**
- * @brief   Device descriptor for ISL29125 sensors
+ * @brief   Device parameters for ISL29125 sensors
  */
 typedef struct {
     i2c_t i2c;                      /**< I2C device the sensor is connected to */
     gpio_t gpio;                    /**< GPIO pin for interrupt/sync mode */
-    isl29125_range_t range;         /**< sensor range */
-    isl29125_resolution_t res;      /**< sensor resolution */
+    isl29125_range_t range;         /**< measurement range */
+    isl29125_mode_t mode;           /**< AD conversion mode */
+    isl29125_resolution_t res;      /**< AD conversion resolution */
+} isl29125_params_t;
+
+/**
+ * @brief   Device descriptor for ISL29125 sensors
+ */
+typedef struct {
+    isl29125_params_t params;       /**< device parameters */
 } isl29125_t;
 
 /**
@@ -141,18 +149,12 @@ typedef enum {
  * @brief   Initialize a new ISL29125 device
  *
  * @param[in] dev           device descriptor of an ISL29125 device
- * @param[in] i2c           I2C device the sensor is connected to
- * @param[in] gpio          GPIO pin for interrupt/sync mode (currently unused)
- * @param[in] mode          operation mode
- * @param[in] range         measurement range
- * @param[in] resolution    AD conversion resolution
+ * @param[in] params        initialization parameters
  *
- * @return              0 on success
- * @return              -1 on error
+ * @return                  0 on success
+ * @return                  -1 on error
  */
-int isl29125_init(isl29125_t *dev, i2c_t i2c, gpio_t gpio,
-                  isl29125_mode_t mode, isl29125_range_t range,
-                  isl29125_resolution_t resolution);
+int isl29125_init(isl29125_t *dev, const isl29125_params_t *params);
 
 /**
  * @brief   Initialize interrupts

--- a/drivers/isl29125/include/isl29125_params.h
+++ b/drivers/isl29125/include/isl29125_params.h
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2017 Freie Universität Berlin
+ * Copyright (C) 2018 HAW-Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_isl29125
+ *
+ * @{
+ * @file
+ * @brief       Default configuration for ISL29125 devices
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author      Michel Rottleuthner <michel.rottleuthner@haw-hamburg.de>
+ */
+
+#ifndef ISL29125_PARAMS_H
+#define ISL29125_PARAMS_H
+
+#include "board.h"
+#include "isl29125.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Set default configuration parameters
+ * @{
+ */
+#ifndef ISL29125_PARAM_I2C
+#define ISL29125_PARAM_I2C              I2C_DEV(0)
+#endif
+#ifndef ISL29125_PARAM_GPIO
+#define ISL29125_PARAM_GPIO             (GPIO_PIN(0, 0))
+#endif
+#ifndef ISL29125_PARAM_RANGE
+#define ISL29125_PARAM_RANGE            (ISL29125_RANGE_10K)
+#endif
+#ifndef ISL29125_PARAM_MODE
+#define ISL29125_PARAM_MODE             (ISL29125_MODE_RGB)
+#endif
+#ifndef ISL29125_PARAM_RES
+#define ISL29125_PARAM_RES              (ISL29125_RESOLUTION_16)
+#endif
+
+#ifndef ISL29125_PARAMS
+#define ISL29125_PARAMS                 { .i2c   = ISL29125_PARAM_I2C,   \
+                                          .gpio  = ISL29125_PARAM_GPIO,  \
+                                          .range = ISL29125_PARAM_RANGE, \
+                                          .mode  = ISL29125_PARAM_MODE,  \
+                                          .res   = ISL29125_PARAM_RES }
+#endif
+/**@}*/
+
+/**
+ * @brief   Allocate some memory to store the actual configuration
+ */
+static const isl29125_params_t isl29125_params[] =
+{
+    ISL29125_PARAMS
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ISL29125_PARAMS_H */
+/** @} */

--- a/drivers/isl29125/isl29125.c
+++ b/drivers/isl29125/isl29125.c
@@ -62,15 +62,11 @@ int isl29125_init(isl29125_t *dev, const isl29125_params_t *params)
     DEBUG("isl29125_init: i2c_acquire\n");
     (void) i2c_acquire(DEV_I2C);
 
-    /* initialize the I2C bus */
-    DEBUG("isl29125_init: i2c_init_master\n");
-    (void) i2c_init_master(DEV_I2C, I2C_SPEED_NORMAL);
-
     /* verify the device ID */
     DEBUG("isl29125_init: i2c_read_reg\n");
     uint8_t reg_id;
-    int ret = i2c_read_reg(DEV_I2C, ISL29125_I2C_ADDRESS, ISL29125_REG_ID, &reg_id);
-    if ((reg_id == ISL29125_ID) && (ret == 1)) {
+    int ret = i2c_read_reg(DEV_I2C, ISL29125_I2C_ADDRESS, ISL29125_REG_ID, &reg_id, 0);
+    if ((reg_id == ISL29125_ID) && (ret == 0)) {
         DEBUG("isl29125_init: ID successfully verified\n");
     }
     else {
@@ -81,10 +77,10 @@ int isl29125_init(isl29125_t *dev, const isl29125_params_t *params)
 
     /* configure and enable the sensor */
     DEBUG("isl29125_init: i2c_write_reg(ISL29125_REG_RESET)\n");
-    (void) i2c_write_reg(DEV_I2C, ISL29125_I2C_ADDRESS, ISL29125_REG_RESET, ISL29125_CMD_RESET);
+    (void) i2c_write_reg(DEV_I2C, ISL29125_I2C_ADDRESS, ISL29125_REG_RESET, ISL29125_CMD_RESET, 0);
 
     DEBUG("isl29125_init: i2c_write_reg(ISL29125_REG_CONF1)\n");
-    (void) i2c_write_reg(DEV_I2C, ISL29125_I2C_ADDRESS, ISL29125_REG_CONF1, conf1);
+    (void) i2c_write_reg(DEV_I2C, ISL29125_I2C_ADDRESS, ISL29125_REG_CONF1, conf1, 0);
 
     /* release the I2C bus */
     DEBUG("isl29125_init: i2c_release\n");
@@ -127,19 +123,19 @@ int isl29125_init_int(isl29125_t *dev, isl29125_interrupt_status_t interrupt_sta
     }
 
     DEBUG("isl29125_init: i2c_write_reg(ISL29125_REG_CONF3)\n");
-    (void) i2c_write_reg(DEV_I2C, ISL29125_I2C_ADDRESS, ISL29125_REG_CONF3, conf3);
+    (void) i2c_write_reg(DEV_I2C, ISL29125_I2C_ADDRESS, ISL29125_REG_CONF3, conf3, 0);
 
     DEBUG("isl29125_init: i2c_write_reg(ISL29125_REG_LTHLB)\n");
-    (void) i2c_write_reg(DEV_I2C, ISL29125_I2C_ADDRESS, ISL29125_REG_LTHLB, lthlb);
+    (void) i2c_write_reg(DEV_I2C, ISL29125_I2C_ADDRESS, ISL29125_REG_LTHLB, lthlb, 0);
 
     DEBUG("isl29125_init: i2c_write_reg(ISL29125_REG_LTHHB)\n");
-    (void) i2c_write_reg(DEV_I2C, ISL29125_I2C_ADDRESS, ISL29125_REG_LTHHB, lthhb);
+    (void) i2c_write_reg(DEV_I2C, ISL29125_I2C_ADDRESS, ISL29125_REG_LTHHB, lthhb, 0);
 
     DEBUG("isl29125_init: i2c_write_reg(ISL29125_REG_HTHLB)\n");
-    (void) i2c_write_reg(DEV_I2C, ISL29125_I2C_ADDRESS, ISL29125_REG_HTHLB, hthlb);
+    (void) i2c_write_reg(DEV_I2C, ISL29125_I2C_ADDRESS, ISL29125_REG_HTHLB, hthlb, 0);
 
     DEBUG("isl29125_init: i2c_write_reg(ISL29125_REG_HTHHB)\n");
-    (void) i2c_write_reg(DEV_I2C, ISL29125_I2C_ADDRESS, ISL29125_REG_HTHHB, hthhb);
+    (void) i2c_write_reg(DEV_I2C, ISL29125_I2C_ADDRESS, ISL29125_REG_HTHHB, hthhb, 0);
 
     if (gpio_init_int(DEV_GPIO, GPIO_IN, GPIO_FALLING, cb, arg) < 0) {
         DEBUG("error: gpio_init_int failed\n");
@@ -156,7 +152,7 @@ void isl29125_read_rgb_lux(const isl29125_t *dev, isl29125_rgb_t *dest)
 
     /* read values */
     uint8_t bytes[6];
-    (void) i2c_read_regs(DEV_I2C, ISL29125_I2C_ADDRESS, ISL29125_REG_GDLB, bytes, 6);
+    (void) i2c_read_regs(DEV_I2C, ISL29125_I2C_ADDRESS, ISL29125_REG_GDLB, bytes, 6, 0);
 
     /* release the I2C bus */
     (void) i2c_release(DEV_I2C);
@@ -184,7 +180,7 @@ void isl29125_read_rgb_color(const isl29125_t *dev, color_rgb_t *dest)
 
     /* read values */
     uint8_t bytes[6];
-    (void) i2c_read_regs(DEV_I2C, ISL29125_I2C_ADDRESS, ISL29125_REG_GDLB, bytes, 6);
+    (void) i2c_read_regs(DEV_I2C, ISL29125_I2C_ADDRESS, ISL29125_REG_GDLB, bytes, 6, 0);
 
     /* release the I2C bus */
     (void) i2c_release(DEV_I2C);
@@ -203,10 +199,10 @@ void isl29125_set_mode(const isl29125_t *dev, isl29125_mode_t mode)
 
     (void) i2c_acquire(DEV_I2C);
 
-    (void) i2c_read_reg(DEV_I2C, ISL29125_I2C_ADDRESS, ISL29125_REG_CONF1, &conf1);
+    (void) i2c_read_reg(DEV_I2C, ISL29125_I2C_ADDRESS, ISL29125_REG_CONF1, &conf1, 0);
     conf1 &= ~ISL29125_CON1_MASK_MODE;
     conf1 |= mode;
-    (void) i2c_write_reg(DEV_I2C, ISL29125_I2C_ADDRESS, ISL29125_REG_CONF1, conf1);
+    (void) i2c_write_reg(DEV_I2C, ISL29125_I2C_ADDRESS, ISL29125_REG_CONF1, conf1, 0);
 
     (void) i2c_release(DEV_I2C);
 }
@@ -218,7 +214,7 @@ int isl29125_read_irq_status(const isl29125_t *dev)
 
     /* read status register */
     uint8_t irq_status;
-    (void) i2c_read_reg(DEV_I2C, ISL29125_I2C_ADDRESS, ISL29125_REG_STATUS, &irq_status);
+    (void) i2c_read_reg(DEV_I2C, ISL29125_I2C_ADDRESS, ISL29125_REG_STATUS, &irq_status, 0);
 
     /* release the I2C bus */
     (void) i2c_release(DEV_I2C);

--- a/tests/driver_isl29125/Makefile
+++ b/tests/driver_isl29125/Makefile
@@ -8,12 +8,4 @@ FEATURES_REQUIRED = periph_i2c
 USEMODULE += isl29125
 USEMODULE += xtimer
 
-# set default device parameters in case they are undefined
-TEST_ISL29125_I2C     ?= I2C_DEV\(0\)
-TEST_ISL29125_IRQ_PIN ?= GPIO_PIN\(0,0\)
-
-# export parameters
-CFLAGS += -DTEST_ISL29125_I2C=$(TEST_ISL29125_I2C)
-CFLAGS += -DTEST_ISL29125_IRQ_PIN=$(TEST_ISL29125_IRQ_PIN)
-
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_isl29125/main.c
+++ b/tests/driver_isl29125/main.c
@@ -21,19 +21,12 @@
  * @}
  */
 
-#ifndef TEST_ISL29125_I2C
-#error "TEST_ISL29125_I2C not defined"
-#endif
-
-#ifndef TEST_ISL29125_IRQ_PIN
-#error "ISL29125_IRQ_PIN not defined"
-#endif
-
 #include <stdio.h>
 #include <string.h>
 
 #include "xtimer.h"
 #include "isl29125.h"
+#include "isl29125_params.h"
 
 #define SLEEP       (250 * 1000U)
 
@@ -55,10 +48,8 @@ int main(void)
     uint16_t higher_threshold = 8000;
 
     puts("ISL29125 light sensor test application\n");
-    printf("Initializing ISL29125 sensor at I2C_%i... ", TEST_ISL29125_I2C);
-    if (isl29125_init(&dev, TEST_ISL29125_I2C, TEST_ISL29125_IRQ_PIN,
-                ISL29125_MODE_RGB, ISL29125_RANGE_10K,
-                ISL29125_RESOLUTION_16) == 0) {
+    printf("Initializing ISL29125 sensor at I2C_%i... ", isl29125_params[0].i2c);
+    if (isl29125_init(&dev, &isl29125_params[0]) == 0) {
         puts("[OK]\n");
     }
     else {


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Analog to #8688 this updates the parameter scheme (#7519) and applies the new i2c API to the isl29125 driver.

tested with sparkfun isl29125 with nucleo-l073

### Issues/PRs references
#6577