### PR TITLE
examples/lorawan: use new nucleo names for BOARD_INSUFFIENT_MEMORY

### DIFF
--- a/examples/lorawan/Makefile
+++ b/examples/lorawan/Makefile
@@ -7,7 +7,7 @@ BOARD ?= b-l072z-lrwan1
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../..
 
-BOARD_INSUFFICIENT_MEMORY := nucleo32-f031 nucleo32-f042 nucleo32-l031
+BOARD_INSUFFICIENT_MEMORY := nucleo-f031k6 nucleo-f042k6 nucleo-l031k6
 
 DEVEUI ?= 0000000000000000
 APPEUI ?= 0000000000000000


### PR DESCRIPTION
### Contribution description
#8789 broke current master on murdock because it was merged based on a build results that was finished before the nucleo-boards got renamed. This fixes it again.

### Issues/PRs references
None