### PR TITLE
newlib: include fixes for newlib-nano

### DIFF
--- a/makefiles/libc/newlib.mk
+++ b/makefiles/libc/newlib.mk
@@ -21,6 +21,13 @@ export LINKFLAGS += -lc
 
 # Search for Newlib include directories
 
+# Try to search for newlib in the standard search path of the compiler for includes
+ifeq (,$(NEWLIB_INCLUDE_DIR))
+  COMPILER_INCLUDE_PATHS := $(shell $(PREFIX)gcc -v -x c -E /dev/null 2>&1 | grep '^\s' | tr -d '\n')
+  NEWLIB_INCLUDE_DIR := $(firstword $(dir $(wildcard $(addsuffix /newlib.h, $(COMPILER_INCLUDE_PATHS)))))
+endif
+
+ifeq (,$(NEWLIB_INCLUDE_DIR))
 # Since Clang is not installed as a separate instance for each crossdev target
 # we need to tell it where to look for platform specific includes (Newlib
 # headers instead of Linux/Glibc headers.)
@@ -35,17 +42,18 @@ export LINKFLAGS += -lc
 # Gentoo crossdev, but we prefer to look at /etc/alternatives first.
 # On OSX, newlib includes are possibly located in
 # /usr/local/opt/arm-none-eabi*/arm-none-eabi/include or /usr/local/opt/gcc-arm/arm-none-eabi/include
-NEWLIB_INCLUDE_PATTERNS ?= \
-  /etc/alternatives/gcc-$(TARGET_ARCH)-include \
-  /usr/$(TARGET_ARCH)/include \
-  /usr/local/opt/$(TARGET_ARCH)*/$(TARGET_ARCH)/include \
-  /usr/local/opt/gcc-*/$(TARGET_ARCH)/include \
-  #
+  NEWLIB_INCLUDE_PATTERNS ?= \
+    /etc/alternatives/gcc-$(TARGET_ARCH)-include \
+    /usr/$(TARGET_ARCH)/include \
+    /usr/local/opt/$(TARGET_ARCH)*/$(TARGET_ARCH)/include \
+    /usr/local/opt/gcc-*/$(TARGET_ARCH)/include \
+    #
 # Use the wildcard Makefile function to search for existing directories matching
 # the patterns above. We use the -isystem gcc/clang argument to add the include
 # directories as system include directories, which means they will not be
 # searched until after all the project specific include directories (-I/path)
-NEWLIB_INCLUDE_DIR ?= $(firstword $(wildcard $(NEWLIB_INCLUDE_PATTERNS)))
+  NEWLIB_INCLUDE_DIR ?= $(firstword $(dir $(wildcard $(addsuffix /newlib.h, $(NEWLIB_INCLUDE_PATTERNS)))))
+endif
 
 # If nothing was found we will try to fall back to searching for a cross-gcc in
 # the current PATH and use a relative path for the includes
@@ -64,7 +72,9 @@ ifeq ($(TOOLCHAIN),llvm)
 endif
 
 ifeq (1,$(USE_NEWLIB_NANO))
-  NEWLIB_NANO_INCLUDE_DIR ?= $(NEWLIB_INCLUDE_DIR)/newlib-nano
+  NEWLIB_NANO_INCLUDE_DIR ?= $(firstword $(wildcard $(NEWLIB_INCLUDE_DIR)newlib-nano \
+                                                    $(NEWLIB_INCLUDE_DIR)newlib/nano \
+                                                    $(NEWLIB_INCLUDE_DIR)nano))
   # newlib-nano overrides newlib.h and its include dir should therefore go before
   # the regular system include dirs.
   INCLUDES := -isystem $(NEWLIB_NANO_INCLUDE_DIR) $(INCLUDES)


### PR DESCRIPTION
### Contribution description
At least for Ubuntu newlib-nano seems to be in a different location
(`/usr/include/newlib/nano/newlib.h`).

This PR fixes #9381 by adding `/usr/include` to the newlib includes and searching for both `newlib-nano` (Arch et al.) and `newlib/nano` (Ubuntu et al.) explicitly.

Tested on Arch and Ubuntu.

---

**EDIT**: The major change in this PR is now to autodetect newlib in the compiler's default search paths, using:
```bash
$(PREFIX)gcc -v -x c -E /dev/null 2>&1 | grep '^\s' | tr -d '\n'
```

### Issues/PRs references
#9381