### PR TITLE
drivers/ccs811: initial implementation

### DIFF
--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -91,6 +91,11 @@ ifneq (,$(filter cc2420,$(USEMODULE)))
   FEATURES_REQUIRED += periph_spi
 endif
 
+ifneq (,$(filter ccs811,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_i2c
+  FEATURES_REQUIRED += periph_gpio
+endif
+
 ifneq (,$(filter dht,$(USEMODULE)))
   USEMODULE += xtimer
   FEATURES_REQUIRED += periph_gpio

--- a/drivers/Makefile.include
+++ b/drivers/Makefile.include
@@ -46,6 +46,10 @@ ifneq (,$(filter cc2420,$(USEMODULE)))
   USEMODULE_INCLUDES += $(RIOTBASE)/drivers/cc2420/include
 endif
 
+ifneq (,$(filter ccs811,$(USEMODULE)))
+  USEMODULE_INCLUDES += $(RIOTBASE)/drivers/ccs811/include
+endif
+
 ifneq (,$(filter dht,$(USEMODULE)))
   USEMODULE_INCLUDES += $(RIOTBASE)/drivers/dht/include
 endif

--- a/drivers/ccs811/Makefile
+++ b/drivers/ccs811/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/drivers/ccs811/ccs811.c
+++ b/drivers/ccs811/ccs811.c
@@ -1,0 +1,227 @@
+/*
+ * Copyright (C) 2018 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_ccs811
+ * @{
+ *
+ * @file
+ * @brief       Device driver implementation for the CCS811 gas sensor.
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ * @}
+ */
+
+#include <string.h>
+#include <errno.h>
+
+#include "ccs811.h"
+#include "ccs811_constants.h"
+#include "ccs811_params.h"
+#include "periph/i2c.h"
+#include "periph/gpio.h"
+
+#define ENABLE_DEBUG        (0)
+#include "debug.h"
+
+#define DEV_I2C             (dev->params.i2c_dev)
+#define DEV_ADDR            (dev->params.i2c_addr)
+#define DEV_WAKE_PIN        (dev->params.wake_pin)
+
+static void _ccs811_poweron(const ccs811_t *dev)
+{
+    if (DEV_WAKE_PIN != GPIO_UNDEF) {
+        DEBUG("[ccs811] power on device \n");
+        gpio_clear(DEV_WAKE_PIN);
+    }
+}
+
+static void _ccs811_poweroff(const ccs811_t *dev)
+{
+    if (DEV_WAKE_PIN != GPIO_UNDEF) {
+        DEBUG("[ccs811] power off device \n");
+        gpio_set(DEV_WAKE_PIN);
+    }
+}
+
+int ccs811_init(ccs811_t *dev, const ccs811_params_t *params)
+{
+    memcpy(&dev->params, params, sizeof(ccs811_params_t));
+
+    DEBUG("[ccs811] info: initializing CCS811 device %i at address %02X\n",
+          DEV_I2C, DEV_ADDR);
+
+    if (DEV_WAKE_PIN != GPIO_UNDEF) {
+        gpio_init(DEV_WAKE_PIN, GPIO_OUT);
+        gpio_clear(DEV_WAKE_PIN); /* power on the device */
+    }
+
+    /* Acquire I2C device */
+    i2c_acquire(DEV_I2C);
+
+    /* Read hardware ID */
+    uint8_t hw_id;
+    if (i2c_read_reg(DEV_I2C, DEV_ADDR, CCS811_REG_HW_ID, &hw_id, 0) < 0) {
+        DEBUG("[ccs811] error: failed to read HW id register '%02X'\n",
+              CCS811_REG_HW_ID);
+        i2c_release(DEV_I2C);
+        return -EIO;
+    }
+
+    DEBUG("[ccs811] info: hardware ID is '0x%02X'\n", hw_id);
+    if (hw_id != CCS811_HW_ID) {
+        DEBUG("[ccs811] error: wrong hardware ID, expected '0x%02X'\n",
+              CCS811_HW_ID);
+        i2c_release(DEV_I2C);
+        return -ENODEV;
+    }
+
+    /* Check status */
+    uint8_t status;
+    if (i2c_read_reg(DEV_I2C, DEV_ADDR, CCS811_REG_STATUS, &status, 0) < 0) {
+        DEBUG("[ccs811] error: failed to read status register '%02X'\n",
+              CCS811_REG_STATUS);
+        i2c_release(DEV_I2C);
+        return -EIO;
+    }
+
+    /* Check for valid application */
+    DEBUG("[ccs811] info: status is '0x%02X'\n", status);
+    if (!(status & CCS811_STATUS_REG_APP_VALID)) {
+        DEBUG("[ccs811] error: invalid application '%02X'\n", status);
+        i2c_release(DEV_I2C);
+        return -ECANCELED;
+    }
+
+    /* Start application */
+    if (i2c_write_byte(DEV_I2C, DEV_ADDR, CCS811_REG_APP_START, 0) < 0) {
+        DEBUG("[ccs811] error: cannot start application\n");
+        i2c_release(DEV_I2C);
+        return -ECANCELED;
+    }
+
+    /* Check application is in firmware mode status */
+    if (i2c_read_reg(DEV_I2C, DEV_ADDR, CCS811_REG_STATUS, &status, 0) < 0) {
+        DEBUG("[ccs811] error: failed to read status register '%02X'\n",
+              CCS811_REG_STATUS);
+        i2c_release(DEV_I2C);
+        return -EIO;
+    }
+
+    DEBUG("[ccs811] info: status is '0x%02X'\n", status);
+    if (!(status & CCS811_STATUS_REG_FW_MODE)) {
+        DEBUG("[ccs811] error: not in firmware mode '%02X'\n", status);
+        i2c_release(DEV_I2C);
+        return -ECANCELED;
+    }
+
+    if (ENABLE_DEBUG) {
+        /* Read hardware version */
+        uint8_t hw_version;
+        if (i2c_read_reg(DEV_I2C, DEV_ADDR,
+                         CCS811_REG_HW_VERSION, &hw_version, 0) < 0) {
+            DEBUG("[ccs811] error: failed to read HW version register '%02X'\n",
+                  CCS811_REG_HW_VERSION);
+            i2c_release(DEV_I2C);
+            return -EIO;
+        }
+        DEBUG("[ccs811] info: hardware version is '0x%02X'\n", hw_version);
+    }
+
+    /* Release I2C device */
+    i2c_release(DEV_I2C);
+
+    _ccs811_poweroff(dev);
+
+    return 0;
+}
+
+int ccs811_set_drive_mode(const ccs811_t *dev, ccs811_drive_mode_t mode)
+{
+    _ccs811_poweron(dev);
+
+    /* Acquire I2C device */
+    i2c_acquire(DEV_I2C);
+
+    if (i2c_write_reg(DEV_I2C, DEV_ADDR,
+                      CCS811_REG_MEAS_MODE, (uint8_t)(mode << 4), 0) < 0) {
+        DEBUG("[ccs811] error: failed to set drive mode '%02X'\n",
+              mode);
+        i2c_release(DEV_I2C);
+        return -EIO;
+    }
+
+    /* Release I2C device */
+    i2c_release(DEV_I2C);
+
+    _ccs811_poweroff(dev);
+
+    return 0;
+}
+
+int ccs811_read_data(const ccs811_t *dev, uint16_t *eco2, uint16_t *tvoc)
+{
+    _ccs811_poweron(dev);
+
+    /* Acquire I2C device */
+    i2c_acquire(DEV_I2C);
+
+    uint8_t status;
+    if (i2c_read_reg(DEV_I2C, DEV_ADDR, CCS811_REG_STATUS, &status, 0) < 0) {
+        DEBUG("[ccs811] error: failed to read status register '%02X'\n",
+              CCS811_REG_STATUS);
+        i2c_release(DEV_I2C);
+        return -EIO;
+    }
+
+    DEBUG("[ccs811] info: status is '0x%02X'\n", status);
+    if (!(status & CCS811_STATUS_REG_DATA_READY)) {
+        DEBUG("[ccs811] error: data not ready '%02X'\n", status);
+        i2c_release(DEV_I2C);
+        return -ECANCELED;
+    }
+
+    uint8_t data[8];
+    if (i2c_read_regs(DEV_I2C, DEV_ADDR, CCS811_REG_ALG_RESULT_DATA, data, 8, 0) < 0) {
+        DEBUG("[ccs811] error: failed to read result data register '%02X'\n",
+              CCS811_REG_ALG_RESULT_DATA);
+        /* Release I2C device */
+        i2c_release(DEV_I2C);
+        return -EIO;
+    }
+
+    DEBUG("[ccs811] read_data: ECO2: %i\n", (uint16_t) (data[0] << 8) + data[1]);
+    DEBUG("[ccs811] read_data: TVOC: %i\n", (uint16_t) (data[2] << 8) + data[3]);
+
+    if (eco2 != NULL) {
+        *eco2 = (uint16_t)(data[0] <<8) + data[1];
+    }
+
+    if (tvoc != NULL) {
+        *tvoc = (uint16_t) (data[2] <<8) + data[3];
+    }
+
+    /* Release I2C device */
+    i2c_release(DEV_I2C);
+
+    _ccs811_poweroff(dev);
+
+    return 0;
+}
+
+int ccs811_read_eco2(const ccs811_t *dev, uint16_t *eco2)
+{
+    return ccs811_read_data(dev, eco2, NULL);
+}
+
+
+int ccs811_read_tvoc(const ccs811_t *dev, uint16_t *tvoc)
+{
+    return ccs811_read_data(dev, NULL, tvoc);
+}

--- a/drivers/ccs811/ccs811_saul.c
+++ b/drivers/ccs811/ccs811_saul.c
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2018 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_ccs811
+ * @{
+ *
+ * @file
+ * @brief       SAUL adaption for CCS811 device
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ * @}
+ */
+
+#include <string.h>
+
+#include "saul.h"
+#include "ccs811.h"
+
+static int read_eco2(const void *dev, phydat_t *res)
+{
+    if (ccs811_read_eco2((const ccs811_t *)dev, (uint16_t *)res->val) < 0) {
+        return -ECANCELED;
+    }
+    res->unit = UNIT_PPM;
+    res->scale = 0;
+    return 1;
+}
+
+static int read_tvoc(const void *dev, phydat_t *res)
+{
+    if (ccs811_read_tvoc((const ccs811_t *)dev, (uint16_t *)res->val) < 0) {
+        return -ECANCELED;
+    }
+    res->unit = UNIT_PPB;
+    res->scale = 0;
+    return 1;
+}
+
+const saul_driver_t ccs811_eco2_saul_driver = {
+    .read = read_eco2,
+    .write = saul_notsup,
+    .type = SAUL_SENSE_CO2
+};
+
+const saul_driver_t ccs811_tvoc_saul_driver = {
+    .read = read_tvoc,
+    .write = saul_notsup,
+    .type = SAUL_SENSE_TVOC
+};

--- a/drivers/ccs811/include/ccs811_constants.h
+++ b/drivers/ccs811/include/ccs811_constants.h
@@ -1,0 +1,77 @@
+/*
+ * Copyright (C) 2018 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_ccs811
+ * @brief       Internal addresses, registers, constants for the CCS811 sensor
+ * @{
+ *
+ * @file
+ * @brief       Internal addresses, registers, constants for the CCS811 sensor
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ */
+
+#ifndef CCS811_CONSTANTS_H
+#define CCS811_CONSTANTS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    CCS811 I2C address
+ * @{
+ */
+#define CCS811_ADDR                      (0x5A) /* 0x5B when i2c addr is high */
+/** @} */
+
+/**
+ * @name    CCS811 registers
+ * @{
+ */
+#define CCS811_REG_STATUS                (0x00)
+#define CCS811_REG_MEAS_MODE             (0x01)
+#define CCS811_REG_ALG_RESULT_DATA       (0x02)
+#define CCS811_REG_RAW_DATA              (0x03)
+#define CCS811_REG_ENV_DATA              (0x05)
+#define CCS811_REG_THRESHOLDS            (0x10)
+#define CCS811_REG_BASELINE              (0x11)
+#define CCS811_REG_HW_ID                 (0x20)
+#define CCS811_REG_HW_VERSION            (0x21)
+#define CCS811_REG_FW_BOOT_VERSION       (0x23)
+#define CCS811_REG_FW_APP_VERSION        (0x24)
+#define CCS811_REG_ERROR_ID              (0xE0)
+#define CCS811_REG_APP_START             (0xF4)
+#define CCS811_REG_SW_RESET              (0xFF)
+/** @} */
+
+/**
+ * @name    CCS811 constants
+ * @{
+ */
+#define CCS811_HW_ID                     (0x81)
+#define CCS811_HW_VERSION                (1 << 4)
+/** @} */
+
+/**
+ * @name    status register constants
+ * @{
+ */
+#define CCS811_STATUS_REG_ERROR         (0)
+#define CCS811_STATUS_REG_DATA_READY    (1 << 3)
+#define CCS811_STATUS_REG_APP_VALID     (1 << 4)
+#define CCS811_STATUS_REG_FW_MODE       (1 << 7)
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* CCS811_CONSTANTS_H */
+/** @} */

--- a/drivers/ccs811/include/ccs811_params.h
+++ b/drivers/ccs811/include/ccs811_params.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2018 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_ccs811
+ *
+ * @{
+ * @file
+ * @brief       Default configuration for CCS811
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ */
+
+#ifndef CCS811_PARAMS_H
+#define CCS811_PARAMS_H
+
+#include "board.h"
+#include "saul_reg.h"
+#include "ccs811.h"
+#include "ccs811_constants.h"
+#include "periph/gpio.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Set default configuration parameters for the CCS811
+ * @{
+ */
+#ifndef CCS811_PARAM_I2C_DEV
+#define CCS811_PARAM_I2C_DEV        I2C_DEV(0)
+#endif
+#ifndef CCS811_PARAM_I2C_ADDR
+#define CCS811_PARAM_I2C_ADDR       CCS811_ADDR
+#endif
+#ifndef CCS811_PARAM_WAKE_PIN
+#define CCS811_PARAM_WAKE_PIN       GPIO_UNDEF /* wake pin directly connected to ground */
+#endif
+#ifndef CCS811_PARAMS
+#define CCS811_PARAMS               { .i2c_dev      = CCS811_PARAM_I2C_DEV,   \
+                                      .i2c_addr     = CCS811_PARAM_I2C_ADDR,  \
+                                      .wake_pin     = CCS811_PARAM_WAKE_PIN }
+#endif
+#ifndef CCS811_SAUL_INFO
+#define CCS811_SAUL_INFO            { .name = "ccs811" }
+#endif
+/**@}*/
+
+/**
+ * @brief   Configure CCS811
+ */
+static const ccs811_params_t ccs811_params[] =
+{
+    CCS811_PARAMS
+};
+
+/**
+ * @brief   Configure SAUL registry entries
+ */
+static const saul_reg_info_t ccs811_saul_info[] =
+{
+    CCS811_SAUL_INFO
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* CCS811_PARAMS_H */
+/** @} */

--- a/drivers/include/ccs811.h
+++ b/drivers/include/ccs811.h
@@ -1,0 +1,121 @@
+/*
+ * Copyright (C) 2018 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    drivers_ccs811 CCS811 Gas sensor (eCO2 and TVOC)
+ * @ingroup     drivers_sensors
+ * @brief       Device driver support for the CCS811 sensor.
+ * @{
+ *
+ * @file
+ * @brief       Device driver interface for the CCS811 sensor.
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ */
+
+#ifndef CCS811_H
+#define CCS811_H
+
+#include "saul.h"
+#include "periph/i2c.h"
+#include "periph/gpio.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Measurements drive mode
+ */
+typedef enum {
+    CCS811_DRIVE_MODE_0,        /**< Measurements disabled */
+    CCS811_DRIVE_MODE_1,        /**< Measure every seconds */
+    CCS811_DRIVE_MODE_2,        /**< Measure every 10 seconds, default value */
+    CCS811_DRIVE_MODE_3,        /**< Measure every 60 seconds (low power) */
+    CCS811_DRIVE_MODE_4,        /**< Constant measure, every 250ms */
+} ccs811_drive_mode_t;
+
+/**
+ * @brief   Device initialization parameters
+ */
+typedef struct {
+    i2c_t i2c_dev;              /**< I2C device which is used */
+    uint8_t i2c_addr;           /**< I2C address */
+    gpio_t wake_pin;            /**< Wake pin */
+} ccs811_params_t;
+
+/**
+ * @brief   Device descriptor for the CCS811 sensor
+ */
+typedef struct {
+    ccs811_params_t params;     /**< Device initialization parameters */
+} ccs811_t;
+
+/**
+ * @brief   Initialize the given CCS811 device
+ *
+ * @param[out] dev          Initialized device descriptor of CCS811 device
+ * @param[in]  params       Initialization parameters
+ *
+ * @return                  0 on success
+ * @return                  -ENODEV if not a CCS811 at given address
+ * @return                  -ECANCELLED if initialization cannot continue
+ */
+int ccs811_init(ccs811_t *dev, const ccs811_params_t *params);
+
+/**
+ * @brief   Set measure drive mode
+ *
+ * @param[in] dev           Device descriptor of CCS811 device
+ * @param[in] mode          The measure drive mode
+ *
+ * @return                  0 on success
+ * @return                  -EIO if the drive could be written
+ */
+int ccs811_set_drive_mode(const ccs811_t *dev, ccs811_drive_mode_t mode);
+
+/**
+ * @brief   Read eCO2 and TVOC data
+ *
+ * @param[in]  dev          Device descriptor of CCS811 device
+ * @param[out] eco2         address of eCO2 measure or NULL
+ * @param[out] tvoc         address of TVOC measure or NULL
+ *
+ * @return                  0 on success
+ * @return                  -EIO on register access error
+ */
+int ccs811_read_data(const ccs811_t *dev, uint16_t *eco2, uint16_t *tvoc);
+
+/**
+ * @brief   Read eCO2 measure
+ *
+ * @param[in]  dev          Device descriptor of CCS811 device
+ * @param[out] eco2         eCO2 measure
+ *
+ * @return                  0 on success
+ * @return                  -EIO on register access error
+ */
+int ccs811_read_eco2(const ccs811_t *dev, uint16_t *eco2);
+
+/**
+ * @brief   Read TVOC measure
+ *
+ * @param[in]  dev          Device descriptor of CCS811 device
+ * @param[out] tvoc         TVOC measure
+ *
+ * @return                  0 on success
+ * @return                  -EIO on register access error
+ */
+int ccs811_read_tvoc(const ccs811_t *dev, uint16_t *tvoc);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* CCS811_H */
+/** @} */

--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -428,6 +428,10 @@ auto_init_mpu9150();
     extern void auto_init_mma7660(void);
     auto_init_mma7660();
 #endif
+#ifdef MODULE_CCS811
+    extern void auto_init_ccs811(void);
+    auto_init_ccs811();
+#endif
 
 #endif /* MODULE_AUTO_INIT_SAUL */
 

--- a/sys/auto_init/saul/auto_init_ccs811.c
+++ b/sys/auto_init/saul/auto_init_ccs811.c
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2018 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     sys_auto_init_saul
+ * @{
+ *
+ * @file
+ * @brief       Auto initialization of CCS811 driver.
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ * @}
+ */
+
+#ifdef MODULE_CCS811
+
+#include "log.h"
+#include "saul_reg.h"
+#include "ccs811.h"
+#include "ccs811_params.h"
+
+/**
+ * @brief   Define the number of configured sensors
+ */
+#define CCS811_NUM      (sizeof(ccs811_params) / sizeof(ccs811_params[0]))
+
+/**
+ * @brief   Allocation of memory for device descriptors
+ */
+static ccs811_t ccs811_devs[CCS811_NUM];
+
+/**
+ * @brief   Memory for the SAUL registry entries
+ */
+static saul_reg_t saul_entries[CCS811_NUM * 2];
+
+/**
+ * @brief   Define the number of saul info
+ */
+#define CCS811_INFO_NUM (sizeof(ccs811_saul_info) / sizeof(ccs811_saul_info[0]))
+
+/**
+ * @name    Reference the driver structs.
+ * @{
+ */
+extern const saul_driver_t ccs811_eco2_saul_driver;
+extern const saul_driver_t ccs811_tvoc_saul_driver;
+/** @} */
+
+void auto_init_ccs811(void)
+{
+    assert(CCS811_INFO_NUM == CCS811_NUM);
+
+    for (unsigned i = 0; i < CCS811_NUM; i++) {
+        LOG_DEBUG("[auto_init_saul] initializing ccs811 #%u\n", i);
+
+        if (ccs811_init(&ccs811_devs[i], &ccs811_params[i]) != 0) {
+            LOG_ERROR("[auto_init_saul] error initializing ccs811 #%u\n", i);
+            continue;
+        }
+
+        /* set permanent measure drive mode (every 250ms) */
+        ccs811_set_drive_mode(&ccs811_devs[i], CCS811_DRIVE_MODE_4);
+
+        /* temperature */
+        saul_entries[(i * 2)].dev = &(ccs811_devs[i]);
+        saul_entries[(i * 2)].name = ccs811_saul_info[i].name;
+        saul_entries[(i * 2)].driver = &ccs811_eco2_saul_driver;
+
+        /* atmospheric pressure */
+        saul_entries[(i * 2) + 1].dev = &(ccs811_devs[i]);
+        saul_entries[(i * 2) + 1].name = ccs811_saul_info[i].name;
+        saul_entries[(i * 2) + 1].driver = &ccs811_tvoc_saul_driver;
+
+        /* register to saul */
+        saul_reg_add(&(saul_entries[(i * 2)]));
+        saul_reg_add(&(saul_entries[(i * 2) + 1]));
+    }
+}
+#else
+typedef int dont_be_pedantic;
+#endif /* MODULE_CCS811 */

--- a/tests/driver_ccs811/Makefile
+++ b/tests/driver_ccs811/Makefile
@@ -1,0 +1,6 @@
+include ../Makefile.tests_common
+
+USEMODULE += ccs811
+USEMODULE += xtimer
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/driver_ccs811/README.md
+++ b/tests/driver_ccs811/README.md
@@ -1,0 +1,16 @@
+## About
+This is a test application for the CCS811 gas sensor that can detect
+Volatile Organic Compounds (VOCs).
+
+## Usage
+The application will first initialize the CCS811 sensor. Please see section 3.4
+of the
+[datasheet](https://ams.com/eng/content/.../CCS811_DS000459_4-00.pdf) for
+details.
+
+After initialization, the application:
+* measures and prints the eCO2 level (in ppm)
+* measures and prints the TVOC level (in ppb)
+
+Note: there's a little boot phase where measures are not ready. After some
+cycles the measures become ready.

--- a/tests/driver_ccs811/main.c
+++ b/tests/driver_ccs811/main.c
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2018 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup tests
+ * @{
+ *
+ * @file
+ * @brief       Test application for the CCS811 gas sensor
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include <inttypes.h>
+
+#include "ccs811.h"
+#include "ccs811_params.h"
+#include "xtimer.h"
+#include "board.h"
+
+int main(void)
+{
+    ccs811_t dev;
+    int result;
+
+    puts("CCS811 test application\n");
+
+    printf("+------------Initializing------------+\n");
+    result = ccs811_init(&dev, &ccs811_params[0]);
+    if (result != 0) {
+        puts("[Error] Failed to initialize the CCS811 sensor");
+        return 1;
+    }
+
+    puts("Initialization successful\n"
+         "\n+--------Starting Measurements--------+");
+
+    /* Measures are acquired every seconds */
+    ccs811_set_drive_mode(&dev, CCS811_DRIVE_MODE_1);
+
+    while (1) {
+        /* Read eCO2 level */
+        uint16_t eco2;
+        int ret = ccs811_read_eco2(&dev, &eco2);
+        if (ret == 0) {
+            /* Print the value */
+            printf("eCO2: %ippm\n", eco2);
+        }
+        else {
+            printf("Data not ready\n\n");
+        }
+
+        xtimer_sleep(1);
+
+        /* Read TVOC level */
+        uint16_t tvoc;
+        ret = ccs811_read_tvoc(&dev, &tvoc);
+        if (ret == 0) {
+            /* Print the value */
+            printf("TVOC: %ippb\n\n", tvoc);
+        }
+        else {
+            printf("Data not ready\n\n");
+        }
+
+        xtimer_sleep(1);
+    }
+
+    return 0;
+}


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR adds support for the [CCS81](https://ams.com/ccs811) gas sensor (eCO2, TVOC).

~The PR is based on commits from #9325 and the new_i2c_if branch. It's not intended to be merged before the I2C Rework, I'm just opening it to avoid duplicate work.~

Internally, the driver only implements polling of data. The interrupt based behaviour is not implemented.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

requires ~#9325~, ~#6577~

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->