### PR TITLE
tests/unittests, cn_cbor: remove invisible unicode char from Makefile

### DIFF
--- a/tests/unittests/tests-cn_cbor/Makefile
+++ b/tests/unittests/tests-cn_cbor/Makefile
@@ -1,4 +1,4 @@
-﻿include $(RIOTBASE)/Makefile.base
+include $(RIOTBASE)/Makefile.base
 
 # Tests will fail on platforms <64 bit if not set.
 # Workaround for missing overflow detection in cn-cbor.


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

fixes/removes an invisible uincode char in the Makefile of `tests-cn_cbor` which causes build failure on macOS

```
-<U+FEFF>include $(RIOTBASE)/Makefile.base
+include $(RIOTBASE)/Makefile.base
```


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->