### PR TITLE
murdock: also compile with LLVM/clang

### DIFF
--- a/.murdock
+++ b/.murdock
@@ -1,6 +1,8 @@
 #!/bin/sh
 
-export TEST_BOARDS_AVAILABLE=${TEST_BOARDS_AVAILABLE:-"samr21-xpro"}
+: ${TEST_BOARDS_AVAILABLE:="samr21-xpro"}
+: ${TEST_BOARDS_LLVM_COMPILE:="native"}
+
 export RIOT_CI_BUILD=1
 export STATIC_TESTS=${STATIC_TESTS:-1}
 export CFLAGS_DBG=""
@@ -92,21 +94,36 @@ get_supported_boards() {
     done | $(_greplist $BOARDS)
 }
 
-# given an app dir as parameter, print "$appdir board" for each supported
-# board. Only print for boards in $BOARDS.
-get_app_board_pairs() {
+get_supported_toolchains() {
+    local appdir=$1
+    local board=$2
+    local toolchains="gnu"
+
+    if is_in_list "${board}" "${TEST_BOARDS_LLVM_COMPILE}"; then
+        toolchains="$(make -s --no-print-directory -C${appdir} BOARD=${board} \
+                      info-toolchains-supported 2> /dev/null | grep -o -e "llvm" -e "gnu")"
+    fi
+    echo "${toolchains}"
+}
+
+# given an app dir as parameter, print "$appdir $board:$toolchain" for each
+# supported board and toolchain. Only print for boards in $BOARDS.
+get_app_board_toolchain_pairs() {
     local appdir=$1
     for board in $(get_supported_boards $appdir)
     do
-        echo $appdir $board
+        for toolchain in $(get_supported_toolchains $appdir $board)
+        do
+            echo $appdir $board:$toolchain
+        done
     done | $(_greplist $BOARDS)
 }
 
-# use dwqc to create full "appdir board" compile job list
+# use dwqc to create full "appdir board toolchain" compile job list
 get_compile_jobs() {
     get_apps | \
         dwqc ${DWQ_ENV} -s \
-        "$0 get_app_board_pairs \${1}" \
+        "$0 get_app_board_toolchain_pairs \${1}" \
         | xargs '-d\n' -n 1 echo $0 compile
 }
 
@@ -115,10 +132,11 @@ print_worker() {
         echo "-- running on worker ${DWQ_WORKER} thread ${DWQ_WORKER_THREAD}, build number $DWQ_WORKER_BUILDNUM."
 }
 
-# compile one app for one board. delete intermediates.
+# compile one app for one board with one toolchain. delete intermediates.
 compile() {
     local appdir=$1
-    local board=$2
+    local board=$(echo $2 | cut -f 1 -d':')
+    local toolchain=$(echo $2 | cut -f 2 -d':')
 
     [ "$board" = "makefile_broken" ] && error "$0: Makefile in \"$appdir\" seems to be broken!"
 
@@ -132,12 +150,12 @@ compile() {
     print_worker
 
     # sanity checks
-    [ $# -ne 2 ] && error "$0: compile: invalid parameters (expected \$appdir \$board)"
+    [ $# -ne 2 ] && error "$0: compile: invalid parameters (expected \$appdir \$board:\$toolchain)"
     [ ! -d "$appdir" ] && error "$0: compile: error: application directory \"$appdir\" doesn't exist"
     [ ! -d "boards/$board" ] && error "$0: compile: error: board directory \"boards/$board\" doesn't exist"
 
     # compile
-    CCACHE_BASEDIR="$(pwd)" BOARD=$board RIOT_CI_BUILD=1 \
+    CCACHE_BASEDIR="$(pwd)" BOARD=$board TOOLCHAIN=$toolchain RIOT_CI_BUILD=1 \
         make -C${appdir} clean all -j${JOBS:-4}
     RES=$?
 
@@ -169,7 +187,8 @@ compile() {
 
 test_job() {
     local appdir=$1
-    local board=$2
+    local board=$(echo $2 | cut -f 1 -d':')
+    local toolchain=$(echo $2 | cut -f 2 -d':')
     local flashfile="$3"
 
     [ ! -f "$flashfile" ] && {
@@ -183,16 +202,17 @@ test_job() {
         --file $flashfile:$appdir/bin/${board}/$(basename $flashfile) \
         --queue ${TEST_QUEUE:-$board} \
         --maxfail 1 \
-        "./.murdock run_test $appdir $board"
+        "./.murdock run_test $appdir $board:$toolchain"
 }
 
 run_test() {
     local appdir=$1
-    local board=$2
+    local board=$(echo $2 | cut -f 1 -d':')
+    local toolchain=$(echo $2 | cut -f 2 -d':')
     print_worker
-    echo "-- executing tests for $appdir on $board:"
+    echo "-- executing tests for $appdir on $board (compiled with $toolchain toolchain):"
     hook run_test_pre
-    BOARD=$board make -C$appdir flash-only test
+    BOARD=$board TOOLCHAIN=${toolchain} make -C$appdir flash-only test
 }
 
 # execute static tests

--- a/makefiles/murdock.inc.mk
+++ b/makefiles/murdock.inc.mk
@@ -16,7 +16,7 @@ test-murdock:
 	cd $(RIOTBASE) && \
 		./.murdock test_job \
 		$$(realpath --relative-to $(RIOTBASE) $(APPDIR)) \
-		$(BOARD) \
+		"$(BOARD):$(TOOLCHAIN)" \
 		$(FLASHFILE)
 
 # don't whitelist tests if there's no binary


### PR DESCRIPTION
### Contribution description
This is just an RFC and just a sketch at the moment, as I don't know how good this idea is (may slow down Murdock builds, but so would any new board) or if what I'm doing here is even correct.

But there are two major reasons for this:

1. clang picks up different errors sometimes than GCC.
2. OSX support is hardened as it is usually the toolchain used there.

### Issues/PRs references
None (but idea sparked by https://github.com/RIOT-OS/RIOT/pull/8646#discussion_r197372867)