### PR TITLE
sock_dns: fix typo in doc

### DIFF
--- a/sys/include/net/sock/dns.h
+++ b/sys/include/net/sock/dns.h
@@ -70,7 +70,7 @@ typedef struct {
  * By supplying AF_INET, AF_INET6 or AF_UNSPEC in @p family requesting of A
  * records (IPv4), AAAA records (IPv6) or both can be selected.
  *
- * This fuction will return the first DNS record it receives. IF both A and
+ * This function will return the first DNS record it receives. IF both A and
  * AAAA are requested, AAAA will be preferred.
  *
  * @note @p addr_out needs to provide space for any possible result!


### PR DESCRIPTION
### Contribution description
`s/fuction/function/` ;-)

### Issues/PRs references
None