### PR TITLE
cpu/nrf52: enable instruction cache

### DIFF
--- a/cpu/nrf52/cpu.c
+++ b/cpu/nrf52/cpu.c
@@ -64,6 +64,9 @@ void cpu_init(void)
     /* initialize hf clock */
     clock_init_hf();
 
+    /* enable instruction cache */
+    NRF_NVMC->ICACHECNF = (NVMC_ICACHECNF_CACHEEN_Msk);
+
     /* softdevice needs to be enabled from ISR context */
 #ifdef SOFTDEVICE_PRESENT
     softdevice_handler_init(NRF_CLOCK_LFCLKSRC_XTAL_20_PPM, &_ble_evt_buffer,


### PR DESCRIPTION
### Contribution description
@bergzand and me were looking at some run-time benchmarks comparing e.g. crypto libraries and simple nop loops. We discovered, that the run-time between a `nrf52dk` and a `nucleo-f446re` were quite different, while both are Cortex-M4F and both were running at 64MHz (we changed the default clock for the `nucleo-f446re`).

It turned out, that the instruction cache for the `nrf52` was not enabled, hence it was quite a bit slower than the nucleo. Enabling the instruction cache lead to both boards performing more or less equal - as would be expected.

This PR does indeed improve the run-time performance of all `nrf52` boards significantly, see the example output for the `test/periph_gpio` app:

Master:
```
GPIO driver run-time performance benchmark                                                  
                                                                                            
                 nop loop:    234375us  ---   0.234us per call  ---    4266666 calls per sec
                 gpio_set:    453126us  ---   0.453us per call  ---    2206891 calls per sec
               gpio_clear:    484376us  ---   0.484us per call  ---    2064511 calls per sec
              gpio_toggle:    531251us  ---   0.531us per call  ---    1882349 calls per sec
                gpio_read:    656251us  ---   0.656us per call  ---    1523807 calls per sec
               gpio_write:    437501us  ---   0.437us per call  ---    2285709 calls per sec
```

with this PR:
```
GPIO driver run-time performance benchmark                                                  
                                                                                            
                 nop loop:    109376us  ---   0.109us per call  ---    9142773 calls per sec
                 gpio_set:    250001us  ---   0.250us per call  ---    3999984 calls per sec
               gpio_clear:    250001us  ---   0.250us per call  ---    3999984 calls per sec
              gpio_toggle:    375001us  ---   0.375us per call  ---    2666659 calls per sec
                gpio_read:    375001us  ---   0.375us per call  ---    2666659 calls per sec
               gpio_write:    296876us  ---   0.296us per call  ---    3368409 calls per sec
```

### Issues/PRs references
none