### PR TITLE
gnrc_pktbuf_cmd: module is not a pktbuf implementation

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -520,6 +520,9 @@ ifneq (,$(filter gnrc_pktbuf, $(USEMODULE)))
   ifeq (,$(filter gnrc_pktbuf_%, $(USEMODULE)))
     USEMODULE += gnrc_pktbuf_static
   endif
+  ifeq (gnrc_pktbuf_cmd,$(filter gnrc_pktbuf_%, $(USEMODULE)))
+    USEMODULE += gnrc_pktbuf_static
+  endif
   USEMODULE += gnrc_pkt
 endif
 


### PR DESCRIPTION
### Contribution description
When I introduced this pseudo-module in #9391 I did not consider, that the way I named it, it is assumed to be an implementation of the `gnrc_pktbuf` interface. However, it is not (it just provides the shell command).

This PR excludes `gnrc_pktbuf_cmd` from the selection algorithm, so that if it is the only `gnrc_pktbuf_%` module, still `gnrc_pktbuf_static` gets selected.

### Issues/PRs references
Fixes an inconvenience introduced in #9391.