### PR TITLE
boards/nrf52: add openocd as programmer option

### DIFF
--- a/boards/acd52832/doc.txt
+++ b/boards/acd52832/doc.txt
@@ -2,4 +2,9 @@
 @defgroup    boards_acd52832 ACD52832
 @ingroup     boards
 @brief       Support for the aconno™ ACD52832
+
+## Flash the board
+
+See the `Flashing` section in @ref boards_common_nrf52.
+
  */

--- a/boards/common/nrf52/Makefile.include
+++ b/boards/common/nrf52/Makefile.include
@@ -27,6 +27,10 @@ ifeq (jlink,$(PROGRAMMER))
   endif
   include $(RIOTMAKE)/tools/jlink.inc.mk
 else ifeq (openocd,$(PROGRAMMER))
+  ifneq (,$(filter $(BOARD),ruuvitag thingy52))
+    # openocd doesn't fully work with ruuvitag and thingy52
+    $(error Cannot use OpenOCD with $(BOARD) board)
+  endif
   # setup OpenOCD for flashing. Version 0.10 of OpenOCD doesn't contain support
   # for nrf52dk and nrf52840dk boards. To use OpenOCD with these a version
   # build from source (master > 2018, August the 13rd) is required.

--- a/boards/common/nrf52/Makefile.include
+++ b/boards/common/nrf52/Makefile.include
@@ -9,17 +9,15 @@ PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 include $(RIOTMAKE)/tools/serial.inc.mk
 
-# define jlink as default programmer, but overridable
-PROGRAMMER ?= jlink
+# The following configuration is dependencies specific
+# but they are resolved later
+# Hack to know now if 'nordic_softdevice_ble' is used
+include $(RIOTBOARD)/$(BOARD)/Makefile.dep
 
+PROGRAMMER ?= jlink
 ifeq (jlink,$(PROGRAMMER))
   # setup JLink for flashing
   export JLINK_DEVICE := nrf52
-
-  # The following configuration is dependencies specific
-  # but they are resolved later
-  # Hack to know now if 'nordic_softdevice_ble' is used
-  include $(RIOTBOARD)/$(BOARD)/Makefile.dep
 
   # special options when using SoftDevice
   ifneq (,$(filter nordic_softdevice_ble,$(USEPKG)))
@@ -27,6 +25,16 @@ ifeq (jlink,$(PROGRAMMER))
     export FLASH_ADDR := 0x1f000
     export LINKER_SCRIPT ?= $(RIOTCPU)/$(CPU)/ldscripts/$(CPU_MODEL)_sd.ld
   endif
-
   include $(RIOTMAKE)/tools/jlink.inc.mk
+else ifeq (openocd,$(PROGRAMMER))
+  # setup OpenOCD for flashing. Version 0.10 of OpenOCD doesn't contain support
+  # for nrf52dk and nrf52840dk boards. To use OpenOCD with these a version
+  # build from source (master > 2018, August the 13rd) is required.
+  ifneq (,$(filter nordic_softdevice_ble,$(USEPKG)))
+    # openocd doesn't work (yet) with softdevice
+    $(error Cannot use OpenOCD with nordic_softdevice module)
+  endif
+  export DEBUG_ADAPTER ?= jlink
+  export OPENOCD_CONFIG := $(RIOTBOARD)/common/nrf52/dist/openocd.cfg
+  include $(RIOTMAKE)/tools/openocd.inc.mk
 endif

--- a/boards/common/nrf52/dist/openocd.cfg
+++ b/boards/common/nrf52/dist/openocd.cfg
@@ -1,0 +1,3 @@
+transport select swd
+
+source [find target/nrf52.cfg]

--- a/boards/common/nrf52/doc.txt
+++ b/boards/common/nrf52/doc.txt
@@ -14,9 +14,11 @@ Example with `hello-world` application:
     make BOARD=<nrf52 board> -C examples/hello-world flash
 ```
 
-OpenOCD can also be used to flash nrf52 boards. For the moment, the latest
-stable version of OpenOCD (0.10) doesn't contain any support for nrf52 but
-versions built against the current development version can be used.
+OpenOCD can also be used to flash nrf52 boards (except thingy52 and ruuvitag
+because they are hardly coupled with JLink segger_rtt stdio).
+For the moment, the latest stable version of OpenOCD (0.10) doesn't contain any
+support for nrf52 but versions built against the current development version
+can be used.
 
 To flash the board with OpenOCD, use the `PROGRAMMER` variable:
 ```

--- a/boards/common/nrf52/doc.txt
+++ b/boards/common/nrf52/doc.txt
@@ -1,0 +1,26 @@
+/**
+@defgroup    boards_common_nrf52 nRF52 common
+@ingroup     boards_common
+@brief       Common files and configuration for nRF52 boards.
+
+## Flashing nrf52 boards
+
+By default, nrf52 boards are flashed using Jlink. @ref boards_nrf52840-mdk
+uses PyOCD by default.
+
+To flash the board, use `BOARD=<nrf52 board>` with the `make` command.<br/>
+Example with `hello-world` application:
+```
+    make BOARD=<nrf52 board> -C examples/hello-world flash
+```
+
+OpenOCD can also be used to flash nrf52 boards. For the moment, the latest
+stable version of OpenOCD (0.10) doesn't contain any support for nrf52 but
+versions built against the current development version can be used.
+
+To flash the board with OpenOCD, use the `PROGRAMMER` variable:
+```
+    PROGRAMMER=openocd make BOARD=<nrf52 board> -C examples/hello-world flash
+```
+
+*/

--- a/boards/common/nrf52/include/board_common.h
+++ b/boards/common/nrf52/include/board_common.h
@@ -7,8 +7,7 @@
  */
 
 /**
- * @defgroup    boards_common_nrf52 NRF52 common
- * @ingroup     boards_common
+ * @ingroup     boards_common_nrf52
  * @brief       Shared files and configuration for all nRF52 boards.
  * @{
  *

--- a/boards/nrf52840-mdk/Makefile.include
+++ b/boards/nrf52840-mdk/Makefile.include
@@ -10,9 +10,6 @@ ifeq (pyocd,$(PROGRAMMER))
   # option is passed explicitly
   export FLASH_TARGET_TYPE ?= -t $(CPU)
   include $(RIOTMAKE)/tools/pyocd.inc.mk
-else ifeq (openocd,$(PROGRAMMER))
-  export DEBUG_ADAPTER ?= dap
-  include $(RIOTMAKE)/tools/openocd.inc.mk
 endif
 
 include $(RIOTBOARD)/common/nrf52/Makefile.include

--- a/boards/nrf52840-mdk/dist/openocd.cfg
+++ b/boards/nrf52840-mdk/dist/openocd.cfg
@@ -1,2 +1,0 @@
-transport select swd
-source [find target/nrf52.cfg]

--- a/boards/nrf52840-mdk/doc.txt
+++ b/boards/nrf52840-mdk/doc.txt
@@ -23,20 +23,8 @@ PyOCD can be installed using Python package manager:
     pip install pyocd --user -U
 ```
 
-To flash the board `BOARD=nrf52840-mdk` with the `make` command.<br/>
-Example with `hello-world` application:
-```
-    make BOARD=nrf52840-mdk -C examples/hello-world flash
-```
+See the `Flashing` section in @ref boards_common_nrf52.
 
-OpenOCD can also be used. For the moment, the latest stable version of OpenOCD
-(0.10) doesn't contain any support for nrf52 but versions built against the
-actual development version can be used.
-
-To flash the board with OpenOCD, use the `PROGRAMMER` variable:
-```
-    PROGRAMMER=openocd make BOARD=nrf52840-mdk -C examples/hello-world flash
-```
 
 ### Accessing STDIO via UART
 

--- a/boards/nrf52840dk/doc.txt
+++ b/boards/nrf52840dk/doc.txt
@@ -15,22 +15,7 @@ work for the time being.
 
 ## Flash the board
 
-By default, the board is flashed with via the on-board Segger JLink adapter.
-
-To flash the board, use `BOARD=nrf52840dk` with the `make` command.<br/>
-Example with `hello-world` application:
-```
-    make BOARD=nrf52840dk -C examples/hello-world flash
-```
-
-OpenOCD can also be used. For the moment, the latest stable version of OpenOCD
-(0.10) doesn't contain any support for nrf52 but versions built against the
-actual development version can be used.
-
-To flash the board with OpenOCD, use the `PROGRAMMER` variable:
-```
-    PROGRAMMER=openocd make BOARD=nrf52840dk -C examples/hello-world flash
-```
+See the `Flashing` section in @ref boards_common_nrf52.
 
 ## Accessing STDIO via UART
 

--- a/boards/nrf52840dk/doc.txt
+++ b/boards/nrf52840dk/doc.txt
@@ -13,4 +13,33 @@ this, RIOT provides a little tool in `dist/tools/nrf52_resetpin_cfg`.
 Simply compile, flash, and run that tool on your board, and the reset pin should
 work for the time being.
 
+## Flash the board
+
+By default, the board is flashed with via the on-board Segger JLink adapter.
+
+To flash the board, use `BOARD=nrf52840dk` with the `make` command.<br/>
+Example with `hello-world` application:
+```
+    make BOARD=nrf52840dk -C examples/hello-world flash
+```
+
+OpenOCD can also be used. For the moment, the latest stable version of OpenOCD
+(0.10) doesn't contain any support for nrf52 but versions built against the
+actual development version can be used.
+
+To flash the board with OpenOCD, use the `PROGRAMMER` variable:
+```
+    PROGRAMMER=openocd make BOARD=nrf52840dk -C examples/hello-world flash
+```
+
+## Accessing STDIO via UART
+
+The STDIO is directly accessible via the USB port. On a Linux host, it's
+generally mapped to `/dev/ttyACM0`.
+
+Use the `term` target to connect to the board serial port<br/>
+```
+    make BOARD=nrf52840dk -C examples/hello-world term
+```
+
  */

--- a/boards/nrf52dk/doc.txt
+++ b/boards/nrf52dk/doc.txt
@@ -104,4 +104,34 @@ work for the time being.
 There are two pins for current measurement on board. Don't connect these pins
 to GND!. The left pin is at 3.3V level and the right pin is connected to V33.
 Divide the measured voltage between this pins by 22 to get the current.
+
+
+## Flash the board
+
+By default, the board is flashed with via the on-board Segger JLink adapter.
+
+To flash the board, use `BOARD=nrf52dk` with the `make` command.<br/>
+Example with `hello-world` application:
+```
+    make BOARD=nrf52dk -C examples/hello-world flash
+```
+
+OpenOCD can also be used. For the moment, the latest stable version of OpenOCD
+(0.10) doesn't contain any support for nrf52 but versions built against the
+actual development version can be used.
+
+To flash the board with OpenOCD, use the `PROGRAMMER` variable:
+```
+    PROGRAMMER=openocd make BOARD=nrf52dk -C examples/hello-world flash
+```
+
+## Accessing STDIO via UART
+
+The STDIO is directly accessible via the USB port. On a Linux host, it's
+generally mapped to `/dev/ttyACM0`.
+
+Use the `term` target to connect to the board serial port<br/>
+```
+    make BOARD=nrf52dk -C examples/hello-world term
+```
  */

--- a/boards/nrf52dk/doc.txt
+++ b/boards/nrf52dk/doc.txt
@@ -105,25 +105,9 @@ There are two pins for current measurement on board. Don't connect these pins
 to GND!. The left pin is at 3.3V level and the right pin is connected to V33.
 Divide the measured voltage between this pins by 22 to get the current.
 
-
 ## Flash the board
 
-By default, the board is flashed with via the on-board Segger JLink adapter.
-
-To flash the board, use `BOARD=nrf52dk` with the `make` command.<br/>
-Example with `hello-world` application:
-```
-    make BOARD=nrf52dk -C examples/hello-world flash
-```
-
-OpenOCD can also be used. For the moment, the latest stable version of OpenOCD
-(0.10) doesn't contain any support for nrf52 but versions built against the
-actual development version can be used.
-
-To flash the board with OpenOCD, use the `PROGRAMMER` variable:
-```
-    PROGRAMMER=openocd make BOARD=nrf52dk -C examples/hello-world flash
-```
+See the `Flashing` section in @ref boards_common_nrf52.
 
 ## Accessing STDIO via UART
 

--- a/boards/ruuvitag/doc.txt
+++ b/boards/ruuvitag/doc.txt
@@ -2,4 +2,9 @@
 @defgroup    boards_ruuvitag RuuviTag
 @ingroup     boards
 @brief       Support for the RuuviTag board
+
+## Flash the board
+
+See the `Flashing` section in @ref boards_common_nrf52.
+
  */

--- a/boards/thingy52/doc.txt
+++ b/boards/thingy52/doc.txt
@@ -2,4 +2,9 @@
 @defgroup    boards_thingy52 Nordic Thingy:52
 @ingroup     boards
 @brief       Support for the Nordic Thingy:52 board
+
+## Flash the board
+
+See the `Flashing` section in @ref boards_common_nrf52.
+
  */


### PR DESCRIPTION
### Contribution description

This PR adds support for openocd as a programmer for nrf52 based board. These boards can be flashed using jlink adapter and openocd (>= 0.10.0) provides everything for this.

Unfortunately, it won't work if the application uses the softdevice blob because the build system doesn't provide a self contained binary in this case. Because of this limitation the jlink programmer is kept as the default one.
If an application requires softdevice and openocd is used then an error message is displayed. A better approach would be to merge the softdevice hex with the compiled binary before flashing it to the board. Maybe using the preflash target or by adding a new post-build target would make this possible ? Makefile experts' opinion is welcome.


### Issues/PRs references

None


### Testing

- [x] `acd52832` (@PeterKietzmann)
- [x] `nrf52dk` (@maribu)
- [x] `nrf52480-dk` (@maribu)
- [x] `nrf52840-mdk` (@aabadie)
- [x] `ruuvitag` & `thingy52` disabled, no testing required

------

Update: Added testing state
Update: Added results for RuuviTag
Update: RuuviTag and Thingy:52, so no testing required