### PR TITLE
cpu/stm_common: fix i2c when address is NACKed

### DIFF
--- a/cpu/stm32_common/periph/i2c_2.c
+++ b/cpu/stm32_common/periph/i2c_2.c
@@ -436,7 +436,7 @@ static int _start(I2C_TypeDef *i2c, uint8_t address, uint8_t rw_flag, uint8_t fl
     while (!(i2c->SR1 & I2C_SR1_ADDR) && tick--) {
         if ((i2c->SR1 & ERROR_FLAG) || !tick) {
             i2c->CR1 |= I2C_CR1_STOP;
-            return -ETIMEDOUT;
+            return -EIO;
         }
     }
 
@@ -500,7 +500,7 @@ static inline int _wait_ready(I2C_TypeDef *i2c)
     while ((i2c->SR2 & I2C_SR2_BUSY) && tick--) {
         if (!tick) {
             DEBUG("[i2c] wait_ready: timeout\n");
-            return -EIO;
+            return -ETIMEDOUT;
         }
     }
 

--- a/cpu/stm32_common/periph/i2c_2.c
+++ b/cpu/stm32_common/periph/i2c_2.c
@@ -500,7 +500,7 @@ static inline int _wait_ready(I2C_TypeDef *i2c)
     while ((i2c->SR2 & I2C_SR2_BUSY) && tick--) {
         if (!tick) {
             DEBUG("[i2c] wait_ready: timeout\n");
-            return -ETIMEDOUT;
+            return -EIO;
         }
     }
 

--- a/cpu/stm32_common/periph/i2c_2.c
+++ b/cpu/stm32_common/periph/i2c_2.c
@@ -226,7 +226,6 @@ int i2c_read_bytes(i2c_t dev, uint16_t address, void *data, size_t length,
         if (ret < 0) {
             return ret;
         }
-        _clear_addr(i2c);
         if (length == 1 && !(flags & I2C_NOSTOP)) {
             DEBUG("[i2c] read_bytes: Set ACK = 0\n");
             i2c->CR1 &= ~(I2C_CR1_ACK);

--- a/cpu/stm32_common/periph/i2c_2.c
+++ b/cpu/stm32_common/periph/i2c_2.c
@@ -236,7 +236,7 @@ int i2c_read_bytes(i2c_t dev, uint16_t address, void *data, size_t length,
         }
         _clear_addr(i2c);
     }
-    else{
+    else {
         if (length == 1 && !(flags & I2C_NOSTOP)) {
             DEBUG("[i2c] read_bytes: Set ACK = 0\n");
             i2c->CR1 &= ~(I2C_CR1_ACK);


### PR DESCRIPTION
### Contribution description

Fixes the fact that the stop bit does not get sent if address is NACKed.  As well as fixes flag issues when using read bytes.  There is still extra reads that go on but from the software it seems to work.  


### Issues/PRs references
See #6577