### PR TITLE
sys/random: fix distribution of random_uint32_range() 

### DIFF
--- a/sys/include/random.h
+++ b/sys/include/random.h
@@ -92,10 +92,7 @@ void random_bytes(uint8_t *buf, size_t size);
  *
  * @return  a random number on [a,b)-interval
  */
-static inline uint32_t random_uint32_range(uint32_t a, uint32_t b)
-{
-    return (random_uint32() % (b - a)) + a;
-}
+uint32_t random_uint32_range(uint32_t a, uint32_t b);
 
 #if PRNG_FLOAT
 /* These real versions are due to Isaku Wada, 2002/01/09 added */

--- a/sys/random/random.c
+++ b/sys/random/random.c
@@ -54,3 +54,30 @@ void random_bytes(uint8_t *target, size_t n)
         *target++ = *random_pos++;
     }
 }
+
+uint32_t random_uint32_range(uint32_t a, uint32_t b)
+{
+    assert(a < b);
+
+    uint32_t divisor, rand_val, range = b - a;
+    uint8_t range_msb = bitarithm_msb(range);
+
+    /* check if range is a power of two */
+    if (!(range & (range - 1))) {
+        divisor = (1 << range_msb) - 1;
+    }
+    else if (range_msb < 31) {
+        /* leftshift for next power of two interval */
+        divisor = (1 << (range_msb + 1)) -1;
+    }
+    else {
+        /* disable modulo operation in loop below */
+        divisor = UINT32_MAX;
+    }
+    /* get random numbers until value is smaller than range */
+    do {
+        rand_val = (random_uint32() & divisor);
+    } while (rand_val >= range);
+    /* return random in range [a,b] */
+    return (rand_val + a);
+}

--- a/tests/rng/README.md
+++ b/tests/rng/README.md
@@ -3,12 +3,14 @@ Test application for the RNG sourcs.
 
 ## Supported commands
 * distributions [N] — Take N samples and print a bit distribution graph on the terminal.
-* dump [N] — Take N samples and print them on the terminal.
+* dump [N][A B] — Take N samples and print them on the terminal. If A and B are
+set, the PRNG returns values in the [A,B)-interval.
 * fips — Run the FIPS 140-2 random number tests.
 * entropy [N] — Calculate Shannon's entropy from N samples.
 * seed [N] — Set the random seed to use.
 * source [N] — Select the RNG source, or list them all.
-* speed [N] — Run a PRNG for N seconds and print the number of KiB/sec afterwards.
+* speed [N][A B] — Run a PRNG for N seconds and print the number of KiB/sec
+afterwards. If A and B are set, the PRNG returns values in the [A,B)-interval.
 
 ## Sources
 The following sources are supported:

--- a/tests/rng/main.c
+++ b/tests/rng/main.c
@@ -90,12 +90,26 @@ static int cmd_dump(int argc, char **argv)
 {
     uint32_t samples = 100;
 
-    if (argc > 1) {
+    if (argc < 2) {
+        /* run the test */
+        test_dump(samples);
+    }
+    else if (argc == 2) {
         samples = strtoul(argv[1], NULL, 0);
+        /* run the test */
+        test_dump(samples);
+    }
+    else if (argc == 4) {
+        samples = strtoul(argv[1], NULL, 0);
+        uint32_t low_thresh = strtoul(argv[2], NULL, 0);
+        uint32_t high_thresh = strtoul(argv[3], NULL, 0);
+        /* run the test */
+        test_dump_range(samples, low_thresh, high_thresh);
+    }
+    else {
+        printf("usage: %s [samples] [lower-bound upper-bound]\n", argv[0]);
     }
 
-    /* run the test */
-    test_dump(samples);
 
     return 0;
 }
@@ -220,12 +234,25 @@ static int cmd_speed(int argc, char **argv)
 {
     uint32_t duration = 10;
 
-    if (argc > 1) {
-        duration = strtoul(argv[1], NULL, 0);
+    if (argc < 2) {
+        /* run the test */
+        test_speed(duration);
     }
-
-    /* run the test */
-    test_speed(duration);
+    else if (argc == 2) {
+        duration = strtoul(argv[1], NULL, 0);
+        /* run the test */
+        test_speed(duration);
+    }
+    else if (argc == 4) {
+        duration = strtoul(argv[1], NULL, 0);
+        uint32_t low_thresh = strtoul(argv[2], NULL, 0);
+        uint32_t high_thresh = strtoul(argv[3], NULL, 0);
+        /* run the test */
+        test_speed_range(duration, low_thresh, high_thresh);
+    }
+    else {
+        printf("usage: %s [duration] [lower-bound upper-bound]\n", argv[0]);
+    }
 
     return 0;
 }

--- a/tests/rng/test.h
+++ b/tests/rng/test.h
@@ -74,6 +74,18 @@ void test_distributions(uint32_t samples);
 void test_dump(uint32_t samples);
 
 /**
+ * @brief   Test for dumping random number r with a <= r < b. Each number
+ *          is printed on a separate line as an unsigned 32-bit number.
+ *
+ * @param[in] samples   Number of samples to print.
+ * @param[in] a         Minimum for random number
+ * @param[in] b         Upper bound for random number
+ *
+ * @pre     a < b
+ */
+void test_dump_range(uint32_t samples, uint32_t a, uint32_t b);
+
+/**
  * @brief   Run the FIPS 140-2 battery of test.
  *
  * The FIPS 140-2 tests are four statistical tests that will test 20000 bits
@@ -103,6 +115,18 @@ void test_entropy(uint32_t samples);
  * @param[in] duration  Test duration (in seconds)
  */
 void test_speed(uint32_t duration);
+
+/**
+ * @brief   Run the speed test for random numbers r with a <= r < b and a given duration.
+ *          It utillizes xtimer for setting an alarm.
+ *
+ * @param[in] duration  Test duration (in seconds)
+ * @param[in] a         Minimum for random number
+ * @param[in] b         Upper bound for random number
+ *
+ * @pre     a < b
+ */
+void test_speed_range(uint32_t duration, uint32_t a, uint32_t b);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
### Contribution description
#8778 depicts that  [`random_uint32_range()`](https://github.com/RIOT-OS/RIOT/blob/master/sys/include/random.h#L95) does not return uniformly distributed numbers in the desired interval. This PR adds a fix that provides uniform distributions (as displayed below) but comes with a certain performance regression.

### Issues/PRs references
 #8778

### Results - Distribution
#### Native with `prng_xorshift`, [0,0xC0000000)-interval, 50k numbers

Old:
![old](https://user-images.githubusercontent.com/7765855/41860514-29cf366a-789f-11e8-8764-75e5f6fda509.png)

With fix:
![new](https://user-images.githubusercontent.com/7765855/41860532-30dd13b4-789f-11e8-8c10-7e0f8ae0538e.png)

### Results - Performance
#### samr21-xpro with `prng_xorshift`, [0,0xC0000000)-interval, 10seconds
Old: 244 KiB/s
With fix: 213 KiB/s

#### samr21-xpro with `prng_xorshift`, [0,0x80000001)-interval, 10seconds
Old: 244 KiB/s
With fix: 206 KiB/s

#### samr21-xpro with `prng_xorshift`, [0,0x80000000)-interval, 10seconds
Old: 244 KiB/s
With fix: 217 KiB/s

#### samr21-xpro with `prng_xorshift`, [0x18000)-interval, 10seconds
Old: 244 KiB/s
With fix: ~~168 KiB/s~~ 202 KiB/s

#### samr21-xpro with `prng_xorshift`, [0x10000)-interval, 10seconds
Old: 244 KiB/s
With fix: ~~186 KiB/s~~ 217 KiB/s


#### samr21-xpro with `prng_tinymt32`, [0,0xC0000000)-interval, 10seconds
Old: 229 KiB/s
With fix: 198 KiB/s

#### samr21-xpro with `prng_tinymt32`, [0,0x18000)-interval, 10seconds
Old: 229 KiB/s
With fix: ~~151 KiB/s~~ 180 KiB/s

#### samr21-xpro with `prng_tinymt32`, [0,0x10000)-interval, 10seconds
Old: 229 KiB/s
With fix: ~~177 KiB/s~~ 205 KiB/s