### PR TITLE
netdev_ieee802154: Use intermediate layer for mac header

### DIFF
--- a/drivers/include/net/netdev/ieee802154.h
+++ b/drivers/include/net/netdev/ieee802154.h
@@ -16,6 +16,7 @@
  * @brief   Definitions for netdev common IEEE 802.15.4 code
  *
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
+ * @author  Koen Zandberg <koen@bergzand.net>
  */
 #ifndef NET_NETDEV_IEEE802154_H
 #define NET_NETDEV_IEEE802154_H
@@ -120,6 +121,46 @@ typedef struct {
  * @brief   Received packet status information for IEEE 802.15.4 radios
  */
 typedef struct netdev_radio_rx_info netdev_ieee802154_rx_info_t;
+
+typedef struct {
+    uint8_t src[IEEE802154_LONG_ADDRESS_LEN];
+    uint8_t dst[IEEE802154_LONG_ADDRESS_LEN];
+    uint8_t src_len;
+    uint8_t dst_len;
+} netdev_ieee802154_mac_t;
+
+/**
+ * @brief   Receive function for netdev IEEE 802.15.4 devices.
+ *
+ * Reformats the ieee802.15.4 mac frame to a generic
+ * @ref netdev_ieee802154_mac_t header using the frame content.
+ *
+ * @param[in]   dev     network device descriptor
+ * @param[out]  buf     buffer to write into or NULL
+ * @param[in]   len     maximum number of bytes to read
+ * @param[out] info     status information for the received packet. Might
+ *                      be of different type for different netdev devices.
+ *                      May be NULL if not needed or applicable.
+ *
+ * @return `< 0` on error
+ * @return number of bytes read if buf != NULL
+ * @return packet size if buf == NULL
+ */
+int netdev_ieee802154_recv(netdev_t *dev, void *buf, size_t len, void *info);
+
+/**
+ * @brief   Send function for netdev IEEE 802.15.4 devices.
+ *
+ * Reformats the generic @ref netdev_ieee802154_mac_t to a real ieee802154 mac
+ * header using the device specific information.
+ *
+ * @param[in]   dev     network device descriptor
+ * @param[in] iolist    io vector list to send
+ *
+ * @return              Number of bytes send
+ * @return              <0 on error
+ */
+int netdev_ieee802154_send(netdev_t *dev, const iolist_t *list);
 
 /**
  * @brief   Fallback function for netdev IEEE 802.15.4 devices' _get function

--- a/drivers/include/net/netdev/ieee802154.h
+++ b/drivers/include/net/netdev/ieee802154.h
@@ -131,7 +131,7 @@ typedef struct {
     uint8_t dst[IEEE802154_LONG_ADDRESS_LEN]; /**< Destination address */
     uint8_t src_len;                          /**< Source address length */
     uint8_t dst_len;                          /**< Destination address length */
-} netdev_ieee802154_data_t;
+} netdev_ieee802154_data_hdr_t;
 
 /**
  * @brief   Receive function for netdev IEEE 802.15.4 devices.

--- a/drivers/include/net/netdev/ieee802154.h
+++ b/drivers/include/net/netdev/ieee802154.h
@@ -127,7 +127,7 @@ typedef struct netdev_radio_rx_info netdev_ieee802154_rx_info_t;
  *          call data to upper network layers.
  */
 typedef struct {
-    uint8_t src[IEEE802154_LONG_ADDRESS_LEN]; /**< source address */
+    uint8_t src[IEEE802154_LONG_ADDRESS_LEN]; /**< Source address */
     uint8_t dst[IEEE802154_LONG_ADDRESS_LEN]; /**< Destination address */
     uint8_t src_len;                          /**< Source address length */
     uint8_t dst_len;                          /**< Destination address length */
@@ -159,7 +159,7 @@ int netdev_ieee802154_recv(netdev_t *dev, void *buf, size_t len, void *info);
  * header using the device specific information.
  *
  * @param[in]   dev     network device descriptor
- * @param[in] iolist    io vector list to send
+ * @param[in]   iolist  io vector list to send
  *
  * @return              Number of bytes send
  * @return              <0 on error

--- a/drivers/include/net/netdev/ieee802154.h
+++ b/drivers/include/net/netdev/ieee802154.h
@@ -142,7 +142,7 @@ typedef struct {
  * @param[in]   dev     network device descriptor
  * @param[out]  buf     buffer to write into or NULL
  * @param[in]   len     maximum number of bytes to read
- * @param[out] info     status information for the received packet. Might
+ * @param[out]  info    status information for the received packet. Might
  *                      be of different type for different netdev devices.
  *                      May be NULL if not needed or applicable.
  *

--- a/drivers/include/net/netdev/ieee802154.h
+++ b/drivers/include/net/netdev/ieee802154.h
@@ -122,12 +122,16 @@ typedef struct {
  */
 typedef struct netdev_radio_rx_info netdev_ieee802154_rx_info_t;
 
+/**
+ * @brief   Data structure for communicating IEEE 802.15.4 send and receive
+ *          call data to upper network layers.
+ */
 typedef struct {
-    uint8_t src[IEEE802154_LONG_ADDRESS_LEN];
-    uint8_t dst[IEEE802154_LONG_ADDRESS_LEN];
-    uint8_t src_len;
-    uint8_t dst_len;
-} netdev_ieee802154_mac_t;
+    uint8_t src[IEEE802154_LONG_ADDRESS_LEN]; /**< source address */
+    uint8_t dst[IEEE802154_LONG_ADDRESS_LEN]; /**< Destination address */
+    uint8_t src_len;                          /**< Source address length */
+    uint8_t dst_len;                          /**< Destination address length */
+} netdev_ieee802154_data_t;
 
 /**
  * @brief   Receive function for netdev IEEE 802.15.4 devices.

--- a/drivers/netdev_ieee802154/netdev_ieee802154.c
+++ b/drivers/netdev_ieee802154/netdev_ieee802154.c
@@ -70,7 +70,7 @@ int netdev_ieee802154_send(netdev_t *dev, const iolist_t *list)
     }
     /* prepare iolist for netdev / mac layer */
     iolist_t iolist = {
-        .iol_next = (iolist_t *)list->iol_next,
+        .iol_next = list->iol_next,
         .iol_base = mhr,
         .iol_len = res
     };

--- a/drivers/netdev_ieee802154/netdev_ieee802154.c
+++ b/drivers/netdev_ieee802154/netdev_ieee802154.c
@@ -12,6 +12,7 @@
  *
  * @file
  * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
+ * @author  Koen Zandberg <koen@bergzand.net>
  */
 
 #include <assert.h>
@@ -48,6 +49,64 @@ static int _get_iid(netdev_ieee802154_t *dev, eui64_t *value, size_t max_len)
     ieee802154_get_iid(value, addr, addr_len);
 
     return sizeof(eui64_t);
+}
+
+int netdev_ieee802154_send(netdev_t *dev, const iolist_t *list)
+{
+    netdev_ieee802154_t *netdev = (netdev_ieee802154_t *)dev;
+    netdev_ieee802154_mac_t *mac_info = list->iol_base;
+    uint8_t mhr[IEEE802154_MAX_HDR_LEN];
+    uint8_t flags = (uint8_t)(netdev->flags & NETDEV_IEEE802154_SEND_MASK);
+    int res = 0;
+    le_uint16_t dev_pan = byteorder_btols(byteorder_htons(netdev->pan));
+    flags |= IEEE802154_FCF_TYPE_DATA;
+    /* fill MAC header, seq should be set by device */
+    if ((res = ieee802154_set_frame_hdr(mhr, mac_info->src, mac_info->src_len,
+                                        mac_info->dst, mac_info->dst_len,
+                                        dev_pan, dev_pan,
+                                        flags, netdev->seq++)) == 0) {
+        DEBUG("netdev_ieee802154: Error preperaring frame\n");
+        return -EINVAL;
+    }
+    /* prepare iolist for netdev / mac layer */
+    iolist_t iolist = {
+        .iol_next = (iolist_t *)list->iol_next,
+        .iol_base = mhr,
+        .iol_len = res
+    };
+    return dev->driver->send(dev, &iolist);
+}
+
+int netdev_ieee802154_recv(netdev_t *dev, void *buf, size_t len, void *info)
+{
+    /* Leave space for the generic mac header */
+    netdev_ieee802154_t *netdev = (netdev_ieee802154_t *)dev;
+    uint8_t *pdu_start = (buf) ? buf + sizeof(netdev_ieee802154_mac_t) : buf;
+    netdev_ieee802154_mac_t *mac = buf;
+    int res = dev->driver->recv(dev, pdu_start, len, info);
+    if (res < 0) {
+        return res;
+    }
+    if (!(netdev->flags & NETDEV_IEEE802154_RAW)) {
+        if (buf) {
+            int dst_len, src_len;
+            le_uint16_t _pan_tmp;
+            size_t mhr_len = ieee802154_get_frame_hdr_len(pdu_start);
+            dst_len = ieee802154_get_dst(pdu_start, mac->dst, &_pan_tmp);
+            src_len = ieee802154_get_src(pdu_start, mac->src, &_pan_tmp);
+            if ((dst_len < 0) || (src_len < 0)) {
+                DEBUG("netdev_ieee802154: unable to get addresses\n");
+                return -EINVAL;
+            }
+            mac->src_len = src_len;
+            mac->dst_len = dst_len;
+            /* Remove the ieee802154 frame header */
+            memmove(pdu_start, pdu_start+mhr_len, res - mhr_len);
+            res -= mhr_len;
+        }
+        res += sizeof(netdev_ieee802154_mac_t);
+    }
+    return res;
 }
 
 int netdev_ieee802154_get(netdev_ieee802154_t *dev, netopt_t opt, void *value,

--- a/sys/net/gnrc/link_layer/gomach/gomach.c
+++ b/sys/net/gnrc/link_layer/gomach/gomach.c
@@ -82,7 +82,6 @@ static gnrc_pktsnip_t *_recv(gnrc_netif_t *netif)
 {
     netdev_t *dev = netif->dev;
     netdev_ieee802154_rx_info_t rx_info;
-    netdev_ieee802154_t *state = (netdev_ieee802154_t *)netif->dev;
     gnrc_pktsnip_t *pkt = NULL;
     int bytes_expected = dev->driver->recv(dev, NULL, 0, NULL);
 
@@ -99,19 +98,16 @@ static gnrc_pktsnip_t *_recv(gnrc_netif_t *netif)
             gnrc_pktbuf_release(pkt);
             return NULL;
         }
-        if (!(state->flags & NETDEV_IEEE802154_RAW)) {
-            gnrc_pktsnip_t *ieee802154_hdr;
-            size_t mhr_len = ieee802154_get_frame_hdr_len(pkt->data);
-
-            if (mhr_len == 0) {
-                DEBUG("_recv_ieee802154: illegally formatted frame received\n");
-                gnrc_pktbuf_release(pkt);
-                return NULL;
-            }
-            nread -= mhr_len;
+        netopt_enable_t raw;
+        if ((dev->driver->get(dev, NETOPT_RAWMODE, &raw, sizeof(raw)) == sizeof(raw))
+                && raw == NETOPT_DISABLE) {
+            gnrc_pktsnip_t *l2data_hdr;
+            /* We know at this point that the first header is a
+             * netdev_ieee802154_data_hdr_t */
+            nread -= sizeof(netdev_ieee802154_data_hdr_t);
             /* mark IEEE 802.15.4 header */
-            ieee802154_hdr = gnrc_pktbuf_mark(pkt, mhr_len, GNRC_NETTYPE_UNDEF);
-            if (ieee802154_hdr == NULL) {
+            l2data_hdr = gnrc_pktbuf_mark(pkt, sizeof(netdev_ieee802154_data_hdr_t), GNRC_NETTYPE_UNDEF);
+            if (l2data_hdr == NULL) {
                 DEBUG("_recv_ieee802154: no space left in packet buffer\n");
                 gnrc_pktbuf_release(pkt);
                 return NULL;

--- a/sys/net/gnrc/netif/gnrc_netif_ieee802154.c
+++ b/sys/net/gnrc/netif/gnrc_netif_ieee802154.c
@@ -145,7 +145,7 @@ static gnrc_pktsnip_t *_recv(gnrc_netif_t *netif)
         gnrc_pktbuf_realloc_data(pkt, nread);
     } else if (bytes_expected > 0) {
         DEBUG("_recv_ieee802154: received frame is too short\n");
-        dev->driver->recv(dev, NULL, bytes_expected, NULL);
+        netdev_ieee802154_recv(dev, NULL, bytes_expected, NULL);
     }
 
     return pkt;

--- a/sys/net/link_layer/csma_sender/csma_sender.c
+++ b/sys/net/link_layer/csma_sender/csma_sender.c
@@ -106,7 +106,7 @@ static int send_if_cca(netdev_t *device, iolist_t *iolist)
     /* if medium is clear, send the packet and return */
     if (hwfeat == NETOPT_ENABLE) {
         DEBUG("csma: Radio medium available: sending packet.\n");
-        return device->driver->send(device, iolist);
+        return netdev_ieee802154_send(device, iolist);
     }
 
     /* if we arrive here, medium was not available for transmission */

--- a/sys/net/link_layer/csma_sender/csma_sender.c
+++ b/sys/net/link_layer/csma_sender/csma_sender.c
@@ -28,6 +28,7 @@
 #include "net/netopt.h"
 
 #include "net/csma_sender.h"
+#include "net/netdev/ieee802154.h"
 
 #define ENABLE_DEBUG    (0)
 #include "debug.h"


### PR DESCRIPTION
### Contribution description

This PR splits the construction of the ieee802154 MAC header. `gnrc_netif_ieee802154` constructs a generic header with only the MAC addresses. The netdev_ieee802154 code then reformats it to a "proper" ieee802.15.4 MAC frame with the information from the device driver.

### Issues/PRs references

#9330 and part of the follow up work of #8198 

WIP as the gomach and the lwmac still need to be adapted.