### PR TITLE
periph/uart: break detection and sleep helper

### DIFF
--- a/cpu/atmega_common/include/periph_cpu_common.h
+++ b/cpu/atmega_common/include/periph_cpu_common.h
@@ -61,6 +61,13 @@ typedef enum {
 /** @} */
 
 /**
+ * @brief   Use some common UART functions
+ * @{
+ */
+#define PERIPH_UART_NEEDS_BREAK_SLEEP
+/** @} */
+
+/**
  * @brief   SPI mode select macro
  *
  * The polarity is determined by bit 3 in the configuration register, the phase

--- a/cpu/atmega_common/periph/uart.c
+++ b/cpu/atmega_common/periph/uart.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2014 Freie Universität Berlin, Hinnerk van Bruinehsen
+ *               2018 Acutam Automation, LLC
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -16,7 +17,7 @@
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  * @author      Hinnerk van Bruinehsen <h.v.bruinehsen@fu-berlin.de>
- *
+ * @author      Matthew Blue <matthew.blue.neuro@gmail.com>
  *
  * Support static BAUD rate calculation using UART_STDIO_BAUDRATE.
  * Set UART_STDIO_BAUDRATE to the desired baud rate and pass it as a -D argument
@@ -28,6 +29,8 @@
  *
  * @}
  */
+
+#include <avr/power.h>
 
 #include "cpu.h"
 #include "sched.h"
@@ -74,36 +77,96 @@ static mega_uart_t *dev[] = {
 };
 
 /**
- * @brief   Allocate memory to store the callback functions.
+ * @brief   Allocate memory to store the settings.
  */
 static uart_isr_ctx_t isr_ctx[UART_NUMOF];
+static uint16_t uart_brr[UART_NUMOF];
+static volatile uart_break_ctx_t break_ctx;
 
-static void _update_brr(uart_t uart, uint16_t brr, bool double_speed)
+static inline uint8_t _is_asleep(uart_t uart)
 {
-    dev[uart]->BRR = brr;
-    if (double_speed) {
-        dev[uart]->CSRA |= (1 << U2X0);
+#if defined(CPU_ATMEGA328P)
+    (void)uart;
+    return ((PRR >> PRUSART0) & 0x1);
+#else
+
+    if (uart == 0) {
+        return ((PRR0 >> PRUSART0) & 0x1);
     }
+
+#if defined(CPU_ATMEGA1284P)
+    else if (uart == 1) {
+        /* ATmega1284P uses PRR0 instead of PRR1 */
+        return ((PRR0 >> PRUSART1) & 0x1);
+    }
+#else
+    else if (uart == 1) {
+        return ((PRR1 >> PRUSART1) & 0x1);
+    }
+#endif /* defined(CPU_ATMEGA1284P) */
+
+#if (UART_NUMOF > 2)
+    else if (uart == 2) {
+        return ((PRR1 >> PRUSART2) & 0x1);
+    }
+#endif
+
+#if (UART_NUMOF > 3)
+    else if (uart == 3) {
+        return ((PRR1 >> PRUSART3) & 0x1);
+    }
+#endif
+
+#endif /* defined(CPU_ATMEGA328P) */
+
+    /* extra return should be unused */
+    return 0;
 }
 
-static void _set_brr(uart_t uart, uint32_t baudrate)
+static inline void _update_brr(uart_t uart)
 {
-    uint16_t brr;
+    dev[uart]->BRR = uart_brr[uart];
 
+#if defined(UART_DOUBLE_SPEED)
+    dev[uart]->CSRA |= (1 << U2X0);
+#endif
+}
+
+static inline void _calc_brr(uart_t uart, uint32_t baudrate)
+{
 #if defined(UART_STDIO_BAUDRATE)
     /* UBRR_VALUE and USE_2X are statically computed from <util/setbaud.h> */
     if (baudrate == UART_STDIO_BAUDRATE) {
-        _update_brr(uart, UBRR_VALUE, USE_2X);
+        uart_brr[uart] = UBRR_VALUE;
         return;
     }
 #endif
 #if defined(UART_DOUBLE_SPEED)
-    brr = (CLOCK_CORECLOCK + 4UL * baudrate) / (8UL * baudrate) - 1UL;
-    _update_brr(uart, brr, true);
+    uart_brr[uart] = (CLOCK_CORECLOCK + 4UL * baudrate) / (8UL * baudrate) - 1UL;
 #else
-    brr = (CLOCK_CORECLOCK + 8UL * baudrate) / (16UL * baudrate) - 1UL;
-    _update_brr(uart, brr, false);
+    uart_brr[uart] = (CLOCK_CORECLOCK + 8UL * baudrate) / (16UL * baudrate) - 1UL;
 #endif
+}
+
+static void _apply_settings(uart_t uart)
+{
+    /* disable and reset UART */
+    dev[uart]->CSRB = 0;
+    dev[uart]->CSRA = 0;
+
+    /* configure UART to 8N1 mode */
+    dev[uart]->CSRC = (1 << UCSZ00) | (1 << UCSZ01);
+
+    /* set clock divider */
+    _update_brr(uart);
+
+    /* enable RX and TX and the RX interrupt */
+    if (isr_ctx[uart].rx_cb) {
+        dev[uart]->CSRB = ((1 << RXCIE0) | (1 << RXEN0) | (1 << TXEN0));
+    }
+    else {
+        dev[uart]->CSRB = (1 << TXEN0);
+    }
 }
 
 int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
@@ -117,51 +180,94 @@ int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
     isr_ctx[uart].rx_cb = rx_cb;
     isr_ctx[uart].arg = arg;
 
-    /* disable and reset UART */
-    dev[uart]->CSRB = 0;
-    dev[uart]->CSRA = 0;
+    /* calculate clock divider */
+    _calc_brr(uart, baudrate);
 
-    /* configure UART to 8N1 mode */
-    dev[uart]->CSRC = (1 << UCSZ00) | (1 << UCSZ01);
-    /* set clock divider */
-    _set_brr(uart, baudrate);
-
-    /* enable RX and TX and the RX interrupt */
-    if (rx_cb) {
-        dev[uart]->CSRB = ((1 << RXCIE0) | (1 << RXEN0) | (1 << TXEN0));
-    }
-    else {
-        dev[uart]->CSRB = (1 << TXEN0);
-    }
+    /* apply the settings to the UART */
+    _apply_settings(uart);
 
     return UART_OK;
 }
 
 void uart_write(uart_t uart, const uint8_t *data, size_t len)
 {
+    uint8_t sleepy = _is_asleep(uart);
+
+    if (sleepy) {
+        uart_poweron(uart);
+    }
+
     for (size_t i = 0; i < len; i++) {
         while (!(dev[uart]->CSRA & (1 << UDRE0))) {}
         dev[uart]->DR = data[i];
     }
+
+    if (sleepy) {
+        uart_poweroff(uart);
+    }
+}
+
+int uart_break_init(uart_break_cb_t break_cb, void *arg)
+{
+    /* Interrupt safe order of assignment */
+    break_ctx.break_cb = NULL;
+    break_ctx.arg = arg;
+    break_ctx.break_cb = break_cb;
+
+    return UART_OK;
 }
 
 void uart_poweron(uart_t uart)
 {
-    (void)uart;
-    /* not implemented (yet) */
+    switch (uart) {
+        case 0: power_usart0_enable();
+#if (UART_NUMOF == 2)
+        case 1: power_usart1_enable();
+#endif
+#if (UART_NUMOF == 3)
+        case 2: power_usart2_enable();
+#endif
+#if (UART_NUMOF == 4)
+        case 3: power_usart3_enable();
+#endif
+    }
+
+    /* bring UART to its state prior to sleeping */
+    _apply_settings(uart);
 }
 
 void uart_poweroff(uart_t uart)
 {
-    (void)uart;
-    /* not implemented (yet) */
+    switch (uart) {
+        case 0: power_usart0_disable();
+#if (UART_NUMOF == 2)
+        case 1: power_usart1_disable();
+#endif
+#if (UART_NUMOF == 3)
+        case 2: power_usart2_disable();
+#endif
+#if (UART_NUMOF == 4)
+        case 3: power_usart3_disable();
+#endif
+    }
 }
 
 static inline void isr_handler(int num)
 {
     __enter_isr();
 
-    isr_ctx[num].rx_cb(isr_ctx[num].arg, dev[num]->DR);
+    volatile uint8_t frame_err = (dev[num]->CSRA >> FE0) & 0x1;
+    volatile uint8_t byte = dev[num]->DR;
+
+    if (frame_err && (byte == 0x0)) {
+        /* break condition detected */
+        if (break_ctx.break_cb != NULL) {
+            break_ctx.break_cb(num, break_ctx.arg);
+        }
+    }
+    else {
+        isr_ctx[num].rx_cb(isr_ctx[num].arg, byte);
+    }
 
     __exit_isr();
 }

--- a/drivers/include/periph/uart.h
+++ b/drivers/include/periph/uart.h
@@ -84,6 +84,15 @@ typedef unsigned int uart_t;
 #endif
 
 /**
+ * @brief   Default wake pins for each UART
+ *
+ * This is only required to be defined if uart_break_sleep is used
+ */
+#ifndef UART_WAKE_PINS
+#define UART_WAKE_PINS(x)    (GPIO_UNDEF)
+#endif
+
+/**
  * @brief   Signature for receive interrupt callback
  *
  * @param[in] arg           context to the callback (optional)
@@ -176,7 +185,8 @@ void uart_write(uart_t uart, const uint8_t *data, size_t len);
  * This callback is executed when a null character is recieved along with a
  * frame error (no stop bit). This occurs when RX is pulled low, and may be
  * used along with a pull-down resistor to detect the absence of a transmitter
- * attached to the RX line.
+ * attached to the RX line. If the break condition is being used to sleep the
+ * UART, it is recommended to use uart_break_sleep instead.
  *
  * @param[in] break_cb      break callback
  * @param[in] arg           optional context passed to the callback function
@@ -196,14 +206,23 @@ int uart_break_init(uart_break_cb_t break_cb, void *arg);
  * line. The function may utilize uart_break_init and the break callback should
  * be considered unavailable while sleeping is enabled.
  *
- * @param[in] uart          the UART device to enable sleeping
- * @param[in] pin           pin to use for wake interrupt
+ * @param[in] uart          the UART device to initialize sleeping
  *
  * @return                  UART_OK on success
  * @return                  UART_NODEV on invalid UART device
  * @return                  UART_INTERR on other errors
  */
-int uart_break_sleep(uart_t uart, gpio_t pin);
+int uart_break_sleep_init(uart_t uart);
+
+/**
+ * @brief   Enable break condition sleeping
+ */
+void uart_break_sleep_enable(void);
+
+/**
+ * @brief   Disable break condition sleeping
+ */
+void uart_break_sleep_disable(void);
 
 /**
  * @brief   Power on the given UART device

--- a/drivers/include/periph/uart.h
+++ b/drivers/include/periph/uart.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2014-2015 Freie Universität Berlin
+ *               2018 Acutam Automation, LLC
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -40,6 +41,7 @@
  * @brief       Low-level UART peripheral driver interface definition
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author      Matthew Blue <matthew.blue.neuro@gmail.com>
  */
 
 #ifndef PERIPH_UART_H
@@ -51,6 +53,8 @@
 
 #include "periph_cpu.h"
 #include "periph_conf.h"
+#include "periph/gpio.h"
+
 /* TODO: remove once all platforms are ported to this interface */
 #include "periph/dev_enums.h"
 
@@ -88,6 +92,14 @@ typedef unsigned int uart_t;
 typedef void(*uart_rx_cb_t)(void *arg, uint8_t data);
 
 /**
+ * @brief   Signature for break condition interrupt callback
+ *
+ * @param[in] uart          the UART device
+ * @param[in] arg           context to the callback (optional)
+ */
+typedef void(*uart_break_cb_t)(uart_t uart, void *arg);
+
+/**
  * @brief   Interrupt context for a UART device
  */
 #ifndef HAVE_UART_ISR_CTX_T
@@ -95,6 +107,16 @@ typedef struct {
     uart_rx_cb_t rx_cb;     /**< data received interrupt callback */
     void *arg;              /**< argument to both callback routines */
 } uart_isr_ctx_t;
+#endif
+
+/**
+ * @brief   Interrupt context for UART break detection
+ */
+#ifndef HAVE_UART_BREAK_CTX_T
+typedef struct {
+    uart_break_cb_t break_cb;    /**< break callback */
+    void *arg;                   /**< argument to callback routine */
+} uart_break_ctx_t;
 #endif
 
 /**
@@ -149,7 +171,45 @@ int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg);
 void uart_write(uart_t uart, const uint8_t *data, size_t len);
 
 /**
+ * @brief   Initialize callback for break condition detection
+ *
+ * This callback is executed when a null character is recieved along with a
+ * frame error (no stop bit). This occurs when RX is pulled low, and may be
+ * used along with a pull-down resistor to detect the absence of a transmitter
+ * attached to the RX line.
+ *
+ * @param[in] break_cb      break callback
+ * @param[in] arg           optional context passed to the callback function
+ *
+ * @return                  UART_OK on success
+ * @return                  UART_INTERR on other errors
+ */
+int uart_break_init(uart_break_cb_t break_cb, void *arg);
+
+/**
+ * @brief   Sleep UART on break condition helper
+ *
+ * This will register a callback to sleep on the selected UART when a break
+ * condition is received. Prior to sleeping, it will register a GPIO interrupt
+ * to wake the UART on a rising edge. This allows the selected UART to sleep
+ * and wake depending on the presence or absence of a transmitter on the RX
+ * line. The function may utilize uart_break_init and the break callback should
+ * be considered unavailable while sleeping is enabled.
+ *
+ * @param[in] uart          the UART device to enable sleeping
+ * @param[in] pin           pin to use for wake interrupt
+ *
+ * @return                  UART_OK on success
+ * @return                  UART_NODEV on invalid UART device
+ * @return                  UART_INTERR on other errors
+ */
+int uart_break_sleep(uart_t uart, gpio_t pin);
+
+/**
  * @brief   Power on the given UART device
+ *
+ * This function is expected to bring the UART back to the state it was in
+ * prior to sleeping.
  *
  * @param[in] uart          the UART device to power on
  */

--- a/drivers/periph_common/uart.c
+++ b/drivers/periph_common/uart.c
@@ -1,0 +1,146 @@
+/*
+ * Copyright (C) 2018 Acutam Automation, LLC
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     drivers_periph_uart
+ * @{
+ *
+ * @file
+ * @brief       common UART function fallback implementations
+ *
+ * @author      Matthew Blue <matthew.blue.neuro@gmail.com>
+ *
+ * @}
+ */
+
+#include "irq.h"
+#include "periph/gpio.h"
+#include "periph/uart.h"
+
+#define ENABLE_DEBUG (0)
+#include "debug.h"
+
+#ifdef UART_NUMOF
+
+#ifdef PERIPH_UART_NEEDS_BREAK_SLEEP
+#if (UART_NUMOF == 1)
+static gpio_t uart_sleep_pins[] = { GPIO_UNDEF };
+#elif (UART_NUMOF == 2)
+static gpio_t uart_sleep_pins[] = { GPIO_UNDEF, GPIO_UNDEF };
+#elif (UART_NUMOF == 3)
+static gpio_t uart_sleep_pins[] = { GPIO_UNDEF, GPIO_UNDEF, GPIO_UNDEF };
+#elif (UART_NUMOF == 4)
+static gpio_t uart_sleep_pins[] = { GPIO_UNDEF, GPIO_UNDEF, GPIO_UNDEF,
+                                    GPIO_UNDEF };
+#elif (UART_NUMOF == 5)
+static gpio_t uart_sleep_pins[] = { GPIO_UNDEF, GPIO_UNDEF, GPIO_UNDEF,
+                                    GPIO_UNDEF, GPIO_UNDEF };
+#elif (UART_NUMOF == 6)
+static gpio_t uart_sleep_pins[] = { GPIO_UNDEF, GPIO_UNDEF, GPIO_UNDEF,
+                                    GPIO_UNDEF, GPIO_UNDEF, GPIO_UNDEF };
+#else
+#error "uart_sleep_pins definition not ready for so many UARTs"
+#endif
+
+static void _break_sleep(uart_t uart, void *arg);
+static void _break_wake(void *arg);
+
+static inline unsigned _uart_revlookup(uart_t uart)
+{
+    for (unsigned i = 0; i < UART_NUMOF; i++) {
+        if (UART_DEV(i) == uart) {
+            return i;
+        }
+    }
+
+    /* return error */
+    return (unsigned)(-1);
+}
+
+int uart_break_sleep(uart_t uart, gpio_t pin)
+{
+    /* make sure the device is valid */
+    if (uart >= UART_NUMOF) {
+        return UART_NODEV;
+    }
+    unsigned uartnum = _uart_revlookup(uart);
+    if (uartnum == (unsigned)(-1)) {
+        return UART_NODEV;
+    }
+
+    unsigned state = irq_disable();
+
+    /* register wake callback */
+    if (gpio_init_int(pin, GPIO_IN_PD, GPIO_RISING,
+                      _break_wake, (void *)(uintptr_t)uartnum) < 0) {
+
+        /* built-in pulldown not supported */
+        if (gpio_init_int(pin, GPIO_IN, GPIO_RISING,
+                          _break_wake, (void *)(uintptr_t)uartnum) < 0) {
+            irq_restore(state);
+            DEBUG("[uart] gpio_init_int failed on %u for UART%i\n",
+                  (unsigned)pin, uartnum);
+            return UART_INTERR;
+        }
+    }
+
+    /* set uart sleep pin */
+    uart_sleep_pins[uartnum] = pin;
+
+    /* register sleep callback */
+    if (uart_break_init(_break_sleep, 0x0) != UART_OK) {
+        irq_restore(state);
+
+        DEBUG("[uart] uart_break_init failed for UART%i\n", uartnum);
+        return UART_INTERR;
+    }
+
+    /* set initial wake state */
+    if (!gpio_read(pin)) {
+        DEBUG("[uart] starting asleep on UART%i\n", uartnum);
+
+        uart_poweroff(uart);
+        gpio_irq_enable(pin);
+    }
+    else {
+        gpio_irq_disable(pin);
+    }
+
+    irq_restore(state);
+
+    DEBUG("[uart] UART%i now set to sleep on break condition\n", uartnum);
+
+    return UART_OK;
+}
+
+static void _break_sleep(uart_t uart, void *arg)
+{
+    (void)arg;
+
+    unsigned uartnum = _uart_revlookup(uart);
+
+    DEBUG("[uart] UART%i going to sleep\n", uartnum);
+
+    if (uart_sleep_pins[uartnum] != GPIO_UNDEF) {
+        uart_poweroff(uart);
+        gpio_irq_enable(uart_sleep_pins[uartnum]);
+    }
+}
+
+static void _break_wake(void *arg)
+{
+    unsigned uartnum = (unsigned)(uintptr_t)arg;
+
+    gpio_irq_disable(uart_sleep_pins[uartnum]);
+    uart_poweron(UART_DEV(uartnum));
+
+    DEBUG("[uart] UART%i waking up\n", uartnum);
+}
+#endif /* PERIPH_UART_NEEDS_BREAK_SLEEP */
+
+#endif /* UART_NUMOF */


### PR DESCRIPTION
This is my attempt to solve the UART sleep issue.

### Background
Entering a CPU sleep mode is problematic when using UART RX. There are several possible methods to detect when it is safe to sleep the UART, but many of them have problems:
- sleep after not receiving for t seconds - can cause data loss on waking
- require a keep-alive character to stay awake (variant of above) - requires modification of software on the other end of the UART
- use a command (sent over the UART) to sleep - requires intervention by the user
- use a UART that is able to receive while sleeping - requires specialized hardware
- probably some others I haven't thought of

The method used here is to detect the disconnection of hardware that is driving the RX line by detecting a break condition. When a driver is attached to RX, it will hold the line in an idle state (high), and only bring it low long enough to transmit a character. Reception of a null character (all zeros) along with a frame error (no high stop bit) should indicate that the line has be non-idle for longer than the expected character time. When this condition is detected it should be safe to sleep, because there is no properly configured driver attached to the RX line (if it is improperly configured or noisy, communication will be unreliable anyway, regardless of sleeping or not). Waking can simply use a pin interrupt with a rising flank to detect the line returning to idle.

In order to detect the break condition a few criteria must be met:
- The port the user is attaching to for communication must be the UART, and not something else such as USB (unless the adapter has been modified to pass on a break condition).
- RX must have a pull-down resistor

I suspect that anything not meeting the first criterion is probably not suitable for very low-power use, because it has been designed with user friendliness as a priority and not power saving. Anything with a built in USB to UART adapter (or similar) that is designed for low-power use will provide some facility for sleeping the adapter and signaling this condition to the CPU. For example, a popular USB to UART adpater chip FT230 has an output to indicate that it is suspended, and can even be programmed to pull the UART RX line low during suspend.

As for the second criterion: I propose that anything that is used in low-power applications will be required to designed to be used in that application in order to be effective. Even if there is no USB to UART adapter chip, what does sleeping the CPU matter when you are wasting tens of milliwatts on common ICs not intended for very low power. For example, many popular linear regulators such as LM317 have a minimum output current of over a milliamp. If a board has been designed for low-power applications it will require putting thought into the interaction between the hardware and the sleep modes programmed into the firmware. Thus, either it has already been designed for low-power use and provides its own signal for the CPU to sleep, or it is yet to be released and asking for a single resistor pull-down to be added to the design will be an insignificant request (as is the case for my board that I am designing).

### Contribution description
This PR adds an API change to ```drivers/include/periph/uart.c``` that adds break detection functionality, and a sleep helper function which uses the break detection to sleep the UART. These API changes do not affect systems that don't implement them. Also, a default sleep helper is implemented in ```drivers/periph_common/uart.c```, and break detection has been implemented for the ATmegas.

### Issues/PRs references
#7947

### Initial status
I am simulating a UART disconnect on the Arduino UNO by forcing the RX pin low with a wire. Since the USB adapter is connected via a 1k resistor this is safe to do. Digital pin 2, which is an asynchronous interrupt pin, is tied to RX to detect the return to idle. It is partially working with problems. I can't seem to get it to say it is sleeping without printing that it is also waking. There is also some garbage and contact bounce issues creating multiple sleeps.

```
user@user ~/Desktop/RIOT_break_condition/examples/arduino_hello-world $ make BOARD=arduino-uno term
/home/user/Desktop/RIOT_break_condition/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "9600"
2018-06-26 14:27:41,288 - INFO # Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.
2018-06-26 14:27:45,104 - INFO # 

2018-06-26 14:27:45,157 - INFO # [uart] UART0 now set to sleep on break condition
2018-06-26 14:27:45,251 - INFO # main(): This is RIOT! (Version: UNKNOWN (builddir: /home/user/Desktop/RIOT_break_condition))
2018-06-26 14:27:45,267 - INFO # Hello Arduino!
hello
2018-06-26 14:27:53,274 - INFO # Echo: hello
2018-06-26 14:27:59,193 - INFO # [uart] UART0 going to sleep�!��W�u�UART0 waking up
2018-06-26 14:27:59,652 - INFO # [uart] UART0 going to sleep�!��W�u�UART0 waking up
2018-06-26 14:27:59,738 - INFO # [uart] UART0 going to sleep�!��W�u�UART0 waking up
2018-06-26 14:28:00,278 - INFO # [uart] UART0 going to sleep�!��W�u�UART0 waking up
2018-06-26 14:28:00,356 - INFO # [uart] UART0 going to sleep�!��W�u�UART0 waking up
2018-06-26 14:28:00,413 - INFO # [uart] UART0 going to sleep�!��W�u�UART0 waking up
2018-06-26 14:28:00,471 - INFO # [uart] UART0 going to sleep�!��W�u�UART0 waking up
hello
2018-06-26 14:28:04,288 - INFO # Echo: hello
/exit
2018-06-26 14:28:10,523 - INFO # Exiting Pyterm
```