### PR TITLE
gnrc_sixlowpan_frag: add asynchronous rbuf GC

### DIFF
--- a/sys/include/net/gnrc/sixlowpan/frag.h
+++ b/sys/include/net/gnrc/sixlowpan/frag.h
@@ -39,9 +39,19 @@ extern "C" {
 #endif
 
 /**
+ * @name    Message types
+ * @{
+ */
+/**
  * @brief   Message type for passing one 6LoWPAN fragment down the network stack
  */
-#define GNRC_SIXLOWPAN_MSG_FRAG_SND    (0x0225)
+#define GNRC_SIXLOWPAN_MSG_FRAG_SND         (0x0225)
+
+/**
+ * @brief   Message type for triggering garbage collection reassembly buffer
+ */
+#define GNRC_SIXLOWPAN_MSG_FRAG_GC_RBUF     (0x0226)
+/** @} */
 
 /**
  * @brief   An entry in the 6LoWPAN reassembly buffer.
@@ -113,6 +123,11 @@ void gnrc_sixlowpan_frag_send(gnrc_pktsnip_t *pkt, void *ctx, unsigned page);
  * @param[in] page      Current 6Lo dispatch parsing page.
  */
 void gnrc_sixlowpan_frag_recv(gnrc_pktsnip_t *pkt, void *ctx, unsigned page);
+
+/**
+ * @brief   Garbage collect reassembly buffer.
+ */
+void gnrc_sixlowpan_frag_gc_rbuf(void);
 
 #ifdef __cplusplus
 }

--- a/sys/net/gnrc/network_layer/sixlowpan/frag/gnrc_sixlowpan_frag.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/gnrc_sixlowpan_frag.c
@@ -320,4 +320,9 @@ void gnrc_sixlowpan_frag_recv(gnrc_pktsnip_t *pkt, void *ctx, unsigned page)
     gnrc_pktbuf_release(pkt);
 }
 
+void gnrc_sixlowpan_frag_gc_rbuf(void)
+{
+    rbuf_gc();
+}
+
 /** @} */

--- a/sys/net/gnrc/network_layer/sixlowpan/frag/rbuf.h
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/rbuf.h
@@ -85,6 +85,11 @@ typedef struct {
 void rbuf_add(gnrc_netif_hdr_t *netif_hdr, gnrc_pktsnip_t *frag,
               size_t frag_size, size_t offset);
 
+/**
+ * @brief   Checks timeouts and removes entries if necessary
+ */
+void rbuf_gc(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/sys/net/gnrc/network_layer/sixlowpan/gnrc_sixlowpan.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/gnrc_sixlowpan.c
@@ -375,6 +375,10 @@ static void *_event_loop(void *args)
                 DEBUG("6lo: send fragmented event received\n");
                 gnrc_sixlowpan_frag_send(NULL, msg.content.ptr, 0);
                 break;
+            case GNRC_SIXLOWPAN_MSG_FRAG_GC_RBUF:
+                DEBUG("6lo: garbage collect reassembly buffer event received\n");
+                gnrc_sixlowpan_frag_gc_rbuf();
+                break;
 #endif
 
             default:


### PR DESCRIPTION
### Contribution description
While the current approach for garbage collection (i.e. only GC if a new fragmented packet is received) in the 6Lo reassembly buffer is good for best-effort handling of *fragmented* packets and nicely RAM saving, it has the problem that incomplete, huge datagrams can basically DoS a node, if no further fragmented datagram is received for a while (since the packet buffer is full and GC is not triggered).

This change adds a asynchronous GC (utilizing the existing functionality) to the reassembly buffer, so that even if there is no new fragmented packet received, fragments older than `RBUF_TIMEOUT` will be
removed from the reassembly buffer, freeing up the otherwise wasted packet buffer space.

An easy example where this leads to problem is storing-mode RPL, where DAOs can become quite large, but are sent rather rarely, while the rest of the traffic tries to avoid fragmentation by having smaller payloads, causing the potentially incomplete DAOs staying in the packet buffer for minutes.

### Issues/PRs references
None