### PR TITLE
remote: add RESET variable

### DIFF
--- a/boards/common/remote/Makefile.include
+++ b/boards/common/remote/Makefile.include
@@ -12,6 +12,7 @@ ifeq ($(PROGRAMMER),cc2538-bsl)
   else ifeq ($(OS),Darwin)
     PORT_BSL ?= $(PORT_DARWIN)
   endif
+  export RESET = $(RIOTTOOLS)/cc2538-bsl/cc2538-bsl.py -p "$(PORT_BSL)"
   export FLASHER = $(RIOTTOOLS)/cc2538-bsl/cc2538-bsl.py
   export FFLAGS  = -p "$(PORT_BSL)" -e -w -v -b 115200 $(HEXFILE)
 else ifeq ($(PROGRAMMER),jlink)
@@ -20,12 +21,12 @@ else ifeq ($(PROGRAMMER),jlink)
   export DEBUGGER = $(RIOTBOARD)/$(BOARD)/dist/debug.sh
   export DEBUGSERVER = JLinkGDBServer -device CC2538SF53
   export RESET = $(RIOTBOARD)/$(BOARD)/dist/reset.sh
+  export RESET_FLAGS = $(BINDIR)
 endif
 
 OFLAGS = --gap-fill 0xff
 HEXFILE = $(BINFILE)
 export DEBUGGER_FLAGS = $(BINDIR) $(ELFFILE)
-export RESET_FLAGS = $(BINDIR)
 export OBJDUMPFLAGS += --disassemble --source --disassembler-options=force-thumb
 
 # include common remote includes


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

For CI HIL purposes a reset is needed before running the test target. The remote board didn't assign a RESET variable to perform a reset, ~~so it wasn't possible to call `make test` correctly.~~
**EDIT:** It is still not possible to execute `make test` correctly
By calling the flash script without arguments, a reset is performed.

### Issues/PRs references
none
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->