### PR TITLE
boards/hifive1: add serial terminal config

### DIFF
--- a/boards/hifive1/Makefile.include
+++ b/boards/hifive1/Makefile.include
@@ -5,6 +5,13 @@ export CPU_MODEL = fe310
 # Uses UART0 for stdio input/output (comment out to disable)
 USEMODULE += uart_stdio
 
+# set default port depending on operating system
+PORT_LINUX ?= /dev/ttyUSB1
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
+
+# setup serial terminal
+include $(RIOTMAKE)/tools/serial.inc.mk
+
 # this board uses openocd
 include $(RIOTMAKE)/tools/openocd.inc.mk
 


### PR DESCRIPTION
### Contribution description

hifive1's ```make term``` is currently non-funcitonal due to missing serial configuration.
This PR adds it.

(uses ttyUSB1 on Linux. No idea how to make this work on OSX. I suggest we provide a fix for OS X with a follow up.)