### PR TITLE
drivers/pn532: adapt to new i2c API

### DIFF
--- a/drivers/pn532/pn532.c
+++ b/drivers/pn532/pn532.c
@@ -80,7 +80,7 @@
 
 #if ENABLE_DEBUG
 #define PRINTBUFF printbuff
-static void printbuff(char *buff, unsigned len)
+static void printbuff(uint8_t *buff, unsigned len)
 {
     while (len) {
         len--;
@@ -120,15 +120,7 @@ int pn532_init(pn532_t *dev, const pn532_params_t *params, pn532_mode_t mode)
     gpio_init(dev->conf->reset, GPIO_OUT);
     gpio_set(dev->conf->reset);
     dev->mode = mode;
-    if (mode == PN532_I2C) {
-#ifdef PN532_SUPPORT_I2C
-        if (i2c_init_master(dev->conf->i2c, I2C_SPEED_FAST) != 0) {
-            DEBUG("pn532: initialization of I2C bus failed\n");
-            return -1;
-        }
-#endif
-    }
-    else {
+    if (mode == PN532_SPI) {
 #ifdef PN532_SUPPORT_SPI
         /* we handle the CS line manually... */
         gpio_init(dev->conf->nss, GPIO_OUT);
@@ -175,7 +167,10 @@ static int _write(const pn532_t *dev, uint8_t *buff, unsigned len)
     if (dev->mode == PN532_I2C) {
 #ifdef PN532_SUPPORT_I2C
         i2c_acquire(dev->conf->i2c);
-        ret = i2c_write_bytes(dev->conf->i2c, PN532_I2C_ADDRESS, buff, len);
+        ret = i2c_write_bytes(dev->conf->i2c, PN532_I2C_ADDRESS, buff, len, 0);
+        if (ret == 0) {
+            ret = len;
+        }
         i2c_release(dev->conf->i2c);
 #endif
     }
@@ -208,7 +203,10 @@ static int _read(const pn532_t *dev, uint8_t *buff, unsigned len)
 #ifdef PN532_SUPPORT_I2C
         i2c_acquire(dev->conf->i2c);
         /* len+1 for RDY after read is accepted */
-        ret = i2c_read_bytes(dev->conf->i2c, PN532_I2C_ADDRESS, buff, len + 1);
+        ret = i2c_read_bytes(dev->conf->i2c, PN532_I2C_ADDRESS, buff, len + 1, 0);
+        if (ret == 0) {
+            ret = len + 1;
+        }
         i2c_release(dev->conf->i2c);
 #endif
     }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Aapplies the new i2c API to the pn532. 
Tested with adafruit PN532 RFID/NFC shield v1.3 and nucleo144-f446
### Issues/PRs references
#6577
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->