### PR TITLE
pic32: Blacklist pic32 boards from some pkg tests

### DIFF
--- a/tests/emb6/Makefile
+++ b/tests/emb6/Makefile
@@ -3,7 +3,8 @@ BOARD ?= samr21-xpro
 include ../Makefile.tests_common
 
 # MSP-430 doesn't support C11's atomic functionality yet
-BOARD_BLACKLIST := msb-430 msb-430h telosb wsn430-v1_3b wsn430-v1_4 z1
+BOARD_BLACKLIST := msb-430 msb-430h pic32-clicker pic32-wifire \
+                   telosb wsn430-v1_3b wsn430-v1_4 z1
 
 BOARD_INSUFFICIENT_MEMORY := msb-430 msb-430h nucleo-l031k6 nucleo-f031k6 \
                              nucleo-f042k6 nucleo-l053r8 stm32f0discovery telosb \

--- a/tests/pkg_semtech-loramac/Makefile
+++ b/tests/pkg_semtech-loramac/Makefile
@@ -4,7 +4,8 @@ include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_MEMORY := nucleo-f031k6 nucleo-f042k6 nucleo-l031k6
 
-BOARD_BLACKLIST := msb-430 msb-430h telosb wsn430-v1_3b wsn430-v1_4 z1
+BOARD_BLACKLIST := msb-430 msb-430h pic32-clicker pic32-wifire \
+                   telosb wsn430-v1_3b wsn430-v1_4 z1
 
 LORA_DRIVER ?= sx1276
 LORA_REGION ?= EU868


### PR DESCRIPTION
Temporarily blacklist pic32 boards from the emb6 and semtech-loramac package
tests as they are not building for MIPS yet.