### PR TITLE
gnrc_pktbuf_static: fix alignment issue / leaks

### DIFF
--- a/sys/net/gnrc/pktbuf_static/gnrc_pktbuf_static.c
+++ b/sys/net/gnrc/pktbuf_static/gnrc_pktbuf_static.c
@@ -33,7 +33,7 @@
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
-#define _ALIGNMENT_MASK    (sizeof(void *) - 1)
+#define _ALIGNMENT_MASK    (sizeof(_unused_t) - 1)
 
 typedef struct _unused {
     struct _unused *next;

--- a/tests/gnrc_ndp/main.c
+++ b/tests/gnrc_ndp/main.c
@@ -79,7 +79,9 @@ static void set_up(void)
 static void fill_pktbuf(void)
 {
     gnrc_pktsnip_t *pkt = gnrc_pktbuf_add(NULL, NULL,
-                                          GNRC_PKTBUF_SIZE - sizeof(gnrc_pktsnip_t),
+                                          /* 24 = sizeof(gnrc_pktsnip_t) +
+                                           * potential alignment */
+                                          GNRC_PKTBUF_SIZE - 24U,
                                           GNRC_NETTYPE_UNDEF);
     TEST_ASSERT_NOT_NULL(pkt);
     TEST_ASSERT(gnrc_pktbuf_is_sane());


### PR DESCRIPTION
### Contribution description
This fixes an alignment issue I encountered in the static version of the packet buffer.

The bug is caused by a race-condition where a certain order of operations leads to a chunk being released according to the byte-alignment of the platform, but overlapping potential space for a future `_unused_t` struct e.g. (x mark allocated regions):

                    Future leak of size sizeof(_unused_t)       Time
                    v                                            |
    +------------+-----+--------------------+                    |
    |xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx|                    +
    +------------+-----+--------------------+                    |
                                                                 |
    +------------+--+--+--------------------+                    |
    |               |xxxxxxxxxxxxxxxxxxxxxxx|                    +
    +------------+--+--+--------------------+                    |
                                                                 |
    +-----+------+--+--+--------------------+                    |
    |xxxxx|         |xxxxxxxxxxxxxxxxxxxxxxx|                    +
    +-----+------+--+--+--------------------+                    |
                                                                 |
    +-----+------+-----+---------+----------+                    |
    |xxxxx|                      |xxxxxxxxxx|                    +
    +-----+------+-----+---------+----------+                    |
                                                                 |
    +------------+-----+--------------------+                    |
    |xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx|                    +
    +------------+-----+--------------------+                    |
                                                                 |
    +------------+-----+--------------------+                    |
    |xxxxxxxxxxxxxxxxxx|                    |                    +
    +------------+-----+--------------------+                    |
                                                                 |
    +------------+-----+--------------------+                    |
    |            |xxxxx|                    |                    +
    +------------+-----+--------------------+                    |
                                                                 v

Sadly, I wasn't able to create a reproducable unittest that show-cases this corner-case, since I don't understand the order of operations that cause this one 100%, but the bug is reproducable (but also not
reliably) by sending large (i.e. fragmented) packets to a 6Lo-enabled host from more than 1 host simultaneously (use `gnrc_pktbuf_cmd` to check but don't confuse incomplete datagrams for leaks; see #9424 for faster clean-up of those). I ran this test twice for an hour with this PR before submitting, to make sure this fixes the issue.

By making the size of `_unused_t` the only condition for alignment, this bug is fixed.

This PR also contains some optimizations that can be done due to the new alignment (acfe57a52b0bf1b0108be347a6f2a228db7b7a96)

### Issues/PRs references
#9424 can simplify testing a bit