### PR TITLE
cpu/stm32f2: make use of CPU_LINE

### DIFF
--- a/cpu/stm32f2/include/cpu_conf.h
+++ b/cpu/stm32f2/include/cpu_conf.h
@@ -23,15 +23,7 @@
 
 #include "cpu_conf_common.h"
 
-#if defined(CPU_MODEL_STM32F205RG)
-#include "vendor/stm32f205xx.h"
-#elif defined(CPU_MODEL_STM32F207ZG)
-#include "vendor/stm32f207xx.h"
-#elif defined(CPU_MODEL_STM32F215RG) || defined(CPU_MODEL_STM32F215VG) || defined(CPU_MODEL_STM32F215VE)
-#include "vendor/stm32f215xx.h"
-#elif defined(CPU_MODEL_STM32F217ZG)
-#include "vendor/stm32f217xx.h"
-#endif
+#include "vendor/stm32f2xx.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/cpu/stm32f2/include/vendor/stm32f2xx.h
+++ b/cpu/stm32f2/include/vendor/stm32f2xx.h
@@ -1,0 +1,209 @@
+/**
+  ******************************************************************************
+  * @file    stm32f2xx.h
+  * @author  MCD Application Team
+  * @version V2.2.0
+  * @date    17-March-2017
+  * @brief   CMSIS STM32F2xx Device Peripheral Access Layer Header File.
+  *
+  *          The file is the unique include file that the application programmer
+  *          is using in the C source code, usually in main.c. This file contains:
+  *           - Configuration section that allows to select:
+  *              - The STM32F2xx device used in the target application
+  *              - To use or not the peripherals drivers in application code(i.e.
+  *                code will be based on direct access to peripherals registers
+  *                rather than drivers API), this option is controlled by
+  *                "#define USE_HAL_DRIVER"
+  *
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2017 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/** @addtogroup CMSIS
+  * @{
+  */
+
+/** @addtogroup stm32f2xx
+  * @{
+  */
+
+#ifndef __STM32F2xx_H
+#define __STM32F2xx_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif /* __cplusplus */
+
+/** @addtogroup Library_configuration_section
+  * @{
+  */
+
+/**
+  * @brief STM32 Family
+  */
+#if !defined (STM32F2)
+#define STM32F2
+#endif /* STM32F2 */
+
+/* Uncomment the line below according to the target STM32 device used in your
+   application
+  */
+#if !defined (STM32F205xx) && !defined (STM32F215xx) && !defined (STM32F207xx) && !defined (STM32F217xx)
+
+  /* #define STM32F205xx */   /*!< STM32F205RG, STM32F205VG, STM32F205ZG, STM32F205RF, STM32F205VF, STM32F205ZF,
+                                   STM32F205RE, STM32F205VE, STM32F205ZE, STM32F205RC, STM32F205VC, STM32F205ZC,
+                                   STM32F205RB and STM32F205VB Devices */
+  /* #define STM32F215xx */   /*!< STM32F215RG, STM32F215VG, STM32F215ZG, STM32F215RE, STM32F215VE and STM32F215ZE Devices */
+  /* #define STM32F207xx */   /*!< STM32F207VG, STM32F207ZG, STM32F207IG, STM32F207VF, STM32F207ZF, STM32F207IF,
+                                   STM32F207VE, STM32F207ZE, STM32F207IE, STM32F207VC, STM32F207ZC and STM32F207IC Devices */
+  /* #define STM32F217xx */   /*!< STM32F217VG, STM32F217ZG, STM32F217IG, STM32F217VE, STM32F217ZE and STM32F217IE Devices */
+
+#endif
+
+/*  Tip: To avoid modifying this file each time you need to switch between these
+        devices, you can define the device in your toolchain compiler preprocessor.
+  */
+#if !defined  (USE_HAL_DRIVER)
+/**
+ * @brief Comment the line below if you will not use the peripherals drivers.
+   In this case, these drivers will not be included and the application code will
+   be based on direct access to peripherals registers
+   */
+  /*#define USE_HAL_DRIVER */
+#endif /* USE_HAL_DRIVER */
+
+/**
+  * @brief CMSIS Device version number V2.2.0
+  */
+#define __STM32F2xx_CMSIS_VERSION_MAIN   (0x02U) /*!< [31:24] main version */
+#define __STM32F2xx_CMSIS_VERSION_SUB1   (0x02U) /*!< [23:16] sub1 version */
+#define __STM32F2xx_CMSIS_VERSION_SUB2   (0x00U) /*!< [15:8]  sub2 version */
+#define __STM32F2xx_CMSIS_VERSION_RC     (0x00U) /*!< [7:0]  release candidate */
+#define __STM32F2xx_CMSIS_VERSION        ((__STM32F2xx_CMSIS_VERSION_MAIN << 24)\
+                                         |(__STM32F2xx_CMSIS_VERSION_SUB1 << 16)\
+                                         |(__STM32F2xx_CMSIS_VERSION_SUB2 << 8 )\
+                                         |(__STM32F2xx_CMSIS_VERSION))
+
+/**
+  * @}
+  */
+
+/** @addtogroup Device_Included
+  * @{
+  */
+
+#if defined(STM32F205xx)
+  #include "stm32f205xx.h"
+#elif defined(STM32F215xx)
+  #include "stm32f215xx.h"
+#elif defined(STM32F207xx)
+  #include "stm32f207xx.h"
+#elif defined(STM32F217xx)
+  #include "stm32f217xx.h"
+#else
+ #error "Please select first the target STM32F2xx device used in your application (in stm32f2xx.h file)"
+#endif
+
+/**
+  * @}
+  */
+
+/** @addtogroup Exported_types
+  * @{
+  */
+typedef enum
+{
+  RESET = 0,
+  SET = !RESET
+} FlagStatus, ITStatus;
+
+typedef enum
+{
+  DISABLE = 0,
+  ENABLE = !DISABLE
+} FunctionalState;
+#define IS_FUNCTIONAL_STATE(STATE) (((STATE) == DISABLE) || ((STATE) == ENABLE))
+
+typedef enum
+{
+  ERROR = 0,
+  SUCCESS = !ERROR
+} ErrorStatus;
+
+/**
+  * @}
+  */
+
+
+/** @addtogroup Exported_macro
+  * @{
+  */
+#define SET_BIT(REG, BIT)     ((REG) |= (BIT))
+
+#define CLEAR_BIT(REG, BIT)   ((REG) &= ~(BIT))
+
+#define READ_BIT(REG, BIT)    ((REG) & (BIT))
+
+#define CLEAR_REG(REG)        ((REG) = (0x0))
+
+#define WRITE_REG(REG, VAL)   ((REG) = (VAL))
+
+#define READ_REG(REG)         ((REG))
+
+#define MODIFY_REG(REG, CLEARMASK, SETMASK)  WRITE_REG((REG), (((READ_REG(REG)) & (~(CLEARMASK))) | (SETMASK)))
+
+#define POSITION_VAL(VAL)     (__CLZ(__RBIT(VAL)))
+
+
+/**
+  * @}
+  */
+
+#if defined (USE_HAL_DRIVER)
+ #include "stm32f2xx_hal.h"
+#endif /* USE_HAL_DRIVER */
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif /* __STM32F2xx_H */
+
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+
+
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/cpu/stm32f2/vectors.c
+++ b/cpu/stm32f2/vectors.c
@@ -185,16 +185,15 @@ ISR_VECTOR(1) const isr_t vector_cpu[CPU_IRQ_NUMOF] = {
     [76] = isr_otg_hs_wkup,          /* [76] USB OTG HS Wakeup through EXTI interrupt */
     [77] = isr_otg_hs,               /* [77] USB OTG HS global interrupt */
 
-#if defined(CPU_MODEL_STM32F207ZG)
+#if defined(CPU_LINE_STM32F207xx)
     [61] = isr_eth,                  /* [61] Ethernet global Interrupt */
     [62] = isr_eth_wkup,             /* [62] Ethernet Wakeup through EXTI line Interrupt */
     [78] = isr_dcmi,                 /* [78] DCMI global interrupt */
     [80] = isr_hash_rng,             /* [80] Hash and RNG global interrupt */
-#elif defined(CPU_MODEL_STM32F215RG) || defined(CPU_MODEL_STM32F215VE) || \
-    defined(CPU_MODEL_STM32F215VG)
+#elif defined(CPU_LINE_STM32F215xx)
     [79] = isr_cryp,                 /* [79] CRYP crypto global interrupt */
     [80] = isr_hash_rng,             /* [80] Hash and RNG global interrupt */
-#elif defined(CPU_MODEL_STM32F217ZG)
+#elif defined(CPU_LINE_STM32F217xx)
     [61] = isr_eth,                  /* [61] Ethernet global Interrupt */
     [62] = isr_eth_wkup,             /* [62] Ethernet Wakeup through EXTI line Interrupt */
     [78] = isr_dcmi,                 /* [78] DCMI global interrupt */


### PR DESCRIPTION
### Contribution description

Refactor stm32f2 to use CPU_LINE_*

### Issues/PRs references

#9096 