### PR TITLE
cpu/stm32f3: make use of CPU_LINE

### DIFF
--- a/cpu/stm32f3/include/cpu_conf.h
+++ b/cpu/stm32f3/include/cpu_conf.h
@@ -24,17 +24,8 @@
 
 #include "cpu_conf_common.h"
 
-#if defined(CPU_MODEL_STM32F303VC)
-#include "vendor/stm32f303xc.h"
-#elif defined(CPU_MODEL_STM32F334R8)
-#include "vendor/stm32f334x8.h"
-#elif defined(CPU_MODEL_STM32F303RE) || defined(CPU_MODEL_STM32F303ZE)
-#include "vendor/stm32f303xe.h"
-#elif defined(CPU_MODEL_STM32F303K8)
-#include "vendor/stm32f303x8.h"
-#elif defined(CPU_MODEL_STM32F302R8)
-#include "vendor/stm32f302x8.h"
-#endif
+#include "vendor/stm32f3xx.h"
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -44,7 +35,7 @@ extern "C" {
  * @{
  */
 #define CPU_DEFAULT_IRQ_PRIO            (1U)
-#if defined(CPU_MODEL_STM32F303RE) || defined (CPU_MODEL_STM32F303ZE)
+#if defined(CPU_LINE_STM32F303xE)
 #define CPU_IRQ_NUMOF                   (85U)
 #else
 #define CPU_IRQ_NUMOF                   (82U)

--- a/cpu/stm32f3/include/vendor/stm32f3xx.h
+++ b/cpu/stm32f3/include/vendor/stm32f3xx.h
@@ -1,0 +1,250 @@
+/**
+  ******************************************************************************
+  * @file    stm32f3xx.h
+  * @author  MCD Application Team
+  * @brief   CMSIS STM32F3xx Device Peripheral Access Layer Header File.
+  *
+  *          The file is the unique include file that the application programmer
+  *          is using in the C source code, usually in main.c. This file contains:
+  *           - Configuration section that allows to select:
+  *              - The STM32F3xx device used in the target application
+  *              - To use or not the peripherals drivers in application code(i.e.
+  *                code will be based on direct access to peripherals registers
+  *                rather than drivers API), this option is controlled by
+  *                "#define USE_HAL_DRIVER"
+  *
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/** @addtogroup CMSIS
+  * @{
+  */
+
+/** @addtogroup stm32f3xx
+  * @{
+  */
+
+#ifndef __STM32F3xx_H
+#define __STM32F3xx_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif /* __cplusplus */
+
+/** @addtogroup Library_configuration_section
+  * @{
+  */
+
+/**
+  * @brief STM32 Family
+  */
+#if !defined (STM32F3)
+#define STM32F3
+#endif /* STM32F3 */
+
+/* Uncomment the line below according to the target STM32 device used in your
+   application
+  */
+
+#if !defined (STM32F301x8) && !defined (STM32F302x8) && !defined (STM32F318xx) && \
+    !defined (STM32F302xC) && !defined (STM32F303xC) && !defined (STM32F358xx) && \
+    !defined (STM32F303x8) && !defined (STM32F334x8) && !defined (STM32F328xx) && \
+    !defined (STM32F302xE) && !defined (STM32F303xE) && !defined (STM32F398xx) && \
+    !defined (STM32F373xC) && !defined (STM32F378xx)
+
+  /* #define STM32F301x8 */   /*!< STM32F301K6, STM32F301K8, STM32F301C6, STM32F301C8,
+                                   STM32F301R6 and STM32F301R8 Devices */
+  /* #define STM32F302x8 */   /*!< STM32F302K6, STM32F302K8, STM32F302C6, STM32F302C8,
+                                   STM32F302R6 and STM32F302R8 Devices */
+  /* #define STM32F302xC */   /*!< STM32F302CB, STM32F302CC, STM32F302RB, STM32F302RC,
+                                   STM32F302VB and STM32F302VC Devices */
+  /* #define STM32F302xE */   /*!< STM32F302RE, STM32F302VE, STM32F302ZE, STM32F302RD,
+                                   STM32F302VD and STM32F302ZD Devices */
+  /* #define STM32F303x8 */   /*!< STM32F303K6, STM32F303K8, STM32F303C6, STM32F303C8,
+                                   STM32F303R6 and STM32F303R8 Devices */
+  /* #define STM32F303xC */   /*!< STM32F303CB, STM32F303CC, STM32F303RB, STM32F303RC,
+                                   STM32F303VB and STM32F303VC Devices */
+  /* #define STM32F303xE */   /*!< STM32F303RE, STM32F303VE, STM32F303ZE, STM32F303RD,
+                                   STM32F303VD and STM32F303ZD Devices */
+  /* #define STM32F373xC */   /*!< STM32F373C8, STM32F373CB, STM32F373CC,
+                                   STM32F373R8, STM32F373RB, STM32F373RC,
+                                   STM32F373V8, STM32F373VB and STM32F373VC Devices */
+  /* #define STM32F334x8 */   /*!< STM32F334K4, STM32F334K6, STM32F334K8,
+                                   STM32F334C4, STM32F334C6, STM32F334C8,
+                                   STM32F334R4, STM32F334R6 and STM32F334R8 Devices */
+  /* #define STM32F318xx */   /*!< STM32F318K8, STM32F318C8: STM32F301x8 with regulator off: STM32F318xx Devices */
+  /* #define STM32F328xx */   /*!< STM32F328C8, STM32F328R8: STM32F334x8 with regulator off: STM32F328xx Devices */
+  /* #define STM32F358xx */   /*!< STM32F358CC, STM32F358RC, STM32F358VC: STM32F303xC with regulator off: STM32F358xx Devices */
+  /* #define STM32F378xx */   /*!< STM32F378CC, STM32F378RC, STM32F378VC: STM32F373xC with regulator off: STM32F378xx Devices */
+  /* #define STM32F398xx */   /*!< STM32F398VE: STM32F303xE with regulator off: STM32F398xx Devices */
+#endif
+
+/*  Tip: To avoid modifying this file each time you need to switch between these
+        devices, you can define the device in your toolchain compiler preprocessor.
+  */
+#if !defined  (USE_HAL_DRIVER)
+/**
+ * @brief Comment the line below if you will not use the peripherals drivers.
+   In this case, these drivers will not be included and the application code will
+   be based on direct access to peripherals registers
+   */
+  /*#define USE_HAL_DRIVER */
+#endif /* USE_HAL_DRIVER */
+
+/**
+  * @brief CMSIS Device version number V2.3.2
+  */
+#define __STM32F3_CMSIS_VERSION_MAIN   (0x02) /*!< [31:24] main version */
+#define __STM32F3_CMSIS_VERSION_SUB1   (0x03) /*!< [23:16] sub1 version */
+#define __STM32F3_CMSIS_VERSION_SUB2   (0x02) /*!< [15:8]  sub2 version */
+#define __STM32F3_CMSIS_VERSION_RC     (0x00) /*!< [7:0]  release candidate */
+#define __STM32F3_CMSIS_VERSION        ((__STM32F3_CMSIS_VERSION_MAIN     << 24)\
+                                       |(__STM32F3_CMSIS_VERSION_SUB1 << 16)\
+                                       |(__STM32F3_CMSIS_VERSION_SUB2 << 8 )\
+                                       |(__STM32F3_CMSIS_VERSION_RC))
+
+/**
+  * @}
+  */
+
+/** @addtogroup Device_Included
+  * @{
+  */
+
+#if defined(STM32F301x8)
+  #include "stm32f301x8.h"
+#elif defined(STM32F302x8)
+  #include "stm32f302x8.h"
+#elif defined(STM32F302xC)
+  #include "stm32f302xc.h"
+#elif defined(STM32F302xE)
+  #include "stm32f302xe.h"
+#elif defined(STM32F303x8)
+  #include "stm32f303x8.h"
+#elif defined(STM32F303xC)
+  #include "stm32f303xc.h"
+#elif defined(STM32F303xE)
+  #include "stm32f303xe.h"
+#elif defined(STM32F373xC)
+  #include "stm32f373xc.h"
+#elif defined(STM32F334x8)
+  #include "stm32f334x8.h"
+#elif defined(STM32F318xx)
+  #include "stm32f318xx.h"
+#elif defined(STM32F328xx)
+  #include "stm32f328xx.h"
+#elif defined(STM32F358xx)
+  #include "stm32f358xx.h"
+#elif defined(STM32F378xx)
+  #include "stm32f378xx.h"
+#elif defined(STM32F398xx)
+  #include "stm32f398xx.h"
+#else
+ #error "Please select first the target STM32F3xx device used in your application (in stm32f3xx.h file)"
+#endif
+
+/**
+  * @}
+  */
+
+/** @addtogroup Exported_types
+  * @{
+  */
+typedef enum
+{
+  RESET = 0,
+  SET = !RESET
+} FlagStatus, ITStatus;
+
+typedef enum
+{
+  DISABLE = 0,
+  ENABLE = !DISABLE
+} FunctionalState;
+#define IS_FUNCTIONAL_STATE(STATE) (((STATE) == DISABLE) || ((STATE) == ENABLE))
+
+typedef enum
+{
+  ERROR = 0,
+  SUCCESS = !ERROR
+} ErrorStatus;
+
+/**
+  * @}
+  */
+
+
+/** @addtogroup Exported_macros
+  * @{
+  */
+#define SET_BIT(REG, BIT)     ((REG) |= (BIT))
+
+#define CLEAR_BIT(REG, BIT)   ((REG) &= ~(BIT))
+
+#define READ_BIT(REG, BIT)    ((REG) & (BIT))
+
+#define CLEAR_REG(REG)        ((REG) = (0x0))
+
+#define WRITE_REG(REG, VAL)   ((REG) = (VAL))
+
+#define READ_REG(REG)         ((REG))
+
+#define MODIFY_REG(REG, CLEARMASK, SETMASK)  WRITE_REG((REG), (((READ_REG(REG)) & (~(CLEARMASK))) | (SETMASK)))
+
+#define POSITION_VAL(VAL)     (__CLZ(__RBIT(VAL)))
+
+
+#if defined (USE_HAL_DRIVER)
+ #include "stm32f3xx_hal.h"
+#endif /* USE_HAL_DRIVER */
+
+
+/**
+  * @}
+  */
+
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif /* __STM32F3xx_H */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+
+
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/cpu/stm32f3/stm32_line.mk
+++ b/cpu/stm32f3/stm32_line.mk
@@ -1,0 +1,25 @@
+# Compute CPU_LINE
+LINE := $(shell echo $(CPU_MODEL) | tr 'a-z-' 'A-Z_' | sed -E -e 's/^STM32F([0-9][0-9][0-9])(.)(.)/\1 \2 \3/')
+TYPE := $(word 1, $(LINE))
+MODEL1 := $(word 2, $(LINE))
+MODEL2 := $(word 3, $(LINE))
+
+ifneq (, $(filter $(TYPE), 301))
+  CPU_LINE = STM32F$(TYPE)x8
+else ifneq (, $(filter $(TYPE), 302 303))
+  ifneq (, $(filter $(MODEL2), 6 8))
+    CPU_LINE = STM32F$(TYPE)x8
+  else ifneq (, $(filter $(MODEL2), B C))
+    CPU_LINE = STM32F$(TYPE)xC
+  else ifneq (, $(filter $(MODEL2), D E))
+    CPU_LINE = STM32F$(TYPE)xE
+  else
+    $(error Unsuported CPU)
+  endif
+else ifneq (, $(filter $(TYPE), 373))
+  CPU_LINE = STM32F$(TYPE)xC
+else ifneq (, $(filter $(TYPE), 334))
+  CPU_LINE = STM32F$(TYPE)x8
+else
+  CPU_LINE = STM32F3$(TYPE)xx
+endif

--- a/cpu/stm32f3/vectors.c
+++ b/cpu/stm32f3/vectors.c
@@ -136,7 +136,7 @@ ISR_VECTOR(1) const isr_t vector_cpu[CPU_IRQ_NUMOF] = {
     isr_tim1_trg_com_tim17, /* [26] TIM1 Trigger and Commutation and TIM17 Interrupt */
     isr_tim1_cc,            /* [27] TIM1 Capture Compare Interrupt */
     isr_tim2,               /* [28] TIM2 global Interrupt */
-#if defined(CPU_MODEL_STM32F302R8)
+#if defined(CPU_LINE_STM32F302x8)
     (0UL),                  /* [29] Reserved */
     (0UL),                  /* [30] Reserved */
     isr_i2c1_ev,            /* [31] I2C1 Event Interrupt & EXTI Line23 Interrupt (I2C1 wakeup) */
@@ -190,7 +190,7 @@ ISR_VECTOR(1) const isr_t vector_cpu[CPU_IRQ_NUMOF] = {
     (0UL),                  /* [79] Reserved */
     (0UL),                  /* [80] Reserved */
     isr_fpu                 /* [81] Floating point Interrupt */
-#elif defined(CPU_MODEL_STM32F303K8)
+#elif defined(CPU_LINE_STM32F303x8)
     isr_tim3,               /* [29] TIM3 global Interrupt */
     (0UL),                  /* [30] Reserved */
     isr_i2c1_ev,            /* [31] I2C1 Event Interrupt & EXTI Line23 Interrupt (I2C1 wakeup) */
@@ -244,7 +244,7 @@ ISR_VECTOR(1) const isr_t vector_cpu[CPU_IRQ_NUMOF] = {
     (0UL),                  /* [79] Reserved */
     (0UL),                  /* [80] Reserved */
     isr_fpu                 /* [81] Floating point Interrupt */
-#elif (CPU_MODEL_STM32F334R8)
+#elif (CPU_LINE_STM32F334x8)
     isr_tim3,               /* [29] TIM3 global Interrupt */
     isr_tim4,               /* [30] TIM4 global Interrupt */
     isr_i2c1_ev,            /* [31] I2C1 Event Interrupt & EXTI Line23 Interrupt (I2C1 wakeup) */
@@ -298,7 +298,7 @@ ISR_VECTOR(1) const isr_t vector_cpu[CPU_IRQ_NUMOF] = {
     (0UL),                  /* [79] Reserved */
     (0UL),                  /* [80] Reserved */
     isr_fpu                 /* [81] Floating point Interrupt */
-#else /* CPU_MODEL_STM32F303VC, CPU_MODEL_STM32F303RE, CPU_MODEL_STM32F303ZE */
+#else /* CPU_LINE_STM32F303xC, CPU_LINE_STM32F303xE */
     isr_tim3,               /* [29] TIM3 global Interrupt */
     isr_tim4,               /* [30] TIM4 global Interrupt */
     isr_i2c1_ev,            /* [31] I2C1 Event Interrupt & EXTI Line23 Interrupt (I2C1 wakeup) */
@@ -318,7 +318,7 @@ ISR_VECTOR(1) const isr_t vector_cpu[CPU_IRQ_NUMOF] = {
     isr_tim8_trg_com,       /* [45] TIM8 Trigger and Commutation Interrupt */
     isr_tim8_cc,            /* [46] TIM8 Capture Compare Interrupt */
     isr_adc3,               /* [47] ADC3 global Interrupt */
-#if defined(CPU_MODEL_STM32F303VC)
+#if defined(CPU_LINE_STM32F303xC)
     (0UL),                  /* [48] Reserved */
 #else
     isr_fmc,                /* [48] FMC global Interrupt */
@@ -346,7 +346,7 @@ ISR_VECTOR(1) const isr_t vector_cpu[CPU_IRQ_NUMOF] = {
     (0UL),                  /* [69] Reserved */
     (0UL),                  /* [70] Reserved */
     (0UL),                  /* [71] Reserved */
-#if defined(CPU_MODEL_STM32F303VC)
+#if defined(CPU_LINE_STM32F303xC)
     (0UL),                  /* [72] Reserved */
     (0UL),                  /* [73] Reserved */
     isr_usb_hp,             /* [74] USB High Priority global Interrupt remap */
@@ -357,7 +357,7 @@ ISR_VECTOR(1) const isr_t vector_cpu[CPU_IRQ_NUMOF] = {
     (0UL),                  /* [79] Reserved */
     (0UL),                  /* [80] Reserved */
     isr_fpu                 /* [81] Floating point Interrupt */
-#else /* CPU_MODEL_STM32F303RE, CPU_MODEL_STM32F303ZE */
+#else /* CPU_LINE_STM32F303xE */
     isr_i2c3_ev,            /* [72] I2C3 event interrupt */
     isr_i2c3_er,            /* [73] I2C3 error interrupt */
     isr_usb_hp,             /* [74] USB High Priority global Interrupt remap */


### PR DESCRIPTION

### Contribution description

Refactor stm32f3 to use CPU_LINE_*

### Issues/PRs references

#9096 