### PR TITLE
drivers/lis3dh: Add missing .clk initializer

### DIFF
--- a/drivers/lis3dh/include/lis3dh_params.h
+++ b/drivers/lis3dh/include/lis3dh_params.h
@@ -37,6 +37,9 @@ extern "C" {
 #ifndef LIS3DH_PARAM_CS
 #define LIS3DH_PARAM_CS             (GPIO_PIN(0, 0))
 #endif
+#ifndef LIS3DH_PARAM_CLK
+#define LIS3DH_PARAM_CLK            (SPI_CLK_5MHZ)
+#endif
 #ifndef LIS3DH_PARAM_INT1
 #define LIS3DH_PARAM_INT1           (GPIO_PIN(0, 1))
 #endif
@@ -51,6 +54,7 @@ extern "C" {
 #endif
 
 #define LIS3DH_PARAMS_DEFAULT       { .spi   = LIS3DH_PARAM_SPI, \
+                                      .clk   = LIS3DH_PARAM_CLK, \
                                       .cs    = LIS3DH_PARAM_CS, \
                                       .int1  = LIS3DH_PARAM_INT1, \
                                       .int2  = LIS3DH_PARAM_INT2, \


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

There was no initializer for the .clk member of lis3dh_params_t, so it was always defaulted to SPI_CLK_100KHZ for platforms which use the default SPI speed definitions. The device is rated for up to 10 MHz SPI speeds, according to the data sheet, so a default setting of 5 MHz should be a safe choice without wasting time on transfers.

### Issues/PRs references

discovered while testing #9438 