### PR TITLE
boards/frdm: Add bus configuration for onboard FXOS8700CQ sensor 

### DIFF
--- a/boards/frdm-k22f/include/board.h
+++ b/boards/frdm-k22f/include/board.h
@@ -55,6 +55,14 @@ extern "C"
 /** @} */
 
 /**
+ * @name    FXOS8700CQ 3-axis accelerometer and magnetometer bus configuration
+ * @{
+ */
+#define FXOS8700_PARAM_I2C          I2C_DEV(0)
+#define FXOS8700_PARAM_ADDR         0x1C
+/** @} */
+
+/**
  * @brief   Initialize board specific hardware, including clock, LEDs and std-IO
  */
 void board_init(void);

--- a/boards/frdm-k64f/include/board.h
+++ b/boards/frdm-k64f/include/board.h
@@ -56,6 +56,14 @@ extern "C"
 /** @} */
 
 /**
+ * @name    FXOS8700CQ 3-axis accelerometer and magnetometer bus configuration
+ * @{
+ */
+#define FXOS8700_PARAM_I2C          I2C_DEV(0)
+#define FXOS8700_PARAM_ADDR         0x1E
+/** @} */
+
+/**
  * @brief   Initialize board specific hardware, including clock, LEDs and std-IO
  */
 void board_init(void);

--- a/boards/frdm-kw41z/include/board.h
+++ b/boards/frdm-kw41z/include/board.h
@@ -87,6 +87,14 @@ extern "C"
 /** @} */
 
 /**
+ * @name    FXOS8700CQ 3-axis accelerometer and magnetometer bus configuration
+ * @{
+ */
+#define FXOS8700_PARAM_I2C          I2C_DEV(1)
+#define FXOS8700_PARAM_ADDR         0x1F
+/** @} */
+
+/**
  * @brief   Initialize board specific hardware, including clock, LEDs and standard I/O
  */
 void board_init(void);


### PR DESCRIPTION
### Contribution description

Adds missing bus and slave address configuration for the supported FRDM Kinetis boards. These boards each have different configurations for the FXOS8700 sensor, so it is necessary to specify the address for each board.
This should not be affected by the i2c embargo because it applies to the device driver configuration and it works exactly the same both in master and after the changes in #9268.

### Issues/PRs references

#9268 