### PR TITLE
cpu/stm32l0: make use of CPU_LINE and STM32_FLASHSIZE

### DIFF
--- a/cpu/stm32_common/periph/pm.c
+++ b/cpu/stm32_common/periph/pm.c
@@ -57,7 +57,7 @@ void pm_set(unsigned mode)
             /* Enable WKUP pin to use for wakeup from standby mode */
 #if defined(CPU_FAM_STM32L0)
             PWR->CSR |= (PWR_CSR_EWUP1 | PWR_CSR_EWUP2);
-#if !defined(CPU_MODEL_STM32L053R8)
+#if !defined(CPU_LINE_STM32L053xx)
             /* STM32L053 only have 2 wake pins */
             PWR->CSR |= PWR_CSR_EWUP3;
 #endif

--- a/cpu/stm32l0/include/cpu_conf.h
+++ b/cpu/stm32l0/include/cpu_conf.h
@@ -58,18 +58,9 @@ extern "C" {
  * @name    Flash page configuration
  * @{
  */
-#if defined(CPU_MODEL_STM32L073RZ) || defined(CPU_MODEL_STM32L072CZ) || \
-    defined(CPU_MODEL_STM32L053R8) || defined(CPU_MODEL_STM32L031K6)
 #define FLASHPAGE_SIZE      (128U)
-#endif
 
-#if defined(CPU_MODEL_STM32L073RZ) || defined(CPU_MODEL_STM32L072CZ)
-#define FLASHPAGE_NUMOF     (1536U)
-#elif defined(CPU_MODEL_STM32L053R8)
-#define FLASHPAGE_NUMOF     (512U)
-#elif defined(CPU_MODEL_STM32L031K6)
-#define FLASHPAGE_NUMOF     (256U)
-#endif
+#define FLASHPAGE_NUMOF     (STM32_FLASHSIZE / FLASHPAGE_SIZE)
 
 /* The minimum block size which can be written is 4B. However, the erase
  * block is always FLASHPAGE_SIZE.

--- a/cpu/stm32l0/include/cpu_conf.h
+++ b/cpu/stm32l0/include/cpu_conf.h
@@ -25,18 +25,7 @@
 
 #include "cpu_conf_common.h"
 
-#ifdef CPU_MODEL_STM32L073RZ
-#include "vendor/stm32l073xx.h"
-#endif
-#ifdef CPU_MODEL_STM32L072CZ
-#include "vendor/stm32l072xx.h"
-#endif
-#ifdef CPU_MODEL_STM32L053R8
-#include "vendor/stm32l053xx.h"
-#endif
-#ifdef CPU_MODEL_STM32L031K6
-#include "vendor/stm32l031xx.h"
-#endif
+#include "vendor/stm32l0xx.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -47,7 +36,7 @@ extern "C" {
  * @{
  */
 #define CPU_DEFAULT_IRQ_PRIO            (1U)
-#if defined(CPU_MODEL_STM32L031K6)
+#if defined(CPU_LINE_STM32L031xx)
 #define CPU_IRQ_NUMOF                   (30U)
 #else
 #define CPU_IRQ_NUMOF                   (32U)

--- a/cpu/stm32l0/include/periph_cpu.h
+++ b/cpu/stm32l0/include/periph_cpu.h
@@ -81,11 +81,11 @@ typedef struct {
  * @{
  */
 #define EEPROM_START_ADDR          (0x08080000)
-#if defined(CPU_MODEL_STM32L073RZ) || defined(CPU_MODEL_STM32L072CZ)
+#if defined(CPU_LINE_STM32L073xx) || defined(CPU_LINE_STM32L072xx)
 #define EEPROM_SIZE                (6144U)  /* 6kB */
-#elif defined(CPU_MODEL_STM32L053R8)
+#elif defined(CPU_LINE_STM32L053xx)
 #define EEPROM_SIZE                (2048U)  /* 2kB */
-#elif defined(CPU_MODEL_STM32L031K6)
+#elif defined(CPU_LINE_STM32L031xx)
 #define EEPROM_SIZE                (1024U)  /* 1kB */
 #endif
 /** @} */

--- a/cpu/stm32l0/include/vendor/stm32l0xx.h
+++ b/cpu/stm32l0/include/vendor/stm32l0xx.h
@@ -1,0 +1,217 @@
+/**
+  ******************************************************************************
+  * @file    stm32l0xx.h
+  * @author  MCD Application Team
+  * @version V1.7.1
+  * @date    25-November-2016
+  * @brief   CMSIS Cortex-M0+ Device Peripheral Access Layer Header File.
+  *          This file contains all the peripheral register's definitions, bits
+  *          definitions and memory mapping for STM32L0xx devices.
+  *
+  *          The file is the unique include file that the application programmer
+  *          is using in the C source code, usually in main.c. This file contains:
+  *           - Configuration section that allows to select:
+  *              - The device used in the target application
+  *              - To use or not the peripheral's drivers in application code(i.e.
+  *                code will be based on direct access to peripheral's registers
+  *                rather than drivers API), this option is controlled by
+  *                "#define USE_HAL_DRIVER"
+  *
+  ******************************************************************************
+  * @attention
+  *
+  * <h2><center>&copy; COPYRIGHT(c) 2016 STMicroelectronics</center></h2>
+  *
+  * Redistribution and use in source and binary forms, with or without modification,
+  * are permitted provided that the following conditions are met:
+  *   1. Redistributions of source code must retain the above copyright notice,
+  *      this list of conditions and the following disclaimer.
+  *   2. Redistributions in binary form must reproduce the above copyright notice,
+  *      this list of conditions and the following disclaimer in the documentation
+  *      and/or other materials provided with the distribution.
+  *   3. Neither the name of STMicroelectronics nor the names of its contributors
+  *      may be used to endorse or promote products derived from this software
+  *      without specific prior written permission.
+  *
+  * THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+  * AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+  * IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+  * DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+  * FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+  * DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+  * SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+  * CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+  * OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+  * OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+  *
+  ******************************************************************************
+  */
+
+/** @addtogroup CMSIS
+  * @{
+  */
+
+/** @addtogroup stm32l0xx
+  * @{
+  */
+
+#ifndef __STM32L0xx_H
+#define __STM32L0xx_H
+
+#ifdef __cplusplus
+ extern "C" {
+#endif /* __cplusplus */
+
+/** @addtogroup Library_configuration_section
+  * @{
+  */
+
+/**
+  * @brief STM32 Family
+  */
+#if !defined (STM32L0)
+#define STM32L0
+#endif /* STM32L0 */
+
+/* Uncomment the line below according to the target STM32 device used in your
+   application
+  */
+
+#if !defined (STM32L011xx) && !defined (STM32L021xx) && \
+    !defined (STM32L031xx) && !defined (STM32L041xx) && \
+    !defined (STM32L051xx) && !defined (STM32L052xx) && !defined (STM32L053xx) && \
+    !defined (STM32L061xx) && !defined (STM32L062xx) && !defined (STM32L063xx) && \
+    !defined (STM32L071xx) && !defined (STM32L072xx) && !defined (STM32L073xx) && \
+    !defined (STM32L081xx) && !defined (STM32L082xx) && !defined (STM32L083xx) \
+  /* #define STM32L011xx */
+  /* #define STM32L021xx */
+  /* #define STM32L031xx */   /*!< STM32L031C6, STM32L031E6, STM32L031F6, STM32L031G6, STM32L031K6 Devices */
+  /* #define STM32L041xx */   /*!< STM32L041C6, STM32L041E6, STM32L041F6, STM32L041G6, STM32L041K6 Devices */
+  /* #define STM32L051xx */   /*!< STM32L051K8, STM32L051C6, STM32L051C8, STM32L051R6, STM32L051R8 Devices */
+  /* #define STM32L052xx */   /*!< STM32L052K6, STM32L052K8, STM32L052C6, STM32L052C8, STM32L052R6, STM32L052R8 Devices */
+  /* #define STM32L053xx */   /*!< STM32L053C6, STM32L053C8, STM32L053R6, STM32L053R8 Devices */
+  /* #define STM32L061xx */   /*!< */
+  /* #define STM32L062xx */   /*!< STM32L062K8 */
+  /* #define STM32L063xx */   /*!< STM32L063C8, STM32L063R8 */
+  /* #define STM32L071xx */   /*!< */
+  /* #define STM32L072xx */   /*!< */
+  /* #define STM32L073xx */   /*!< STM32L073V8, STM32L073VB, STM32L073RB, STM32L073VZ, STM32L073RZ Devices */
+  /* #define STM32L081xx */   /*!< */
+  /* #define STM32L082xx */   /*!< */
+  /* #define STM32L083xx */   /*!< */
+#endif
+
+/*  Tip: To avoid modifying this file each time you need to switch between these
+        devices, you can define the device in your toolchain compiler preprocessor.
+  */
+#if !defined  (USE_HAL_DRIVER)
+/**
+ * @brief Comment the line below if you will not use the peripherals drivers.
+   In this case, these drivers will not be included and the application code will
+   be based on direct access to peripherals registers
+   */
+  /*#define USE_HAL_DRIVER */
+#endif /* USE_HAL_DRIVER */
+
+/**
+  * @brief CMSIS Device version number V1.7.1
+  */
+#define __STM32L0xx_CMSIS_VERSION_MAIN   (0x01) /*!< [31:24] main version */
+#define __STM32L0xx_CMSIS_VERSION_SUB1   (0x07) /*!< [23:16] sub1 version */
+#define __STM32L0xx_CMSIS_VERSION_SUB2   (0x01) /*!< [15:8]  sub2 version */
+#define __STM32L0xx_CMSIS_VERSION_RC     (0x00) /*!< [7:0]  release candidate */
+#define __STM32L0xx_CMSIS_VERSION        ((__STM32L0xx_CMSIS_VERSION_MAIN     << 24)\
+                                         |(__STM32L0xx_CMSIS_VERSION_SUB1 << 16)\
+                                         |(__STM32L0xx_CMSIS_VERSION_SUB2 << 8 )\
+                                         |(__STM32L0xx_CMSIS_VERSION_RC))
+
+/**
+  * @}
+  */
+
+/** @addtogroup Device_Included
+  * @{
+  */
+#if defined(STM32L011xx)
+  #include "stm32l011xx.h"
+#elif defined(STM32L021xx)
+  #include "stm32l021xx.h"
+#elif defined(STM32L031xx)
+  #include "stm32l031xx.h"
+#elif defined(STM32L041xx)
+  #include "stm32l041xx.h"
+#elif defined(STM32L051xx)
+  #include "stm32l051xx.h"
+#elif defined(STM32L052xx)
+  #include "stm32l052xx.h"
+#elif defined(STM32L053xx)
+  #include "stm32l053xx.h"
+#elif defined(STM32L062xx)
+  #include "stm32l062xx.h"
+#elif defined(STM32L063xx)
+  #include "stm32l063xx.h"
+#elif defined(STM32L061xx)
+  #include "stm32l061xx.h"
+#elif defined(STM32L071xx)
+  #include "stm32l071xx.h"
+#elif defined(STM32L072xx)
+  #include "stm32l072xx.h"
+#elif defined(STM32L073xx)
+  #include "stm32l073xx.h"
+#elif defined(STM32L082xx)
+  #include "stm32l082xx.h"
+#elif defined(STM32L083xx)
+  #include "stm32l083xx.h"
+#elif defined(STM32L081xx)
+  #include "stm32l081xx.h"
+#else
+ #error "Please select first the target STM32L0xx device used in your application (in stm32l0xx.h file)"
+#endif
+
+/**
+  * @}
+  */
+
+
+/** @addtogroup Exported_macro
+  * @{
+  */
+#define SET_BIT(REG, BIT)     ((REG) |= (BIT))
+
+#define CLEAR_BIT(REG, BIT)   ((REG) &= ~(BIT))
+
+#define READ_BIT(REG, BIT)    ((REG) & (BIT))
+
+#define CLEAR_REG(REG)        ((REG) = (0x0))
+
+#define WRITE_REG(REG, VAL)   ((REG) = (VAL))
+
+#define READ_REG(REG)         ((REG))
+
+#define MODIFY_REG(REG, CLEARMASK, SETMASK)  WRITE_REG((REG), (((READ_REG(REG)) & (~(CLEARMASK))) | (SETMASK)))
+
+/**
+  * @}
+  */
+
+#if defined (USE_HAL_DRIVER)
+ #include "stm32l0xx_hal.h"
+#endif /* USE_HAL_DRIVER */
+
+#ifdef __cplusplus
+}
+#endif /* __cplusplus */
+
+#endif /* __STM32L0xx_H */
+/**
+  * @}
+  */
+
+/**
+  * @}
+  */
+
+
+
+
+/************************ (C) COPYRIGHT STMicroelectronics *****END OF FILE****/

--- a/cpu/stm32l0/vectors.c
+++ b/cpu/stm32l0/vectors.c
@@ -83,10 +83,10 @@ ISR_VECTOR(1) const isr_t vector_cpu[CPU_IRQ_NUMOF] = {
     [25] = isr_spi1,                 /* [25] SPI1 Interrupt */
     [28] = isr_usart2,               /* [28] USART2 Interrupt */
 
-#if defined(CPU_MODEL_STM32L031K6)
+#if defined(CPU_LINE_STM32L031xx)
     [ 4] = isr_rcc,                  /* [ 4] RCC Interrupt */
     [29] = isr_lpuart1,              /* [29] LPUART1 Interrupt */
-#elif defined(CPU_MODEL_STM32L053R8)
+#elif defined(CPU_LINE_STM32L053xx)
     [ 4] = isr_rcc_crs,              /* [ 4] RCC and CRS Interrupts */
     [ 8] = isr_tsc,                  /* [ 8] TSC Interrupt */
     [17] = isr_tim6_dac,             /* [17] TIM6 and DAC Interrupts */
@@ -96,7 +96,7 @@ ISR_VECTOR(1) const isr_t vector_cpu[CPU_IRQ_NUMOF] = {
     [29] = isr_rng_lpuart1,          /* [29] RNG and LPUART1 Interrupts */
     [30] = isr_lcd,                  /* [30] LCD Interrupt */
     [31] = isr_usb,                  /* [31] USB global Interrupt */
-#elif defined(CPU_MODEL_STM32L072CZ)
+#elif defined(CPU_LINE_STM32L072xx)
     [ 4] = isr_rcc_crs,              /* [ 4] RCC and CRS Interrupts */
     [ 8] = isr_tsc,                  /* [ 8] TSC Interrupt */
     [14] = isr_usart4_5,             /* [14] USART4 and USART5 Interrupt */
@@ -109,7 +109,7 @@ ISR_VECTOR(1) const isr_t vector_cpu[CPU_IRQ_NUMOF] = {
     [27] = isr_usart1,               /* [27] USART1 Interrupt */
     [29] = isr_rng_lpuart1,          /* [29] RNG and LPUART1 Interrupts */
     [31] = isr_usb,                  /* [31] USB global Interrupt */
-#elif defined(CPU_MODEL_STM32L073RZ)
+#elif defined(CPU_LINE_STM32L073xx)
     [ 4] = isr_rcc_crs,              /* [ 4] RCC and CRS Interrupts */
     [ 8] = isr_tsc,                  /* [ 8] TSC Interrupt */
     [14] = isr_usart4_5,             /* [14] USART4 and USART5 Interrupt */


### PR DESCRIPTION
### Contribution description

Refactor stm32l0 to use CPU_LINE_* and STM32_FLASHSIZE

### Issues/PRs references

#9096
