### PR TITLE
net/nanocoap: test coap_get_uri() boundaries

### DIFF
--- a/tests/unittests/tests-nanocoap/tests-nanocoap.c
+++ b/tests/unittests/tests-nanocoap/tests-nanocoap.c
@@ -144,6 +144,81 @@ static void test_nanocoap__get_multi_path(void)
     TEST_ASSERT_EQUAL_STRING((char *)path, (char *)uri);
 }
 
+/*
+ * Builds on get_req test, to test '/' path. This path is the default when
+ * otherwise not specified.
+ */
+static void test_nanocoap__get_root_path(void)
+{
+    uint8_t buf[128];
+    coap_pkt_t pkt;
+    uint16_t msgid = 0xABCD;
+    uint8_t token[2] = {0xDA, 0xEC};
+    char path[] = "/";
+
+    size_t len = coap_build_hdr((coap_hdr_t *)&buf[0], COAP_TYPE_NON,
+                                &token[0], 2, COAP_METHOD_GET, msgid);
+
+    coap_pkt_init(&pkt, &buf[0], sizeof(buf), len);
+
+    char uri[10] = {0};
+    coap_get_uri(&pkt, (uint8_t *)&uri[0]);
+    TEST_ASSERT_EQUAL_STRING((char *)path, (char *)uri);
+}
+
+/*
+ * Builds on get_req test, to test max length path.
+ */
+static void test_nanocoap__get_max_path(void)
+{
+    uint8_t buf[128];
+    coap_pkt_t pkt;
+    uint16_t msgid = 0xABCD;
+    uint8_t token[2] = {0xDA, 0xEC};
+    char path[] = "/23456789012345678901234567890123456789012345678901234567890123";
+    /* includes extra byte for option length > 12 */
+    size_t uri_opt_len = 64;
+
+    size_t len = coap_build_hdr((coap_hdr_t *)&buf[0], COAP_TYPE_NON,
+                                &token[0], 2, COAP_METHOD_GET, msgid);
+
+    coap_pkt_init(&pkt, &buf[0], sizeof(buf), len);
+
+    len = coap_opt_add_string(&pkt, COAP_OPT_URI_PATH, &path[0], '/');
+    TEST_ASSERT_EQUAL_INT(uri_opt_len, len);
+
+    char uri[NANOCOAP_URI_MAX] = {0};
+    coap_get_uri(&pkt, (uint8_t *)&uri[0]);
+    TEST_ASSERT_EQUAL_STRING((char *)path, (char *)uri);
+}
+
+/*
+ * Builds on get_req test, to test path longer than NANOCOAP_URI_MAX. We
+ * expect coap_get_uri() to return -ENOSPC.
+ */
+static void test_nanocoap__get_path_too_long(void)
+{
+    uint8_t buf[128];
+    coap_pkt_t pkt;
+    uint16_t msgid = 0xABCD;
+    uint8_t token[2] = {0xDA, 0xEC};
+    char path[] = "/234567890123456789012345678901234567890123456789012345678901234";
+    /* includes extra byte for option length > 12 */
+    size_t uri_opt_len = 65;
+
+    size_t len = coap_build_hdr((coap_hdr_t *)&buf[0], COAP_TYPE_NON,
+                                &token[0], 2, COAP_METHOD_GET, msgid);
+
+    coap_pkt_init(&pkt, &buf[0], sizeof(buf), len);
+
+    len = coap_opt_add_string(&pkt, COAP_OPT_URI_PATH, &path[0], '/');
+    TEST_ASSERT_EQUAL_INT(uri_opt_len, len);
+
+    char uri[NANOCOAP_URI_MAX] = {0};
+    int get_len = coap_get_uri(&pkt, (uint8_t *)&uri[0]);
+    TEST_ASSERT_EQUAL_INT(-ENOSPC, get_len);
+}
+
 Test *tests_nanocoap_tests(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
@@ -151,6 +226,9 @@ Test *tests_nanocoap_tests(void)
         new_TestFixture(test_nanocoap__get_req),
         new_TestFixture(test_nanocoap__put_req),
         new_TestFixture(test_nanocoap__get_multi_path),
+        new_TestFixture(test_nanocoap__get_root_path),
+        new_TestFixture(test_nanocoap__get_max_path),
+        new_TestFixture(test_nanocoap__get_path_too_long),
     };
 
     EMB_UNIT_TESTCALLER(nanocoap_tests, NULL, NULL, fixtures);


### PR DESCRIPTION
### Contribution description

Adds unit tests for retrieval of large and small URI paths via coap_get_uri(). See PR [comment](https://github.com/RIOT-OS/RIOT/pull/9156#discussion_r198369956) for motivation.

### Issues/PRs references

Supports #9156.