### PR TITLE
gnrc_sixlowpan_frag: add current_size to exposed struct

### DIFF
--- a/sys/include/net/gnrc/sixlowpan/frag.h
+++ b/sys/include/net/gnrc/sixlowpan/frag.h
@@ -67,6 +67,10 @@ typedef struct {
     uint8_t src_len;                            /**< length of gnrc_sixlowpan_rbuf_t::src */
     uint8_t dst_len;                            /**< length of gnrc_sixlowpan_rbuf_t::dst */
     uint16_t tag;                               /**< the datagram's tag */
+    /**
+     * @brief   The number of bytes currently received of the complete datagram
+     */
+    uint16_t current_size;
 } gnrc_sixlowpan_rbuf_t;
 
 /**

--- a/sys/net/gnrc/network_layer/sixlowpan/frag/rbuf.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/rbuf.c
@@ -152,12 +152,12 @@ void rbuf_add(gnrc_netif_hdr_t *netif_hdr, gnrc_pktsnip_t *pkt,
 
     if (_rbuf_update_ints(entry, offset, frag_size)) {
         DEBUG("6lo rbuf: add fragment data\n");
-        entry->cur_size += (uint16_t)frag_size;
+        entry->super.current_size += (uint16_t)frag_size;
         memcpy(((uint8_t *)entry->super.pkt->data) + offset + data_offset, data,
                frag_size - data_offset);
     }
 
-    if (entry->cur_size == entry->super.pkt->size) {
+    if (entry->super.current_size == entry->super.pkt->size) {
         gnrc_pktsnip_t *netif = gnrc_netif_hdr_build(entry->super.src,
                                                      entry->super.src_len,
                                                      entry->super.dst,
@@ -337,7 +337,7 @@ static rbuf_t *_rbuf_get(const void *src, size_t src_len,
     res->super.src_len = src_len;
     res->super.dst_len = dst_len;
     res->super.tag = tag;
-    res->cur_size = 0;
+    res->super.current_size = 0;
 
     DEBUG("6lo rfrag: entry %p (%s, ", (void *)res,
           gnrc_netif_addr_to_str(res->super.src, res->super.src_len,

--- a/sys/net/gnrc/network_layer/sixlowpan/frag/rbuf.h
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/rbuf.h
@@ -65,7 +65,6 @@ typedef struct {
     rbuf_int_t *ints;                   /**< intervals of the fragment */
     uint32_t arrival;                   /**< time in microseconds of arrival of
                                          *   last received fragment */
-    uint16_t cur_size;                  /**< the datagram's current size */
 } rbuf_t;
 
 /**


### PR DESCRIPTION
### Contribution description
Since IPHC also manipulates the total number of bytes of a received
datagram (by decompressing it), this also needs to be exposed. I guess
I was too focused on introducing a *generic* packet buffer for a future
virtual reassembly buffer (where it isn't needed, but so isn't `pkt` to
be honest), that I totally forgot about it in #9352.

### Issues/PRs references
Follow-up to #9352 towards #8511.