### PR TITLE
doc: add requirement for two acks for changes

### DIFF
--- a/MAINTAINING.md
+++ b/MAINTAINING.md
@@ -15,7 +15,9 @@ Notes:
     might be more efficient to give the contributor some broader comments for
     improvement before further review.
 -   This is a working document and any changes, additions, or other discussions
-    are encouraged, via PRs raised against the document.
+    are encouraged, via PRs raised against the document. Changes to this
+    document should however have at least two ACKs, to ensure these guidelines
+    are well thought out, and that they reflect community consensus.
 
 The [list of maintainers] gives information on the current maintainers and the
 areas of RIOT they each maintain.


### PR DESCRIPTION
### Contribution description

This adds the requirement for two ACKs, for changes to the maintainer guidelines, to ensure that they remain high quality and credible.

As I recall, in GitHub you can only enforce reviews on a per-branch basis, so this would be a text change to the guidelines only. Also, I don't think this is required.