### PR TITLE
[WIP] sock_secure module

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -756,6 +756,13 @@ ifneq (,$(filter uuid,$(USEMODULE)))
   USEMODULE += random
 endif
 
+ifneq (,$(filter sock_secure,$(USEMODULE)))
+  USEMODULE += tlsman
+  ifneq (,$(filter tinydtls,$(USEMODULE)))
+    USEMODULE += tlsman_tinydtls
+  endif
+endif
+
 # always select gpio (until explicit dependencies are sorted out)
 FEATURES_OPTIONAL += periph_gpio
 

--- a/examples/nanocoap_server/Makefile
+++ b/examples/nanocoap_server/Makefile
@@ -53,6 +53,18 @@ endif
 # Change this to 0 show compiler invocation lines by default:
 QUIET ?= 1
 
+#Enable support for DTLS
+USEMODULE += sock_secure
+
+ifneq (,$(filter sock_secure,$(USEMODULE)))
+  USEPKG += tinydtls
+  INCLUDES += -I$(APPDIR)/../sock_secure/keys
+	CFLAGS += -DTHREAD_STACKSIZE_MAIN=\(3*THREAD_STACKSIZE_DEFAULT\)
+
+	#Just for parsing when ENABLE_DEBUG is used
+	USEMODULE += od
+endif
+
 include $(RIOTBASE)/Makefile.include
 
 # Set a custom channel if needed

--- a/examples/nanocoap_server/main.c
+++ b/examples/nanocoap_server/main.c
@@ -48,7 +48,11 @@ int main(void)
 
     /* initialize nanocoap server instance */
     uint8_t buf[COAP_INBUF_SIZE];
+#ifdef MODULE_SOCK_SECURE
+    sock_udp_ep_t local = { .port=COAP_PORT + 1, .family=AF_INET6 };
+#else
     sock_udp_ep_t local = { .port=COAP_PORT, .family=AF_INET6 };
+#endif
     nanocoap_server(&local, buf, sizeof(buf));
 
     /* should be never reached */

--- a/examples/nanocoap_server/main.c
+++ b/examples/nanocoap_server/main.c
@@ -53,8 +53,19 @@ int main(void)
 #else
     sock_udp_ep_t local = { .port=COAP_PORT, .family=AF_INET6 };
 #endif
-    nanocoap_server(&local, buf, sizeof(buf));
 
+#if 0
+    (void) local;
+    sock_udp_ep_t remote = SOCK_IPV6_EP_ANY;
+    remote.port = 5684;
+    char addr_str[] = "fe80::ac9f:5dff:feb3:866e";
+    char path[] = "/riot/board";
+    ipv6_addr_from_str((ipv6_addr_t *)&remote.addr.ipv6, addr_str);
+
+    nanocoap_get(&remote, path, buf, COAP_INBUF_SIZE);
+#else
+    nanocoap_server(&local, buf, sizeof(buf));
+#endif
     /* should be never reached */
     return 0;
 }

--- a/examples/sock_secure/Makefile
+++ b/examples/sock_secure/Makefile
@@ -1,0 +1,47 @@
+APPLICATION = sock_secyure_echo
+
+# If no BOARD is found in the environment, use this default:
+BOARD ?= native
+
+# This has to be the absolute path to the RIOT base directory:
+RIOTBASE ?= $(CURDIR)/../..
+
+# Minimum setting
+USEMODULE += gnrc_netdev_default
+USEMODULE += auto_init_gnrc_netif
+USEMODULE += gnrc_ipv6_default
+
+# NOTE: Network stack must be defined by the user not by TLSMAN
+USEMODULE += gnrc_sock_udp
+
+USEMODULE += sock_secure
+USEPKG += tinydtls
+
+# Additional networking modules that can be dropped if not needed
+USEMODULE += gnrc_icmpv6_echo
+# Add also the shell, some shell commands
+USEMODULE += shell
+USEMODULE += shell_commands
+USEMODULE += ps
+
+
+# Special include directory with the (D)TLS keys required for the test
+INCLUDES += -I$(APPDIR)/keys
+
+# Default DTLS Server for the test
+REM_SERVER ?='"fd00:dead:beef::1"'
+CFLAGS += -DREMOTE_SERVER=$(REM_SERVER)
+
+# FIXME: This is a temporary patch
+# TinyDTLS <= 0.8.6 requires around 426 bytes in RAM.
+CFLAGS += -DTHREAD_STACKSIZE_MAIN=\(3*THREAD_STACKSIZE_DEFAULT\)
+
+# Comment this out to disable code in RIOT that does safety checking
+# which is not needed in a production environment but helps in the
+# development process:
+CFLAGS += -DDEVELHELP
+
+# Change this to 0 show compiler invocation lines by default:
+QUIET ?= 1
+
+include $(RIOTBASE)/Makefile.include

--- a/examples/sock_secure/client.c
+++ b/examples/sock_secure/client.c
@@ -1,0 +1,121 @@
+/*
+ * Copyright (C) 2018 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+
+/**
+ * @ingroup     examples
+ * @{
+ *
+ * @file
+ * @brief       Example application  for sock_secure
+ *
+ * @author      Raul Fuentes <>
+ *
+ * @}
+ */
+
+ #include <stdio.h>
+
+#include "net/sock/udp.h"
+#include "net/sock/secure.h"
+
+#define ENABLE_DEBUG (1)
+#include "debug.h"
+
+/* Our custom response handler (optional) */
+static void _resp_handler(uint8_t *data, size_t data_size, void *sock);
+
+extern sock_secure_session_t secure_session;
+
+static void _resp_handler(uint8_t *data, size_t data_size, void *sock)
+{
+
+    (void) sock;
+    printf("Data received (%i bytes): \t--%s--\n", data_size, data);
+}
+
+
+int _client_side(char *addr_str,  uint16_t  port)
+{
+
+    /* TODO: Payload should be given by the user  */
+
+    sock_udp_t sock;
+    sock_udp_ep_t local = SOCK_IPV6_EP_ANY;
+    sock_udp_ep_t remote = SOCK_IPV6_EP_ANY;
+
+    uint8_t packet[] = "Hello world!";
+
+    secure_session.flag |= TLSMAN_FLAG_SIDE_CLIENT;
+
+    local.port = (unsigned short) port + 10;
+    remote.port = (unsigned short) port;
+    ipv6_addr_from_str((ipv6_addr_t *)&remote.addr.ipv6, addr_str);
+    DEBUG("Remote server: [%s]:%u\n", addr_str, port);
+
+    sock_udp_create(&sock, &local, &remote, 0);
+
+    /* To be called when a new session is going to be created */
+    ssize_t res = sock_secure_initialized(&secure_session, _resp_handler, (void *)&sock,
+                            (sock_secure_ep_t*)&local,
+                            (sock_secure_ep_t *)&remote);
+
+    if (res != 0) {
+        puts("ERROR: Unable to init sock_secure!");
+        return -1;
+    }
+
+    /*
+     * Optinal though can be very useful for asynchronous apps.
+     * The main benefit should be to start the secure channel or restarted
+     * before real data is ready.
+     * If not called here, will be called by sock_secure_write() and
+     * sock_secure_read()
+     */
+#if 0
+    /* NOTE: After sock_secure_initialized() secure_session has all the sock info */
+    sock_secure_update(&secure_session);
+#endif
+
+    /* We send the user data by means of the (D)TLS session */
+    /* TODO: Handling error codes */
+    sock_secure_write(&secure_session, packet, sizeof(packet));
+
+    /* We check if there is Upper data received by the (D)TLS session
+    * NOTE: IF not callback was given in sock_secure_initialized() the use of
+    * DEBUG can help to see the raw received data
+     (See sys/net/tlsman/tinydtls_sock.c).
+    * Anyway, sock_secure_write() will operate properly without it.
+    */
+    xtimer_usleep(400); /* Just give time to the remote node to answer */
+    /* FIXME The user will receive the data on the callback */
+    /* TODO: Handling error codes */
+    sock_secure_read(&secure_session);
+
+    /* Release all the resources used for the secure session */
+    sock_secure_release(&secure_session);
+    /* NOTE: If update, write or send is called again at this point, a new secure session will be established */
+    sock_udp_close(&sock);
+
+    DEBUG("Client session finished\n");
+
+    return 0;
+}
+
+int client_cmd(int argc, char **argv)
+{
+
+    if ((argc != 3)) {
+        printf("usage: %s <IPv6 Address> <(UDP|TCP) Port>\n", argv[0]);
+        return 1;
+    }
+
+    /* TODO Add safe guard with the atoi */
+
+    return _client_side(argv[1], atoi(argv[2]) );
+}

--- a/examples/sock_secure/keys/dtls_keys.h
+++ b/examples/sock_secure/keys/dtls_keys.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2018 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       tlsman test application (PSK and ECC keys)
+ *
+ * Small test for TLSMAN. Many definitions defined here are also available at
+ * sock_secure (and are intended to be used in standard applications)
+ *
+ * @author      Raul Fuentes <raul.fuentes-samaniego@inria.fr>
+ *
+ * @}
+ */
+
+#ifndef DTLS_KEYS_H
+#define DTLS_KEYS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ *  Defautl keys examples for tinyDTLS (for RIOT, Linux and Contiki)
+ */
+#ifdef MODULE_TLSMAN_TINYDTLS
+#ifdef DTLS_PSK
+#define PSK_DEFAULT_IDENTITY "Client_identity"
+#define PSK_DEFAULT_KEY "secretPSK"
+#define PSK_OPTIONS "i:k:"
+#define PSK_ID_MAXLEN 32
+#define PSK_MAXLEN 32
+
+unsigned char psk_id[PSK_ID_MAXLEN] = PSK_DEFAULT_IDENTITY;
+size_t psk_id_length = sizeof(PSK_DEFAULT_IDENTITY) - 1;
+unsigned char psk_key[PSK_MAXLEN] = PSK_DEFAULT_KEY;
+size_t psk_key_length = sizeof(PSK_DEFAULT_KEY) - 1;
+
+#endif /* DTLS_PSK */
+
+#ifdef DTLS_ECC
+static const unsigned char ecdsa_priv_key[] = {
+    0x41, 0xC1, 0xCB, 0x6B, 0x51, 0x24, 0x7A, 0x14,
+    0x43, 0x21, 0x43, 0x5B, 0x7A, 0x80, 0xE7, 0x14,
+    0x89, 0x6A, 0x33, 0xBB, 0xAD, 0x72, 0x94, 0xCA,
+    0x40, 0x14, 0x55, 0xA1, 0x94, 0xA9, 0x49, 0xFA
+};
+
+static const unsigned char ecdsa_pub_key_x[] = {
+    0x36, 0xDF, 0xE2, 0xC6, 0xF9, 0xF2, 0xED, 0x29,
+    0xDA, 0x0A, 0x9A, 0x8F, 0x62, 0x68, 0x4E, 0x91,
+    0x63, 0x75, 0xBA, 0x10, 0x30, 0x0C, 0x28, 0xC5,
+    0xE4, 0x7C, 0xFB, 0xF2, 0x5F, 0xA5, 0x8F, 0x52
+};
+
+static const unsigned char ecdsa_pub_key_y[] = {
+    0x71, 0xA0, 0xD4, 0xFC, 0xDE, 0x1A, 0xB8, 0x78,
+    0x5A, 0x3C, 0x78, 0x69, 0x35, 0xA7, 0xCF, 0xAB,
+    0xE9, 0x3F, 0x98, 0x72, 0x09, 0xDA, 0xED, 0x0B,
+    0x4F, 0xAB, 0xC3, 0x6F, 0xC7, 0x72, 0xF8, 0x29
+};
+#endif /* DTLS_ECC */
+#endif /* MODULE_TLSMAN_TINYDTLS */
+
+#ifdef MODULE_TLSMAN_WOLFSSL
+/* TODO: Default set of keys for WolfSSL*/
+#endif /* MODULE_TLSMAN_WOLFSSL */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DTLS_KEYS_H */

--- a/examples/sock_secure/main.c
+++ b/examples/sock_secure/main.c
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2018 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+
+/**
+ * @ingroup     examples
+ * @{
+ *
+ * @file
+ * @brief       Example application  for sock_secure
+ *
+ * @author      Raul Fuentes <>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+
+#include "shell.h"
+#include "msg.h"
+#include "net/sock/secure.h"
+
+#define ENABLE_DEBUG (1)
+#include "debug.h"
+
+#define MAIN_QUEUE_SIZE     (8)
+
+extern int client_cmd(int argc, char **argv);
+extern int server_cmd(int argc, char **argv);
+
+static msg_t _main_msg_queue[MAIN_QUEUE_SIZE];
+
+/* TODO: Define them on the Makefile  */
+#define SECURE_CIPHER_PSK_IDS (0xC0A8)
+#define SECURE_CIPHER_RPK_IDS (0xC0AE)
+#define SECURE_CIPHER_LIST { SECURE_CIPHER_PSK_IDS, SECURE_CIPHER_RPK_IDS }
+
+
+static const shell_command_t shell_commands[] = {
+    { "client", "Start the testing clientt", client_cmd},
+    { "server", "Start the testing server", server_cmd},
+    { NULL, NULL, NULL }
+};
+
+sock_secure_session_t secure_session = { .flag=0, .cb=NULL};
+
+int main(void)
+{
+    /* we need a message queue for the thread running the shell in order to
+     * receive potentially fast incoming networking packets */
+    msg_init_queue(_main_msg_queue, MAIN_QUEUE_SIZE);
+    puts("RIOT sock_secure testing implementation");
+
+    secure_session.flag = TLSMAN_FLAG_STACK_DTLS;
+
+    uint16_t ciphers[] = SECURE_CIPHER_LIST;
+
+    /* To be called only ONCE time */
+    ssize_t res =  sock_secure_load_stack(&secure_session, ciphers, sizeof(ciphers));
+
+    if (res) {
+      puts("ERROR: Unable to load (D)TLS stack ");
+      return -1;
+    }
+
+    /* start shell */
+    puts("All up, running the shell now");
+    char line_buf[SHELL_DEFAULT_BUFSIZE];
+    shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
+
+    /* should be never reached */
+    return 0;
+}

--- a/examples/sock_secure/server.c
+++ b/examples/sock_secure/server.c
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2018 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+
+/**
+ * @ingroup     examples
+ * @{
+ *
+ * @file
+ * @brief       Example application  for sock_secure
+ *
+ * @author      Raul Fuentes <>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include <inttypes.h>
+
+#include "net/sock/udp.h"
+#include "net/sock/secure.h"
+
+#include "msg.h" /* TODO */
+
+#define ENABLE_DEBUG (1)
+#include "debug.h"
+
+
+#ifndef DTLS_DEFAULT_PORT
+#define DTLS_DEFAULT_PORT 20220 /* DTLS default port */
+#endif
+
+#define READER_QUEUE_SIZE (8U)
+
+static void _resp_handler(uint8_t *data, size_t data_size, void *sock);
+
+extern sock_secure_session_t secure_session;
+
+static void _resp_handler(uint8_t *data, size_t data_size, void *sock)
+{
+    (void) sock;
+
+    printf("Got (string) data -- ");
+    for (size_t i = 0; i < data_size; i++) {
+        printf("%c", data[i]);
+    }
+    printf(" -- (Total: %i bytes)\n",data_size );
+
+    /* TODO DEBUG lines of the remote peer  */
+    /* NOTE: Remote is already in secure_session */
+    sock_secure_write(&secure_session, data, data_size); /* echo back! */
+}
+
+void _server_wrapper(void *arg)
+{
+    (void) arg;
+
+    /* FIXME The maximum size  */
+    // ssize_t pckt_size = DTLS_MAX_BUF;
+    // uint8_t pckt_rcvd[DTLS_MAX_BUF];
+
+    sock_udp_t sock;
+    sock_udp_ep_t local = SOCK_IPV6_EP_ANY;
+    sock_udp_ep_t remote = SOCK_IPV6_EP_ANY;
+
+    /* The behavior of sock_secure_read() will be different */
+    secure_session.flag |= TLSMAN_FLAG_SIDE_SERVER;
+
+    /* TODO Prepare (thread) messages reception */
+
+
+    local.port = DTLS_DEFAULT_PORT;
+    if (sock_udp_create(&sock, &local, NULL, 0) < 0) {
+        puts("ERROR: Unable create sock.");
+        return;
+    }
+
+    ssize_t res = sock_secure_initialized(&secure_session, _resp_handler, (void *)&sock,
+                            (sock_secure_ep_t*)&local,
+                            (sock_secure_ep_t *)&remote);
+
+    if (res != 0) {
+        puts("ERROR: Unable to init sock_secure!");
+        return;
+    }
+
+    /* NOTE: Must not call sock_secure_update()? */
+
+#if ENABLE_DEBUG
+    ipv6_addr_t addrs[GNRC_NETIF_IPV6_ADDRS_NUMOF];
+    gnrc_netif_t *netif = gnrc_netif_iter(NULL);
+    if ((netif != NULL) &&
+        ((res = gnrc_netif_ipv6_addrs_get(netif, addrs, sizeof(addrs))) > 0)) {
+        printf("Listening (D)TLS request in: ");
+        for (unsigned i = 0; i < (res / sizeof(ipv6_addr_t)); i++) {
+            printf("[");
+            ipv6_addr_print(&addrs[i]);
+            printf("]:%u\n", DTLS_DEFAULT_PORT);
+        }
+    }
+#endif
+
+  while(sock_secure_read(&secure_session))
+  {
+    xtimer_usleep(500);
+  }
+
+  sock_secure_release(&secure_session);
+  sock_udp_close(&sock);
+  return;
+}
+
+int server_cmd(int argc, char **argv)
+{
+    (void) argc;
+    (void) argv;
+    /* TODO Upgrade this */
+    _server_wrapper(NULL);
+    return 0;
+}

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -74,6 +74,7 @@ PSEUDOMODULES += sock
 PSEUDOMODULES += sock_ip
 PSEUDOMODULES += sock_tcp
 PSEUDOMODULES += sock_udp
+PSEUDOMODULES += tlsman_tinydtls
 
 # print ascii representation in function od_hex_dump()
 PSEUDOMODULES += od_string

--- a/sys/Makefile
+++ b/sys/Makefile
@@ -136,6 +136,9 @@ endif
 ifneq (,$(filter tlsman,$(USEMODULE)))
     DIRS += net/tlsman
 endif
+ifneq (,$(filter sock_secure,$(USEMODULE)))
+    DIRS += net/sock/secure
+endif
 
 DIRS += $(dir $(wildcard $(addsuffix /Makefile, $(USEMODULE))))
 

--- a/sys/Makefile
+++ b/sys/Makefile
@@ -133,6 +133,9 @@ endif
 ifneq (,$(filter rdcli_simple,$(USEMODULE)))
     DIRS += net/application_layer/rdcli_simple
 endif
+ifneq (,$(filter tlsman,$(USEMODULE)))
+    DIRS += net/tlsman
+endif
 
 DIRS += $(dir $(wildcard $(addsuffix /Makefile, $(USEMODULE))))
 

--- a/sys/include/net/sock/secure.h
+++ b/sys/include/net/sock/secure.h
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2018 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    sock_secure  Sock Secure API
+ * @ingroup     net_sock
+ * @brief      Sock submodule for TLSMAN
+ *
+ * @{
+ *
+ * @file
+ * @brief       sock secure definition
+ *
+ * @author      Raul Fuentes <raul.fuentes-samaniego@inria.fr>
+ *
+ * @}
+ */
+
+#ifndef NET_SOCK_SECURE_H
+#define NET_SOCK_SECURE_H
+
+#include "net/tlsman.h"
+
+typedef struct sock_secure_session sock_secure_session_t;
+
+/* This is merely a Proof of concept  */
+typedef struct tlsman_ep_t sock_secure_ep_t; /**< Endpoint for a sock_secure object (FIXME) */
+
+
+/* DISCUSSION Duplicate values from TLSMAN ? */
+enum {
+  SOCK_SECURE_STATE_NON_STARTED = TLSMAN_ERROR_NON_STARTED, /** Resources assigned, non secure session started yet */
+  SOCK_SECURE_STATE_FATAL, /** It's impossible to create a secure channel */
+  SOCK_SECURE_STATE_NON_INITIALIZED, /** There are not resources asigned for making a new secure channel */
+  SOCK_SECURE_STATE_STARTED, /** The (D)TLS handshake already started (current status is unknown) */
+  SOCK_SECURE_STATE_ERROR, /** Secure channel not established but is possible to attempt again */
+  SOCK_SECURE_STATE_SERVER_LISTENING /** The behavior for a server side is different from a client */
+};
+
+struct sock_secure_session {
+  uint8_t flag;
+  uint8_t state;
+  tlsman_driver_t session; /* DISCUSSION: Should be "tlsman"? (to avoid confusion with the "session" term) */
+  tlsman_resp_handler_t cb;
+
+};
+
+/**
+ * Loads the (D)TLS stack and it(s) cipher suite(s). Must be called once time
+ * TODO FIXME Break into two part (load stack  which only require flags and cipher suites)
+ * and the rest must be integrated into sock_secure_initialized()
+ */
+ssize_t sock_secure_load_stack(sock_secure_session_t *sock_secure,
+                             uint16_t *ciphers, size_t ciphers_size);
+
+/* Preapare the resources required for a new secure session   */
+ssize_t sock_secure_initialized(sock_secure_session_t *sock_secure,
+                              tlsman_resp_handler_t callback,
+                              void *sock,
+                              sock_secure_ep_t *local,
+                              sock_secure_ep_t *remote);
+
+
+
+/* Updates the status of the (D)TLS session (the secure channel between local
+ * and remote).  */
+ssize_t sock_secure_update(sock_secure_session_t *sock_secure);
+
+/* Executes a step of the (D)TLS handshake (by processing the last DTLS record
+ * or by sending the next one) between the local and remote members of the sock */
+// sock_secure_handshake()
+
+
+/* Send data by means of the secure session */
+ssize_t sock_secure_write(sock_secure_session_t *sock_secure,
+                          const void* data, size_t len);
+
+
+/* Check if data was received by means of the secure session */
+ssize_t sock_secure_read(sock_secure_session_t *sock_secure);
+
+
+/* Relase the resources assigned for a secure session (and ends any current active session) */
+void sock_secure_release(sock_secure_session_t *sock_secure);
+
+#endif /* NET_SOCK_SECURE_H */

--- a/sys/include/net/tlsman.h
+++ b/sys/include/net/tlsman.h
@@ -1,0 +1,320 @@
+/*
+ * Copyright (C) 2018 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    net_tlsman  TLSMAN
+ * @ingroup     net
+ * @brief       High-level interface to (D)TLS stack Manager
+ *
+ * @{
+ *
+ * @file
+ * @brief       tlsman definition
+ *
+ * @author      Raul Fuentes <raul.fuentes-samaniego@inria.fr>
+ *
+ * @}
+ */
+
+#ifndef NET_TLSMAN_H
+#define NET_TLSMAN_H
+
+#include <stdint.h>
+#include <stdio.h>
+
+#ifdef MODULE_TLSMAN_TINYDTLS
+#include "net/tlsman/tinydtls.h"
+#endif
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct _sock_tl_ep tlsman_ep_t; /**< Endpoint for a tlsman object */
+
+/*
+ * Control flags for the (D)TLS stacks
+ *
+ * Flags UU-BB-S-TTT: Unused (U), Blocking behavior (B), Side behavior (S),
+ * (D)TLS stack (T)
+ *
+ */
+#define TLSMAN_FLAG_STACK_UNIVERSAL (0x00)  /**< Loads the default (D)TLS stack (bits TTT) */
+#define TLSMAN_FLAG_STACK_TLS (0x01)        /**< Only loads TLS stack (bits TTT) */
+#define TLSMAN_FLAG_STACK_DTLS (0x02)       /**< Only loads DTLS stack (bits TTT) */
+#define TLSMAN_FLAG_STACK_IPSEC (0x03)      /**< Only loads IPSEC (bits TTT) @note not supported yet  */
+#define TLSMAN_FLAG_NONBLOCKING (0x10)      /**< Define [non-]blocking behavior (BB) @note If supported */
+#define TLSMAN_FLAG_SIDE_CLIENT (0x00)      /**< Define the behavior as a client side (bits S) */
+#define TLSMAN_FLAG_SIDE_SERVER (0x04)      /**< Define the behavior as a server side (bits S)*/
+
+/** Maximum number of attempts for completing a (D)TLS Handhsake */
+#define TLSMAN_HANDSHAKE_MAX_TRY 10
+
+/**
+ * Error codes
+ */
+enum {
+    TLSMAN_ERROR_SUCCESS    = 0x00,         /**< Non-error */
+    TLSMAN_ERROR_FATAL      = 0x01,         /**< Fatal error (non specified below) */
+    TLSMAN_ERROR_UNABLE_CONTEXT,            /**< Unable to create context */
+    TLSMAN_ERROR_TRANSPORT_NOT_SUPPORTED,   /**< TCP/UDP stack selected not supported  */
+    TLSMAN_ERROR_CIPHER_NOT_SUPPORTED,      /**< Cipher suite(s) selected not supported */
+    TLSMAN_ERROR_HANDSHAKE_TIMEOUT,         /**< Timeout for the handshake (first negotiation) */
+    TLSMAN_ERROR_DATA_APP_WRITE,            /**< Unable to send a DTLS Data App record   */
+    TLSMAN_ERROR_SESSION_REN,               /**< TODO: Separated both types of re-negotiation? */
+    TLSMAN_ERROR_NON_STARTED,               /**< Non secure session has ben done yet */
+    TLSMAN_ERROR_REMOTE_RESET,              /**< Got a remote DTLS Alert record */
+    TLSMAN_ERROR_UNABLE_CLOSE               /**< Unable to close the (D)TLS session */
+
+};
+
+/**
+ * @brief  Abstract (D)TLS secure session between peers.
+ *
+ */
+typedef struct {
+
+#ifdef MODULE_TLSMAN_TINYDTLS
+    /**
+     * @brief The tinyDTLS context for handling the secure session.
+     *
+     * @note only avaliable if the submodule secure_sock_tinydtls is defined.
+     */
+    tinydtls_session_t tinydtls_context;
+#endif
+#ifdef MODULE_TLSMAN_WOLFSSL
+    /**
+     * @brief The WolfSSL context for handling the secure session.
+     *
+     * @note only avaliable if the submodule secure_sock_wolfssl is defined.
+     */
+    wolffssl_session_t wolfssl_context;
+#endif
+
+} tlsman_session_t;
+
+/**
+ * @brief Initializes the (D)TLS stack loaded.
+ *
+ * Loads the initialization of the (D)TLS stack. It's expected to be only one
+ * compiled stack (tinydtls, wolfssl, etc.).
+ *
+ * @note Not all the (D)TLS stacks can support loading cipher suites (e.g.
+ * tinyDTLS). In such cases, is only checked that the stack was compiled with
+ * one or more of the cipher suites provided in cipersuites_list.
+ * @param[in]  ciphersuites_list An array of cipher suites ID to load
+ * @param[in]  total             Size of ciphersuites_list
+ * @param[in]  flags             Flags for handling the initialization.
+ *
+ * @return  0 in Success
+ * @return  TLSMAN_ERROR_TRANSPORT_NOT_SUPPORTED if the TCP/UDP stack intended
+ *            is not supported by the (D)TLS stack (e.g. tinyDTLs does not
+ *            support TCP)
+ * @return  TLSMAN_ERROR_CIPHER_NOT_SUPPORTED if the cipher suite selected is
+ *          not supported (or compiled) for the (D)TLS stack.
+ */
+ssize_t tlsman_load_stack(int *ciphersuites_list, size_t total, uint8_t flags);
+
+/**
+ * Creates the (D)TLS context.
+ *
+ * @param[in] local     Local peer. Can be NULL only if sockets are being used
+ * @param[in] remote    Remote peer. Can be NULL only if sockets are being used
+ * @param[inout] session   The (D)TLS session to create (it can be NULL)
+ * @param[in] sock     A pointer for a sock (or socket) used. Must not be NULL
+ * @param[in] cb       Callback handler for the (D)TLS Data App record
+ * @param[in] flags    Flags for handling the (D)TLS context
+ *
+ * @return 0 in success.
+ * @return TLSMAN_ERROR_UNABLE_CONTEXT if it was impossible to load a new context.
+ */
+ssize_t tlsman_init_context(tlsman_ep_t *local, tlsman_ep_t *remote,
+                            tlsman_session_t *session, void *sock,
+                            tlsman_resp_handler_t cb, const uint8_t flags);
+
+/**
+ * @brief Preapre the (D)TLS peer and start a new secure channel.
+ *
+ * The (D)TLS handshake process is started here.
+ *
+ * @param[inout] session The (D)TLS session to create (it can be NULL)
+ * @param[in] flags        Defines the peer side (client/server) and the
+ *                         blocking/non-blocking behavior.
+ * @param[in] packet_buff  The buffer to use for handling (D)TLS records
+ * @param[in] packet_size  The size of the buffer.
+ *
+ * @return 0 on success
+ * @return TLSMAN_ERROR_HANDSHAKE_TIMEOUT if the handshake was not completed
+ * into a defined interval (default 10 seconds). And only if the behavior is
+ * blocking.
+ */
+ssize_t tlsman_create_channel(tlsman_session_t *session, uint8_t flags,
+                              uint8_t *packet_buff, size_t packet_size);
+
+#if defined(SOCK_HAS_ASYNC) || defined(DOXYGEN)
+/**
+ * @brief Sets the parameters required for sock asynchronous.
+ *
+ * This sets the queue for the sock and also provides pointers for the buffer to
+ * be used for sending and receiving (D)TLS records.
+ *
+ * @param[in] session            The (D)TLS session to create (Must not be NULL)
+ * @param[in] sock_event_queue   The event queue to link to the (D)TLS session
+ * @param[in] buffer             The buffer to use for handling (D)TLS records
+ * @param[in] size               The size of the buffer.
+ */
+void tlsman_set_async_parameters(tlsman_session_t *session,
+                                 event_queue_t *sock_event_queue,
+                                 uint8_t *buffer, ssize_t size);
+
+/**
+ * Enables the non-blocking listening state for the (D)TLS stack.
+ */
+void tlsman_set_async_listening(void);
+
+#endif /* SOCK_HAS_ASYNC */
+
+/**
+ * return the last error known (Alerts, retransmission, wrong cipher suites,
+ * etc.).
+ *
+ * @return 0 on success
+ * @return TLSMAN_ERROR_NON_STARTED if not recorded.
+ */
+ssize_t tlsman_return_last_known_error(void);
+
+/**
+ * Processes the error_id and identifies if the (D)TLS session must be terminated.
+ *
+ * @param[in] error_id  Error ID
+ * @return True if error is non-fatal.
+ */
+bool tlsman_process_is_error_code_nonfatal(ssize_t error_id);
+
+/**
+ * @brief Determines if the (D)TLS session is ready for sending data.
+ *
+ * If the behavior is non-blocking, the application must not proceed until
+ * this return True.
+ * @note TODO: Creates a queue buffer
+ *
+ * @param[in] session   The secure session to analyze
+ *
+ * @return True if it's ready
+ */
+bool tlsman_is_channel_ready(tlsman_session_t *session);
+
+/**
+ * @brief Sends upper layer data by means of the secure session.
+ *
+ * The data will be sent in one or multiples (D)TLS records.
+ * @note TODO: Use a queue buffer(?)
+ *
+ * @param[in] session       The secure session to use
+ * @param[in] data          The (plaintext) data to send
+ * @param[in] len           Size of the data buffer
+ *
+ * @return 0 on success
+ * @return TLSMAN_ERROR_DATA_APP_WRITE if the packet(s) were unable to be sent
+ *
+ */
+ssize_t tlsman_send_data_app(tlsman_session_t *session, const void *data, size_t len);
+
+/**
+ * Processes the last (D)TLS Data Application record available.
+ *
+ * @param[in] session           The secure session to use.
+ * @param[in] data              Pointer where the received data should be stored.
+ * @param[in] max_len           Maximum space available in the data buffer.
+ *
+ * @return If SOCK_HAS_ASYNC return 0 on success
+ * @return If !SOCK_HAS_ASYNC return 0 on success otherwise code error
+ * @return TLSMAN_ERROR_REMOTE_RESET if got an DTLS record alert
+ */
+ssize_t tlsman_retrieve_data_app(tlsman_session_t *session,
+                                 void *data,
+                                 size_t max_len);
+
+/**
+ * @brief Close the (D) TLS channel established between the peers of the session.
+ *
+ * This also sends a last DTLS Alert record.
+ *
+ * @param[in]    session  The secure session to use.
+ *
+ * @return  0 on success,
+ * @return TLSMAN_ERROR_UNABLE_CLOSE if unable to close the session
+ */
+ssize_t tlsman_close_channel(tlsman_session_t *session);
+
+/**
+ * @brief Relaase all the resources involved in the (D) TLS channel.
+ *
+ * This also sends a last DTLS Alert record and releases memory used for the
+ * session.
+ *
+ * @param[in]    session  The secure session to use.
+ */
+void tlsman_release_resources(tlsman_session_t *session);
+
+/**
+ * @brief Renegotiates the current secure session between the peers.
+ *
+ * @param[in]  session  The secure session to use.
+ * @param[in]  flags    Flags for defining the [nonb-]blocking behavior.
+ * @param[in]  pkt_buff If nonb-bloking, pointer to packet buffer to be used. Otherwise can be NULL
+ * @param[in]  pkt_size Size of pkt_buff
+ *
+ * @return 0 on success.
+ * @return TLSMAN_ERROR_SESSION_REN if renegotiation failed.
+ */
+ssize_t tlsman_renegotiate_session(tlsman_session_t *session, uint8_t flags,
+                                   uint8_t *pkt_buff, size_t pkt_size);
+
+/**
+ *  @brief Generates a new (D)TLS handshake for the current secure session.
+ *
+ * @param[in]  session  The secure session to use.
+ * @param[in]  flags    Flags for defining the [nonb-]blocking behavior.
+ * @param[in]  pkt_buff If nonb-bloking, pointer to packet buffer to be used. Otherwise can be NULL
+ * @param[in]  pkt_size Size of pkt_buff
+ *
+ * @return 0 on success.
+ * @return TLSMAN_ERROR_SESSION_REN if renegotiation failed.
+ */
+ssize_t tlsman_new_handshake(tlsman_session_t *session, uint8_t flags,
+                             uint8_t *pkt_buff, size_t pkt_size);
+
+/**
+ * @brief Listen for an incoming connection request
+ *
+ * The server side for any (D)TLS channel. The reception handling of any type
+ * of (D)TLS record, including those involved in the handshake is done here.
+ *
+ * For answers incoming requests with (D)TLS Data Application records, please
+ * use tlsman_send_data_app() inside of the tlsman_resp_handler_t callback.
+ *
+ * @note TODO Create the non-blocking behavior
+ *
+ * @param[in]  session  The secure session to use.
+ * @param[in]  flags    Flags for deining the behavior
+ * @param[in]  pkt_buff Pointer to packet buffer to be used (for reception).
+ * @param[in]  pkt_size Buffer size.
+ *
+ * @return 0 on success.
+ */
+ssize_t tlsman_listening(tlsman_session_t *session, uint8_t flags,
+                         uint8_t *pkt_buff, size_t pkt_size);
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* NET_TLSMAN_H */
+/** @} */

--- a/sys/include/net/tlsman.h
+++ b/sys/include/net/tlsman.h
@@ -28,7 +28,9 @@
 #include <stdio.h>
 
 #ifdef MODULE_TLSMAN_TINYDTLS
-#include "net/tlsman/tinydtls.h"
+#ifdef WITH_RIOT_GNRC
+#include "net/tlsman/tinydtls_sock.h"
+#endif
 #endif
 
 #ifdef __cplusplus
@@ -52,7 +54,7 @@ typedef struct _sock_tl_ep tlsman_ep_t; /**< Endpoint for a tlsman object */
 #define TLSMAN_FLAG_SIDE_CLIENT (0x00)      /**< Define the behavior as a client side (bits S) */
 #define TLSMAN_FLAG_SIDE_SERVER (0x04)      /**< Define the behavior as a server side (bits S)*/
 
-/** Maximum number of attempts for completing a (D)TLS Handhsake */
+/** Maximum number of attempts for completing a (D)TLS Handshake */
 #define TLSMAN_HANDSHAKE_MAX_TRY 10
 
 /**
@@ -60,43 +62,195 @@ typedef struct _sock_tl_ep tlsman_ep_t; /**< Endpoint for a tlsman object */
  */
 enum {
     TLSMAN_ERROR_SUCCESS    = 0x00,         /**< Non-error */
-    TLSMAN_ERROR_FATAL      = 0x01,         /**< Fatal error (non specified below) */
+    /* FIXME negative values for errors */
+    TLSMAN_ERROR_FATAL      = 0x9C,         /**< Fatal error (non specified below) */
     TLSMAN_ERROR_UNABLE_CONTEXT,            /**< Unable to create context */
     TLSMAN_ERROR_TRANSPORT_NOT_SUPPORTED,   /**< TCP/UDP stack selected not supported  */
     TLSMAN_ERROR_CIPHER_NOT_SUPPORTED,      /**< Cipher suite(s) selected not supported */
     TLSMAN_ERROR_HANDSHAKE_TIMEOUT,         /**< Timeout for the handshake (first negotiation) */
     TLSMAN_ERROR_DATA_APP_WRITE,            /**< Unable to send a DTLS Data App record   */
     TLSMAN_ERROR_SESSION_REN,               /**< TODO: Separated both types of re-negotiation? */
-    TLSMAN_ERROR_NON_STARTED,               /**< Non secure session has ben done yet */
+    TLSMAN_ERROR_NON_STARTED,               /**< Non secure session has been done yet */
     TLSMAN_ERROR_REMOTE_RESET,              /**< Got a remote DTLS Alert record */
     TLSMAN_ERROR_UNABLE_CLOSE               /**< Unable to close the (D)TLS session */
 
 };
 
-/**
- * @brief  Abstract (D)TLS secure session between peers.
- *
- */
-typedef struct {
+/* DISCUSSION: tlsman_controller ?  tlsman_settings? */
+typedef struct tlsman_driver {
 
-#ifdef MODULE_TLSMAN_TINYDTLS
-    /**
-     * @brief The tinyDTLS context for handling the secure session.
-     *
-     * @note only avaliable if the submodule secure_sock_tinydtls is defined.
-     */
-    tinydtls_session_t tinydtls_context;
-#endif
-#ifdef MODULE_TLSMAN_WOLFSSL
-    /**
-     * @brief The WolfSSL context for handling the secure session.
-     *
-     * @note only avaliable if the submodule secure_sock_wolfssl is defined.
-     */
-    wolffssl_session_t wolfssl_context;
-#endif
+  tlsman_session_t session; /**  Abstract (D)TLS secure session between peers. */
 
-} tlsman_session_t;
+  ssize_t (*tlsman_load_stack)(uint16_t *ciphersuites_list, size_t total, uint8_t flags);
+
+  /**
+   * Creates the (D)TLS context.
+   *
+   * @param[inout] session   The (D)TLS session to create (it can be NULL)
+   * @param[in] resp_cb      Callback handler for the (D)TLS Data App record
+   * @param[in] flags        Flags for handling the (D)TLS context
+   *
+   * @return 0 in success.
+   * @return TLSMAN_ERROR_UNABLE_CONTEXT if it was impossible to load a new context.
+   */
+  ssize_t (*tlsman_init_context)(tlsman_session_t *session, tlsman_resp_handler_t resp_cb,
+                          const uint8_t flags);
+
+
+  /**
+   * @brief Prepare the (D)TLS peer and start a new secure channel.
+   *
+   * The (D)TLS handshake process is started here.
+   *
+   * @param[inout] session The (D)TLS session to create (it can be NULL)
+   * @param[in] flags        Defines the peer side (client/server) and the
+   *                         blocking/non-blocking behavior.
+   * @param[in] pkt_buff  The buffer to use for handling (D)TLS records
+   * @param[in] pkt_size  The size of the buffer.
+   *
+   * @return 0 on success
+   * @return TLSMAN_ERROR_HANDSHAKE_TIMEOUT if the handshake was not completed
+   * into a defined interval (default 10 seconds). And only if the behavior is
+   * blocking.
+   */
+  ssize_t (*tlsman_create_channel)(tlsman_session_t *session, uint8_t flags,
+                            uint8_t *pkt_buff, size_t pkt_size);
+
+#if defined(SOCK_HAS_ASYNC) || defined(DOXYGEN)
+
+  /**
+   * @brief Sets the parameters required for sock asynchronous.
+   *
+   * This sets the queue for the sock and also provides pointers for the buffer to
+   * be used for sending and receiving (D)TLS records.
+   *
+   * @param[inout] session        (D)TLS session to use.
+   * @param[in] sock_event_queue  The event queue to link to the (D)TLS session
+   * @param[in] pkt_buff          Buffer to use for handling (D)TLS records.
+   * @param[in] pkt_size          Size of the buffer.
+   */
+  void (*tlsman_set_async_parameters)(tlsman_session_t *session,
+                                   event_queue_t *sock_event_queue,
+                                   uint8_t *pkt_buff, ssize_t pkt_size);
+
+  /**
+   * Enables the non-blocking listening state for the (D)TLS stack.
+   */
+  void (*tlsman_set_async_listening)(void);
+#endif /* SOCK_HAS_ASYNC */
+
+  /**
+   * @brief Determines if the (D)TLS session is ready for sending data.
+   *
+   * If the behavior is non-blocking, the application must not proceed until
+   * this return True.
+   *
+   * @note TODO: Creates a queue buffer?
+   *
+   * @param[in] session   (D)TLS session to use.
+   *
+   * @return True if it's ready
+   */
+  bool (*tlsman_is_channel_ready)(tlsman_session_t *session);
+
+  /**
+   * @brief Sends upper layer data by means of the secure session.
+   *
+   * The data will be sent in one or multiples (D)TLS records.
+   * @note TODO: Use a queue buffer(?)
+   *
+   * @param[in] session       (D)TLS secure session to use
+   * @param[in] data          The (plaintext) data to send
+   * @param[in] len           Size of the data buffer
+   *
+   * @return 0 on success
+   * @return TLSMAN_ERROR_DATA_APP_WRITE if the packet(s) were unable to be sent
+   *
+   */
+  ssize_t (*tlsman_send_data_app)(tlsman_session_t *session, const void *data, size_t len);
+
+  /**
+   * Processes the last (D)TLS Data Application record available.
+   *
+   * @param[in] session      (D)TLS secure session to use.
+   * @param[in] pkt_buff     Pointer where the received data should be stored.
+   * @param[in] max_len      Maximum space available in the data buffer.
+   *
+   * @return If SOCK_HAS_ASYNC return 0 on success
+   * @return If !SOCK_HAS_ASYNC return 0 on success otherwise code error (FIXME)
+   * @return TLSMAN_ERROR_REMOTE_RESET if got an DTLS record alert
+   */
+  ssize_t (*tlsman_retrieve_data_app)(tlsman_session_t *session, void *pkt_buff, size_t max_len);
+
+  /**
+   * @brief Close the (D)TLS channel established between the peers of the session.
+   *
+   * @param[in]    session  (D)TLS secure session to use.
+   *
+   * @return  0 on success,
+   * @return TLSMAN_ERROR_UNABLE_CLOSE if unable to close the session
+   */
+  ssize_t (*tlsman_close_channel)(tlsman_session_t *session);
+
+  /**
+   * @brief Release all the resources involved in the (D) TLS channel.
+   *
+   * This also sends a last DTLS Alert record and releases memory used for the
+   * session.
+   *
+   * @param[in]    session  (D)TLS secure session to use.
+   */
+  void (*tlsman_release_resources)(tlsman_session_t *dtls_session);
+
+  /**
+   * @brief Renegotiates the current secure session between the peers.
+   *
+   * @param[in]  session  (D)TLS secure session to use.
+   * @param[in]  flags    Flags for definning the [non-]blocking behavior.
+   * @param[in]  pkt_buff If Nona-blocking, pointer to packet buffer to be used. Otherwise can be NULL
+   * @param[in]  pkt_size Size of pkt_buff
+   *
+   * @return 0 on success.
+   * @return TLSMAN_ERROR_SESSION_REN if renegotiation failed.
+   */
+  ssize_t (*tlsman_renegotiate)(tlsman_session_t *session, uint8_t flags, uint8_t *pkt_buff, size_t pkt_size);
+
+  /**
+   *  @brief Generates a new (D)TLS handshake for the current secure session.
+   *
+   * @param[in]  session  (D)TLS secure session to use.
+   * @param[in]  flags    Flags for defining the [non-]blocking behavior.
+   * @param[in]  pkt_buff If Nona-blocking, pointer to packet buffer to be used. Otherwise can be NULL
+   * @param[in]  pkt_size Size of pkt_buff
+   *
+   * @return 0 on success.
+   * @return TLSMAN_ERROR_SESSION_REN if renegotiation failed.
+   */
+  ssize_t (*tlsman_rehandshake)(tlsman_session_t *session, uint8_t flags, uint8_t *pkt_buff, size_t pkt_size);
+
+  /**
+   * @brief Listen for an incoming connection request
+   *
+   * The server side for any (D)TLS channel. The reception handling of any type
+   * of (D)TLS record, including those involved in the handshake is done here.
+   *
+   * For answers incoming requests with (D)TLS Data Application records, please
+   * use tlsman_send_data_app() inside of the tlsman_resp_handler_t callback.
+   *
+   * @note TODO Create the non-blocking behavior
+   *
+   * @param[in]  session  (D)TLS secure session to use.
+   * @param[in]  flags    Flags for defining the behavior
+   * @param[in]  pkt_buff Pointer to packet buffer to be used (for reception).
+   * @param[in]  pkt_size Buffer size.
+   *
+   * @return 0 on success.
+   */
+  ssize_t (*tlsman_listening)(tlsman_session_t *session, uint8_t flags,
+                    uint8_t *pkt_buff, size_t pkt_size);
+
+} tlsman_driver_t;
+
 
 /**
  * @brief Initializes the (D)TLS stack loaded.
@@ -107,86 +261,32 @@ typedef struct {
  * @note Not all the (D)TLS stacks can support loading cipher suites (e.g.
  * tinyDTLS). In such cases, is only checked that the stack was compiled with
  * one or more of the cipher suites provided in cipersuites_list.
+ *
+ * FIXME session
  * @param[in]  ciphersuites_list An array of cipher suites ID to load
- * @param[in]  total             Size of ciphersuites_list
+ * @param[in]  total             Size of cipher suites_list
  * @param[in]  flags             Flags for handling the initialization.
  *
  * @return  0 in Success
  * @return  TLSMAN_ERROR_TRANSPORT_NOT_SUPPORTED if the TCP/UDP stack intended
- *            is not supported by the (D)TLS stack (e.g. tinyDTLs does not
+ *            is not supported by the (D)TLS stack (e.g. tinyDTLS does not
  *            support TCP)
  * @return  TLSMAN_ERROR_CIPHER_NOT_SUPPORTED if the cipher suite selected is
  *          not supported (or compiled) for the (D)TLS stack.
  */
-ssize_t tlsman_load_stack(int *ciphersuites_list, size_t total, uint8_t flags);
-
-/**
- * Creates the (D)TLS context.
- *
- * @param[in] local     Local peer. Can be NULL only if sockets are being used
- * @param[in] remote    Remote peer. Can be NULL only if sockets are being used
- * @param[inout] session   The (D)TLS session to create (it can be NULL)
- * @param[in] sock     A pointer for a sock (or socket) used. Must not be NULL
- * @param[in] cb       Callback handler for the (D)TLS Data App record
- * @param[in] flags    Flags for handling the (D)TLS context
- *
- * @return 0 in success.
- * @return TLSMAN_ERROR_UNABLE_CONTEXT if it was impossible to load a new context.
- */
-ssize_t tlsman_init_context(tlsman_ep_t *local, tlsman_ep_t *remote,
-                            tlsman_session_t *session, void *sock,
-                            tlsman_resp_handler_t cb, const uint8_t flags);
-
-/**
- * @brief Preapre the (D)TLS peer and start a new secure channel.
- *
- * The (D)TLS handshake process is started here.
- *
- * @param[inout] session The (D)TLS session to create (it can be NULL)
- * @param[in] flags        Defines the peer side (client/server) and the
- *                         blocking/non-blocking behavior.
- * @param[in] packet_buff  The buffer to use for handling (D)TLS records
- * @param[in] packet_size  The size of the buffer.
- *
- * @return 0 on success
- * @return TLSMAN_ERROR_HANDSHAKE_TIMEOUT if the handshake was not completed
- * into a defined interval (default 10 seconds). And only if the behavior is
- * blocking.
- */
-ssize_t tlsman_create_channel(tlsman_session_t *session, uint8_t flags,
-                              uint8_t *packet_buff, size_t packet_size);
-
-#if defined(SOCK_HAS_ASYNC) || defined(DOXYGEN)
-/**
- * @brief Sets the parameters required for sock asynchronous.
- *
- * This sets the queue for the sock and also provides pointers for the buffer to
- * be used for sending and receiving (D)TLS records.
- *
- * @param[in] session            The (D)TLS session to create (Must not be NULL)
- * @param[in] sock_event_queue   The event queue to link to the (D)TLS session
- * @param[in] buffer             The buffer to use for handling (D)TLS records
- * @param[in] size               The size of the buffer.
- */
-void tlsman_set_async_parameters(tlsman_session_t *session,
-                                 event_queue_t *sock_event_queue,
-                                 uint8_t *buffer, ssize_t size);
-
-/**
- * Enables the non-blocking listening state for the (D)TLS stack.
- */
-void tlsman_set_async_listening(void);
-
-#endif /* SOCK_HAS_ASYNC */
+ssize_t tlsman_load_stack(tlsman_driver_t *session,
+                                   uint16_t *ciphersuites_list, size_t total,
+                                   uint8_t flags);
 
 /**
  * return the last error known (Alerts, retransmission, wrong cipher suites,
  * etc.).
  *
+ * TODO tlsman_session
  * @return 0 on success
  * @return TLSMAN_ERROR_NON_STARTED if not recorded.
  */
-ssize_t tlsman_return_last_known_error(void);
+ssize_t tlsman_return_last_known_error(tlsman_driver_t *tlsman_session);
 
 /**
  * Processes the error_id and identifies if the (D)TLS session must be terminated.
@@ -195,121 +295,6 @@ ssize_t tlsman_return_last_known_error(void);
  * @return True if error is non-fatal.
  */
 bool tlsman_process_is_error_code_nonfatal(ssize_t error_id);
-
-/**
- * @brief Determines if the (D)TLS session is ready for sending data.
- *
- * If the behavior is non-blocking, the application must not proceed until
- * this return True.
- * @note TODO: Creates a queue buffer
- *
- * @param[in] session   The secure session to analyze
- *
- * @return True if it's ready
- */
-bool tlsman_is_channel_ready(tlsman_session_t *session);
-
-/**
- * @brief Sends upper layer data by means of the secure session.
- *
- * The data will be sent in one or multiples (D)TLS records.
- * @note TODO: Use a queue buffer(?)
- *
- * @param[in] session       The secure session to use
- * @param[in] data          The (plaintext) data to send
- * @param[in] len           Size of the data buffer
- *
- * @return 0 on success
- * @return TLSMAN_ERROR_DATA_APP_WRITE if the packet(s) were unable to be sent
- *
- */
-ssize_t tlsman_send_data_app(tlsman_session_t *session, const void *data, size_t len);
-
-/**
- * Processes the last (D)TLS Data Application record available.
- *
- * @param[in] session           The secure session to use.
- * @param[in] data              Pointer where the received data should be stored.
- * @param[in] max_len           Maximum space available in the data buffer.
- *
- * @return If SOCK_HAS_ASYNC return 0 on success
- * @return If !SOCK_HAS_ASYNC return 0 on success otherwise code error
- * @return TLSMAN_ERROR_REMOTE_RESET if got an DTLS record alert
- */
-ssize_t tlsman_retrieve_data_app(tlsman_session_t *session,
-                                 void *data,
-                                 size_t max_len);
-
-/**
- * @brief Close the (D) TLS channel established between the peers of the session.
- *
- * This also sends a last DTLS Alert record.
- *
- * @param[in]    session  The secure session to use.
- *
- * @return  0 on success,
- * @return TLSMAN_ERROR_UNABLE_CLOSE if unable to close the session
- */
-ssize_t tlsman_close_channel(tlsman_session_t *session);
-
-/**
- * @brief Relaase all the resources involved in the (D) TLS channel.
- *
- * This also sends a last DTLS Alert record and releases memory used for the
- * session.
- *
- * @param[in]    session  The secure session to use.
- */
-void tlsman_release_resources(tlsman_session_t *session);
-
-/**
- * @brief Renegotiates the current secure session between the peers.
- *
- * @param[in]  session  The secure session to use.
- * @param[in]  flags    Flags for defining the [nonb-]blocking behavior.
- * @param[in]  pkt_buff If nonb-bloking, pointer to packet buffer to be used. Otherwise can be NULL
- * @param[in]  pkt_size Size of pkt_buff
- *
- * @return 0 on success.
- * @return TLSMAN_ERROR_SESSION_REN if renegotiation failed.
- */
-ssize_t tlsman_renegotiate_session(tlsman_session_t *session, uint8_t flags,
-                                   uint8_t *pkt_buff, size_t pkt_size);
-
-/**
- *  @brief Generates a new (D)TLS handshake for the current secure session.
- *
- * @param[in]  session  The secure session to use.
- * @param[in]  flags    Flags for defining the [nonb-]blocking behavior.
- * @param[in]  pkt_buff If nonb-bloking, pointer to packet buffer to be used. Otherwise can be NULL
- * @param[in]  pkt_size Size of pkt_buff
- *
- * @return 0 on success.
- * @return TLSMAN_ERROR_SESSION_REN if renegotiation failed.
- */
-ssize_t tlsman_new_handshake(tlsman_session_t *session, uint8_t flags,
-                             uint8_t *pkt_buff, size_t pkt_size);
-
-/**
- * @brief Listen for an incoming connection request
- *
- * The server side for any (D)TLS channel. The reception handling of any type
- * of (D)TLS record, including those involved in the handshake is done here.
- *
- * For answers incoming requests with (D)TLS Data Application records, please
- * use tlsman_send_data_app() inside of the tlsman_resp_handler_t callback.
- *
- * @note TODO Create the non-blocking behavior
- *
- * @param[in]  session  The secure session to use.
- * @param[in]  flags    Flags for deining the behavior
- * @param[in]  pkt_buff Pointer to packet buffer to be used (for reception).
- * @param[in]  pkt_size Buffer size.
- *
- * @return 0 on success.
- */
-ssize_t tlsman_listening(tlsman_session_t *session, uint8_t flags,
-                         uint8_t *pkt_buff, size_t pkt_size);
 
 
 #ifdef __cplusplus

--- a/sys/include/net/tlsman/tinydtls.h
+++ b/sys/include/net/tlsman/tinydtls.h
@@ -1,0 +1,239 @@
+/*
+ * Copyright (C) 2018 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    net_tlsman  TLSMAN
+ * @ingroup     net
+ * @brief       High-level interface to (D)TLS stack Manager
+ *
+ * @{
+ *
+ * @file
+ * @brief       tlsman handlers for tinyDTLS
+ *
+ * @author      Raul Fuentes <raul.fuentes-samaniego@inria.fr>
+ *
+ * @}
+ */
+#ifndef NET_TLSMAN_TINYDTLS_H
+#define NET_TLSMAN_TINYDTLS_H
+
+#include "dtls.h"
+#include "dtls_debug.h"
+
+#if WITH_RIOT_GNRC
+#include "net/sock/udp.h"
+#endif /* WITH_RIOT_GNRC */
+
+#if WITH_RIOT_SOCKETS
+#error "Not tested yet!"
+#endif /* WITH_RIOT_SOCKETS */
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/* NOTE DISCUSSION: This should not be at tlsman.h? (but circular reference?)*/
+/**
+ * @brief   Handler function for the reception of a DTLS data app record.
+ *
+ */
+typedef void (*tlsman_resp_handler_t)(uint8_t *data, size_t data_size, void *tlsman_session);
+
+/**
+ * @brief The DTLS handshake states
+ */
+enum {
+    TINYDTLS_EVENTS_ZERO = 0x00,    /**< Not DTLS handshake has been runned */
+    TINYDTLS_EVENT_START,           /**< Firts DTLS Client Hello sent */
+    TINYDTLS_EVENT_FINISHED,        /**< DTLS Handshake finished */
+    TINYDTLS_EVENT_RENEGOTIATE      /**< Signals that a new handshake must take place */
+};
+
+/**
+ *  @brief The state of the handshake process
+ *
+ * Those determine if a new DTLS record was received in middle of a DTLS Handhsake
+ * and if it's requries to restart the handhsake.
+ */
+enum {
+    TINYDTLS_HANDSHAKE_NON_RECORD = 0x00,   /**< Non DTLS record was received */
+    TINYDTLS_HANDSHAKE_NEW_RECORD,          /**< A valid handshake record was received */
+    TINYDTLS_HANDSHAKE_RESTART_SVP,         /**< Call of dtls_connect() is required */
+    TINYDTLS_HANDSHAKE_IS_FATAL             /**< TODO */
+};
+
+/**
+ * @brief tinyDTLS metadata for handling a secure session between peers
+ */
+typedef struct {
+    uint8_t is_connected;               /**< Status of the DTLS channel >*/
+    bool is_data_app;                   /**< Status of the reception of DTLS Data APpp records> */
+    session_t dst;                      /**< The secure session */
+    dtls_context_t *context;            /**< The DTLS Context for the secure session */
+    dtls_context_t *cache;              /**< A temporary cached context required for renegotiation*/
+    tlsman_resp_handler_t resp_handler; /**< Response callback */
+
+#if WITH_RIOT_SOCKETS
+    /* TODO */
+#endif /* WITH_RIOT_SOCKETS */
+
+#if WITH_RIOT_GNRC
+    /* FIXME Be able to recover local and/or remote from sock */
+    sock_udp_t *sock;       /**< The Sock used for establishing the Secure session */
+    sock_udp_ep_t *local;   /**< The local peer of the sock */
+    sock_udp_ep_t *remote;  /**< The remote peer of the sock */
+
+#ifdef SOCK_HAS_ASYNC
+    event_queue_t *sock_event_queue; /**< Event queue for asynhcronous sock */
+#endif /* SOCK_HAS_ASYNC */
+
+#endif /* WITH_RIOT_GNRC */
+} tinydtls_session_t;
+
+/**
+ * @brief Determine if the list of cipher suites is valid
+ *
+ * The only two cipher suites supported by tinyDTLS are selected at compilation
+ * time. This only verifies if said cipher suites are present in the compiled
+ * code and at least one of them matches the cipher suite listed.
+ *
+ * @param[in] cipher    Cipher suite to check
+ *
+ * @return true if cipher sutie is supported
+ */
+bool is_cipher_tinydtls(int cipher);
+
+/**
+ * @brief Creates the tinydtls context
+ *
+ * @param[inout] dtls_session A tinydtls_session_t to store the the new context
+ * @param[in] resp_cb         Callback handler for the (D)TLS Data App record
+ * @param[in] Flags           Determine the behavior.
+ *
+ * @return  0 on success
+ * @return TLSMAN_ERROR_UNABLE_CONTEXT if unable to load the context
+ */
+ssize_t tlsman_tinydtls_init_context(tinydtls_session_t *dtls_session,
+                                     tlsman_resp_handler_t resp_cb,
+                                     const uint8_t flags);
+
+/**
+ * @brief Starts the DTLS channel. If blocking, stay there until is ready.
+ *
+ * If the behavior is non-blocking this returns as soon as the first DTLS Hello
+ * Client record is put in the sending buffer. Otherwise, it will wait until the
+ * handshake is finished, or a timeout had happened.
+ *
+ * @param[in] dtls_session      Tinydtls session
+ * @param[in] pkt_buff          Packet buffer to use for sending DTLS handshake records.
+ * @param[in] pkt_size          Size of the packet buffer.
+ * @param[in] flags             Determine the behavior (blocking or non-blocking)
+ *
+ * @return 0 on success
+ * @return TLSMAN_ERROR_FATAL if unable to generate (or send) the first DTLS record.
+ * @return TLSMAN_ERROR_HANDSHAKE_TIMEOUT if the handshake was not completed.
+ **/
+ssize_t tlsman_tinydtls_connect(tinydtls_session_t *dtls_session,
+                                uint8_t *pkt_buff, size_t pkt_size,
+                                uint8_t flags);
+
+/**
+ * @brief  Send data by means of DTLS Data app records
+ *
+ * @param[in] dtls_session  Tinydtls session
+ * @param[in] data          Data buffer
+ * @param[in] data_size     Size of the data buffer.
+ * @param[in] flags         Determine the behavior (blocking or non-blocking)
+ *
+ * @return 0 on sucess.
+ * @return TLSMAN_ERROR_DATA_APP_WRITE if unable to send package.
+ */
+ssize_t tlsman_tinydtls_send(tinydtls_session_t *dtls_session,
+                             uint8_t *data, size_t data_size,
+                             uint8_t flags);
+/**
+ * @brief Retrieve the last DTLS data app record received
+ *
+ * The blocking behavior impact on this function. If settled with non-blocking
+ * (SOCK_HAS_ASYNC is set). This will remain on listening loop for time equal
+ * to TINYDTLS_HDSK_TIMEOUT seconds (it's expected to be running in its own
+ * thread). If blocking state, this will only check if there is a DTLS record
+ * available in the receive buffer.
+ *
+ * TODO DISCUSSION: Maybe both behaviors should do exactly the same?
+ *
+ * @param[in] dtls_session      Tinydtls session
+ * @param[in] pkt_buff          Packet buffer to use for sending DTLS handshake records.
+ * @param[in] pkt_size          Size of the packet buffer.
+ *
+ * @return  If behavior is non-blocking, return 0 once a timeout is passed
+ * @return  If the behavior is blocking, returns 0 or code error if the DTLS session was closed.
+ */
+size_t tlsman_tintdytls_rcv(tinydtls_session_t *dtls_session,
+                            void *pkt_buff,
+                            size_t pkt_size);
+
+/**
+ * @brief Release the resources associated to the DTLS session
+ *
+ * @param[in] dtls_session      Tinydtls session
+ */
+void tlsman_tinydtls_free_context(tinydtls_session_t *dtls_session);
+
+/**
+ * @brief Renegotiates the DTLS session
+ *
+ * TODO FIXME (Known issues with tinydtls)
+ */
+ssize_t tlsman_tinydtls_renegotiate(tinydtls_session_t *dtls_session,
+                                    uint8_t *pkt_buff, size_t pkt_size,
+                                    uint8_t flags);
+
+/**
+ * @brief Rehandshake connection
+ *
+ * TODO FIXME (Known issues with tinydtls)
+ */
+ssize_t tlsman_tinydtls_rehandshake(tinydtls_session_t *dtls_session,
+                                    uint8_t *pkt_buff, size_t pkt_size,
+                                    uint8_t flags);
+
+/**
+ * @brief Listening mode for the server side
+ *
+ * @param[in] dtls_session      Tinydtls session
+ * @param[in] pkt_buff          Packet buffer to use for sending DTLS handshake records.
+ * @param[in] pkt_size          Size of the packet buffer.
+ *
+ * returns 0 on normal operation
+ */
+ssize_t tlsman_tinydtls_listening(tinydtls_session_t *dtls_session,
+                            void *pkt_buff,
+                            size_t pkt_size);
+
+#ifdef SOCK_HAS_ASYNC
+void tlsman_tinydtls_set_async_parameters(tinydtls_session_t *dtls_session,
+                                          event_queue_t *sock_event_queue,
+                                          uint8_t *buffer, ssize_t size);
+
+/**
+ * @brief Launch an timer event
+ *
+ * @note A timer event is used for those scenarios where not extra threads are being used
+ */
+void tlsman_tinydtls_set_listening_timeout(void);
+
+#endif /* SOCK_HAS_ASYNC */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* NET_TLSMAN_TINYDTLS_H */
+/** @} */

--- a/sys/net/sock/secure/Makefile
+++ b/sys/net/sock/secure/Makefile
@@ -1,0 +1,2 @@
+MODULE = sock_secure
+include $(RIOTBASE)/Makefile.base

--- a/sys/net/sock/secure/sock_secure.c
+++ b/sys/net/sock/secure/sock_secure.c
@@ -1,0 +1,207 @@
+/*
+ * Copyright (C) 2018 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     sock
+ * @{
+ *
+ * @file
+ * @brief       sock_secure utility functions implementation
+ *
+ * @author      Raul Fuentes <raul.fuentes-samaniego@inria.fr>
+ *
+ * @}
+ */
+
+#include "net/sock/secure.h"
+#include "net/tlsman.h"
+
+
+#define ENABLE_DEBUG (1)
+#include "debug.h"
+
+/* TODO FIXME universal buffer (which in turn must be enough bigh for payload) */
+
+/* FIXME Maximum size is defined by (D)TLS library stack (example DTLS_MAX_BUFF for tinydtls) */
+/* TODO: Switch to something similar for TCP
+ * NOTE: Probably not feasible because exteneral packages handles the
+ *       assembly of the DTLS packets)
+ */
+static uint8_t dtls_header[100];
+
+static ssize_t _connect(sock_secure_session_t *sock_secure, uint8_t *data,
+                 size_t data_size){
+  sock_secure->session.tlsman_create_channel(&sock_secure->session.session,
+     sock_secure->flag, data, data_size);
+
+  sock_secure->state = SOCK_SECURE_STATE_STARTED;
+  return 0;
+}
+
+ssize_t sock_secure_load_stack(sock_secure_session_t *sock_secure,
+                             uint16_t *ciphers, size_t ciphers_size)
+ {
+
+   /* TODO Add DEBUG lines for display technical info? */
+  ssize_t res = tlsman_load_stack(&sock_secure->session, ciphers, ciphers_size,
+                    sock_secure->flag);
+
+  if (res == 0) {
+    sock_secure->state = SOCK_SECURE_STATE_NON_STARTED;
+    return 0;
+  } else {
+    sock_secure->state =  SOCK_SECURE_STATE_FATAL;
+    return SOCK_SECURE_STATE_FATAL;
+  }
+
+}
+
+ssize_t sock_secure_initialized(sock_secure_session_t *sock_secure,
+                              tlsman_resp_handler_t callback,
+                              void *sock,
+                              sock_secure_ep_t *local,
+                              sock_secure_ep_t *remote)
+{
+   ssize_t res;
+
+   sock_secure->session.session.sock = sock;
+   sock_secure->cb = callback;
+
+  /*
+   *  FIXME: TLSMAN Should handling this part
+   *  HOWEVER, TLSMAN should be agnostic to sock, socket or whatever library is being used
+   */
+   sock_secure->session.session.local = (sock_udp_ep_t *) local;
+   sock_secure->session.session.remote = (sock_udp_ep_t *) remote;
+
+
+   /* TODO: SOCK_HAS_ASYNC suppport */
+
+   res = sock_secure->session.tlsman_init_context(&sock_secure->session.session,
+                              callback,
+                              sock_secure->flag);
+
+    if (res == 0) {
+       if (sock_secure->flag & TLSMAN_FLAG_SIDE_SERVER) {
+          sock_secure->state = SOCK_SECURE_STATE_SERVER_LISTENING;
+       }
+       else {
+          sock_secure->state = SOCK_SECURE_STATE_NON_STARTED;
+        }
+    }
+
+   return 0;
+}
+
+ssize_t sock_secure_update(sock_secure_session_t *sock_secure)
+{
+  /* Check the status, if necessary coonnect to the peeer (create the secure session)*/
+
+  /* FIXME: Verify that not new resource is required */
+
+  switch (sock_secure->state) {
+    case SOCK_SECURE_STATE_NON_INITIALIZED:
+      /* FIXME  What type of error? Is */
+      DEBUG("%s: Secure session parameters not initialized!\n", __func__);
+      return -1;
+
+    case SOCK_SECURE_STATE_NON_STARTED:
+      DEBUG("%s: Creating the secure channel between locan and remote!\n", __func__);
+      _connect(sock_secure, dtls_header, sizeof(dtls_header));
+    break;
+
+    case SOCK_SECURE_STATE_STARTED:
+      DEBUG("%s: (D)TLS Handshake started\n", __func__);
+      /* TODO: Identify the current status of the handshake */
+    break;
+
+    case SOCK_SECURE_STATE_FATAL:
+      DEBUG("%s: Unable to advnace!\n", __func__);
+      return -1;
+    break;
+
+    case SOCK_SECURE_STATE_SERVER_LISTENING:
+      DEBUG("%s: Server is in permanent listening mode\n", __func__);
+    break;
+
+    default:
+      DEBUG("%s: Unknown sock_secure session status (%u)\n", __func__, sock_secure->state );
+    break;
+  }
+
+  return 0;
+}
+
+ssize_t sock_secure_write(sock_secure_session_t *sock_secure,
+                          const void* data, size_t len)
+{
+
+  if (sock_secure->flag & TLSMAN_FLAG_SIDE_SERVER){
+    DEBUG("%s: Server side sending data app\n",__func__);
+    return sock_secure->session.tlsman_send_data_app(&sock_secure->session.session,
+                                                     data, len);
+  }
+
+  sock_secure_update(sock_secure);
+
+  /* TODO: Identify the current status of the handshake   */
+
+  /* TODO: Create events or timeouts here */
+  if (sock_secure->state != SOCK_SECURE_STATE_STARTED) {
+    sock_secure->state = SOCK_SECURE_STATE_ERROR;
+    return -1;
+  }
+  DEBUG("%s: Client side sending data app\n",__func__);
+  sock_secure->session.tlsman_send_data_app(&sock_secure->session.session,
+                      data, len);
+
+  return 0;
+}
+
+ssize_t sock_secure_read(sock_secure_session_t *sock_secure)
+{
+
+  if (sock_secure->flag & TLSMAN_FLAG_SIDE_SERVER){
+
+    return sock_secure->session.tlsman_listening(&sock_secure->session.session,
+                                                 sock_secure->flag,
+                                                 dtls_header,
+                                                 sizeof(dtls_header));
+  }
+
+  /* TODO: Identify the current status of the handshake   */
+  /* NOTE: If channel is not ready then exit? (Check TCP behavior) */
+  sock_secure_update(sock_secure);
+  sock_secure->session.tlsman_retrieve_data_app(&sock_secure->session.session,
+                        dtls_header, sizeof(dtls_header));
+
+  return 0;
+}
+
+void sock_secure_release(sock_secure_session_t *sock_secure)
+{
+  /* TODO is worth to check the current status? */
+
+  sock_secure->session.tlsman_release_resources(&sock_secure->session.session);
+  /*
+   * WARNING: Some (D)TLS stacks will send back a DTLS alert record
+   * If not handled properly (remove it from the gnrc queue) will have a negative
+   * impact for the next time time a secure session is attempted.
+   */
+  sock_secure->session.tlsman_retrieve_data_app(&sock_secure->session.session,
+                        dtls_header, sizeof(dtls_header));
+
+  /* This is ready for a new secure session */
+  sock_secure->state = SOCK_SECURE_STATE_NON_STARTED;
+
+  /* TODO DISCUSSION should be in its own function?  */
+  /* NOTE: Probably tinydtls?sock.c must rework this part  if tlsman_release_resources()
+  *  was called previously */
+  sock_secure->session.tlsman_close_channel(&sock_secure->session.session);
+
+}

--- a/sys/net/tlsman/Makefile
+++ b/sys/net/tlsman/Makefile
@@ -1,7 +1,9 @@
 SRC := tlsman.c
 
 ifneq (,$(filter tlsman_tinydtls,$(USEMODULE)))
-	SRC += tinydtls.c
+	ifneq (,$(filter sock_udp,$(USEMODULE)))
+		SRC += tinydtls_sock.c
+	endif
 endif
 
 include $(RIOTBASE)/Makefile.base

--- a/sys/net/tlsman/Makefile
+++ b/sys/net/tlsman/Makefile
@@ -1,0 +1,7 @@
+SRC := tlsman.c
+
+ifneq (,$(filter tlsman_tinydtls,$(USEMODULE)))
+	SRC += tinydtls.c
+endif
+
+include $(RIOTBASE)/Makefile.base

--- a/sys/net/tlsman/tinydtls.c
+++ b/sys/net/tlsman/tinydtls.c
@@ -1,0 +1,968 @@
+/*
+ * Copyright (C) 2018 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tlsman
+ * @{
+ *
+ * @file
+ * @brief       tlsman utility functions implementation
+ *
+ * @author      Raul Fuentes <raul.fuentes-samaniego@inria.fr>
+ *
+ * @}
+ */
+
+#include "net/tlsman.h"
+#include "net/tlsman/tinydtls.h"
+#include "dtls.h"
+
+/* NOTE DISCUSSION: Should be in sys/include/tlsman or in the app directory? */
+#include "dtls_keys.h"
+
+#ifdef SOCK_HAS_ASYNC
+#include "event/timeout.h"
+#endif
+
+#define ENABLE_DEBUG (0)
+#include "debug.h"
+
+#define TINYDTLS_HDSK_TIMEOUT 1 * US_PER_SEC
+
+static int _send_to_peer(struct dtls_context_t *ctx,
+                         session_t *session, uint8 *buf, size_t len);
+static int _read_from_peer(struct dtls_context_t *ctx,
+                           session_t *session,
+                           uint8 *data, size_t len);
+static int _client_events(struct dtls_context_t *ctx,
+                          session_t *session,
+                          dtls_alert_level_t level,
+                          unsigned short code);
+
+#ifdef DTLS_PSK
+/* This function is the "key store" for tinyDTLS. It is called to
+ * retrieve a key for the given identity within this particular
+ * session. */
+static int _get_psk_info(struct dtls_context_t *ctx,
+                         const session_t *session,
+                         dtls_credentials_type_t type,
+                         const unsigned char *id, size_t id_len,
+                         unsigned char *result, size_t result_length);
+#endif /* DTLS_PSK */
+#ifdef DTLS_ECC
+static int _peer_verify_ecdsa_key(struct dtls_context_t *ctx,
+                                  const session_t *session,
+                                  const unsigned char *other_pub_x,
+                                  const unsigned char *other_pub_y,
+                                  size_t key_size);
+static int _peer_get_ecdsa_key(struct dtls_context_t *ctx,
+                               const session_t *session,
+                               const dtls_ecdsa_key_t **result);
+#endif /* DTLS_ECC */
+/* Collection of callbacks for tinydtls operation */
+static dtls_handler_t _tinydtls_handler_cbs = {
+    .write = _send_to_peer,
+    .read = _read_from_peer,
+    .event = NULL,
+#ifdef DTLS_PSK
+    .get_psk_info = NULL,
+#endif /* DTLS_PSK */
+#ifdef DTLS_ECC
+    .get_ecdsa_key = _peer_get_ecdsa_key,
+    .verify_ecdsa_key = _peer_verify_ecdsa_key
+#endif /* DTLS_ECC */
+};
+
+#ifdef SOCK_HAS_ASYNC
+
+static void _kill_handshake(event_t *event);
+static void _stop_listening(event_t *event);
+
+static event_t kill_handshake_event = { .handler = _kill_handshake };
+static event_t stop_listening_event = { .handler = _stop_listening };
+static event_timeout_t kill_handshake_timeout;
+static event_timeout_t stop_listening_timeout;
+
+static uint8_t _async_recv_watchdog;    /* Counter for disabling the listening mode */
+static bool _async_rcv_pkt;             /** Flag to determine if a packet was recveided */
+
+/* NOTE: Global pointers required for current limitations of event.h */
+/* NOTE DISCUSSION: This approach is adequate? can be replicated for tinyDTLS interanl buffers? */
+static ssize_t _tinydtls_packet_received_size;
+static uint8_t *_tinydtls_packet_received;
+static tinydtls_session_t *_async_session;
+
+/*
+ * This event permits to advance on event_get() and terminate it if necessary
+ */
+static void _kill_handshake(event_t *event)
+{
+    (void) event;
+
+    _async_rcv_pkt ? ++_async_recv_watchdog : --_async_recv_watchdog;
+    _async_rcv_pkt = false;
+
+    DEBUG("(%s): Event timeout (%i)\n", __func__, _async_recv_watchdog);
+    if (_async_recv_watchdog > 0) {
+        event_timeout_set(&kill_handshake_timeout, TINYDTLS_HDSK_TIMEOUT);
+    }
+    else {
+        DEBUG("(%s): DTLS Handshake timeout\n", __func__);
+        /* FIXME How to cancel the sock_udp_recv() ? */
+    }
+}
+
+static void _stop_listening(event_t *event)
+{
+
+    (void) event;
+    DEBUG("(%s): Disabling the listening for DTLS records...\n", __func__);
+    _async_recv_watchdog = 0;
+}
+
+/**
+ * This is the generic evnt for retrieving sock messages.
+ * There are two m
+ */
+static void _async_tinydtls_handle_read(event_t *arg)
+{
+    /* TODO: Check this */
+
+    sock_event_t *event = (sock_event_t *)arg;
+    static session_t session;
+    session_t *peer = &_async_session->dst;
+
+    DEBUG("(%s): Event received! (type 0x%08x) \n", __func__, event->type);
+
+    /* TODO: Generate our own TLS_APP_DATA_RECV */
+    if (event->type & SOCK_EVENT_RECV) {
+        sock_udp_ep_t remote = { .family = AF_INET6 };
+        ssize_t res;
+
+        while ((res = sock_udp_recv(event->sock,
+                                    _tinydtls_packet_received,
+                                    _tinydtls_packet_received_size,
+                                    TINYDTLS_HDSK_TIMEOUT, /* WARNING NO SOCK_NO_TIMEOUT*/
+                                    &remote)) >= 0) {
+            if (res >= 0) {
+
+                _async_rcv_pkt = true; /* Notify to the other events */
+
+                session.size = sizeof(uint8_t) * 16 + sizeof(unsigned short);
+                session.port = remote.port;
+                if (peer->ifindex == SOCK_ADDR_ANY_NETIF) {
+                    session.ifindex = SOCK_ADDR_ANY_NETIF;
+                }
+                else {
+                    session.ifindex = remote.netif;
+                }
+
+                if (memcpy(&session.addr, remote.addr.ipv6, 16) == NULL) {
+                    DEBUG("ERROR: memcpy failed!");
+                    continue;
+                }
+
+                if (ENABLE_DEBUG) {
+                    DEBUG("(%s): Msg received from [", __func__);
+                    ipv6_addr_print(&session.addr);
+                    DEBUG("]:%u (netif: %i)\n", session.port, session.ifindex);
+                }
+
+                dtls_handle_message(_async_session->context, &session,
+                                    _tinydtls_packet_received, (int) res);
+
+            }
+            else if (ENABLE_DEBUG) {
+                DEBUG("%s: sock_udp_recv error code: %i\n", __func__, res);
+            }
+        } /* while */
+
+    }
+}
+
+void tlsman_tinydtls_set_async_parameters(tinydtls_session_t *dtls_session,
+                                          event_queue_t *sock_event_queue,
+                                          uint8_t *buffer, ssize_t size)
+{
+    dtls_session->sock_event_queue = sock_event_queue;
+
+    _tinydtls_packet_received = buffer;
+    _tinydtls_packet_received_size = size;
+
+    event_queue_init(dtls_session->sock_event_queue);
+    /* FIXME: Here or in the hadnshake? */
+    event_timeout_init(&kill_handshake_timeout, dtls_session->sock_event_queue,
+                       &kill_handshake_event);
+    event_timeout_init(&stop_listening_timeout, dtls_session->sock_event_queue,
+                       &stop_listening_event);
+
+    sock_udp_set_event_queue(dtls_session->sock,
+                             dtls_session->sock_event_queue,
+                             _async_tinydtls_handle_read);
+
+    DEBUG("(%s)> gnrc_sock_async set!\n", __func__);
+
+}
+
+void tlsman_tinydtls_set_listening_timeout(void)
+{
+
+    event_timeout_set(&stop_listening_timeout, TINYDTLS_HDSK_TIMEOUT);
+}
+
+#endif /* SOCK_HAS_ASYNC */
+
+#ifdef DTLS_PSK
+
+static int _get_psk_info(struct dtls_context_t *ctx,
+                         const session_t *session,
+                         dtls_credentials_type_t type,
+                         const unsigned char *id, size_t id_len,
+                         unsigned char *result, size_t result_length)
+{
+
+    (void) ctx;
+    (void) session;
+    /* Client side  */
+    switch (type) {
+        case DTLS_PSK_IDENTITY:
+            if (id_len) {
+                dtls_debug("got psk_identity_hint: '%.*s'\n", id_len, id);
+            }
+
+            if (result_length < psk_id_length) {
+                dtls_warn("cannot set psk_identity -- buffer too small\n");
+                return dtls_alert_fatal_create(DTLS_ALERT_INTERNAL_ERROR);
+            }
+
+            memcpy(result, psk_id, psk_id_length);
+            return psk_id_length;
+        case DTLS_PSK_KEY:
+            if (id_len != psk_id_length || memcmp(psk_id, id, id_len) != 0) {
+                dtls_warn("PSK for unknown id requested, exiting\n");
+                return dtls_alert_fatal_create(DTLS_ALERT_ILLEGAL_PARAMETER);
+            }
+            else if (result_length < psk_key_length) {
+                dtls_warn("cannot set psk -- buffer too small\n");
+                return dtls_alert_fatal_create(DTLS_ALERT_INTERNAL_ERROR);
+            }
+
+            memcpy(result, psk_key, psk_key_length);
+            return psk_key_length;
+        default:
+            dtls_warn("unsupported request type: %d\n", type);
+    }
+
+    return dtls_alert_fatal_create(DTLS_ALERT_INTERNAL_ERROR);
+}
+
+
+static int
+_server_get_psk_info(struct dtls_context_t *ctx, const session_t *session,
+                     dtls_credentials_type_t type,
+                     const unsigned char *id, size_t id_len,
+                     unsigned char *result, size_t result_length)
+{
+
+    (void) ctx;
+    (void) session;
+
+    struct keymap_t {
+        unsigned char *id;
+        size_t id_length;
+        unsigned char *key;
+        size_t key_length;
+    } psk[3] = {
+        /* FIXME */
+        { (unsigned char *)psk_id, psk_id_length,
+          (unsigned char *)psk_key, psk_key_length },
+        { (unsigned char *)"default identity", 16,  /* FIXME */
+          (unsigned char *)"\x11\x22\x33", 3 },     /* FIXME */
+        { (unsigned char *)"\0", 2,                 /* FIXME */
+          (unsigned char *)"", 1 }                  /* FIXME */
+    };
+
+    if (type != DTLS_PSK_KEY) {
+        return 0;
+    }
+
+    if (id) {
+        uint8_t i;
+        for (i = 0; i < sizeof(psk) / sizeof(struct keymap_t); i++) {
+            if (id_len == psk[i].id_length && memcmp(id, psk[i].id, id_len) == 0) {
+                if (result_length < psk[i].key_length) {
+                    dtls_warn("buffer too small for PSK");
+                    return dtls_alert_fatal_create(DTLS_ALERT_INTERNAL_ERROR);
+                }
+
+                memcpy(result, psk[i].key, psk[i].key_length);
+                return psk[i].key_length;
+            }
+        }
+    }
+
+    return dtls_alert_fatal_create(DTLS_ALERT_DECRYPT_ERROR);
+}
+
+#endif /* DTLS_PSK */
+
+#ifdef DTLS_ECC
+static int _peer_get_ecdsa_key(struct dtls_context_t *ctx,
+                               const session_t *session,
+                               const dtls_ecdsa_key_t **result)
+{
+    (void) ctx;
+    (void) session;
+
+    /*TODO: Load the key from external source */
+
+    static const dtls_ecdsa_key_t ecdsa_key = {
+        .curve = DTLS_ECDH_CURVE_SECP256R1,
+        .priv_key = ecdsa_priv_key,
+        .pub_key_x = ecdsa_pub_key_x,
+        .pub_key_y = ecdsa_pub_key_y
+    };
+
+    *result = &ecdsa_key;
+    return 0;
+}
+
+static int _peer_verify_ecdsa_key(struct dtls_context_t *ctx,
+                                  const session_t *session,
+                                  const unsigned char *other_pub_x,
+                                  const unsigned char *other_pub_y,
+                                  size_t key_size)
+{
+    (void) ctx;
+    (void) session;
+    (void) other_pub_y;
+    (void) other_pub_x;
+    (void) key_size;
+
+    /* TODO: As far for tinyDTLS 0.8.2 this is not used */
+
+    return 0;
+}
+#endif /* DTLS_ECC */
+
+/*
+ * Handles the reception of the DTLS flights.
+ *
+ * Handles all the packets arriving at the node and identifies those that are
+ * DTLS records. Also, it determines if said DTLS record is coming from a new
+ * peer or a currently established peer.
+ *
+ * TODO (return values)
+ *
+ */
+ssize_t _tinydtls_handle_read(tinydtls_session_t *tinydtls_session,
+                              uint8_t *pkt_buff, size_t pkt_buff_size)
+{
+
+    ssize_t pckt_rcvd_size;
+    static session_t session;
+    session_t *peer = &tinydtls_session->dst;
+    static sock_udp_ep_t remote = { .family = AF_INET6 };
+
+    pckt_rcvd_size = sock_udp_recv(tinydtls_session->sock, pkt_buff, pkt_buff_size,
+                                   TINYDTLS_HDSK_TIMEOUT, &remote);
+
+    if (pckt_rcvd_size <= 0) {
+        DEBUG("%s: sock_udp_recv error code: %i\n", __func__, pckt_rcvd_size);
+        return TINYDTLS_HANDSHAKE_NON_RECORD;
+    }
+
+    /* session requires the remote socket address (and netif) */
+    session.size = sizeof(uint8_t) * 16 + sizeof(unsigned short);
+    session.port = remote.port;
+    if (peer->ifindex == SOCK_ADDR_ANY_NETIF) {
+        /*
+         * TODO DISCUSSION: Is this approach correct?
+         * The IP%netif:PORT combo is used for identifying different sessions
+         * This approach tries to have an "universal" netif
+         */
+        session.ifindex = SOCK_ADDR_ANY_NETIF;
+    }
+    else {
+        session.ifindex = remote.netif;
+    }
+
+    if (memcpy(&session.addr, remote.addr.ipv6, 16) == NULL) {
+        DEBUG("ERROR: memcpy failed!");
+        return TINYDTLS_HANDSHAKE_NON_RECORD;
+    }
+
+    if (ENABLE_DEBUG) {
+        DEBUG("(%s): Msg received from [", __func__);
+        ipv6_addr_print(&session.addr);
+        DEBUG("]:%u (netif: %i)\n", session.port, session.ifindex);
+    }
+
+    ssize_t res = dtls_handle_message(tinydtls_session->context, &session, pkt_buff, (int) pckt_rcvd_size);
+
+    if (res < 0) {
+        /* Are we getting noise from a previous DTLS ALert record? */
+        if (res == dtls_alert_fatal_create(DTLS_ALERT_DECRYPT_ERROR)) {
+            DEBUG("%s: Got DTLS_ALERT_DECRYPT_ERROR!\n", __func__);
+            return TINYDTLS_HANDSHAKE_RESTART_SVP;
+        }
+        /* TODO: Try to determine other valid reasons to re-start the handshake */
+        return TINYDTLS_HANDSHAKE_NON_RECORD; /* TODO: or FATAL?*/
+    }
+
+    return TINYDTLS_HANDSHAKE_NEW_RECORD;
+}
+
+bool is_cipher_tinydtls(int cipher)
+{
+
+#if defined(DTLS_PSK)
+    if (cipher == TLS_PSK_WITH_AES_128_CCM_8) {
+        DEBUG("DTLS_PSK ciphersuite Detected\n");
+        return true;
+    }
+#endif
+
+#if defined(DTLS_ECC)
+    if (cipher == TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8) {
+        DEBUG("DTLS_ECC ciphersuite Detected\n");
+        return true;
+    }
+#endif
+
+    return false;
+}
+
+/**
+ * @brief Handles the DTLS communication with the other peer.
+ */
+static int _send_to_peer(struct dtls_context_t *ctx,
+                         session_t *session, uint8 *buf, size_t len)
+{
+    (void) session;
+    assert(dtls_get_app_data(ctx));
+
+    tinydtls_session_t *remote_peer;
+    remote_peer = (tinydtls_session_t *) dtls_get_app_data(ctx);
+
+    if (ENABLE_DEBUG) {
+        printf("(%s): Sending DTLS record to [", __func__);
+        ipv6_addr_print(&session->addr);
+        printf("]:%u (netif: %i)", session->port, session->ifindex);
+        printf(" Size of packet:%zu\n", len);
+    }
+
+    if (ipv6_addr_is_unspecified(&session->addr)) {
+        puts("Error: Unable to send DTLS record (Session is [::]!\n)");
+        return 0;
+    }
+
+    ssize_t res = sock_udp_send(remote_peer->sock, buf, len, remote_peer->remote);
+
+    if ((res < 0) && ENABLE_DEBUG) {
+        printf("Error: Unable to send DTLS record (Error code: %zd\n)", res);
+    }
+
+    return res;
+}
+
+/**
+ * @brief Reception of a DTLS Applicaiton data record.
+ */
+static int _read_from_peer(struct dtls_context_t *ctx,
+                           session_t *session,
+                           uint8 *data, size_t len)
+{
+    (void) session;
+
+    tinydtls_session_t *user_session;
+    user_session = (tinydtls_session_t *) dtls_get_app_data(ctx);
+
+    user_session->is_data_app = true;
+
+#if ENABLE_DEBUG
+    size_t i;
+    printf("%s: DTLS Data Application record (raw hex) -- ", __func__);
+    for (i = 0; i < len; i++) {
+        printf("%2X ", data[i]);
+    }
+    printf(" -- (Total: %i bytes)\n", len );
+    if (!user_session->resp_handler) {
+        printf("%s: No callback was provided by the user!\n", __func__);
+    }
+#endif /* ENABLE_DEBUG */
+
+    if (user_session->resp_handler) {
+        DEBUG("%s: Launching callback...\n", __func__);
+#ifdef WITH_RIOT_GNRC
+        (*user_session->resp_handler)((uint8_t *)data, len, (void *) user_session->sock);
+#endif  /* WITH_RIOT_GNRC */
+
+#ifdef WITH_RIOT_SOCKETS
+#warning "Not supported yet"
+#endif  /* WITH_RIOT_SOCKETS */
+    }
+
+    return TLSMAN_ERROR_SUCCESS;
+}
+
+/**
+ * @brief TinyDTLS callback for detecting the state of the DTLS channel.
+ *
+ * Exclusive of the TinyDTLS Client (For now).
+ *
+ * NOTE DISCUSSION Only for client side?
+ *
+ * @note Once renegotiation is included this is also affected.
+ */
+static int _client_events(struct dtls_context_t *ctx,
+                          session_t *session,
+                          dtls_alert_level_t level,
+                          unsigned short code)
+{
+    (void) ctx;
+    (void) session;
+    (void) level;
+
+    tinydtls_session_t *remote_peer;
+    remote_peer = (tinydtls_session_t *) dtls_get_app_data(ctx);
+
+    if (code == DTLS_EVENT_CONNECTED) {
+        DEBUG("CLIENT: DTLS Channel established!\n");
+        remote_peer->is_connected = TINYDTLS_EVENT_FINISHED;
+
+#ifdef SOCK_HAS_ASYNC
+        _async_recv_watchdog = -1; /* FIXME: Mutex? */
+#endif /* SOCK_HAS_ASYNC */
+    }
+    /* At least a DTLS Client Hello was prepared? */
+    else if (code == DTLS_EVENT_CONNECT) {
+        DEBUG("CLIENT: DTLS Channel started\n");
+        remote_peer->is_connected = TINYDTLS_EVENT_START;
+    }
+    else if (code == DTLS_EVENT_RENEGOTIATE) {
+        DEBUG("CLIENT: DTLS Renegotiates!\n");
+        remote_peer->is_connected = TINYDTLS_EVENT_FINISHED;
+    }
+
+    return TLSMAN_ERROR_SUCCESS;
+}
+
+ssize_t tlsman_tinydtls_init_context(tinydtls_session_t *dtls_session,
+                                     tlsman_resp_handler_t resp_cb,
+                                     const uint8_t flags)
+{
+
+    dtls_session->context = NULL;
+    session_t *dst = &dtls_session->dst;
+    sock_udp_ep_t *remote = dtls_session->remote;
+
+    /* FIXME: Risk of race condition? */
+    dtls_session->is_connected = TINYDTLS_EVENTS_ZERO;
+
+    dtls_set_log_level(TINYDTLS_LOG_LVL);
+
+#ifdef WITH_RIOT_GNRC
+
+    DEBUG("%s: Linking DTLS session to UDP sock\n", __func__);
+
+    dtls_session->dst.size = sizeof(uint8_t) * 16 + sizeof(unsigned short);
+    dtls_session->dst.port = dtls_session->remote->port;
+
+    /* NOTE: Parsing iface for the remote */
+    if (gnrc_netif_numof() == 1) {
+        /* assign the single interface found in gnrc_netif_numof() */
+        dtls_session->dst.ifindex = (uint16_t)gnrc_netif_iter(NULL)->pid;
+        dtls_session->remote->netif = (uint16_t)gnrc_netif_iter(NULL)->pid;
+    }
+    else {
+        /* FIXME This probably is not valid with multiple interfaces */
+        dtls_session->dst.ifindex = dtls_session->remote->netif;
+    }
+
+    /* NOTE: remote.addr and dst->addr are different structures. */
+    if (memcpy(&dst->addr, &remote->addr.ipv6, 16) == NULL) {
+        DEBUG("ERROR: memcpy failed!");
+        return -1;
+    }
+
+    dtls_session->resp_handler = resp_cb;
+    dtls_session->context = dtls_new_context(dtls_session);
+
+    if (flags & TLSMAN_FLAG_SIDE_SERVER) {
+        _tinydtls_handler_cbs.event = NULL; /* FIXME REMOVE(?) */
+#ifdef DTLS_PSK
+        _tinydtls_handler_cbs.get_psk_info = _server_get_psk_info;
+#endif  /* DTLS_PSK */
+    }
+    else {
+        _tinydtls_handler_cbs.event = _client_events;
+#ifdef DTLS_PSK
+        _tinydtls_handler_cbs.get_psk_info = _get_psk_info;
+#endif  /* DTLS_PSK */
+    }
+
+    if (dtls_session->context) {
+        dtls_set_handler(dtls_session->context, &_tinydtls_handler_cbs);
+        return 0;
+    }
+
+    return TLSMAN_ERROR_UNABLE_CONTEXT;
+
+#endif /* WITH_RIOT_GNRC */
+
+#ifdef WITH_RIOT_SOCKETS
+#warning "tinyDTLS with sockets not tested yet"
+
+#endif /* WITH_RIOT_SOCKETS */
+
+    return TLSMAN_ERROR_FATAL;
+}
+
+ssize_t tlsman_tinydtls_send(tinydtls_session_t *dtls_session,
+                             uint8_t *data, size_t data_size,
+                             uint8_t flags)
+{
+    ssize_t len = data_size;
+
+    /* TODO: Test this with longer buffers */
+    /* TODO: Sock_async support */
+    (void) flags;
+
+    while (len > 0) {
+        DEBUG("%s: Sending %zu bytes...\n", __func__, len);
+        ssize_t res = dtls_write(dtls_session->context, &dtls_session->dst, (uint8 *)data, len);
+        if (res >= 0) {
+            /* DISCUSSION: This is appropiate? */
+            memmove(data, data + res, len - res);
+            len -= res;
+
+            if (res == 0) {
+                return 0;
+            }
+        }
+        else {
+            DEBUG("%s: dtls_write() Error code: %zd\n", __func__, res);
+            return TLSMAN_ERROR_DATA_APP_WRITE;
+        }
+    } /* while */
+
+    return 0;
+}
+
+ssize_t tlsman_tinydtls_listening(tinydtls_session_t *dtls_session,
+                                  void *pkt_buff,
+                                  size_t pkt_size)
+{
+
+    /*
+     * This intented to handle handshake and reception of real data
+     * WITHOUT timeouts (and server side)
+     */
+    /* TODO Be able to kill it */
+    /* TODO Handle errors */
+
+#ifdef  SOCK_HAS_ASYNC
+    (void) pkt_buff;
+    (void) pkt_size;
+    DEBUG("%s: Starting (Async) listening for DTLS records!\n", __func__);
+    _async_session = dtls_session;  /* FIXME: Mutex here? */
+    _async_recv_watchdog = 1;       /* We are to use it as boolean now */
+
+    while (_async_recv_watchdog > 0) {
+        event_t *event = event_get(dtls_session->sock_event_queue);
+        if (event) {
+            event->handler(event);
+        }
+        xtimer_usleep(200); /* FIXME: Magic number for now */
+    }
+    DEBUG("%s: Stopping (Async) listening for DTLS records!\n", __func__);
+
+#else /* SOCK_HAS_ASYNC */
+
+    ssize_t pckt_rcvd_size;
+    session_t *peer = &dtls_session->dst;
+    static sock_udp_ep_t remote = { .family = AF_INET6 };
+
+    /* NOTE FIXME Blocking? one second?  */
+    pckt_rcvd_size = sock_udp_recv(dtls_session->sock, pkt_buff, pkt_size,
+                                   0, &remote);
+
+    if (pckt_rcvd_size <= 0) {
+        if ((pckt_rcvd_size != -ETIMEDOUT)
+            && ((pckt_rcvd_size != -EAGAIN))
+            && ENABLE_DEBUG) {
+            DEBUG("%s: sock_udp_recv error code is %i\n", __func__, pckt_rcvd_size);
+        }
+        return 0;
+    }
+
+    /* We need to update the remote (and the session) */
+    dtls_session->remote = &remote;
+
+    /* Equivalent to  _tinydtls_handle_read() */
+    peer->size = sizeof(uint8_t) * 16 + sizeof(unsigned short);
+    peer->port = remote.port;
+
+    /* TESTING : Override behavior for the server? */
+    peer->ifindex = SOCK_ADDR_ANY_NETIF;
+
+    if (memcpy(&peer->addr, remote.addr.ipv6, 16) == NULL) {
+        DEBUG("ERROR: memcpy failed!");
+        return TINYDTLS_HANDSHAKE_NON_RECORD;
+    }
+
+    if (ENABLE_DEBUG) {
+        DEBUG("(%s): Msg received from [", __func__);
+        ipv6_addr_print(&peer->addr);
+        DEBUG("]:%u (netif: %i)\n", peer->port, peer->ifindex);
+    }
+
+    /* Server dont care about the result */
+    dtls_handle_message(dtls_session->context, peer, pkt_buff, (int) pckt_rcvd_size);
+
+#endif
+
+    return 0;
+}
+
+size_t tlsman_tintdytls_rcv(tinydtls_session_t *dtls_session,
+                            void *pkt_buff,
+                            size_t pkt_size)
+{
+    /* TODO: Handle the flag argument? */
+
+#ifdef SOCK_HAS_ASYNC
+    (void) pkt_buff;
+    (void) pkt_size;
+
+    /*
+     * This behavior is different from the Handshake.
+     * Not event_timeout is settled here.
+     */
+
+    _async_session = dtls_session;  /* FIXME: Mutex here? */
+    _async_recv_watchdog = 1;       /* We are to use it as boolean now */
+
+    DEBUG("%s: Starting NON-blocking Listening for DTLS records!\n", __func__);
+    while (_async_recv_watchdog > 0) {
+        event_t *event = event_get(dtls_session->sock_event_queue);
+        if (event) {
+            event->handler(event);
+        }
+        xtimer_usleep(200); /* FIXME: Magic number for now */
+    }
+    DEBUG("%s: Stoping NON-blocking Listening for DTLS records!\n", __func__);
+    return 0;
+
+#else /* SOCK_HAS_ASYNC */
+    /* NOTE: This should be OK for sock or socket */
+    DEBUG("%s: Starting blocking Listening for DTLS records!\n", __func__);
+
+    dtls_session->is_data_app = false;
+    /* Extract any type of DTLS record until finding the first Data App */
+    do {
+        ssize_t res = _tinydtls_handle_read(dtls_session, pkt_buff, pkt_size);
+        if (res == TINYDTLS_HANDSHAKE_RESTART_SVP) {
+            return TLSMAN_ERROR_REMOTE_RESET;
+        }
+        else if (res == TINYDTLS_HANDSHAKE_NON_RECORD) {
+            DEBUG("%s: Not more DTLS records avaiable in the buffer\n", __func__);
+            return 0;
+        }
+    } while (!dtls_session->is_data_app);
+
+    return 0;
+#endif /* SOCK_HAS_ASYNC */
+}
+
+ssize_t _tinydtls_handshake(tinydtls_session_t *session,
+                            uint8_t *pkt_buff, size_t pkt_size, uint8_t flags)
+{
+
+#ifdef WITH_RIOT_GNRC
+
+    if (flags && 0x10 == TLSMAN_FLAG_NONBLOCKING) {
+        DEBUG("%s: Starting NON-blocking DTLS handshake!\n", __func__);
+#ifdef SOCK_HAS_ASYNC
+        (void) pkt_buff;
+        (void) pkt_size;
+        /* Set the timer event */
+        _async_session = session; /* FIXME: Mutex here? */
+        _async_recv_watchdog = TLSMAN_HANDSHAKE_MAX_TRY;
+        _async_rcv_pkt = false;
+
+        event_timeout_set(&kill_handshake_timeout, TINYDTLS_HDSK_TIMEOUT);
+
+        while ((session->is_connected != TINYDTLS_EVENT_FINISHED) &&
+               (_async_recv_watchdog > 0)) {
+            /*
+             * We are using kill_handshake_timeout to be able to advance in
+             * the event queue. It's possible to ignore kill_handshake_timeout()
+             * however, we need to give enough time for the other side to send
+             * a DTLS record.
+             *
+             * The current configuration let's to await for the timeout at the
+             * same time that we can answer very fast at any UDP packet received
+             *
+             * NOTE: event_get() is non-blocking. However, _async_tinydtls_handle_read()
+             *       its blocking (sock_udp_recv() set to SOCK_NO_TIMEOUT).
+             */
+            event_t *event = event_get(session->sock_event_queue);
+            if (event) {
+                event->handler(event);
+            }
+
+            if (session->is_connected == TINYDTLS_EVENTS_ZERO) {
+                event_timeout_clear(&kill_handshake_timeout); /* Reset the timer */
+                dtls_connect(session->context, &session->dst);
+                event_timeout_set(&kill_handshake_timeout, TINYDTLS_HDSK_TIMEOUT);
+            }
+            xtimer_usleep(200);  /* FIXME: Magic number for now */
+        }
+
+        DEBUG("%s:NON-blocking DTLS handshake finished!\n", __func__);
+
+        /* TODO: Disable temporary the events queue? */
+        event_timeout_clear(&kill_handshake_timeout);
+        event_cancel(session->sock_event_queue, &kill_handshake_event);
+
+        if (session->is_connected != TINYDTLS_EVENT_FINISHED) {
+            return TLSMAN_ERROR_HANDSHAKE_TIMEOUT;
+        }
+
+#else   /* SOCK_HAS_ASYNC */
+        /* TODO DISCUSSION: Throw error instead of this? */
+        puts("WARNING: Non event module! behavior is synncrhonous!");
+#endif  /* SOCK_HAS_ASYNC */
+    }
+
+#ifndef SOCK_HAS_ASYNC
+    DEBUG("%s: Starting blocking DTLS handshake!\n", __func__);
+
+    uint8_t watchdog = TLSMAN_HANDSHAKE_MAX_TRY;
+
+    while ((session->is_connected != TINYDTLS_EVENT_FINISHED) &&
+           (watchdog > 0U)) {
+
+        ssize_t res = _tinydtls_handle_read(session, pkt_buff, pkt_size);
+
+        /* NOTE: There is an implicit sleep() function here */
+        if (res == TINYDTLS_HANDSHAKE_NEW_RECORD) {
+            watchdog++; /* NOTE: Maybe too much? */
+        }
+        else if (res == TINYDTLS_HANDSHAKE_RESTART_SVP) {
+            watchdog = 1U;
+            /* TODO: New handshake error for tlsman? */
+        }
+
+        if (session->is_connected == TINYDTLS_EVENTS_ZERO) {
+            /* NOTE: Sometimes tinydtls don't send the first msg */
+            DEBUG("%s: Sending a new DTLS Client Hello\n", __func__);
+            dtls_connect(session->context, &session->dst);
+        }
+
+        if ((--watchdog == 0U) || (res == TINYDTLS_HANDSHAKE_IS_FATAL)) {
+            DEBUG("%s: DTLS handhsake timeout!\n", __func__);
+            return TLSMAN_ERROR_HANDSHAKE_TIMEOUT;
+        }
+
+        xtimer_usleep(500);
+    }
+#endif  /* !SOCK_HAS_ASYNC */
+#endif  /* WITH_RIOT_GNRC */
+
+#ifdef WITH_RIOT_SOCKETS
+#warning "Not tested yet"
+#endif /* WITH_RIOT_SOCKETS */
+
+    return 0;
+
+}
+
+ssize_t tlsman_tinydtls_renegotiate(tinydtls_session_t *session,
+                                    uint8_t *pkt_buff, size_t pkt_size,
+                                    uint8_t flags)
+{
+
+    if (dtls_renegotiate(session->context, &session->dst) < 0) {
+        DEBUG("%s: DTLS renegotiate failed!\n", __func__);
+        return -1;
+    }
+
+    /* This is very similar to the first connect, but the context is ready */
+    session->is_connected = TINYDTLS_EVENTS_ZERO;
+    return _tinydtls_handshake(session, pkt_buff, pkt_size, flags);
+}
+
+ssize_t tlsman_tinydtls_rehandshake(tinydtls_session_t *dtls_session,
+                                    uint8_t *pkt_buff, size_t pkt_size,
+                                    uint8_t flags)
+{
+
+    if (dtls_session->cache == NULL) {
+        /*
+         * NOTE: We cannot free the current context as it will notify
+         * the Server to close the connection (which we do not want).
+         */
+        dtls_session->cache = dtls_session->context;
+        dtls_session->is_connected = TINYDTLS_EVENTS_ZERO;
+
+        /* NOTE: Create a new context and attempt to initiate a handshake. */
+        dtls_session->context = dtls_new_context(dtls_session);
+        if (!dtls_session->context) {
+            dtls_emerg("cannot create context\n");
+            return TLSMAN_ERROR_UNABLE_CONTEXT;
+        }
+
+        dtls_set_handler(dtls_session->context, &_tinydtls_handler_cbs);
+        if (dtls_connect(dtls_session->context, &dtls_session->dst)) {
+            DEBUG("%s: Unable to send the first ClientHello!\n", __func__);
+            /* NOTE: _tinydtls_handshake will try to send it again */
+        }
+        return _tinydtls_handshake(dtls_session, pkt_buff, pkt_size, flags);
+
+    }
+
+    return TLSMAN_ERROR_UNABLE_CONTEXT; /* TODO: New error type? */
+}
+
+ssize_t tlsman_tinydtls_connect(tinydtls_session_t *dtls_session,
+                                uint8_t *pkt_buff, size_t pkt_size,
+                                uint8_t flags)
+{
+
+    /* NOTE: Irrelevant if socks or sockets */
+    if (dtls_session->is_connected == TINYDTLS_EVENT_RENEGOTIATE) {
+        /* TODO FIXME: Do we need to do something to our current peer? */
+    }
+    if (dtls_connect(dtls_session->context, &dtls_session->dst) < 0) {
+        DEBUG("ERROR: Unable to start a DTLS channel!\n");
+        return TLSMAN_ERROR_FATAL;
+    }
+
+    return _tinydtls_handshake(dtls_session, pkt_buff, pkt_size, flags);
+}
+
+void tlsman_tinydtls_free_context(tinydtls_session_t *dtls_session)
+{
+
+    dtls_free_context(dtls_session->context);
+    dtls_free_context(dtls_session->cache);
+    dtls_session->is_connected = TINYDTLS_EVENTS_ZERO;
+
+#ifdef SOCK_HAS_ASYNC
+    event_timeout_clear(&kill_handshake_timeout);
+    event_timeout_clear(&stop_listening_timeout);
+    event_timeout_clear(&kill_handshake_timeout);
+    event_timeout_clear(&stop_listening_timeout);
+    sock_udp_set_event_queue(dtls_session->sock, NULL, NULL);
+#endif /* SOCK_HAS_ASYNC */
+
+    DEBUG("%s: Resources released\n", __func__);
+}

--- a/sys/net/tlsman/tinydtls_sock.c
+++ b/sys/net/tlsman/tinydtls_sock.c
@@ -19,7 +19,7 @@
  */
 
 #include "net/tlsman.h"
-#include "net/tlsman/tinydtls.h"
+#include "net/tlsman/tinydtls_sock.h"
 #include "dtls.h"
 
 /* NOTE DISCUSSION: Should be in sys/include/tlsman or in the app directory? */
@@ -80,8 +80,10 @@ static dtls_handler_t _tinydtls_handler_cbs = {
 
 #ifdef SOCK_HAS_ASYNC
 
+/* Asynchronous events */
 static void _kill_handshake(event_t *event);
 static void _stop_listening(event_t *event);
+static void _async_tinydtls_handle_read(event_t *arg);
 
 static event_t kill_handshake_event = { .handler = _kill_handshake };
 static event_t stop_listening_event = { .handler = _stop_listening };
@@ -89,21 +91,23 @@ static event_timeout_t kill_handshake_timeout;
 static event_timeout_t stop_listening_timeout;
 
 static uint8_t _async_recv_watchdog;    /* Counter for disabling the listening mode */
-static bool _async_rcv_pkt;             /** Flag to determine if a packet was recveided */
+static bool _async_rcv_pkt;             /** Flag to determine if a packet was received */
 
 /* NOTE: Global pointers required for current limitations of event.h */
-/* NOTE DISCUSSION: This approach is adequate? can be replicated for tinyDTLS interanl buffers? */
+/* NOTE DISCUSSION: This approach is adequate? can be replicated for tinyDTLS internal buffers? */
 static ssize_t _tinydtls_packet_received_size;
 static uint8_t *_tinydtls_packet_received;
 static tinydtls_session_t *_async_session;
 
 /*
  * This event permits to advance on event_get() and terminate it if necessary
+ *  to terminate the asynchronous listening status for the handshake.
  */
 static void _kill_handshake(event_t *event)
 {
     (void) event;
 
+    /* TODO DISCUSSION Risk of race condition? */
     _async_rcv_pkt ? ++_async_recv_watchdog : --_async_recv_watchdog;
     _async_rcv_pkt = false;
 
@@ -117,6 +121,9 @@ static void _kill_handshake(event_t *event)
     }
 }
 
+/*
+ * Disable the listening mode
+ */
 static void _stop_listening(event_t *event)
 {
 
@@ -126,7 +133,7 @@ static void _stop_listening(event_t *event)
 }
 
 /**
- * This is the generic evnt for retrieving sock messages.
+ * This is the generic event for retrieving sock messages.
  * There are two m
  */
 static void _async_tinydtls_handle_read(event_t *arg)
@@ -185,34 +192,37 @@ static void _async_tinydtls_handle_read(event_t *arg)
     }
 }
 
-void tlsman_tinydtls_set_async_parameters(tinydtls_session_t *dtls_session,
-                                          event_queue_t *sock_event_queue,
-                                          uint8_t *buffer, ssize_t size)
+void set_async_listening(void)
 {
-    dtls_session->sock_event_queue = sock_event_queue;
+    DEBUG("%s: Launching timer event\n", __func__);
+    event_timeout_set(&stop_listening_timeout, TINYDTLS_HDSK_TIMEOUT);
+}
+
+void set_async_parameters(tlsman_session_t *session,
+                          event_queue_t *sock_event_queue,
+                          uint8_t *buffer, ssize_t size)
+{
+
+    DEBUG("%s: Linking buffer %p (size %u) to sock\n", __func__, buffer, size);
+
+    session->sock_event_queue = sock_event_queue;
 
     _tinydtls_packet_received = buffer;
     _tinydtls_packet_received_size = size;
 
-    event_queue_init(dtls_session->sock_event_queue);
-    /* FIXME: Here or in the hadnshake? */
-    event_timeout_init(&kill_handshake_timeout, dtls_session->sock_event_queue,
+    event_queue_init(session->sock_event_queue);
+    /* FIXME: Here or in the handshake? */
+    event_timeout_init(&kill_handshake_timeout, session->sock_event_queue,
                        &kill_handshake_event);
-    event_timeout_init(&stop_listening_timeout, dtls_session->sock_event_queue,
+    event_timeout_init(&stop_listening_timeout, session->sock_event_queue,
                        &stop_listening_event);
 
-    sock_udp_set_event_queue(dtls_session->sock,
-                             dtls_session->sock_event_queue,
+    sock_udp_set_event_queue(session->sock,
+                             session->sock_event_queue,
                              _async_tinydtls_handle_read);
 
-    DEBUG("(%s)> gnrc_sock_async set!\n", __func__);
+    DEBUG("%s: gnrc_sock_async set!\n", __func__);
 
-}
-
-void tlsman_tinydtls_set_listening_timeout(void)
-{
-
-    event_timeout_set(&stop_listening_timeout, TINYDTLS_HDSK_TIMEOUT);
 }
 
 #endif /* SOCK_HAS_ASYNC */
@@ -374,6 +384,7 @@ ssize_t _tinydtls_handle_read(tinydtls_session_t *tinydtls_session,
 
     if (pckt_rcvd_size <= 0) {
         DEBUG("%s: sock_udp_recv error code: %i\n", __func__, pckt_rcvd_size);
+
         return TINYDTLS_HANDSHAKE_NON_RECORD;
     }
 
@@ -418,19 +429,30 @@ ssize_t _tinydtls_handle_read(tinydtls_session_t *tinydtls_session,
     return TINYDTLS_HANDSHAKE_NEW_RECORD;
 }
 
-bool is_cipher_tinydtls(int cipher)
+/*
+ * @brief Determine if the list of cipher suites is valid
+ *
+ * The only two cipher suites supported by tinyDTLS are selected at compilation
+ * time. This only verifies if said cipher suites are present in the compiled
+ * code and at least one of them matches the cipher suite listed.
+ *
+ * @param[in] cipher    Cipher suite to check
+ *
+ * @return true if cipher suite is supported
+ */
+bool _is_cipher_tinydtls(uint16_t cipher)
 {
 
 #if defined(DTLS_PSK)
     if (cipher == TLS_PSK_WITH_AES_128_CCM_8) {
-        DEBUG("DTLS_PSK ciphersuite Detected\n");
+        DEBUG("DTLS_PSK cipher suite Detected\n");
         return true;
     }
 #endif
 
 #if defined(DTLS_ECC)
     if (cipher == TLS_ECDHE_ECDSA_WITH_AES_128_CCM_8) {
-        DEBUG("DTLS_ECC ciphersuite Detected\n");
+        DEBUG("DTLS_ECC cipher suite Detected\n");
         return true;
     }
 #endif
@@ -472,7 +494,7 @@ static int _send_to_peer(struct dtls_context_t *ctx,
 }
 
 /**
- * @brief Reception of a DTLS Applicaiton data record.
+ * @brief Reception of a DTLS Application data record.
  */
 static int _read_from_peer(struct dtls_context_t *ctx,
                            session_t *session,
@@ -491,7 +513,7 @@ static int _read_from_peer(struct dtls_context_t *ctx,
     for (i = 0; i < len; i++) {
         printf("%2X ", data[i]);
     }
-    printf(" -- (Total: %i bytes)\n", len );
+    printf(" -- (Total: %zu bytes)\n", len );
     if (!user_session->resp_handler) {
         printf("%s: No callback was provided by the user!\n", __func__);
     }
@@ -499,13 +521,8 @@ static int _read_from_peer(struct dtls_context_t *ctx,
 
     if (user_session->resp_handler) {
         DEBUG("%s: Launching callback...\n", __func__);
-#ifdef WITH_RIOT_GNRC
         (*user_session->resp_handler)((uint8_t *)data, len, (void *) user_session->sock);
-#endif  /* WITH_RIOT_GNRC */
 
-#ifdef WITH_RIOT_SOCKETS
-#warning "Not supported yet"
-#endif  /* WITH_RIOT_SOCKETS */
     }
 
     return TLSMAN_ERROR_SUCCESS;
@@ -553,80 +570,10 @@ static int _client_events(struct dtls_context_t *ctx,
     return TLSMAN_ERROR_SUCCESS;
 }
 
-ssize_t tlsman_tinydtls_init_context(tinydtls_session_t *dtls_session,
-                                     tlsman_resp_handler_t resp_cb,
-                                     const uint8_t flags)
-{
 
-    dtls_session->context = NULL;
-    session_t *dst = &dtls_session->dst;
-    sock_udp_ep_t *remote = dtls_session->remote;
-
-    /* FIXME: Risk of race condition? */
-    dtls_session->is_connected = TINYDTLS_EVENTS_ZERO;
-
-    dtls_set_log_level(TINYDTLS_LOG_LVL);
-
-#ifdef WITH_RIOT_GNRC
-
-    DEBUG("%s: Linking DTLS session to UDP sock\n", __func__);
-
-    dtls_session->dst.size = sizeof(uint8_t) * 16 + sizeof(unsigned short);
-    dtls_session->dst.port = dtls_session->remote->port;
-
-    /* NOTE: Parsing iface for the remote */
-    if (gnrc_netif_numof() == 1) {
-        /* assign the single interface found in gnrc_netif_numof() */
-        dtls_session->dst.ifindex = (uint16_t)gnrc_netif_iter(NULL)->pid;
-        dtls_session->remote->netif = (uint16_t)gnrc_netif_iter(NULL)->pid;
-    }
-    else {
-        /* FIXME This probably is not valid with multiple interfaces */
-        dtls_session->dst.ifindex = dtls_session->remote->netif;
-    }
-
-    /* NOTE: remote.addr and dst->addr are different structures. */
-    if (memcpy(&dst->addr, &remote->addr.ipv6, 16) == NULL) {
-        DEBUG("ERROR: memcpy failed!");
-        return -1;
-    }
-
-    dtls_session->resp_handler = resp_cb;
-    dtls_session->context = dtls_new_context(dtls_session);
-
-    if (flags & TLSMAN_FLAG_SIDE_SERVER) {
-        _tinydtls_handler_cbs.event = NULL; /* FIXME REMOVE(?) */
-#ifdef DTLS_PSK
-        _tinydtls_handler_cbs.get_psk_info = _server_get_psk_info;
-#endif  /* DTLS_PSK */
-    }
-    else {
-        _tinydtls_handler_cbs.event = _client_events;
-#ifdef DTLS_PSK
-        _tinydtls_handler_cbs.get_psk_info = _get_psk_info;
-#endif  /* DTLS_PSK */
-    }
-
-    if (dtls_session->context) {
-        dtls_set_handler(dtls_session->context, &_tinydtls_handler_cbs);
-        return 0;
-    }
-
-    return TLSMAN_ERROR_UNABLE_CONTEXT;
-
-#endif /* WITH_RIOT_GNRC */
-
-#ifdef WITH_RIOT_SOCKETS
-#warning "tinyDTLS with sockets not tested yet"
-
-#endif /* WITH_RIOT_SOCKETS */
-
-    return TLSMAN_ERROR_FATAL;
-}
-
-ssize_t tlsman_tinydtls_send(tinydtls_session_t *dtls_session,
-                             uint8_t *data, size_t data_size,
-                             uint8_t flags)
+ssize_t _tinydtls_send(tlsman_session_t *dtls_session,
+                       uint8_t *data, size_t data_size,
+                       uint8_t flags)
 {
     ssize_t len = data_size;
 
@@ -635,10 +582,10 @@ ssize_t tlsman_tinydtls_send(tinydtls_session_t *dtls_session,
     (void) flags;
 
     while (len > 0) {
-        DEBUG("%s: Sending %zu bytes...\n", __func__, len);
+        /* DEBUG("%s: Sending %zu bytes...\n", __func__, len); */
         ssize_t res = dtls_write(dtls_session->context, &dtls_session->dst, (uint8 *)data, len);
         if (res >= 0) {
-            /* DISCUSSION: This is appropiate? */
+            /* DISCUSSION: This is appropriate? */
             memmove(data, data + res, len - res);
             len -= res;
 
@@ -655,85 +602,9 @@ ssize_t tlsman_tinydtls_send(tinydtls_session_t *dtls_session,
     return 0;
 }
 
-ssize_t tlsman_tinydtls_listening(tinydtls_session_t *dtls_session,
-                                  void *pkt_buff,
-                                  size_t pkt_size)
-{
-
-    /*
-     * This intented to handle handshake and reception of real data
-     * WITHOUT timeouts (and server side)
-     */
-    /* TODO Be able to kill it */
-    /* TODO Handle errors */
-
-#ifdef  SOCK_HAS_ASYNC
-    (void) pkt_buff;
-    (void) pkt_size;
-    DEBUG("%s: Starting (Async) listening for DTLS records!\n", __func__);
-    _async_session = dtls_session;  /* FIXME: Mutex here? */
-    _async_recv_watchdog = 1;       /* We are to use it as boolean now */
-
-    while (_async_recv_watchdog > 0) {
-        event_t *event = event_get(dtls_session->sock_event_queue);
-        if (event) {
-            event->handler(event);
-        }
-        xtimer_usleep(200); /* FIXME: Magic number for now */
-    }
-    DEBUG("%s: Stopping (Async) listening for DTLS records!\n", __func__);
-
-#else /* SOCK_HAS_ASYNC */
-
-    ssize_t pckt_rcvd_size;
-    session_t *peer = &dtls_session->dst;
-    static sock_udp_ep_t remote = { .family = AF_INET6 };
-
-    /* NOTE FIXME Blocking? one second?  */
-    pckt_rcvd_size = sock_udp_recv(dtls_session->sock, pkt_buff, pkt_size,
-                                   0, &remote);
-
-    if (pckt_rcvd_size <= 0) {
-        if ((pckt_rcvd_size != -ETIMEDOUT)
-            && ((pckt_rcvd_size != -EAGAIN))
-            && ENABLE_DEBUG) {
-            DEBUG("%s: sock_udp_recv error code is %i\n", __func__, pckt_rcvd_size);
-        }
-        return 0;
-    }
-
-    /* We need to update the remote (and the session) */
-    dtls_session->remote = &remote;
-
-    /* Equivalent to  _tinydtls_handle_read() */
-    peer->size = sizeof(uint8_t) * 16 + sizeof(unsigned short);
-    peer->port = remote.port;
-
-    /* TESTING : Override behavior for the server? */
-    peer->ifindex = SOCK_ADDR_ANY_NETIF;
-
-    if (memcpy(&peer->addr, remote.addr.ipv6, 16) == NULL) {
-        DEBUG("ERROR: memcpy failed!");
-        return TINYDTLS_HANDSHAKE_NON_RECORD;
-    }
-
-    if (ENABLE_DEBUG) {
-        DEBUG("(%s): Msg received from [", __func__);
-        ipv6_addr_print(&peer->addr);
-        DEBUG("]:%u (netif: %i)\n", peer->port, peer->ifindex);
-    }
-
-    /* Server dont care about the result */
-    dtls_handle_message(dtls_session->context, peer, pkt_buff, (int) pckt_rcvd_size);
-
-#endif
-
-    return 0;
-}
-
-size_t tlsman_tintdytls_rcv(tinydtls_session_t *dtls_session,
-                            void *pkt_buff,
-                            size_t pkt_size)
+size_t _tintdytls_rcv(tinydtls_session_t *dtls_session,
+                      void *pkt_buff,
+                      size_t pkt_size)
 {
     /* TODO: Handle the flag argument? */
 
@@ -757,7 +628,8 @@ size_t tlsman_tintdytls_rcv(tinydtls_session_t *dtls_session,
         }
         xtimer_usleep(200); /* FIXME: Magic number for now */
     }
-    DEBUG("%s: Stoping NON-blocking Listening for DTLS records!\n", __func__);
+    event_timeout_clear(&stop_listening_timeout);
+    DEBUG("%s: Stopping NON-blocking Listening for DTLS records!\n", __func__);
     return 0;
 
 #else /* SOCK_HAS_ASYNC */
@@ -772,7 +644,7 @@ size_t tlsman_tintdytls_rcv(tinydtls_session_t *dtls_session,
             return TLSMAN_ERROR_REMOTE_RESET;
         }
         else if (res == TINYDTLS_HANDSHAKE_NON_RECORD) {
-            DEBUG("%s: Not more DTLS records avaiable in the buffer\n", __func__);
+            DEBUG("%s: Not more DTLS records available in the buffer\n", __func__);
             return 0;
         }
     } while (!dtls_session->is_data_app);
@@ -784,10 +656,7 @@ size_t tlsman_tintdytls_rcv(tinydtls_session_t *dtls_session,
 ssize_t _tinydtls_handshake(tinydtls_session_t *session,
                             uint8_t *pkt_buff, size_t pkt_size, uint8_t flags)
 {
-
-#ifdef WITH_RIOT_GNRC
-
-    if (flags && 0x10 == TLSMAN_FLAG_NONBLOCKING) {
+    if (flags & TLSMAN_FLAG_NONBLOCKING) {
         DEBUG("%s: Starting NON-blocking DTLS handshake!\n", __func__);
 #ifdef SOCK_HAS_ASYNC
         (void) pkt_buff;
@@ -811,7 +680,7 @@ ssize_t _tinydtls_handshake(tinydtls_session_t *session,
              * same time that we can answer very fast at any UDP packet received
              *
              * NOTE: event_get() is non-blocking. However, _async_tinydtls_handle_read()
-             *       its blocking (sock_udp_recv() set to SOCK_NO_TIMEOUT).
+             *       it's blocking (sock_udp_recv() set to SOCK_NO_TIMEOUT).
              */
             event_t *event = event_get(session->sock_event_queue);
             if (event) {
@@ -819,11 +688,12 @@ ssize_t _tinydtls_handshake(tinydtls_session_t *session,
             }
 
             if (session->is_connected == TINYDTLS_EVENTS_ZERO) {
+                DEBUG("%s: session->is_connected is TINYDTLS_EVENTS_ZERO!\n", __func__);
                 event_timeout_clear(&kill_handshake_timeout); /* Reset the timer */
                 dtls_connect(session->context, &session->dst);
                 event_timeout_set(&kill_handshake_timeout, TINYDTLS_HDSK_TIMEOUT);
             }
-            xtimer_usleep(200);  /* FIXME: Magic number for now */
+            xtimer_usleep(500);  /* FIXME: Magic number for now */
         }
 
         DEBUG("%s:NON-blocking DTLS handshake finished!\n", __func__);
@@ -838,7 +708,7 @@ ssize_t _tinydtls_handshake(tinydtls_session_t *session,
 
 #else   /* SOCK_HAS_ASYNC */
         /* TODO DISCUSSION: Throw error instead of this? */
-        puts("WARNING: Non event module! behavior is synncrhonous!");
+        puts("WARNING: module gnrc_sock_async not enabled. Behavior is synchronous!");
 #endif  /* SOCK_HAS_ASYNC */
     }
 
@@ -868,26 +738,20 @@ ssize_t _tinydtls_handshake(tinydtls_session_t *session,
         }
 
         if ((--watchdog == 0U) || (res == TINYDTLS_HANDSHAKE_IS_FATAL)) {
-            DEBUG("%s: DTLS handhsake timeout!\n", __func__);
+            DEBUG("%s: DTLS handshake timeout!\n", __func__);
             return TLSMAN_ERROR_HANDSHAKE_TIMEOUT;
         }
 
         xtimer_usleep(500);
     }
 #endif  /* !SOCK_HAS_ASYNC */
-#endif  /* WITH_RIOT_GNRC */
-
-#ifdef WITH_RIOT_SOCKETS
-#warning "Not tested yet"
-#endif /* WITH_RIOT_SOCKETS */
 
     return 0;
-
 }
 
-ssize_t tlsman_tinydtls_renegotiate(tinydtls_session_t *session,
-                                    uint8_t *pkt_buff, size_t pkt_size,
-                                    uint8_t flags)
+ssize_t _tinydtls_renegotiate(tinydtls_session_t *session,
+                              uint8_t *pkt_buff, size_t pkt_size,
+                              uint8_t flags)
 {
 
     if (dtls_renegotiate(session->context, &session->dst) < 0) {
@@ -900,9 +764,9 @@ ssize_t tlsman_tinydtls_renegotiate(tinydtls_session_t *session,
     return _tinydtls_handshake(session, pkt_buff, pkt_size, flags);
 }
 
-ssize_t tlsman_tinydtls_rehandshake(tinydtls_session_t *dtls_session,
-                                    uint8_t *pkt_buff, size_t pkt_size,
-                                    uint8_t flags)
+ssize_t _tinydtls_rehandshake(tinydtls_session_t *dtls_session,
+                              uint8_t *pkt_buff, size_t pkt_size,
+                              uint8_t flags)
 {
 
     if (dtls_session->cache == NULL) {
@@ -932,37 +796,313 @@ ssize_t tlsman_tinydtls_rehandshake(tinydtls_session_t *dtls_session,
     return TLSMAN_ERROR_UNABLE_CONTEXT; /* TODO: New error type? */
 }
 
-ssize_t tlsman_tinydtls_connect(tinydtls_session_t *dtls_session,
-                                uint8_t *pkt_buff, size_t pkt_size,
-                                uint8_t flags)
+ssize_t load_stack(uint16_t *ciphersuites_list, size_t total, uint8_t flags)
 {
+    bool match = false;
 
+    if (!(flags & TLSMAN_FLAG_STACK_DTLS)) {
+        DEBUG("%s: TinyDTLS only support UDP!\n", __func__);
+        return TLSMAN_ERROR_TRANSPORT_NOT_SUPPORTED;
+    }
+
+    /* NOTE: tinyDTLS can only select cipher suites at the compilation time */
+    size_t aux;
+    for (aux = 0; aux <  total; aux++) {
+        if (_is_cipher_tinydtls(ciphersuites_list[aux])) {
+            match = true;
+            break;
+        }
+    }
+
+    if (!match) {
+        DEBUG("%s: TinyDTLS Cipher suite not supported!\n", __func__);
+        return TLSMAN_ERROR_CIPHER_NOT_SUPPORTED;
+    }
+
+    dtls_init(); /*TinyDTLS mandatory starting settings*/
+
+#ifdef TINYDTLS_LOG_LVL
+    dtls_set_log_level(TINYDTLS_LOG_LVL);
+#endif
+
+    return 0;
+}
+
+
+ssize_t init_context(tlsman_session_t *session, tlsman_resp_handler_t resp_cb,
+                     const uint8_t flags)
+{
+    /*
+     * FIXME DISCUSSION: A more elegant solution need to be used!
+     *
+     * We are dereferencing a structure which the first time should be
+     * pointing to null.
+     *
+     * This also will change if tinydtls_session_t is modified.
+     * Including compilation with PSK or ECC
+     *
+     */
+    /*
+       if ((session->tinydtls_context.context != (void *)0x1) &&
+        (session->tinydtls_context.context != NULL)){
+        DEBUG("tinyDTLS: DTLS context already exist!\n");
+        return 0;
+       }
+     */
+
+    assert(session);
+    /* assert(session->local); */
+    assert(session->remote);
+    assert(session->sock);
+    DEBUG("tinyDTLS: Creating context (sock)\n");
+
+    session->context = NULL;
+    session_t *dst = &session->dst;
+    sock_udp_ep_t *remote = session->remote;
+
+    /* FIXME: Risk of race condition? */
+    session->last_known_error = TLSMAN_ERROR_NON_STARTED;
+    session->is_connected = TINYDTLS_EVENTS_ZERO;
+
+    DEBUG("%s: Linking DTLS session to UDP sock\n", __func__);
+
+    session->dst.size = sizeof(uint8_t) * 16 + sizeof(unsigned short);
+    session->dst.port = session->remote->port;
+
+    /* NOTE: Parsing iface for the remote */
+    if (gnrc_netif_numof() == 1) {
+        /* assign the single interface found in gnrc_netif_numof() */
+        session->dst.ifindex = (uint16_t)gnrc_netif_iter(NULL)->pid;
+        session->remote->netif = (uint16_t)gnrc_netif_iter(NULL)->pid;
+    }
+    else {
+        /* FIXME This probably is not valid with multiple interfaces */
+        session->dst.ifindex = session->remote->netif;
+    }
+
+    /* NOTE: remote.addr and dst->addr are different structures. */
+    if (memcpy(&dst->addr, &remote->addr.ipv6, 16) == NULL) {
+        DEBUG("ERROR: memcpy failed!");
+        return -1;
+    }
+
+    session->resp_handler = resp_cb;
+    session->context = dtls_new_context(session);
+
+    if (flags & TLSMAN_FLAG_SIDE_SERVER) {
+        _tinydtls_handler_cbs.event = NULL; /* FIXME REMOVE(?) */
+#ifdef DTLS_PSK
+        _tinydtls_handler_cbs.get_psk_info = _server_get_psk_info;
+#endif  /* DTLS_PSK */
+    }
+    else {
+        _tinydtls_handler_cbs.event = _client_events;
+#ifdef DTLS_PSK
+        _tinydtls_handler_cbs.get_psk_info = _get_psk_info;
+#endif  /* DTLS_PSK */
+    }
+
+    if (session->context) {
+        dtls_set_handler(session->context, &_tinydtls_handler_cbs);
+        return 0;
+    }
+
+    session->last_known_error = TLSMAN_ERROR_UNABLE_CONTEXT;
+    return TLSMAN_ERROR_UNABLE_CONTEXT;
+}
+
+ssize_t connect(tlsman_session_t *session, uint8_t flags,
+                uint8_t *pkt_buff, size_t pkt_size)
+{
     /* NOTE: Irrelevant if socks or sockets */
-    if (dtls_session->is_connected == TINYDTLS_EVENT_RENEGOTIATE) {
+    if (session->is_connected == TINYDTLS_EVENT_RENEGOTIATE) {
         /* TODO FIXME: Do we need to do something to our current peer? */
     }
-    if (dtls_connect(dtls_session->context, &dtls_session->dst) < 0) {
+    if (dtls_connect(session->context, &session->dst) < 0) {
         DEBUG("ERROR: Unable to start a DTLS channel!\n");
         return TLSMAN_ERROR_FATAL;
     }
 
-    return _tinydtls_handshake(dtls_session, pkt_buff, pkt_size, flags);
+    ssize_t res =  _tinydtls_handshake(session, pkt_buff, pkt_size, flags);
+    session->last_known_error = res;
+    return res;
 }
 
-void tlsman_tinydtls_free_context(tinydtls_session_t *dtls_session)
+bool is_channel_ready(tlsman_session_t *session)
 {
 
-    dtls_free_context(dtls_session->context);
-    dtls_free_context(dtls_session->cache);
-    dtls_session->is_connected = TINYDTLS_EVENTS_ZERO;
+    if (session->is_connected == TINYDTLS_EVENT_FINISHED) {
+        return true;
+    }
+
+    return false;
+}
+
+
+ssize_t send_data_app(tlsman_session_t *session, const void *data, size_t len)
+{
+
+    DEBUG("%s: Starting to send upper layer data (Size: %zu)\n", __func__, len);
+
+    ssize_t res;
+
+    /* TODO DISCUSSION: UDP fragmentation handled here or by the client? */
+    res = _tinydtls_send(session, (uint8 *) data, len, 0);
+
+    session->last_known_error = res;
+
+    return res;
+}
+
+ssize_t retrieve_data_app(tlsman_session_t *session, void *pkt_buff, size_t max_len)
+{
+    /* DEBUG("%s: checking if there is (D)TLS Data Application data\n", __func__); */
+
+    ssize_t res = _tintdytls_rcv(session, pkt_buff, max_len);
+
+    session->last_known_error = res;
+
+    return res;
+}
+
+void release_resources(tlsman_session_t *session)
+{
+
+    dtls_free_context(session->context);
+    dtls_free_context(session->cache);
+    session->is_connected = TINYDTLS_EVENTS_ZERO;
 
 #ifdef SOCK_HAS_ASYNC
     event_timeout_clear(&kill_handshake_timeout);
     event_timeout_clear(&stop_listening_timeout);
-    event_timeout_clear(&kill_handshake_timeout);
-    event_timeout_clear(&stop_listening_timeout);
-    sock_udp_set_event_queue(dtls_session->sock, NULL, NULL);
+    sock_udp_set_event_queue(session->sock, NULL, NULL);
 #endif /* SOCK_HAS_ASYNC */
 
     DEBUG("%s: Resources released\n", __func__);
+}
+
+ssize_t close_channel(tlsman_session_t *session)
+{
+    if (dtls_close(session->context, &session->dst) < 0) {
+        DEBUG("ERROR: Unable to close DTLS channel!\n");
+        session->last_known_error = TLSMAN_ERROR_UNABLE_CLOSE;
+        return TLSMAN_ERROR_UNABLE_CLOSE;
+    }
+
+    /* NOTE DISCUSSION: This state is correct? or should be TINYDTLS_EVENTS_ZERO?  */
+    session->is_connected = TINYDTLS_EVENT_RENEGOTIATE;
+
+    session->last_known_error = 0;
+    return 0;
+}
+
+
+ssize_t renegotiate(tlsman_session_t *session, uint8_t flags,
+                    uint8_t *pkt_buff, size_t pkt_size)
+{
+
+    ssize_t res;
+
+    res = _tinydtls_renegotiate(session, pkt_buff, pkt_size, flags);
+    if (res < 0) {
+        DEBUG("%s: DTLS renegotiation failed!\n", __func__);
+        session->last_known_error = TLSMAN_ERROR_SESSION_REN;
+        return TLSMAN_ERROR_SESSION_REN;
+    }
+    session->last_known_error = 0;
+    return 0;
+}
+
+ssize_t rehandshake(tlsman_session_t *session, uint8_t flags,
+                    uint8_t *pkt_buff, size_t pkt_size)
+{
+    ssize_t res = _tinydtls_rehandshake(session, pkt_buff, pkt_size, flags);
+
+    if (res < 0) {
+        DEBUG("%s: DTLS attempt for a new handshake failed!\n", __func__);
+        session->last_known_error = TLSMAN_ERROR_SESSION_REN;
+        return TLSMAN_ERROR_SESSION_REN;
+    }
+
+    session->last_known_error = 0;
+
+    return 0;
+}
+
+ssize_t listening(tlsman_session_t *session, uint8_t flags,
+                  uint8_t *pkt_buff, size_t pkt_size)
+{
+
+    (void) flags; /* TODO */
+
+    /*
+     * This intended to handle handshake and reception of real data
+     * WITHOUT timeouts (and only for the server side)
+     */
+    /* TODO Be able to kill it */
+    /* TODO Handle errors */
+
+#ifdef  SOCK_HAS_ASYNC
+    (void) pkt_buff;
+    (void) pkt_size;
+    DEBUG("%s: Starting (Async) listening for DTLS records!\n", __func__);
+    _async_session = session;   /* FIXME: Mutex here? */
+    _async_recv_watchdog = 1;   /* We are to use it as boolean now */
+
+    while (_async_recv_watchdog > 0) {
+        event_t *event = event_get(session->sock_event_queue);
+        if (event) {
+            event->handler(event);
+        }
+        xtimer_usleep(200); /* FIXME: Magic number for now */
+    }
+    DEBUG("%s: Stopping (Async) listening for DTLS records!\n", __func__);
+
+#else /* SOCK_HAS_ASYNC */
+
+    ssize_t pckt_rcvd_size;
+    session_t *peer = &session->dst;
+    static sock_udp_ep_t remote = { .family = AF_INET6 };
+
+    /* NOTE FIXME Blocking? one second?  */
+    pckt_rcvd_size = sock_udp_recv(session->sock, pkt_buff, pkt_size,
+                                   0, &remote);
+    if (pckt_rcvd_size <= 0) {
+        if ((pckt_rcvd_size != -ETIMEDOUT)
+            && ((pckt_rcvd_size != -EAGAIN))
+            && ENABLE_DEBUG) {
+            DEBUG("%s: sock_udp_recv error code is %i\n", __func__, pckt_rcvd_size);
+            return 0;
+        }
+        return 1;
+    }
+
+    /* We need to update the remote (and the session) */
+    session->remote = &remote;
+
+    /* Equivalent to  _tinydtls_handle_read() */
+    peer->size = sizeof(uint8_t) * 16 + sizeof(unsigned short);
+    peer->port = remote.port;
+
+    /* TESTING : Override behavior for the server? */
+    peer->ifindex = SOCK_ADDR_ANY_NETIF;
+
+    if (memcpy(&peer->addr, remote.addr.ipv6, 16) == NULL) {
+        DEBUG("ERROR: memcpy failed!");
+        return TINYDTLS_HANDSHAKE_NON_RECORD;
+    }
+
+    if (ENABLE_DEBUG) {
+        DEBUG("(%s): Msg received from [", __func__);
+        ipv6_addr_print(&peer->addr);
+        DEBUG("]:%u (netif: %i)\n", peer->port, peer->ifindex);
+    }
+
+    /* Server don't care about the result */
+    dtls_handle_message(session->context, peer, pkt_buff, (int) pckt_rcvd_size);
+
+#endif
+
+    return 1;
+
 }

--- a/sys/net/tlsman/tlsman.c
+++ b/sys/net/tlsman/tlsman.c
@@ -20,79 +20,71 @@
 
 #include "net/tlsman.h"
 
-#ifdef MODULE_TLSMAN_TINYDTLS
-#include "net/tlsman/tinydtls.h"
-#endif
-
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
-/**
- *  @brieff Last known error message.
- */
-static ssize_t _tlsman_last_known_error = TLSMAN_ERROR_NON_STARTED;
+/* Defined in the net/tlsman/[a-z]*.h library */
+extern ssize_t load_stack(uint16_t *ciphersuites_list, size_t total, uint8_t flags);
+extern ssize_t init_context(tlsman_session_t *session, tlsman_resp_handler_t resp_cb,
+                            const uint8_t flags);
+extern ssize_t connect(tlsman_session_t *session, uint8_t flags,
+                       uint8_t *packet_buff, size_t packet_size);
 
-ssize_t tlsman_load_stack(int *ciphersuites_list, size_t total, uint8_t flags)
+extern bool is_channel_ready(tlsman_session_t *session);
+
+extern ssize_t send_data_app(tlsman_session_t *session, const void *data,
+                             size_t len);
+
+extern ssize_t retrieve_data_app(tlsman_session_t *session, void *data, size_t max_len);
+extern void release_resources(tlsman_session_t *dtls_session);
+extern ssize_t close_channel(tlsman_session_t *session);
+
+extern ssize_t renegotiate(tlsman_session_t *session, uint8_t flags,
+                           uint8_t *pkt_buff, size_t pkt_size);
+
+extern ssize_t rehandshake(tlsman_session_t *session, uint8_t flags,
+                           uint8_t *pkt_buff, size_t pkt_size);
+extern ssize_t listening(tlsman_session_t *session, uint8_t flags,
+                         uint8_t *pkt_buff, size_t pkt_size);
+
+#ifdef SOCK_HAS_ASYNC
+extern void set_async_parameters(tlsman_session_t *session,
+                                 event_queue_t *sock_event_queue,
+                                 uint8_t *buffer, ssize_t size);
+extern void set_async_listening(void);
+#endif /* SOCK_HAS_ASYNC */
+
+ssize_t tlsman_load_stack(tlsman_driver_t *session,
+                          uint16_t *ciphersuites_list, size_t total,
+                          uint8_t flags)
 {
 
-#ifdef MODULE_TLSMAN_TINYDTLS
+    session->tlsman_load_stack = load_stack;
+    session->tlsman_init_context = init_context;
+    session->tlsman_create_channel = connect;
+#ifdef SOCK_HAS_ASYNC
+    session->tlsman_set_async_parameters = set_async_parameters;
+    session->tlsman_set_async_listening = set_async_listening;
+#endif /* SOCK_HAS_ASYNC */
+    session->tlsman_is_channel_ready = is_channel_ready;
+    session->tlsman_send_data_app = send_data_app;
+    session->tlsman_retrieve_data_app = retrieve_data_app;
+    session->tlsman_release_resources = release_resources;
+    session->tlsman_close_channel = close_channel;
+    session->tlsman_listening = listening;
+    session->tlsman_renegotiate = renegotiate;
+    session->tlsman_rehandshake = rehandshake;
 
-    bool match = false;
-
-    if (!(flags & TLSMAN_FLAG_STACK_DTLS)) {
-        DEBUG("TinyDTLS only support UDP!\n");
-        _tlsman_last_known_error = TLSMAN_ERROR_TRANSPORT_NOT_SUPPORTED;
-        return _tlsman_last_known_error;
-    }
-    /* NOTE: tinyDTLS can only select cipher suites at the compilation time */
-    size_t aux;
-    for (aux = 0; aux <  total; aux++) {
-        if (is_cipher_tinydtls(ciphersuites_list[aux])) {
-            match = true;
-            break;
-        }
-    }
-
-    if (!match) {
-        DEBUG("TinyDTLS Cipher suite not supported!\n");
-        _tlsman_last_known_error = TLSMAN_ERROR_CIPHER_NOT_SUPPORTED;
-        return _tlsman_last_known_error;
-    }
-
-    dtls_init(); /*TinyDTLS mandatory starting settings*/
-
-#ifdef TINYDTLS_LOG_LVL
-    dtls_set_log_level(TINYDTLS_LOG_LVL);
-#endif
-
-    /* TODO Upgrade to avoid DTLS_PSK and DTLS_ECC */
-#ifdef DTLS_PSK
-    DEBUG("tinyDTLS compiled with PSK\n");
-#endif
-#ifdef DTLS_ECC
-    DEBUG("tinyDTLS compiled with ECC\n");
-#endif
-
-    return 0;
-
-#endif /* MODULE_TLSMAN_TINYDTLS */
-
-#if MODULE_TLSMAN_WOLFSSL
-
-    /* TODO */
-    _tlsman_last_known_error = TLSMAN_ERROR_FATAL;
-    return _tlsman_last_known_error;
-
-#endif
-
-    return 0;
-
+    /* Loads the (D)TLS stack */
+    return session->tlsman_load_stack(ciphersuites_list, total, flags);
 }
 
-ssize_t tlsman_return_last_known_error(void)
+ssize_t tlsman_return_last_known_error(tlsman_driver_t *tlsman_session)
 {
-    if (_tlsman_last_known_error != TLSMAN_ERROR_NON_STARTED) {
-        return _tlsman_last_known_error;
+    DEBUG("%s: Last known error code: %i\n", __func__,
+          tlsman_session->session.last_known_error);
+    if (tlsman_session->session.last_known_error != TLSMAN_ERROR_NON_STARTED) {
+        return tlsman_session->session.last_known_error;
     }
 
     return 0;
@@ -110,296 +102,3 @@ bool tlsman_process_is_error_code_nonfatal(ssize_t error_id)
 
     return false;
 }
-
-ssize_t tlsman_init_context(tlsman_ep_t *local, tlsman_ep_t *remote,
-                            tlsman_session_t *session, void *sock,
-                            tlsman_resp_handler_t cb, const uint8_t flags)
-{
-
-#ifdef MODULE_TLSMAN_TINYDTLS
-
-    /*
-     * FIXME DISCUSSION: A more elegant solution need to be used!
-     *
-     * We are dereferencing a structure which the first time should be
-     * pointing to null.
-     *
-     * This also will change if tinydtls_session_t is modified.
-     * Inclunding compilation with PSK or ECC
-     *
-     */
-    /*
-       if ((session->tinydtls_context.context != (void *)0x1) &&
-        (session->tinydtls_context.context != NULL)){
-        DEBUG("tinyDTLS: DTLS context already exist!\n");
-        return 0;
-       }
-     */
-
-#ifdef WITH_RIOT_GNRC
-    assert(local);
-    assert(remote);
-    assert(session);
-    DEBUG("tinyDTLS: Creating context (sock)\n");
-
-    session->tinydtls_context.local = local;
-    session->tinydtls_context.remote = remote;
-    session->tinydtls_context.sock = sock;
-    session->tinydtls_context.context = NULL;
-    session->tinydtls_context.cache = NULL;
-#endif /* WITH_RIOT_GNRC */
-
-#ifdef WITH_RIOT_SOCKETS
-    (void) local;
-    (void) remote;
-
-    assert(sock);
-    DEBUG("tinyDTLS: Creating context (socket)\n")
-#warning "tinyDTLS socket struct not defined yet"
-
-#endif /* WITH_RIOT_SOCKETS */
-
-    return tlsman_tinydtls_init_context(&session->tinydtls_context, cb, flags);
-
-#endif /* MODULE_TLSMAN_TINYDTLS */
-
-#ifdef MODULE_TLSMAN_WOLFSSL
-#warning "WolfSSL not supported yet"
-#endif /* MODULE_WOLFSSL */
-
-    return 0;
-}
-
-ssize_t tlsman_create_channel(tlsman_session_t *session, uint8_t flags,
-                              uint8_t *packet_buff, size_t packet_size)
-{
-
-    DEBUG("%s: Starting (D)TLS Channel\n", __func__);
-
-    ssize_t res = 0;
-#ifdef MODULE_TLSMAN_TINYDTLS
-
-    res = tlsman_tinydtls_connect(&session->tinydtls_context, packet_buff,
-                                  packet_size, flags);
-#endif
-
-#ifdef MODULE_TLSMAN_WOLFSSL
-#warning "WolfSSL not supported yet"
-#endif /* MODULE_WOLFSSL */
-
-    if (res == TLSMAN_ERROR_HANDSHAKE_TIMEOUT) {
-        _tlsman_last_known_error = res;
-    }
-
-    return res;
-}
-
-bool tlsman_is_channel_ready(tlsman_session_t *session)
-{
-
-    /* NOTE DISCUSSION: Add a loop here? */
-
-#ifdef MODULE_TLSMAN_TINYDTLS
-    if (session->tinydtls_context.is_connected == TINYDTLS_EVENT_FINISHED) {
-        return true;
-    }
-#endif /* MODULE_TLSMAN_TINYDTLS */
-
-#ifdef MODULE_WOLFSSL
-#warning "Not tested"
-#endif /* MODULE_WOLFSSL */
-
-    return false;
-}
-
-ssize_t tlsman_send_data_app(tlsman_session_t *session, const void *data, size_t len)
-{
-
-    DEBUG("%s: Starting to send upper layer data (Size: %zu)\n", __func__, len);
-
-#ifdef MODULE_TLSMAN_TINYDTLS
-    tinydtls_session_t *aux = &session->tinydtls_context;
-    ssize_t res;
-
-    /* TODO DISCUSSION: UDP fragmentation handled here or by the client? */
-    res = tlsman_tinydtls_send(aux, (uint8 *) data, len, 0);
-
-    if (res != 0) {
-        _tlsman_last_known_error = res;
-    }
-
-    return res;
-
-#ifdef WITH_RIOT_SOCKETS
-#warning "Not tested"
-#endif /* WITH_RIOT_SOCKETS */
-
-    return 0;
-
-#endif /* MODULE_TLSMAN_TINYDTLS */
-
-#ifdef MODULE_TLSMAN_WOLFSSL
-#warning "WolfSSL not supported yet"
-#endif /* MODULE_WOLFSSL */
-
-    return -1; /* Should not be reachable */
-}
-
-ssize_t tlsman_retrieve_data_app(tlsman_session_t *session,
-                                 void *data,
-                                 size_t max_len)
-{
-    DEBUG("%s: checking if there is (D)TLS Data Application data\n", __func__);
-
-#ifdef MODULE_TLSMAN_TINYDTLS
-
-    return tlsman_tintdytls_rcv(&session->tinydtls_context, data, max_len);
-
-#endif /* MODULE_TLSMAN_TINYDTLS */
-
-#ifdef MODULE_WOLFSSL
-#warning "WolfSSL not supported yet"
-#endif /* MODULE_WOLFSSL */
-
-    return 0;
-
-}
-
-void tlsman_release_resources(tlsman_session_t *session)
-{
-
-    DEBUG("%s: Releasing resources\n", __func__);
-
-#ifdef MODULE_TLSMAN_TINYDTLS
-    tlsman_tinydtls_free_context(&session->tinydtls_context);
-#endif /* MODULE_TLSMAN_TINYDTLS */
-
-#ifdef MODULE_WOLFSSL
-#warning "WolfSSL not supported yet"
-#endif /* MODULE_WOLFSSL */
-
-}
-
-ssize_t tlsman_close_channel(tlsman_session_t *session)
-{
-
-#ifdef MODULE_TLSMAN_TINYDTLS
-    tinydtls_session_t *tiny;
-    tiny = (tinydtls_session_t *) &session->tinydtls_context;
-    if (dtls_close(tiny->context, &tiny->dst) < 0) {
-        DEBUG("ERROR: Unable to close DTLS channel!");
-        return TLSMAN_ERROR_UNABLE_CLOSE;
-    }
-
-    /* NOTE DISCUSSION: This state is correct? or should be TINYDTLS_EVENTS_ZERO?  */
-    tiny->is_connected = TINYDTLS_EVENT_RENEGOTIATE;
-
-#endif /* MODULE_TLSMAN_TINYDTLS */
-
-#ifdef MODULE_WOLFSSL
-#warning "WolfSSL not supported yet"
-#endif /* MODULE_WOLFSSL */
-
-    return 0;
-}
-
-ssize_t tlsman_renegotiate_session(tlsman_session_t *session, uint8_t flags,
-                                   uint8_t *pkt_buff, size_t pkt_size)
-{
-
-#ifdef MODULE_TLSMAN_TINYDTLS
-    ssize_t res;
-
-    res = tlsman_tinydtls_renegotiate(&session->tinydtls_context, pkt_buff, pkt_size, flags);
-    if (res < 0) {
-        DEBUG("%s: DTLS renegotiation failed!\n", __func__);
-        _tlsman_last_known_error = TLSMAN_ERROR_SESSION_REN;
-        return TLSMAN_ERROR_SESSION_REN;
-    }
-
-#endif /* MODULE_TLSMAN_TINYDTLS */
-
-#ifdef MODULE_TLSMAN_WOLFSSL
-#warning "WolfSSL not supported yet"
-#endif /* MODULE_TLSMAN_WOLFSSL */
-
-    return 0;
-}
-
-ssize_t tlsman_new_handshake(tlsman_session_t *session, uint8_t flags,
-                             uint8_t *pkt_buff, size_t pkt_size)
-{
-#ifdef MODULE_TLSMAN_TINYDTLS
-    ssize_t res;
-
-    res = tlsman_tinydtls_rehandshake(&session->tinydtls_context, pkt_buff, pkt_size, flags);
-    if (res < 0) {
-        DEBUG("%s: DTLS attempt for a new handshake failed!\n", __func__);
-        _tlsman_last_known_error = TLSMAN_ERROR_SESSION_REN;
-        return TLSMAN_ERROR_SESSION_REN;
-    }
-
-#endif /* MODULE_TLSMAN_TINYDTLS */
-
-#ifdef MODULE_TLSMAN_WOLFSSL
-#warning "WolfSSL not supported yet"
-#endif /* MODULE_TLSMAN_WOLFSSL */
-
-    return 0;
-}
-
-ssize_t tlsman_listening(tlsman_session_t *session, uint8_t flags,
-                         uint8_t *pkt_buff, size_t pkt_size)
-{
-
-    (void) flags; /* TODO */
-
-#ifdef MODULE_TLSMAN_TINYDTLS
-
-    tlsman_tinydtls_listening(&session->tinydtls_context, pkt_buff, pkt_size);
-    /* TODO Handle errors */
-
-#ifdef WITH_RIOT_SOCKETS
-    /* TODO FIXME */
-#warning "No tested"
-#endif  /* WITH_RIOT_SOCKETS */
-
-#endif  /* MODULE_TLSMAN_TINYDTLS */
-
-#ifdef MODULE_TLSMAN_WOLFSSL
-#warning "WolfSSL not supported yet"
-#endif /* MODULE_TLSMAN_WOLFSSL */
-
-    return 1;
-
-}
-
-#ifdef SOCK_HAS_ASYNC
-
-void tlsman_set_async_parameters(tlsman_session_t *session,
-                                 event_queue_t *sock_event_queue,
-                                 uint8_t *buffer, ssize_t size)
-{
-
-    DEBUG("%s: Linking buffer %p (size %u) to sock\n", __func__, buffer, size);
-#ifdef MODULE_TLSMAN_TINYDTLS
-
-    tlsman_tinydtls_set_async_parameters(&session->tinydtls_context,
-                                         sock_event_queue, buffer, size);
-
-#endif /*MODULE_TLSMAN_TINYDTLS */
-
-    /* TODO: WolfSSL support */
-
-}
-
-void tlsman_set_async_listening(void)
-{
-
-#ifdef MODULE_TLSMAN_TINYDTLS
-    DEBUG("%s: Launching timer event\n", __func__);
-    tlsman_tinydtls_set_listening_timeout();
-#endif
-}
-
-#endif /* SOCK_HAS_ASYNC */

--- a/sys/net/tlsman/tlsman.c
+++ b/sys/net/tlsman/tlsman.c
@@ -1,0 +1,405 @@
+/*
+ * Copyright (C) 2018 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tlsman
+ * @{
+ *
+ * @file
+ * @brief       tlsman utility functions implementation
+ *
+ * @author      Raul Fuentes <raul.fuentes-samaniego@inria.fr>
+ *
+ * @}
+ */
+
+#include "net/tlsman.h"
+
+#ifdef MODULE_TLSMAN_TINYDTLS
+#include "net/tlsman/tinydtls.h"
+#endif
+
+#define ENABLE_DEBUG (0)
+#include "debug.h"
+
+/**
+ *  @brieff Last known error message.
+ */
+static ssize_t _tlsman_last_known_error = TLSMAN_ERROR_NON_STARTED;
+
+ssize_t tlsman_load_stack(int *ciphersuites_list, size_t total, uint8_t flags)
+{
+
+#ifdef MODULE_TLSMAN_TINYDTLS
+
+    bool match = false;
+
+    if (!(flags & TLSMAN_FLAG_STACK_DTLS)) {
+        DEBUG("TinyDTLS only support UDP!\n");
+        _tlsman_last_known_error = TLSMAN_ERROR_TRANSPORT_NOT_SUPPORTED;
+        return _tlsman_last_known_error;
+    }
+    /* NOTE: tinyDTLS can only select cipher suites at the compilation time */
+    size_t aux;
+    for (aux = 0; aux <  total; aux++) {
+        if (is_cipher_tinydtls(ciphersuites_list[aux])) {
+            match = true;
+            break;
+        }
+    }
+
+    if (!match) {
+        DEBUG("TinyDTLS Cipher suite not supported!\n");
+        _tlsman_last_known_error = TLSMAN_ERROR_CIPHER_NOT_SUPPORTED;
+        return _tlsman_last_known_error;
+    }
+
+    dtls_init(); /*TinyDTLS mandatory starting settings*/
+
+#ifdef TINYDTLS_LOG_LVL
+    dtls_set_log_level(TINYDTLS_LOG_LVL);
+#endif
+
+    /* TODO Upgrade to avoid DTLS_PSK and DTLS_ECC */
+#ifdef DTLS_PSK
+    DEBUG("tinyDTLS compiled with PSK\n");
+#endif
+#ifdef DTLS_ECC
+    DEBUG("tinyDTLS compiled with ECC\n");
+#endif
+
+    return 0;
+
+#endif /* MODULE_TLSMAN_TINYDTLS */
+
+#if MODULE_TLSMAN_WOLFSSL
+
+    /* TODO */
+    _tlsman_last_known_error = TLSMAN_ERROR_FATAL;
+    return _tlsman_last_known_error;
+
+#endif
+
+    return 0;
+
+}
+
+ssize_t tlsman_return_last_known_error(void)
+{
+    if (_tlsman_last_known_error != TLSMAN_ERROR_NON_STARTED) {
+        return _tlsman_last_known_error;
+    }
+
+    return 0;
+}
+
+bool tlsman_process_is_error_code_nonfatal(ssize_t error_id)
+{
+    switch (error_id) {
+        case TLSMAN_ERROR_FATAL:
+        case TLSMAN_ERROR_UNABLE_CONTEXT:
+        case TLSMAN_ERROR_TRANSPORT_NOT_SUPPORTED: /* NOTE: Or isn't? */
+        case TLSMAN_ERROR_CIPHER_NOT_SUPPORTED:
+            return true;
+    }
+
+    return false;
+}
+
+ssize_t tlsman_init_context(tlsman_ep_t *local, tlsman_ep_t *remote,
+                            tlsman_session_t *session, void *sock,
+                            tlsman_resp_handler_t cb, const uint8_t flags)
+{
+
+#ifdef MODULE_TLSMAN_TINYDTLS
+
+    /*
+     * FIXME DISCUSSION: A more elegant solution need to be used!
+     *
+     * We are dereferencing a structure which the first time should be
+     * pointing to null.
+     *
+     * This also will change if tinydtls_session_t is modified.
+     * Inclunding compilation with PSK or ECC
+     *
+     */
+    /*
+       if ((session->tinydtls_context.context != (void *)0x1) &&
+        (session->tinydtls_context.context != NULL)){
+        DEBUG("tinyDTLS: DTLS context already exist!\n");
+        return 0;
+       }
+     */
+
+#ifdef WITH_RIOT_GNRC
+    assert(local);
+    assert(remote);
+    assert(session);
+    DEBUG("tinyDTLS: Creating context (sock)\n");
+
+    session->tinydtls_context.local = local;
+    session->tinydtls_context.remote = remote;
+    session->tinydtls_context.sock = sock;
+    session->tinydtls_context.context = NULL;
+    session->tinydtls_context.cache = NULL;
+#endif /* WITH_RIOT_GNRC */
+
+#ifdef WITH_RIOT_SOCKETS
+    (void) local;
+    (void) remote;
+
+    assert(sock);
+    DEBUG("tinyDTLS: Creating context (socket)\n")
+#warning "tinyDTLS socket struct not defined yet"
+
+#endif /* WITH_RIOT_SOCKETS */
+
+    return tlsman_tinydtls_init_context(&session->tinydtls_context, cb, flags);
+
+#endif /* MODULE_TLSMAN_TINYDTLS */
+
+#ifdef MODULE_TLSMAN_WOLFSSL
+#warning "WolfSSL not supported yet"
+#endif /* MODULE_WOLFSSL */
+
+    return 0;
+}
+
+ssize_t tlsman_create_channel(tlsman_session_t *session, uint8_t flags,
+                              uint8_t *packet_buff, size_t packet_size)
+{
+
+    DEBUG("%s: Starting (D)TLS Channel\n", __func__);
+
+    ssize_t res = 0;
+#ifdef MODULE_TLSMAN_TINYDTLS
+
+    res = tlsman_tinydtls_connect(&session->tinydtls_context, packet_buff,
+                                  packet_size, flags);
+#endif
+
+#ifdef MODULE_TLSMAN_WOLFSSL
+#warning "WolfSSL not supported yet"
+#endif /* MODULE_WOLFSSL */
+
+    if (res == TLSMAN_ERROR_HANDSHAKE_TIMEOUT) {
+        _tlsman_last_known_error = res;
+    }
+
+    return res;
+}
+
+bool tlsman_is_channel_ready(tlsman_session_t *session)
+{
+
+    /* NOTE DISCUSSION: Add a loop here? */
+
+#ifdef MODULE_TLSMAN_TINYDTLS
+    if (session->tinydtls_context.is_connected == TINYDTLS_EVENT_FINISHED) {
+        return true;
+    }
+#endif /* MODULE_TLSMAN_TINYDTLS */
+
+#ifdef MODULE_WOLFSSL
+#warning "Not tested"
+#endif /* MODULE_WOLFSSL */
+
+    return false;
+}
+
+ssize_t tlsman_send_data_app(tlsman_session_t *session, const void *data, size_t len)
+{
+
+    DEBUG("%s: Starting to send upper layer data (Size: %zu)\n", __func__, len);
+
+#ifdef MODULE_TLSMAN_TINYDTLS
+    tinydtls_session_t *aux = &session->tinydtls_context;
+    ssize_t res;
+
+    /* TODO DISCUSSION: UDP fragmentation handled here or by the client? */
+    res = tlsman_tinydtls_send(aux, (uint8 *) data, len, 0);
+
+    if (res != 0) {
+        _tlsman_last_known_error = res;
+    }
+
+    return res;
+
+#ifdef WITH_RIOT_SOCKETS
+#warning "Not tested"
+#endif /* WITH_RIOT_SOCKETS */
+
+    return 0;
+
+#endif /* MODULE_TLSMAN_TINYDTLS */
+
+#ifdef MODULE_TLSMAN_WOLFSSL
+#warning "WolfSSL not supported yet"
+#endif /* MODULE_WOLFSSL */
+
+    return -1; /* Should not be reachable */
+}
+
+ssize_t tlsman_retrieve_data_app(tlsman_session_t *session,
+                                 void *data,
+                                 size_t max_len)
+{
+    DEBUG("%s: checking if there is (D)TLS Data Application data\n", __func__);
+
+#ifdef MODULE_TLSMAN_TINYDTLS
+
+    return tlsman_tintdytls_rcv(&session->tinydtls_context, data, max_len);
+
+#endif /* MODULE_TLSMAN_TINYDTLS */
+
+#ifdef MODULE_WOLFSSL
+#warning "WolfSSL not supported yet"
+#endif /* MODULE_WOLFSSL */
+
+    return 0;
+
+}
+
+void tlsman_release_resources(tlsman_session_t *session)
+{
+
+    DEBUG("%s: Releasing resources\n", __func__);
+
+#ifdef MODULE_TLSMAN_TINYDTLS
+    tlsman_tinydtls_free_context(&session->tinydtls_context);
+#endif /* MODULE_TLSMAN_TINYDTLS */
+
+#ifdef MODULE_WOLFSSL
+#warning "WolfSSL not supported yet"
+#endif /* MODULE_WOLFSSL */
+
+}
+
+ssize_t tlsman_close_channel(tlsman_session_t *session)
+{
+
+#ifdef MODULE_TLSMAN_TINYDTLS
+    tinydtls_session_t *tiny;
+    tiny = (tinydtls_session_t *) &session->tinydtls_context;
+    if (dtls_close(tiny->context, &tiny->dst) < 0) {
+        DEBUG("ERROR: Unable to close DTLS channel!");
+        return TLSMAN_ERROR_UNABLE_CLOSE;
+    }
+
+    /* NOTE DISCUSSION: This state is correct? or should be TINYDTLS_EVENTS_ZERO?  */
+    tiny->is_connected = TINYDTLS_EVENT_RENEGOTIATE;
+
+#endif /* MODULE_TLSMAN_TINYDTLS */
+
+#ifdef MODULE_WOLFSSL
+#warning "WolfSSL not supported yet"
+#endif /* MODULE_WOLFSSL */
+
+    return 0;
+}
+
+ssize_t tlsman_renegotiate_session(tlsman_session_t *session, uint8_t flags,
+                                   uint8_t *pkt_buff, size_t pkt_size)
+{
+
+#ifdef MODULE_TLSMAN_TINYDTLS
+    ssize_t res;
+
+    res = tlsman_tinydtls_renegotiate(&session->tinydtls_context, pkt_buff, pkt_size, flags);
+    if (res < 0) {
+        DEBUG("%s: DTLS renegotiation failed!\n", __func__);
+        _tlsman_last_known_error = TLSMAN_ERROR_SESSION_REN;
+        return TLSMAN_ERROR_SESSION_REN;
+    }
+
+#endif /* MODULE_TLSMAN_TINYDTLS */
+
+#ifdef MODULE_TLSMAN_WOLFSSL
+#warning "WolfSSL not supported yet"
+#endif /* MODULE_TLSMAN_WOLFSSL */
+
+    return 0;
+}
+
+ssize_t tlsman_new_handshake(tlsman_session_t *session, uint8_t flags,
+                             uint8_t *pkt_buff, size_t pkt_size)
+{
+#ifdef MODULE_TLSMAN_TINYDTLS
+    ssize_t res;
+
+    res = tlsman_tinydtls_rehandshake(&session->tinydtls_context, pkt_buff, pkt_size, flags);
+    if (res < 0) {
+        DEBUG("%s: DTLS attempt for a new handshake failed!\n", __func__);
+        _tlsman_last_known_error = TLSMAN_ERROR_SESSION_REN;
+        return TLSMAN_ERROR_SESSION_REN;
+    }
+
+#endif /* MODULE_TLSMAN_TINYDTLS */
+
+#ifdef MODULE_TLSMAN_WOLFSSL
+#warning "WolfSSL not supported yet"
+#endif /* MODULE_TLSMAN_WOLFSSL */
+
+    return 0;
+}
+
+ssize_t tlsman_listening(tlsman_session_t *session, uint8_t flags,
+                         uint8_t *pkt_buff, size_t pkt_size)
+{
+
+    (void) flags; /* TODO */
+
+#ifdef MODULE_TLSMAN_TINYDTLS
+
+    tlsman_tinydtls_listening(&session->tinydtls_context, pkt_buff, pkt_size);
+    /* TODO Handle errors */
+
+#ifdef WITH_RIOT_SOCKETS
+    /* TODO FIXME */
+#warning "No tested"
+#endif  /* WITH_RIOT_SOCKETS */
+
+#endif  /* MODULE_TLSMAN_TINYDTLS */
+
+#ifdef MODULE_TLSMAN_WOLFSSL
+#warning "WolfSSL not supported yet"
+#endif /* MODULE_TLSMAN_WOLFSSL */
+
+    return 1;
+
+}
+
+#ifdef SOCK_HAS_ASYNC
+
+void tlsman_set_async_parameters(tlsman_session_t *session,
+                                 event_queue_t *sock_event_queue,
+                                 uint8_t *buffer, ssize_t size)
+{
+
+    DEBUG("%s: Linking buffer %p (size %u) to sock\n", __func__, buffer, size);
+#ifdef MODULE_TLSMAN_TINYDTLS
+
+    tlsman_tinydtls_set_async_parameters(&session->tinydtls_context,
+                                         sock_event_queue, buffer, size);
+
+#endif /*MODULE_TLSMAN_TINYDTLS */
+
+    /* TODO: WolfSSL support */
+
+}
+
+void tlsman_set_async_listening(void)
+{
+
+#ifdef MODULE_TLSMAN_TINYDTLS
+    DEBUG("%s: Launching timer event\n", __func__);
+    tlsman_tinydtls_set_listening_timeout();
+#endif
+}
+
+#endif /* SOCK_HAS_ASYNC */

--- a/tests/tlsman_tinydtls_sock/Makefile
+++ b/tests/tlsman_tinydtls_sock/Makefile
@@ -3,7 +3,7 @@ include ../Makefile.tests_common
 # If no BOARD is found in the environment, use this default:
 BOARD ?= native
 
-# Minimun setting
+# Minimum setting
 USEMODULE += gnrc_netdev_default
 USEMODULE += auto_init_gnrc_netif
 USEMODULE += gnrc_ipv6_default
@@ -13,7 +13,7 @@ USEMODULE += tlsman
 # NOTE: Network stack must be defined by the user not by TLSMAN
 USEMODULE += gnrc_sock_udp
 
-# This is intented to be handled by sock_secure for normal applications
+# This is intended to be handled by sock_secure for normal applications
 # NOTE (TODO): Equivalent to use `USEMODULE += tlsman_tinydtls`
 USEPKG += tinydtls
 ifneq (,$(filter tinydtls,$(USEPKG)))
@@ -26,14 +26,6 @@ ifneq (,$(filter tinydtls,$(USEPKG)))
 	CFLAGS += -DDTLS_CONTEXT_MAX=2
 	CFLAGS += -DDTLS_PEER_MAX=2
 	CFLAGS += -DDTLS_HANDSHAKE_MAX=2
-
-	ifneq (,$(filter gnrc_sock_async,$(USEMODULE)))
-		# NOTE: Temporary while sock_asyn is in beta (this called by gnrc_sock_async)
-		USEMODULE += core_thread_flags
-
-		# NOTE: At least for tinyDTLS, we are making use of event timeout
-		USEMODULE += event_timeout
-	endif
 endif
 
 # Special include directory with the (D)TLS keys required for the test

--- a/tests/tlsman_tinydtls_sock/Makefile
+++ b/tests/tlsman_tinydtls_sock/Makefile
@@ -1,0 +1,49 @@
+include ../Makefile.tests_common
+
+# If no BOARD is found in the environment, use this default:
+BOARD ?= native
+
+# Minimun setting
+USEMODULE += gnrc_netdev_default
+USEMODULE += auto_init_gnrc_netif
+USEMODULE += gnrc_ipv6_default
+
+USEMODULE += tlsman
+
+# NOTE: Network stack must be defined by the user not by TLSMAN
+USEMODULE += gnrc_sock_udp
+
+# This is intented to be handled by sock_secure for normal applications
+# NOTE (TODO): Equivalent to use `USEMODULE += tlsman_tinydtls`
+USEPKG += tinydtls
+ifneq (,$(filter tinydtls,$(USEPKG)))
+	USEMODULE += tlsman_tinydtls
+
+	CFLAGS += -DTHREAD_STACKSIZE_MAIN=\(3*THREAD_STACKSIZE_DEFAULT\)
+	# NOTE: For "rehandhsake", tinydtls requires at least two peers.
+	# With the default values, the boards will not crash but tinydtls will
+	# be unable to generate the context.
+	CFLAGS += -DDTLS_CONTEXT_MAX=2
+	CFLAGS += -DDTLS_PEER_MAX=2
+	CFLAGS += -DDTLS_HANDSHAKE_MAX=2
+
+	ifneq (,$(filter gnrc_sock_async,$(USEMODULE)))
+		# NOTE: Temporary while sock_asyn is in beta (this called by gnrc_sock_async)
+		USEMODULE += core_thread_flags
+
+		# NOTE: At least for tinyDTLS, we are making use of event timeout
+		USEMODULE += event_timeout
+	endif
+endif
+
+# Special include directory with the (D)TLS keys required for the test
+INCLUDES += -I$(APPDIR)/keys
+
+# Default DTLS Server for the test
+REM_SERVER ?='"fd00:dead:beef::1"'
+CFLAGS += -DREMOTE_SERVER=$(REM_SERVER)
+
+include $(RIOTBASE)/Makefile.include
+
+test:
+	./tests/01-run.py

--- a/tests/tlsman_tinydtls_sock/README.md
+++ b/tests/tlsman_tinydtls_sock/README.md
@@ -1,0 +1,57 @@
+# About
+
+This test application allows to review the (D)TLS Manager (TLSMAN) module for
+the tinyDTLS package.
+
+This test consists only of a (D)TLS client side that is expected to communicate
+with a server, which echoes back the messages from the client. The client will
+perform the standard (D)TLS handshake, send data and then execute
+renegotiations, and even closing and re-opening the connection.
+
+The differences between the different tests should be minimum and mostly
+concentrated in the Makefile files.
+
+# (D)TLS stacks
+
+## tinyDTLS
+
+The pkg/tinyDTLS can be used with sock_udp (including sock_async) or socket.
+
+For this test, tinyDTLS is tested with sock_udp. Although can be compiled with
+sock_async with a sub-optimal performance.
+
+The test is using the default PSK mode with the cipher suite
+TLS_PSK_WITH_AES_128_CCM_8. Most of the default values for tinyDTLS (and RIOT)
+are used, except for the following variables:
+
+* DTLS_CONTEXT_MAX
+* DTLS_PEER_MAX
+* DTLS_HANDSHAKE_MAX
+
+All of them have an impact on memory allocation and are settled by default to
+one. But, for one type of renegotiation the nodes must be able to accept
+temporary up to two peers.
+
+---
+
+# Debugging the tests
+
+If debugging is required it's possible to enable debugging in the following
+files:
+
+- tests/tlsman_tinydtls*/main.c
+- tests/tlsman_tinydtls*/client.c
+- sys/net/tlsman/tlsman.c
+- sys/net/tlsman/tinydtls.c (Probably the most relevant)
+
+Additionally, it's possible to increase tinyDTLS verbosity in the Makefile by means of the following variable:
+
+- `TINYDTLS_LOG`: Set to 0 - 6  that are equivalent to EMERG (Default), ALERT,
+  CRIT, WARN, NOTICE,  INFO  and DEBUG.
+
+# Running a valid server side
+
+The examples/dlts-echo application is enough for this series of tests. Also, the
+keys used for this test are the default one for the official tinyDTLS
+repository. Therefore, the test server located in its repository is also
+feasible for the testings.

--- a/tests/tlsman_tinydtls_sock/README.md
+++ b/tests/tlsman_tinydtls_sock/README.md
@@ -1,15 +1,12 @@
 # About
 
 This test application allows to review the (D)TLS Manager (TLSMAN) module for
-the tinyDTLS package.
+the tinyDTLS package with support for sock.
 
 This test consists only of a (D)TLS client side that is expected to communicate
 with a server, which echoes back the messages from the client. The client will
 perform the standard (D)TLS handshake, send data and then execute
-renegotiations, and even closing and re-opening the connection.
-
-The differences between the different tests should be minimum and mostly
-concentrated in the Makefile files.
+re-negotiations, and even closing and re-opening the connection.
 
 # (D)TLS stacks
 
@@ -42,7 +39,7 @@ files:
 - tests/tlsman_tinydtls*/main.c
 - tests/tlsman_tinydtls*/client.c
 - sys/net/tlsman/tlsman.c
-- sys/net/tlsman/tinydtls.c (Probably the most relevant)
+- sys/net/tlsman/tinydtls_sock.c (Probably the most relevant)
 
 Additionally, it's possible to increase tinyDTLS verbosity in the Makefile by means of the following variable:
 
@@ -52,6 +49,6 @@ Additionally, it's possible to increase tinyDTLS verbosity in the Makefile by me
 # Running a valid server side
 
 The examples/dlts-echo application is enough for this series of tests. Also, the
-keys used for this test are the default one for the official tinyDTLS
+keys used for this test are the default one for the official TinyDTLS
 repository. Therefore, the test server located in its repository is also
 feasible for the testings.

--- a/tests/tlsman_tinydtls_sock/client.c
+++ b/tests/tlsman_tinydtls_sock/client.c
@@ -21,7 +21,8 @@
  * @}
  */
 
- #include <stdio.h>
+
+#include <stdio.h>
 #include <assert.h>
 
 #include "net/sock/udp.h"
@@ -32,9 +33,8 @@
 
 /**
  * Our custom response handler to be sent to TLSMAN
- * It will be inkoved each time a DTLS data app record is retrieved
+ * It will be invoked each time a DTLS data app record is retrieved
  *
- * NOTE (TODO): The (void) * argument is more like a comodin as TLSMAN can deliver
  * a sock, socket or other network stack.
  */
 static void _resp_handler(uint8_t *data, size_t data_size, void *sock);
@@ -60,16 +60,12 @@ static void _resp_handler(uint8_t *data, size_t data_size, void *sock);
 #define DBG_DELAY()
 #endif
 
-#ifdef SOCK_HAS_ASYNC
-static event_queue_t sock_event_queue;
-#endif
-
 static uint8_t _upper_data[] = "Hello world!\n";
 
 static void _resp_handler(uint8_t *data, size_t data_size, void *sock)
 {
 
-    (void) sock; /* For this test, our comodin (sock or socket) is irrelevant */
+    (void) sock;
 
     DEBUG("Echo (string %i): %s\n", data_size, data);
     /* We are expecting an echo */
@@ -80,171 +76,174 @@ static void _resp_handler(uint8_t *data, size_t data_size, void *sock)
 
 static void test_creating_context(sock_udp_ep_t *local, sock_udp_ep_t *remote,
                                   sock_udp_t *udp_sock,
-                                  tlsman_session_t *dtls_session,
+                                  tlsman_driver_t *dtls_session,
                                   uint8_t tlsman_flags)
 {
 
     local->port = (unsigned short) CLIENT_PORT;
     remote->port = (unsigned short) SERVER_PORT;
 
-    ssize_t res;
-
     /* Socks must be ready before step 3 */
     assert(ipv6_addr_from_str((ipv6_addr_t *)remote->addr.ipv6, REMOTE_SERVER));
     assert(0 == sock_udp_create(udp_sock, local, remote, 0));
-    res = tlsman_init_context((tlsman_ep_t *) local, (tlsman_ep_t *) remote,
-                              dtls_session, udp_sock, _resp_handler,
-                              tlsman_flags);
-    assert(res == 0);
+
+    /* NOTE tlsman_session_t must be populated according to the network stack */
+    dtls_session->session.local = local;
+    dtls_session->session.remote = remote;
+    dtls_session->session.sock = udp_sock;
+
+    assert(0 ==
+           dtls_session->tlsman_init_context( &dtls_session->session, _resp_handler,
+                                              tlsman_flags));
+
+
 }
 
-static void test_creating_channel(tlsman_session_t *dtls_session,
+static void test_creating_channel(tlsman_driver_t *dtls_session,
                                   uint8_t tlsman_flags, uint8_t *packet_rcvd)
 {
-    tlsman_create_channel(dtls_session, tlsman_flags, packet_rcvd, DTLS_MAX_BUF);
+    dtls_session->tlsman_create_channel(&dtls_session->session, tlsman_flags, packet_rcvd, DTLS_MAX_BUF);
     /* NOTE: Assert is not called as the next test is equivalent */
 }
 
-static void test_checking_errors(void)
+static void test_checking_errors(tlsman_driver_t *dtls_session)
 {
-    ssize_t res = tlsman_return_last_known_error();
+    ssize_t res = tlsman_return_last_known_error(dtls_session);
 
     if (tlsman_process_is_error_code_nonfatal(res)) {
-        puts("ERROR: Unable to start (D)TLS handhsake process!");
+        puts("ERROR: Unable to start (D)TLS handshake process!");
     }
     else if (res == TLSMAN_ERROR_HANDSHAKE_TIMEOUT) {
-        /* NOTE: Handhsake timeout can be not fatal but is part of our test */
+        /* NOTE: Handshake timeout can be not fatal but is part of our test */
         puts("ERROR: (D)TLS handshake timeout!");
     }
 
     assert((res != TLSMAN_ERROR_HANDSHAKE_TIMEOUT) &&
            (!tlsman_process_is_error_code_nonfatal(res)));
-
 }
 
-static void test_sending_uper_data(tlsman_session_t *dtls_session)
+static void test_sending_upper_data(tlsman_driver_t *dtls_session)
 {
     /*
      * For a blocking testing, this would be equivalent to test for
      * TLSMAN_ERROR_HANDSHAKE_TIMEOUT
      */
-    assert(tlsman_is_channel_ready(dtls_session));
+    assert(dtls_session->tlsman_is_channel_ready(&dtls_session->session));
+
 
     /* NOTE: It's possible to share the buffer for sending and receiving */
-    assert(0 == tlsman_send_data_app(dtls_session, _upper_data, sizeof(_upper_data)));
+    assert(0 ==
+           dtls_session->tlsman_send_data_app(&dtls_session->session, _upper_data,
+                                              sizeof(_upper_data)));
 }
 
-static void test_retrieve_data(tlsman_session_t *dtls_session, uint8_t *data,
+static void test_retrieve_data(tlsman_driver_t *dtls_session, uint8_t *data,
                                size_t data_size)
 {
     /* NOTE: This test is synchronous, but the sock_async has impact here */
     /* NOTE: This can retrieve other types of DTLS records (e.g. alerts) */
-#ifdef SOCK_HAS_ASYNC
-    /* NOTE: If tinydtls is running on it's own thread, tlsman_retrieve_data_app()
-     * can be called first.
-     * However, for this test is not the case.
-     */
-    tlsman_set_async_listening();
-#endif
-
-    assert(0 == tlsman_retrieve_data_app(dtls_session, data, data_size));
-
+    assert(0 == dtls_session->tlsman_retrieve_data_app(&dtls_session->session, data, data_size));
 }
 
-static void test_sending_uper_data_MULTIPLE(tlsman_session_t *dtls_session,
-                                            uint8_t *data, size_t data_size)
-{
-    /* Testing encryption and not more renegotiation between peers */
-    assert(tlsman_is_channel_ready(dtls_session));
-
-    /* NOTE: It's possible to share the buffer for sending and receiving */
-    assert(0 == tlsman_send_data_app(dtls_session, _upper_data, sizeof(_upper_data)));
-    assert(0 == tlsman_send_data_app(dtls_session, _upper_data, sizeof(_upper_data)));
-    assert(0 == tlsman_send_data_app(dtls_session, _upper_data, sizeof(_upper_data)));
-    assert(0 == tlsman_send_data_app(dtls_session, _upper_data, sizeof(_upper_data)));
-
-#ifdef SOCK_HAS_ASYNC
-    tlsman_set_async_listening();
-#endif
-
-    assert(0 == tlsman_retrieve_data_app(dtls_session, data, data_size));
-    assert(0 == tlsman_retrieve_data_app(dtls_session, data, data_size));
-    assert(0 == tlsman_retrieve_data_app(dtls_session, data, data_size));
-    assert(0 == tlsman_retrieve_data_app(dtls_session, data, data_size));
-
-}
-
-static void test_release_resources_IGNORING_ALERT(tlsman_session_t *dtls_session,
+static void test_release_resources_IGNORING_ALERT(tlsman_driver_t *dtls_session,
                                                   sock_udp_t *udp_sock,
-                                                  uint8_t tlsman_flags, uint8_t *packet_rcvd)
+                                                  uint8_t tlsman_flags,
+                                                  uint8_t *packet_rcvd)
 {
     /* FIXME */
     (void) tlsman_flags;
     (void) packet_rcvd;
     (void) udp_sock;
 
-    tlsman_release_resources(dtls_session);
+    dtls_session->tlsman_release_resources(&dtls_session->session);
 
 }
 
 static void test_reconnect_COMMON_ERROR(sock_udp_ep_t *local, sock_udp_ep_t *remote,
-                                        sock_udp_t *udp_sock, tlsman_session_t *dtls_session,
+                                        sock_udp_t *udp_sock, tlsman_driver_t *dtls_session,
                                         uint8_t tlsman_flags, uint8_t *packet, size_t pkt_size)
 {
     /*
-     * This test first attempts to retrieve any (D)TLS record avaiable.
-     * With tinyDTLS therere is a high chanche that DTLS Alert record was received.
+     * This test first attempts to retrieve any (D)TLS record available.
+     * With tinyDTLS there is a high chance that DTLS Alert record was received.
      * This record can interfere with tlsman_create_channel()
      */
 
     DBG_DELAY();
 
-    assert(0 == tlsman_init_context((tlsman_ep_t *) local, (tlsman_ep_t *) remote,
-                                    dtls_session, udp_sock, _resp_handler,
-                                    tlsman_flags));
+    /* FIXME? tlsman_session_t must be populated according to the network stack */
+    dtls_session->session.local = local;
+    dtls_session->session.remote = remote;
+    dtls_session->session.sock = udp_sock;
+    assert(0 == dtls_session->tlsman_init_context( &dtls_session->session, _resp_handler,
+                                                   tlsman_flags));
 
-    ssize_t res = tlsman_create_channel(dtls_session, tlsman_flags, packet,
-                                        pkt_size);
+    ssize_t res = dtls_session->tlsman_create_channel(&dtls_session->session, tlsman_flags, packet,
+                                                      pkt_size);
 
     assert(res == TLSMAN_ERROR_HANDSHAKE_TIMEOUT);
 
     /* This fail is due a DTLS Alert record sent by the remote node as result from the previous test.
-       Therefore for this test, we only try to do a new handshake
+       Therefore for this test, we only try to do a new handshake.
+       NOTE: This affects both way of operation (synchronous and asynchronous).
      */
 
-    /* This is for fixing our intenral chaos */
-    tlsman_close_channel(dtls_session);
-    tlsman_retrieve_data_app(dtls_session, packet, sizeof(pkt_size));
+    /* This is for fixing our internal chaos */
+    dtls_session->tlsman_close_channel(&dtls_session->session);
+    dtls_session->tlsman_retrieve_data_app(&dtls_session->session, packet, sizeof(pkt_size));
 
     sock_udp_close(udp_sock);
     sock_udp_create(udp_sock, (sock_udp_ep_t *)local, (sock_udp_ep_t *)remote, 0);
 
-    res = tlsman_create_channel(dtls_session, tlsman_flags, packet,
-                                pkt_size);
+    res = dtls_session->tlsman_create_channel(&dtls_session->session, tlsman_flags, packet,
+                                              pkt_size);
 
     assert((res != TLSMAN_ERROR_HANDSHAKE_TIMEOUT) &&
            (!tlsman_process_is_error_code_nonfatal(res)));
 
 }
 
+static void test_sending_upper_data_MULTIPLE(tlsman_driver_t *dtls_session,
+                                             uint8_t *data, size_t data_size)
+{
+    /* Testing encryption and not more renegotiation between peers */
+    assert(dtls_session->tlsman_is_channel_ready(&dtls_session->session));
+
+    /* NOTE: It's possible to share the buffer for sending and receiving */
+    assert(0 == dtls_session->tlsman_send_data_app(&dtls_session->session, _upper_data, sizeof(_upper_data)));
+    assert(0 == dtls_session->tlsman_send_data_app(&dtls_session->session, _upper_data, sizeof(_upper_data)));
+    assert(0 == dtls_session->tlsman_send_data_app(&dtls_session->session, _upper_data, sizeof(_upper_data)));
+    assert(0 == dtls_session->tlsman_send_data_app(&dtls_session->session, _upper_data, sizeof(_upper_data)));
+
+    assert(0 == dtls_session->tlsman_retrieve_data_app(&dtls_session->session, data, data_size));
+    assert(0 == dtls_session->tlsman_retrieve_data_app(&dtls_session->session, data, data_size));
+    assert(0 == dtls_session->tlsman_retrieve_data_app(&dtls_session->session, data, data_size));
+    assert(0 == dtls_session->tlsman_retrieve_data_app(&dtls_session->session, data, data_size));
+
+}
+
 static void test_reconnect_CLOSING_SOCKETS(sock_udp_ep_t *local, sock_udp_ep_t *remote,
-                                           sock_udp_t *udp_sock, tlsman_session_t *dtls_session,
+                                           sock_udp_t *udp_sock, tlsman_driver_t *dtls_session,
                                            uint8_t tlsman_flags, uint8_t *packet, size_t pkt_size)
 {
     DBG_DELAY();
 
     /* Equivalent to test_release_resources_IGNORING_ALERT */
-    tlsman_release_resources(dtls_session);
+    dtls_session->tlsman_release_resources(&dtls_session->session);
 
     /*
      * This test tries more safe approach than test_reconnect_COMMON_ERROR()
      * By closing the udp sock we are also dropping any remaining DTLS record on the buffer */
-    assert(0 == tlsman_init_context((tlsman_ep_t *) local, (tlsman_ep_t *) remote,
-                                    dtls_session, udp_sock, _resp_handler,
-                                    tlsman_flags));
+    /* FIXME? tlsman_session_t must be populated according to the network stack */
+    dtls_session->session.local = local;
+    dtls_session->session.remote = remote;
+    dtls_session->session.sock = udp_sock;
+    assert(0 == dtls_session->tlsman_init_context( &dtls_session->session,
+                                                   _resp_handler,
+                                                   tlsman_flags));
 
-    ssize_t res = tlsman_create_channel(dtls_session, tlsman_flags, packet,
-                                        pkt_size);
+    ssize_t res = dtls_session->tlsman_create_channel(&dtls_session->session, tlsman_flags, packet,
+                                                      pkt_size);
 
     assert(res == TLSMAN_ERROR_HANDSHAKE_TIMEOUT);
 
@@ -252,84 +251,79 @@ static void test_reconnect_CLOSING_SOCKETS(sock_udp_ep_t *local, sock_udp_ep_t *
        Therefore for this test, we only try to do a new handshake
      */
 
-    /* This is for fixing our intenral chaos */
-    tlsman_close_channel(dtls_session);
+    /* This is for fixing our internal chaos */
+    dtls_session->tlsman_close_channel(&dtls_session->session);
     sock_udp_close(udp_sock);
     sock_udp_create(udp_sock, (sock_udp_ep_t *)local, (sock_udp_ep_t *)remote, 0);
 
-    res = tlsman_create_channel(dtls_session, tlsman_flags, packet,
-                                pkt_size);
+    res = dtls_session->tlsman_create_channel(&dtls_session->session, tlsman_flags, packet,
+                                              pkt_size);
 
     assert((res != TLSMAN_ERROR_HANDSHAKE_TIMEOUT) &&
            (!tlsman_process_is_error_code_nonfatal(res)));
 
 }
 
-static void test_retrieve_data_TIMEOUT(tlsman_session_t *dtls_session, uint8_t *data,
+static void test_retrieve_data_TIMEOUT(tlsman_driver_t *dtls_session, uint8_t *data,
                                        size_t data_size)
 {
     /* NOTE: This test is synchronous, but the sock_async has impact here */
     /* NOTE: This can retrieve other types of DTLS records (e.g. alerts) */
-#ifdef SOCK_HAS_ASYNC
-    /* NOTE: If tinydtls is running on it's own thread, tlsman_retrieve_data_app()
-     * can be called first.
-     * However, for this test is not the case.
-     */
-    tlsman_set_async_listening();
-#endif
 
     /* This test should be called without additional calls */
-    assert(0 == tlsman_retrieve_data_app(dtls_session, data, data_size));
+    assert(0 == dtls_session->tlsman_retrieve_data_app(&dtls_session->session, data, data_size));
 }
 
-static void test_renegotiation(tlsman_session_t *dtls_session,
+static void test_renegotiation(tlsman_driver_t *dtls_session,
                                uint8_t tlsman_flags, uint8_t *packet_rcvd)
 {
     DBG_DELAY();
 
     /* NOTE: There is a known issue in tinydtls' commit for this test */
     assert(TLSMAN_ERROR_SESSION_REN !=
-           tlsman_renegotiate_session(dtls_session, tlsman_flags, packet_rcvd,
-                                      DTLS_MAX_BUF));
+           dtls_session->tlsman_renegotiate(&dtls_session->session, tlsman_flags, packet_rcvd,
+                                            DTLS_MAX_BUF));
 }
 
-static void test_chanel_working(tlsman_session_t *dtls_session, uint8_t *data,
+static void test_chanel_working(tlsman_driver_t *dtls_session, uint8_t *data,
                                 size_t data_size)
 {
-    /* This is equivalent to test_retrieve_data() and test_sending_uper_data() */
+    /* This is equivalent to test_retrieve_data() and test_sending_upper_data() */
 
-    assert(tlsman_is_channel_ready(dtls_session));
-    assert(0 == tlsman_send_data_app(dtls_session, _upper_data, sizeof(_upper_data)));
+    assert(dtls_session->tlsman_is_channel_ready(&dtls_session->session));
+    assert(0 == dtls_session->tlsman_send_data_app(&dtls_session->session, _upper_data, sizeof(_upper_data)));
 
-#ifdef SOCK_HAS_ASYNC
-    tlsman_set_async_listening();
-#endif
-    assert(0 == tlsman_retrieve_data_app(dtls_session, data, data_size));
+    assert(0 == dtls_session->tlsman_retrieve_data_app(&dtls_session->session, data, data_size));
 
 }
 
-static void test_rehandshake(tlsman_session_t *dtls_session,
+static void test_rehandshake(tlsman_driver_t *dtls_session,
                              uint8_t tlsman_flags, uint8_t *packet_rcvd)
 {
     DBG_DELAY();
 
-    assert(0 == tlsman_new_handshake(dtls_session, tlsman_flags,
-                                     packet_rcvd, DTLS_MAX_BUF));
+    assert(0 == dtls_session->tlsman_rehandshake(&dtls_session->session, tlsman_flags,
+                                                 packet_rcvd, DTLS_MAX_BUF));
 }
 
-static void test_closing_channel(tlsman_session_t *dtls_session,
+static void test_closing_channel(tlsman_driver_t *dtls_session,
                                  uint8_t *packet, size_t pkt_size)
 {
-    assert(TLSMAN_ERROR_UNABLE_CLOSE != tlsman_close_channel(dtls_session));
-    tlsman_retrieve_data_app(dtls_session, packet, sizeof(pkt_size));
+    assert(TLSMAN_ERROR_UNABLE_CLOSE != dtls_session->tlsman_close_channel(&dtls_session->session));
+    dtls_session->tlsman_retrieve_data_app(&dtls_session->session, packet, sizeof(pkt_size));
 
     /* Release resources */
-    tlsman_release_resources(dtls_session);
+    dtls_session->tlsman_release_resources(&dtls_session->session);
 }
 
-void client_side(void)
+
+void client_side(tlsman_driver_t *tlsman_session, const uint8_t tlsman_flags)
 {
 
+    (void) _upper_data; /* FIXME */
+    (void) _resp_handler;
+    (void) tlsman_session;
+    (void) tlsman_flags;
     /*
      * TLSMAN handles everything related to the (D)TLS stacks but not the
      * the network stack itself. Additionally, there are limits:
@@ -340,73 +334,66 @@ void client_side(void)
     sock_udp_ep_t local = SOCK_IPV6_EP_ANY;
     sock_udp_ep_t remote = SOCK_IPV6_EP_ANY;
     sock_udp_t udp_sock;
-    uint8_t tlsman_flags = TLSMAN_FLAG_STACK_UNIVERSAL | TLSMAN_FLAG_SIDE_CLIENT;
-
-    /* Storage for the context and secure session (for all the (D)TLS stacks) */
-    tlsman_session_t dtls_session;
 
     /* This is the buffer to be used for sending AND receiving DTLS Records */
     uint8_t packet_rcvd[DTLS_MAX_BUF];
+    (void) packet_rcvd; /* FIXME Remove this  */
 
     DEBUG("Remote server: [%s]:%u\n", REMOTE_SERVER, SERVER_PORT);
 
     /* 2nd step: Create the (D)TLS context and load the keys */
     /* NOTE: 1st step is located at main.c */
-    CALL(test_creating_context(&local, &remote, &udp_sock, &dtls_session, tlsman_flags));
-
-#ifdef SOCK_HAS_ASYNC
-    /* This step is also required before tlsman_create_channel() */
-    tlsman_set_async_parameters(&dtls_session, &sock_event_queue, packet_rcvd, sizeof(packet_rcvd));
-    tlsman_flags |= TLSMAN_FLAG_NONBLOCKING;
-#endif
+    CALL(test_creating_context(&local, &remote, &udp_sock, tlsman_session, tlsman_flags));
 
     /* 3th step: Start the (D)TLS channel! (the handshake process) */
-    CALL(test_creating_channel(&dtls_session, tlsman_flags, packet_rcvd));
+    CALL(test_creating_channel(tlsman_session, tlsman_flags, packet_rcvd));
 
     /* 4th step: The DTLS handshake was started correctly? */
-    CALL(test_checking_errors());
+    CALL(test_checking_errors(tlsman_session));
 
     /* 5th step: Send and receiving data */
-    CALL(test_sending_uper_data(&dtls_session));
-    CALL(test_retrieve_data(&dtls_session, packet_rcvd, DTLS_MAX_BUF));
+    CALL(test_sending_upper_data(tlsman_session));
+    CALL(test_retrieve_data(tlsman_session, packet_rcvd, DTLS_MAX_BUF));
 
     /* 6th step: Wrongly releasing resources and reconnect */
-    CALL(test_release_resources_IGNORING_ALERT(&dtls_session, &udp_sock, 0, NULL));
-    CALL(test_reconnect_COMMON_ERROR(&local, &remote, &udp_sock, &dtls_session, \
+    CALL(test_release_resources_IGNORING_ALERT(tlsman_session, &udp_sock, 0, NULL));
+
+
+    CALL(test_reconnect_COMMON_ERROR(&local, &remote, &udp_sock, tlsman_session, \
                                      tlsman_flags, packet_rcvd, sizeof(packet_rcvd)));
-    CALL(test_sending_uper_data_MULTIPLE(&dtls_session, packet_rcvd, DTLS_MAX_BUF));
-    CALL(test_reconnect_CLOSING_SOCKETS(&local, &remote, &udp_sock, &dtls_session, \
+
+    CALL(test_sending_upper_data_MULTIPLE(tlsman_session, packet_rcvd, DTLS_MAX_BUF));
+
+    CALL(test_reconnect_CLOSING_SOCKETS(&local, &remote, &udp_sock, tlsman_session, \
                                         tlsman_flags, packet_rcvd, sizeof(packet_rcvd)));
-    CALL(test_retrieve_data_TIMEOUT(&dtls_session, packet_rcvd, DTLS_MAX_BUF));
+    CALL(test_retrieve_data_TIMEOUT(tlsman_session, packet_rcvd, DTLS_MAX_BUF));
 
 #if 0 /* WARNING: TinyDTLS has a known bug with this test */
-      /* 6th step: renegotiation of (D)TLS session */
-    CALL(test_renegotiation(&dtls_session, tlsman_flags, packet_rcvd));
+    /* 7th step: renegotiation of (D)TLS session */
+    CALL(test_renegotiation(tlsman_session, tlsman_flags, packet_rcvd));
 
-    /* 7th step: Send/Retrieve data after the renegotiation (again) */
-    CALL(test_chanel_working(&dtls_session, packet_rcvd, DTLS_MAX_BUF));
+    /* 8th step: Send/Retrieve data after the renegotiation (again) */
+    CALL(test_chanel_working(tlsman_session, packet_rcvd, DTLS_MAX_BUF));
 #else
     (void) test_renegotiation;
     (void) test_chanel_working;
 #endif
 
 #if 0 /* WARNING: TinyDTLS has a known issue with this test (memarray?) */
-    /* 8th step: Renegotiation with existing parameters (RFC 6347 4.2.7) */
-    CALL(test_rehandshake(&dtls_session, tlsman_flags, packet_rcvd));
-    /* 9th step: Send/Retrieve data after the new contextfr (again) */
-    CALL(test_chanel_working(&dtls_session, packet_rcvd, DTLS_MAX_BUF));
+    /* 9th step: Renegotiation with existing parameters (RFC 6347 4.2.7) */
+    CALL(test_rehandshake(tlsman_session, tlsman_flags, packet_rcvd));
+    /* 10th step: Send/Retrieve data after the new context (again) */
+    CALL(test_chanel_working(tlsman_session, packet_rcvd, DTLS_MAX_BUF));
 #else
-    (void) test_rehandshake;;
+    (void) test_rehandshake;
     (void) test_chanel_working;
 #endif
 
     /* 10th close connection */
-    CALL(test_closing_channel(&dtls_session, packet_rcvd, DTLS_MAX_BUF));
+    CALL(test_closing_channel(tlsman_session, packet_rcvd, DTLS_MAX_BUF));
 
     /* NOTE: This also drops any DTLS alert record */
     sock_udp_close(&udp_sock);
 
     puts("ALL TESTS SUCCESSFUL");
-
-    return;
 }

--- a/tests/tlsman_tinydtls_sock/client.c
+++ b/tests/tlsman_tinydtls_sock/client.c
@@ -1,0 +1,412 @@
+/*
+ * Copyright (C) 2018 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       tlsman test application (client side)
+ *
+ * Small test for TLSMAN. Many definitions defined here are also available at
+ * sock_secure (and are intended to be used in standard applications)
+ *
+ * @author      Raul Fuentes <raul.fuentes-samaniego@inria.fr>
+ *
+ * @}
+ */
+
+ #include <stdio.h>
+#include <assert.h>
+
+#include "net/sock/udp.h"
+#include "net/tlsman.h"
+
+#define ENABLE_DEBUG (0)
+#include "debug.h"
+
+/**
+ * Our custom response handler to be sent to TLSMAN
+ * It will be inkoved each time a DTLS data app record is retrieved
+ *
+ * NOTE (TODO): The (void) * argument is more like a comodin as TLSMAN can deliver
+ * a sock, socket or other network stack.
+ */
+static void _resp_handler(uint8_t *data, size_t data_size, void *sock);
+
+#define CALL(fn)            puts("Calling " # fn); fn;
+
+#ifndef REMOTE_SERVER
+#define REMOTE_SERVER "fd00:dead:beef::1"
+#endif
+
+#ifndef SERVER_PORT
+#define SERVER_PORT 20220
+#endif
+
+#ifndef CLIENT_PORT
+#define CLIENT_PORT SERVER_PORT + 5
+#endif
+
+/* A small delay for debugging more easily network traffic */
+#ifdef ENABLE_DEBUG
+#define DBG_DELAY() xtimer_sleep(3)
+#else
+#define DBG_DELAY()
+#endif
+
+#ifdef SOCK_HAS_ASYNC
+static event_queue_t sock_event_queue;
+#endif
+
+static uint8_t _upper_data[] = "Hello world!\n";
+
+static void _resp_handler(uint8_t *data, size_t data_size, void *sock)
+{
+
+    (void) sock; /* For this test, our comodin (sock or socket) is irrelevant */
+
+    DEBUG("Echo (string %i): %s\n", data_size, data);
+    /* We are expecting an echo */
+    assert((0 == strncmp((char *) data, (char *) _upper_data,
+                         sizeof(_upper_data))) &&
+           (sizeof(_upper_data) == data_size));
+}
+
+static void test_creating_context(sock_udp_ep_t *local, sock_udp_ep_t *remote,
+                                  sock_udp_t *udp_sock,
+                                  tlsman_session_t *dtls_session,
+                                  uint8_t tlsman_flags)
+{
+
+    local->port = (unsigned short) CLIENT_PORT;
+    remote->port = (unsigned short) SERVER_PORT;
+
+    ssize_t res;
+
+    /* Socks must be ready before step 3 */
+    assert(ipv6_addr_from_str((ipv6_addr_t *)remote->addr.ipv6, REMOTE_SERVER));
+    assert(0 == sock_udp_create(udp_sock, local, remote, 0));
+    res = tlsman_init_context((tlsman_ep_t *) local, (tlsman_ep_t *) remote,
+                              dtls_session, udp_sock, _resp_handler,
+                              tlsman_flags);
+    assert(res == 0);
+}
+
+static void test_creating_channel(tlsman_session_t *dtls_session,
+                                  uint8_t tlsman_flags, uint8_t *packet_rcvd)
+{
+    tlsman_create_channel(dtls_session, tlsman_flags, packet_rcvd, DTLS_MAX_BUF);
+    /* NOTE: Assert is not called as the next test is equivalent */
+}
+
+static void test_checking_errors(void)
+{
+    ssize_t res = tlsman_return_last_known_error();
+
+    if (tlsman_process_is_error_code_nonfatal(res)) {
+        puts("ERROR: Unable to start (D)TLS handhsake process!");
+    }
+    else if (res == TLSMAN_ERROR_HANDSHAKE_TIMEOUT) {
+        /* NOTE: Handhsake timeout can be not fatal but is part of our test */
+        puts("ERROR: (D)TLS handshake timeout!");
+    }
+
+    assert((res != TLSMAN_ERROR_HANDSHAKE_TIMEOUT) &&
+           (!tlsman_process_is_error_code_nonfatal(res)));
+
+}
+
+static void test_sending_uper_data(tlsman_session_t *dtls_session)
+{
+    /*
+     * For a blocking testing, this would be equivalent to test for
+     * TLSMAN_ERROR_HANDSHAKE_TIMEOUT
+     */
+    assert(tlsman_is_channel_ready(dtls_session));
+
+    /* NOTE: It's possible to share the buffer for sending and receiving */
+    assert(0 == tlsman_send_data_app(dtls_session, _upper_data, sizeof(_upper_data)));
+}
+
+static void test_retrieve_data(tlsman_session_t *dtls_session, uint8_t *data,
+                               size_t data_size)
+{
+    /* NOTE: This test is synchronous, but the sock_async has impact here */
+    /* NOTE: This can retrieve other types of DTLS records (e.g. alerts) */
+#ifdef SOCK_HAS_ASYNC
+    /* NOTE: If tinydtls is running on it's own thread, tlsman_retrieve_data_app()
+     * can be called first.
+     * However, for this test is not the case.
+     */
+    tlsman_set_async_listening();
+#endif
+
+    assert(0 == tlsman_retrieve_data_app(dtls_session, data, data_size));
+
+}
+
+static void test_sending_uper_data_MULTIPLE(tlsman_session_t *dtls_session,
+                                            uint8_t *data, size_t data_size)
+{
+    /* Testing encryption and not more renegotiation between peers */
+    assert(tlsman_is_channel_ready(dtls_session));
+
+    /* NOTE: It's possible to share the buffer for sending and receiving */
+    assert(0 == tlsman_send_data_app(dtls_session, _upper_data, sizeof(_upper_data)));
+    assert(0 == tlsman_send_data_app(dtls_session, _upper_data, sizeof(_upper_data)));
+    assert(0 == tlsman_send_data_app(dtls_session, _upper_data, sizeof(_upper_data)));
+    assert(0 == tlsman_send_data_app(dtls_session, _upper_data, sizeof(_upper_data)));
+
+#ifdef SOCK_HAS_ASYNC
+    tlsman_set_async_listening();
+#endif
+
+    assert(0 == tlsman_retrieve_data_app(dtls_session, data, data_size));
+    assert(0 == tlsman_retrieve_data_app(dtls_session, data, data_size));
+    assert(0 == tlsman_retrieve_data_app(dtls_session, data, data_size));
+    assert(0 == tlsman_retrieve_data_app(dtls_session, data, data_size));
+
+}
+
+static void test_release_resources_IGNORING_ALERT(tlsman_session_t *dtls_session,
+                                                  sock_udp_t *udp_sock,
+                                                  uint8_t tlsman_flags, uint8_t *packet_rcvd)
+{
+    /* FIXME */
+    (void) tlsman_flags;
+    (void) packet_rcvd;
+    (void) udp_sock;
+
+    tlsman_release_resources(dtls_session);
+
+}
+
+static void test_reconnect_COMMON_ERROR(sock_udp_ep_t *local, sock_udp_ep_t *remote,
+                                        sock_udp_t *udp_sock, tlsman_session_t *dtls_session,
+                                        uint8_t tlsman_flags, uint8_t *packet, size_t pkt_size)
+{
+    /*
+     * This test first attempts to retrieve any (D)TLS record avaiable.
+     * With tinyDTLS therere is a high chanche that DTLS Alert record was received.
+     * This record can interfere with tlsman_create_channel()
+     */
+
+    DBG_DELAY();
+
+    assert(0 == tlsman_init_context((tlsman_ep_t *) local, (tlsman_ep_t *) remote,
+                                    dtls_session, udp_sock, _resp_handler,
+                                    tlsman_flags));
+
+    ssize_t res = tlsman_create_channel(dtls_session, tlsman_flags, packet,
+                                        pkt_size);
+
+    assert(res == TLSMAN_ERROR_HANDSHAKE_TIMEOUT);
+
+    /* This fail is due a DTLS Alert record sent by the remote node as result from the previous test.
+       Therefore for this test, we only try to do a new handshake
+     */
+
+    /* This is for fixing our intenral chaos */
+    tlsman_close_channel(dtls_session);
+    tlsman_retrieve_data_app(dtls_session, packet, sizeof(pkt_size));
+
+    sock_udp_close(udp_sock);
+    sock_udp_create(udp_sock, (sock_udp_ep_t *)local, (sock_udp_ep_t *)remote, 0);
+
+    res = tlsman_create_channel(dtls_session, tlsman_flags, packet,
+                                pkt_size);
+
+    assert((res != TLSMAN_ERROR_HANDSHAKE_TIMEOUT) &&
+           (!tlsman_process_is_error_code_nonfatal(res)));
+
+}
+
+static void test_reconnect_CLOSING_SOCKETS(sock_udp_ep_t *local, sock_udp_ep_t *remote,
+                                           sock_udp_t *udp_sock, tlsman_session_t *dtls_session,
+                                           uint8_t tlsman_flags, uint8_t *packet, size_t pkt_size)
+{
+    DBG_DELAY();
+
+    /* Equivalent to test_release_resources_IGNORING_ALERT */
+    tlsman_release_resources(dtls_session);
+
+    /*
+     * This test tries more safe approach than test_reconnect_COMMON_ERROR()
+     * By closing the udp sock we are also dropping any remaining DTLS record on the buffer */
+    assert(0 == tlsman_init_context((tlsman_ep_t *) local, (tlsman_ep_t *) remote,
+                                    dtls_session, udp_sock, _resp_handler,
+                                    tlsman_flags));
+
+    ssize_t res = tlsman_create_channel(dtls_session, tlsman_flags, packet,
+                                        pkt_size);
+
+    assert(res == TLSMAN_ERROR_HANDSHAKE_TIMEOUT);
+
+    /* This fail is due a DTLS Alert record sent by the remote node as result from the previous test.
+       Therefore for this test, we only try to do a new handshake
+     */
+
+    /* This is for fixing our intenral chaos */
+    tlsman_close_channel(dtls_session);
+    sock_udp_close(udp_sock);
+    sock_udp_create(udp_sock, (sock_udp_ep_t *)local, (sock_udp_ep_t *)remote, 0);
+
+    res = tlsman_create_channel(dtls_session, tlsman_flags, packet,
+                                pkt_size);
+
+    assert((res != TLSMAN_ERROR_HANDSHAKE_TIMEOUT) &&
+           (!tlsman_process_is_error_code_nonfatal(res)));
+
+}
+
+static void test_retrieve_data_TIMEOUT(tlsman_session_t *dtls_session, uint8_t *data,
+                                       size_t data_size)
+{
+    /* NOTE: This test is synchronous, but the sock_async has impact here */
+    /* NOTE: This can retrieve other types of DTLS records (e.g. alerts) */
+#ifdef SOCK_HAS_ASYNC
+    /* NOTE: If tinydtls is running on it's own thread, tlsman_retrieve_data_app()
+     * can be called first.
+     * However, for this test is not the case.
+     */
+    tlsman_set_async_listening();
+#endif
+
+    /* This test should be called without additional calls */
+    assert(0 == tlsman_retrieve_data_app(dtls_session, data, data_size));
+}
+
+static void test_renegotiation(tlsman_session_t *dtls_session,
+                               uint8_t tlsman_flags, uint8_t *packet_rcvd)
+{
+    DBG_DELAY();
+
+    /* NOTE: There is a known issue in tinydtls' commit for this test */
+    assert(TLSMAN_ERROR_SESSION_REN !=
+           tlsman_renegotiate_session(dtls_session, tlsman_flags, packet_rcvd,
+                                      DTLS_MAX_BUF));
+}
+
+static void test_chanel_working(tlsman_session_t *dtls_session, uint8_t *data,
+                                size_t data_size)
+{
+    /* This is equivalent to test_retrieve_data() and test_sending_uper_data() */
+
+    assert(tlsman_is_channel_ready(dtls_session));
+    assert(0 == tlsman_send_data_app(dtls_session, _upper_data, sizeof(_upper_data)));
+
+#ifdef SOCK_HAS_ASYNC
+    tlsman_set_async_listening();
+#endif
+    assert(0 == tlsman_retrieve_data_app(dtls_session, data, data_size));
+
+}
+
+static void test_rehandshake(tlsman_session_t *dtls_session,
+                             uint8_t tlsman_flags, uint8_t *packet_rcvd)
+{
+    DBG_DELAY();
+
+    assert(0 == tlsman_new_handshake(dtls_session, tlsman_flags,
+                                     packet_rcvd, DTLS_MAX_BUF));
+}
+
+static void test_closing_channel(tlsman_session_t *dtls_session,
+                                 uint8_t *packet, size_t pkt_size)
+{
+    assert(TLSMAN_ERROR_UNABLE_CLOSE != tlsman_close_channel(dtls_session));
+    tlsman_retrieve_data_app(dtls_session, packet, sizeof(pkt_size));
+
+    /* Release resources */
+    tlsman_release_resources(dtls_session);
+}
+
+void client_side(void)
+{
+
+    /*
+     * TLSMAN handles everything related to the (D)TLS stacks but not the
+     * the network stack itself. Additionally, there are limits:
+     * - tinyDTLS only supports socks or socket (TODO)
+     * - WolfSSL: TODO
+     */
+
+    sock_udp_ep_t local = SOCK_IPV6_EP_ANY;
+    sock_udp_ep_t remote = SOCK_IPV6_EP_ANY;
+    sock_udp_t udp_sock;
+    uint8_t tlsman_flags = TLSMAN_FLAG_STACK_UNIVERSAL | TLSMAN_FLAG_SIDE_CLIENT;
+
+    /* Storage for the context and secure session (for all the (D)TLS stacks) */
+    tlsman_session_t dtls_session;
+
+    /* This is the buffer to be used for sending AND receiving DTLS Records */
+    uint8_t packet_rcvd[DTLS_MAX_BUF];
+
+    DEBUG("Remote server: [%s]:%u\n", REMOTE_SERVER, SERVER_PORT);
+
+    /* 2nd step: Create the (D)TLS context and load the keys */
+    /* NOTE: 1st step is located at main.c */
+    CALL(test_creating_context(&local, &remote, &udp_sock, &dtls_session, tlsman_flags));
+
+#ifdef SOCK_HAS_ASYNC
+    /* This step is also required before tlsman_create_channel() */
+    tlsman_set_async_parameters(&dtls_session, &sock_event_queue, packet_rcvd, sizeof(packet_rcvd));
+    tlsman_flags |= TLSMAN_FLAG_NONBLOCKING;
+#endif
+
+    /* 3th step: Start the (D)TLS channel! (the handshake process) */
+    CALL(test_creating_channel(&dtls_session, tlsman_flags, packet_rcvd));
+
+    /* 4th step: The DTLS handshake was started correctly? */
+    CALL(test_checking_errors());
+
+    /* 5th step: Send and receiving data */
+    CALL(test_sending_uper_data(&dtls_session));
+    CALL(test_retrieve_data(&dtls_session, packet_rcvd, DTLS_MAX_BUF));
+
+    /* 6th step: Wrongly releasing resources and reconnect */
+    CALL(test_release_resources_IGNORING_ALERT(&dtls_session, &udp_sock, 0, NULL));
+    CALL(test_reconnect_COMMON_ERROR(&local, &remote, &udp_sock, &dtls_session, \
+                                     tlsman_flags, packet_rcvd, sizeof(packet_rcvd)));
+    CALL(test_sending_uper_data_MULTIPLE(&dtls_session, packet_rcvd, DTLS_MAX_BUF));
+    CALL(test_reconnect_CLOSING_SOCKETS(&local, &remote, &udp_sock, &dtls_session, \
+                                        tlsman_flags, packet_rcvd, sizeof(packet_rcvd)));
+    CALL(test_retrieve_data_TIMEOUT(&dtls_session, packet_rcvd, DTLS_MAX_BUF));
+
+#if 0 /* WARNING: TinyDTLS has a known bug with this test */
+      /* 6th step: renegotiation of (D)TLS session */
+    CALL(test_renegotiation(&dtls_session, tlsman_flags, packet_rcvd));
+
+    /* 7th step: Send/Retrieve data after the renegotiation (again) */
+    CALL(test_chanel_working(&dtls_session, packet_rcvd, DTLS_MAX_BUF));
+#else
+    (void) test_renegotiation;
+    (void) test_chanel_working;
+#endif
+
+#if 0 /* WARNING: TinyDTLS has a known issue with this test (memarray?) */
+    /* 8th step: Renegotiation with existing parameters (RFC 6347 4.2.7) */
+    CALL(test_rehandshake(&dtls_session, tlsman_flags, packet_rcvd));
+    /* 9th step: Send/Retrieve data after the new contextfr (again) */
+    CALL(test_chanel_working(&dtls_session, packet_rcvd, DTLS_MAX_BUF));
+#else
+    (void) test_rehandshake;;
+    (void) test_chanel_working;
+#endif
+
+    /* 10th close connection */
+    CALL(test_closing_channel(&dtls_session, packet_rcvd, DTLS_MAX_BUF));
+
+    /* NOTE: This also drops any DTLS alert record */
+    sock_udp_close(&udp_sock);
+
+    puts("ALL TESTS SUCCESSFUL");
+
+    return;
+}

--- a/tests/tlsman_tinydtls_sock/keys/dtls_keys.h
+++ b/tests/tlsman_tinydtls_sock/keys/dtls_keys.h
@@ -1,0 +1,81 @@
+/*
+ * Copyright (C) 2018 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       tlsman test application (PSK and ECC keys)
+ *
+ * Small test for TLSMAN. Many definitions defined here are also available at
+ * sock_secure (and are intended to be used in standard applications)
+ *
+ * @author      Raul Fuentes <raul.fuentes-samaniego@inria.fr>
+ *
+ * @}
+ */
+
+#ifndef DTLS_KEYS_H
+#define DTLS_KEYS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/*
+ *  Defautl keys examples for tinyDTLS (for RIOT, Linux and Contiki)
+ */
+#ifdef MODULE_TLSMAN_TINYDTLS
+#ifdef DTLS_PSK
+#define PSK_DEFAULT_IDENTITY "Client_identity"
+#define PSK_DEFAULT_KEY "secretPSK"
+#define PSK_OPTIONS "i:k:"
+#define PSK_ID_MAXLEN 32
+#define PSK_MAXLEN 32
+
+unsigned char psk_id[PSK_ID_MAXLEN] = PSK_DEFAULT_IDENTITY;
+size_t psk_id_length = sizeof(PSK_DEFAULT_IDENTITY) - 1;
+unsigned char psk_key[PSK_MAXLEN] = PSK_DEFAULT_KEY;
+size_t psk_key_length = sizeof(PSK_DEFAULT_KEY) - 1;
+
+#endif /* DTLS_PSK */
+
+#ifdef DTLS_ECC
+static const unsigned char ecdsa_priv_key[] = {
+    0x41, 0xC1, 0xCB, 0x6B, 0x51, 0x24, 0x7A, 0x14,
+    0x43, 0x21, 0x43, 0x5B, 0x7A, 0x80, 0xE7, 0x14,
+    0x89, 0x6A, 0x33, 0xBB, 0xAD, 0x72, 0x94, 0xCA,
+    0x40, 0x14, 0x55, 0xA1, 0x94, 0xA9, 0x49, 0xFA
+};
+
+static const unsigned char ecdsa_pub_key_x[] = {
+    0x36, 0xDF, 0xE2, 0xC6, 0xF9, 0xF2, 0xED, 0x29,
+    0xDA, 0x0A, 0x9A, 0x8F, 0x62, 0x68, 0x4E, 0x91,
+    0x63, 0x75, 0xBA, 0x10, 0x30, 0x0C, 0x28, 0xC5,
+    0xE4, 0x7C, 0xFB, 0xF2, 0x5F, 0xA5, 0x8F, 0x52
+};
+
+static const unsigned char ecdsa_pub_key_y[] = {
+    0x71, 0xA0, 0xD4, 0xFC, 0xDE, 0x1A, 0xB8, 0x78,
+    0x5A, 0x3C, 0x78, 0x69, 0x35, 0xA7, 0xCF, 0xAB,
+    0xE9, 0x3F, 0x98, 0x72, 0x09, 0xDA, 0xED, 0x0B,
+    0x4F, 0xAB, 0xC3, 0x6F, 0xC7, 0x72, 0xF8, 0x29
+};
+#endif /* DTLS_ECC */
+#endif /* MODULE_TLSMAN_TINYDTLS */
+
+#ifdef MODULE_TLSMAN_WOLFSSL
+/* TODO: Default set of keys for WolfSSL*/
+#endif /* MODULE_TLSMAN_WOLFSSL */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* DTLS_KEYS_H */

--- a/tests/tlsman_tinydtls_sock/main.c
+++ b/tests/tlsman_tinydtls_sock/main.c
@@ -39,24 +39,31 @@
 #define SECURE_CIPHER_LIST { SECURE_CIPHER_PSK_IDS, SECURE_CIPHER_RPK_IDS }
 
 #define MAIN_QUEUE_SIZE     (8)
+
+extern void client_side(tlsman_driver_t *tlsman_session, const uint8_t tlsman_flags);
+
 static msg_t _main_msg_queue[MAIN_QUEUE_SIZE];
 
-extern void client_side(void);
+tlsman_driver_t tlsman_session;
 
-static void test_load_stack(void)
+
+
+static void test_load_stack(uint8_t tlsman_flags)
 {
 
     /* The Cipher(s) the application must use (Hardcoded) */
-    int cipers[] = SECURE_CIPHER_LIST;
+    uint16_t ciphers[] = SECURE_CIPHER_LIST;
 
-    assert(0 ==
-           tlsman_load_stack(cipers, sizeof(cipers), TLSMAN_FLAG_STACK_DTLS));
+     assert (!tlsman_load_stack(&tlsman_session, ciphers, sizeof(ciphers),
+                                       tlsman_flags));
 
 }
 
 int main(void)
 {
 
+    uint8_t tlsman_flags = TLSMAN_FLAG_SIDE_CLIENT     |
+                           TLSMAN_FLAG_STACK_DTLS;
 
     /* we need a message queue for the thread running the shell in order to
      * receive potentially fast incoming networking packets */
@@ -67,9 +74,9 @@ int main(void)
      * First step: Init the (D)TLS stack. Either server or client
      * NOTE: This must be called once time only.
      */
-    CALL(test_load_stack());
+    CALL(test_load_stack(tlsman_flags));
 
-    client_side();
+    client_side(&tlsman_session, tlsman_flags);
 
     return 0;
 }

--- a/tests/tlsman_tinydtls_sock/main.c
+++ b/tests/tlsman_tinydtls_sock/main.c
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2018 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       tlsman test application
+ *
+ * Small test for TLSMAN. Many definitions defined here are also available at
+ * sock_secure (and are intended to be used in standard applications)
+ *
+ * @author      Raul Fuentes <raul.fuentes-samaniego@inria.fr>
+ *
+ * @}
+ */
+
+ #include <stdio.h>
+
+ #include "msg.h"
+ #include "net/tlsman.h"
+
+#define CALL(fn)            puts("Calling " # fn); fn;
+
+#ifndef DTLS_DEFAULT_PORT
+#define DTLS_DEFAULT_PORT 20220 /* DTLS default port */
+#endif
+
+/* List of acceptable cipher suites (T) */
+/* NOTE: For now, only CoAP Secure candidates (RFC 7252 9.1.3) */
+#define SECURE_CIPHER_PSK_IDS (0xC0A8)
+#define SECURE_CIPHER_RPK_IDS (0xC0AE)
+#define SECURE_CIPHER_LIST { SECURE_CIPHER_PSK_IDS, SECURE_CIPHER_RPK_IDS }
+
+#define MAIN_QUEUE_SIZE     (8)
+static msg_t _main_msg_queue[MAIN_QUEUE_SIZE];
+
+extern void client_side(void);
+
+static void test_load_stack(void)
+{
+
+    /* The Cipher(s) the application must use (Hardcoded) */
+    int cipers[] = SECURE_CIPHER_LIST;
+
+    assert(0 ==
+           tlsman_load_stack(cipers, sizeof(cipers), TLSMAN_FLAG_STACK_DTLS));
+
+}
+
+int main(void)
+{
+
+
+    /* we need a message queue for the thread running the shell in order to
+     * receive potentially fast incoming networking packets */
+    msg_init_queue(_main_msg_queue, MAIN_QUEUE_SIZE);
+    puts("TLSMAN Module testing implementation");
+
+    /*
+     * First step: Init the (D)TLS stack. Either server or client
+     * NOTE: This must be called once time only.
+     */
+    CALL(test_load_stack());
+
+    client_side();
+
+    return 0;
+}

--- a/tests/tlsman_tinydtls_sock/tests/01-run.py
+++ b/tests/tlsman_tinydtls_sock/tests/01-run.py
@@ -11,22 +11,23 @@ import sys
 
 
 def testfunc(child):
-    child.expect_exact(u"Calling test_load_stack()")
-    child.expect_exact(u"Calling test_creating_context(&local, &remote, &udp_sock, &dtls_session)")
-    child.expect_exact(u"Calling test_creating_channel(&dtls_session, tlsman_flags, packet_rcvd)")
-    child.expect_exact(u"Calling test_checking_errors()")
-    child.expect_exact(u"Calling test_sending_uper_data(&dtls_session)")
-    child.expect_exact(u"Calling test_retrieve_data(&dtls_session, packet_rcvd, DTLS_MAX_BUF)")
-    child.expect_exact(u"Calling test_release_resources_IGNORING_ALERT(&dtls_session, &udp_sock, 0, NULL)")
-    child.expect_exact(u"Calling test_reconnect_COMMON_ERROR(&local, &remote, &udp_sock, &dtls_session, tlsman_flags, packet_rcvd, sizeof(packet_rcvd))")
-    child.expect_exact(u"Calling test_sending_uper_data_MULTIPLE(&dtls_session, packet_rcvd, DTLS_MAX_BUF)")
-    child.expect_exact(u"Calling test_reconnect_CLOSING_SOCKETS(&local, &remote, &udp_sock, &dtls_session, tlsman_flags, packet_rcvd, sizeof(packet_rcvd))")
-    child.expect_exact(u"Calling test_retrieve_data_TIMEOUT(&dtls_session, packet_rcvd, DTLS_MAX_BUF)")
-    child.expect_exact(u"Calling test_closing_channel(&dtls_session, packet_rcvd, DTLS_MAX_BUF)")
+    child.expect_exact(u"Calling test_load_stack")
+    child.expect_exact(u"Calling test_creating_context")
+    child.expect_exact(u"Calling test_creating_channel")
+    child.expect_exact(u"Calling test_checking_errors")
+    child.expect_exact(u"Calling test_sending_upper_data")
+    child.expect_exact(u"Calling test_retrieve_data")
+    child.expect_exact(u"Calling test_release_resources_IGNORING_ALERT")
+    child.expect_exact(u"Calling test_reconnect_COMMON_ERROR")
+    child.expect_exact(u"Calling test_sending_upper_data_MULTIPLE")
+    child.expect_exact(u"Calling test_reconnect_CLOSING_SOCKETS")
+    child.expect_exact(u"Calling test_retrieve_data_TIMEOUT")
+    child.expect_exact(u"Calling test_closing_channel")
     child.expect_exact(u"ALL TESTS SUCCESSFUL")
+
 
 if __name__ == "__main__":
     sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
     from testrunner import run
-    timer = 10 # NOTE: DTLS timeout is around 10 seconds
+    timer = 10  # NOTE: DTLS timeout is around 10 seconds
     sys.exit(run(testfunc, timeout=timer))

--- a/tests/tlsman_tinydtls_sock/tests/01-run.py
+++ b/tests/tlsman_tinydtls_sock/tests/01-run.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2018 Raul Fuentes <raul.fuentes-samaniego@inria.fr>
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import os
+import sys
+
+
+def testfunc(child):
+    child.expect_exact(u"Calling test_load_stack()")
+    child.expect_exact(u"Calling test_creating_context(&local, &remote, &udp_sock, &dtls_session)")
+    child.expect_exact(u"Calling test_creating_channel(&dtls_session, tlsman_flags, packet_rcvd)")
+    child.expect_exact(u"Calling test_checking_errors()")
+    child.expect_exact(u"Calling test_sending_uper_data(&dtls_session)")
+    child.expect_exact(u"Calling test_retrieve_data(&dtls_session, packet_rcvd, DTLS_MAX_BUF)")
+    child.expect_exact(u"Calling test_release_resources_IGNORING_ALERT(&dtls_session, &udp_sock, 0, NULL)")
+    child.expect_exact(u"Calling test_reconnect_COMMON_ERROR(&local, &remote, &udp_sock, &dtls_session, tlsman_flags, packet_rcvd, sizeof(packet_rcvd))")
+    child.expect_exact(u"Calling test_sending_uper_data_MULTIPLE(&dtls_session, packet_rcvd, DTLS_MAX_BUF)")
+    child.expect_exact(u"Calling test_reconnect_CLOSING_SOCKETS(&local, &remote, &udp_sock, &dtls_session, tlsman_flags, packet_rcvd, sizeof(packet_rcvd))")
+    child.expect_exact(u"Calling test_retrieve_data_TIMEOUT(&dtls_session, packet_rcvd, DTLS_MAX_BUF)")
+    child.expect_exact(u"Calling test_closing_channel(&dtls_session, packet_rcvd, DTLS_MAX_BUF)")
+    child.expect_exact(u"ALL TESTS SUCCESSFUL")
+
+if __name__ == "__main__":
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    timer = 10 # NOTE: DTLS timeout is around 10 seconds
+    sys.exit(run(testfunc, timeout=timer))


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

This PoC PR is trying to achieve the second step for the modules proposed in #7649 (TLSMAN) and #7397 (sock_secure). Sock_secure has as objective of adding an extension to sock which makes transparent the addition of a secure channel to current applications.

**NOTE**: This is making use of sock_udp for sending the DTLS records.

#### Working in progress

This is still in early steps and should be considered a proof of concept. The API is not finished. Comments about the API, or a better integration with sock are more than welcome.

Currently sock_secure is able to create the resources, establish the secure channel, send and receive upper data by means of the secure channel, and release resources.

Important steps to do: 
- [ ] Add the ability of renegotiating the current channel or recovered it if it was lost. 
- [ ] Be able to determine if resources are already allocated.
- [ ] Be able to work more transparently for server or client (for gcoap at least)
  * (4th/july) Add timeout when listening for incoming upper data
- [ ] Create a test case
- [ ] Upgrade the example to something more useful (right now is duplicating dtls-echo)   
   * Client should be able to preserve the secure channel and renegotiating it at will.

#### Current support for CoAP

##### nanocoap 

I'm adding two commits with the integration of sock_secure over nanocoap.
This is working fine with the default example. 

##### gcoap

In a very fast attempt to implement sock_secure for gcoap I screwed gcoap's machine state. The CoAP Secure message was sent and received, but the memo mechanism was unable to register the message and thus was dropping the received answer. Before attempting something similar to #7177 (e.g. adding more mbox messages) I would like to discuss with @kb2ma, maybe in the next riot summit?

##### Other CoAP apps

It's possible to use gcoap to generate the CoAP message and then sending it manually instead of using `gcoap_req_send2()`. Applications like [this one](https://github.com/aabadie/riot-firmwares/blob/master/modules/coap_utils/coap_utils.c) should be easier to adapt for sock_secure.   

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

Discussed on: 
* Issue #7397

Depends on: 

* ~~PR #7615~~ 
* PR #9066
