### PR TITLE
Makefile.include: fully define BASELIBS before using its value

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -362,6 +362,9 @@ LINKFLAGPREFIX ?= -Wl,
 
 DIRS += $(EXTERNAL_MODULE_DIRS)
 
+# Save value to verify it is not modified later
+_BASELIBS_VALUE_BEFORE_USAGE := $(BASELIBS)
+
 # Linker rule
 $(ELFFILE): FORCE
 ifeq ($(BUILDOSXNATIVE),1)
@@ -642,6 +645,14 @@ include $(RIOTMAKE)/murdock.inc.mk
 # Sanity check, 'all' should be the default goal
 ifneq (all, $(.DEFAULT_GOAL))
   $(error .DEFAULT_GOAL := $(.DEFAULT_GOAL))
+endif
+
+
+# Detect if BASELIBS changed since its first use
+ifneq ($(_BASELIBS_VALUE_BEFORE_USAGE),$(BASELIBS))
+  $(warning $(sort $(filter-out $(_BASELIBS_VALUE_BEFORE_USAGE), $(BASELIBS)) \
+                   $(filter-out $(BASELIBS), $(_BASELIBS_VALUE_BEFORE_USAGE))))
+  $(error BASELIBS value changed)
 endif
 
 endif # BOARD=none

--- a/Makefile.include
+++ b/Makefile.include
@@ -311,6 +311,25 @@ BASELIBS += $(BINDIR)/$(APPLICATION_MODULE).a
 BASELIBS += $(APPDEPS)
 
 
+# add extra include paths for packages in $(USEMODULE)
+export USEMODULE_INCLUDES =
+
+include $(RIOTBASE)/sys/Makefile.include
+include $(RIOTBASE)/drivers/Makefile.include
+
+# include Makefile.includes for packages in $(USEPKG)
+$(RIOTPKG)/%/Makefile.include::
+	$(Q)"$(MAKE)" -C $(RIOTPKG)/$* Makefile.include
+
+$(info $(USEPKG:%=$(RIOTPKG)/%/Makefile.include))
+.PHONY: $(USEPKG:%=$(RIOTPKG)/%/Makefile.include)
+-include $(USEPKG:%=$(RIOTPKG)/%/Makefile.include)
+
+USEMODULE_INCLUDES_ = $(shell echo $(USEMODULE_INCLUDES) | tr ' ' '\n' | awk '!a[$$0]++' | tr '\n' ' ')
+
+INCLUDES += $(USEMODULE_INCLUDES_:%=-I%)
+
+
 # include bindist target
 include $(RIOTMAKE)/bindist.inc.mk
 
@@ -399,27 +418,10 @@ endef
 	@$(COLOR_ECHO) '$(COLOR_GREEN)Building application "$(APPLICATION)" for "$(BOARD)" with MCU "$(MCU)".$(COLOR_RESET)'
 	@$(COLOR_ECHO)
 
-# add extra include paths for packages in $(USEMODULE)
-export USEMODULE_INCLUDES =
-
-include $(RIOTBASE)/sys/Makefile.include
-include $(RIOTBASE)/drivers/Makefile.include
-
 # The `clean` needs to be serialized before everything else.
 ifneq (, $(filter clean, $(MAKECMDGOALS)))
     all $(BASELIBS) $(USEPKG:%=$(RIOTPKG)/%/Makefile.include) $(RIOTBUILD_CONFIG_HEADER_C) pkg-prepare: clean
 endif
-
-# include Makefile.includes for packages in $(USEPKG)
-$(RIOTPKG)/%/Makefile.include::
-	$(Q)"$(MAKE)" -C $(RIOTPKG)/$* Makefile.include
-
-.PHONY: $(USEPKG:%=$(RIOTPKG)/%/Makefile.include)
--include $(USEPKG:%=$(RIOTPKG)/%/Makefile.include)
-
-USEMODULE_INCLUDES_ = $(shell echo $(USEMODULE_INCLUDES) | tr ' ' '\n' | awk '!a[$$0]++' | tr '\n' ' ')
-
-INCLUDES += $(USEMODULE_INCLUDES_:%=-I%)
 
 .PHONY: pkg-prepare $(USEPKG:%=$(BINDIR)/%.a)
 pkg-prepare:

--- a/Makefile.include
+++ b/Makefile.include
@@ -310,6 +310,14 @@ APPLICATION_MODULE ?= application_$(APPLICATION)
 BASELIBS += $(BINDIR)/$(APPLICATION_MODULE).a
 BASELIBS += $(APPDEPS)
 
+
+# include bindist target
+include $(RIOTMAKE)/bindist.inc.mk
+
+# Add all USEMODULE modules to CFLAGS and populate BASELIBS
+include $(RIOTMAKE)/modules.inc.mk
+
+
 .PHONY: all link clean flash flash-only term doc debug debug-server reset objdump help info-modules
 .PHONY: print-size elffile binfile hexfile
 .PHONY: ..in-docker-container
@@ -602,12 +610,6 @@ endif
 
 # Include desvirt Makefile
 include $(RIOTTOOLS)/desvirt/Makefile.desvirt
-
-# include bindist target
-include $(RIOTMAKE)/bindist.inc.mk
-
-# Add all USEMODULE modules to CFLAGS
-include $(RIOTMAKE)/modules.inc.mk
 
 # Build a header file with all common macro definitions and undefinitions
 # make it phony to force re-run of the script every time even if the file exists


### PR DESCRIPTION
### Contribution description

As described in https://github.com/RIOT-OS/RIOT/issues/8913 some places are using the immediate value of `BASELIBS` before it is actually set (== use of non initialized variables…). The problem was mitigated because ELFFILE is always rebuild even if files in `$(BASELIBS)` did not change.

This PR addresses this by moving the definition of `BASELIBS` sooner in `Makefile.include`.

This required:

* processing `modules.inc.mk` earlier
* process all `pkg/*/Makefile.include` as `libcose` defines `PSEUDOMODULES` which modifies `BASELIBS` https://github.com/RIOT-OS/RIOT/issues/8984 and https://github.com/RIOT-OS/RIOT/pull/9003

I also added a debug commit that asserts that `BASELIBS` was not changed during build. It can be removed before merging.

### Issues/PRs references

This was problematic when trying to reference `$(BASELIBS)` as a target dependency in the application Makefile: https://github.com/RIOT-OS/RIOT/pull/9351