### PR TITLE
gnrc_sock_udp: use sock's local end-point for listening

### DIFF
--- a/sys/net/gnrc/sock/udp/gnrc_sock_udp.c
+++ b/sys/net/gnrc/sock/udp/gnrc_sock_udp.c
@@ -136,7 +136,7 @@ int sock_udp_create(sock_udp_t *sock, const sock_udp_ep_t *local,
     }
     if (local != NULL) {
         /* listen only with local given */
-        gnrc_sock_create(&sock->reg, GNRC_NETTYPE_UDP, local->port);
+        gnrc_sock_create(&sock->reg, GNRC_NETTYPE_UDP, sock->local.port);
     }
     sock->flags = flags;
     return 0;


### PR DESCRIPTION
### Contribution description
Without this fix the listener doesn't actually listen on the (potentially) ephemeral port introduced in #9382, but on port 0 which is wrong.

Also, a new test case is provided to confirm that it works now.

### Issues/PRs references
Amends to #9382.