### PR TITLE
drivers/tmp006: adapt to new i2c API

### DIFF
--- a/drivers/tmp006/tmp006.c
+++ b/drivers/tmp006/tmp006.c
@@ -58,7 +58,6 @@
 #define TMP006_MID_VALUE            (0x5449) /**< Manufacturer ID */
 #define TMP006_DID_VALUE            (0x0067) /**< Device ID */
 
-#define I2C_SPEED                   I2C_SPEED_FAST
 #define BUS                         (dev->p.i2c)
 #define ADDR                        (dev->p.addr)
 
@@ -78,15 +77,9 @@ int tmp006_init(tmp006_t *dev, const tmp006_params_t *params)
         return -TMP006_ERROR_CONF;
     }
 
-    /* setup the I2C bus */
-    i2c_acquire(BUS);
-    if (i2c_init_master(BUS, I2C_SPEED) < 0) {
-        i2c_release(BUS);
-        LOG_ERROR("tmp006_init: error initializing I2C bus\n");
-        return -TMP006_ERROR_BUS;
-    }
     /* test device id */
-    if (i2c_read_regs(BUS, ADDR, TMP006_REGS_DEVICE_ID, reg, 2) != 2) {
+    i2c_acquire(BUS);
+    if (i2c_read_regs(BUS, ADDR, TMP006_REGS_DEVICE_ID, reg, 2, 0) < 0) {
         i2c_release(BUS);
         LOG_ERROR("tmp006_init: error reading device ID!\n");
         return -TMP006_ERROR_BUS;
@@ -99,7 +92,7 @@ int tmp006_init(tmp006_t *dev, const tmp006_params_t *params)
     tmp = TMP006_CONFIG_CR(dev->p.rate);
     reg[0] = (tmp >> 8);
     reg[1] = tmp;
-    if (i2c_write_regs(BUS, ADDR, TMP006_REGS_CONFIG, reg, 2) != 2) {
+    if (i2c_write_regs(BUS, ADDR, TMP006_REGS_CONFIG, reg, 2, 0) < 0) {
         i2c_release(BUS);
         LOG_ERROR("tmp006_init: error setting conversion rate!\n");
         return -TMP006_ERROR_BUS;
@@ -118,7 +111,7 @@ int tmp006_reset(const tmp006_t *dev)
 
     /* Acquire exclusive access to the bus. */
     i2c_acquire(BUS);
-    if (i2c_write_regs(BUS, ADDR, TMP006_REGS_CONFIG, reg, 2) != 2) {
+    if (i2c_write_regs(BUS, ADDR, TMP006_REGS_CONFIG, reg, 2, 0) < 0) {
         i2c_release(BUS);
         return -TMP006_ERROR_BUS;
     }
@@ -131,13 +124,13 @@ int tmp006_set_active(const tmp006_t *dev)
     uint8_t reg[2];
 
     i2c_acquire(BUS);
-    if (i2c_read_regs(BUS, ADDR, TMP006_REGS_CONFIG, reg, 2) != 2) {
+    if (i2c_read_regs(BUS, ADDR, TMP006_REGS_CONFIG, reg, 2, 0) < 0) {
         i2c_release(BUS);
         return -TMP006_ERROR_BUS;
     }
 
     reg[0] |= (TMP006_CONFIG_MOD(TMP006_CONFIG_MOD_CC) >> 8);
-    if (i2c_write_regs(BUS, ADDR, TMP006_REGS_CONFIG, reg, 2) != 2) {
+    if (i2c_write_regs(BUS, ADDR, TMP006_REGS_CONFIG, reg, 2, 0) < 0) {
         i2c_release(BUS);
         return -TMP006_ERROR_BUS;
     }
@@ -150,13 +143,13 @@ int tmp006_set_standby(const tmp006_t *dev)
     uint8_t reg[2];
 
     i2c_acquire(BUS);
-    if (i2c_read_regs(BUS, ADDR, TMP006_REGS_CONFIG, reg, 2) != 2) {
+    if (i2c_read_regs(BUS, ADDR, TMP006_REGS_CONFIG, reg, 2, 0) < 0) {
         i2c_release(BUS);
         return -TMP006_ERROR_BUS;
     }
 
     reg[0] &= ~(TMP006_CONFIG_MOD(TMP006_CONFIG_MOD_CC) >> 8);
-    if (i2c_write_regs(BUS, ADDR, TMP006_REGS_CONFIG, reg, 2) != 2) {
+    if (i2c_write_regs(BUS, ADDR, TMP006_REGS_CONFIG, reg, 2, 0) < 0) {
         i2c_release(BUS);
         return -TMP006_ERROR_BUS;
     }
@@ -170,7 +163,7 @@ int tmp006_read(const tmp006_t *dev, int16_t *rawv, int16_t *rawt, uint8_t *drdy
 
     i2c_acquire(BUS);
     /* Register bytes are sent MSB first. */
-    if (i2c_read_regs(BUS, ADDR, TMP006_REGS_CONFIG, reg, 2) != 2) {
+    if (i2c_read_regs(BUS, ADDR, TMP006_REGS_CONFIG, reg, 2, 0) < 0) {
         i2c_release(BUS);
         return -TMP006_ERROR_BUS;
     }
@@ -183,7 +176,7 @@ int tmp006_read(const tmp006_t *dev, int16_t *rawv, int16_t *rawt, uint8_t *drdy
     }
 
     i2c_acquire(BUS);
-    if (i2c_read_regs(BUS, ADDR, TMP006_REGS_V_OBJECT, reg, 2) != 2) {
+    if (i2c_read_regs(BUS, ADDR, TMP006_REGS_V_OBJECT, reg, 2, 0) < 0) {
         i2c_release(BUS);
         return -TMP006_ERROR_BUS;
     }
@@ -192,7 +185,7 @@ int tmp006_read(const tmp006_t *dev, int16_t *rawv, int16_t *rawt, uint8_t *drdy
     *rawv = ((uint16_t)reg[0] << 8) | reg[1];
 
     i2c_acquire(BUS);
-    if (i2c_read_regs(BUS, ADDR, TMP006_REGS_T_AMBIENT, reg, 2) != 2) {
+    if (i2c_read_regs(BUS, ADDR, TMP006_REGS_T_AMBIENT, reg, 2, 0) < 0) {
         i2c_release(BUS);
         return -TMP006_ERROR_BUS;
     }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Update tmp006 for the new I2C interface.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references
#6577
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->