### PR TITLE
tools: add mosquitto.rsmb MQTT-SN broker

### DIFF
--- a/dist/tools/mosquitto_rsmb/.gitignore
+++ b/dist/tools/mosquitto_rsmb/.gitignore
@@ -1,0 +1,3 @@
+mosquitto_rsmb
+Messages.1.*
+FFDC.CWNAN.*.dmp

--- a/dist/tools/mosquitto_rsmb/Makefile
+++ b/dist/tools/mosquitto_rsmb/Makefile
@@ -1,0 +1,36 @@
+PKG_NAME     = mosquitto_rsmb
+PKG_URL      = https://github.com/eclipse/mosquitto.rsmb
+PKG_VERSION  = 9b99a3be9a26635b93aec8fa2ed744e8c49e7262
+PKG_LICENSE  = EPL-1.0
+PKG_BUILDDIR = $(CURDIR)/bin
+
+# set default configuration file
+RSMB_CFG ?= $(CURDIR)/config.cnf
+
+# manually set some RIOT env vars, so this Makefile can be called stand-alone
+RIOTBASE ?= $(CURDIR)/../../..
+RIOTTOOLS ?= $(CURDIR)/..
+GITCACHE ?= $(RIOTTOOLS)/git/git-cache
+
+$(info $(RIOTBASE))
+
+.PHONY: all clean
+
+all: git-download
+# Start mosquitto_rsmb build in a clean environment, so variables set by RIOT's
+# build process for cross compiling a specific target platform are reset and
+# mosquitto_rsmb can be built cleanly for the host platform.
+	env -i PATH=$(PATH) TERM=$(TERM) "$(MAKE)" -C $(PKG_BUILDDIR)/rsmb/src
+	cp $(PKG_BUILDDIR)/rsmb/src/broker_mqtts $(CURDIR)/mosquitto_rsmb
+	cp $(PKG_BUILDDIR)/rsmb/src/Messages.1.* $(CURDIR)/
+
+run:
+	@$(CURDIR)/mosquitto_rsmb $(RSMB_CFG)
+
+clean::
+	@rm -rf $(CURDIR)/bin
+	@rm -f $(CURDIR)/mosquitto_rsmb
+	@rm -f $(CURDIR)/Messages.1.*
+	@rm -f $(CURDIR)/FFDC.CWNAN.*.dmp
+
+include $(RIOTBASE)/pkg/pkg.mk

--- a/dist/tools/mosquitto_rsmb/config.cnf
+++ b/dist/tools/mosquitto_rsmb/config.cnf
@@ -1,0 +1,6 @@
+# Uncomment this to show you packets being sent and received
+trace_output protocol
+
+# MQTT-SN listener
+listener 1883 INADDR_ANY mqtts
+ipv6 true

--- a/makefiles/tools/targets.inc.mk
+++ b/makefiles/tools/targets.inc.mk
@@ -4,6 +4,8 @@
 # (as `all`), so `all` will always be the first target defined and thereby the
 # default target when `make` is called without any further argument.
 
+.PHONY: mosquitto_rsmb
+
 # target for building the bossac binary
 $(RIOTTOOLS)/bossa/bossac:
 	@echo "[INFO] bossac binary not found - building it from source"
@@ -14,3 +16,11 @@ $(RIOTTOOLS)/edbg/edbg:
 	@echo "[INFO] edbg binary not found - building it from source now"
 	CC= CFLAGS= make -C $(RIOTTOOLS)/edbg
 	@echo "[INFO] edbg binary successfully build!"
+
+$(RIOTTOOLS)/mosquitto_rsmb/mosquitto_rsmb:
+	@echo "[INFO] rsmb binary not found - building it from source now"
+	@make -C $(RIOTTOOLS)/mosquitto_rsmb
+	@echo "[INFO] rsmb binary successfully build!"
+
+mosquitto_rsmb: $(RIOTTOOLS)/mosquitto_rsmb/mosquitto_rsmb
+	@make -C $(RIOTTOOLS)/mosquitto_rsmb run


### PR DESCRIPTION
### Contribution description
This PR adds the build and a run configuration for the [Mosquitto.rsmb (really small message broker)](https://github.com/eclipse/mosquitto.rsmb), a small MQTT(-SN) gateway and server. Having this in RIOT is very helpful when testing anything MQTT-SN related (as e.g. `examples/emcute` or my upcoming, asynchronous MQTT-SN client implementation). So instead of going through the trouble following the 'setup-guide' in [examples/emcute_mqttsn/README.md](https://github.com/RIOT-OS/RIOT/blob/master/examples/emcute_mqttsn/README.md), one can now simply start a pre-configured MQTT-SN gateway instance by simply issuing
```
make rsmb
```
This will further be useful when designing an automated test setup...

### Issues/PRs references
none yet