### PR TITLE
drivers/pn532: fix wrong buffer type

### DIFF
--- a/drivers/pn532/pn532.c
+++ b/drivers/pn532/pn532.c
@@ -80,7 +80,7 @@
 
 #if ENABLE_DEBUG
 #define PRINTBUFF printbuff
-static void printbuff(char *buff, unsigned len)
+static void printbuff(uint8_t *buff, unsigned len)
 {
     while (len) {
         len--;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Fixes a type error when debug is enabled.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references
discovered while testing #9458
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->