### PR TITLE
Monocypher: Initial import of package

### DIFF
--- a/pkg/monocypher/Makefile
+++ b/pkg/monocypher/Makefile
@@ -1,0 +1,11 @@
+PKG_NAME=monocypher
+PKG_URL=https://github.com/LoupVaillant/Monocypher
+PKG_VERSION=6c2edbb48a61f43452c48c5f1e3ddabb19af3111
+PKG_LICENSE=CC-0
+
+.PHONY: all
+
+all: git-download
+	$(Q)"$(MAKE)" -C $(PKG_BUILDDIR)/src
+
+include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/monocypher/Makefile.dep
+++ b/pkg/monocypher/Makefile.dep
@@ -1,0 +1,1 @@
+USEMODULE += monocypher_sha512

--- a/pkg/monocypher/Makefile.include
+++ b/pkg/monocypher/Makefile.include
@@ -1,0 +1,7 @@
+INCLUDES += -I$(PKGDIRBASE)/monocypher/src
+INCLUDES += -I$(PKGDIRBASE)/monocypher/src/optional
+
+ifneq (,$(filter monocypher_sha512,$(USEMODULE)))
+  CFLAGS += -DED25519_SHA512
+  DIRS += $(PKGDIRBASE)/monocypher/src/optional
+endif

--- a/pkg/monocypher/doc.txt
+++ b/pkg/monocypher/doc.txt
@@ -1,0 +1,40 @@
+/**
+ * @defgroup pkg_monocypher Monocypher cryptographic library
+ * @ingroup  pkg
+ * @brief    Provides the Monocypher cryptographic library.
+ *
+ * # Monocypher RIOT package
+ *
+ * Monocypher is a high performance cryptographic library. It provides functions
+ * for authenticated encryption, hashing, password key derivation, key
+ * exchange, and public key signatures.
+ *
+ * You can find the API and more information
+ * [here](https://monocypher.org/manual)
+ *
+ * ## Requirements
+ *
+ * @note    Monocypher only supports 32bit platforms.
+ *
+ * Monocypher requires around 3K of stack space depending slightly on the
+ * platform, so beware that you're allocating at
+ * least `THREAD_STACKSIZE_DEFAULT + 3072` bytes.
+ *
+ * You can do it easily by adding:
+ *
+ * ```makefile
+ * CFLAGS += '-DTHREAD_STACKSIZE_MAIN=(THREAD_STACKSIZE_DEFAULT + 3072)'
+ * ```
+ *
+ * to your makefile.
+ *
+ * ## Usage
+ *
+ * Just add it as a package in your application:
+ *
+ * ```makefile
+ * USEPKG += monocypher
+ * ```
+ *
+ * @see     https://monocypher.org/
+ */

--- a/pkg/monocypher/patches/0001-Monocypher-add-riot-makefiles.patch
+++ b/pkg/monocypher/patches/0001-Monocypher-add-riot-makefiles.patch
@@ -1,0 +1,33 @@
+From a8f8636c0b72d32a931c743d611bba4291a10eb5 Mon Sep 17 00:00:00 2001
+From: Koen Zandberg <koen@bergzand.net>
+Date: Fri, 29 Jun 2018 15:33:52 +0200
+Subject: [PATCH] Monocypher: add riot makefiles
+
+---
+ src/Makefile          | 3 +++
+ src/optional/Makefile | 3 +++
+ 2 files changed, 6 insertions(+)
+ create mode 100644 src/Makefile
+ create mode 100644 src/optional/Makefile
+
+diff --git a/src/Makefile b/src/Makefile
+new file mode 100644
+index 0000000..c0f8d6c
+--- /dev/null
++++ b/src/Makefile
+@@ -0,0 +1,3 @@
++MODULE := monocypher
++
++include $(RIOTBASE)/Makefile.base
+diff --git a/src/optional/Makefile b/src/optional/Makefile
+new file mode 100644
+index 0000000..784d588
+--- /dev/null
++++ b/src/optional/Makefile
+@@ -0,0 +1,3 @@
++MODULE := monocypher_sha512
++
++include $(RIOTBASE)/Makefile.base
+-- 
+2.16.4
+

--- a/tests/pkg_monocypher/Makefile
+++ b/tests/pkg_monocypher/Makefile
@@ -1,0 +1,16 @@
+include ../Makefile.tests_common
+
+# No 8 bit and 16 bit support
+BOARD_BLACKLIST := arduino-duemilanove arduino-mega2560 arduino-uno chronos \
+        jiminy-mega256rfr2 mega-xplained msb-430 msb-430h telosb \
+        waspmote-pro wsn430-v1_3b wsn430-v1_4 z1
+
+USEMODULE += embunit
+USEMODULE += random
+USEPKG += monocypher
+
+TEST_ON_CI_WHITELIST += all
+include $(RIOTBASE)/Makefile.include
+
+test:
+	tests/01-run.py

--- a/tests/pkg_monocypher/main.c
+++ b/tests/pkg_monocypher/main.c
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2018 Freie Universität Berlin
+ * Copyright (C) 2018 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Monocypher package
+ *
+ * @author      Koen Zandberg <koen@bergzand.net>
+ *
+ * @}
+ */
+
+#include <string.h>
+
+#include "monocypher.h"
+#include "embUnit.h"
+#include "random.h"
+
+static uint8_t message[] = "0123456789abcdef";
+
+static uint8_t sign_sk[32];
+static uint8_t sign_pk[32];
+static uint8_t signature[64];
+
+static void setUp(void)
+{
+    random_init(0);
+}
+
+static void test_monocypher_signverify(void)
+{
+    int res;
+    /* Creating keypair ... */
+    random_bytes(sign_sk, sizeof(sign_sk));
+    crypto_sign_public_key(sign_pk, sign_sk);
+
+    /* Sign */
+    crypto_sign(signature, sign_sk, sign_pk, message, sizeof(message));
+
+    /* Verifying... */
+    res = crypto_check(signature, sign_pk, message, sizeof(message));
+    TEST_ASSERT_EQUAL_INT(0, res);
+}
+
+static void test_monocypher_verifynegative(void)
+{
+    int res;
+
+    /* changing message at random position (10) */
+    message[0] = 'A';
+
+    /* Verifying... */
+    res = crypto_check(signature, sign_pk, message, sizeof(message));
+    TEST_ASSERT_EQUAL_INT(-1, res);
+}
+
+Test *tests_monocypher(void)
+{
+    EMB_UNIT_TESTFIXTURES(fixtures) {
+        new_TestFixture(test_monocypher_signverify),
+        new_TestFixture(test_monocypher_verifynegative)
+    };
+
+    EMB_UNIT_TESTCALLER(monocypher_tests, setUp, NULL, fixtures);
+    return (Test*)&monocypher_tests;
+}
+
+int main(void)
+{
+    TESTS_START();
+    TESTS_RUN(tests_monocypher());
+    TESTS_END();
+
+    return 0;
+}

--- a/tests/pkg_monocypher/tests/01-run.py
+++ b/tests/pkg_monocypher/tests/01-run.py
@@ -1,0 +1,22 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2016 Kaspar Schleiser <kaspar@schleiser.de>
+# Copyright (C) 2016 Takuo Yonezawa <Yonezawa-T2@mail.dnp.co.jp>
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import os
+import sys
+
+
+def testfunc(child):
+    child.expect(r"OK \(2 tests\)")
+
+
+if __name__ == "__main__":
+    sys.path.append(os.path.join(os.environ['RIOTBASE'],
+                                 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc))


### PR DESCRIPTION
### Contribution description

Add support for the [Monocypher] crypto library as external package. Compared to TweetNaCl, the flash usage is twice the size (around 10K), but signature generation and verification is 5 - 8 times as fast as TweetNaCl on the different ARM cortex versions.

### Issues/PRs references

None

[Monocypher]: https://monocypher.org