### PR TITLE
boards/mulle: Fix mixed up RX TX pins on UART0

### DIFF
--- a/boards/mulle/include/periph_conf.h
+++ b/boards/mulle/include/periph_conf.h
@@ -128,8 +128,8 @@ static const uart_conf_t uart_config[] = {
     {
         .dev    = UART0,
         .freq   = CLOCK_CORECLOCK,
-        .pin_rx = GPIO_PIN(PORT_A, 14),
-        .pin_tx = GPIO_PIN(PORT_A, 15),
+        .pin_rx = GPIO_PIN(PORT_A, 15),
+        .pin_tx = GPIO_PIN(PORT_A, 14),
         .pcr_rx = PORT_PCR_MUX(3),
         .pcr_tx = PORT_PCR_MUX(3),
         .irqn   = UART0_RX_TX_IRQn,


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

The TX and RX definitions were accidentally switched compared to the actual pin functions in the CPU.

### Issues/PRs references

Discovered when testing #7897 