### PR TITLE
gnrc_netif: Introduce GNRC_NETIF_HDR_FLAGS_MORE_DATA

### DIFF
--- a/sys/include/net/gnrc/netif/hdr.h
+++ b/sys/include/net/gnrc/netif/hdr.h
@@ -70,6 +70,21 @@ extern "C" {
  *          this flag the same way it does @ref GNRC_NETIF_HDR_FLAGS_BROADCAST.
  */
 #define GNRC_NETIF_HDR_FLAGS_MULTICAST  (0x40)
+
+/**
+ * @brief   More data will follow
+ *
+ * @details This flag signals that this packet is part of a burst of packets.
+ *          The link layer implementation can choose to translate this flag into
+ *          frame header bits to tell the remote node that more traffic will
+ *          follow shortly. The most direct use case for this flag is to set it
+ *          for fragmented packets in duty cycled networks to tell the remote
+ *          node to keep its radio turned on after receiving the first fragment.
+ *
+ * @see     The corresponding bit in the IEEE 802.15.4 frame control field,
+ *          @ref IEEE802154_FCF_FRAME_PEND
+ */
+#define GNRC_NETIF_HDR_FLAGS_MORE_DATA  (0x10)
 /**
  * @}
  */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Introduce a flag that can be set in the [gnrc_netif_hdr_t::flags](http://api.riot-os.org/structgnrc__netif__hdr__t.html#abbf718ba7223770b72eb8fbd39dd85f6), [gnrc/netif/hdr.h](http://api.riot-os.org/gnrc_2netif_2hdr_8h.html).
The purpose is to use this flag for communicating between the upper layers when there is a burst of TX traffic expected. The first actual usage will be introduced in separate PRs as a part of 6lo fragmentation to set the IEEE 802.15.4 FCF frame pending bit on all but the last fragment.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->