### PR TITLE
gnrc_netif_ieee802154: Set FCF Frame Pending when more data is expected

### DIFF
--- a/sys/include/net/gnrc/netif/hdr.h
+++ b/sys/include/net/gnrc/netif/hdr.h
@@ -70,6 +70,21 @@ extern "C" {
  *          this flag the same way it does @ref GNRC_NETIF_HDR_FLAGS_BROADCAST.
  */
 #define GNRC_NETIF_HDR_FLAGS_MULTICAST  (0x40)
+
+/**
+ * @brief   More data will follow
+ *
+ * @details This flag signals that this packet is part of a burst of packets.
+ *          The link layer implementation can choose to translate this flag into
+ *          frame header bits to tell the remote node that more traffic will
+ *          follow shortly. The most direct use case for this flag is to set it
+ *          for fragmented packets in duty cycled networks to tell the remote
+ *          node to keep its radio turned on after receiving the first fragment.
+ *
+ * @see     The corresponding bit in the IEEE 802.15.4 frame control field,
+ *          @ref IEEE802154_FCF_FRAME_PEND
+ */
+#define GNRC_NETIF_HDR_FLAGS_MORE_DATA  (0x10)
 /**
  * @}
  */

--- a/sys/net/gnrc/netif/gnrc_netif_ieee802154.c
+++ b/sys/net/gnrc/netif/gnrc_netif_ieee802154.c
@@ -187,6 +187,10 @@ static int _send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
         return -EBADMSG;
     }
     netif_hdr = pkt->data;
+    if (netif_hdr->flags & GNRC_NETIF_HDR_FLAGS_MORE_DATA) {
+        /* Set frame pending field */
+        flags |= IEEE802154_FCF_FRAME_PEND;
+    }
     /* prepare destination address */
     if (netif_hdr->flags & /* If any of these flags is set assume broadcast */
         (GNRC_NETIF_HDR_FLAGS_BROADCAST | GNRC_NETIF_HDR_FLAGS_MULTICAST)) {


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Use the flag introduced in #9469 for setting the Frame Pending bit in the IEEE 802.15.4 Frame Control Field (FCF) when building the outgoing frame.

### Issues/PRs references

Depends on #9469 