### PR TITLE
gnrc/6lo: Set more data flag on all but last fragment

### DIFF
--- a/sys/net/gnrc/network_layer/sixlowpan/frag/gnrc_sixlowpan_frag.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/gnrc_sixlowpan_frag.c
@@ -259,7 +259,7 @@ void gnrc_sixlowpan_frag_send(gnrc_pktsnip_t *pkt, void *ctx, unsigned page)
     }
 #endif
 
-    /* Check weater to send the first or an Nth fragment */
+    /* Check whether to send the first or an Nth fragment */
     if (fragment_msg->offset == 0) {
         /* increment tag for successive, fragmented datagrams */
         _tag++;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Use the flag introduced in #9469 to signal to the link layer that more data will follow this packet on outgoing fragments, except for the final frag of the datagram.

### Issues/PRs references

Depends on #9469 
Does not do much difference without also merging #9470