### PR TITLE
kinetis: Conditionally enable MCG

### DIFF
--- a/cpu/kinetis/Makefile.features
+++ b/cpu/kinetis/Makefile.features
@@ -1,5 +1,6 @@
 FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_hwrng
 FEATURES_PROVIDED += periph_gpio
+FEATURES_PROVIDED += periph_mcg
 
 include $(RIOTCPU)/cortexm_common/Makefile.features

--- a/cpu/kinetis/cpu.c
+++ b/cpu/kinetis/cpu.c
@@ -19,7 +19,9 @@
 
 #include "cpu.h"
 #include "periph/init.h"
+#ifdef MODULE_PERIPH_MCG
 #include "mcg.h"
+#endif
 
 /**
  * @brief Initialize the CPU, set IRQ priorities
@@ -33,8 +35,10 @@ void cpu_init(void)
     /* Note: This register can only be written once after each reset, so we must
      * enable all power modes that we wish to use. */
     SMC->PMPROT |= SMC_PMPROT_ALLS_MASK | SMC_PMPROT_AVLP_MASK;
+#ifdef MODULE_PERIPH_MCG
     /* initialize the CPU clocking provided by the MCG module */
     kinetis_mcg_init();
+#endif
     /* trigger static peripheral initialization */
     periph_init();
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Small cleanup that allows a build without the Kinetis multipurpose clock generator (MCG) driver. Might become useful in a bootloader build where ROM space is very constrained.

Saves 788 bytes of ROM on examples/hello-world when building with 
```
BOARD=mulle DISABLE_MODULE=periph_mcg make
```

The clock speed definition must be updated to match the power on reset default for the CPU in order to get proper output on UART etc, but it is out of scope for this PR.

### Issues/PRs references

Split from #7897 