### PR TITLE
cpu/nrf51: adapt to new I2C api

### DIFF
--- a/boards/airfy-beacon/include/periph_conf.h
+++ b/boards/airfy-beacon/include/periph_conf.h
@@ -101,13 +101,15 @@ static const i2c_conf_t i2c_config[] = {
         .dev     = NRF_TWI0,
         .pin_scl = 7,
         .pin_sda = 8,
-        .ppi     = 0
+        .ppi     = 0,
+        .speed   = I2C_SPEED_NORMAL,
     },
     {
         .dev     = NRF_TWI1,
         .pin_scl = 9,
         .pin_sda = 10,
-        .ppi     = 1
+        .ppi     = 1,
+        .speed   = I2C_SPEED_NORMAL,
     }
 };
 

--- a/boards/calliope-mini/include/periph_conf.h
+++ b/boards/calliope-mini/include/periph_conf.h
@@ -96,7 +96,8 @@ static const i2c_conf_t i2c_config[] = {
         .dev     = NRF_TWI0,
         .pin_scl = 19,
         .pin_sda = 20,
-        .ppi     = 0
+        .ppi     = 0,
+        .speed   = I2C_SPEED_NORMAL,
     }
 };
 

--- a/boards/microbit/include/board.h
+++ b/boards/microbit/include/board.h
@@ -69,8 +69,9 @@ extern "C" {
  * @name    MMA8653 accelerometer configuration
  * @{
  */
-#define MMA8653_PARAM_I2C           I2C_DEV(0)
-#define MMA8653_PARAM_ADDR          0x1d
+#define MMA8X5X_PARAM_I2C           I2C_DEV(0)
+#define MMA8X5X_PARAM_ADDR          0x1d
+#define MMA8X5X_PARAM_TYPE          0x5a
 /** @} */
 
 /**

--- a/boards/microbit/include/periph_conf.h
+++ b/boards/microbit/include/periph_conf.h
@@ -102,7 +102,8 @@ static const i2c_conf_t i2c_config[] = {
         .dev     = NRF_TWI0,
         .pin_scl = 0,
         .pin_sda = 30,
-        .ppi     = 0
+        .ppi     = 0,
+        .speed   = I2C_SPEED_NORMAL,
     }
 };
 

--- a/cpu/nrf51/include/periph_cpu.h
+++ b/cpu/nrf51/include/periph_cpu.h
@@ -55,6 +55,16 @@ typedef enum {
 /** @} */
 
 /**
+ * @name    Use the shared I2C functions
+ * @{
+ */
+/** Use read reg function from periph common */
+#define PERIPH_I2C_NEED_READ_REG
+/** Use write reg function from periph common */
+#define PERIPH_I2C_NEED_WRITE_REG
+/** @} */
+
+/**
  * @brief   Override ADC resolution values
  * @{
  */
@@ -77,6 +87,7 @@ typedef struct {
     uint8_t pin_scl;            /**< SCL pin */
     uint8_t pin_sda;            /**< SDA pin */
     uint8_t ppi;                /**< PPI channel to use */
+    i2c_speed_t speed;          /**< bus speed */
 } i2c_conf_t;
 
 #ifdef __cplusplus


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR provides the adaption of nrf51 cpus to the new I2C api. The microbit board peripheral configuration was also adapted.

A fix for the on-board accelerometer driver defines is also provided here. I tested this PR with success with `tests/drivers_mma8x5x` application.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

#6577 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->