### PR TITLE
contikimac: a ContikiMAC compatible netdev layer

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -21,6 +21,12 @@ ifneq (,$(filter ndn-riot,$(USEPKG)))
   USEPKG += micro-ecc
 endif
 
+ifneq (,$(filter contikimac,$(USEMODULE)))
+  USEMODULE += netdev_layer
+  USEMODULE += gnrc_netif_events
+  USEMODULE += xtimer
+endif
+
 ifneq (,$(filter csma_sender,$(USEMODULE)))
   USEMODULE += random
   USEMODULE += xtimer

--- a/Makefile.dep
+++ b/Makefile.dep
@@ -148,6 +148,11 @@ ifneq (,$(filter gnrc_netif,$(USEMODULE)))
   USEMODULE += fmt
 endif
 
+ifneq (,$(filter gnrc_netif_events,$(USEMODULE)))
+  USEMODULE += core_thread_flags
+  USEMODULE += event
+endif
+
 ifneq (,$(filter ieee802154 nrfmin,$(USEMODULE)))
   ifneq (,$(filter gnrc_ipv6, $(USEMODULE)))
     USEMODULE += gnrc_sixlowpan

--- a/examples/gnrc_networking/Makefile
+++ b/examples/gnrc_networking/Makefile
@@ -39,6 +39,7 @@ USEMODULE += ps
 USEMODULE += netstats_l2
 USEMODULE += netstats_ipv6
 USEMODULE += netstats_rpl
+USEMODULE += contikimac
 
 # Comment this out to disable code in RIOT that does safety checking
 # which is not needed in a production environment but helps in the

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -23,6 +23,7 @@ PSEUDOMODULES += gnrc_netdev_default
 PSEUDOMODULES += gnrc_neterr
 PSEUDOMODULES += gnrc_netapi_callbacks
 PSEUDOMODULES += gnrc_netapi_mbox
+PSEUDOMODULES += gnrc_netif_events
 PSEUDOMODULES += gnrc_pktbuf_cmd
 PSEUDOMODULES += gnrc_sixlowpan_border_router_default
 PSEUDOMODULES += gnrc_sixlowpan_default

--- a/sys/Makefile
+++ b/sys/Makefile
@@ -19,6 +19,9 @@ endif
 ifneq (,$(filter shell_commands,$(USEMODULE)))
   DIRS += shell/commands
 endif
+ifneq (,$(filter contikimac,$(USEMODULE)))
+  DIRS += net/link_layer/contikimac
+endif
 ifneq (,$(filter net_help,$(USEMODULE)))
   DIRS += net/crosslayer/net_help
 endif

--- a/sys/auto_init/netif/auto_init_at86rf2xx.c
+++ b/sys/auto_init/netif/auto_init_at86rf2xx.c
@@ -7,7 +7,7 @@
  *
  */
 
-/*
+/**
  * @ingroup sys_auto_init_gnrc_netif
  * @{
  *
@@ -29,6 +29,9 @@
 #include "net/gnrc/gomach/gomach.h"
 #endif
 #include "net/gnrc.h"
+#ifdef MODULE_CONTIKIMAC
+#include "net/contikimac.h"
+#endif /* MODULE_CONTIKIMAC */
 
 #include "at86rf2xx.h"
 #include "at86rf2xx_params.h"
@@ -46,6 +49,9 @@
 
 static at86rf2xx_t at86rf2xx_devs[AT86RF2XX_NUM];
 static char _at86rf2xx_stacks[AT86RF2XX_NUM][AT86RF2XX_MAC_STACKSIZE];
+#ifdef MODULE_CONTIKIMAC
+static contikimac_t contikimac_devs[AT86RF2XX_NUM];
+#endif /* MODULE_CONTIKIMAC */
 
 void auto_init_at86rf2xx(void)
 {
@@ -63,6 +69,12 @@ void auto_init_at86rf2xx(void)
                                 AT86RF2XX_MAC_STACKSIZE,
                                 AT86RF2XX_MAC_PRIO, "at86rf2xx-lwmac",
                                 (netdev_t *)&at86rf2xx_devs[i]);
+#elif defined(MODULE_CONTIKIMAC)
+        contikimac_setup(&contikimac_devs[i], &at86rf2xx_devs[i].netdev.netdev);
+        gnrc_netif_ieee802154_create(_at86rf2xx_stacks[i],
+                                     AT86RF2XX_MAC_STACKSIZE,
+                                     AT86RF2XX_MAC_PRIO, "at86rf2xx-contikimac",
+                                     (netdev_t *)&contikimac_devs[i]);
 #else
         gnrc_netif_ieee802154_create(_at86rf2xx_stacks[i],
                                      AT86RF2XX_MAC_STACKSIZE,

--- a/sys/include/net/contikimac.h
+++ b/sys/include/net/contikimac.h
@@ -1,0 +1,589 @@
+/*
+ * Copyright (C) 2017 SKF AB
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    net_contikimac ContikiMAC compatible MAC layer
+ * @ingroup     net
+ * @brief       Duty cycling MAC protocol for low power communication over IEEE 802.15.4 networks
+ *
+ * @see Dunkels, A. (2011). The contikimac radio duty cycling protocol.
+ *      http://soda.swedish-ict.se/5128/1/contikimac-report.pdf
+ * @see Michel, M., & Quoitin, B. (2014). Technical report: ContikiMAC vs X-MAC
+ *      performance analysis. arXiv preprint arXiv:1404.3589. https://arxiv.org/abs/1404.3589
+ *
+ * # Summary
+ *
+ * ContikiMAC is a duty cycling MAC layer protocol which uses strobing (repeated
+ * transmissions) of actual data packets to ensure that sleeping nodes will
+ * receive the transmission as they wake up. This is similar to the X-MAC
+ * protocol, except X-MAC uses special strobe frames to signal incoming data
+ * instead of the actual data frame.
+ *
+ * \note This implementation supports the ContikiMAC fast sleep optimization, and
+ *       the ContikiMAC burst optimization (frame pending field)
+ *
+ * \todo Add support for the ContikiMAC phase lock optimization
+ *
+ * # Algorithm description
+ *
+ * ContikiMAC nodes wake the radio at a regular interval,
+ * and performs a number of CCA checks to check the radio medium for energy. If
+ * one of the CCA checks report that the medium is busy, the radio is switched
+ * to listening mode and waiting for incoming packets. On the other hand, if all
+ * of the CCA checks report channel idle, the radio is put back to sleep.
+ * When listening, if no packet is received before a timeout is hit, the radio
+ * is put back to sleep.
+ * If a packet is received correctly, the radio is put back to sleep immediately,
+ * unless more data is expected.
+ *
+ * ## Optimizations
+ *
+ * The MAC layer can use knowledge of the algorithm behavior to further reduce
+ * the power usage.
+ *
+ * ### Fast sleep
+ *
+ * If a CCA check signals channel busy, but further CCA checks do not detect any
+ * silence after the time it takes to transmit the longest possible packet, the
+ * MAC layer will assume that the detected radio energy is noise from some other
+ * source, e.g. WiFi networks or microwave ovens, and put the radio back to sleep.
+ *
+ * If a CCA check signals channel busy, and then some silence is detected, but
+ * there is no reported incoming reception from the radio after the strobe
+ * interval has passed, the radio is put back to sleep.
+ *
+ * ### Burst transmission
+ *
+ * If a sender has more data than fits in a single frame, a special flag is used
+ * to tell the receiver to keep the radio turned on and listening after the
+ * current frame has been received. For IEEE 802.15.4, the Frame Pending flag in
+ * the Frame Control Field is used for this purpose. This optimization increases
+ * network throughput if used correctly. The 6lowpan fragmentation module
+ * automatically tells the MAC layer to set this flag on any fragmented packets,
+ * but it can also be used from the application layer if the application knows
+ * that there will be more data immediately after the current.
+ *
+ * ### Expecting immediate unicast replies
+ *
+ * When a unicast packet is successfully delivered, the next channel check of
+ * the sender will be scheduled at a short interval from the reception of the
+ * Ack frame in an attempt to catch an immediate reply from the other node. This
+ * interval is currently hard-coded at 1/8 of the channel check interval, but
+ * should be made configurable in a future enhancement.
+ * This method should in theory reduce communication latency and reduce energy
+ * consumption of the remote node by reducing the number of transmission retries
+ * required. Experiments seem to indicate that this is theory works in real
+ * applications too, but this has not been statistically proven yet.
+ *
+ * ### Phase lock
+ *
+ * \note Not yet implemented in netdev contikimac
+ *
+ * If a unicast transmission succeeds with a correctly received Ack packet, the
+ * sender can record the time of the last transmission start. The next time a
+ * unicast packet is directed to the same destination, the registered phase will
+ * be used as a reference, and the tranmission will be started right before the
+ * receiver is expected to wake up.
+ *
+ * # Implementation details
+ *
+ * This section gives some extra information regarding this specific
+ * implementation. This implementation was inspired by Contiki code, but written
+ * from scratch to fit RIOT and the GNRC stack. All algorithmic details are
+ * taken from [dunkels11].
+ *
+ * The timing is handled by the xtimer system, this means that the platform
+ * needs to use a low power timer for xtimer in order to use the low power modes
+ * of the MCU. At the time of writing (2018-07-02), most boards' default
+ * configurations are using high precision timers for xtimer (one notable
+ * exception is the frdm-kw41z board), but many boards can be easily
+ * reconfigured to use low power timers via board.h. Check your CPU manual for
+ * the proper timer to use.
+ *
+ * All radio state switching, CCA checks, etc. are called via the netdev get/set
+ * API. This makes the code platform independent, but the radio drivers need to
+ * support the options used by the implementation. The options required for full
+ * functionality are:
+ *
+ * - @ref NETOPT_PRELOADING, for loading the TX frame once and transmitting many times
+ * - @ref NETOPT_STATE_TX, for triggering retransmission
+ * - @ref NETOPT_STATE_STANDBY, for radio low power CCA checking
+ * - @ref NETOPT_STATE_SLEEP, for radio low power mode
+ * - @ref NETOPT_STATE_IDLE, for radio RX listen
+ * - @ref NETOPT_CSMA, to disable hardware CSMA, not required if the radio does not support CSMA
+ * - @ref NETOPT_RETRANS, to disable automatic retransmissions
+ * - @ref NETOPT_TX_END_IRQ, to be alerted about end of TX
+ * - @ref NETOPT_RX_START_IRQ, to be alerted about preamble detections
+ * - @ref NETOPT_RX_END_IRQ, to be alerted about received frames
+ * - @ref NETOPT_IS_CHANNEL_CLR, for performing CCA checks
+ *
+ * Additionally, the radio must allow the same frame to be transmitted multiple
+ * times. The implementation will switch the radio to standby before any TX
+ * preloading, to avoid corrupting the TX buffer with incoming RX packets on
+ * single buffered devices, e.g. at86rf2xx. The device driver must allow
+ * multiple calls to @ref NETOPT_STATE_TX after a single preload, for retransmissions
+ * while strobing.
+ * @ref NETOPT_IS_CHANNEL_CLR, @ref netdev_driver::send(), and
+ * @ref NETOPT_STATE_TX are called while the radio is in @ref NETOPT_STATE_STANDBY.
+ *
+ * ## Collision avoidance
+ *
+ * The implementation does not perform CCA checks before every retransmission,
+ * which may lead to collisions in crowded environments. The default timing
+ * parameters need to be adjusted if CSMA/CA is going to be enabled for the
+ * device.
+ *
+ * Before the first transmission of a strobe, the radio will perform CCA checks
+ * in the same way as the channel check procedure does, in an attempt to avoid
+ * collisions, but no automatic retry or random backoff is implemented.
+ *
+ * ## Fast sleep
+ *
+ * During a wake up, the fast sleep implementation will perform additional
+ * periodic CCA checks after the first energy detection on the channel. The
+ * periodic CCA checks continue until either an idle channel is detected, or a
+ * timeout occurs. The timeout must be greater than the time it takes to
+ * transmit the longest possible frame, or else it may time out before seeing
+ * the end of a packet if the first ED occurred right at the beginning of the
+ * frame. After silence is detected, the radio is switched to listening state,
+ * and a new timeout is set. If an RX begin event occurs before the timeout, the
+ * timeout is incremented to the length of the longest frame, to allow for the
+ * complete reception. If the timeout is hit, the radio is put back to sleep. No
+ * further CCA checks are performed after switching the radio to listening state,
+ * to avoid interfering with the frame reception.
+ *
+ * ## Burst reception
+ *
+ * The frame pending field of the IEEE 802.15.4 Frame Control Field is checked
+ * on all received frames to determine whether to keep the radio on or to put it
+ * back to sleep.
+ *
+ * ## Expecting immediate replies on unicast transmissions
+ *
+ * When a unicast transmission is completed successfully (i.e. Ack received),
+ * an extra channel check is scheduled outside of the regular schedule, in order
+ * to catch quick replies from remote nodes.
+ *
+ * # ContikiMAC Timing constraints
+ *
+ * In order to ensure reliable transmissions while duty cycling the receiver,
+ * there are some constraints on the timings for the ContikiMAC algorithm.
+ *
+ * @note These constraints are also given in [dunkels11], but written with an
+ *       implicit \f$n_c = 2\f$.
+ *
+ * To reliably detect Ack packets:
+ *
+ * \f[T_a + T_d < T_i\f]
+ *
+ * To reliably detect incoming packets during CCA cycles:
+ *
+ * \f[T_i < (n_c - 1) \cdot T_c + n_c \cdot T_r\f]
+ *
+ * and
+ *
+ * \f[(T_c + 2 T_r) < T_s\f]
+ *
+ * The variables in the above conditions are described below:
+ *
+ * \f$T_a\f$ is the time between reception end and Ack TX begin.
+ *
+ * \f$T_d\f$ is the time it takes for the transceiver to receive the Ack packet.
+ *
+ * \f$T_i\f$ is the time between the end of transmission, and the start of retransmission
+ *
+ * \f$T_c\f$ is the time between CCA checks during CCA cycles
+ *
+ * \f$n_c\f$ is the maximum number of CCA checks to perform during the CCA cycle
+ *
+ * \f$T_r\f$ is the time it takes to perform one CCA check
+ *
+ * \f$T_s\f$ is the time it takes to transmit the shortest allowed frame
+ *
+ * The constraint on \f$T_s\f$ yields a minimum packet length in bytes:
+ *
+ * \f[T_s = n_s \cdot T_b \Leftrightarrow n_s = \frac{T_s}{T_b}\f]
+ *
+ * where \f$n_s\f$ is the number of bytes in the shortest packet, and \f$T_b\f$
+ * is the time it takes to transmit one byte.
+ *
+ * For packets shorter than \f$n_s\f$ bytes, extra padding must be added to ensure
+ * reliable transmission, or else the packet may fall between two CCA checks and
+ * remain undetected.
+ *
+ * From the above equations it can be seen that using \f$n_c > 2\f$ relaxes the
+ * constraint on minimum packet length, making it possible to eliminate the extra
+ * frame padding completely, at the cost of additional CCA checks.
+ *
+ * ## Fast sleep
+ *
+ * For fast sleep, some additional timing information is needed. \f$T_l\f$, the
+ * time to transmit the longest possible frame is a lower limit for timeouts in
+ * the fast sleep optimization.
+ *
+ * The interval between CCA checks during the fast sleep silence detection must
+ * be less than \f$T_i\f$ in order to be able to reliably sample the silence
+ * between two transmissions.
+ *
+ * ## Example timing parameters for O-QPSK 250 kbit/s
+ *
+ * O-QPSK 250 kbit/s is the most widely used mode for 802.15.4 radios in the 2.4 GHz band.
+ *
+ * \f[T_a = 12~\mathrm{symbols} = 192~\mathrm{\mu{}s}\f]
+ *
+ * \f[T_a\f] is defined in IEEE 802.15.4 (AIFS = macSifsPeriod = aTurnaroundTime)
+ *
+ * \f[T_d = 5 + 1 + 5~\mathrm{bytes} = 352~\mathrm{\mu{}s}\f]
+ *
+ * A standard Ack packet is 5 bytes long, the preamble and start-of-frame
+ * delimiter (SFD) is 5 bytes, and the PHY header (PHR) is 1 byte.
+ *
+ * \f[T_r = 8~\mathrm{symbols} = 128~\mathrm{\mu{}s}\f]
+ *
+ * \f[T_r\f] is defined in IEEE 802.15.4 (aCcaTime)
+ *
+ * \f[T_b = 2~\mathrm{symbols} = 32~\mathrm{\mu{}s}\f]
+ *
+ * \f[T_b\f] is derived from definitions in IEEE 802.15.4 (4 bits per symbol)
+ *
+ * \f[T_l = T_b \cdot (5 + 1 + 127) = 4320~\mathrm{\mu{}s}\f]
+ *
+ * The longest possible payload is 127 bytes, SFD+preamble is 5 bytes, PHR is 1
+ * byte.
+ *
+ * Additionally, the hardware may have some timing constraints as well. For
+ * example, the at86rf2xx transceiver has a fixed Ack timeout (when using
+ * hardware Ack reception) of 54 symbols (\f$864~\mathrm{\mu{}s}\f$), this means
+ * that the configuration must satisfy \f$T_i > 864~\mathrm{\mu{}s}\f$ if
+ * using a at86rf2xx transceiver.
+ *
+ * Due to CPU processing constraints, there are lower limits on all timings. For
+ * example, the reception and CCA check results need to be processed by the CPU
+ * and passed to the ContikiMAC thread, which may not be an insignificant time
+ * depending on the CPU speed and the radio interface bus speed (SPI, UART etc.).
+ *
+ * # Configuring timing parameters
+ *
+ * The timing parameters are set using an instance of contikimac_params_t.
+ * Some parameters can be automatically derived from the other parameters. The
+ * constants that must be configured manually for a minimum working configuration
+ * are:
+ *
+ * - @c cca_count_max =\f$n_c\f$, the maximum number of CCA checks in each wake up
+ * - @c inter_packet_interval =\f$T_i\f$, interval between retransmissions
+ * - @c cca_cycle_period =\f$T_c\f$, the time between consecutive CCA checks
+ * - @c after_ed_scan_timeout >\f$T_l\f$, time to keep checking for silence after detecting energy
+ * - @c after_ed_scan_interval <\f$T_i\f$, interval between CCA checks after detecting energy
+ * - @c rx_timeout =\f$T_l\f$, time to transmit the longest possible frame
+ *
+ * Default configurations are provided for some common 802.15.4 radio modes:
+ * O-QPSK250, O-QPSK100, BPSK40, BPSK20
+ * These parameters are automatically selected at run time based on the radio mode.
+ *
+ * The following parameters are not dependent on the radio bit rate or mode and
+ * can be reconfigured at run time:
+ *
+ * - @c channel_check_period =\f$T_w\f$, the time between wake ups
+ *
+ * # Suggested topics for future improvements
+ *
+ * Some areas of improvement for this implementation are listed below.
+ *
+ * ## Collision avoidance
+ *
+ * Enabling CSMA/CA should be trivial, however, the timings need to account for
+ * the added latency on every retransmission. In particular, the backoff
+ * exponents (macMinBE, macMaxBE) should be reduced from their defaults (3, 5).
+ *
+ * The parameters @c cca_count_max, @c cca_cycle_period will need to be
+ * incremented to allow for a longer \f$T_i\f$.
+ * \f[T_i = \mathtt{inter\_packet\_interval} + T_{CSMA}\f]
+ *
+ * ## Phase lock optimization
+ *
+ * The phase of the Acked packet must be recorded and remembered for each
+ * unicast destination. For each unicast packet, the send function will then
+ * look up the registry for the correct timing to use for the particular
+ * destination.
+ *
+ * ## Automatic noise level calibration
+ *
+ * The CCA process is critical for the correct operation of the ContikiMAC
+ * protocol. If the CCA threshold is too low, then noise will trigger wake ups
+ * all the time, but the fast sleep optimization will put the radio back to
+ * sleep after the @c after_ed_scan_timeout interval has passed. If the CCA
+ * threshold is too high, then real frames will fail to be detected and the
+ * radio will be put back to sleep immediately. Both faults result in a failure
+ * to receive incoming frames.
+ *
+ * By measuring the RSSI level periodically it should be possible to dynamically
+ * adjust the CCA threshold to ensure the best possible chance of successfully
+ * detecting real incoming traffic.
+ *
+ * @{
+ *
+ * @file
+ * @brief       Interface definition for the ContikiMAC layer
+ *
+ * @author      Joakim Nohlgård <joakim.nohlgard@eistec.se>
+ */
+
+#ifndef NET_CONTIKIMAC_H
+#define NET_CONTIKIMAC_H
+
+#include <stdint.h>
+#include "net/netdev.h"
+#include "net/netdev/ieee802154.h"
+#include "event.h"
+#include "xtimer.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief (usec) Default time between wake ups, @ref contikimac_t::channel_check_period
+ *
+ * This is the default interval between periodic wake ups for checking the
+ * channel for energy.
+ *
+ * This time period is also used as the maximum time to keep strobing
+ * (retransmitting) outgoing packets.
+ *
+ * For unicast, this is the maximum time to keep retransmitting before
+ * giving up. Strobing will stop earlier if an Ack packet arrives before
+ * this time has passed.
+ *
+ * For broadcast/multicast, each packet will always be retransmitted until
+ * this time has passed.
+ *
+ * This period can be changed at runtime by setting a new value for the
+ * NETOPT_MAC_CHECK_PERIOD setting.
+ */
+#ifndef CONTIKIMAC_DEFAULT_CHANNEL_CHECK_PERIOD
+#define CONTIKIMAC_DEFAULT_CHANNEL_CHECK_PERIOD (1000000ul / 8)
+#endif
+
+/**
+ * @brief (usec) Default time for @ref contikimac_t::burst_timeout
+ *
+ * This is the default value for the RX frame detection timeout while receiving
+ * transmission bursts. The burst timeout should be kept low to avoid wasting
+ * energy, but it has to be set long enough to allow the remote node to prepare
+ * the next frame and begin transmission.
+ */
+#ifndef CONTIKIMAC_DEFAULT_BURST_TIMEOUT
+#define CONTIKIMAC_DEFAULT_BURST_TIMEOUT        (1000000ul / 64)
+#endif
+
+/**
+ * @brief (usec) Default time for @ref contikimac_t::reply_delay
+ *
+ * This is the default waiting time for immediate unicast replies. When the
+ * contikimac module has sent a unicast frame, an extra channel check is injected
+ * to catch any immediate replies from the remote node. This may improve network
+ * throughput.
+ */
+#ifndef CONTIKIMAC_DEFAULT_REPLY_DELAY
+#define CONTIKIMAC_DEFAULT_REPLY_DELAY          (1000000ul / 32)
+#endif
+
+/**
+ * @brief ContikiMAC configuration parameters
+ */
+typedef struct {
+    /**
+     * @brief (usec) time between successive CCA checks during wake ups
+     *
+     * This setting, together with cca_count_max, defines the detection
+     * window for incoming traffic
+     */
+    uint32_t cca_cycle_period;
+    /**
+     * @brief (usec) interval to wait between each TX packet while strobing
+     *
+     * This time counts from when the end of TX is signalled from the device
+     * driver.
+     *
+     * \note This interval must be long enough to allow an Ack packet to arrive
+     * after transmitting.
+     */
+    uint32_t inter_packet_interval;
+    /**
+     * @brief (usec) maximum time to scan for channel idle after an energy detection
+     *
+     * Fast sleep optimization: After energy has been detected on the channel,
+     * the MAC layer will keep scanning the channel until it sees some silence.
+     *
+     * For reliable communication, this must be at least as long as the time it
+     * takes to transmit the longest possible frame.
+     */
+    uint32_t after_ed_scan_timeout;
+    /**
+     * @brief (usec) interval between successive CCA checks after an energy detection
+     */
+    uint32_t after_ed_scan_interval;
+    /**
+     * @brief (usec) time to wait while listening for incoming packets before
+     * turning off the radio
+     *
+     * For reliable communication, this must be at least inter_packet_interval +
+     * the time it takes for the radio to detect and signal the RX begin interrupt.
+     */
+    uint32_t listen_timeout;
+    /**
+     * @brief (usec) time to wait after an RX begin event before turning off the
+     * radio
+     *
+     * For reliable communication, this must be at least as long as the time it
+     * takes to transmit the longest possible frame.
+     */
+    uint32_t rx_timeout;
+    /**
+     * @brief Maximum number of times to perform CCA checks during a wake up
+     * window
+     *
+     * This setting, together with cca_cycle_period, defines the detection
+     * window for incoming traffic
+     */
+    uint8_t cca_count_max;
+} contikimac_params_t;
+
+/**
+ * @brief   Event type for asynchronous events used internally
+ */
+typedef struct {
+    event_t super;
+    void *ctx;
+} event_contikimac_t;
+
+/**
+ * @brief   ContikiMAC device descriptor
+ */
+typedef struct {
+    /**
+     * @brief   netdev parent struct
+     */
+    netdev_ieee802154_t dev;
+    /**
+     * @brief   Pointer to timing parameters
+     */
+    const contikimac_params_t *params;
+    /**
+     * @brief   Pointer to event queue in the upper layer for scheduling our events
+     *
+     * While listening, ContikiMAC will post events into this queue and the
+     * upper layer will drain the queue.
+     * While sending, ContikiMAC will post events but also run a small event
+     * loop to be able to perform retransmissions. This means that ContikiMAC
+     * will process all events in this queue, but without processing any IPC
+     * messages from higher layers.
+     */
+    event_queue_t *evq;
+    /**
+     * @brief   (usec) Channel check period
+     */
+    uint32_t channel_check_period;
+    /**
+     * @brief   (usec) Timeout for RX frame detection while waiting for the next
+     *          frame of a burst
+     */
+    uint32_t burst_timeout;
+    /**
+     * @brief   (usec) Unicast reply delay
+     *
+     * An extra channel check event outside of the normal schedule is inserted
+     * at this interval after a unicast transmission has completed successfully.
+     */
+    uint32_t reply_delay;
+    struct {
+        /**
+         * @brief   Regular channel check interval timer
+         */
+        xtimer_t channel_check;
+        /**
+         * @brief   Extra channel check events outside of the normal schedule
+         *
+         * Set by the TX algorithm to catch replies to unicast transmissions
+         * quicker than the regular channel check interval.
+         */
+        xtimer_t extra_channel_check;
+        /**
+         * @brief   Periodic updates after energy detection
+         */
+        xtimer_t periodic;
+        /**
+         * @brief   Timeouts used in various places in the algorithm
+         */
+        xtimer_t timeout;
+    } timers;
+    /**
+     * @brief   Timestamp of last IRQ
+     *
+     * Used for timing inside the transmit loop
+     */
+    xtimer_ticks32_t last_irq;
+    struct {
+        /**
+         * @brief   Channel check event
+         */
+        event_contikimac_t channel_check;
+        /**
+         * @brief   Extra channel check event outside of the normal schedule
+         */
+        event_contikimac_t extra_channel_check;
+        /**
+         * @brief   Periodic state updates part of the RX algorithm
+         */
+        event_contikimac_t periodic;
+        /**
+         * @brief   Radio driver triggered interrupt requests
+         */
+        event_contikimac_t isr;
+    } events;
+    /**
+     * @brief   Silence detected flag, part of the RX state machine
+     */
+    uint8_t seen_silence;
+    /**
+     * @brief   RX in progress flag
+     */
+    uint8_t rx_in_progress;
+    /**
+     * @brief   Timeout flag, set by cb_timeout
+     */
+    uint8_t timeout_flag;
+    /**
+     * @brief   No sleep flag, set via NETOPT_MAC_NO_SLEEP
+     */
+    uint8_t no_sleep;
+    /**
+     * @brief   TX progress, part of the TX algorithm state machine
+     */
+    uint8_t tx_status;
+} contikimac_t;
+
+/**
+ * @brief   Reference to the netdev device driver struct
+ */
+extern const netdev_driver_t contikimac_driver;
+
+/**
+ * @brief   Setup the ContikiMAC descriptor
+ *
+ * @param[out]  ctx     ContikiMAC descriptor to initialize
+ * @param[in]   lower   device descriptor for the underlying device
+ */
+void contikimac_setup(contikimac_t *ctx, netdev_t *lower);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* NET_CONTIKIMAC_H */
+/** @} */

--- a/sys/include/net/contikimac.h
+++ b/sys/include/net/contikimac.h
@@ -458,8 +458,8 @@ typedef struct {
  * @brief   Event type for asynchronous events used internally
  */
 typedef struct {
-    event_t super;
-    void *ctx;
+    event_t super;      /**< parent event class */
+    void *ctx;          /**< pointer to ContikiMAC context */
 } event_contikimac_t;
 
 /**
@@ -501,6 +501,9 @@ typedef struct {
      * at this interval after a unicast transmission has completed successfully.
      */
     uint32_t reply_delay;
+    /**
+     * @brief   Timers used internally to drive the radio duty cycle
+     */
     struct {
         /**
          * @brief   Regular channel check interval timer
@@ -528,6 +531,9 @@ typedef struct {
      * Used for timing inside the transmit loop
      */
     xtimer_ticks32_t last_irq;
+    /**
+     * @brief   Events used internally
+     */
     struct {
         /**
          * @brief   Channel check event

--- a/sys/include/net/contikimac.h
+++ b/sys/include/net/contikimac.h
@@ -407,7 +407,7 @@ typedef struct {
     /**
      * @brief (usec) interval to wait between each TX packet while strobing
      *
-     * This time counts from when the end of TX is signalled from the device
+     * This time counts from when the end of TX is signaled from the device
      * driver.
      *
      * \note This interval must be long enough to allow an Ack packet to arrive

--- a/sys/include/net/contikimac.h
+++ b/sys/include/net/contikimac.h
@@ -553,6 +553,10 @@ typedef struct {
         event_contikimac_t isr;
     } events;
     /**
+     * @brief   flags for some netopt options
+     */
+    uint8_t flags;
+    /**
      * @brief   Silence detected flag, part of the RX state machine
      */
     uint8_t seen_silence;
@@ -564,10 +568,6 @@ typedef struct {
      * @brief   Timeout flag, set by cb_timeout
      */
     uint8_t timeout_flag;
-    /**
-     * @brief   No sleep flag, set via NETOPT_MAC_NO_SLEEP
-     */
-    uint8_t no_sleep;
     /**
      * @brief   TX progress, part of the TX algorithm state machine
      */

--- a/sys/include/net/contikimac.h
+++ b/sys/include/net/contikimac.h
@@ -566,6 +566,14 @@ typedef struct {
      * @brief   TX progress, part of the TX algorithm state machine
      */
     uint8_t tx_status;
+    /**
+     * @brief   Emulated netdev state
+     *
+     * This is used when getting/setting the NETOPT_STATE value.
+     * Provides a way to disable the radio completely and suspend the channel
+     * check events when we need to conserve power.
+     */
+    uint8_t state;
 } contikimac_t;
 
 /**

--- a/sys/include/net/contikimac.h
+++ b/sys/include/net/contikimac.h
@@ -390,7 +390,7 @@ extern "C" {
  * throughput.
  */
 #ifndef CONTIKIMAC_DEFAULT_REPLY_DELAY
-#define CONTIKIMAC_DEFAULT_REPLY_DELAY          (1000000ul / 32)
+#define CONTIKIMAC_DEFAULT_REPLY_DELAY          (8192u)
 #endif
 
 /**

--- a/sys/include/net/gnrc/netif.h
+++ b/sys/include/net/gnrc/netif.h
@@ -84,15 +84,15 @@ typedef struct {
      */
     event_queue_t evq;
     /**
-     * @brief   Pointer to event instance table
+     * @brief   Pointer to ISR event
      *
-     * This pointer gives a way to allocate events on the stack of each
+     * This pointer gives a way to allocate ISR events on the stack of each
      * gnrc_netif thread, instead of having a single global instance which will
      * not work if the system has more than one network interface.
      * The _event_cb function of gnrc_netif.c uses this pointer to be able to
      * post events from interrupt context.
      */
-    void *events;
+    void *event_isr; /* void * to keep implementation details private to gnrc_netif.c */
 #endif /* MODULE_GNRC_NETIF_EVENTS */
 #if (GNRC_NETIF_L2ADDR_MAXLEN > 0)
     /**

--- a/sys/include/net/gnrc/netif.h
+++ b/sys/include/net/gnrc/netif.h
@@ -30,6 +30,9 @@
 
 #include "kernel_types.h"
 #include "msg.h"
+#ifdef MODULE_GNRC_NETIF_EVENTS
+#include "event.h"
+#endif /* MODULE_GNRC_NETIF_EVENTS */
 #include "net/ipv6/addr.h"
 #include "net/gnrc/netapi.h"
 #include "net/gnrc/pkt.h"
@@ -75,6 +78,22 @@ typedef struct {
      * @see net_gnrc_netif_flags
      */
     uint32_t flags;
+#if defined(MODULE_GNRC_NETIF_EVENTS) || DOXYGEN
+    /**
+     * @brief   Event queue for asynchronous events
+     */
+    event_queue_t evq;
+    /**
+     * @brief   Pointer to event instance table
+     *
+     * This pointer gives a way to allocate events on the stack of each
+     * gnrc_netif thread, instead of having a single global instance which will
+     * not work if the system has more than one network interface.
+     * The _event_cb function of gnrc_netif.c uses this pointer to be able to
+     * post events from interrupt context.
+     */
+    void *events;
+#endif /* MODULE_GNRC_NETIF_EVENTS */
 #if (GNRC_NETIF_L2ADDR_MAXLEN > 0)
     /**
      * @brief   The link-layer address currently used as the source address

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -1417,6 +1417,8 @@ static void *_gnrc_netif_thread(void *args)
 
     while (1) {
         msg_t msg;
+        /* msg will be filled by _process_events_await_msg.
+         * The function will not return until a message has been received. */
         _process_events_await_msg(netif, &msg);
 
         /* dispatch netdev, MAC and gnrc_netapi messages */

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -48,10 +48,6 @@ typedef struct {
     event_t super;
     netdev_t *dev;
 } event_netdev_t;
-
-typedef struct {
-    event_netdev_t isr;
-} gnrc_netif_events_t;
 #endif /* MODULE_GNRC_NETIF_EVENTS */
 
 static gnrc_netif_t _netifs[GNRC_NETIF_NUMOF];
@@ -1337,13 +1333,11 @@ static void *_gnrc_netif_thread(void *args)
     dev = netif->dev;
     netif->pid = sched_active_pid;
 #ifdef MODULE_GNRC_NETIF_EVENTS
-    gnrc_netif_events_t event_table = {
-        .isr = {
-            .super = { .handler = _event_handler_isr, },
-            .dev = dev,
-        },
+    event_netdev_t ev_isr = {
+        .super = { .handler = _event_handler_isr, },
+        .dev = dev,
     };
-    netif->events = &event_table;
+    netif->event_isr = &ev_isr;
     /* set up the event queue */
     event_queue_init(&netif->evq);
 #endif /* MODULE_GNRC_NETIF_EVENTS */
@@ -1486,8 +1480,8 @@ static void _event_cb(netdev_t *dev, netdev_event_t event)
 
     if (event == NETDEV_EVENT_ISR) {
 #ifdef MODULE_GNRC_NETIF_EVENTS
-        gnrc_netif_events_t *etp = netif->events;
-        event_post(&netif->evq, &etp->isr.super);
+        event_netdev_t *etp = netif->event_isr;
+        event_post(&netif->evq, &etp->super);
 #else /* MODULE_GNRC_NETIF_EVENTS */
         msg_t msg = { .type = NETDEV_MSG_TYPE_EVENT,
                       .content = { .ptr = netif } };

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -1357,6 +1357,7 @@ static void _process_events_await_msg(gnrc_netif_t *netif, msg_t *msg)
         thread_flags_wait_any(THREAD_FLAG_MSG_WAITING | THREAD_FLAG_EVENT);
     }
 #else /* MODULE_GNRC_NETIF_EVENTS */
+    (void) netif;
     /* Only messages used for event handling */
     DEBUG("gnrc_netif: waiting for incoming messages\n");
     msg_receive(msg);

--- a/sys/net/link_layer/contikimac/Makefile
+++ b/sys/net/link_layer/contikimac/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/sys/net/link_layer/contikimac/contikimac.c
+++ b/sys/net/link_layer/contikimac/contikimac.c
@@ -32,7 +32,7 @@
 /* Set ENABLE_TRACE to 1 to print single character status bytes over stderr to
  * see algorithm events, useful for debugging */
 #define ENABLE_TRACE    (0)
-#define TRACE(msg)      if (ENABLE_TRACE) { LOG_ERROR(msg); }
+#define TRACE(...)      if (ENABLE_TRACE) { LOG_ERROR(__VA_ARGS__); }
 
 /* Set to 1 to enable debug prints of the time spent in radio ON modes */
 #define ENABLE_TIMING_INFO (0)

--- a/sys/net/link_layer/contikimac/contikimac.c
+++ b/sys/net/link_layer/contikimac/contikimac.c
@@ -1,0 +1,1139 @@
+/*
+ * Copyright (C) 2017-2018 SKF AB
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ * @ingroup     net
+ * @file
+ * @brief       ContikiMAC netdev implementation
+ *
+ * @author      Joakim Nohlgård <joakim.nohlgard@eistec.se>
+ * @}
+ */
+
+#include <stdint.h>
+#include <string.h>
+#include <errno.h>
+#include "net/contikimac.h"
+#include "net/ieee802154.h"
+#include "net/netdev/layer.h"
+#include "net/gnrc/netif.h"
+#include "thread.h" /* for thread_getpid */
+
+#include "log.h"
+#define ENABLE_DEBUG    (0)
+#include "debug.h"
+
+/* Set ENABLE_TRACE to 1 to print single character status bytes over stderr to
+ * see algorithm events, useful for debugging */
+#define ENABLE_TRACE    (0)
+#define TRACE(msg)      if (ENABLE_TRACE) { LOG_ERROR(msg); }
+
+/* Set to 1 to enable debug prints of the time spent in radio ON modes */
+#define ENABLE_TIMING_INFO (0)
+
+/* Set to 1 to use LED0_ON/LED0_OFF for a visual feedback of the radio power state */
+#ifndef CONTIKIMAC_DEBUG_LEDS
+#define CONTIKIMAC_DEBUG_LEDS 0
+#endif
+
+#if ENABLE_TIMING_INFO
+#define TIMING_PRINTF LOG_ERROR
+#else
+#define TIMING_PRINTF(...)
+#endif
+
+#if CONTIKIMAC_DEBUG_LEDS
+#define CONTIKIMAC_LED_ON LED0_ON
+#define CONTIKIMAC_LED_OFF LED0_OFF
+#else
+#define CONTIKIMAC_LED_ON
+#define CONTIKIMAC_LED_OFF
+#endif
+
+#if defined(MODULE_OD) && ENABLE_DEBUG
+#include "od.h"
+#endif
+
+/**
+ * @brief   TX status definitions
+ */
+enum {
+    CONTIKIMAC_TX_IDLE = 0,
+    CONTIKIMAC_TX_STARTED,
+    CONTIKIMAC_TX_COMPLETE,
+    CONTIKIMAC_TX_MEDIUM_BUSY,
+    CONTIKIMAC_TX_NOACK,
+};
+
+/**
+ * @brief   netdev option flag definitions
+ */
+enum {
+    CONTIKIMAC_OPT_TELL_TX_START   = (1 <<  8),
+    CONTIKIMAC_OPT_TELL_TX_END     = (1 <<  9),
+    CONTIKIMAC_OPT_TELL_RX_START   = (1 << 10),
+    CONTIKIMAC_OPT_TELL_RX_END     = (1 << 11),
+};
+
+/**
+ * @brief Default timing settings for O-QPSK 250 kbit/s
+ */
+extern const contikimac_params_t contikimac_params_OQPSK250;
+
+/**
+ * @brief Default timing settings for O-QPSK 100 kbit/s
+ */
+extern const contikimac_params_t contikimac_params_OQPSK100;
+
+/**
+ * @brief Default timing settings for BPSK 40 kbit/s
+ */
+extern const contikimac_params_t contikimac_params_BPSK40;
+
+/**
+ * @brief Default timing settings for BPSK 20 kbit/s
+ */
+extern const contikimac_params_t contikimac_params_BPSK20;
+
+/* Internal constants used for the netdev set NETOPT_STATE calls, as it requires
+ * a pointer to the value as argument */
+static const netopt_state_t state_standby = NETOPT_STATE_STANDBY;
+static const netopt_state_t state_listen  = NETOPT_STATE_IDLE;
+static const netopt_state_t state_tx      = NETOPT_STATE_TX;
+
+static uint32_t time_begin = 0;
+
+/**
+ * @brief   Check the timeout flag and report timeouts
+ *
+ * @return  0 if no timeout has occurred
+ * @return  non-zero if a timeout has occurred
+ */
+static int contikimac_check_timeouts(contikimac_t *ctx);
+
+/**
+ * @brief   Begin performing a channel check
+ *
+ * @param[in]   ctx         ContikiMAC context
+ */
+static void contikimac_channel_check(contikimac_t *ctx);
+
+/**
+ * @brief   Check the channel to detect strobes
+ *
+ * This will perform up to @c cca_count_max CCA checks spaced @c cca_cycle_period
+ * usec apart. If any check detects energy on the channel the function will
+ * return 1.
+ * The function will return early if energy is detected before @c cca_count_max
+ * checks have been performed.
+ *
+ * @param[in]   ctx         ContikiMAC context
+ *
+ * @return 1 if a transmission was detected
+ * @return 0 if none of the CCA checks detected any energy
+ */
+static int contikimac_channel_energy_detect(contikimac_t *ctx);
+
+/**
+ * @brief   Put the radio device to sleep immediately
+ *
+ * @param[in]   dev     device to put to sleep
+ */
+static void contikimac_radio_sleep(netdev_t *dev);
+
+/**
+ * @brief  Transmit a packet until timeout or an Ack has been received
+ *
+ * @pre Packet data has been preloaded
+ *
+ * @param[in]   ctx         ContikiMAC context
+ * @param[in]   broadcast   set to 1 if the frame should use broadcast transmission rules
+ */
+static void contikimac_send(contikimac_t *ctx, int broadcast);
+
+/**
+ * @brief   Periodic handler during wake times to determine when to go back to sleep
+ *
+ * @param[in]   ctx         ContikiMAC context
+ */
+static void contikimac_periodic_handler(contikimac_t *ctx);
+
+/**
+ * @brief   Set all required network interface options on the lower netdev
+ *
+ * @param[in]   dev         netdev device to configure
+ */
+static void contikimac_configure_lower(netdev_t *dev);
+
+/**
+ * @brief   Select timing parameters based on current configuration of the lower interface
+ *
+ * @param[in]   ctx         ContikiMAC context
+ */
+static void contikimac_select_params(contikimac_t *ctx);
+
+/**
+ * @brief   Cancel all timeouts and periodic timers
+ *
+ * Cancels @c ctx->timers.timeout, @c ctx->timers.periodic, and @c ctx->events.periodic.
+ * @c ctx->timers.channel_check is not affected.
+ *
+ * @param[in]   ctx         ContikiMAC context
+ */
+static void contikimac_cancel_timers(contikimac_t *ctx);
+
+/**
+ * @brief   Set a new timeout
+ *
+ * Used to put a time limit on certain operations in both the send path and in
+ * channel check/receive path.
+ *
+ * @param[in]   ctx         ContikiMAC context
+ * @param[in]   timeout_us  Timeout value, in microseconds
+ */
+static void contikimac_set_timeout(contikimac_t *ctx, uint32_t timeout_us);
+
+/**
+ * @brief   Read a IEEE802.15.4 frame header to see if it is a broadcast frame
+ *
+ * @param[in]   iolist  IEEE802.15.4 frame in iolist_t format
+ *
+ * @return 0 if iolist contains a unicast frame
+ * @return non-zero if iolist contains a broadcast frame
+ */
+static int contikimac_is_bcast(const iolist_t *iolist);
+
+/**
+ * @brief   Code deduplication for handling on/off options which correspond to
+ *          flags in @ref netdev_ieee802154_t
+ *
+ * @param[in]   ctx         ContikiMAC context
+ * @param[in]   flags       flags mask
+ * @param[in]   value       pointer to value (NETOPT_ENABLE, NETOPT_DISABLE)
+ * @param[in]   len         value length
+ *
+ * @return  @c -EOVERFLOW if @p len != @c sizeof(netopt_enable_t)
+ * @return  sizeof(netopt_enable_t) otherwise
+ */
+static int contikimac_netopt_flag_change(contikimac_t *ctx, uint16_t flags,
+    const netopt_enable_t *value, size_t len);
+
+/**
+ * @brief   xtimer callback for posting events to the event loop
+ */
+static void cb_post_event(void *arg);
+
+/**
+ * @brief   xtimer callback for timeouts during fast sleep
+ */
+static void cb_timeout(void *arg);
+
+/**
+ * @brief   Netdev event callback for the lower device
+ *
+ * @param[in]   lower       pointer to lower device
+ * @param[in]   ev          netdev event
+ */
+static void cb_netdev(netdev_t *lower, netdev_event_t ev);
+
+/**
+ * @brief   Event trampoline for @ref contikimac_channel_check
+ *
+ * This will also reschedule another channel check event
+ */
+static void ev_channel_check(event_t *evp);
+/**
+ * @brief   Event trampoline for @ref contikimac_channel_check
+ *
+ * This will not reschedule another channel check event
+ */
+static void ev_channel_check_no_resched(event_t *evp);
+/**
+ * @brief   Event trampoline for @ref contikimac_periodic
+ */
+static void ev_periodic(event_t *evp);
+/**
+ * @brief   Event trampoline for @ref contikimac_netdev_isr
+ */
+static void ev_isr(event_t *evp);
+
+static void cb_netdev(netdev_t *lower, netdev_event_t ev)
+{
+    contikimac_t *ctx = lower->context;
+    switch (ev) {
+        case NETDEV_EVENT_ISR:
+            event_post(ctx->evq, &ctx->events.isr.super);
+            break;
+        case NETDEV_EVENT_RX_STARTED:
+            ctx->rx_in_progress = 1;
+            if (!ctx->no_sleep) {
+                contikimac_cancel_timers(ctx);
+                /* Set a timeout for the currently in progress RX frame */
+                contikimac_set_timeout(ctx, ctx->params->rx_timeout);
+            }
+            TRACE("r");
+            if (ctx->dev.flags & CONTIKIMAC_OPT_TELL_RX_START) {
+                ctx->dev.netdev.event_callback(&ctx->dev.netdev, NETDEV_EVENT_RX_STARTED);
+            }
+            break;
+        case NETDEV_EVENT_RX_COMPLETE:
+            contikimac_cancel_timers(ctx);
+            TIMING_PRINTF("u: %lu\n", (unsigned long)xtimer_now_usec() - time_begin);
+            TRACE("R\n");
+            if (ctx->dev.flags & CONTIKIMAC_OPT_TELL_RX_END) {
+                /* Defer sleep until netdev_recv is called */
+                /* some transceivers, e.g. at86rf2xx, lose their RX buffer
+                 * contents when the device enters deep sleep */
+                int res = lower->driver->set(lower, NETOPT_STATE, &state_standby, sizeof(state_standby));
+                if (res < 0) {
+                    DEBUG("contikimac(%d): Failed setting NETOPT_STATE_STANDBY: %d\n",
+                          thread_getpid(), res);
+                }
+                ctx->dev.netdev.event_callback(&ctx->dev.netdev, NETDEV_EVENT_RX_COMPLETE);
+            }
+            else {
+                contikimac_radio_sleep(lower);
+            }
+
+            break;
+        case NETDEV_EVENT_TX_MEDIUM_BUSY:
+            TRACE("m");
+            ctx->tx_status = CONTIKIMAC_TX_MEDIUM_BUSY;
+#ifdef MODULE_NETSTATS_L2
+            lower->stats.tx_failed++;
+#endif /* MODULE_NETSTATS_L2 */
+            break;
+        case NETDEV_EVENT_TX_NOACK:
+            TRACE("n");
+            ctx->tx_status = CONTIKIMAC_TX_NOACK;
+#ifdef MODULE_NETSTATS_L2
+            lower->stats.tx_failed++;
+#endif /* MODULE_NETSTATS_L2 */
+            break;
+        case NETDEV_EVENT_TX_COMPLETE:
+            TRACE("c");
+            ctx->tx_status = CONTIKIMAC_TX_COMPLETE;
+#ifdef MODULE_NETSTATS_L2
+            lower->stats.tx_success++;
+#endif /* MODULE_NETSTATS_L2 */
+            break;
+        default:
+            /* pass through event to upper layer */
+            ctx->dev.netdev.event_callback(&ctx->dev.netdev, ev);
+            break;
+    }
+}
+
+void contikimac_setup(contikimac_t *ctx, netdev_t *lower)
+{
+    ctx->channel_check_period = CONTIKIMAC_DEFAULT_CHANNEL_CHECK_PERIOD;
+    ctx->dev.netdev.driver = &contikimac_driver;
+    ctx->dev.netdev.lower = lower;
+    lower->context = &ctx->dev;
+    lower->event_callback = cb_netdev;
+}
+
+static int contikimac_netdev_init(netdev_t *dev)
+{
+    contikimac_t *ctx = (contikimac_t *)dev;
+    ctx->seen_silence = 0;
+    ctx->rx_in_progress = 0;
+    ctx->timeout_flag = 0;
+    ctx->no_sleep = 0;
+    ctx->tx_status = CONTIKIMAC_TX_IDLE;
+
+    static const netopt_enable_t enable = NETOPT_ENABLE;
+    /* ContikiMAC requires link layer ACK requests on outgoing unicast frames */
+    netdev_ieee802154_set((netdev_ieee802154_t *)dev, NETOPT_ACK_REQ, &enable, sizeof(enable));
+
+    ctx->evq = &((gnrc_netif_t *)(dev->context))->evq;
+    ctx->channel_check_period = CONTIKIMAC_DEFAULT_CHANNEL_CHECK_PERIOD;
+    ctx->burst_timeout = CONTIKIMAC_DEFAULT_BURST_TIMEOUT;
+    ctx->reply_delay = CONTIKIMAC_DEFAULT_REPLY_DELAY;
+    ctx->timers.channel_check = (const xtimer_t) {
+        .target = 0, .long_target = 0,
+        .callback = cb_post_event,
+        .arg = &ctx->events.channel_check,
+    };
+    ctx->timers.extra_channel_check = (const xtimer_t) {
+        .target = 0, .long_target = 0,
+        .callback = cb_post_event,
+        .arg = &ctx->events.extra_channel_check,
+    };
+    ctx->timers.periodic = (const xtimer_t) {
+        .target = 0, .long_target = 0,
+        .callback = cb_post_event,
+        .arg = &ctx->events.periodic,
+    };
+    ctx->timers.timeout = (const xtimer_t) {
+        .target = 0, .long_target = 0,
+        .callback = cb_timeout,
+        /* The periodic handler will check the timeout flag and put the device to sleep */
+        .arg = &ctx->events.periodic,
+    };
+    ctx->events.channel_check = (const event_contikimac_t) {
+        .super = { .list_node.next = NULL, .handler = ev_channel_check, },
+        .ctx = ctx,
+    };
+    ctx->events.extra_channel_check = (const event_contikimac_t) {
+        .super = { .list_node.next = NULL, .handler = ev_channel_check_no_resched, },
+        .ctx = ctx,
+    };
+    ctx->events.periodic = (const event_contikimac_t) {
+        .super = { .list_node.next = NULL, .handler = ev_periodic, },
+        .ctx = ctx,
+    };
+    ctx->events.isr = (const event_contikimac_t) {
+        .super = { .list_node.next = NULL, .handler = ev_isr, },
+        .ctx = ctx,
+    };
+    /* initialize lower driver */
+    netdev_t *lower_netdev = dev->lower;
+    netdev_ieee802154_t *lower_802154 = (netdev_ieee802154_t*)lower_netdev;
+    lower_netdev->driver->init(lower_netdev);
+
+    /* configure netopt settings on the lower interface */
+    contikimac_configure_lower(lower_netdev);
+    contikimac_select_params(ctx);
+    /* Copy default protocol and PAN ID from lower device */
+    ctx->dev.proto = lower_802154->proto;
+    ctx->dev.pan = lower_802154->pan;
+    /* start the event loop by posting a channel check event */
+    cb_post_event(&ctx->events.channel_check);
+
+    return 0;
+}
+
+static int contikimac_is_bcast(const iolist_t *iolist)
+{
+    size_t len = 0;
+    uint8_t buf[IEEE802154_MAX_HDR_LEN] = {0};
+    while (iolist) {
+        if ((len + iolist->iol_len) >= sizeof(buf)) {
+            memcpy(&buf[len], iolist->iol_base, sizeof(buf) - len);
+            len = sizeof(buf);
+            break;
+        }
+        memcpy(&buf[len], iolist->iol_base, iolist->iol_len);
+        len += iolist->iol_len;
+    }
+    if (len >= IEEE802154_MIN_FRAME_LEN) {
+        uint8_t dst[IEEE802154_LONG_ADDRESS_LEN];
+        le_uint16_t dst_pan;
+        int res = ieee802154_get_dst(buf, dst, &dst_pan);
+        if ((res == IEEE802154_ADDR_BCAST_LEN) &&
+            (memcmp(ieee802154_addr_bcast, dst, IEEE802154_ADDR_BCAST_LEN) == 0)) {
+            return 1;
+        }
+    }
+    return 0;
+}
+
+static int contikimac_netdev_send(netdev_t *dev, const iolist_t *iolist)
+{
+    contikimac_t *ctx = (contikimac_t *)dev;
+    netdev_t *lower = ctx->dev.netdev.lower;
+    if (ctx->tx_status) {
+        /* TX already in progress, something must be wrong */
+        LOG_ERROR("contikimac(%d): double TX!\n", thread_getpid());
+        return -1;
+    }
+    if (ctx->rx_in_progress) {
+        /* TODO let the in progress RX frame finish before starting TX */
+    }
+    /* Go to standby before transmitting to avoid having incoming
+     * packets corrupt the frame buffer on single buffered
+     * transceivers (e.g. at86rf2xx). Also works around an issue
+     * on at86rf2xx where the frame buffer is lost after the
+     * first transmission because the driver puts the transceiver
+     * in sleep mode. */
+    int res = lower->driver->set(lower, NETOPT_STATE, &state_standby, sizeof(state_standby));
+    if (res < 0) {
+        DEBUG("contikimac(%d): Failed setting NETOPT_STATE_STANDBY: %d\n",
+              thread_getpid(), res);
+    }
+    uint8_t broadcast = contikimac_is_bcast(iolist);
+    /* Preload the frame */
+    res = lower->driver->send(lower, iolist);
+    if (res < 0) {
+        LOG_ERROR("contikimac(%d): Preload failed: %d\n",
+              thread_getpid(), res);
+        return res;
+    }
+    if (ctx->dev.flags & CONTIKIMAC_OPT_TELL_TX_START) {
+        ctx->dev.netdev.event_callback(&ctx->dev.netdev, NETDEV_EVENT_TX_STARTED);
+    }
+    contikimac_send(ctx, broadcast);
+    if (ctx->dev.flags & CONTIKIMAC_OPT_TELL_TX_END) {
+        switch (ctx->tx_status) {
+            case CONTIKIMAC_TX_IDLE:
+            case CONTIKIMAC_TX_COMPLETE:
+                ctx->dev.netdev.event_callback(&ctx->dev.netdev, NETDEV_EVENT_TX_COMPLETE);
+                break;
+            case CONTIKIMAC_TX_MEDIUM_BUSY:
+                ctx->dev.netdev.event_callback(&ctx->dev.netdev, NETDEV_EVENT_TX_MEDIUM_BUSY);
+                break;
+            case CONTIKIMAC_TX_NOACK:
+            default:
+                ctx->dev.netdev.event_callback(&ctx->dev.netdev, NETDEV_EVENT_TX_NOACK);
+                break;
+        }
+    }
+    ctx->tx_status = CONTIKIMAC_TX_IDLE;
+    if (ctx->no_sleep) {
+        res = lower->driver->set(lower, NETOPT_STATE, &state_listen, sizeof(state_listen));
+        if (res < 0) {
+            DEBUG("contikimac(%d): Failed setting NETOPT_STATE_IDLE: %d\n",
+                  thread_getpid(), res);
+        }
+    }
+    else {
+        /* The current RX cycle will have been disrupted by the TX,
+         * switch back to sleep state */
+        if (!broadcast) {
+            /* If we sent a unicast message we trigger a channel check after a short
+             * delay to catch immediate replies from the other node. This should improve
+             * latency and reduce the energy usage of the other node by reducing the
+             * number of retries needed. */
+            /* TODO make this configurable */
+            xtimer_set(&ctx->timers.extra_channel_check, ctx->reply_delay);
+        }
+        contikimac_radio_sleep(lower);
+        ctx->rx_in_progress = 0;
+    }
+    return 0;
+}
+
+static int contikimac_netdev_recv(netdev_t *dev, void *buf, size_t len, void *info)
+{
+    contikimac_t *ctx = (contikimac_t *)dev;
+    netdev_t *lower = ctx->dev.netdev.lower;
+    ctx->rx_in_progress = 0;
+    int res = lower->driver->recv(lower, buf, len, info);
+    if (buf || len) {
+        /* buf == NULL && len == 0 is used to query the frame length without
+         * discarding the RX buffer, only allow state transitions if we are
+         * finished with the buffer */
+        TRACE("G\n");
+        unsigned expect_burst = 0;
+        if (res > 0) {
+            /* Assume IEEE 802.15.4 frame header */
+            if (buf && (((uint8_t *)buf)[0] & IEEE802154_FCF_FRAME_PEND)) {
+                expect_burst = 1;
+            }
+        }
+        if (ctx->tx_status != CONTIKIMAC_TX_IDLE) {
+            /* TX in progress, don't touch the state */
+            return res;
+        }
+        if (ctx->no_sleep || expect_burst) {
+            res = lower->driver->set(lower, NETOPT_STATE, &state_listen, sizeof(state_listen));
+            if (res < 0) {
+                DEBUG("contikimac(%d): Failed setting NETOPT_STATE_IDLE: %d\n",
+                          thread_getpid(), res);
+                return res;
+            }
+            if (!ctx->no_sleep) {
+                contikimac_set_timeout(ctx, ctx->burst_timeout);
+            }
+        }
+        else {
+            /* We are done with this transaction, go back to sleep */
+            contikimac_radio_sleep(lower);
+        }
+    }
+    return res;
+}
+
+static int contikimac_netdev_get(netdev_t *dev, netopt_t opt, void *value, size_t len)
+{
+    contikimac_t *ctx = (contikimac_t *)dev;
+    netdev_t *lower = ctx->dev.netdev.lower;
+    switch (opt) {
+        case NETOPT_MAC_NO_SLEEP:
+            if (len != sizeof(netopt_enable_t)) {
+                return -EOVERFLOW;
+            }
+            *((netopt_enable_t *)value) = (ctx->no_sleep ? NETOPT_ENABLE : NETOPT_DISABLE);
+            return sizeof(netopt_enable_t);
+
+        default:
+            break;
+    }
+    int res = lower->driver->get(lower, opt, value, len);
+    return res;
+}
+
+static int contikimac_netopt_flag_change(contikimac_t *ctx, uint16_t flags,
+    const netopt_enable_t *value, size_t len)
+{
+    if (len != sizeof(const netopt_enable_t)) {
+        return -EOVERFLOW;
+    }
+    const netopt_enable_t *enable = value;
+    if (*enable == NETOPT_DISABLE) {
+        ctx->dev.flags &= ~(flags);
+    }
+    else {
+        ctx->dev.flags |= flags;
+    }
+    return sizeof(const netopt_enable_t);
+}
+
+static int contikimac_netdev_set(netdev_t *dev, netopt_t opt, const void *value, size_t len)
+{
+    contikimac_t *ctx = (contikimac_t *)dev;
+    DEBUG("opt: %u\n", (unsigned) opt);
+    switch (opt) {
+        /* ContikiMAC provides its own TX/RX feedback events.
+         * The corresponding events on the lower device are used internally by
+         * the implementation to provide feedback for timeouts */
+        case NETOPT_TX_START_IRQ:
+            return contikimac_netopt_flag_change(ctx, CONTIKIMAC_OPT_TELL_TX_START, value, len);
+        case NETOPT_TX_END_IRQ:
+            return contikimac_netopt_flag_change(ctx, CONTIKIMAC_OPT_TELL_TX_END, value, len);
+        case NETOPT_RX_START_IRQ:
+            return contikimac_netopt_flag_change(ctx, CONTIKIMAC_OPT_TELL_RX_START, value, len);
+        case NETOPT_RX_END_IRQ:
+            return contikimac_netopt_flag_change(ctx, CONTIKIMAC_OPT_TELL_RX_END, value, len);
+
+        /* Disallow changing these setting from higher layers */
+        case NETOPT_PRELOADING:
+        case NETOPT_CSMA:
+        case NETOPT_RETRANS:
+            return -EINVAL;
+
+        case NETOPT_MAC_NO_SLEEP:
+            if (len != sizeof(const netopt_enable_t)) {
+                return -EOVERFLOW;
+            }
+            ctx->no_sleep = (*((const netopt_enable_t *)value) != NETOPT_DISABLE);
+            /* Reset the radio duty cycling state */
+            contikimac_cancel_timers(ctx);
+            ctx->rx_in_progress = 0;
+            ctx->seen_silence = 0;
+            if (ctx->no_sleep) {
+                /* switch the radio to listen state */
+                int res = dev->lower->driver->set(dev->lower, NETOPT_STATE, &state_listen, sizeof(state_listen));
+                if (res < 0) {
+                    DEBUG("contikimac(%d): Failed setting NETOPT_STATE_IDLE: %d\n",
+                          thread_getpid(), res);
+                }
+            }
+            else {
+                /* start the event loop by posting a channel check event */
+                cb_post_event(&ctx->events.channel_check);
+            }
+            return sizeof(const netopt_enable_t);
+
+        case NETOPT_STATE:
+            DEBUG("State: %u\n", *((unsigned *)value));
+            break;
+
+        default:
+            break;
+    }
+    int res = dev->lower->driver->set(dev->lower, opt, value, len);
+    if (res > 0) {
+        /*  XXX refactor this when the IEEE 802.15.4 state is refactored */
+        netdev_ieee802154_set((netdev_ieee802154_t *)dev, opt, value, len);
+        switch (opt) {
+            case NETOPT_CHANNEL:
+            case NETOPT_CHANNEL_PAGE:
+                contikimac_select_params(ctx);
+                break;
+            default:
+                break;
+        }
+    }
+    return res;
+}
+
+static void contikimac_netdev_isr(netdev_t *dev)
+{
+    contikimac_t *ctx = (contikimac_t *)dev;
+    /* To get the wait timing right we will save the timestamp here.
+     * The time of the last IRQ before the TX_OK or TX_NOACK flag was
+     * set is used as an approximation of when the TX operation finished */
+    ctx->last_irq = xtimer_now();
+
+    dev->lower->driver->isr(dev->lower);
+}
+
+const netdev_driver_t contikimac_driver = {
+    .init = contikimac_netdev_init,
+    .send = contikimac_netdev_send,
+    .recv = contikimac_netdev_recv,
+    .get  = contikimac_netdev_get,
+    .set  = contikimac_netdev_set,
+    .isr  = contikimac_netdev_isr,
+};
+
+/**
+ * @brief   Shared asserts for the xtimer callbacks below
+ */
+static inline void event_asserts(void *arg)
+{
+    assert(arg);
+    event_contikimac_t *evp = arg;
+    contikimac_t *ctx = evp->ctx;
+    assert(ctx);
+    assert(ctx->evq);
+}
+
+static void cb_post_event(void *arg)
+{
+    event_asserts(arg);
+    event_contikimac_t *evp = arg;
+    contikimac_t *ctx = evp->ctx;
+    event_post(ctx->evq, &evp->super);
+}
+
+static void cb_timeout(void *arg)
+{
+    event_asserts(arg);
+    event_contikimac_t *evp = arg;
+    contikimac_t *ctx = evp->ctx;
+    ctx->timeout_flag = 1;
+    event_post(ctx->evq, &evp->super);
+}
+
+static int contikimac_check_timeouts(contikimac_t *ctx)
+{
+    if (ctx->timeout_flag) {
+        contikimac_cancel_timers(ctx);
+        TIMING_PRINTF("t: %lu\n", (unsigned long)xtimer_now_usec() - time_begin);
+        if (ctx->tx_status) {
+            DEBUG("contikimac(%d): TX timeout\n",
+                      thread_getpid());
+        }
+        else if (ctx->rx_in_progress) {
+            DEBUG("contikimac(%d): RX timeout\n",
+                      thread_getpid());
+        }
+        else if (ctx->seen_silence) {
+            DEBUG("contikimac(%d): Fast sleep (long silence)\n",
+                      thread_getpid());
+        }
+        else {
+            DEBUG("contikimac(%d): Fast sleep (noise)\n",
+                      thread_getpid());
+        }
+        return 1;
+    }
+    return 0;
+}
+
+static void contikimac_periodic_handler(contikimac_t *ctx)
+{
+    if (ctx->no_sleep) {
+        return;
+    }
+    if (ctx->tx_status) {
+        /* Transmission in progress, do not do anything to disrupt it */
+        return;
+    }
+    netdev_t *lower = ctx->dev.netdev.lower;
+    if (contikimac_check_timeouts(ctx)) {
+        /* Timeout has occurred */
+        TRACE("T\n");
+        contikimac_radio_sleep(lower);
+        ctx->rx_in_progress = 0;
+        return;
+    }
+    /* Periodically perform CCA checks to evaluate channel usage */
+    if (ctx->seen_silence) {
+        /* Performing a CCA check while a packet is being received may cause the
+         * driver to abort the reception, we will only do CCAs while waiting for
+         * the first silence */
+        TRACE("s");
+        return;
+    }
+    /* We have detected some energy on the channel, we will keep checking
+     * the channel periodically until it is idle, then switch to listen state */
+    netopt_enable_t channel_clear;
+    int res = lower->driver->get(lower, NETOPT_IS_CHANNEL_CLR, &channel_clear, sizeof(channel_clear));
+    if (res < 0) {
+        DEBUG("contikimac(%d): Failed getting NETOPT_IS_CHANNEL_CLR: %d\n",
+                  thread_getpid(), res);
+        return;
+    }
+    if (!channel_clear) {
+        TRACE("B");
+        /* Do next CCA */
+        xtimer_set(&ctx->timers.periodic, ctx->params->after_ed_scan_interval);
+        event_post(ctx->evq, &ctx->events.periodic.super);
+        return;
+    }
+    /* Silence detected */
+    ctx->seen_silence = 1;
+    /* We have detected an idle channel, expect incoming traffic very soon */
+    res = lower->driver->set(lower, NETOPT_STATE, &state_listen, sizeof(state_listen));
+    if (res < 0) {
+        DEBUG("contikimac(%d): Failed setting NETOPT_STATE_IDLE: %d\n",
+                  thread_getpid(), res);
+        return;
+    }
+    /* Set timeout in case we only detected noise */
+    TRACE("L");
+    netopt_state_t state;
+    res = lower->driver->get(lower, NETOPT_STATE, &state, sizeof(state));
+    DEBUG("S:%u\n", (unsigned)state);
+    contikimac_set_timeout(ctx, ctx->params->listen_timeout);
+}
+
+static void contikimac_channel_check(contikimac_t *ctx)
+{
+    if (ctx->no_sleep) {
+        return;
+    }
+    if (ctx->tx_status) {
+        /* Transmission in progress, do not do anything to disrupt it */
+        return;
+    }
+    if (contikimac_check_timeouts(ctx)) {
+        /* Timeout has occurred */
+    }
+    else if (ctx->rx_in_progress) {
+        /* Currently sending/receiving a frame, skip this channel check */
+        TRACE("_");
+        DEBUG("contikimac(%d): Skip channel check, RX in progress\n",
+            thread_getpid());
+        return;
+    }
+    netdev_t *lower = ctx->dev.netdev.lower;
+
+    if (ENABLE_TIMING_INFO) {
+        time_begin = xtimer_now_usec();
+    }
+    contikimac_cancel_timers(ctx);
+    DEBUG("contikimac(%d): Checking channel\n", thread_getpid());
+    /* Perform multiple CCA and check the results */
+    /* Bring the radio out of sleep mode */
+    int res = lower->driver->set(lower, NETOPT_STATE, &state_standby, sizeof(state_standby));
+    if (res < 0) {
+        DEBUG("contikimac(%d): Failed setting NETOPT_STATE_STANDBY: %d\n",
+            thread_getpid(), res);
+        return;
+    }
+    CONTIKIMAC_LED_ON;
+    if (contikimac_channel_energy_detect(ctx)) {
+        /* Set the radio to listen for incoming packets */
+        DEBUG("contikimac(%d): Detected, looking for silence\n", thread_getpid());
+        /* Reset the periodic handler state */
+        ctx->seen_silence = 0;
+        event_post(ctx->evq, &ctx->events.periodic.super);
+        TRACE("D\n");
+        /* Set timeout in case we only detected noise */
+        contikimac_set_timeout(ctx, ctx->params->after_ed_scan_timeout);
+    }
+    else {
+        /* Nothing detected, immediately return to sleep */
+        DEBUG("contikimac(%d): Nothing seen\n", thread_getpid());
+        TRACE("d");
+        contikimac_radio_sleep(lower);
+    }
+}
+
+static int contikimac_channel_energy_detect(contikimac_t *ctx)
+{
+    netdev_t *dev = &ctx->dev.netdev;
+    xtimer_ticks32_t last_wakeup = xtimer_now();
+    for (uint8_t cca = ctx->params->cca_count_max; cca > 0; --cca) {
+        netopt_enable_t channel_clear;
+        int res = dev->driver->get(dev, NETOPT_IS_CHANNEL_CLR, &channel_clear, sizeof(channel_clear));
+        if (res < 0) {
+            DEBUG("contikimac(%d): Failed getting NETOPT_IS_CHANNEL_CLR: %d\n",
+                thread_getpid(), res);
+            break;
+        }
+        if (!channel_clear) {
+            /* Detected some radio energy on the channel */
+            return 1;
+        }
+        xtimer_periodic_wakeup(&last_wakeup, ctx->params->cca_cycle_period);
+    }
+    return 0;
+}
+
+static void contikimac_radio_sleep(netdev_t *dev)
+{
+    static const netopt_state_t state_sleep = NETOPT_STATE_SLEEP;
+    DEBUG("contikimac(%d): Going to sleep\n", thread_getpid());
+    int res = dev->driver->set(dev, NETOPT_STATE, &state_sleep, sizeof(state_sleep));
+    if (res < 0) {
+        DEBUG("contikimac(%d): Failed setting NETOPT_STATE_SLEEP: %d\n",
+              thread_getpid(), res);
+    }
+    CONTIKIMAC_LED_OFF;
+    TIMING_PRINTF("r: %lu\n", (unsigned long)xtimer_now_usec() - time_begin);
+}
+
+static void contikimac_send(contikimac_t *ctx, int broadcast)
+{
+    ctx->tx_status = CONTIKIMAC_TX_STARTED;
+    int do_transmit = 1;
+    uint32_t time_before = 0;
+    (void) time_before;
+    if (ENABLE_TIMING_INFO) {
+        time_before = xtimer_now_usec();
+    }
+    /* For reliable communications, we need to strobe the frame transmission for
+     * at least the full wake-up interval, plus the length of two CCA checks,
+     * plus one more frame to allow the receiver to detect the packet on the
+     * wake-up interval boundary, plus yet one more frame for the actual
+     * transmission in the worst case scenario. */
+    uint32_t tx_strobe_timeout = ctx->channel_check_period + 2 * ctx->params->cca_cycle_period;
+    /* TX aborts listening mode */
+    contikimac_cancel_timers(ctx);
+    /* Check that the channel is clear before starting strobe */
+    /* This check avoids problems where a reply sent in response to a broadcast
+     * transmission interrupts the broadcasting node and prevents other nodes
+     * from detecting the broadcast. The broadcasting node will also sometimes
+     * fail to receive the reply because it is still in strobe mode */
+    /* We avoid using CSMA on the actual TX operations below because it will add
+     * variable delays to the transmission and mess up the protocol timing */
+    contikimac_set_timeout(ctx, tx_strobe_timeout + ctx->params->rx_timeout);
+    while (contikimac_channel_energy_detect(ctx)) {
+        DEBUG("contikimac(%d): wait for TX opportunity\n", thread_getpid());
+        if (ctx->timeout_flag) {
+            DEBUG("contikimac(%d): Channel busy\n", thread_getpid());
+            ctx->tx_status = CONTIKIMAC_TX_MEDIUM_BUSY;
+            return;
+        }
+    }
+    contikimac_cancel_timers(ctx);
+    /* Set timeout for TX strobe */
+    contikimac_set_timeout(ctx, tx_strobe_timeout);
+    netdev_t *lower = ctx->dev.netdev.lower;
+    unsigned tx_sequence = 2; /* counts down after the strobe timeout has happened */
+    while(tx_sequence) {
+        if (do_transmit) {
+            /* For extra verbose TX timing info: */
+            /*
+            TIMING_PRINTF("S: %lu\n", (unsigned long)xtimer_now_usec() - time_before);
+            */
+            do_transmit = 0;
+            ctx->tx_status = CONTIKIMAC_TX_STARTED;
+            if (ENABLE_TIMING_INFO) {
+                time_before = xtimer_now_usec();
+            }
+            lower->driver->set(lower, NETOPT_STATE, &state_tx, sizeof(state_tx));
+        }
+        thread_flags_t tf = thread_flags_wait_any(THREAD_FLAG_EVENT);
+        if (tf & THREAD_FLAG_EVENT) {
+            event_t *evp;
+            /* Perform event queue drain */
+            while ((evp = event_get(ctx->evq))) {
+                DEBUG("contikimac(%d): event %p\n", thread_getpid(), (void *)evp);
+                if (evp->handler) {
+                    evp->handler(evp);
+                }
+            }
+        }
+        /* Check the TX progress */
+        switch (ctx->tx_status) {
+            case CONTIKIMAC_TX_COMPLETE:
+                /* For unicast, stop after receiving the first Ack */
+                TRACE("C");
+                if (!broadcast) {
+                    TRACE("U\n");
+                    TIMING_PRINTF("O: %lu\n", (unsigned long)xtimer_now_usec() - time_before);
+                    /* Cancel timeout */
+                    contikimac_cancel_timers(ctx);
+                    ctx->tx_status = CONTIKIMAC_TX_IDLE;
+                    return;
+                }
+                /* For broadcast and multicast, always transmit for the full strobe
+                 * duration, but wait for a short while before retransmitting */
+                xtimer_periodic_wakeup(&ctx->last_irq, ctx->params->inter_packet_interval);
+                /* fall through */
+            case CONTIKIMAC_TX_NOACK:
+            case CONTIKIMAC_TX_MEDIUM_BUSY:
+                /* Skip wait on TX errors */
+                /* Consider the inter_packet_interval already passed without calling
+                 * xtimer to verify. Modify this part if inter_packet_interval is much
+                 * longer than the Ack timeout */
+                TRACE("x");
+                /* retransmit */
+                do_transmit = 1;
+                if (ctx->timeout_flag) {
+                    /* Strobe time has passed, try to transmit one more frame
+                     * before stopping.
+                     * When tx_sequence reaches 0 we will stop retrying */
+                     TRACE("X");
+                    --tx_sequence;
+                }
+                break;
+            default:
+                /* Still waiting to hear back from the TX operation */
+                break;
+        }
+        /* Keep retransmitting until the strobe time has passed, or until we
+         * receive an Ack for unicast. */
+    }
+    /* Timeout flag was set */
+    TRACE("t\n");
+    contikimac_cancel_timers(ctx);
+    ctx->tx_status = CONTIKIMAC_TX_IDLE;
+    return;
+}
+
+static void contikimac_configure_lower(netdev_t *dev)
+{
+    /* Enable RX- and TX-started interrupts */
+    static const netopt_enable_t enable = NETOPT_ENABLE;
+    static const netopt_enable_t disable = NETOPT_DISABLE;
+    static const uint8_t zero = 0;
+
+    int res;
+    res = dev->driver->set(dev, NETOPT_CSMA, &disable, sizeof(disable));
+    if (res < 0) {
+        DEBUG("contikimac(%d): disable NETOPT_CSMA failed: %d\n",
+                  thread_getpid(), res);
+    }
+    res = dev->driver->set(dev, NETOPT_RETRANS, &zero, sizeof(zero));
+    if (res < 0) {
+        DEBUG("contikimac(%d): disable NETOPT_RETRANS failed: %d\n",
+                  thread_getpid(), res);
+    }
+    res = dev->driver->set(dev, NETOPT_RX_START_IRQ, &enable, sizeof(enable));
+    if (res < 0) {
+        DEBUG("contikimac(%d): enable NETOPT_RX_START_IRQ failed: %d\n",
+                  thread_getpid(), res);
+    }
+    res = dev->driver->set(dev, NETOPT_RX_END_IRQ, &enable, sizeof(enable));
+    if (res < 0) {
+        DEBUG("contikimac(%d): enable NETOPT_RX_END_IRQ failed: %d\n",
+                  thread_getpid(), res);
+    }
+    res = dev->driver->set(dev, NETOPT_TX_END_IRQ, &enable, sizeof(enable));
+    if (res < 0) {
+        DEBUG("contikimac(%d): enable NETOPT_TX_END_IRQ failed: %d\n",
+                  thread_getpid(), res);
+    }
+    res = dev->driver->set(dev, NETOPT_PRELOADING, &enable, sizeof(enable));
+    if (res < 0) {
+        DEBUG("contikimac(%d): enable NETOPT_PRELOADING failed: %d\n",
+                  thread_getpid(), res);
+        LOG_ERROR("contikimac requires NETOPT_PRELOADING, this node will "
+                  "likely not be able to communicate with other nodes!\n");
+    }
+}
+
+static void contikimac_select_params(contikimac_t *ctx)
+{
+    netdev_t *lower = ctx->dev.netdev.lower;
+    /* 802.15.4 channel and page determine which set of parameters we use */
+    uint16_t channel;
+    uint16_t page;
+    int res = lower->driver->get(lower, NETOPT_CHANNEL, &channel, sizeof(channel));
+    if (res < 0) {
+        LOG_ERROR("contikimac(%d): Error %d reading device channel. "
+            "Fall back to timings for O-QPSK 250 kbit/s\n",
+            thread_getpid(), res);
+        ctx->params = &contikimac_params_OQPSK250;
+        return;
+    }
+    res = lower->driver->get(lower, NETOPT_CHANNEL_PAGE, &page, sizeof(page));
+    if (res < 0) {
+        /* Assume page = 0 if the device driver does not support NETOPT_CHANNEL_PAGE */
+        page = 0;
+    }
+    switch (page) {
+        case 0:
+            if (channel == IEEE802154_CHANNEL_MIN_SUBGHZ) {
+                /* 868 MHz band, BPSK 20 kbit/s */
+                DEBUG("contikimac(%d): using timings for BPSK 20 kbit/s\n",
+                    thread_getpid());
+                ctx->params = &contikimac_params_BPSK20;
+            }
+            else if ((channel > IEEE802154_CHANNEL_MIN_SUBGHZ) &&
+                     (channel <= IEEE802154_CHANNEL_MAX_SUBGHZ)) {
+                /* 915 MHz band, BPSK 40 kbit/s */
+                DEBUG("contikimac(%d): using timings for BPSK 40 kbit/s\n",
+                    thread_getpid());
+                ctx->params = &contikimac_params_BPSK40;
+            }
+            else if ((channel >= IEEE802154_CHANNEL_MIN) &&
+                (channel <= IEEE802154_CHANNEL_MAX)) {
+                /* 2.4 GHz band, O-QPSK 250 kbit/s */
+                DEBUG("contikimac(%d): using timings for O-QPSK 250 kbit/s\n",
+                    thread_getpid());
+                ctx->params = &contikimac_params_OQPSK250;
+            }
+            break;
+        case 2:
+            if (channel == IEEE802154_CHANNEL_MIN_SUBGHZ) {
+                /* 868 MHz band, O-QPSK 100 kbit/s */
+                DEBUG("contikimac(%d): using timings for O-QPSK 100 kbit/s\n",
+                    thread_getpid());
+                ctx->params = &contikimac_params_OQPSK100;
+            }
+            else if ((channel > IEEE802154_CHANNEL_MIN_SUBGHZ) &&
+                     (channel <= IEEE802154_CHANNEL_MAX_SUBGHZ)) {
+                /* 915 MHz band, O-QPSK 250 kbit/s */
+                DEBUG("contikimac(%d): using timings for O-QPSK 250 kbit/s\n",
+                    thread_getpid());
+                ctx->params = &contikimac_params_OQPSK250;
+            }
+            break;
+            /* TODO handle more pages and bands */
+        default:
+            break;
+    }
+    if (ctx->params == NULL) {
+        LOG_ERROR("contikimac(%d): No timing configuration exists "
+            "for page %u, channel %u. Fall back to timings for O-QPSK 250 kbit/s\n",
+            thread_getpid(), (unsigned int)page, (unsigned int)channel);
+        ctx->params = &contikimac_params_OQPSK250;
+    }
+}
+
+static void contikimac_cancel_timers(contikimac_t *ctx)
+{
+    xtimer_remove(&ctx->timers.periodic);
+    xtimer_remove(&ctx->timers.timeout);
+    event_cancel(ctx->evq, &ctx->events.periodic.super);
+    ctx->timeout_flag = 0;
+}
+
+static void contikimac_set_timeout(contikimac_t *ctx, uint32_t timeout_us)
+{
+    xtimer_remove(&ctx->timers.timeout);
+    ctx->timeout_flag = 0;
+    xtimer_set(&ctx->timers.timeout, timeout_us);
+}
+
+static void ev_channel_check(event_t *evp)
+{
+    contikimac_t *ctx = ((event_contikimac_t *)evp)->ctx;
+    /* immediately schedule the next channel check */
+    xtimer_set(&ctx->timers.channel_check, ctx->channel_check_period);
+    contikimac_channel_check(ctx);
+}
+
+static void ev_channel_check_no_resched(event_t *evp)
+{
+    contikimac_t *ctx = ((event_contikimac_t *)evp)->ctx;
+    /* skip scheduling a new channel check */
+    contikimac_channel_check(ctx);
+}
+
+static void ev_periodic(event_t *evp)
+{
+    contikimac_t *ctx = ((event_contikimac_t *)evp)->ctx;
+    contikimac_periodic_handler(ctx);
+}
+
+static void ev_isr(event_t *evp)
+{
+    contikimac_t *ctx = ((event_contikimac_t *)evp)->ctx;
+    contikimac_netdev_isr(&ctx->dev.netdev);
+}

--- a/sys/net/link_layer/contikimac/contikimac.c
+++ b/sys/net/link_layer/contikimac/contikimac.c
@@ -73,14 +73,14 @@ enum {
 };
 
 /**
- * @brief   netdev option flag definitions
+ * @name    netdev option flag definitions
+ * @{
  */
-enum {
-    CONTIKIMAC_OPT_TELL_TX_START   = (1 <<  8),
-    CONTIKIMAC_OPT_TELL_TX_END     = (1 <<  9),
-    CONTIKIMAC_OPT_TELL_RX_START   = (1 << 10),
-    CONTIKIMAC_OPT_TELL_RX_END     = (1 << 11),
-};
+#define CONTIKIMAC_OPT_TELL_TX_START    (1u <<  8)
+#define CONTIKIMAC_OPT_TELL_TX_END      (1u <<  9)
+#define CONTIKIMAC_OPT_TELL_RX_START    (1u << 10)
+#define CONTIKIMAC_OPT_TELL_RX_END      (1u << 11)
+/** @} */
 
 /**
  * @brief Default timing settings for O-QPSK 250 kbit/s

--- a/sys/net/link_layer/contikimac/contikimac.c
+++ b/sys/net/link_layer/contikimac/contikimac.c
@@ -782,9 +782,6 @@ static void contikimac_periodic_handler(contikimac_t *ctx)
     }
     /* Set timeout in case we only detected noise */
     TRACE("L");
-    netopt_state_t state;
-    res = lower->driver->get(lower, NETOPT_STATE, &state, sizeof(state));
-    DEBUG("S:%u\n", (unsigned)state);
     contikimac_set_timeout(ctx, ctx->params->listen_timeout);
 }
 

--- a/sys/net/link_layer/contikimac/contikimac.c
+++ b/sys/net/link_layer/contikimac/contikimac.c
@@ -499,15 +499,13 @@ static int contikimac_netdev_send(netdev_t *dev, const iolist_t *iolist)
     else {
         /* The current RX cycle will have been disrupted by the TX,
          * switch back to sleep state */
-        if (!broadcast) {
-            /* If we sent a unicast message we trigger a channel check after a short
-             * delay to catch immediate replies from the other node. This should improve
-             * latency and reduce the energy usage of the other node by reducing the
-             * number of retries needed. */
-            /* TODO make this configurable */
-            xtimer_set(&ctx->timers.extra_channel_check, ctx->reply_delay);
-        }
-        contikimac_radio_sleep(lower);
+        /* We trigger an extra channel check outside of the normal schedule
+         * after a short delay to catch any immediate replies from the other
+         * node. This should improve latency and reduce the energy usage of the
+         * other node by reducing the number of retries needed. */
+        /* TODO make this configurable */
+        xtimer_set(&ctx->timers.extra_channel_check, ctx->reply_delay);
+        contikimac_radio_sleep(ctx);
         ctx->rx_in_progress = 0;
     }
     return 0;

--- a/sys/net/link_layer/contikimac/contikimac.c
+++ b/sys/net/link_layer/contikimac/contikimac.c
@@ -564,6 +564,15 @@ static int contikimac_netdev_get(netdev_t *dev, netopt_t opt, void *value, size_
             *((netopt_enable_t *)value) = (ctx->no_sleep ? NETOPT_ENABLE : NETOPT_DISABLE);
             return sizeof(netopt_enable_t);
 
+        case NETOPT_PRELOADING:
+            /* We use NETOPT_PRELOADING on the lower driver, but we do not
+             * emulate that behavior towards the upper layers. */
+            if (len != sizeof(netopt_enable_t)) {
+                return -EOVERFLOW;
+            }
+            *((netopt_enable_t *)value) = NETOPT_DISABLE;
+            return sizeof(netopt_enable_t);
+
         default:
             break;
     }

--- a/sys/net/link_layer/contikimac/contikimac.c
+++ b/sys/net/link_layer/contikimac/contikimac.c
@@ -887,8 +887,19 @@ static void contikimac_send(contikimac_t *ctx, int broadcast)
      * wake-up interval boundary, plus yet one more frame for the actual
      * transmission in the worst case scenario. */
     uint32_t tx_strobe_timeout = ctx->channel_check_period + 2 * ctx->params->cca_cycle_period;
+
     /* TX aborts listening mode */
     contikimac_cancel_timers(ctx);
+
+#ifdef MODULE_NETSTATS_L2
+    if (broadcast) {
+        ++lower->stats.tx_mcast_count;
+    }
+    else {
+        ++lower->stats.tx_unicast_count;
+    }
+#endif
+
     /* Check that the channel is clear before starting strobe */
     /* This check avoids problems where a reply sent in response to a broadcast
      * transmission interrupts the broadcasting node and prevents other nodes

--- a/sys/net/link_layer/contikimac/contikimac_params_BPSK20.c
+++ b/sys/net/link_layer/contikimac/contikimac_params_BPSK20.c
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2017 SKF AB
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ * @ingroup     net
+ * @file
+ * @brief       GNRC ContikiMAC timing settings for BPSK 20 kbit/s
+ *
+ * These timings are valid for STD IEEE 802.15.4 channel page 0 in the 868 MHz
+ * band.
+ *
+ * @author      Joakim Nohlgård <joakim.nohlgard@eistec.se>
+ * @}
+ */
+
+#include "net/contikimac.h"
+
+/* (usec) time to transmit one symbol */
+#define SYMBOL_TIME 50
+/* (usec) time to transmit one byte */
+#define OCTET_TIME (SYMBOL_TIME * 8)
+/* (usec) time to transmit the longest possible frame */
+#define LONGEST_FRAME_TIME (OCTET_TIME * (4 + 1 + 1 + 127))
+/* (usec) timeout waiting for Ack after TX complete */
+#define ACK_TIMEOUT (120 * SYMBOL_TIME)
+
+const contikimac_params_t contikimac_params_BPSK20 = {
+    .cca_cycle_period = ACK_TIMEOUT / 2,                /* T_c = T_i / (n_c - 1) */
+    .inter_packet_interval = ACK_TIMEOUT,               /* T_i = Ack timeout */
+    .after_ed_scan_timeout = LONGEST_FRAME_TIME + 1000, /* > T_l */
+    .after_ed_scan_interval = (ACK_TIMEOUT * 3) / 4,    /* < T_i */
+    .listen_timeout = ACK_TIMEOUT + 1000,               /* > T_i */
+    .rx_timeout = LONGEST_FRAME_TIME + 500,             /* > T_l */
+    .cca_count_max = 3,                                 /* = n_c */
+};

--- a/sys/net/link_layer/contikimac/contikimac_params_BPSK20.c
+++ b/sys/net/link_layer/contikimac/contikimac_params_BPSK20.c
@@ -35,7 +35,7 @@ const contikimac_params_t contikimac_params_BPSK20 = {
     .inter_packet_interval = ACK_TIMEOUT,               /* T_i = Ack timeout */
     .after_ed_scan_timeout = LONGEST_FRAME_TIME + 1000, /* > T_l */
     .after_ed_scan_interval = (ACK_TIMEOUT * 3) / 4,    /* < T_i */
-    .listen_timeout = ACK_TIMEOUT + 1000,               /* > T_i */
-    .rx_timeout = LONGEST_FRAME_TIME + 500,             /* > T_l */
-    .cca_count_max = 3,                                 /* = n_c */
+    .listen_timeout = 2 * ACK_TIMEOUT,                  /* > T_i */
+    .rx_timeout = LONGEST_FRAME_TIME + ACK_TIMEOUT,     /* > T_l */
+    .cca_count_max = 4,                                 /* = n_c */
 };

--- a/sys/net/link_layer/contikimac/contikimac_params_BPSK40.c
+++ b/sys/net/link_layer/contikimac/contikimac_params_BPSK40.c
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2017 SKF AB
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ * @ingroup     net
+ * @file
+ * @brief       GNRC ContikiMAC timing settings for BPSK 40 kbit/s
+ *
+ * These timings are valid for STD IEEE 802.15.4 channel page 0 in the 915 MHz
+ * band.
+ *
+ * @author      Joakim Nohlgård <joakim.nohlgard@eistec.se>
+ * @}
+ */
+
+#include "net/contikimac.h"
+
+/* (usec) time to transmit one symbol */
+#define SYMBOL_TIME 25
+/* (usec) time to transmit one byte */
+#define OCTET_TIME (SYMBOL_TIME * 8)
+/* (usec) time to transmit the longest possible frame */
+#define LONGEST_FRAME_TIME (OCTET_TIME * (4 + 1 + 1 + 127))
+/* (usec) timeout waiting for Ack after TX complete */
+#define ACK_TIMEOUT (120 * SYMBOL_TIME)
+
+const contikimac_params_t contikimac_params_BPSK40 = {
+    .cca_cycle_period = ACK_TIMEOUT / 2,                /* T_c = T_i / (n_c - 1) */
+    .inter_packet_interval = ACK_TIMEOUT,               /* T_i = Ack timeout */
+    .after_ed_scan_timeout = LONGEST_FRAME_TIME + 1000, /* > T_l */
+    .after_ed_scan_interval = (ACK_TIMEOUT * 3) / 4,    /* < T_i */
+    .listen_timeout = ACK_TIMEOUT + 1000,               /* > T_i */
+    .rx_timeout = LONGEST_FRAME_TIME + 500,             /* > T_l */
+    .cca_count_max = 3,                                 /* = n_c */
+};

--- a/sys/net/link_layer/contikimac/contikimac_params_BPSK40.c
+++ b/sys/net/link_layer/contikimac/contikimac_params_BPSK40.c
@@ -35,7 +35,7 @@ const contikimac_params_t contikimac_params_BPSK40 = {
     .inter_packet_interval = ACK_TIMEOUT,               /* T_i = Ack timeout */
     .after_ed_scan_timeout = LONGEST_FRAME_TIME + 1000, /* > T_l */
     .after_ed_scan_interval = (ACK_TIMEOUT * 3) / 4,    /* < T_i */
-    .listen_timeout = ACK_TIMEOUT + 1000,               /* > T_i */
-    .rx_timeout = LONGEST_FRAME_TIME + 500,             /* > T_l */
-    .cca_count_max = 3,                                 /* = n_c */
+    .listen_timeout = 2 * ACK_TIMEOUT,                  /* > T_i */
+    .rx_timeout = LONGEST_FRAME_TIME + ACK_TIMEOUT,     /* > T_l */
+    .cca_count_max = 4,                                 /* = n_c */
 };

--- a/sys/net/link_layer/contikimac/contikimac_params_OQPSK100.c
+++ b/sys/net/link_layer/contikimac/contikimac_params_OQPSK100.c
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2017 SKF AB
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ * @ingroup     net
+ * @file
+ * @brief       GNRC ContikiMAC timing settings for O-QPSK 100 kbit/s
+ *
+ * These timings are valid for STD IEEE 802.15.4 channel page 2 in the 868 MHz
+ * band.
+ *
+ * @author      Joakim Nohlgård <joakim.nohlgard@eistec.se>
+ * @}
+ */
+
+#include "net/contikimac.h"
+
+/* (usec) time to transmit one symbol */
+#define SYMBOL_TIME 40
+/* (usec) time to transmit one byte */
+#define OCTET_TIME (SYMBOL_TIME * 2)
+/* (usec) time to transmit the longest possible frame */
+#define LONGEST_FRAME_TIME (OCTET_TIME * (5 + 1 + 1 + 127))
+/* (usec) timeout waiting for Ack after TX complete */
+#define ACK_TIMEOUT (54 * SYMBOL_TIME)
+
+const contikimac_params_t contikimac_params_OQPSK100 = {
+    .cca_cycle_period = ACK_TIMEOUT / 2,                /* T_c = T_i / (n_c - 1) */
+    .inter_packet_interval = ACK_TIMEOUT,               /* T_i = Ack timeout */
+    .after_ed_scan_timeout = LONGEST_FRAME_TIME + 200,  /* > T_l */
+    .after_ed_scan_interval = (ACK_TIMEOUT * 3) / 4,    /* < T_i */
+    .listen_timeout = ACK_TIMEOUT + 1000,               /* > T_i */
+    .rx_timeout = LONGEST_FRAME_TIME + 500,             /* > T_l */
+    .cca_count_max = 3,                                 /* = n_c */
+};

--- a/sys/net/link_layer/contikimac/contikimac_params_OQPSK100.c
+++ b/sys/net/link_layer/contikimac/contikimac_params_OQPSK100.c
@@ -35,7 +35,7 @@ const contikimac_params_t contikimac_params_OQPSK100 = {
     .inter_packet_interval = ACK_TIMEOUT,               /* T_i = Ack timeout */
     .after_ed_scan_timeout = LONGEST_FRAME_TIME + 200,  /* > T_l */
     .after_ed_scan_interval = (ACK_TIMEOUT * 3) / 4,    /* < T_i */
-    .listen_timeout = ACK_TIMEOUT + 1000,               /* > T_i */
-    .rx_timeout = LONGEST_FRAME_TIME + 500,             /* > T_l */
-    .cca_count_max = 3,                                 /* = n_c */
+    .listen_timeout = 2 * ACK_TIMEOUT,                  /* > T_i */
+    .rx_timeout = LONGEST_FRAME_TIME + ACK_TIMEOUT,     /* > T_l */
+    .cca_count_max = 4,                                 /* = n_c */
 };

--- a/sys/net/link_layer/contikimac/contikimac_params_OQPSK250.c
+++ b/sys/net/link_layer/contikimac/contikimac_params_OQPSK250.c
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2017 SKF AB
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @{
+ * @ingroup     net
+ * @file
+ * @brief       GNRC ContikiMAC timing settings for O-QPSK 250 kbit/s
+ *
+ * These timings are valid for STD IEEE 802.15.4 channel page 0 in the 2.4 GHz
+ * band, and for channel page 2 in the 915 MHz band.
+ *
+ * @author      Joakim Nohlgård <joakim.nohlgard@eistec.se>
+ * @}
+ */
+
+#include "net/contikimac.h"
+
+/* (usec) time to transmit one symbol */
+#define SYMBOL_TIME 16
+/* (usec) time to transmit one byte */
+#define OCTET_TIME (SYMBOL_TIME * 2)
+/* (usec) time to transmit the longest possible frame */
+#define LONGEST_FRAME_TIME (OCTET_TIME * (5 + 1 + 1 + 127))
+/* (usec) timeout waiting for Ack after TX complete */
+#define ACK_TIMEOUT (54 * SYMBOL_TIME)
+
+const contikimac_params_t contikimac_params_OQPSK250 = {
+    .cca_cycle_period = ACK_TIMEOUT / 2,                /* T_c = T_i / (n_c - 1) */
+    .inter_packet_interval = ACK_TIMEOUT,               /* T_i = Ack timeout */
+    .after_ed_scan_timeout = LONGEST_FRAME_TIME + 200,  /* > T_l */
+    .after_ed_scan_interval = (ACK_TIMEOUT * 3) / 4,    /* < T_i */
+    .listen_timeout = ACK_TIMEOUT + 1000,               /* > T_i */
+    .rx_timeout = LONGEST_FRAME_TIME + 500,             /* > T_l */
+    .cca_count_max = 3,                                 /* = n_c */
+};

--- a/sys/net/link_layer/contikimac/contikimac_params_OQPSK250.c
+++ b/sys/net/link_layer/contikimac/contikimac_params_OQPSK250.c
@@ -35,7 +35,7 @@ const contikimac_params_t contikimac_params_OQPSK250 = {
     .inter_packet_interval = ACK_TIMEOUT,               /* T_i = Ack timeout */
     .after_ed_scan_timeout = LONGEST_FRAME_TIME + 200,  /* > T_l */
     .after_ed_scan_interval = (ACK_TIMEOUT * 3) / 4,    /* < T_i */
-    .listen_timeout = ACK_TIMEOUT + 1000,               /* > T_i */
-    .rx_timeout = LONGEST_FRAME_TIME + 500,             /* > T_l */
-    .cca_count_max = 3,                                 /* = n_c */
+    .listen_timeout = 2 * ACK_TIMEOUT,                  /* > T_i */
+    .rx_timeout = LONGEST_FRAME_TIME + ACK_TIMEOUT,     /* > T_l */
+    .cca_count_max = 4,                                 /* = n_c */
 };


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Introduce a ContikiMAC compatible radio duty cycling MAC layer as a netdev layer.
The implementation uses netdev layers to wrap an underlying netdev transceiver, which means that from the gnrc_netif module the ContikiMAC layer looks and behaves as if it were a normal netdev transceiver driver.
The primary goal is to reduce power consumption, and as a proof of concept for the idea of implementing MAC layer as a netdev layer. 
The module documentation is quite extensive, see contikimac.h for details. 

### Limitations

The implementation has a few minor direct dependencies/interactions against gnrc_netif, but this situation can be improved as the netdev layer implementation is evolved (#7736, #9417 etc) 
Not yet verified against other implementations due to lack of time. Only tested against itself between samr21-xpro and frdm-kw41z.
The implementation uses the event queue introduced in #9326 to handle events from timers and handle feedback from the underlying device. The send method hijacks the event loop internally to avoid races between the IPC messages and the frame transmit algorithm. 

TODO add some more text from the module documentation. 

### Comparison to lwmac, gomach implementations

This is implemented as a netdev layer and therefore is less intrusive and does not require modifications to the network stack (gnrc). The only requirement is a netdev compatible transceiver and a working xtimer configuration. For better power savings, the platform should be configured to use a low power timer with xtimer. This is the default for frdm-kw41z, but most other boards need a configuration modification. This should only affect CPU power consumption, it should not affect communications in any way. 

### Issues/PRs references

Depends on ~~#9469~~, ~~#9470~~, ~~#9471~~, #9326  
Also useful #7577 
Description of the algorithm: http://dunkels.com/adam/dunkels11contikimac.pdf