### PR TITLE
gnrc_sixlowpan_frag: add page context to reassembly buffer

### DIFF
--- a/sys/net/gnrc/network_layer/sixlowpan/frag/gnrc_sixlowpan_frag.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/gnrc_sixlowpan_frag.c
@@ -294,18 +294,14 @@ void gnrc_sixlowpan_frag_recv(gnrc_pktsnip_t *pkt, void *ctx, unsigned page)
     gnrc_netif_hdr_t *hdr = pkt->next->data;
     sixlowpan_frag_t *frag = pkt->data;
     uint16_t offset = 0;
-    size_t frag_size;
 
     (void)ctx;
-    (void)page;
     switch (frag->disp_size.u8[0] & SIXLOWPAN_FRAG_DISP_MASK) {
         case SIXLOWPAN_FRAG_1_DISP:
-            frag_size = (pkt->size - sizeof(sixlowpan_frag_t));
             break;
 
         case SIXLOWPAN_FRAG_N_DISP:
             offset = (((sixlowpan_frag_n_t *)frag)->offset * 8);
-            frag_size = (pkt->size - sizeof(sixlowpan_frag_n_t));
             break;
 
         default:
@@ -315,7 +311,7 @@ void gnrc_sixlowpan_frag_recv(gnrc_pktsnip_t *pkt, void *ctx, unsigned page)
             return;
     }
 
-    rbuf_add(hdr, pkt, frag_size, offset);
+    rbuf_add(hdr, pkt, offset, page);
 
     gnrc_pktbuf_release(pkt);
 }

--- a/sys/net/gnrc/network_layer/sixlowpan/frag/rbuf.h
+++ b/sys/net/gnrc/network_layer/sixlowpan/frag/rbuf.h
@@ -76,13 +76,13 @@ typedef struct {
  *                          gnrc_netif_hdr_t::if_pid and its source and
  *                          destination address set.
  * @param[in] frag          The fragment to add.
- * @param[in] frag_size     The fragment's size.
  * @param[in] offset        The fragment's offset.
+ * @param[in] page          Current 6Lo dispatch parsing page.
  *
  * @internal
  */
 void rbuf_add(gnrc_netif_hdr_t *netif_hdr, gnrc_pktsnip_t *frag,
-              size_t frag_size, size_t offset);
+              size_t offset, unsigned page);
 
 /**
  * @brief   Checks timeouts and removes entries if necessary


### PR DESCRIPTION
### Contribution description
While refactoring IPHC I noticed that the page actually can already be used for fragmentation: Given @cgundogan's work on [ICN LoWPAN] we can already assume, that the page context may (among other thing) determine the type of the reassembled packet. This PR provides the basis for that.

[ICN LoWPAN]: https://tools.ietf.org/html/draft-gundogan-icnrg-ccnlowpan-01

### Issues/PRs references
None