### PR TITLE
tests/monocypher: disable TEST_ON_CI_WHITELIST

### DIFF
--- a/tests/pkg_monocypher/Makefile
+++ b/tests/pkg_monocypher/Makefile
@@ -9,7 +9,6 @@ USEMODULE += embunit
 USEMODULE += random
 USEPKG += monocypher
 
-TEST_ON_CI_WHITELIST += all
 include $(RIOTBASE)/Makefile.include
 
 test:


### PR DESCRIPTION
Test application somehow hangs on a samr21-xpro, needs more
investigating, but disabled for now as not to break CI run tests anymore

### Issues/PRs references

#9172 