### PR TITLE
tests/driver_pir: remove redundant/double configuration from Makefile

### DIFF
--- a/tests/driver_pir/Makefile
+++ b/tests/driver_pir/Makefile
@@ -2,28 +2,7 @@ include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_MEMORY := nucleo-f031k6
 
-FEATURES_REQUIRED = periph_gpio
-
 USEMODULE += pir
-USEMODULE += xtimer
-
-# define parameters for selected boards
-ifneq (,$(filter stm32f4discovery,$(BOARD)))
-  PIR_PARAM_GPIO ?= GPIO_PIN\(3,7\)
-  PIR_PARAM_ACTIVE_HIGH ?= 1
-endif
-ifneq (,$(filter arduino-due,$(BOARD)))
-  PIR_PARAM_GPIO ?= GPIO_PIN\(0,20\)
-  PIR_PARAM_ACTIVE_HIGH ?= 1
-endif
-
-# set default device parameters in case they are undefined
-PIR_PARAM_GPIO ?= GPIO_PIN\(0,0\)
-PIR_PARAM_ACTIVE_HIGH ?= 1
-
-# export parameters
-CFLAGS += -DPIR_PARAM_GPIO=$(PIR_PARAM_GPIO)
-CFLAGS += -DPIR_PARAM_ACTIVE_HIGH=$(PIR_PARAM_ACTIVE_HIGH)
 
 include $(RIOTBASE)/Makefile.include
 

--- a/tests/driver_pir/README.md
+++ b/tests/driver_pir/README.md
@@ -15,12 +15,9 @@ Connect the sensor's "out" pin to a GPIO of your board that can be
 configured to create interrupts.
 Compile and flash this test application like:
 
-    export BOARD=your_board
-    export PIR_PARAM_GPIO=name_of_your_pin
-    export PIR_PARAM_ACTIVE_HIGH=if_gpio_pin_is_high_or_low_when_pir_is_active
-    make clean
-    make all-interrupt
-    make flash
+    CFLAGS="-DPIR_PARAM_GPIO=name_of_your_pin -DPIR_PARAM_ACTIVE_HIGH=if_gpio_pin_is_high_or_low_when_pir_is_active" make BOARD=your_board clean all-interrupt flash
+
+Ideally, the above configuration passed via CFLAGS should be in "board.h"
 
 The output should look like:
 
@@ -40,12 +37,9 @@ The output should look like:
 Connect the sensor's "out" pin to any GPIO pin of you board.
 Compile and flash this test application like:
 
-    export BOARD=your_board
-    export PIR_PARAM_GPIO=name_of_your_pin
-    export PIR_PARAM_ACTIVE_HIGH=if_gpio_pin_is_high_or_low_when_pir_is_active
-    make clean
-    make all-polling
-    make flash
+    CFLAGS="-DPIR_PARAM_GPIO=name_of_your_pin -DPIR_PARAM_ACTIVE_HIGH=if_gpio_pin_is_high_or_low_when_pir_is_active" make BOARD=your_board make clean all-polling flash
+
+Ideally, the above configuration passed via CFLAGS should be in "board.h"
 
 The output should look like this:
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Current PIR test application sets default parameters in the application Makefile, which should be removed because:
1. This incurs conflict when a board has its own PIR parameter configuration in "board.h" (e.g., Hamilton #9013)
2. "main.c" in the test application includes "pir_params.h", which has default parameters anyway.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references
#9013 
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->