### PR TITLE
cpu/atmega_common: UART sleep support

### DIFF
--- a/cpu/atmega_common/periph/uart.c
+++ b/cpu/atmega_common/periph/uart.c
@@ -241,12 +241,6 @@ void uart_poweron(uart_t uart)
 
 void uart_poweroff(uart_t uart)
 {
-    unsigned state = irq_disable();
-
-    /* disable and reset UART */
-    dev[uart]->CSRB = 0;
-    dev[uart]->CSRA = 0;
-
     switch (uart) {
         case 0: power_usart0_disable();
 #if (UART_NUMOF == 2)
@@ -261,8 +255,6 @@ void uart_poweroff(uart_t uart)
 #endif
         default: return;
     }
-
-    irq_restore(state);
 }
 
 static inline void isr_handler(int num)

--- a/cpu/atmega_common/periph/uart.c
+++ b/cpu/atmega_common/periph/uart.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2014 Freie Universität Berlin, Hinnerk van Bruinehsen
+ *               2018 Acutam Automation, LLC
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -16,7 +17,7 @@
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  * @author      Hinnerk van Bruinehsen <h.v.bruinehsen@fu-berlin.de>
- *
+ * @author      Matthew Blue <matthew.blue.neuro@gmail.com>
  *
  * Support static BAUD rate calculation using UART_STDIO_BAUDRATE.
  * Set UART_STDIO_BAUDRATE to the desired baud rate and pass it as a -D argument
@@ -29,7 +30,10 @@
  * @}
  */
 
+#include <avr/power.h>
+
 #include "cpu.h"
+#include "irq.h"
 #include "sched.h"
 #include "thread.h"
 
@@ -74,36 +78,95 @@ static mega_uart_t *dev[] = {
 };
 
 /**
- * @brief   Allocate memory to store the callback functions.
+ * @brief   Allocate memory to store the settings.
  */
 static uart_isr_ctx_t isr_ctx[UART_NUMOF];
+static uint16_t uart_brr[UART_NUMOF];
 
-static void _update_brr(uart_t uart, uint16_t brr, bool double_speed)
+static inline uint8_t _is_asleep(uart_t uart)
 {
-    dev[uart]->BRR = brr;
-    if (double_speed) {
-        dev[uart]->CSRA |= (1 << U2X0);
+#if defined(CPU_ATMEGA328P)
+    (void)uart;
+    return ((PRR >> PRUSART0) & 0x1);
+#else
+
+    if (uart == 0) {
+        return ((PRR0 >> PRUSART0) & 0x1);
     }
+
+#if defined(CPU_ATMEGA1284P)
+    else if (uart == 1) {
+        /* ATmega1284P uses PRR0 instead of PRR1 */
+        return ((PRR0 >> PRUSART1) & 0x1);
+    }
+#else
+    else if (uart == 1) {
+        return ((PRR1 >> PRUSART1) & 0x1);
+    }
+#endif /* defined(CPU_ATMEGA1284P) */
+
+#if (UART_NUMOF > 2)
+    else if (uart == 2) {
+        return ((PRR1 >> PRUSART2) & 0x1);
+    }
+#endif
+
+#if (UART_NUMOF > 3)
+    else if (uart == 3) {
+        return ((PRR1 >> PRUSART3) & 0x1);
+    }
+#endif
+
+#endif /* defined(CPU_ATMEGA328P) */
+
+    /* extra return should be unused */
+    return 0;
 }
 
-static void _set_brr(uart_t uart, uint32_t baudrate)
+static inline void _update_brr(uart_t uart)
 {
-    uint16_t brr;
+    dev[uart]->BRR = uart_brr[uart];
 
+#if defined(UART_DOUBLE_SPEED)
+    dev[uart]->CSRA |= (1 << U2X0);
+#endif
+}
+
+static inline void _calc_brr(uart_t uart, uint32_t baudrate)
+{
 #if defined(UART_STDIO_BAUDRATE)
     /* UBRR_VALUE and USE_2X are statically computed from <util/setbaud.h> */
     if (baudrate == UART_STDIO_BAUDRATE) {
-        _update_brr(uart, UBRR_VALUE, USE_2X);
+        uart_brr[uart] = UBRR_VALUE;
         return;
     }
 #endif
 #if defined(UART_DOUBLE_SPEED)
-    brr = (CLOCK_CORECLOCK + 4UL * baudrate) / (8UL * baudrate) - 1UL;
-    _update_brr(uart, brr, true);
+    uart_brr[uart] = (CLOCK_CORECLOCK + 4UL * baudrate) / (8UL * baudrate) - 1UL;
 #else
-    brr = (CLOCK_CORECLOCK + 8UL * baudrate) / (16UL * baudrate) - 1UL;
-    _update_brr(uart, brr, false);
+    uart_brr[uart] = (CLOCK_CORECLOCK + 8UL * baudrate) / (16UL * baudrate) - 1UL;
 #endif
+}
+
+static void _apply_settings(uart_t uart)
+{
+    /* disable and reset UART */
+    dev[uart]->CSRB = 0;
+    dev[uart]->CSRA = 0;
+
+    /* configure UART to 8N1 mode */
+    dev[uart]->CSRC = (1 << UCSZ00) | (1 << UCSZ01);
+
+    /* set clock divider */
+    _update_brr(uart);
+
+    /* enable RX and TX and the RX interrupt */
+    if (isr_ctx[uart].rx_cb) {
+        dev[uart]->CSRB = ((1 << RXCIE0) | (1 << RXEN0) | (1 << TXEN0));
+    }
+    else {
+        dev[uart]->CSRB = (1 << TXEN0);
+    }
 }
 
 int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
@@ -117,51 +180,95 @@ int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
     isr_ctx[uart].rx_cb = rx_cb;
     isr_ctx[uart].arg = arg;
 
-    /* disable and reset UART */
-    dev[uart]->CSRB = 0;
-    dev[uart]->CSRA = 0;
+    /* calculate clock divider */
+    _calc_brr(uart, baudrate);
 
-    /* configure UART to 8N1 mode */
-    dev[uart]->CSRC = (1 << UCSZ00) | (1 << UCSZ01);
-    /* set clock divider */
-    _set_brr(uart, baudrate);
-
-    /* enable RX and TX and the RX interrupt */
-    if (rx_cb) {
-        dev[uart]->CSRB = ((1 << RXCIE0) | (1 << RXEN0) | (1 << TXEN0));
-    }
-    else {
-        dev[uart]->CSRB = (1 << TXEN0);
-    }
+    /* apply the settings to the UART */
+    _apply_settings(uart);
 
     return UART_OK;
 }
 
 void uart_write(uart_t uart, const uint8_t *data, size_t len)
 {
+    uint8_t sleepy = _is_asleep(uart);
+
+    if (sleepy) {
+        uart_poweron(uart);
+    }
+
     for (size_t i = 0; i < len; i++) {
         while (!(dev[uart]->CSRA & (1 << UDRE0))) {}
         dev[uart]->DR = data[i];
+    }
+
+    if (sleepy) {
+        uart_poweroff(uart);
     }
 }
 
 void uart_poweron(uart_t uart)
 {
-    (void)uart;
-    /* not implemented (yet) */
+    unsigned state = irq_disable();
+
+    switch (uart) {
+        case 0: power_usart0_enable();
+#if (UART_NUMOF == 2)
+        case 1: power_usart1_enable();
+#endif
+#if (UART_NUMOF == 3)
+        case 2: power_usart2_enable();
+#endif
+#if (UART_NUMOF == 4)
+        case 3: power_usart3_enable();
+#endif
+    }
+
+    /* bring UART to its state prior to sleeping */
+    _apply_settings(uart);
+
+    /* flush 2 bytes from input buffer */
+    volatile uint8_t tmp;
+    tmp = dev[uart]->DR;
+    (void)tmp;
+    tmp = dev[uart]->DR;
+    (void)tmp;
+
+    irq_restore(state);
 }
 
 void uart_poweroff(uart_t uart)
 {
-    (void)uart;
-    /* not implemented (yet) */
+    unsigned state = irq_disable();
+
+    /* disable and reset UART */
+    dev[uart]->CSRB = 0;
+    dev[uart]->CSRA = 0;
+
+    switch (uart) {
+        case 0: power_usart0_disable();
+#if (UART_NUMOF == 2)
+        case 1: power_usart1_disable();
+#endif
+#if (UART_NUMOF == 3)
+        case 2: power_usart2_disable();
+#endif
+#if (UART_NUMOF == 4)
+        case 3: power_usart3_disable();
+#endif
+    }
+
+    irq_restore(state);
 }
 
 static inline void isr_handler(int num)
 {
     __enter_isr();
 
-    isr_ctx[num].rx_cb(isr_ctx[num].arg, dev[num]->DR);
+    /* check for valid byte */
+    if (!((dev[num]->CSRA >> FE0) & 0x1)) {
+        isr_ctx[num].rx_cb(isr_ctx[num].arg, dev[num]->DR);
+    }
 
     __exit_isr();
 }

--- a/cpu/atmega_common/periph/uart.c
+++ b/cpu/atmega_common/periph/uart.c
@@ -223,6 +223,7 @@ void uart_poweron(uart_t uart)
         /* workaround missing library function */
         case 3: PRR1 &= ~(1 << PRUSART3);
 #endif
+        default: return;
     }
 
     /* bring UART to its state prior to sleeping */
@@ -258,6 +259,7 @@ void uart_poweroff(uart_t uart)
         /* workaround missing library function */
         case 3: PRR1 |= (1 << PRUSART3);
 #endif
+        default: return;
     }
 
     irq_restore(state);

--- a/cpu/atmega_common/periph/uart.c
+++ b/cpu/atmega_common/periph/uart.c
@@ -220,7 +220,8 @@ void uart_poweron(uart_t uart)
         case 2: power_usart2_enable();
 #endif
 #if (UART_NUMOF == 4)
-        case 3: power_usart3_enable();
+        /* workaround missing library function */
+        case 3: PRR1 &= ~(1 << PRUSART3);
 #endif
     }
 
@@ -254,7 +255,8 @@ void uart_poweroff(uart_t uart)
         case 2: power_usart2_disable();
 #endif
 #if (UART_NUMOF == 4)
-        case 3: power_usart3_disable();
+        /* workaround missing library function */
+        case 3: PRR1 |= (1 << PRUSART3);
 #endif
     }
 

--- a/cpu/atmega_common/periph/uart.c
+++ b/cpu/atmega_common/periph/uart.c
@@ -94,16 +94,14 @@ static inline uint8_t _is_asleep(uart_t uart)
         return ((PRR0 >> PRUSART0) & 0x1);
     }
 
-#if defined(CPU_ATMEGA1284P)
     else if (uart == 1) {
+#if defined(CPU_ATMEGA1284P)
         /* ATmega1284P uses PRR0 instead of PRR1 */
         return ((PRR0 >> PRUSART1) & 0x1);
-    }
 #else
-    else if (uart == 1) {
         return ((PRR1 >> PRUSART1) & 0x1);
+#endif
     }
-#endif /* defined(CPU_ATMEGA1284P) */
 
 #if (UART_NUMOF > 2)
     else if (uart == 2) {


### PR DESCRIPTION
### Contribution description
This adds support for ```uart_poweron``` and ```uart_poweroff``` to cpu/atmega_common. This is in preparation for more complete power management on the ATmega.

### Issues/PRs references
Contains code salvaged from #9420