### PR TITLE
drivers/jc42: adapt to new i2c API

### DIFF
--- a/drivers/jc42/jc42.c
+++ b/drivers/jc42/jc42.c
@@ -31,7 +31,7 @@
 static int jc42_get_register(const jc42_t* dev, uint8_t reg, uint16_t* data)
 {
     i2c_acquire(dev->i2c);
-    if (i2c_read_regs(dev->i2c, dev->addr, reg, data, 2) <= 0) {
+    if (i2c_read_regs(dev->i2c, dev->addr, reg, data, 2, 0) != 0) {
         DEBUG("[jc42] Problem reading register 0x%x\n", reg);
         i2c_release(dev->i2c);
         return JC42_NODEV;
@@ -43,7 +43,7 @@ static int jc42_get_register(const jc42_t* dev, uint8_t reg, uint16_t* data)
 static int jc42_set_register(const jc42_t* dev, uint8_t reg, uint16_t* data)
 {
     i2c_acquire(dev->i2c);
-    if (i2c_write_regs(dev->i2c, dev->addr, reg, data, 2) <= 0) {
+    if (i2c_write_regs(dev->i2c, dev->addr, reg, data, 2, 0) != 0) {
         DEBUG("[jc42] Problem writing to register 0x%x\n", reg);
         i2c_release(dev->i2c);
         return JC42_NODEV;
@@ -83,13 +83,6 @@ int jc42_init(jc42_t* dev, const jc42_params_t* params)
     uint16_t config;
     dev->i2c = params->i2c;
     dev->addr = params->addr;
-    i2c_acquire(dev->i2c);
-    if (i2c_init_master(dev->i2c, params->speed) != 0) {
-        DEBUG("[jc42] Problem initializing I2C master\n");
-        i2c_release(dev->i2c);
-        return JC42_NOI2C;
-    }
-    i2c_release(dev->i2c);
 
     /* Poll the device, fail if unavailable */
     if (jc42_get_config(dev, &config) != 0) {


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This adapts the jc42 driver to the new i2c api. I don't have hardware to test.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references
#6577
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->