### PR TITLE
 drivers/ds1307: adapt to new i2c API

### DIFF
--- a/drivers/ds1307/ds1307.c
+++ b/drivers/ds1307/ds1307.c
@@ -56,24 +56,18 @@ int ds1307_init(ds1307_t *dev, const ds1307_params_t *params)
     dev->i2c = params->i2c;
 
     i2c_acquire(dev->i2c);
-    res = i2c_init_master(dev->i2c, params->clk);
-    if (res < 0) {
-        i2c_release(dev->i2c);
-        DEBUG("ds1307: Error initializing I2C: %i\n", res);
-        return -1;
-    }
     /* normalize hour format */
-    res = i2c_read_reg(dev->i2c, DS1307_I2C_ADDRESS, DS1307_REG_HOUR, &hour);
-    if (res <= 0) { /* should be 1 if device is connected */
+    res = i2c_read_reg(dev->i2c, DS1307_I2C_ADDRESS, DS1307_REG_HOUR, &hour, 0);
+    if (res != 0) { /* should be 0 if device is connected */
         i2c_release(dev->i2c);
         DEBUG("ds1307: Error reading HOUR register on init: %i\n", res);
         return -1;
     }
     res = i2c_write_reg(dev->i2c, DS1307_I2C_ADDRESS, DS1307_REG_HOUR,
-                        _convert_12_to_24(hour));
+                        _convert_12_to_24(hour), 0);
     i2c_release(dev->i2c);
 
-    if (res <= 0) {
+    if (res != 0) {
         DEBUG("ds1307: Error writing HOUR register on init: %i\n", res);
         return -1;
     }
@@ -101,13 +95,13 @@ int ds1307_set_time(const ds1307_t *dev, const struct tm *time)
     regs[DS1307_REG_YEAR] = bcd_from_byte(time->tm_year + DS1307_YEAR_OFFSET);
     i2c_acquire(dev->i2c);
     res = i2c_write_regs(dev->i2c, DS1307_I2C_ADDRESS, DS1307_REG_SEC, regs,
-                         sizeof(regs));
+                         sizeof(regs), 0);
     DEBUG("ds1307: wrote bytes %02x %02x %02x %02x %02x %02x %02x to device (result: %i)\n",
           regs[DS1307_REG_SEC], regs[DS1307_REG_MIN], regs[DS1307_REG_HOUR],
           regs[DS1307_REG_DOW], regs[DS1307_REG_DOM], regs[DS1307_REG_MON],
           regs[DS1307_REG_YEAR], res);
     i2c_release(dev->i2c);
-    return (res < 0) ? -1 : 0;
+    return (res != 0) ? -1 : 0;
 }
 
 int ds1307_get_time(const ds1307_t *dev, struct tm *time)
@@ -117,13 +111,13 @@ int ds1307_get_time(const ds1307_t *dev, struct tm *time)
 
     i2c_acquire(dev->i2c);
     res = i2c_read_regs(dev->i2c, DS1307_I2C_ADDRESS, DS1307_REG_SEC, regs,
-                         sizeof(regs));
+                         sizeof(regs), 0);
     DEBUG("ds1307: read bytes %02x %02x %02x %02x %02x %02x %02x from device (result: %i)\n",
           regs[DS1307_REG_SEC], regs[DS1307_REG_MIN], regs[DS1307_REG_HOUR],
           regs[DS1307_REG_DOW], regs[DS1307_REG_DOM], regs[DS1307_REG_MON],
           regs[DS1307_REG_YEAR], res);
     i2c_release(dev->i2c);
-    if (res < 0) {
+    if (res != 0) {
         return -1;
     }
     time->tm_sec = bcd_to_byte(regs[DS1307_REG_SEC] & DS1307_REG_SEC_MASK);
@@ -145,16 +139,16 @@ int ds1307_halt(const ds1307_t *dev)
     uint8_t sec;
 
     i2c_acquire(dev->i2c);
-    res = i2c_read_reg(dev->i2c, DS1307_I2C_ADDRESS, DS1307_REG_SEC, &sec);
-    if (res < 0) {
+    res = i2c_read_reg(dev->i2c, DS1307_I2C_ADDRESS, DS1307_REG_SEC, &sec, 0);
+    if (res != 0) {
         i2c_release(dev->i2c);
         DEBUG("ds1307: Error reading SEC register on halt: %i\n", res);
         return -1;
     }
     sec |= DS1307_REG_SEC_CH;
-    res = i2c_write_reg(dev->i2c, DS1307_I2C_ADDRESS, DS1307_REG_SEC, sec);
+    res = i2c_write_reg(dev->i2c, DS1307_I2C_ADDRESS, DS1307_REG_SEC, sec, 0);
     i2c_release(dev->i2c);
-    return (res < 0) ? -1 : 0;
+    return (res != 0) ? -1 : 0;
 }
 
 int ds1307_set_sqw_mode(const ds1307_t *dev, ds1307_sqw_mode_t mode)
@@ -163,7 +157,7 @@ int ds1307_set_sqw_mode(const ds1307_t *dev, ds1307_sqw_mode_t mode)
 
     i2c_acquire(dev->i2c);
     res = i2c_write_reg(dev->i2c, DS1307_I2C_ADDRESS, DS1307_REG_SQW_CTL,
-                        (uint8_t)mode);
+                        (uint8_t)mode, 0);
     i2c_release(dev->i2c);
     return res;
 }
@@ -174,7 +168,8 @@ int ds1307_get_sqw_mode(const ds1307_t *dev)
     int res;
 
     i2c_acquire(dev->i2c);
-    res = i2c_read_reg(dev->i2c, DS1307_I2C_ADDRESS, DS1307_REG_SQW_CTL, &mode);
+    res = i2c_read_reg(dev->i2c, DS1307_I2C_ADDRESS, DS1307_REG_SQW_CTL,
+                       &mode, 0);
     i2c_release(dev->i2c);
     return (res < 0) ? res : (int)mode;
 }
@@ -190,9 +185,9 @@ static int _nvram_read(struct nvram *nvram, uint8_t *dst, uint32_t src,
     }
     i2c_acquire(dev->i2c);
     res = i2c_read_regs(dev->i2c, DS1307_I2C_ADDRESS,
-                        DS1307_REG_RAM_FIRST + src, dst, size);
+                        DS1307_REG_RAM_FIRST + src, dst, size, 0);
     i2c_release(dev->i2c);
-    return res;
+    return (res == 0) ? (int)size : -1;
 }
 
 static int _nvram_write(struct nvram *nvram, const uint8_t *src, uint32_t dst,
@@ -206,9 +201,9 @@ static int _nvram_write(struct nvram *nvram, const uint8_t *src, uint32_t dst,
     }
     i2c_acquire(dev->i2c);
     res = i2c_write_regs(dev->i2c, DS1307_I2C_ADDRESS,
-                         DS1307_REG_RAM_FIRST + dst, src, size);
+                         DS1307_REG_RAM_FIRST + dst, src, size, 0);
     i2c_release(dev->i2c);
-    return res;
+    return (res == 0) ? (int)size : -1;
 }
 
 /** @} */

--- a/drivers/ds1307/include/ds1307_params.h
+++ b/drivers/ds1307/include/ds1307_params.h
@@ -32,13 +32,9 @@ extern "C" {
 #ifndef DS1307_PARAM_I2C
 #define DS1307_PARAM_I2C        (I2C_DEV(0))
 #endif
-#ifndef DS1307_PARAM_I2C_CLK
-#define DS1307_PARAM_I2C_CLK    (DS1307_I2C_MAX_CLK)
-#endif
 
 #ifndef DS1307_PARAMS
-#define DS1307_PARAMS           {   .i2c = DS1307_PARAM_I2C, \
-                                    .clk = DS1307_PARAM_I2C_CLK }
+#define DS1307_PARAMS           { .i2c = DS1307_PARAM_I2C }
 #endif
 /** @} */
 

--- a/drivers/include/ds1307.h
+++ b/drivers/include/ds1307.h
@@ -63,7 +63,6 @@ typedef struct {
  */
 typedef struct {
     i2c_t i2c;                  /**< I2C bus the device is connected to */
-    i2c_speed_t clk;            /**< clock speed to use on the I2C bus */
 } ds1307_params_t;
 
 /**


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This adapts the ds1307 driver to the new i2c api. I don't have hardware to test.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references
#6577
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->