### PR TITLE
drivers/bh1750fvi: adapt to new i2c API

### DIFF
--- a/drivers/bh1750fvi/bh1750fvi.c
+++ b/drivers/bh1750fvi/bh1750fvi.c
@@ -38,10 +38,9 @@ int bh1750fvi_init(bh1750fvi_t *dev, bh1750fvi_params_t *params)
 
     /* initialize the I2C bus */
     i2c_acquire(dev->i2c);
-    i2c_init_master(dev->i2c, params->clk);
 
     /* send a power down command to make sure we can speak to the device */
-    res = i2c_write_byte(dev->i2c, dev->addr, OP_POWER_DOWN);
+    res = i2c_write_byte(dev->i2c, dev->addr, OP_POWER_DOWN, 0);
     i2c_release(dev->i2c);
     if (res < 0) {
         return BH1750FVI_ERR_I2C;
@@ -57,8 +56,8 @@ uint16_t bh1750fvi_sample(const bh1750fvi_t *dev)
     /* power on the device and send single H-mode measurement command */
     DEBUG("[bh1750fvi] sample: triggering a conversion\n");
     i2c_acquire(dev->i2c);
-    i2c_write_byte(dev->i2c, dev->addr, OP_POWER_ON);
-    i2c_write_byte(dev->i2c, dev->addr, OP_SINGLE_HRES1);
+    i2c_write_byte(dev->i2c, dev->addr, OP_POWER_ON, 0);
+    i2c_write_byte(dev->i2c, dev->addr, OP_SINGLE_HRES1, 0);
     i2c_release(dev->i2c);
 
     /* wait for measurement to complete */
@@ -67,7 +66,7 @@ uint16_t bh1750fvi_sample(const bh1750fvi_t *dev)
     /* read the results */
     DEBUG("[bh1750fvi] sample: reading the results\n");
     i2c_acquire(dev->i2c);
-    i2c_read_bytes(dev->i2c, dev->addr, raw, 2);
+    i2c_read_bytes(dev->i2c, dev->addr, raw, 2, 0);
     i2c_release(dev->i2c);
 
     /* and finally we calculate the actual LUX value */

--- a/drivers/bh1750fvi/include/bh1750fvi_params.h
+++ b/drivers/bh1750fvi/include/bh1750fvi_params.h
@@ -36,14 +36,10 @@ extern "C" {
 #ifndef BH1750FVI_PARAM_ADDR
 #define BH1750FVI_PARAM_ADDR        (BH1750FVI_DEFAULT_ADDR)
 #endif
-#ifndef BH1750FVI_PARAM_I2C_CLK
-#define BH1750FVI_PARAM_I2C_CLK     (BH1750FVI_I2C_MAX_CLK)
-#endif
 
 #ifndef BH1750FVI_PARAMS
 #define BH1750FVI_PARAMS            { .i2c = BH1750FVI_PARAM_I2C,   \
-                                      .addr = BH1750FVI_PARAM_ADDR, \
-                                      .clk = BH1750FVI_PARAM_I2C_CLK }
+                                      .addr = BH1750FVI_PARAM_ADDR }
 #endif
 /**@}*/
 

--- a/drivers/include/bh1750fvi.h
+++ b/drivers/include/bh1750fvi.h
@@ -69,7 +69,6 @@ typedef struct {
 typedef struct {
     i2c_t i2c;          /**< I2C bus the device is connected to */
     uint8_t addr;       /**< slave address of the device */
-    i2c_speed_t clk;    /**< clock speed to use on the I2C bus */
 } bh1750fvi_params_t;
 
 /**


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This adapts the bh1750fvi driver to the new i2c api. I don't have hardware to test.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references
#6577
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->