### PR TITLE
driver: fix cppcheck error in pn532

### DIFF
--- a/drivers/pn532/pn532.c
+++ b/drivers/pn532/pn532.c
@@ -164,18 +164,19 @@ static int _write(const pn532_t *dev, uint8_t *buff, unsigned len)
     (void)buff;
     (void)len;
 
-    if (dev->mode == PN532_I2C) {
+    switch (dev->mode) {
 #ifdef PN532_SUPPORT_I2C
+    case PN532_I2C:
         i2c_acquire(dev->conf->i2c);
         ret = i2c_write_bytes(dev->conf->i2c, PN532_I2C_ADDRESS, buff, len, 0);
         if (ret == 0) {
             ret = (int)len;
         }
         i2c_release(dev->conf->i2c);
+        break;
 #endif
-    }
-    else {
 #ifdef PN532_SUPPORT_SPI
+    case PN532_SPI:
         spi_acquire(dev->conf->spi, SPI_CS_UNDEF, SPI_MODE, SPI_CLK);
         gpio_clear(dev->conf->nss);
         xtimer_usleep(SPI_WRITE_DELAY_US);
@@ -185,7 +186,10 @@ static int _write(const pn532_t *dev, uint8_t *buff, unsigned len)
         gpio_set(dev->conf->nss);
         spi_release(dev->conf->spi);
         ret = (int)len;
+        break;
 #endif
+    default:
+        DEBUG("pn532: invalid mode (%i)!\n", dev->mode);
     }
     DEBUG("pn532: -> ");
     PRINTBUFF(buff, len);
@@ -199,8 +203,9 @@ static int _read(const pn532_t *dev, uint8_t *buff, unsigned len)
     (void)buff;
     (void)len;
 
-    if (dev->mode == PN532_I2C) {
+    switch (dev->mode) {
 #ifdef PN532_SUPPORT_I2C
+    case PN532_I2C:
         i2c_acquire(dev->conf->i2c);
         /* len+1 for RDY after read is accepted */
         ret = i2c_read_bytes(dev->conf->i2c, PN532_I2C_ADDRESS, buff, len + 1, 0);
@@ -208,10 +213,10 @@ static int _read(const pn532_t *dev, uint8_t *buff, unsigned len)
             ret = (int)len + 1;
         }
         i2c_release(dev->conf->i2c);
+        break;
 #endif
-    }
-    else {
 #ifdef PN532_SUPPORT_SPI
+    case PN532_SPI:
         spi_acquire(dev->conf->spi, SPI_CS_UNDEF, SPI_MODE, SPI_CLK);
         gpio_clear(dev->conf->nss);
         spi_transfer_byte(dev->conf->spi, SPI_CS_UNDEF, true, SPI_DATA_READ);
@@ -222,10 +227,15 @@ static int _read(const pn532_t *dev, uint8_t *buff, unsigned len)
         buff[0] = 0x80;
         reverse(buff, len);
         ret = (int)len + 1;
+        break;
 #endif
+    default:
+        DEBUG("pn532: invalid mode (%i)!\n", dev->mode);
     }
-    DEBUG("pn532: <- ");
-    PRINTBUFF(buff, len);
+    if (ret > 0) {
+        DEBUG("pn532: <- ");
+        PRINTBUFF(buff, len);
+    }
     return ret;
 }
 


### PR DESCRIPTION
    cppcheck reported 'duplicateBranch' error in 2 if-else
    statements, b/c they are empty when running static-tests.

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

should fix cppcheck error: https://travis-ci.org/RIOT-OS/RIOT/builds/399003316?utm_source=github_status&utm_medium=notification


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->