### PR TITLE
sys/embunit: Fix incompatible declaration in outputter. [new_i2c_if]

### DIFF
--- a/sys/embunit/CompilerOutputter.c
+++ b/sys/embunit/CompilerOutputter.c
@@ -35,10 +35,9 @@
 #include <stdio.h>
 #include "CompilerOutputter.h"
 
-static void CompilerOutputter_printHeader(OutputterRef self,TestRef test)
+static void CompilerOutputter_printHeader(OutputterRef self)
 {
     (void)self;
-    (void)test;
 }
 
 static void CompilerOutputter_printStartTest(OutputterRef self,TestRef test)


### PR DESCRIPTION
OutputterPrintHeaderFunction is declared as a function of 1 parameter
but CompilerOutputter_printHeader was defined as taking 2.

It is a mystery why this code compiled before.

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This is a copy of #9242 which is already merged to master. The fix is needed in i2c_new_if branch for successful compilation of embunit based tests like `tests/driver_ds1307`.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references
#9493
#6577
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->