### PR TITLE
core/byteorder: fix naming for htobebufs/bebuftohs functions

### DIFF
--- a/core/include/byteorder.h
+++ b/core/include/byteorder.h
@@ -225,7 +225,7 @@ static inline uint32_t byteorder_swapl(uint32_t v);
 static inline uint64_t byteorder_swapll(uint64_t v);
 
 /**
- * @brief           Read a little endian encoded unsigned integer from a buffer
+ * @brief           Read a big endian encoded unsigned integer from a buffer
  *                  into host byte order encoded variable, 16-bit
  *
  * @note            This function is agnostic to the alignment of the target
@@ -235,10 +235,10 @@ static inline uint64_t byteorder_swapll(uint64_t v);
  *
  * @return          16-bit unsigned integer in host byte order
  */
-static inline uint16_t byteorder_lebuftohs(const uint8_t *buf);
+static inline uint16_t byteorder_bebuftohs(const uint8_t *buf);
 
 /**
- * @brief           Write a host byte order encoded unsigned integer as little
+ * @brief           Write a host byte order encoded unsigned integer as big
  *                  endian encoded value into a buffer, 16-bit
  *
  * @note            This function is alignment agnostic and works with any given
@@ -247,7 +247,7 @@ static inline uint16_t byteorder_lebuftohs(const uint8_t *buf);
  * @param[out] buf  target buffer, must be able to accept 2 bytes
  * @param[in]  val  value written to the buffer, in host byte order
  */
-static inline void byteorder_htolebufs(uint8_t *buf, uint16_t val);
+static inline void byteorder_htobebufs(uint8_t *buf, uint16_t val);
 
 /**
  * @brief          Convert from host byte order to network byte order, 16 bit.
@@ -443,7 +443,7 @@ static inline uint64_t ntohll(uint64_t v)
     return byteorder_ntohll(input);
 }
 
-static inline uint16_t byteorder_lebuftohs(const uint8_t *buf)
+static inline uint16_t byteorder_bebuftohs(const uint8_t *buf)
 {
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
     return (uint16_t)((buf[0] << 8) | buf[1]);
@@ -452,7 +452,7 @@ static inline uint16_t byteorder_lebuftohs(const uint8_t *buf)
 #endif
 }
 
-static inline void byteorder_htolebufs(uint8_t *buf, uint16_t val)
+static inline void byteorder_htobebufs(uint8_t *buf, uint16_t val)
 {
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
     buf[0] = (uint8_t)(val >> 8);

--- a/sys/net/application_layer/emcute/emcute.c
+++ b/sys/net/application_layer/emcute/emcute.c
@@ -68,7 +68,7 @@ static size_t set_len(uint8_t *buf, size_t len)
     }
     else {
         buf[0] = 0x01;
-        byteorder_htolebufs(&tbuf[1], (uint16_t)(len + 3));
+        byteorder_htobebufs(&tbuf[1], (uint16_t)(len + 3));
         return 3;
     }
 }
@@ -80,7 +80,7 @@ static size_t get_len(uint8_t *buf, uint16_t *len)
         return 1;
     }
     else {
-        *len = byteorder_lebuftohs(&buf[1]);
+        *len = byteorder_bebuftohs(&buf[1]);
         return 3;
     }
 }
@@ -133,12 +133,12 @@ static void on_disconnect(void)
 static void on_ack(uint8_t type, int id_pos, int ret_pos, int res_pos)
 {
     if ((waiton == type) &&
-        (!id_pos || (waitonid == byteorder_lebuftohs(&rbuf[id_pos])))) {
+        (!id_pos || (waitonid == byteorder_bebuftohs(&rbuf[id_pos])))) {
         if (!ret_pos || (rbuf[ret_pos] == ACCEPT)) {
             if (res_pos == 0) {
                 result = EMCUTE_OK;
             } else {
-                result = (int)byteorder_lebuftohs(&rbuf[res_pos]);
+                result = (int)byteorder_bebuftohs(&rbuf[res_pos]);
             }
         } else {
             result = EMCUTE_REJECT;
@@ -155,7 +155,7 @@ static void on_publish(size_t len, size_t pos)
     }
 
     emcute_sub_t *sub;
-    uint16_t tid = byteorder_lebuftohs(&rbuf[pos + 2]);
+    uint16_t tid = byteorder_bebuftohs(&rbuf[pos + 2]);
 
     /* allocate a response packet */
     uint8_t buf[7] = { 7, PUBACK, 0, 0, 0, 0, ACCEPT };
@@ -237,7 +237,7 @@ int emcute_con(sock_udp_ep_t *remote, bool clean, const char *will_topic,
     tbuf[1] = CONNECT;
     tbuf[2] = flags;
     tbuf[3] = PROTOCOL_VERSION;
-    byteorder_htolebufs(&tbuf[4], EMCUTE_KEEPALIVE);
+    byteorder_htobebufs(&tbuf[4], EMCUTE_KEEPALIVE);
     memcpy(&tbuf[6], cli_id, strlen(cli_id));
 
     /* configure 'state machine' and send the connection request */
@@ -311,8 +311,8 @@ int emcute_reg(emcute_topic_t *topic)
 
     tbuf[0] = (strlen(topic->name) + 6);
     tbuf[1] = REGISTER;
-    byteorder_htolebufs(&tbuf[2], 0);
-    byteorder_htolebufs(&tbuf[4], id_next);
+    byteorder_htobebufs(&tbuf[2], 0);
+    byteorder_htobebufs(&tbuf[4], id_next);
     waitonid = id_next++;
     memcpy(&tbuf[6], topic->name, strlen(topic->name));
 
@@ -347,9 +347,9 @@ int emcute_pub(emcute_topic_t *topic, const void *data, size_t len,
     len += (pos + 6);
     tbuf[pos++] = PUBLISH;
     tbuf[pos++] = flags;
-    byteorder_htolebufs(&tbuf[pos], topic->id);
+    byteorder_htobebufs(&tbuf[pos], topic->id);
     pos += 2;
-    byteorder_htolebufs(&tbuf[pos], id_next);
+    byteorder_htobebufs(&tbuf[pos], id_next);
     waitonid = id_next++;
     pos += 2;
     memcpy(&tbuf[pos], data, len);
@@ -381,7 +381,7 @@ int emcute_sub(emcute_sub_t *sub, unsigned flags)
     tbuf[0] = (strlen(sub->topic.name) + 5);
     tbuf[1] = SUBSCRIBE;
     tbuf[2] = flags;
-    byteorder_htolebufs(&tbuf[3], id_next);
+    byteorder_htobebufs(&tbuf[3], id_next);
     waitonid = id_next++;
     memcpy(&tbuf[5], sub->topic.name, strlen(sub->topic.name));
 
@@ -417,7 +417,7 @@ int emcute_unsub(emcute_sub_t *sub)
     tbuf[0] = (strlen(sub->topic.name) + 5);
     tbuf[1] = UNSUBSCRIBE;
     tbuf[2] = 0;
-    byteorder_htolebufs(&tbuf[3], id_next);
+    byteorder_htobebufs(&tbuf[3], id_next);
     waitonid = id_next++;
     memcpy(&tbuf[5], sub->topic.name, strlen(sub->topic.name));
 


### PR DESCRIPTION
### Contribution description
This is almost embarrassing: the functions introduced in #9301 are not converting from/to little endian, but to big endian... This PR renames the functions to what they actually do :-)

This PR also adapts 'emCute', the so far only user of the effected functions.

### Issues/PRs references
fixes an error introduced with #9301