### PR TITLE
sock_util: add posix dependency

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -676,6 +676,10 @@ ifneq (,$(filter sock_dns,$(USEMODULE)))
   USEMODULE += sock_util
 endif
 
+ifneq (,$(filter sock_util,$(USEMODULE)))
+  USEMODULE += posix
+endif
+
 ifneq (,$(filter event_%,$(USEMODULE)))
   USEMODULE += event
 endif


### PR DESCRIPTION
### Contribution description
`sock_util` includes the `arpa/inet.h` header so it has `posix` as a dependency to include the `sys/posix/include` include path.

I kept the explicit inclusion in `tests/gnrc_sock_dns`, since its main file also includes `arpa/inet.h`.

### Issues/PRs references
Originally created in #8646, but since the review is stalled there and `sock_util` is needed for #9464 to remove some code duplication / misplacement of new functionality, I cherry-picked it out of there 