### PR TITLE
boards/arduino-nano: Support for the Arduino Nano

### DIFF
--- a/boards/arduino-nano/Makefile
+++ b/boards/arduino-nano/Makefile
@@ -1,0 +1,5 @@
+MODULE = board
+
+DIRS = $(RIOTBOARD)/common/arduino-atmega
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/arduino-nano/Makefile.dep
+++ b/boards/arduino-nano/Makefile.dep
@@ -1,0 +1,3 @@
+USEMODULE += boards_common_arduino-atmega
+
+include $(RIOTBOARD)/common/arduino-atmega/Makefile.dep

--- a/boards/arduino-nano/Makefile.features
+++ b/boards/arduino-nano/Makefile.features
@@ -1,0 +1,3 @@
+include $(RIOTBOARD)/common/arduino-atmega/Makefile.features
+
+include $(RIOTCPU)/atmega328p/Makefile.features

--- a/boards/arduino-nano/Makefile.include
+++ b/boards/arduino-nano/Makefile.include
@@ -1,0 +1,23 @@
+# define the cpu used by the Arduino Nano board
+export CPU = atmega328p
+
+# configure the terminal program
+PORT_LINUX  ?= /dev/ttyUSB0
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
+BAUD        ?= 9600
+
+PROGRAMMER ?= arduino
+
+ifeq (arduino,$(PROGRAMMER))
+  # the Arduino Nano bootloader is 2KiB in size
+  BOOTLOADER_SIZE ?= 2048
+  # the Nano's bootloader uses 57600 baud for programming
+  FFLAGS_EXTRA += -b 57600
+else
+  # not using the bootloader for programming, thus the whole flash can be used
+  BOOTLOADER_SIZE ?= 0
+endif
+
+ROM_RESERVED ?= $(BOOTLOADER_SIZE)
+
+include $(RIOTBOARD)/common/arduino-atmega/Makefile.include

--- a/boards/arduino-nano/doc.txt
+++ b/boards/arduino-nano/doc.txt
@@ -1,0 +1,42 @@
+/**
+@defgroup    boards_arduino-nano Arduino Nano
+@ingroup     boards
+@brief       Support for the Arduino Nano board
+
+## Overview
+
+The Arduino Nano is the cheapest member of the Arduino family. It is based on
+Atmel's AVR architecture and sports an ATmega328p MCU. It is like many Arduinos
+extensible by using shields.
+
+### MCU
+| MCU           | ATmega328p                                    |
+|:------------- |:--------------------------------------------- |
+| Family        | AVR/ATmega                                    |
+| Vendor        | Atmel                                         |
+| RAM           | 2 KiB                                         |
+| Flash         | 32 KiB (2 KiB reserved for the bootloader)    |
+| Frequency     | 16 MHz                                        |
+| Timers        | 3 (2x 8bit, 1x 16bit)                         |
+| ADCs          | 6 analog input pins                           |
+| UARTs         | 1                                             |
+| SPIs          | 1                                             |
+| I2Cs          | 1 (called TWI)                                |
+| Vcc           | 5.0V                                          |
+| MCU Datasheet | [ATmega328p datasheet](http://ww1.microchip.com/downloads/en/DeviceDoc/ATmega48A-PA-88A-PA-168A-PA-328-P-DS-DS40002061A.pdf) |
+| Board Manual  | [Board Manual](https://www.arduino.cc/en/uploads/Main/ArduinoNanoManual23.pdf) |
+
+## Flashing the device
+Flashing RIOT on the Arduino Nano is quite straight forward, just connect your
+Arduino Nano via the USB connector to your host computer and type:
+
+`make BOARD=arduino-nano flash`
+
+This should take care of everything!
+
+We use the open `avrdude` tool to write the new code into the ATmega328p's
+flash
+
+##Caution
+Don't expect having a working network stack due to very limited resources.
+ */

--- a/boards/arduino-nano/include/board.h
+++ b/boards/arduino-nano/include/board.h
@@ -1,0 +1,33 @@
+/*
+ * Copyright (C) 2017   Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_arduino-nano
+ * @{
+ *
+ * @file
+ * @brief       Board specific definitions for the Arduino Uno board
+ *
+ * @author      Martine Lenders <m.lenders@fu-berlin.de>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include "board_common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/examples/asymcute_mqttsn/Makefile
+++ b/examples/asymcute_mqttsn/Makefile
@@ -10,8 +10,9 @@ RIOTBASE ?= $(CURDIR)/../..
 # Not all boards have enough memory to build the default configuration of this
 # example...
 BOARD_INSUFFICIENT_MEMORY := airfy-beacon arduino-duemilanove arduino-mega2560 \
-                             arduino-uno chronos hifive1 mega-xplained \
-                             microbit msb-430  msb-430h nrf51dk nrf51dongle nrf6310 \
+                             arduino-nano arduino-uno chronos hifive1 \
+                             mega-xplained microbit msb-430  msb-430h nrf51dk \
+                             nrf51dongle nrf6310 \
                              nucleo-f030r8 nucleo-f031k6 nucleo-f042k6 \
                              nucleo-f070rb nucleo-f072rb nucleo-f303k8 \
                              nucleo-f334r8 nucleo-l031k6 nucleo-l053r8 \

--- a/examples/cord_ep/Makefile
+++ b/examples/cord_ep/Makefile
@@ -7,12 +7,12 @@ BOARD ?= native
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../..
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-mega2560 arduino-uno \
-                             chronos hifive1 mega-xplained msb-430 msb-430h  \
-                             nucleo-f030r8 nucleo-l053r8 nucleo-f031k6 \
-                             nucleo-f042k6 nucleo-f303k8 nucleo-f334r8 \
-                             nucleo-l031k6 stm32f0discovery telosb waspmote-pro \
-                             wsn430-v1_3b wsn430-v1_4 z1
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-mega2560 arduino-nano \
+                             arduino-uno chronos hifive1 mega-xplained msb-430 \
+                             msb-430h nucleo-f030r8 nucleo-l053r8 \
+                             nucleo-f031k6 nucleo-f042k6 nucleo-f303k8 \
+                             nucleo-f334r8 nucleo-l031k6 stm32f0discovery \
+                             telosb waspmote-pro wsn430-v1_3b wsn430-v1_4 z1
 
 USEMODULE += gnrc_netdev_default
 USEMODULE += auto_init_gnrc_netif

--- a/examples/cord_epsim/Makefile
+++ b/examples/cord_epsim/Makefile
@@ -7,12 +7,12 @@ BOARD ?= native
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../..
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-mega2560 arduino-uno \
-                             chronos hifive1 msb-430 msb-430h nucleo-f030r8 \
-                             nucleo-l053r8 nucleo-f031k6 nucleo-f042k6 \
-                             nucleo-f303k8 nucleo-f334r8 nucleo-l031k6 \
-                             mega-xplained stm32f0discovery telosb waspmote-pro \
-                             wsn430-v1_3b wsn430-v1_4 z1
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-mega2560 arduino-nano \
+                             arduino-uno chronos hifive1 msb-430 msb-430h \
+                             nucleo-f030r8 nucleo-l053r8 nucleo-f031k6 \
+                             nucleo-f042k6 nucleo-f303k8 nucleo-f334r8 \
+                             nucleo-l031k6 mega-xplained stm32f0discovery \
+                             telosb waspmote-pro wsn430-v1_3b wsn430-v1_4 z1
 
 # Enable GNRC networking
 USEMODULE += gnrc_netdev_default

--- a/examples/default/Makefile
+++ b/examples/default/Makefile
@@ -7,7 +7,7 @@ BOARD ?= native
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../..
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-nano arduino-uno
 
 # Uncomment these lines if you want to use platform support from external
 # repositories:

--- a/examples/dtls-echo/Makefile
+++ b/examples/dtls-echo/Makefile
@@ -8,9 +8,10 @@ BOARD ?= native
 RIOTBASE ?= $(CURDIR)/../..
 
 # TinyDTLS only has support for 32-bit architectures ATM
-BOARD_BLACKLIST := arduino-duemilanove arduino-mega2560 arduino-uno chronos \
-                   jiminy-mega256rfr2 mega-xplained msb-430 msb-430h telosb \
-                   waspmote-pro wsn430-v1_3b wsn430-v1_4 z1
+BOARD_BLACKLIST := arduino-duemilanove arduino-mega2560 arduino-nano \
+                   arduino-uno chronos jiminy-mega256rfr2 mega-xplained \
+                   msb-430 msb-430h telosb waspmote-pro wsn430-v1_3b \
+                   wsn430-v1_4 z1
 
 BOARD_INSUFFICIENT_MEMORY := airfy-beacon b-l072z-lrwan1 blackpill bluepill calliope-mini \
                              cc2650-launchpad cc2650stk hifive1 maple-mini \

--- a/examples/emcute_mqttsn/Makefile
+++ b/examples/emcute_mqttsn/Makefile
@@ -7,9 +7,10 @@ BOARD ?= native
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../..
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-mega2560 arduino-uno \
-                             chronos hifive1 msb-430 msb-430h nucleo-f031k6 nucleo-f042k6 \
-                             nucleo-f303k8 nucleo-l031k6 nucleo-f030r8 nucleo-f070rb \
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-mega2560 arduino-nano \
+                             arduino-uno chronos hifive1 msb-430 msb-430h \
+                             nucleo-f031k6 nucleo-f042k6 nucleo-f303k8 \
+                             nucleo-l031k6 nucleo-f030r8 nucleo-f070rb \
                              nucleo-f072rb nucleo-f302r8 nucleo-f334r8 nucleo-l053r8 \
                              stm32f0discovery telosb waspmote-pro wsn430-v1_3b \
                              wsn430-v1_4 z1 mega-xplained

--- a/examples/filesystem/Makefile
+++ b/examples/filesystem/Makefile
@@ -15,7 +15,8 @@ BOARD_BLACKLIST :=  chronos \
                     z1 \
                     #
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno nucleo-f031k6
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-nano arduino-uno \
+                             nucleo-f031k6
 
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../..

--- a/examples/gcoap/Makefile
+++ b/examples/gcoap/Makefile
@@ -9,12 +9,12 @@ BOARD ?= native
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../..
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-mega2560 arduino-uno \
-                             chronos mega-xplained msb-430 msb-430h \
-                             nucleo-f031k6 nucleo-f042k6 nucleo-l031k6 \
-                             nucleo-f030r8 nucleo-f303k8 nucleo-f334r8 \
-                             nucleo-l053r8 stm32f0discovery telosb \
-                             waspmote-pro wsn430-v1_3b wsn430-v1_4 z1
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-mega2560 arduino-nano \
+                             arduino-uno chronos mega-xplained msb-430 \
+                             msb-430h nucleo-f031k6 nucleo-f042k6 \
+                             nucleo-l031k6 nucleo-f030r8 nucleo-f303k8 \
+                             nucleo-f334r8 nucleo-l053r8 stm32f0discovery \
+                             telosb waspmote-pro wsn430-v1_3b wsn430-v1_4 z1
 
 ## Uncomment to redefine port, for example use 61616 for RFC 6282 UDP compression.
 #GCOAP_PORT = 5683

--- a/examples/gnrc_border_router/Makefile
+++ b/examples/gnrc_border_router/Makefile
@@ -8,10 +8,11 @@ BOARD ?= samr21-xpro
 RIOTBASE ?= $(CURDIR)/../..
 
 BOARD_INSUFFICIENT_MEMORY := airfy-beacon arduino-duemilanove arduino-mega2560 \
-                             arduino-uno b-l072z-lrwan1 blackpill bluepill calliope-mini \
-                             cc2650-launchpad cc2650stk hifive1 maple-mini \
-                             mega-xplained microbit msb-430 msb-430h \
-                             nrf51dk nrf51dongle nrf6310 nucleo-f031k6 nucleo-f042k6 \
+                             arduino-nano arduino-uno b-l072z-lrwan1 blackpill \
+                             bluepill calliope-mini cc2650-launchpad cc2650stk \
+                             hifive1 maple-mini mega-xplained microbit msb-430 \
+                             msb-430h nrf51dk nrf51dongle nrf6310 \
+                             nucleo-f031k6 nucleo-f042k6 \
                              nucleo-f303k8 nucleo-l031k6 nucleo-f030r8 \
                              nucleo-f070rb nucleo-f072rb nucleo-f103rb \
                              nucleo-f302r8 nucleo-f334r8 nucleo-l053r8 \

--- a/examples/gnrc_minimal/Makefile
+++ b/examples/gnrc_minimal/Makefile
@@ -7,7 +7,8 @@ BOARD ?= native
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../..
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno nucleo-f031k6
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-nano arduino-uno \
+                             nucleo-f031k6
 
 # Comment this out to disable code in RIOT that does safety checking
 # which is not needed in a production environment but helps in the

--- a/examples/gnrc_networking/Makefile
+++ b/examples/gnrc_networking/Makefile
@@ -7,14 +7,14 @@ BOARD ?= native
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../..
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-mega2560 arduino-uno \
-                             calliope-mini chronos hifive1 mega-xplained \
-                             microbit msb-430 msb-430h nucleo-f031k6 \
-                             nucleo-f042k6 nucleo-f303k8 nucleo-l031k6 \
-                             nucleo-f030r8 nucleo-f070rb nucleo-f072rb \
-                             nucleo-f103rb nucleo-f302r8 nucleo-f334r8 \
-                             nucleo-l053r8 saml10-xpro saml11-xpro \
-                             spark-core stm32f0discovery telosb \
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-mega2560 arduino-nano \
+                             arduino-uno calliope-mini chronos hifive1 \
+                             mega-xplained microbit msb-430 msb-430h \
+                             nucleo-f031k6 nucleo-f042k6 nucleo-f303k8 \
+                             nucleo-l031k6 nucleo-f030r8 nucleo-f070rb \
+                             nucleo-f072rb nucleo-f103rb nucleo-f302r8 \
+                             nucleo-f334r8 nucleo-l053r8 saml10-xpro \
+                             saml11-xpro spark-core stm32f0discovery telosb \
                              waspmote-pro wsn430-v1_3b wsn430-v1_4 z1
 
 # Include packages that pull up and auto-init the link layer.

--- a/examples/gnrc_tftp/Makefile
+++ b/examples/gnrc_tftp/Makefile
@@ -8,7 +8,8 @@ BOARD ?= native
 RIOTBASE ?= $(CURDIR)/../..
 
 BOARD_INSUFFICIENT_MEMORY := airfy-beacon arduino-duemilanove arduino-mega2560 \
-                             arduino-uno b-l072z-lrwan1 blackpill bluepill calliope-mini \
+                             arduino-nano arduino-uno b-l072z-lrwan1 blackpill \
+                             bluepill calliope-mini \
                              chronos hifive1 mega-xplained microbit \
                              msb-430 msb-430h nrf51dk nrf51dongle nrf6310 nucleo-f031k6 \
                              nucleo-f042k6 nucleo-f303k8 nucleo-l031k6 \

--- a/examples/ipc_pingpong/Makefile
+++ b/examples/ipc_pingpong/Makefile
@@ -4,8 +4,8 @@ APPLICATION = ipc_pingpong
 # If no BOARD is found in the environment, use this default:
 BOARD ?= native
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno nucleo-f031k6 \
-
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-nano arduino-uno \
+                             nucleo-f031k6
 
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../..

--- a/examples/javascript/Makefile
+++ b/examples/javascript/Makefile
@@ -17,7 +17,8 @@ BOARD_INSUFFICIENT_MEMORY := airfy-beacon b-l072z-lrwan1 blackpill bluepill call
                              nucleo-l031k6 opencm904 saml10-xpro saml11-xpro \
                              spark-core stm32f0discovery yunjia-nrf51822
 
-BOARD_BLACKLIST := arduino-duemilanove arduino-mega2560 arduino-uno chronos \
+BOARD_BLACKLIST := arduino-duemilanove arduino-mega2560 arduino-nano \
+                   arduino-uno chronos \
                    msb-430 msb-430h telosb waspmote-pro wsn430-v1_3b \
                    wsn430-v1_4 z1 pic32-wifire pic32-clicker jiminy-mega256rfr2 \
                    mega-xplained

--- a/examples/lua_REPL/Makefile
+++ b/examples/lua_REPL/Makefile
@@ -27,7 +27,7 @@ BOARD_INSUFFICIENT_MEMORY := blackpill bluepill calliope-mini cc2650-launchpad \
                              yunjia-nrf51822 esp8266-esp-12x esp8266-olimex-mod \
                              esp8266-sparkfun-thing firefly
 
-BOARD_BLACKLIST := arduino-duemilanove arduino-mega2560 arduino-uno \
+BOARD_BLACKLIST := arduino-duemilanove arduino-mega2560 arduino-nano arduino-uno \
                    chronos hifive1 jiminy-mega256rfr2 mega-xplained mips-malta \
                    msb-430 msb-430h pic32-clicker pic32-wifire telosb \
                    waspmote-pro wsn430-v1_3b wsn430-v1_4 z1

--- a/examples/lua_basic/Makefile
+++ b/examples/lua_basic/Makefile
@@ -15,10 +15,10 @@ BOARD_INSUFFICIENT_MEMORY := blackpill bluepill calliope-mini cc2650-launchpad \
                              nucleo-l053r8 opencm904 saml10-xpro saml11-xpro \
                              spark-core stm32f0discovery
 
-BOARD_BLACKLIST := arduino-duemilanove arduino-mega2560 arduino-uno \
-                   chronos hifive1 jiminy-mega256rfr2 mega-xplained mips-malta \
-                   msb-430 msb-430h pic32-clicker pic32-wifire telosb \
-                   waspmote-pro wsn430-v1_3b wsn430-v1_4 z1
+BOARD_BLACKLIST := arduino-duemilanove arduino-mega2560 arduino-nano \
+                   arduino-uno chronos hifive1 jiminy-mega256rfr2 \
+                   mega-xplained mips-malta msb-430 msb-430h pic32-clicker \
+                   pic32-wifire telosb waspmote-pro wsn430-v1_3b wsn430-v1_4 z1
 
 
 # Comment this out to disable code in RIOT that does safety checking

--- a/examples/nanocoap_server/Makefile
+++ b/examples/nanocoap_server/Makefile
@@ -7,11 +7,12 @@ BOARD ?= native
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../..
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-mega2560 arduino-uno \
-                             chronos msb-430 msb-430h nucleo-f031k6 \
-                             nucleo-f042k6 nucleo-l031k6 nucleo-f030r8 \
-                             nucleo-f303k8 nucleo-l053r8 stm32f0discovery \
-                             telosb waspmote-pro wsn430-v1_3b wsn430-v1_4 z1
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-mega2560 arduino-nano \
+                             arduino-uno chronos msb-430 msb-430h \
+                             nucleo-f031k6 nucleo-f042k6 nucleo-l031k6 \
+                             nucleo-f030r8 nucleo-f303k8 nucleo-l053r8 \
+                             stm32f0discovery telosb waspmote-pro wsn430-v1_3b \
+                             wsn430-v1_4 z1
 
 # Include packages that pull up and auto-init the link layer.
 # NOTE: 6LoWPAN will be included if IEEE802.15.4 devices are present

--- a/examples/ndn-ping/Makefile
+++ b/examples/ndn-ping/Makefile
@@ -7,12 +7,12 @@ BOARD ?= native
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../../
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-mega2560 arduino-uno \
-                             chronos mega-xplained msb-430 msb-430h \
-                             nucleo-f042k6 nucleo-f031k6 nucleo-l031k6 \
-                             nucleo-f030r8 nucleo-l053r8 stm32f0discovery \
-                             telosb waspmote-pro weio wsn430-v1_3b wsn430-v1_4 \
-                             z1
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-mega2560 arduino-nano \
+                             arduino-uno chronos mega-xplained msb-430 \
+                             msb-430h nucleo-f042k6 nucleo-f031k6 \
+                             nucleo-l031k6 nucleo-f030r8 nucleo-l053r8 \
+                             stm32f0discovery telosb waspmote-pro weio \
+                             wsn430-v1_3b wsn430-v1_4 z1
 
 # Include packages that pull up and auto-init the link layer.
 USEMODULE += gnrc_netdev_default

--- a/examples/posix_sockets/Makefile
+++ b/examples/posix_sockets/Makefile
@@ -8,13 +8,13 @@ BOARD ?= native
 RIOTBASE ?= $(CURDIR)/../..
 
 BOARD_INSUFFICIENT_MEMORY := airfy-beacon arduino-duemilanove arduino-mega2560 \
-                             arduino-uno chronos mega-xplained msb-430 \
-                             msb-430h nrf51dk nrf51dongle nrf6310 nucleo-f031k6 \
-                             nucleo-f042k6 nucleo-l031k6 nucleo-f030r8 \
-                             nucleo-f070rb nucleo-f072rb nucleo-f334r8 \
-                             nucleo-f303k8 nucleo-l053r8 stm32f0discovery \
-                             telosb wsn430-v1_3b wsn430-v1_4 yunjia-nrf51822 \
-                             waspmote-pro z1
+                             arduino-nano arduino-uno chronos mega-xplained \
+                             msb-430 msb-430h nrf51dk nrf51dongle nrf6310 \
+                             nucleo-f031k6 nucleo-f042k6 nucleo-l031k6 \
+                             nucleo-f030r8 nucleo-f070rb nucleo-f072rb \
+                             nucleo-f334r8 nucleo-f303k8 nucleo-l053r8 \
+                             stm32f0discovery telosb wsn430-v1_3b wsn430-v1_4 \
+                             yunjia-nrf51822 waspmote-pro z1
 
 # Include packages that pull up and auto-init the link layer.
 # NOTE: 6LoWPAN will be included if IEEE802.15.4 devices are present

--- a/examples/saul/Makefile
+++ b/examples/saul/Makefile
@@ -7,7 +7,7 @@ BOARD ?= native
 # This has to be the absolute path to the RIOT base directory:
 RIOTBASE ?= $(CURDIR)/../..
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-nano arduino-uno
 
 # we want to use SAUL:
 USEMODULE += saul_default

--- a/tests/bench_sizeof_coretypes/Makefile
+++ b/tests/bench_sizeof_coretypes/Makefile
@@ -1,6 +1,6 @@
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-nano arduino-uno
 
 # Modules that will have an impact on the size of the TCB (thread_t):
 #

--- a/tests/bench_timers/Makefile
+++ b/tests/bench_timers/Makefile
@@ -1,6 +1,6 @@
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-nano arduino-uno
 
 # These boards only have a single timer in their periph_conf.h, needs special
 # CFLAGS configuration to build properly

--- a/tests/bloom_bytes/Makefile
+++ b/tests/bloom_bytes/Makefile
@@ -1,7 +1,8 @@
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno chronos \
-                             msb-430 msb-430h telosb wsn430-v1_3b wsn430-v1_4 z1
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-nano arduino-uno \
+                             chronos msb-430 msb-430h telosb wsn430-v1_3b \
+                             wsn430-v1_4 z1
 
 USEMODULE += hashes
 USEMODULE += bloom

--- a/tests/can_trx/Makefile
+++ b/tests/can_trx/Makefile
@@ -1,7 +1,7 @@
 export APPLICATION = can_trx
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-nano arduino-uno
 
 USEMODULE += shell
 USEMODULE += shell_commands

--- a/tests/cond_order/Makefile
+++ b/tests/cond_order/Makefile
@@ -1,8 +1,9 @@
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := nucleo32-f031 nucleo32-f042 nucleo32-l031 nucleo-f030 \
-                             nucleo-l053 stm32f0discovery arduino-duemilanove \
-							 arduino-uno nucleo-f030r8 nucleo-f031k6 nucleo-f042k6 \
-							 nucleo-l031k6 nucleo-l053r8
+BOARD_INSUFFICIENT_MEMORY := nucleo32-f031 nucleo32-f042 nucleo32-l031 \
+                             nucleo-f030 nucleo-l053 stm32f0discovery \
+                             arduino-duemilanove arduino-nano arduino-uno \
+                             nucleo-f030r8 nucleo-f031k6 nucleo-f042k6 \
+                             nucleo-l031k6 nucleo-l053r8
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/conn_can/Makefile
+++ b/tests/conn_can/Makefile
@@ -1,13 +1,13 @@
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-mega2560 arduino-uno \
-                             chronos hifive1 msb-430 msb-430h nucleo-f031k6 \
-                             nucleo-f042k6 nucleo-f303k8 nucleo-l031k6 \
-                             nucleo-f030r8 nucleo-f070rb nucleo-f072rb \
-                             nucleo-f302r8 nucleo-f303re nucleo-f334r8 \
-                             nucleo-l053r8 saml10-xpro saml11-xpro \
-                             stm32f0discovery telosb waspmote-pro wsn430-v1_3b \
-                             wsn430-v1_4 z1
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-mega2560 arduino-nano \
+                             arduino-uno chronos hifive1 msb-430 msb-430h \
+                             nucleo-f031k6 nucleo-f042k6 nucleo-f303k8 \
+                             nucleo-l031k6 nucleo-f030r8 nucleo-f070rb \
+                             nucleo-f072rb nucleo-f302r8 nucleo-f303re \
+                             nucleo-f334r8 nucleo-l053r8 saml10-xpro \
+                             saml11-xpro stm32f0discovery telosb waspmote-pro \
+                             wsn430-v1_3b wsn430-v1_4 z1
 
 CFLAGS += -DLOG_LEVEL=LOG_ALL
 

--- a/tests/driver_at/Makefile
+++ b/tests/driver_at/Makefile
@@ -1,6 +1,7 @@
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno nucleo-f031k6
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-nano arduino-uno \
+                             nucleo-f031k6
 
 USEMODULE += shell
 USEMODULE += at

--- a/tests/driver_at30tse75x/Makefile
+++ b/tests/driver_at30tse75x/Makefile
@@ -1,6 +1,6 @@
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-nano arduino-uno
 
 USEMODULE += at30tse75x
 USEMODULE += shell

--- a/tests/driver_at86rf2xx/Makefile
+++ b/tests/driver_at86rf2xx/Makefile
@@ -1,7 +1,8 @@
 include ../Makefile.tests_common
 
 # exclude boards with insufficient memory
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno nucleo-f031k6
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-nano arduino-uno \
+                             nucleo-f031k6
 
 DISABLE_MODULE += auto_init
 

--- a/tests/driver_ata8520e/Makefile
+++ b/tests/driver_ata8520e/Makefile
@@ -1,6 +1,6 @@
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-nano arduino-uno
 
 USEMODULE += ata8520e
 USEMODULE += shell

--- a/tests/driver_bmx055/Makefile
+++ b/tests/driver_bmx055/Makefile
@@ -1,6 +1,6 @@
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-nano arduino-uno
 
 # include and auto-initialize all available sensors
 USEMODULE += saul_default

--- a/tests/driver_dynamixel/Makefile
+++ b/tests/driver_dynamixel/Makefile
@@ -1,6 +1,6 @@
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-nano arduino-uno
 
 # chronos : USART_1 undeclared
 BOARD_BLACKLIST += chronos

--- a/tests/driver_enc28j60/Makefile
+++ b/tests/driver_enc28j60/Makefile
@@ -1,10 +1,11 @@
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-mega2560 arduino-uno \
-                             msb-430 msb-430h nucleo-f334r8 nucleo-l053r8 \
-                             nucleo-f031k6 nucleo-f042k6 nucleo-f303k8 \
-                             nucleo-l031k6 mega-xplained stm32f0discovery telosb \
-                             waspmote-pro wsn430-v1_3b wsn430-v1_4 z1
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-mega2560 arduino-nano \
+                             arduino-uno msb-430 msb-430h nucleo-f334r8 \
+                             nucleo-l053r8 nucleo-f031k6 nucleo-f042k6 \
+                             nucleo-f303k8 nucleo-l031k6 mega-xplained \
+                             stm32f0discovery telosb waspmote-pro wsn430-v1_3b \
+                             wsn430-v1_4 z1
 
 USEMODULE += auto_init_gnrc_netif
 USEMODULE += enc28j60

--- a/tests/driver_encx24j600/Makefile
+++ b/tests/driver_encx24j600/Makefile
@@ -1,7 +1,7 @@
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-mega2560 arduino-uno \
-                             msb-430 msb-430h \
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-mega2560 arduino-nano \
+                             arduino-uno msb-430 msb-430h \
                              nucleo-l053r8 nucleo-f031k6 nucleo-f042k6 \
                              nucleo-l031k6 stm32f0discovery telosb \
                              waspmote-pro wsn430-v1_3b wsn430-v1_4 z1

--- a/tests/driver_feetech/Makefile
+++ b/tests/driver_feetech/Makefile
@@ -1,6 +1,6 @@
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-nano arduino-uno
 
 # chronos : USART_1 undeclared
 BOARD_BLACKLIST += chronos

--- a/tests/driver_kw2xrf/Makefile
+++ b/tests/driver_kw2xrf/Makefile
@@ -1,9 +1,9 @@
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-mega2560 arduino-uno \
-                             nucleo-f031k6 nucleo-f042k6 nucleo-l031k6 \
-                             nucleo-f334r8 nucleo-l053r8 stm32f0discovery \
-                             waspmote-pro
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-mega2560 arduino-nano \
+                             arduino-uno nucleo-f031k6 nucleo-f042k6 \
+                             nucleo-l031k6 nucleo-f334r8 nucleo-l053r8 \
+                             stm32f0discovery waspmote-pro
 
 USEMODULE += auto_init_gnrc_netif
 USEMODULE += gnrc_netdev_default

--- a/tests/driver_ltc4150/Makefile
+++ b/tests/driver_ltc4150/Makefile
@@ -1,6 +1,6 @@
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY += arduino-uno arduino-duemilanove
+BOARD_INSUFFICIENT_MEMORY += arduino-uno arduino-nano arduino-duemilanove
 
 BOARD ?= msba2
 

--- a/tests/driver_mpu9150/Makefile
+++ b/tests/driver_mpu9150/Makefile
@@ -1,6 +1,6 @@
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-nano arduino-uno
 
 USEMODULE += mpu9150
 USEMODULE += xtimer

--- a/tests/driver_nrf24l01p_lowlevel/Makefile
+++ b/tests/driver_nrf24l01p_lowlevel/Makefile
@@ -1,7 +1,8 @@
 include ../Makefile.tests_common
 
 # exclude boards with insufficient memory
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno nucleo-f031k6
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-nano arduino-uno \
+                             nucleo-f031k6
 
 USEMODULE += shell
 USEMODULE += shell_commands

--- a/tests/driver_nvram_spi/Makefile
+++ b/tests/driver_nvram_spi/Makefile
@@ -1,6 +1,6 @@
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-nano arduino-uno
 
 USEMODULE += nvram_spi
 USEMODULE += xtimer

--- a/tests/driver_pcd8544/Makefile
+++ b/tests/driver_pcd8544/Makefile
@@ -1,6 +1,6 @@
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-nano arduino-uno
 
 USEMODULE += shell
 USEMODULE += pcd8544

--- a/tests/driver_pir/Makefile
+++ b/tests/driver_pir/Makefile
@@ -1,6 +1,7 @@
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno nucleo-f031k6
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-nano arduino-uno \
+                             nucleo-f031k6
 
 USEMODULE += pir
 

--- a/tests/driver_rn2xx3/Makefile
+++ b/tests/driver_rn2xx3/Makefile
@@ -1,6 +1,6 @@
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-nano arduino-uno
 
 DRIVER ?= rn2483
 

--- a/tests/driver_sdcard_spi/Makefile
+++ b/tests/driver_sdcard_spi/Makefile
@@ -1,7 +1,8 @@
 include ../Makefile.tests_common
 
 # exclude boards with insufficient memory
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno nucleo-f031k6
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-nano arduino-uno \
+                             nucleo-f031k6
 
 USEMODULE += sdcard_spi
 USEMODULE += auto_init_storage

--- a/tests/driver_sht1x/Makefile
+++ b/tests/driver_sht1x/Makefile
@@ -1,6 +1,6 @@
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-nano arduino-uno
 
 DRIVER ?= sht11
 BOARD ?= msba2

--- a/tests/driver_srf02/Makefile
+++ b/tests/driver_srf02/Makefile
@@ -1,6 +1,6 @@
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-nano arduino-uno
 
 USEMODULE += xtimer
 USEMODULE += srf02

--- a/tests/driver_sx127x/Makefile
+++ b/tests/driver_sx127x/Makefile
@@ -2,7 +2,8 @@ BOARD ?= b-l072z-lrwan1
 
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno nucleo-f031k6
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-nano arduino-uno \
+                             nucleo-f031k6
 
 USEMODULE += od
 USEMODULE += shell

--- a/tests/driver_tsl4531x/Makefile
+++ b/tests/driver_tsl4531x/Makefile
@@ -1,6 +1,6 @@
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-nano arduino-uno
 
 USEMODULE += tsl4531x
 USEMODULE += xtimer

--- a/tests/driver_xbee/Makefile
+++ b/tests/driver_xbee/Makefile
@@ -1,8 +1,8 @@
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno nucleo-f031k6 \
-                             nucleo-f042k6 nucleo-f030r8 nucleo-f334r8 \
-                             stm32f0discovery waspmote-pro
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-nano arduino-uno \
+                             nucleo-f031k6 nucleo-f042k6 nucleo-f030r8 \
+                             nucleo-f334r8 stm32f0discovery waspmote-pro
 
 USEMODULE += xbee
 USEMODULE += gnrc_txtsnd

--- a/tests/emb6/Makefile
+++ b/tests/emb6/Makefile
@@ -6,10 +6,11 @@ include ../Makefile.tests_common
 BOARD_BLACKLIST := msb-430 msb-430h pic32-clicker pic32-wifire \
                    telosb wsn430-v1_3b wsn430-v1_4 z1
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-mega2560 arduino-uno \
-                             msb-430 msb-430h nucleo-l031k6 nucleo-f031k6 \
-                             nucleo-f042k6 nucleo-l053r8 stm32f0discovery \
-                             telosb waspmote-pro wsn430-v1_3b wsn430-v1_4 z1
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-mega2560 arduino-nano \
+                             arduino-uno msb-430 msb-430h nucleo-l031k6 \
+                             nucleo-f031k6 nucleo-f042k6 nucleo-l053r8 \
+                             stm32f0discovery telosb waspmote-pro wsn430-v1_3b \
+                             wsn430-v1_4 z1
 
 USEPKG += emb6
 

--- a/tests/events/Makefile
+++ b/tests/events/Makefile
@@ -1,6 +1,6 @@
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-nano arduino-uno
 
 FORCE_ASSERTS = 1
 USEMODULE += event_callback

--- a/tests/evtimer_msg/Makefile
+++ b/tests/evtimer_msg/Makefile
@@ -1,7 +1,7 @@
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno nucleo-f031k6 \
-                             nucleo-f042k6
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-nano arduino-uno \
+                             nucleo-f031k6 nucleo-f042k6
 
 USEMODULE += evtimer
 

--- a/tests/evtimer_underflow/Makefile
+++ b/tests/evtimer_underflow/Makefile
@@ -1,7 +1,7 @@
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno nucleo-f031k6 \
-                             nucleo-f042k6
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-nano arduino-uno \
+                             nucleo-f031k6 nucleo-f042k6
 
 USEMODULE += evtimer
 

--- a/tests/gnrc_ipv6_ext/Makefile
+++ b/tests/gnrc_ipv6_ext/Makefile
@@ -2,13 +2,13 @@ DEVELHELP := 1
 # name of your application
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-mega2560 arduino-uno \
-                             hifive1 mega-xplained msb-430 msb-430h \
-                             nucleo-f030r8 nucleo-f031k6 nucleo-f042k6 \
-                             nucleo-f070rb nucleo-f072rb nucleo-f303k8 \
-                             nucleo-f334r8 nucleo-l031k6 nucleo-l053r8 \
-                             stm32f0discovery telosb thingy52 waspmote-pro \
-                             wsn430-v1_3b wsn430-v1_4 z1
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-mega2560 arduino-nano \
+                             arduino-uno hifive1 mega-xplained msb-430 \
+                             msb-430h nucleo-f030r8 nucleo-f031k6 \
+                             nucleo-f042k6 nucleo-f070rb nucleo-f072rb \
+                             nucleo-f303k8 nucleo-f334r8 nucleo-l031k6 \
+                             nucleo-l053r8 stm32f0discovery telosb thingy52 \
+                             waspmote-pro wsn430-v1_3b wsn430-v1_4 z1
 # chronos, mips-malta, and ruuvitag boards don't support ethos
 BOARD_BLACKLIST := chronos mips-malta ruuvitag
 

--- a/tests/gnrc_ipv6_nib/Makefile
+++ b/tests/gnrc_ipv6_nib/Makefile
@@ -1,8 +1,9 @@
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-mega2560 arduino-uno \
-                             chronos nucleo-f031k6 nucleo-f042k6 nucleo-l031k6 \
-                             telosb waspmote-pro wsn430-v1_3b wsn430-v1_4
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-mega2560 arduino-nano \
+                             arduino-uno chronos nucleo-f031k6 nucleo-f042k6 \
+                             nucleo-l031k6 telosb waspmote-pro wsn430-v1_3b \
+                             wsn430-v1_4
 
 USEMODULE += gnrc_ipv6
 USEMODULE += gnrc_ipv6_nib

--- a/tests/gnrc_ipv6_nib_6ln/Makefile
+++ b/tests/gnrc_ipv6_nib_6ln/Makefile
@@ -1,9 +1,10 @@
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-mega2560 arduino-uno \
-                             chronos nucleo-f030r8 nucleo-l053r8 nucleo-f031k6 \
-                             nucleo-l031k6 nucleo-f042k6 stm32f0discovery \
-                             telosb waspmote-pro wsn430-v1_3b wsn430-v1_4
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-mega2560 arduino-nano \
+                             arduino-uno chronos nucleo-f030r8 nucleo-l053r8 \
+                             nucleo-f031k6 nucleo-l031k6 nucleo-f042k6 \
+                             stm32f0discovery telosb waspmote-pro wsn430-v1_3b \
+                             wsn430-v1_4
 
 USEMODULE += gnrc_ipv6
 USEMODULE += gnrc_sixlowpan

--- a/tests/gnrc_mac_timeout/Makefile
+++ b/tests/gnrc_mac_timeout/Makefile
@@ -1,9 +1,10 @@
 APPLICATION = gnrc_mac_timeout
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-mega2560 arduino-uno \
-                             chronos nucleo-f030r8 nucleo-f031k6 nucleo-f042k6 \
-                             nucleo-l031k6 nucleo-l053r8 stm32f0discovery waspmote-pro
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-mega2560 arduino-nano \
+                             arduino-uno chronos nucleo-f030r8 nucleo-f031k6 \
+                             nucleo-f042k6 nucleo-l031k6 nucleo-l053r8 \
+                             stm32f0discovery waspmote-pro
 
 USEMODULE += gnrc_mac
 

--- a/tests/gnrc_ndp/Makefile
+++ b/tests/gnrc_ndp/Makefile
@@ -1,9 +1,10 @@
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-mega2560 arduino-uno \
-                             chronos nucleo-f030r8 nucleo-f031k6 nucleo-f042k6 \
-                             nucleo-l031k6 nucleo-l053r8 stm32f0discovery \
-                             telosb waspmote-pro wsn430-v1_3b wsn430-v1_4
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-mega2560 arduino-nano \
+                             arduino-uno chronos nucleo-f030r8 nucleo-f031k6 \
+                             nucleo-f042k6 nucleo-l031k6 nucleo-l053r8 \
+                             stm32f0discovery telosb waspmote-pro wsn430-v1_3b \
+                             wsn430-v1_4
 
 USEMODULE += gnrc_ipv6_nib_router
 USEMODULE += gnrc_ndp

--- a/tests/gnrc_netif/Makefile
+++ b/tests/gnrc_netif/Makefile
@@ -1,9 +1,9 @@
 include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_MEMORY := airfy-beacon arduino-duemilanove arduino-mega2560 \
-                             arduino-uno b-l072z-lrwan1 blackpill bluepill calliope-mini \
-                             cc2650-launchpad cc2650stk chronos hifive1 \
-                             maple-mini mega-xplained microbit \
+                             arduino-nano arduino-uno b-l072z-lrwan1 blackpill \
+                             bluepill calliope-mini cc2650-launchpad cc2650stk \
+                             chronos hifive1 maple-mini mega-xplained microbit \
                              msb-430 msb-430h nrf51dk nrf51dongle nrf6310 \
                              nucleo-f030r8 nucleo-f070rb nucleo-f072rb \
                              nucleo-f103rb nucleo-f302r8 nucleo-f334r8 \

--- a/tests/gnrc_rpl_srh/Makefile
+++ b/tests/gnrc_rpl_srh/Makefile
@@ -2,13 +2,14 @@ DEVELHELP := 1
 # name of your application
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-mega2560 arduino-uno \
-                             hifive1 mega-xplained msb-430 msb-430h \
-                             nucleo-f030r8 nucleo-f031k6 nucleo-f042k6 \
-                             nucleo-f070rb nucleo-f072rb nucleo-f303k8 \
-                             nucleo-f334r8 nucleo-l031k6 nucleo-l053r8 \
-                             saml10-xpro saml11-xpro stm32f0discovery telosb \
-                             thingy52 waspmote-pro wsn430-v1_3b wsn430-v1_4 z1
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-mega2560 arduino-nano \
+                             arduino-uno hifive1 mega-xplained msb-430 \
+                             msb-430h nucleo-f030r8 nucleo-f031k6 \
+                             nucleo-f042k6 nucleo-f070rb nucleo-f072rb \
+                             nucleo-f303k8 nucleo-f334r8 nucleo-l031k6 \
+                             nucleo-l053r8 saml10-xpro saml11-xpro \
+                             stm32f0discovery telosb thingy52 waspmote-pro \
+                             wsn430-v1_3b wsn430-v1_4 z1
 # chronos, mips-malta, and ruuvitag boards don't support ethos
 BOARD_BLACKLIST := chronos mips-malta ruuvitag
 

--- a/tests/gnrc_sixlowpan/Makefile
+++ b/tests/gnrc_sixlowpan/Makefile
@@ -1,13 +1,14 @@
 # name of your application
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-mega2560 arduino-uno \
-                             chronos hifive1 msb-430 msb-430h nucleo-f030r8 \
-                             nucleo-f031k6 nucleo-f042k6 nucleo-f070rb \
-                             nucleo-f070rb nucleo-f072rb nucleo-f303k8 \
-                             nucleo-f334r8 nucleo-l031k6 nucleo-l053r8 \
-                             saml10-xpro saml11-xpro stm32f0discovery telosb \
-                             waspmote-pro wsn430-v1_3b wsn430-v1_4 z1
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-mega2560 arduino-nano \
+                             arduino-uno chronos hifive1 msb-430 msb-430h \
+                             nucleo-f030r8 nucleo-f031k6 nucleo-f042k6 \
+                             nucleo-f070rb nucleo-f070rb nucleo-f072rb \
+                             nucleo-f303k8 nucleo-f334r8 nucleo-l031k6 \
+                             nucleo-l053r8 saml10-xpro saml11-xpro \
+                             stm32f0discovery telosb waspmote-pro wsn430-v1_3b \
+                             wsn430-v1_4 z1
 
 # use IEEE 802.15.4 as link-layer protocol
 USEMODULE += netdev_ieee802154

--- a/tests/gnrc_sixlowpan_frag/Makefile
+++ b/tests/gnrc_sixlowpan_frag/Makefile
@@ -1,6 +1,7 @@
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno nucleo-f031k6
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-nano arduino-uno \
+                             nucleo-f031k6
 
 USEMODULE += gnrc_sixlowpan_frag
 USEMODULE += embunit

--- a/tests/gnrc_sock_dns/Makefile
+++ b/tests/gnrc_sock_dns/Makefile
@@ -2,10 +2,11 @@ include ../Makefile.tests_common
 
 RIOTBASE ?= $(CURDIR)/../..
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-mega2560 arduino-uno \
-                             chronos telosb nucleo-f042k6 nucleo-f031k6 \
-                             nucleo-f030r8 nucleo-f303k8 nucleo-l053r8 \
-                             nucleo-l031k6 stm32f0discovery waspmote-pro z1
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-mega2560 arduino-nano \
+                             arduino-uno chronos telosb nucleo-f042k6 \
+                             nucleo-f031k6 nucleo-f030r8 nucleo-f303k8 \
+                             nucleo-l053r8 nucleo-l031k6 stm32f0discovery \
+                             waspmote-pro z1
 
 USEMODULE += sock_dns
 USEMODULE += gnrc_sock_udp

--- a/tests/gnrc_sock_ip/Makefile
+++ b/tests/gnrc_sock_ip/Makefile
@@ -1,6 +1,6 @@
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno \
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-nano arduino-uno \
                              chronos nucleo-f031k6 nucleo-f042k6 nucleo-l031k6
 
 USEMODULE += gnrc_sock_ip

--- a/tests/gnrc_sock_udp/Makefile
+++ b/tests/gnrc_sock_udp/Makefile
@@ -1,8 +1,8 @@
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := arduino-mega2560 arduino-duemilanove arduino-uno \
-                             chronos nucleo-f031k6 nucleo-f042k6 nucleo-l031k6 \
-                             waspmote-pro
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-mega2560 arduino-nano \
+                             arduino-uno chronos nucleo-f031k6 nucleo-f042k6 \
+                             nucleo-l031k6 waspmote-pro
 
 USEMODULE += gnrc_sock_check_reuse
 USEMODULE += gnrc_sock_udp

--- a/tests/gnrc_tcp_client/Makefile
+++ b/tests/gnrc_tcp_client/Makefile
@@ -14,12 +14,15 @@ TCP_TEST_CYCLES ?= 3
 
 # Mark Boards with insufficient memory
 BOARD_INSUFFICIENT_MEMORY := airfy-beacon arduino-duemilanove arduino-mega2560 \
-                             arduino-uno calliope-mini chronos hifive1 mega-xplained microbit \
-                             msb-430 msb-430h nrf51dk nrf51dongle nrf6310 nucleo-f031k6 \
-                             nucleo-f042k6 nucleo-f303k8 nucleo-l031k6 nucleo-f030r8 \
-                             nucleo-f070rb nucleo-f072rb nucleo-f302r8 nucleo-f334r8 nucleo-l053r8 \
-                             saml10-xpro saml11-xpro sb-430 sb-430h stm32f0discovery telosb \
-                             waspmote-pro wsn430-v1_3b wsn430-v1_4 yunjia-nrf51822 z1
+                             arduino-nano arduino-uno calliope-mini chronos \
+                             hifive1 mega-xplained microbit msb-430 msb-430h \
+                             nrf51dk nrf51dongle nrf6310 nucleo-f031k6 \
+                             nucleo-f042k6 nucleo-f303k8 nucleo-l031k6 \
+                             nucleo-f030r8 nucleo-f070rb nucleo-f072rb \
+                             nucleo-f302r8 nucleo-f334r8 nucleo-l053r8 \
+                             saml10-xpro saml11-xpro sb-430 sb-430h \
+                             stm32f0discovery telosb waspmote-pro wsn430-v1_3b \
+                             wsn430-v1_4 yunjia-nrf51822 z1
 
 # Target Address, Target Port and number of Test Cycles
 CFLAGS += -DSERVER_ADDR=\"$(TCP_SERVER_ADDR)\"

--- a/tests/gnrc_tcp_server/Makefile
+++ b/tests/gnrc_tcp_server/Makefile
@@ -13,12 +13,15 @@ TCP_TEST_CYCLES ?= 3
 
 # Mark Boards with insufficient memory
 BOARD_INSUFFICIENT_MEMORY := airfy-beacon arduino-duemilanove arduino-mega2560 \
-                             arduino-uno calliope-mini chronos hifive1 mega-xplained \
-                             microbit msb-430 msb-430h nrf51dk nrf51dongle nrf6310 nucleo-f031k6 \
-                             nucleo-f042k6 nucleo-f303k8 nucleo-l031k6 nucleo-f030r8 \
-                             nucleo-f070rb nucleo-f072rb nucleo-f302r8 nucleo-f334r8 nucleo-l053r8 \
-                             saml10-xpro saml11-xpro sb-430 sb-430h stm32f0discovery telosb \
-                             waspmote-pro wsn430-v1_3b wsn430-v1_4 yunjia-nrf51822 z1
+                             arduino-nano arduino-uno calliope-mini chronos \
+                             hifive1 mega-xplained microbit msb-430 msb-430h \
+                             nrf51dk nrf51dongle nrf6310 nucleo-f031k6 \
+                             nucleo-f042k6 nucleo-f303k8 nucleo-l031k6 \
+                             nucleo-f030r8 nucleo-f070rb nucleo-f072rb \
+                             nucleo-f302r8 nucleo-f334r8 nucleo-l053r8 \
+                             saml10-xpro saml11-xpro sb-430 sb-430h \
+                             stm32f0discovery telosb waspmote-pro wsn430-v1_3b \
+                             wsn430-v1_4 yunjia-nrf51822 z1
 
 # Local Address, Local Port and number of Test Cycles
 CFLAGS += -DSERVER_ADDR=\"$(TCP_SERVER_ADDR)\"

--- a/tests/gnrc_udp/Makefile
+++ b/tests/gnrc_udp/Makefile
@@ -1,12 +1,14 @@
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-mega2560 arduino-uno \
-                             calliope-mini chronos hifive1 mega-xplained \
-                             microbit msb-430 msb-430h \
-                             nucleo-f031k6 nucleo-f042k6 nucleo-f303k8 nucleo-l031k6 \
-                             nucleo-f030r8 nucleo-f070rb nucleo-f072rb nucleo-f103rb nucleo-f302r8 \
-                             nucleo-f334r8 nucleo-l053r8 spark-core stm32f0discovery telosb \
-                             waspmote-pro wsn430-v1_3b wsn430-v1_4 z1
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-mega2560 arduino-nano \
+                             arduino-uno calliope-mini chronos hifive1 \
+                             mega-xplained microbit msb-430 msb-430h \
+                             nucleo-f031k6 nucleo-f042k6 nucleo-f303k8 \
+                             nucleo-l031k6 nucleo-f030r8 nucleo-f070rb \
+                             nucleo-f072rb nucleo-f103rb nucleo-f302r8 \
+                             nucleo-f334r8 nucleo-l053r8 spark-core \
+                             stm32f0discovery telosb waspmote-pro wsn430-v1_3b \
+                             wsn430-v1_4 z1
 
 USEMODULE += gnrc_netdev_default
 USEMODULE += auto_init_gnrc_netif

--- a/tests/irq/Makefile
+++ b/tests/irq/Makefile
@@ -1,6 +1,7 @@
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno nucleo-f031k6
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-nano arduino-uno \
+                             nucleo-f031k6
 
 USEMODULE += auto_init
 USEMODULE += xtimer

--- a/tests/isr_yield_higher/Makefile
+++ b/tests/isr_yield_higher/Makefile
@@ -1,7 +1,8 @@
 APPLICATION = isr_yield_higher
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno nucleo-f031k6
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-nano arduino-uno \
+                             nucleo-f031k6
 
 USEMODULE += xtimer
 

--- a/tests/libfixmath_unittests/Makefile
+++ b/tests/libfixmath_unittests/Makefile
@@ -1,7 +1,7 @@
 include ../Makefile.tests_common
 
-BOARD_BLACKLIST := arduino-mega2560 waspmote-pro arduino-uno arduino-duemilanove \
-                   jiminy-mega256rfr2 mega-xplained
+BOARD_BLACKLIST := arduino-duemilanove arduino-mega2560 arduino-nano \
+                   arduino-uno jiminy-mega256rfr2 mega-xplained waspmote-pro
 # arduino-mega2560: builds locally but breaks travis (possibly because of
 # differences in the toolchain)
 # The MSP boards don't feature round(), exp(), and log(), which are used in the unittests

--- a/tests/lwip/Makefile
+++ b/tests/lwip/Makefile
@@ -2,10 +2,11 @@ include ../Makefile.tests_common
 
 # lwIP's memory management doesn't seem to work on non 32-bit platforms at the
 # moment.
-BOARD_BLACKLIST := arduino-uno arduino-duemilanove arduino-mega2560 chronos \
-                   esp8266-esp-12x esp8266-olimex-mod esp8266-sparkfun-thing \
-                   msb-430 msb-430h telosb waspmote-pro wsn430-v1_3b \
-                   wsn430-v1_4 z1 jiminy-mega256rfr2 mega-xplained
+BOARD_BLACKLIST := arduino-duemilanove arduino-mega2560 arduino-nano \
+                   arduino-uno chronos esp8266-esp-12x esp8266-olimex-mod \
+                   esp8266-sparkfun-thing jiminy-mega256rfr2 mega-xplained \
+                   msb-430 msb-430h telosb waspmote-pro \
+                   wsn430-v1_3b wsn430-v1_4 z1
 BOARD_INSUFFICIENT_MEMORY := airfy-beacon hifive1 nrf6310 nucleo-f031k6 nucleo-f042k6 \
                              nucleo-l031k6 nucleo-f030r8 nucleo-f303k8 \
                              nucleo-f334r8 nucleo-l053r8 stm32f0discovery \

--- a/tests/lwip_sock_ip/Makefile
+++ b/tests/lwip_sock_ip/Makefile
@@ -2,10 +2,11 @@ include ../Makefile.tests_common
 
 # lwIP's memory management doesn't seem to work on non 32-bit platforms at the
 # moment.
-BOARD_BLACKLIST := arduino-uno arduino-duemilanove arduino-mega2560 chronos \
-                   esp8266-esp-12x esp8266-olimex-mod esp8266-sparkfun-thing \
-                   msb-430 msb-430h telosb waspmote-pro wsn430-v1_3b \
-                   wsn430-v1_4 z1 jiminy-mega256rfr2 mega-xplained
+BOARD_BLACKLIST := arduino-duemilanove arduino-mega2560 arduino-nano \
+                   arduino-uno chronos esp8266-esp-12x esp8266-olimex-mod \
+                   esp8266-sparkfun-thing jiminy-mega256rfr2 mega-xplained \
+                   msb-430 msb-430h telosb waspmote-pro \
+                   wsn430-v1_3b wsn430-v1_4 z1
 BOARD_INSUFFICIENT_MEMORY = nucleo-f031k6 nucleo-f042k6 nucleo-l031k6 nucleo-f030r8 \
                             nucleo-f303k8 nucleo-f334r8 nucleo-l053r8 \
                             stm32f0discovery

--- a/tests/lwip_sock_tcp/Makefile
+++ b/tests/lwip_sock_tcp/Makefile
@@ -2,10 +2,11 @@ include ../Makefile.tests_common
 
 # lwIP's memory management doesn't seem to work on non 32-bit platforms at the
 # moment.
-BOARD_BLACKLIST := arduino-uno arduino-duemilanove arduino-mega2560 chronos \
-                   esp8266-esp-12x esp8266-olimex-mod esp8266-sparkfun-thing \
-                   msb-430 msb-430h telosb waspmote-pro wsn430-v1_3b \
-                   wsn430-v1_4 z1 jiminy-mega256rfr2 mega-xplained
+BOARD_BLACKLIST := arduino-duemilanove arduino-mega2560 arduino-nano \
+                   arduino-uno chronos esp8266-esp-12x esp8266-olimex-mod \
+                   esp8266-sparkfun-thing jiminy-mega256rfr2 mega-xplained \
+                   msb-430 msb-430h telosb waspmote-pro \
+                   wsn430-v1_3b wsn430-v1_4 z1
 BOARD_INSUFFICIENT_MEMORY = blackpill bluepill nucleo-f031k6 nucleo-f042k6 \
                             nucleo-l031k6 nucleo-f030r8 nucleo-f302r8 \
                             nucleo-f303k8 nucleo-f334r8 nucleo-l053r8 \

--- a/tests/lwip_sock_udp/Makefile
+++ b/tests/lwip_sock_udp/Makefile
@@ -2,10 +2,11 @@ include ../Makefile.tests_common
 
 # lwIP's memory management doesn't seem to work on non 32-bit platforms at the
 # moment.
-BOARD_BLACKLIST := arduino-uno arduino-duemilanove arduino-mega2560 chronos \
-                   esp8266-esp-12x esp8266-olimex-mod esp8266-sparkfun-thing \
-                   msb-430 msb-430h telosb waspmote-pro wsn430-v1_3b \
-                   wsn430-v1_4 z1 jiminy-mega256rfr2 mega-xplained
+BOARD_BLACKLIST := arduino-duemilanove arduino-mega2560 arduino-nano \
+                   arduino-uno chronos esp8266-esp-12x esp8266-olimex-mod \
+                   esp8266-sparkfun-thing jiminy-mega256rfr2 mega-xplained \
+                   msb-430 msb-430h telosb waspmote-pro \
+                   wsn430-v1_3b wsn430-v1_4 z1
 BOARD_INSUFFICIENT_MEMORY = nucleo-f031k6 nucleo-f042k6 nucleo-l031k6 nucleo-f030r8 \
                             nucleo-f303k8 nucleo-f334r8 nucleo-l053r8 \
                             stm32f0discovery

--- a/tests/msg_send_receive/Makefile
+++ b/tests/msg_send_receive/Makefile
@@ -1,6 +1,7 @@
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno nucleo-f031k6
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-nano arduino-uno \
+                             nucleo-f031k6
 
 TEST_ON_CI_WHITELIST += all
 

--- a/tests/mutex_order/Makefile
+++ b/tests/mutex_order/Makefile
@@ -1,6 +1,6 @@
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno \
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-nano arduino-uno \
                              nucleo-f031k6 nucleo-f042k6 nucleo-l031k6 \
                              nucleo-f030r8 nucleo-l053r8 stm32f0discovery
 

--- a/tests/nanocoap_cli/Makefile
+++ b/tests/nanocoap_cli/Makefile
@@ -1,7 +1,8 @@
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-mega2560 arduino-uno \
-                             chronos mega-xplained msb-430 msb-430h nucleo-f030r8 \
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-mega2560 arduino-nano \
+                             arduino-uno chronos mega-xplained msb-430 \
+                             msb-430h nucleo-f030r8 \
                              nucleo-f031k6 nucleo-f042k6 nucleo-f303k8 \
                              nucleo-f334r8 nucleo-l031k6 nucleo-l053r8 \
                              stm32f0discovery telosb waspmote-pro z1

--- a/tests/netdev_test/Makefile
+++ b/tests/netdev_test/Makefile
@@ -4,7 +4,8 @@
 CFLAGS += -DNDEBUG
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno nucleo-f031k6
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-nano arduino-uno \
+                             nucleo-f031k6
 
 DISABLE_MODULE = auto_init
 

--- a/tests/nhdp/Makefile
+++ b/tests/nhdp/Makefile
@@ -1,8 +1,9 @@
 include ../Makefile.tests_common
 
-BOARD_BLACKLIST := arduino-mega2560 chronos msb-430 msb-430h telosb \
-                   wsn430-v1_3b wsn430-v1_4 z1 waspmote-pro arduino-uno \
-                   arduino-duemilanove jiminy-mega256rfr2 mega-xplained
+BOARD_BLACKLIST := arduino-duemilanove arduino-mega2560 arduino-nano \
+                   arduino-uno chronos jiminy-mega256rfr2 mega-xplained \
+                   msb-430 msb-430h telosb waspmote-pro \
+                   wsn430-v1_3b wsn430-v1_4 z1
 BOARD_INSUFFICIENT_MEMORY := nucleo-f031k6 nucleo-f042k6 nucleo-l031k6 nucleo-f030r8 \
                              nucleo-f303k8 nucleo-f334r8 nucleo-l053r8 \
                              stm32f0discovery

--- a/tests/periph_eeprom/Makefile
+++ b/tests/periph_eeprom/Makefile
@@ -3,7 +3,7 @@ include ../Makefile.tests_common
 
 FEATURES_REQUIRED += periph_eeprom
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-nano arduino-uno
 
 USEMODULE += shell
 USEMODULE += shell_commands  # provides reboot command

--- a/tests/periph_gpio/Makefile
+++ b/tests/periph_gpio/Makefile
@@ -1,6 +1,6 @@
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-nano arduino-uno
 
 FEATURES_REQUIRED = periph_gpio
 FEATURES_OPTIONAL = periph_gpio_irq

--- a/tests/periph_gpio_arduino/Makefile
+++ b/tests/periph_gpio_arduino/Makefile
@@ -1,6 +1,6 @@
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-nano arduino-uno
 
 FEATURES_REQUIRED = periph_gpio
 

--- a/tests/periph_i2c/Makefile
+++ b/tests/periph_i2c/Makefile
@@ -1,7 +1,7 @@
 BOARD ?= samr21-xpro
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-nano arduino-uno
 
 FEATURES_REQUIRED = periph_i2c
 

--- a/tests/periph_pwm/Makefile
+++ b/tests/periph_pwm/Makefile
@@ -1,7 +1,7 @@
 BOARD ?= samr21-xpro
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-nano arduino-uno
 
 FEATURES_REQUIRED = periph_pwm
 

--- a/tests/periph_spi/Makefile
+++ b/tests/periph_spi/Makefile
@@ -1,7 +1,7 @@
 BOARD ?= samr21-xpro
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-nano arduino-uno
 
 FEATURES_REQUIRED = periph_spi
 

--- a/tests/periph_timer/Makefile
+++ b/tests/periph_timer/Makefile
@@ -1,6 +1,6 @@
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-nano arduino-uno
 
 FEATURES_REQUIRED = periph_timer
 

--- a/tests/periph_uart/Makefile
+++ b/tests/periph_uart/Makefile
@@ -1,6 +1,7 @@
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno nucleo-f031k6
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-nano arduino-uno \
+                             nucleo-f031k6
 
 FEATURES_REQUIRED += periph_uart
 FEATURES_OPTIONAL += periph_lpuart  # STM32 L0 and L4 provides lpuart support

--- a/tests/pipe/Makefile
+++ b/tests/pipe/Makefile
@@ -2,7 +2,8 @@ include ../Makefile.tests_common
 
 #malloc.h not found
 BOARD_BLACKLIST := jiminy-mega256rfr2 mega-xplained
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno nucleo-f031k6
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-nano arduino-uno \
+                             nucleo-f031k6
 
 USEMODULE += pipe
 

--- a/tests/pkg_cn-cbor/Makefile
+++ b/tests/pkg_cn-cbor/Makefile
@@ -2,6 +2,7 @@ include ../Makefile.tests_common
 
 BOARD_BLACKLIST :=  arduino-duemilanove \
                     arduino-mega2560 \
+                    arduino-nano \
                     arduino-uno \
                     chronos \
                     jiminy-mega256rfr2 \

--- a/tests/pkg_fatfs/Makefile
+++ b/tests/pkg_fatfs/Makefile
@@ -2,7 +2,7 @@ include ../Makefile.tests_common
 
 BOARD ?= native
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-nano arduino-uno
 
 FEATURES_OPTIONAL += periph_rtc
 

--- a/tests/pkg_fatfs_vfs/Makefile
+++ b/tests/pkg_fatfs_vfs/Makefile
@@ -25,7 +25,7 @@ else
   USEMODULE += mtd_sdcard
 endif
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno \
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-nano arduino-uno \
                              msb-430 msb-430h nucleo-f031k6 telosb \
                              wsn430-v1_3b wsn430-v1_4 z1
 

--- a/tests/pkg_hacl/Makefile
+++ b/tests/pkg_hacl/Makefile
@@ -1,8 +1,9 @@
 include ../Makefile.tests_common
 
-BOARD_BLACKLIST := arduino-duemilanove arduino-mega2560 arduino-uno \
-                   jiminy-mega256rfr2 mega-xplained waspmote-pro \
-                   chronos msb-430 msb-430h telosb wsn430-v1_3b wsn430-v1_4 z1
+BOARD_BLACKLIST := arduino-duemilanove arduino-mega2560 arduino-nano \
+                   arduino-uno chronos jiminy-mega256rfr2 mega-xplained \
+                   msb-430 msb-430h telosb waspmote-pro wsn430-v1_3b \
+                   wsn430-v1_4 z1
 
 BOARD_INSUFFICIENT_MEMORY := nucleo-f031k6 nucleo-f042k6
 

--- a/tests/pkg_heatshrink/Makefile
+++ b/tests/pkg_heatshrink/Makefile
@@ -1,6 +1,7 @@
 include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove \
+                             arduino-nano \
                              arduino-uno \
                              nucleo-f031k6 \
                              #

--- a/tests/pkg_libb2/Makefile
+++ b/tests/pkg_libb2/Makefile
@@ -1,10 +1,10 @@
 include ../Makefile.tests_common
 
 # BLAKE2s + BLAKE2 is too big for these boards
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno chronos \
-                             mega-xplained msb-430 msb-430h nucleo-f031k6 \
-                             nucleo-f042k6 nucleo-l031k6 telosb waspmote-pro \
-                             wsn430-v1_3b wsn430-v1_4 z1
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-nano arduino-uno \
+                             chronos mega-xplained msb-430 msb-430h \
+                             nucleo-f031k6 nucleo-f042k6 nucleo-l031k6 telosb \
+                             waspmote-pro wsn430-v1_3b wsn430-v1_4 z1
 
 TEST_ON_CI_WHITELIST += all
 

--- a/tests/pkg_libcoap/Makefile
+++ b/tests/pkg_libcoap/Makefile
@@ -1,9 +1,9 @@
 include ../Makefile.tests_common
 
 # msp430 and avr have problems with int width and libcoaps usage of :x notation in structs
-BOARD_BLACKLIST := arduino-mega2560 chronos msb-430 msb-430h telosb wsn430-v1_3b \
-                   wsn430-v1_4 z1 waspmote-pro arduino-uno arduino-duemilanove \
-                   jiminy-mega256rfr2 mega-xplained
+BOARD_BLACKLIST := arduino-duemilanove arduino-mega2560 arduino-nano \
+                   arduino-uno chronos jiminy-mega256rfr2 mega-xplained msb-430 \
+                   msb-430h telosb waspmote-pro wsn430-v1_3b wsn430-v1_4 z1
 BOARD_INSUFFICIENT_MEMORY := chronos msb-430 msb-430h nucleo-f031k6 nucleo-f042k6 \
                              nucleo-l031k6 nucleo-f030r8 nucleo-f070rb \
                              nucleo-f303k8 nucleo-f334r8 nucleo-l053r8 \

--- a/tests/pkg_libcose/Makefile
+++ b/tests/pkg_libcose/Makefile
@@ -1,9 +1,10 @@
 include ../Makefile.tests_common
 
 # HACL* only compiles on 32bit platforms
-BOARD_BLACKLIST := arduino-duemilanove arduino-mega2560 arduino-uno \
-                   jiminy-mega256rfr2 mega-xplained waspmote-pro \
-                   chronos msb-430 msb-430h telosb wsn430-v1_3b wsn430-v1_4 z1
+BOARD_BLACKLIST := arduino-duemilanove arduino-mega2560 arduino-nano \
+                   arduino-uno chronos jiminy-mega256rfr2 mega-xplained \
+                   msb-430 msb-430h telosb waspmote-pro wsn430-v1_3b \
+                   wsn430-v1_4 z1
 
 BOARD_INSUFFICIENT_MEMORY := nucleo-f030r8 nucleo-f031k6 nucleo-f042k6 \
                              nucleo-l031k6 nucleo-l053r8 stm32f0discovery

--- a/tests/pkg_micro-ecc/Makefile
+++ b/tests/pkg_micro-ecc/Makefile
@@ -1,6 +1,6 @@
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-nano arduino-uno
 
 # micro-ecc is not 16 bit compatible
 BOARD_BLACKLIST = chronos msb-430 msb-430h telosb wsn430-v1_3b wsn430-v1_4 z1

--- a/tests/pkg_microcoap/Makefile
+++ b/tests/pkg_microcoap/Makefile
@@ -1,10 +1,10 @@
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-mega2560 arduino-uno \
-                             chronos msb-430 msb-430h nucleo-f031k6 \
-                             nucleo-f042k6 nucleo-f303k8 nucleo-l031k6 \
-                             nucleo-f030r8 nucleo-l053r8 stm32f0discovery \
-                             telosb waspmote-pro z1
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-mega2560 arduino-nano \
+                             arduino-uno chronos msb-430 msb-430h \
+                             nucleo-f031k6 nucleo-f042k6 nucleo-f303k8 \
+                             nucleo-l031k6 nucleo-f030r8 nucleo-l053r8 \
+                             stm32f0discovery telosb waspmote-pro z1
 
 # Include packages that pull up and auto-init the link layer.
 # NOTE: 6LoWPAN will be included if IEEE802.15.4 devices are present

--- a/tests/pkg_minmea/Makefile
+++ b/tests/pkg_minmea/Makefile
@@ -8,6 +8,7 @@ BOARD_BLACKLIST := chronos msb-430 msb-430h telosb wsn430-v1_3b wsn430-v1_4 z1
 # Incompatible due to non-standard ATmega time.h
 BOARD_BLACKLIST += arduino-duemilanove \
                    arduino-mega2560 \
+                   arduino-nano \
                    arduino-uno \
                    jiminy-mega256rfr2 \
                    mega-xplained \

--- a/tests/pkg_monocypher/Makefile
+++ b/tests/pkg_monocypher/Makefile
@@ -1,9 +1,10 @@
 include ../Makefile.tests_common
 
 # No 8 bit and 16 bit support
-BOARD_BLACKLIST := arduino-duemilanove arduino-mega2560 arduino-uno chronos \
-        jiminy-mega256rfr2 mega-xplained msb-430 msb-430h telosb \
-        waspmote-pro wsn430-v1_3b wsn430-v1_4 z1
+BOARD_BLACKLIST := arduino-duemilanove arduino-mega2560 arduino-nano \
+                   arduino-uno chronos jiminy-mega256rfr2 mega-xplained \
+                   msb-430 msb-430h telosb waspmote-pro wsn430-v1_3b \
+                   wsn430-v1_4 z1
 
 BOARD_INSUFFICIENT_MEMORY := nucleo-f031k6 nucleo-f042k6
 

--- a/tests/pkg_qdsa/Makefile
+++ b/tests/pkg_qdsa/Makefile
@@ -5,7 +5,8 @@ TEST_ON_CI_WHITELIST += all
 # qDSA is not 16 bit compatible
 BOARD_BLACKLIST := chronos msb-430 msb-430h telosb wsn430-v1_3b wsn430-v1_4 z1
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno nucleo-f031k6
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-nano arduino-uno \
+                             nucleo-f031k6
 
 CFLAGS += -DTHREAD_STACKSIZE_MAIN=\(4*THREAD_STACKSIZE_DEFAULT\)
 

--- a/tests/pkg_relic/Makefile
+++ b/tests/pkg_relic/Makefile
@@ -3,6 +3,7 @@ include ../Makefile.tests_common
 # The following boards are known to fail or have not been tested.
 BOARD_BLACKLIST :=  arduino-duemilanove \
                     arduino-mega2560 \
+                    arduino-nano \
                     arduino-uno \
                     chronos \
                     f4vi1 \

--- a/tests/pkg_semtech-loramac/Makefile
+++ b/tests/pkg_semtech-loramac/Makefile
@@ -2,7 +2,7 @@ BOARD ?= b-l072z-lrwan1
 
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno \
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-nano arduino-uno \
                              nucleo-f031k6 nucleo-f042k6 nucleo-l031k6
 
 BOARD_BLACKLIST := msb-430 msb-430h pic32-clicker pic32-wifire \

--- a/tests/pkg_tiny-asn1/Makefile
+++ b/tests/pkg_tiny-asn1/Makefile
@@ -1,6 +1,6 @@
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-nano arduino-uno
 
 BOARD_BLACKLIST := wsn430-v1_3b wsn430-v1_4
 

--- a/tests/pkg_tinycbor/Makefile
+++ b/tests/pkg_tinycbor/Makefile
@@ -1,11 +1,12 @@
 include ../Makefile.tests_common
 
 # No 8 bit and 16 bit support yet
-BOARD_BLACKLIST := arduino-duemilanove arduino-mega2560 arduino-uno chronos \
-	jiminy-mega256rfr2 mega-xplained msb-430 msb-430h telosb \
-	waspmote-pro wsn430-v1_3b wsn430-v1_4 z1 \
-    esp32-mh-et-live-minikit esp32-olimex-evb esp32-wemos-lolin-d32-pro \
-    esp32-wroom-32 esp32-wrover-kit
+BOARD_BLACKLIST := arduino-duemilanove arduino-mega2560 arduino-nano \
+                   arduino-uno chronos esp32-mh-et-live-minikit \
+                   esp32-olimex-evb esp32-wemos-lolin-d32-pro \
+                   esp32-wroom-32 esp32-wrover-kit jiminy-mega256rfr2 \
+                   mega-xplained msb-430 msb-430h telosb waspmote-pro \
+                   wsn430-v1_3b wsn430-v1_4 z1 \
 
 USEMODULE += embunit
 USEMODULE += fmt

--- a/tests/pkg_tweetnacl/Makefile
+++ b/tests/pkg_tweetnacl/Makefile
@@ -3,6 +3,7 @@ include ../Makefile.tests_common
 BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove \
                              arduino-uno \
                              arduino-mega2560 \
+                             arduino-nano \
                              mega-xplained \
                              nucleo-f031k6 \
                              nucleo-f042k6 \

--- a/tests/pkg_u8g2/Makefile
+++ b/tests/pkg_u8g2/Makefile
@@ -1,6 +1,6 @@
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno \
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-nano arduino-uno \
                              chronos msb-430 msb-430h nucleo-f031k6 telosb \
                              wsn430-v1_3b wsn430-v1_4 z1
 

--- a/tests/pkg_ucglib/Makefile
+++ b/tests/pkg_ucglib/Makefile
@@ -1,7 +1,7 @@
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-mega2560 arduino-uno \
-                             waspmote-pro
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-mega2560 arduino-nano \
+                             arduino-uno waspmote-pro
 
 USEMODULE += xtimer
 

--- a/tests/posix_semaphore/Makefile
+++ b/tests/posix_semaphore/Makefile
@@ -1,6 +1,6 @@
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno \
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-nano arduino-uno \
                              chronos mbed_lpc1768 msb-430 msb-430h nrf6310 \
                              nucleo-f031k6 nucleo-f042k6 nucleo-l031k6 \
                              nucleo-f030r8 nucleo-f303k8 nucleo-f334r8 \

--- a/tests/ps_schedstatistics/Makefile
+++ b/tests/ps_schedstatistics/Makefile
@@ -1,6 +1,6 @@
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno \
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-nano arduino-uno \
                              chronos msb-430 msb-430h nucleo-f030r8 \
                              nucleo-l053r8 nucleo-f031k6 nucleo-f042k6 \
                              nucleo-l031k6 stm32f0discovery telosb \

--- a/tests/pthread/Makefile
+++ b/tests/pthread/Makefile
@@ -1,7 +1,7 @@
 include ../Makefile.tests_common
 
-BOARD_BLACKLIST := arduino-mega2560 waspmote-pro arduino-uno arduino-duemilanove \
-                   jiminy-mega256rfr2 mega-xplained
+BOARD_BLACKLIST := arduino-duemilanove arduino-mega2560 arduino-nano \
+                   arduino-uno jiminy-mega256rfr2 mega-xplained waspmote-pro
 # arduino mega2560 uno duemilanove : unknown type name: clockid_t
 # jiminy-mega256rfr2: unknown type name: clockid_t
 # mega-xplained: unknown type name: clockid_t

--- a/tests/pthread_barrier/Makefile
+++ b/tests/pthread_barrier/Makefile
@@ -1,7 +1,7 @@
 include ../Makefile.tests_common
 
-BOARD_BLACKLIST := arduino-mega2560 waspmote-pro arduino-uno arduino-duemilanove \
-                   jiminy-mega256rfr2 mega-xplained
+BOARD_BLACKLIST := arduino-duemilanove arduino-mega2560 arduino-nano \
+                   arduino-uno jiminy-mega256rfr2 mega-xplained waspmote-pro
 # arduino mega2560 uno duemilanove : unknown type name: clockid_t
 # jiminy-mega256rfr2: unknown type name: clockid_t
 # mega-xplained: unknown type name: clockid_t

--- a/tests/pthread_cleanup/Makefile
+++ b/tests/pthread_cleanup/Makefile
@@ -1,7 +1,7 @@
 include ../Makefile.tests_common
 
-BOARD_BLACKLIST := arduino-mega2560 waspmote-pro arduino-uno arduino-duemilanove \
-                   jiminy-mega256rfr2 mega-xplained
+BOARD_BLACKLIST := arduino-duemilanove arduino-mega2560 arduino-nano \
+                   arduino-uno jiminy-mega256rfr2 mega-xplained waspmote-pro
 # arduino mega2560 uno duemilanove : unknown type name: clockid_t
 # jiminy-mega256rfr2: unknown type name: clockid_t
 # mega-xplained: unknown type name: clockid_t

--- a/tests/pthread_condition_variable/Makefile
+++ b/tests/pthread_condition_variable/Makefile
@@ -1,7 +1,7 @@
 include ../Makefile.tests_common
 
-BOARD_BLACKLIST := arduino-mega2560 waspmote-pro arduino-uno arduino-duemilanove \
-                   jiminy-mega256rfr2 mega-xplained
+BOARD_BLACKLIST := arduino-duemilanove arduino-mega2560 arduino-nano \
+                   arduino-uno jiminy-mega256rfr2 mega-xplained waspmote-pro
 # arduino mega2560 uno duemilanove : unknown type name: clockid_t
 # jiminy-mega256rfr2: unknown type name: clockid_t
 # mega-xplained: unknown type name: clockid_t

--- a/tests/pthread_cooperation/Makefile
+++ b/tests/pthread_cooperation/Makefile
@@ -1,7 +1,7 @@
 include ../Makefile.tests_common
 
-BOARD_BLACKLIST := arduino-mega2560 waspmote-pro arduino-uno arduino-duemilanove \
-                   jiminy-mega256rfr2 mega-xplained
+BOARD_BLACKLIST := arduino-duemilanove arduino-mega2560 arduino-nano \
+                   arduino-uno jiminy-mega256rfr2 mega-xplained waspmote-pro
 # arduino mega2560 uno duemilanove : unknown type name: clockid_t
 # jiminy-mega256rfr2: unknown type name: clockid_t
 # mega-xplained: unknown type name: clockid_t

--- a/tests/pthread_rwlock/Makefile
+++ b/tests/pthread_rwlock/Makefile
@@ -1,7 +1,7 @@
 include ../Makefile.tests_common
 
-BOARD_BLACKLIST := arduino-mega2560 waspmote-pro arduino-uno arduino-duemilanove \
-                   jiminy-mega256rfr2 mega-xplained
+BOARD_BLACKLIST := arduino-duemilanove arduino-mega2560 arduino-nano \
+                   arduino-uno jiminy-mega256rfr2 mega-xplained waspmote-pro
 # arduino mega2560 uno duemilanove : unknown type name: clockid_t
 # jiminy-mega256rfr2: unknown type name: clockid_t
 # mega-xplained: unknown type name: clockid_t

--- a/tests/pthread_tls/Makefile
+++ b/tests/pthread_tls/Makefile
@@ -1,7 +1,7 @@
 include ../Makefile.tests_common
 
-BOARD_BLACKLIST := arduino-mega2560 waspmote-pro arduino-uno arduino-duemilanove \
-                   jiminy-mega256rfr2 mega-xplained
+BOARD_BLACKLIST := arduino-duemilanove arduino-mega2560 arduino-nano \
+                   arduino-uno jiminy-mega256rfr2 mega-xplained waspmote-pro
 # arduino mega2560 uno duemilanove : unknown type name: clockid_t
 # jiminy-mega256rfr2: unknown type name: clockid_t
 # mega-xplained: unknown type name: clockid_t

--- a/tests/rmutex/Makefile
+++ b/tests/rmutex/Makefile
@@ -1,6 +1,6 @@
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno \
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-nano arduino-uno \
                              nucleo-f031k6 nucleo-f042k6 nucleo-l031k6 \
                              nucleo-f030r8 nucleo-l053r8 stm32f0discovery
 

--- a/tests/rng/Makefile
+++ b/tests/rng/Makefile
@@ -2,7 +2,7 @@ include ../Makefile.tests_common
 
 # some boards have not enough rom and/or ram
 BOARD_BLACKLIST += nucleo-f031k6 nucleo-f042k6 nucleo-l031k6 pic32-clicker
-BOARD_INSUFFICIENT_MEMORY += arduino-duemilanove arduino-uno
+BOARD_INSUFFICIENT_MEMORY += arduino-duemilanove arduino-nano arduino-uno
 
 # override PRNG if desired (see sys/random for alternatives)
 # USEMODULE += prng_minstd

--- a/tests/saul/Makefile
+++ b/tests/saul/Makefile
@@ -6,6 +6,6 @@ USEMODULE += saul_default
 USEMODULE += xtimer
 
 # Too little flash:
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-nano arduino-uno
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/sched_testing/Makefile
+++ b/tests/sched_testing/Makefile
@@ -1,6 +1,7 @@
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno nucleo-f031k6
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-nano arduino-uno \
+                             nucleo-f031k6
 
 TEST_ON_CI_WHITELIST += all
 

--- a/tests/shell/Makefile
+++ b/tests/shell/Makefile
@@ -12,6 +12,7 @@ DISABLE_MODULE += auto_init
 BOARD_BLACKLIST += chronos
 
 BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove \
+                             arduino-nano \
                              arduino-uno
 
 TEST_ON_CI_WHITELIST += all

--- a/tests/slip/Makefile
+++ b/tests/slip/Makefile
@@ -1,10 +1,10 @@
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-mega2560 arduino-uno \
-                             msb-430 msb-430h nucleo-f031k6 nucleo-f042k6 \
-                             nucleo-l031k6 nucleo-f030r8 nucleo-f303k8 \
-                             nucleo-f334r8 nucleo-l053r8 stm32f0discovery \
-                             waspmote-pro
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-mega2560 arduino-nano \
+                             arduino-uno msb-430 msb-430h nucleo-f031k6 \
+                             nucleo-f042k6 nucleo-l031k6 nucleo-f030r8 \
+                             nucleo-f303k8 nucleo-f334r8 nucleo-l053r8 \
+                             stm32f0discovery waspmote-pro
 
 BOARD_BLACKLIST += mips-malta
 

--- a/tests/sntp/Makefile
+++ b/tests/sntp/Makefile
@@ -1,11 +1,11 @@
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-mega2560 arduino-uno \
-                             chronos msb-430 msb-430h nucleo-f031k6 \
-                             nucleo-f042k6 nucleo-l031k6 nucleo-f030r8 \
-                             nucleo-f303k8 nucleo-f334r8 nucleo-l053r8 \
-                             stm32f0discovery telosb waspmote-pro \
-                             wsn430-v1_3b wsn430-v1_4 z1
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-mega2560 arduino-nano \
+                             arduino-uno chronos msb-430 msb-430h \
+                             nucleo-f031k6 nucleo-f042k6 nucleo-l031k6 \
+                             nucleo-f030r8 nucleo-f303k8 nucleo-f334r8 \
+                             nucleo-l053r8 stm32f0discovery telosb \
+                             waspmote-pro wsn430-v1_3b wsn430-v1_4 z1
 
 USEMODULE += sntp
 USEMODULE += gnrc_sock_udp

--- a/tests/ssp/Makefile
+++ b/tests/ssp/Makefile
@@ -1,10 +1,11 @@
 include ../Makefile.tests_common
 
 # avr8, msp430, esp8266 and mips don't support ssp (yet)
-BOARD_BLACKLIST := arduino-mega2560 waspmote-pro arduino-uno arduino-duemilanove \
-                   chronos msb-430 msb-430h telosb wsn430-v1_3b wsn430-v1_4 z1 \
-                   pic32-clicker pic32-wifire jiminy-mega256rfr2 mega-xplained \
-                   esp8266-esp-12x esp8266-olimex-mod esp8266-sparkfun-thing
+BOARD_BLACKLIST := arduino-duemilanove arduino-mega2560 arduino-nano \
+                   arduino-uno chronos esp8266-esp-12x esp8266-olimex-mod \
+                   esp8266-sparkfun-thing jiminy-mega256rfr2 mega-xplained \
+                   msb-430 msb-430h pic32-clicker pic32-wifire telosb \
+                   waspmote-pro wsn430-v1_3b wsn430-v1_4 z1
 
 USEMODULE += ssp
 

--- a/tests/struct_tm_utility/Makefile
+++ b/tests/struct_tm_utility/Makefile
@@ -2,7 +2,7 @@ include ../Makefile.tests_common
 
 DISABLE_MODULE += auto_init
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-nano arduino-uno
 
 USEMODULE += shell
 USEMODULE += timex

--- a/tests/thread_cooperation/Makefile
+++ b/tests/thread_cooperation/Makefile
@@ -1,6 +1,6 @@
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno \
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-nano arduino-uno \
                              chronos msb-430 msb-430h nucleo-f031k6 \
                              nucleo-f303k8
 

--- a/tests/thread_exit/Makefile
+++ b/tests/thread_exit/Makefile
@@ -1,6 +1,7 @@
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno nucleo-f031k6
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-nano arduino-uno \
+                             nucleo-f031k6
 
 DISABLE_MODULE += auto_init
 

--- a/tests/thread_flags/Makefile
+++ b/tests/thread_flags/Makefile
@@ -1,6 +1,7 @@
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno nucleo-f031k6
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-nano arduino-uno \
+                             nucleo-f031k6
 
 USEMODULE += core_thread_flags
 USEMODULE += xtimer

--- a/tests/thread_float/Makefile
+++ b/tests/thread_float/Makefile
@@ -2,9 +2,9 @@ APPLICATION = thread_float
 include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_MEMORY := airfy-beacon arduino-uno arduino-duemilanove \
-			     alliope-mini cc2650stk chronos maple-mini \
-                             mbed_lpc1768 microbit msb-430 msb-430h nrf51dongle \
-                             nrf6310 nucleo-f031k6 nucleo-f042k6 \
+                             arduino-nano alliope-mini cc2650stk chronos \
+                             maple-mini mbed_lpc1768 microbit msb-430 msb-430h \
+                             nrf51dongle nrf6310 nucleo-f031k6 nucleo-f042k6 \
                              opencm9-04 pca10000 pca10005 spark-core \
                              stm32f0discovery weio yunjia-nrf51822
 

--- a/tests/thread_msg/Makefile
+++ b/tests/thread_msg/Makefile
@@ -1,6 +1,6 @@
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno \
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-nano arduino-uno \
                              nucleo-f031k6 nucleo-f042k6
 
 DISABLE_MODULE += auto_init

--- a/tests/thread_msg_seq/Makefile
+++ b/tests/thread_msg_seq/Makefile
@@ -1,6 +1,6 @@
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno \
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-nano arduino-uno \
                              nucleo-f031k6 nucleo-f042k6
 
 DISABLE_MODULE += auto_init

--- a/tests/thread_priority_inversion/Makefile
+++ b/tests/thread_priority_inversion/Makefile
@@ -3,6 +3,7 @@ include ../Makefile.tests_common
 
 USEMODULE += xtimer
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno nucleo-f031k6
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-nano arduino-uno \
+                             nucleo-f031k6
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/thread_race/Makefile
+++ b/tests/thread_race/Makefile
@@ -2,7 +2,7 @@ include ../Makefile.tests_common
 
 DISABLE_MODULE += auto_init
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-nano arduino-uno
 
 TEST_ON_CI_WHITELIST += all
 

--- a/tests/unittests/Makefile
+++ b/tests/unittests/Makefile
@@ -7,6 +7,7 @@ BOARD_INSUFFICIENT_MEMORY := airfy-beacon \
                              arduino-mkr1000 \
                              arduino-mkrfox1200 \
                              arduino-mkrzero \
+                             arduino-nano \
                              arduino-uno \
                              arduino-zero \
                              avsextrem \

--- a/tests/xtimer_drift/Makefile
+++ b/tests/xtimer_drift/Makefile
@@ -1,6 +1,6 @@
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno \
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-nano arduino-uno \
                              nucleo-f031k6 nucleo-f042k6
 
 USEMODULE += xtimer

--- a/tests/xtimer_hang/Makefile
+++ b/tests/xtimer_hang/Makefile
@@ -1,6 +1,7 @@
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno nucleo-f031k6
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-nano arduino-uno \
+                             nucleo-f031k6
 
 USEMODULE += xtimer
 

--- a/tests/xtimer_longterm/Makefile
+++ b/tests/xtimer_longterm/Makefile
@@ -1,6 +1,6 @@
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno \
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-nano arduino-uno \
                              nucleo-f031k6 nucleo-f042k6
 
 USEMODULE += xtimer

--- a/tests/xtimer_msg/Makefile
+++ b/tests/xtimer_msg/Makefile
@@ -1,6 +1,7 @@
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno nucleo-f031k6
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-nano arduino-uno \
+                             nucleo-f031k6
 
 USEMODULE += xtimer
 

--- a/tests/xtimer_periodic_wakeup/Makefile
+++ b/tests/xtimer_periodic_wakeup/Makefile
@@ -1,6 +1,7 @@
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno chronos
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-nano  arduino-uno \
+                             chronos
 
 USEMODULE += xtimer
 


### PR DESCRIPTION
### Contribution description

This PR adds support for the Arduino Nano. The Arduino Nano board is the cheapest member of the Arduino family and used the same MCU as the Arduino Uno. It differs in the form factor (the Nano is much smaller), it uses an integrated FT232RL TTL adapter instead of an ATmega16u2 to provide access to the serial console via USB, and it uses a different bootloader (which occupies 2 KiB of the 32 KiB flash instead of 0.5 KiB occupied on the Arduino Uno). This commit mostly copy pastes code from the Arduino Uno.  

### Testing procedure

- Check the provided documentation
- Check if `make BOARD=arduino-nano flash` and `make BOARD=arduino-nano term` works for `examples/hello-world` 

As this shares most code with the Arduino UNO, no huge troubles are expected.

### Issues/PRs references

None