### PR TITLE
cpu/nrf5x_common: add PUF SRAM feature to makefile

### DIFF
--- a/cpu/nrf5x_common/Makefile.features
+++ b/cpu/nrf5x_common/Makefile.features
@@ -5,5 +5,6 @@ FEATURES_PROVIDED += periph_hwrng
 
 # Various other features (if any)
 FEATURES_PROVIDED += radio_nrfmin
+FEATURES_PROVIDED += puf_sram
 
 -include $(RIOTCPU)/cortexm_common/Makefile.features


### PR DESCRIPTION
### Contribution description
This PR adds the `puf_sram` (PRNG seeder) feature to NRF5x based boards. I'm brave and include it in the common folder. Tests ran on:

**nrf52840dk**
```
Number of seeds: 500       
Seed length    : 32 Bit   
Abs. Entropy   : 30.48 Bit   
Rel. Entropy   : 95.25 perc. 
```
**yunjia-nrf51822**
```
Number of seeds: 500       
Seed length    : 32 Bit   
Abs. Entropy   : 30.43 Bit   
Rel. Entropy   : 95.10 perc. 
```
### Issues/PRs references
#9290