### PR TITLE
dist/tools: update EDBG version

### DIFF
--- a/dist/tools/edbg/Makefile
+++ b/dist/tools/edbg/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME=edbg
 PKG_URL=https://github.com/ataradov/edbg
-PKG_VERSION=76f85abdea212ba23760723cce15e00ca4ae4b76
+PKG_VERSION=a59b16ea18ea095135362035dcfd990ca1dd3af2
 PKG_LICENSE=BSD-3-Clause
 PKG_BUILDDIR=$(CURDIR)/bin
 

--- a/makefiles/tools/targets.inc.mk
+++ b/makefiles/tools/targets.inc.mk
@@ -12,7 +12,7 @@ $(RIOTTOOLS)/bossa/bossac:
 	@make -C $(RIOTTOOLS)/bossa
 	@echo "[INFO] bossac binary successfully build!"
 
-$(RIOTTOOLS)/edbg/edbg:
+$(RIOTTOOLS)/edbg/edbg: $(RIOTTOOLS)/edbg/Makefile
 	@echo "[INFO] edbg binary not found - building it from source now"
 	CC= CFLAGS= make -C $(RIOTTOOLS)/edbg
 	@echo "[INFO] edbg binary successfully build!"


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR updates EDBG version of RIOT to the lastest.
I had a lot of troubles when playing with low power modes or DPLL/DFLL on SAM0 based board. Most of the time, the board was stuck in a unrecoverable state for EDBG and I had to erase the flash using Atmel Studio (switch back to windows to unbrick the board...)
The lastest version of EDBG get rid of this problem as I can now erase/reflash the board in all situations. No need to use Atmel Studio anymore to unbrick a board !
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->