### PR TITLE
cpu/stm32_common: add PUF SRAM feature to makefile

### DIFF
--- a/cpu/stm32_common/Makefile.features
+++ b/cpu/stm32_common/Makefile.features
@@ -1,4 +1,5 @@
 FEATURES_PROVIDED += periph_cpuid
+FEATURES_PROVIDED += puf_sram
 
 ifneq (,$(filter $(BOARDS_WITHOUT_HWRNG),$(BOARD)))
   FEATURES_PROVIDED := $(filter-out periph_hwrng,$(FEATURES_PROVIDED))

--- a/cpu/stm32f4/Makefile.features
+++ b/cpu/stm32f4/Makefile.features
@@ -1,5 +1,4 @@
 FEATURES_PROVIDED += periph_hwrng
-FEATURES_PROVIDED += puf_sram
 
 # the granularity of provided feature definition for STMs is currently by CPU
 # sub-family (e.g., stm32f[1234]).  Unfortunately, only some of e.g., the


### PR DESCRIPTION
### Contribution description
Similar to #9500 this PR adds the `puf_sram` (PRNG seeder) feature to all STM32 based boards. Tests ran on following platforms. Unfortunately I'm missing STM32F2 ~and STM32F7~ which is why I set the WIP label.

```
STM32F7 - nucleo-f767zi:
Number of seeds: 500       
Seed length    : 32 Bit   
Abs. Entropy   : 30.33 Bit   
Rel. Entropy   : 94.79 perc. 

STM32F4 - stm32f4discovery:
Number of seeds: 500       
Seed length    : 32 Bit   
Abs. Entropy   : 30.45 Bit   
Rel. Entropy   : 95.16 perc. 

STM32F3 - stm32f3discovery:
Number of seeds: 500       
Seed length    : 32 Bit   
Abs. Entropy   : 30.40 Bit   
Rel. Entropy   : 94.99 perc. 

STM32F2 - nucleo-f207zg:
Number of seeds: 500       
Seed length    : 32 Bit   
Abs. Entropy   : 30.59 Bit   
Rel. Entropy   : 95.58 perc. 

STM32F1 - nucleo-f103rb:
Number of seeds: 500       
Seed length    : 32 Bit   
Abs. Entropy   : 30.43 Bit   
Rel. Entropy   : 95.10 perc. 

STM32F0 - nucleo-f030r8:
(note that I needed to use the FET as low-side switch here in order to get fresh 
SRAM patterns whereas I used a high-side switch in the other cases*)
Number of seeds: 500       
Seed length    : 32 Bit   
Abs. Entropy   : 30.29 Bit   
Rel. Entropy   : 94.65 perc. 

STM32L0 - nucleo-l073rz:
Number of seeds: 500       
Seed length    : 32 Bit   
Abs. Entropy   : 30.34 Bit   
Rel. Entropy   : 94.82 perc. 

STM32L1 - nucleo-l152re:
Number of seeds: 500       
Seed length    : 32 Bit   
Abs. Entropy   : 29.91 Bit   
Rel. Entropy   : 93.47 perc. 

STM32L4 - nucleo-l476rg:
Number of seeds: 500       
Seed length    : 32 Bit   
Abs. Entropy   : 30.53 Bit   
Rel. Entropy   : 95.40 perc. 
```
### Issues/PRs references
#9290, #9500