### PR TITLE
Uncrustify: ternary operator indentation

### DIFF
--- a/uncrustify-riot.cfg
+++ b/uncrustify-riot.cfg
@@ -1,9 +1,10 @@
-indent_with_tabs   = 0                 # 1=indent to level only, 2=indent with tabs
-input_tab_size     = 4                 # original tab size
-output_tab_size    = 4                 # new tab size
-indent_columns     = output_tab_size   #
-indent_label       = 1                 # pos: absolute col, neg: relative column
-indent_switch_case = 4                 # number
+indent_with_tabs        = 0                 # 1=indent to level only, 2=indent with tabs
+input_tab_size          = 4                 # original tab size
+output_tab_size         = 4                 # new tab size
+indent_columns          = output_tab_size   #
+indent_label            = 1                 # pos: absolute col, neg: relative column
+indent_switch_case      = 4                 # number
+indent_ternary_operator = 2                 # When the `:` is a continuation, indent it under `?`
 
 #
 # inter-symbol newlines


### PR DESCRIPTION
When the `:` is a continuation, indent it under `?`

When using uncrustify now the result looks like this:
```
            tmp = (state) ? (tmp |  AT86RF2XX_CSMA_SEED_1__AACK_DIS_ACK)
                  : (tmp & ~AT86RF2XX_CSMA_SEED_1__AACK_DIS_ACK);
```

with this PR
```
            tmp = (state) ? (tmp |  AT86RF2XX_CSMA_SEED_1__AACK_DIS_ACK)
                          : (tmp & ~AT86RF2XX_CSMA_SEED_1__AACK_DIS_ACK);
```