### PR TITLE
tests/*: memory blacklisting for new Docker image

### DIFF
--- a/tests/pkg_fatfs_vfs/Makefile
+++ b/tests/pkg_fatfs_vfs/Makefile
@@ -25,14 +25,15 @@ else
   USEMODULE += mtd_sdcard
 endif
 
-BOARD_INSUFFICIENT_MEMORY := nucleo-f031k6
+BOARD_INSUFFICIENT_MEMORY := msb-430 msb-430h nucleo-f031k6 telosb \
+                             wsn430-v1_3b wsn430-v1_4 z1
 
 # this list is composed of boards with sufficient memory and support spi/gpio + native
 BOARD_WHITELIST := airfy-beacon arduino-due arduino-duemilanove arduino-mega2560 \
                    arduino-mkr1000 arduino-mkrzero arduino-uno arduino-zero avsextrem \
                    b-l072z-lrwan1 b-l475e-iot01a bluepill cc2538dk ek-lm4f120xl \
                    feather-m0 fox frdm-k22f frdm-k64f ikea-tradfri iotlab-a8-m3 \
-                   iotlab-m3 limifrog-v1 maple-mini msb-430 msb-430h msba2 msbiot \
+                   iotlab-m3 limifrog-v1 maple-mini msba2 msbiot \
                    mulle nrf52840dk nrf52dk nrf6310 nucleo-f207zg nucleo-f303ze \
                    nucleo-f412zg nucleo-f413zh nucleo-f429zi nucleo-f446ze \
                    nucleo-f042k6 nucleo-f303k8 nucleo-l031k6 \
@@ -42,8 +43,8 @@ BOARD_WHITELIST := airfy-beacon arduino-due arduino-duemilanove arduino-mega2560
                    nz32-sc151 openmote-cc2538 pba-d-01-kw2x remote-pa remote-reva \
                    remote-revb samd21-xpro saml21-xpro samr21-xpro sltb001a \
                    sodaq-autonomo sodaq-explorer spark-core stm32f0discovery \
-                   stm32f3discovery stm32f4discovery telosb udoo waspmote-pro \
-                   wsn430-v1_3b wsn430-v1_4 yunjia-nrf51822 z1 native
+                   stm32f3discovery stm32f4discovery udoo waspmote-pro \
+                   yunjia-nrf51822 native
 
 include $(RIOTBASE)/Makefile.include
 

--- a/tests/pkg_u8g2/Makefile
+++ b/tests/pkg_u8g2/Makefile
@@ -1,6 +1,7 @@
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := nucleo-f031k6
+BOARD_INSUFFICIENT_MEMORY := chronos msb-430 msb-430h nucleo-f031k6 telosb \
+                             wsn430-v1_3b wsn430-v1_4 z1
 
 USEMODULE += xtimer
 


### PR DESCRIPTION
### Contribution description
This adds boards to ```BOARD_INSUFFICIENT_MEMORY``` for tests that failed due to memory errors on the new Docker image.

### Issues/PRs references
https://github.com/RIOT-OS/riotdocker/pull/42
#9405