### PR TITLE
at86rf2xx: uncrustify and changed parenthesis order of NETOPT_CSMA_RETRIES check

### DIFF
--- a/drivers/at86rf2xx/at86rf2xx.c
+++ b/drivers/at86rf2xx/at86rf2xx.c
@@ -179,6 +179,7 @@ bool at86rf2xx_cca(at86rf2xx_t *dev)
     uint8_t old_state = at86rf2xx_set_state(dev, AT86RF2XX_STATE_TRX_OFF);
     /* Disable RX path */
     uint8_t rx_syn = at86rf2xx_reg_read(dev, AT86RF2XX_REG__RX_SYN);
+
     reg = rx_syn | AT86RF2XX_RX_SYN__RX_PDT_DIS;
     at86rf2xx_reg_write(dev, AT86RF2XX_REG__RX_SYN, reg);
     /* Manually triggered CCA is only possible in RX_ON (basic operating mode) */

--- a/drivers/at86rf2xx/at86rf2xx_getset.c
+++ b/drivers/at86rf2xx/at86rf2xx_getset.c
@@ -35,20 +35,20 @@
 #ifdef MODULE_AT86RF212B
 /* See: Table 9-15. Recommended Mapping of TX Power, Frequency Band, and
  * PHY_TX_PWR (register 0x05), AT86RF212B data sheet. */
-static const uint8_t dbm_to_tx_pow_868[] = {0x1d, 0x1c, 0x1b, 0x1a, 0x19, 0x18,
-                                            0x17, 0x15, 0x14, 0x13, 0x12, 0x11,
-                                            0x10, 0x0f, 0x31, 0x30, 0x2f, 0x94,
-                                            0x93, 0x91, 0x90, 0x29, 0x49, 0x48,
-                                            0x47, 0xad, 0xcd, 0xcc, 0xcb, 0xea,
-                                            0xe9, 0xe8, 0xe7, 0xe6, 0xe4, 0x80,
-                                            0xa0};
-static const uint8_t dbm_to_tx_pow_915[] = {0x1d, 0x1c, 0x1b, 0x1a, 0x19, 0x17,
-                                            0x16, 0x15, 0x14, 0x13, 0x12, 0x11,
-                                            0x10, 0x0f, 0x0e, 0x0d, 0x0c, 0x0b,
-                                            0x09, 0x91, 0x08, 0x07, 0x05, 0x27,
-                                            0x04, 0x03, 0x02, 0x01, 0x00, 0x86,
-                                            0x40, 0x84, 0x83, 0x82, 0x80, 0xc1,
-                                            0xc0};
+static const uint8_t dbm_to_tx_pow_868[] = { 0x1d, 0x1c, 0x1b, 0x1a, 0x19, 0x18,
+                                             0x17, 0x15, 0x14, 0x13, 0x12, 0x11,
+                                             0x10, 0x0f, 0x31, 0x30, 0x2f, 0x94,
+                                             0x93, 0x91, 0x90, 0x29, 0x49, 0x48,
+                                             0x47, 0xad, 0xcd, 0xcc, 0xcb, 0xea,
+                                             0xe9, 0xe8, 0xe7, 0xe6, 0xe4, 0x80,
+                                             0xa0 };
+static const uint8_t dbm_to_tx_pow_915[] = { 0x1d, 0x1c, 0x1b, 0x1a, 0x19, 0x17,
+                                             0x16, 0x15, 0x14, 0x13, 0x12, 0x11,
+                                             0x10, 0x0f, 0x0e, 0x0d, 0x0c, 0x0b,
+                                             0x09, 0x91, 0x08, 0x07, 0x05, 0x27,
+                                             0x04, 0x03, 0x02, 0x01, 0x00, 0x86,
+                                             0x40, 0x84, 0x83, 0x82, 0x80, 0xc1,
+                                             0xc0 };
 
 static int16_t _tx_pow_to_dbm_212b(uint8_t channel, uint8_t page, uint8_t reg)
 {
@@ -78,19 +78,19 @@ static int16_t _tx_pow_to_dbm_212b(uint8_t channel, uint8_t page, uint8_t reg)
 }
 
 #elif MODULE_AT86RF233
-static const int16_t tx_pow_to_dbm[] = {4, 4, 3, 3, 2, 2, 1,
-                                        0, -1, -2, -3, -4, -6, -8, -12, -17};
-static const uint8_t dbm_to_tx_pow[] = {0x0f, 0x0f, 0x0f, 0x0e, 0x0e, 0x0e,
-                                        0x0e, 0x0d, 0x0d, 0x0d, 0x0c, 0x0c,
-                                        0x0b, 0x0b, 0x0a, 0x09, 0x08, 0x07,
-                                        0x06, 0x05, 0x03,0x00};
+static const int16_t tx_pow_to_dbm[] = { 4, 4, 3, 3, 2, 2, 1,
+                                         0, -1, -2, -3, -4, -6, -8, -12, -17 };
+static const uint8_t dbm_to_tx_pow[] = { 0x0f, 0x0f, 0x0f, 0x0e, 0x0e, 0x0e,
+                                         0x0e, 0x0d, 0x0d, 0x0d, 0x0c, 0x0c,
+                                         0x0b, 0x0b, 0x0a, 0x09, 0x08, 0x07,
+                                         0x06, 0x05, 0x03, 0x00 };
 #else
-static const int16_t tx_pow_to_dbm[] = {3, 3, 2, 2, 1, 1, 0,
-                                        -1, -2, -3, -4, -5, -7, -9, -12, -17};
-static const uint8_t dbm_to_tx_pow[] = {0x0f, 0x0f, 0x0f, 0x0e, 0x0e, 0x0e,
-                                        0x0e, 0x0d, 0x0d, 0x0c, 0x0c, 0x0b,
-                                        0x0b, 0x0a, 0x09, 0x08, 0x07, 0x06,
-                                        0x05, 0x03, 0x00};
+static const int16_t tx_pow_to_dbm[] = { 3, 3, 2, 2, 1, 1, 0,
+                                         -1, -2, -3, -4, -5, -7, -9, -12, -17 };
+static const uint8_t dbm_to_tx_pow[] = { 0x0f, 0x0f, 0x0f, 0x0e, 0x0e, 0x0e,
+                                         0x0e, 0x0d, 0x0d, 0x0c, 0x0c, 0x0b,
+                                         0x0b, 0x0a, 0x09, 0x08, 0x07, 0x06,
+                                         0x05, 0x03, 0x00 };
 #endif
 
 uint16_t at86rf2xx_get_addr_short(const at86rf2xx_t *dev)
@@ -117,6 +117,7 @@ uint64_t at86rf2xx_get_addr_long(const at86rf2xx_t *dev)
 {
     uint64_t addr;
     uint8_t *ap = (uint8_t *)(&addr);
+
     for (int i = 0; i < 8; i++) {
         ap[i] = dev->netdev.long_addr[i];
     }
@@ -183,6 +184,7 @@ uint16_t at86rf2xx_get_pan(const at86rf2xx_t *dev)
 void at86rf2xx_set_pan(at86rf2xx_t *dev, uint16_t pan)
 {
     le_uint16_t le_pan = byteorder_btols(byteorder_htons(pan));
+
     dev->netdev.pan = pan;
     DEBUG("pan0: %u, pan1: %u\n", le_pan.u8[0], le_pan.u8[1]);
     at86rf2xx_reg_write(dev, AT86RF2XX_REG__PAN_ID_0, le_pan.u8[0]);
@@ -197,7 +199,7 @@ int16_t at86rf2xx_get_txpower(const at86rf2xx_t *dev)
     return _tx_pow_to_dbm_212b(dev->netdev.chan, dev->page, txpower);
 #else
     uint8_t txpower = at86rf2xx_reg_read(dev, AT86RF2XX_REG__PHY_TX_PWR)
-                & AT86RF2XX_PHY_TX_PWR_MASK__TX_PWR;
+                      & AT86RF2XX_PHY_TX_PWR_MASK__TX_PWR;
     return tx_pow_to_dbm[txpower];
 #endif
 }
@@ -235,6 +237,7 @@ uint8_t at86rf2xx_get_max_retries(const at86rf2xx_t *dev)
 void at86rf2xx_set_max_retries(const at86rf2xx_t *dev, uint8_t max)
 {
     uint8_t tmp = at86rf2xx_reg_read(dev, AT86RF2XX_REG__XAH_CTRL_0);
+
     tmp &= ~(AT86RF2XX_XAH_CTRL_0__MAX_FRAME_RETRIES);
     tmp |= ((max > 7) ? 7 : max) << 4;
     at86rf2xx_reg_write(dev, AT86RF2XX_REG__XAH_CTRL_0, tmp);
@@ -243,7 +246,8 @@ void at86rf2xx_set_max_retries(const at86rf2xx_t *dev, uint8_t max)
 uint8_t at86rf2xx_get_csma_max_retries(const at86rf2xx_t *dev)
 {
     uint8_t tmp;
-    tmp  = at86rf2xx_reg_read(dev, AT86RF2XX_REG__XAH_CTRL_0);
+
+    tmp = at86rf2xx_reg_read(dev, AT86RF2XX_REG__XAH_CTRL_0);
     tmp &= AT86RF2XX_XAH_CTRL_0__MAX_CSMA_RETRIES;
     tmp >>= 1;
     return tmp;
@@ -251,8 +255,8 @@ uint8_t at86rf2xx_get_csma_max_retries(const at86rf2xx_t *dev)
 
 void at86rf2xx_set_csma_max_retries(const at86rf2xx_t *dev, int8_t retries)
 {
-    retries = (retries > 5) ? 5 : retries; /* valid values: 0-5 */
-    retries = (retries < 0) ? 7 : retries; /* max < 0 => disable CSMA (set to 7) */
+    retries = (retries > 5) ? 5 : retries;  /* valid values: 0-5 */
+    retries = (retries < 0) ? 7 : retries;  /* max < 0 => disable CSMA (set to 7) */
     DEBUG("[at86rf2xx] opt: Set CSMA retries to %u\n", retries);
 
     uint8_t tmp = at86rf2xx_reg_read(dev, AT86RF2XX_REG__XAH_CTRL_0);
@@ -273,7 +277,7 @@ void at86rf2xx_set_csma_backoff_exp(const at86rf2xx_t *dev,
 
 void at86rf2xx_set_csma_seed(const at86rf2xx_t *dev, const uint8_t entropy[2])
 {
-    if(entropy == NULL) {
+    if (entropy == NULL) {
         DEBUG("[at86rf2xx] opt: CSMA seed entropy is nullpointer\n");
         return;
     }
@@ -290,6 +294,7 @@ void at86rf2xx_set_csma_seed(const at86rf2xx_t *dev, const uint8_t entropy[2])
 int8_t at86rf2xx_get_cca_threshold(const at86rf2xx_t *dev)
 {
     int8_t tmp = at86rf2xx_reg_read(dev, AT86RF2XX_REG__CCA_THRES);
+
     tmp &= AT86RF2XX_CCA_THRES_MASK__CCA_ED_THRES;
     tmp <<= 1;
     return (RSSI_BASE_VAL + tmp);
@@ -315,6 +320,7 @@ void at86rf2xx_set_cca_threshold(const at86rf2xx_t *dev, int8_t value)
 int8_t at86rf2xx_get_ed_level(at86rf2xx_t *dev)
 {
     uint8_t tmp = at86rf2xx_reg_read(dev, AT86RF2XX_REG__PHY_ED_LEVEL);
+
 #if MODULE_AT86RF212B
     /* AT86RF212B has different scale than the other variants */
     int8_t ed = (int8_t)(((int16_t)tmp * 103) / 100) + RSSI_BASE_VAL;
@@ -452,13 +458,14 @@ uint8_t at86rf2xx_set_state(at86rf2xx_t *dev, uint8_t state)
         if (state == AT86RF2XX_STATE_SLEEP) {
             /* First go to TRX_OFF */
             _set_state(dev, AT86RF2XX_STATE_TRX_OFF,
-                            AT86RF2XX_STATE_FORCE_TRX_OFF);
+                       AT86RF2XX_STATE_FORCE_TRX_OFF);
             /* Discard all IRQ flags, framebuffer is lost anyway */
             at86rf2xx_reg_read(dev, AT86RF2XX_REG__IRQ_STATUS);
             /* Go to SLEEP mode from TRX_OFF */
             gpio_set(dev->params.sleep_pin);
             dev->state = state;
-        } else {
+        }
+        else {
             if (old_state == AT86RF2XX_STATE_SLEEP) {
                 DEBUG("at86rf2xx: waking up from sleep mode\n");
                 at86rf2xx_assert_awake(dev);

--- a/drivers/at86rf2xx/at86rf2xx_netdev.c
+++ b/drivers/at86rf2xx/at86rf2xx_netdev.c
@@ -153,10 +153,10 @@ static int _recv(netdev_t *netdev, void *buf, size_t len, void *info)
         at86rf2xx_fb_stop(dev);
         return -ENOBUFS;
     }
-    #ifdef MODULE_NETSTATS_L2
-        netdev->stats.rx_count++;
-        netdev->stats.rx_bytes += pkt_len;
-    #endif
+#ifdef MODULE_NETSTATS_L2
+    netdev->stats.rx_count++;
+    netdev->stats.rx_bytes += pkt_len;
+#endif
     /* copy payload */
     at86rf2xx_fb_read(dev, (uint8_t *)buf, pkt_len);
 
@@ -332,7 +332,7 @@ static int _get(netdev_t *netdev, netopt_t opt, void *val, size_t max_len)
     int res;
 
     if (((res = netdev_ieee802154_get((netdev_ieee802154_t *)netdev, opt, val,
-                                       max_len)) >= 0) || (res != -ENOTSUP)) {
+                                      max_len)) >= 0) || (res != -ENOTSUP)) {
         return res;
     }
 
@@ -381,7 +381,7 @@ static int _get(netdev_t *netdev, netopt_t opt, void *val, size_t max_len)
             res = sizeof(int8_t);
             break;
 
-        case NETOPT_AUTOACK :
+        case NETOPT_AUTOACK:
             assert(max_len >= sizeof(netopt_enable_t));
             uint8_t tmp = at86rf2xx_reg_read(dev, AT86RF2XX_REG__CSMA_SEED_1);
             *((netopt_enable_t *)val) = (tmp & AT86RF2XX_CSMA_SEED_1__AACK_DIS_ACK) ? false : true;
@@ -545,8 +545,8 @@ static int _set(netdev_t *netdev, netopt_t opt, const void *val, size_t len)
 
         case NETOPT_CSMA_RETRIES:
             assert(len <= sizeof(uint8_t));
-            if( !(dev->netdev.flags & AT86RF2XX_OPT_CSMA ||
-                (*((uint8_t *)val) > 5)) ) {
+            if (!(dev->netdev.flags & AT86RF2XX_OPT_CSMA ||
+                  (*((uint8_t *)val) > 5))) {
                 /* If CSMA is disabled, don't allow setting retries */
                 res = -EINVAL;
             }

--- a/drivers/at86rf2xx/at86rf2xx_netdev.c
+++ b/drivers/at86rf2xx/at86rf2xx_netdev.c
@@ -545,8 +545,8 @@ static int _set(netdev_t *netdev, netopt_t opt, const void *val, size_t len)
 
         case NETOPT_CSMA_RETRIES:
             assert(len <= sizeof(uint8_t));
-            if (!(dev->netdev.flags & AT86RF2XX_OPT_CSMA ||
-                  (*((uint8_t *)val) > 5))) {
+            if (!(dev->netdev.flags & AT86RF2XX_OPT_CSMA) ||
+                (*((uint8_t *)val) > 5)) {
                 /* If CSMA is disabled, don't allow setting retries */
                 res = -EINVAL;
             }


### PR DESCRIPTION
Uncrustified the at86rf2xx driver files.

Changed the parenthesis of  `NETOPT_CSMA_RETRIES`  to be better readable.
