### PR TITLE
at86rf2xx: correct rssi

### DIFF
--- a/drivers/at86rf2xx/at86rf2xx_netdev.c
+++ b/drivers/at86rf2xx/at86rf2xx_netdev.c
@@ -166,18 +166,39 @@ static int _recv(netdev_t *netdev, void *buf, size_t len, void *info)
     at86rf2xx_fb_read(dev, tmp, 2);
     (void)tmp;
 
+    /* at86rf212  RSSI_BASE_VAL +3.1*RSSI, base varies for diff. modulation and datarates
+     * at86RF232  RSSI_BASE_VAL +3.0*RSSI, base -91dBm
+     * at86RF233  RSSI_BASE_VAL +3.0*RSSI, base -94dBm
+     * at86RF231  RSSI_BASE_VAL +3.0*(RSSI-1), base -91dBm
+     * at***RFR2  RSSI_BASE_VAL +3.0*(RSSI-1), base -90dBm
+     *
+     * AT86RF231 MAN. p.89 8.3.2 Reading RSSI
+     * AT86RF232 MAN. p.88 8.3.2 Reading RSSI
+     * AT86RF233 MAN. p.99 8.4.2 Reading RSSI
+     * "It is not recommended reading the RSSI value when using the Extended
+     * Operating Modes, use ED instead"
+     * at86RF231  RSSI_BASE_VAL +ED, base -90dBm
+     * at86RF232  RSSI_BASE_VAL +ED, base -91dBm
+     * at86RF233  RSSI_BASE_VAL +ED, base -94dBm
+     * at***RFR2  RSSI_BASE_VAL +ED, base -90dBm
+     */
     if (info != NULL) {
         uint8_t rssi = 0;
         netdev_ieee802154_rx_info_t *radio_info = info;
+
+#if defined(MODULE_AT86RF231) || defined(MODULE_AT86RF232) || defined(MODULE_AT86RF233)
         at86rf2xx_fb_read(dev, &(radio_info->lqi), 1);
-#ifndef MODULE_AT86RF231
-        at86rf2xx_fb_read(dev, &(rssi), 1);
-        at86rf2xx_fb_stop(dev);
-#else
         at86rf2xx_fb_stop(dev);
         rssi = at86rf2xx_reg_read(dev, AT86RF2XX_REG__PHY_ED_LEVEL);
+#else
+        at86rf2xx_fb_read(dev, &(radio_info->lqi), 1);
+        at86rf2xx_fb_read(dev, &(rssi), 1);
+        at86rf2xx_fb_stop(dev);
+        rssi = 3 * rssi;
 #endif
         radio_info->rssi = RSSI_BASE_VAL + rssi;
+        DEBUG("[at86rf2xx] LQI:%d high is good, RSSI:%d high is either good or"
+              "too much interference.\n", radio_info->lqi, radio_info->rssi);
     }
     else {
         at86rf2xx_fb_stop(dev);


### PR DESCRIPTION
This PR changes the the rssi value to be based on the ED and not on the RSSI value as stated in the manuel for the extended operation mode of the 23x devices.
The ifdefs are reordered to to be extended more easier.

### Issues/PRs references
#9172 