### PR TITLE
sock: Add dependencies for sock_util

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -693,6 +693,8 @@ endif
 
 ifneq (,$(filter sock_util,$(USEMODULE)))
   USEMODULE += posix
+  USEMODULE += fmt
+  USEMODULE += sock_udp
 endif
 
 ifneq (,$(filter event_%,$(USEMODULE)))


### PR DESCRIPTION
### Contribution description

Split of from #9341 for more easy reviewing.

- fmt required for the string formatting as we're always compiling with `RIOT_VERSION` defined here.
- sock_udp is required since the `net/sock/udp.h` header is included, and that one is only in the include path if there is a sock_udp module selected.

### Issues/PRs references

Originally part of #9341 