### PR TITLE
WIP newlib.mk: fix regressions and global cleanups, tracking evolutions of newlib.mk

### DIFF
--- a/makefiles/libc/assert_newlib_nano_included.h
+++ b/makefiles/libc/assert_newlib_nano_included.h
@@ -1,0 +1,5 @@
+/* Warn if newlib_nano is requested but not actually used */
+#include <newlib.h>
+#ifndef _NANO_FORMATTED_IO
+#warning newlib-nano requested but not included by the build system
+#endif

--- a/makefiles/libc/newlib.mk
+++ b/makefiles/libc/newlib.mk
@@ -32,30 +32,30 @@ ifeq (,$(NEWLIB_INCLUDE_DIR))
 endif
 
 ifeq (,$(NEWLIB_INCLUDE_DIR))
-# Since Clang is not installed as a separate instance for each crossdev target
-# we need to tell it where to look for platform specific includes (Newlib
-# headers instead of Linux/Glibc headers.)
-# On GCC this is done when building the cross compiler toolchain so we do not
-# actually need to specify the include paths for system includes.
-# Ubuntu gcc-arm-embedded toolchain (https://launchpad.net/gcc-arm-embedded)
-# places newlib headers in several places, but the primary source seem to be
-# /etc/alternatives/gcc-arm-none-eabi-include
-# Gentoo Linux crossdev place the newlib headers in /usr/arm-none-eabi/include
-# Arch Linux also place the newlib headers in /usr/arm-none-eabi/include
-# Ubuntu seem to put a copy of the newlib headers in the same place as
-# Gentoo crossdev, but we prefer to look at /etc/alternatives first.
-# On OSX, newlib includes are possibly located in
-# /usr/local/opt/arm-none-eabi*/arm-none-eabi/include or /usr/local/opt/gcc-arm/arm-none-eabi/include
+  # Since Clang is not installed as a separate instance for each crossdev target
+  # we need to tell it where to look for platform specific includes (Newlib
+  # headers instead of Linux/Glibc headers.)
+  # On GCC this is done when building the cross compiler toolchain so we do not
+  # actually need to specify the include paths for system includes.
+  # Ubuntu gcc-arm-embedded toolchain (https://launchpad.net/gcc-arm-embedded)
+  # places newlib headers in several places, but the primary source seem to be
+  # /etc/alternatives/gcc-arm-none-eabi-include
+  # Gentoo Linux crossdev place the newlib headers in /usr/arm-none-eabi/include
+  # Arch Linux also place the newlib headers in /usr/arm-none-eabi/include
+  # Ubuntu seem to put a copy of the newlib headers in the same place as
+  # Gentoo crossdev, but we prefer to look at /etc/alternatives first.
+  # On OSX, newlib includes are possibly located in
+  # /usr/local/opt/arm-none-eabi*/arm-none-eabi/include or /usr/local/opt/gcc-arm/arm-none-eabi/include
   NEWLIB_INCLUDE_PATTERNS ?= \
     /etc/alternatives/gcc-$(TARGET_ARCH)-include \
     /usr/$(TARGET_ARCH)/include \
     /usr/local/opt/$(TARGET_ARCH)*/$(TARGET_ARCH)/include \
     /usr/local/opt/gcc-*/$(TARGET_ARCH)/include \
     #
-# Use the wildcard Makefile function to search for existing directories matching
-# the patterns above. We use the -isystem gcc/clang argument to add the include
-# directories as system include directories, which means they will not be
-# searched until after all the project specific include directories (-I/path)
+  # Use the wildcard Makefile function to search for existing directories matching
+  # the patterns above. We use the -isystem gcc/clang argument to add the include
+  # directories as system include directories, which means they will not be
+  # searched until after all the project specific include directories (-I/path)
   NEWLIB_INCLUDE_DIR := $(firstword $(abspath $(dir $(wildcard $(addsuffix /newlib.h, $(NEWLIB_INCLUDE_PATTERNS))))))
 endif
 

--- a/makefiles/libc/newlib.mk
+++ b/makefiles/libc/newlib.mk
@@ -52,7 +52,7 @@ ifeq (,$(NEWLIB_INCLUDE_DIR))
 # the patterns above. We use the -isystem gcc/clang argument to add the include
 # directories as system include directories, which means they will not be
 # searched until after all the project specific include directories (-I/path)
-  NEWLIB_INCLUDE_DIR ?= $(firstword $(dir $(wildcard $(addsuffix /newlib.h, $(NEWLIB_INCLUDE_PATTERNS)))))
+  NEWLIB_INCLUDE_DIR := $(firstword $(dir $(wildcard $(addsuffix /newlib.h, $(NEWLIB_INCLUDE_PATTERNS)))))
 endif
 
 # If nothing was found we will try to fall back to searching for a cross-gcc in

--- a/makefiles/libc/newlib.mk
+++ b/makefiles/libc/newlib.mk
@@ -23,7 +23,11 @@ export LINKFLAGS += -lc
 
 # Try to search for newlib in the standard search path of the compiler for includes
 ifeq (,$(NEWLIB_INCLUDE_DIR))
-  COMPILER_INCLUDE_PATHS := $(shell $(PREFIX)gcc -v -x c -E /dev/null 2>&1 | grep '^\s' | tr -d '\n')
+  COMPILER_INCLUDE_PATHS := $(shell $(PREFIX)gcc -v -x c -E /dev/null 2>&1 | \
+                              sed \
+                              -e '1,/\#include <...> search starts here:/d' \
+                              -e '/End of search list./,$$d' \
+                              -e 's/\s//')
   NEWLIB_INCLUDE_DIR := $(firstword $(dir $(wildcard $(addsuffix /newlib.h, $(COMPILER_INCLUDE_PATHS)))))
 endif
 

--- a/makefiles/libc/newlib.mk
+++ b/makefiles/libc/newlib.mk
@@ -28,7 +28,7 @@ ifeq (,$(NEWLIB_INCLUDE_DIR))
                               -e '1,/\#include <...> search starts here:/d' \
                               -e '/End of search list./,$$d' \
                               -e 's/\s//')
-  NEWLIB_INCLUDE_DIR := $(firstword $(dir $(wildcard $(addsuffix /newlib.h, $(COMPILER_INCLUDE_PATHS)))))
+  NEWLIB_INCLUDE_DIR := $(firstword $(abspath $(dir $(wildcard $(addsuffix /newlib.h, $(COMPILER_INCLUDE_PATHS))))))
 endif
 
 ifeq (,$(NEWLIB_INCLUDE_DIR))
@@ -56,7 +56,7 @@ ifeq (,$(NEWLIB_INCLUDE_DIR))
 # the patterns above. We use the -isystem gcc/clang argument to add the include
 # directories as system include directories, which means they will not be
 # searched until after all the project specific include directories (-I/path)
-  NEWLIB_INCLUDE_DIR := $(firstword $(dir $(wildcard $(addsuffix /newlib.h, $(NEWLIB_INCLUDE_PATTERNS)))))
+  NEWLIB_INCLUDE_DIR := $(firstword $(abspath $(dir $(wildcard $(addsuffix /newlib.h, $(NEWLIB_INCLUDE_PATTERNS))))))
 endif
 
 # If nothing was found we will try to fall back to searching for a cross-gcc in

--- a/makefiles/libc/newlib.mk
+++ b/makefiles/libc/newlib.mk
@@ -14,10 +14,10 @@ ifneq (,$(filter newlib_gnu_source,$(USEMODULE)))
 endif
 
 ifeq (1,$(USE_NEWLIB_NANO))
-  export LINKFLAGS += -specs=nano.specs
+  LINKFLAGS += -specs=nano.specs
 endif
 
-export LINKFLAGS += -lc
+LINKFLAGS += -lc
 
 # Search for Newlib include directories
 
@@ -89,4 +89,4 @@ endif
 # bundled headers. Clang compatible versions of those headers are already
 # provided by Newlib, so placing this directory first will eliminate those problems.
 # The above problem was observed with LLVM 3.9.1 when building against GCC 6.3.0 headers.
-export INCLUDES := $(NEWLIB_INCLUDES) $(INCLUDES)
+INCLUDES := $(NEWLIB_INCLUDES) $(INCLUDES)

--- a/makefiles/libc/newlib.mk
+++ b/makefiles/libc/newlib.mk
@@ -67,7 +67,7 @@ endif
 # the current PATH and use a relative path for the includes
 ifeq (,$(NEWLIB_INCLUDE_DIR))
   GCC_RELATIVE_INCLUDE_PATH := $(dir $(shell command -v $(PREFIX)gcc 2>/dev/null))/../$(TARGET_ARCH)/include
-  NEWLIB_INCLUDE_DIR := $(abspath $(wildcard $(GCC_RELATIVE_INCLUDE_PATH)))
+  NEWLIB_INCLUDE_DIR := $(call dir_contains_newlib_h, $(GCC_RELATIVE_INCLUDE_PATH))
 endif
 
 ifeq ($(TOOLCHAIN),llvm)
@@ -86,7 +86,7 @@ ifeq (1,$(USE_NEWLIB_NANO))
     $(NEWLIB_INCLUDE_DIR)/newlib/nano \
     $(NEWLIB_INCLUDE_DIR)/nano \
     #
-  NEWLIB_NANO_INCLUDE_DIR ?= $(firstword $(wildcard $(NEWLIB_NANO_INCLUDE_PATTERNS)))
+  NEWLIB_NANO_INCLUDE_DIR ?= $(firstword $(call dir_contains_newlib_h, $(NEWLIB_NANO_INCLUDE_PATTERNS)))
 
   # newlib-nano overrides newlib.h and its include dir should therefore go before
   # the regular system include dirs.

--- a/makefiles/libc/newlib.mk
+++ b/makefiles/libc/newlib.mk
@@ -78,6 +78,13 @@ ifeq ($(TOOLCHAIN),llvm)
   # in case some header is missing from the cross tool chain
   NEWLIB_INCLUDES := $(addprefix -isystem ,$(NEWLIB_INCLUDE_DIR)) -nostdinc
   NEWLIB_INCLUDES += $(addprefix -isystem ,$(abspath $(wildcard $(dir $(NEWLIB_INCLUDE_DIR))/usr/include)))
+
+  # Newlib includes should go before GCC includes. This is especially important
+  # when using Clang, because Clang will yield compilation errors on some GCC-
+  # bundled headers. Clang compatible versions of those headers are already
+  # provided by Newlib, so placing this directory first will eliminate those problems.
+  # The above problem was observed with LLVM 3.9.1 when building against GCC 6.3.0 headers.
+  INCLUDES := $(NEWLIB_INCLUDES) $(INCLUDES)
 endif
 
 ifeq (1,$(USE_NEWLIB_NANO))
@@ -97,10 +104,3 @@ ifeq (1,$(USE_NEWLIB_NANO))
     CFLAGS += -include '$(RIOTMAKE)/libc/assert_newlib_nano_included.h'
   endif
 endif
-
-# Newlib includes should go before GCC includes. This is especially important
-# when using Clang, because Clang will yield compilation errors on some GCC-
-# bundled headers. Clang compatible versions of those headers are already
-# provided by Newlib, so placing this directory first will eliminate those problems.
-# The above problem was observed with LLVM 3.9.1 when building against GCC 6.3.0 headers.
-INCLUDES := $(NEWLIB_INCLUDES) $(INCLUDES)

--- a/makefiles/libc/newlib.mk
+++ b/makefiles/libc/newlib.mk
@@ -21,6 +21,10 @@ LINKFLAGS += -lc
 
 # Search for Newlib include directories
 
+# Function that returns absolute path to directories that contain newlib.h
+# It returns the directory without trailing slash
+dir_contains_newlib_h = $(abspath $(dir $(wildcard $(addsuffix /newlib.h, $(1)))))
+
 # Try to search for newlib in the standard search path of the compiler for includes
 ifeq (,$(NEWLIB_INCLUDE_DIR))
   COMPILER_INCLUDE_PATHS := $(shell $(PREFIX)gcc -v -x c -E /dev/null 2>&1 | \

--- a/makefiles/libc/newlib.mk
+++ b/makefiles/libc/newlib.mk
@@ -91,6 +91,11 @@ ifeq (1,$(USE_NEWLIB_NANO))
   # newlib-nano overrides newlib.h and its include dir should therefore go before
   # the regular system include dirs.
   INCLUDES := $(addprefix -isystem ,$(NEWLIB_NANO_INCLUDE_DIR)) $(INCLUDES)
+
+  ifneq (,$(filter 1, $(ASSERT_NEWLIB_NANO_HEADER)))
+    # Add a check to assert newlib-nano is used
+    CFLAGS += -include '$(RIOTMAKE)/libc/assert_newlib_nano_included.h'
+  endif
 endif
 
 # Newlib includes should go before GCC includes. This is especially important

--- a/makefiles/libc/newlib.mk
+++ b/makefiles/libc/newlib.mk
@@ -72,9 +72,9 @@ ifeq ($(TOOLCHAIN),llvm)
 endif
 
 ifeq (1,$(USE_NEWLIB_NANO))
-  NEWLIB_NANO_INCLUDE_DIR ?= $(firstword $(wildcard $(NEWLIB_INCLUDE_DIR)newlib-nano \
-                                                    $(NEWLIB_INCLUDE_DIR)newlib/nano \
-                                                    $(NEWLIB_INCLUDE_DIR)nano))
+  NEWLIB_NANO_INCLUDE_DIR ?= $(firstword $(wildcard $(NEWLIB_INCLUDE_DIR)/newlib-nano \
+                                                    $(NEWLIB_INCLUDE_DIR)/newlib/nano \
+                                                    $(NEWLIB_INCLUDE_DIR)/nano))
   # newlib-nano overrides newlib.h and its include dir should therefore go before
   # the regular system include dirs.
   INCLUDES := $(addprefix -isystem ,$(NEWLIB_NANO_INCLUDE_DIR)) $(INCLUDES)

--- a/makefiles/libc/newlib.mk
+++ b/makefiles/libc/newlib.mk
@@ -67,7 +67,7 @@ ifeq ($(TOOLCHAIN),llvm)
   # for the system being built.
   # We also add -nostdinc to avoid including the host system headers by mistake
   # in case some header is missing from the cross tool chain
-  NEWLIB_INCLUDES := -isystem $(NEWLIB_INCLUDE_DIR) -nostdinc
+  NEWLIB_INCLUDES := $(addprefix -isystem ,$(NEWLIB_INCLUDE_DIR)) -nostdinc
   NEWLIB_INCLUDES += $(addprefix -isystem ,$(abspath $(wildcard $(dir $(NEWLIB_INCLUDE_DIR))/usr/include)))
 endif
 
@@ -77,7 +77,7 @@ ifeq (1,$(USE_NEWLIB_NANO))
                                                     $(NEWLIB_INCLUDE_DIR)nano))
   # newlib-nano overrides newlib.h and its include dir should therefore go before
   # the regular system include dirs.
-  INCLUDES := -isystem $(NEWLIB_NANO_INCLUDE_DIR) $(INCLUDES)
+  INCLUDES := $(addprefix -isystem ,$(NEWLIB_NANO_INCLUDE_DIR)) $(INCLUDES)
 endif
 
 # Newlib includes should go before GCC includes. This is especially important

--- a/makefiles/libc/newlib.mk
+++ b/makefiles/libc/newlib.mk
@@ -32,7 +32,7 @@ ifeq (,$(NEWLIB_INCLUDE_DIR))
                               -e '1,/\#include <...> search starts here:/d' \
                               -e '/End of search list./,$$d' \
                               -e 's/\s//')
-  NEWLIB_INCLUDE_DIR := $(firstword $(abspath $(dir $(wildcard $(addsuffix /newlib.h, $(COMPILER_INCLUDE_PATHS))))))
+  NEWLIB_INCLUDE_DIR := $(firstword $(call dir_contains_newlib_h, $(COMPILER_INCLUDE_PATHS)))
 endif
 
 ifeq (,$(NEWLIB_INCLUDE_DIR))
@@ -60,7 +60,7 @@ ifeq (,$(NEWLIB_INCLUDE_DIR))
   # the patterns above. We use the -isystem gcc/clang argument to add the include
   # directories as system include directories, which means they will not be
   # searched until after all the project specific include directories (-I/path)
-  NEWLIB_INCLUDE_DIR := $(firstword $(abspath $(dir $(wildcard $(addsuffix /newlib.h, $(NEWLIB_INCLUDE_PATTERNS))))))
+  NEWLIB_INCLUDE_DIR := $(firstword $(call dir_contains_newlib_h, $(NEWLIB_INCLUDE_PATTERNS)))
 endif
 
 # If nothing was found we will try to fall back to searching for a cross-gcc in

--- a/makefiles/libc/newlib.mk
+++ b/makefiles/libc/newlib.mk
@@ -77,9 +77,13 @@ ifeq ($(TOOLCHAIN),llvm)
 endif
 
 ifeq (1,$(USE_NEWLIB_NANO))
-  NEWLIB_NANO_INCLUDE_DIR ?= $(firstword $(wildcard $(NEWLIB_INCLUDE_DIR)/newlib-nano \
-                                                    $(NEWLIB_INCLUDE_DIR)/newlib/nano \
-                                                    $(NEWLIB_INCLUDE_DIR)/nano))
+  NEWLIB_NANO_INCLUDE_PATTERNS ?= \
+    $(NEWLIB_INCLUDE_DIR)/newlib-nano \
+    $(NEWLIB_INCLUDE_DIR)/newlib/nano \
+    $(NEWLIB_INCLUDE_DIR)/nano \
+    #
+  NEWLIB_NANO_INCLUDE_DIR ?= $(firstword $(wildcard $(NEWLIB_NANO_INCLUDE_PATTERNS)))
+
   # newlib-nano overrides newlib.h and its include dir should therefore go before
   # the regular system include dirs.
   INCLUDES := $(addprefix -isystem ,$(NEWLIB_NANO_INCLUDE_DIR)) $(INCLUDES)

--- a/makefiles/libc/newlib.mk
+++ b/makefiles/libc/newlib.mk
@@ -62,7 +62,8 @@ endif
 # If nothing was found we will try to fall back to searching for a cross-gcc in
 # the current PATH and use a relative path for the includes
 ifeq (,$(NEWLIB_INCLUDE_DIR))
-  NEWLIB_INCLUDE_DIR := $(abspath $(wildcard $(dir $(shell command -v $(PREFIX)gcc 2>/dev/null))/../$(TARGET_ARCH)/include))
+  GCC_RELATIVE_INCLUDE_PATH := $(dir $(shell command -v $(PREFIX)gcc 2>/dev/null))/../$(TARGET_ARCH)/include
+  NEWLIB_INCLUDE_DIR := $(abspath $(wildcard $(GCC_RELATIVE_INCLUDE_PATH)))
 endif
 
 ifeq ($(TOOLCHAIN),llvm)

--- a/makefiles/libc/newlib.mk
+++ b/makefiles/libc/newlib.mk
@@ -92,7 +92,7 @@ ifeq (1,$(USE_NEWLIB_NANO))
   # the regular system include dirs.
   INCLUDES := $(addprefix -isystem ,$(NEWLIB_NANO_INCLUDE_DIR)) $(INCLUDES)
 
-  ifneq (,$(filter 1, $(ASSERT_NEWLIB_NANO_HEADER)))
+  ifneq (,$(filter 1, $(ASSERT_NEWLIB_NANO_HEADER) $(RIOT_CI_BUILD)))
     # Add a check to assert newlib-nano is used
     CFLAGS += -include '$(RIOTMAKE)/libc/assert_newlib_nano_included.h'
   endif


### PR DESCRIPTION
### Contribution description

**WARN**: I wanted to re-test commits from this PR after rebasing them multiple times, but could not find time. However I prefer uploading it instead of keeping it local

This started as a PR to fix:

* The need to have a trailing slash in `NEWLIB_INCLUDE_DIR`
* adding `-isystem $(empty_variable)` to INCLUDES
* clean the output of gcc to get compiler includes
* Patterns not be taken into account

And this ended up in also some refactoring, tests.
It is still work in progress

This PR grew quite big and went beyond what I originally planed.
I will split it, refactor and re-organize commits.

I also plan to add parts of https://github.com/RIOT-OS/RIOT/pull/9415 but not the 'nano.specs' this should be kept in the original pr.


I on purpose separated commits to allow adding small parts separately and removing other too problematic ones.

### Issues/PRs references

Problems mentioned in https://github.com/RIOT-OS/RIOT/issues/9452