### PR TITLE
make/flash: make flasher take the file used for flashing from command line argument

### DIFF
--- a/boards/calliope-mini/Makefile.include
+++ b/boards/calliope-mini/Makefile.include
@@ -10,7 +10,7 @@ PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 PROGRAMMER ?= fscopy
 
 ifeq (fscopy,$(PROGRAMMER))
-  export FFLAGS =
+  export FFLAGS = $(HEXFILE)
   export DEBUGGER_FLAGS =
 
   export FLASHER = $(RIOTBOARD)/$(BOARD)/dist/flash.sh

--- a/boards/calliope-mini/dist/flash.sh
+++ b/boards/calliope-mini/dist/flash.sh
@@ -18,6 +18,8 @@ OS=`uname`
 DID_MOUNT=false
 NAME="MINI"
 
+HEXFILE=$1
+
 # set the mount path depending on the OS
 if [ ${OS} = "Linux" ]
 then

--- a/boards/mbed_lpc1768/Makefile.include
+++ b/boards/mbed_lpc1768/Makefile.include
@@ -6,7 +6,7 @@ export DEBUGGER =
 export DEBUGSERVER =
 
 HEXFILE = $(BINFILE)
-export FFLAGS =
+export FFLAGS = $(HEXFILE)
 export DEBUGGER_FLAGS =
 
 # define the default port depending on the host OS

--- a/boards/mbed_lpc1768/dist/flash.sh
+++ b/boards/mbed_lpc1768/dist/flash.sh
@@ -21,6 +21,8 @@
 OS=`uname`
 DID_MOUNT=false
 
+BINFILE=$1
+
 # set the mount path depending on the OS
 if [ ${OS} = "Linux" ]
 then
@@ -55,7 +57,7 @@ fi
 # remove old binary
 rm -f ${MOUNT}/*.bin
 # copy new binary to device
-cp ${HEXFILE} ${MOUNT}
+cp ${BINFILE} ${MOUNT}
 # make sure hexfile was written
 sync
 

--- a/boards/microbit/Makefile.include
+++ b/boards/microbit/Makefile.include
@@ -10,7 +10,7 @@ PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
 PROGRAMMER ?= fscopy
 
 ifeq (fscopy,$(PROGRAMMER))
-  export FFLAGS =
+  export FFLAGS = $(HEXFILE)
   export DEBUGGER_FLAGS =
 
   export FLASHER = $(RIOTBOARD)/$(BOARD)/dist/flash.sh

--- a/boards/microbit/dist/flash.sh
+++ b/boards/microbit/dist/flash.sh
@@ -18,6 +18,8 @@ OS=`uname`
 DID_MOUNT=false
 NAME="MICROBIT"
 
+HEXFILE=$1
+
 # set the mount path depending on the OS
 if [ ${OS} = "Linux" ]
 then

--- a/boards/seeeduino_arch-pro/Makefile.include
+++ b/boards/seeeduino_arch-pro/Makefile.include
@@ -11,7 +11,7 @@ include $(RIOTMAKE)/tools/serial.inc.mk
 DEBUG_ADAPTER ?= dap
 
 # this board uses openocd
-export IMAGE_FILE = $(HEXFILE)
+FFLAGS ?= flash $(HEXFILE)
 include $(RIOTMAKE)/tools/openocd.inc.mk
 
 # generate image checksum from hex file

--- a/dist/tools/jlink/jlink.sh
+++ b/dist/tools/jlink/jlink.sh
@@ -18,23 +18,25 @@
 #
 # The script supports the following actions:
 #
-# flash:        flash a given hex file to the target.
-#               hexfile is expected in ihex format and is pointed to
-#               by BINFILE environment variable
+# flash:        flash <binfile>
+#
+#               flash given binary format file to the target.
 #
 #               options:
-#               BINFILE: path to the binary file that is flashed
+#               <binfile>:      path to the binary file that is flashed
 #
-# debug:        starts JLink as GDB server in the background and
+# debug:        debug <elffile>
+#
+#               starts JLink as GDB server in the background and
 #               connects to the server with the GDB client specified by
 #               the board (DBG environment variable)
 #
 #               options:
+#               <elffile>:      path to the ELF file to debug
 #               GDB_PORT:       port opened for GDB connections
 #               TELNET_PORT:    port opened for telnet connections
 #               DBG:            debugger client command, default: 'gdb -q'
 #               TUI:            if TUI!=null, the -tui option will be used
-#               ELFFILE:        path to the ELF file to debug
 #
 # debug-server: starts JLink as GDB server, but does not connect to
 #               to it with any frontend. This might be useful when using
@@ -88,10 +90,10 @@ test_config() {
     fi
 }
 
-test_hexfile() {
-    if [ ! -f "${HEXFILE}" ]; then
-        echo "Error: Unable to locate HEXFILE"
-        echo "       (${HEXFILE})"
+test_binfile() {
+    if [ ! -f "${BINFILE}" ]; then
+        echo "Error: Unable to locate BINFILE"
+        echo "       (${BINFILE})"
         exit 1
     fi
 }
@@ -145,16 +147,17 @@ test_term() {
 # now comes the actual actions
 #
 do_flash() {
+    BINFILE=$1
     test_config
     test_serial
-    test_hexfile
+    test_binfile
     # clear any existing contents in burn file
     /bin/echo -n "" > ${BINDIR}/burn.seg
     # create temporary burn file
     if [ ! -z "${JLINK_PRE_FLASH}" ]; then
         printf "${JLINK_PRE_FLASH}\n" >> ${BINDIR}/burn.seg
     fi
-    echo "loadbin ${HEXFILE} ${FLASH_ADDR}" >> ${BINDIR}/burn.seg
+    echo "loadbin ${BINFILE} ${FLASH_ADDR}" >> ${BINDIR}/burn.seg
     if [ ! -z "${JLINK_POST_FLASH}" ]; then
         printf "${JLINK_POST_FLASH}\n" >> ${BINDIR}/burn.seg
     fi
@@ -169,6 +172,7 @@ do_flash() {
 }
 
 do_debug() {
+    ELFFILE=$1
     test_config
     test_serial
     test_elffile
@@ -275,5 +279,7 @@ case "${ACTION}" in
     ;;
   *)
     echo "Usage: $0 {flash|debug|debug-server|reset}"
+    echo "          flash <flash_file>"
+    echo "          debug <elffile>"
     ;;
 esac

--- a/dist/tools/openocd/openocd.sh
+++ b/dist/tools/openocd/openocd.sh
@@ -17,30 +17,33 @@
 #
 # The script supports the following actions:
 #
-# flash:        flash a given ELF file to the target.
+# flash:        flash <image_file>
+#               flash given file to the target.
 #
 #               options:
-#               IMAGE_FILE: Filename of the file that will be flashed
+#               <image_file>:   Filename of the file that will be flashed
 #               PRE_FLASH_CHECK_SCRIPT: a command to run before flashing to
-#               verify the integrity of the image to be flashed. ELFFILE is
+#               verify the integrity of the image to be flashed. <image_file> is
 #               passed as a command line argument to this command.
-#               Even though the file name variable is named ELFFILE, flashing
-#               works with any file format recognized by OpenOCD (elf, ihex, s19, bin).
 #
-# debug:        starts OpenOCD as GDB server in the background and
+#               Flashing works with any file format recognized by OpenOCD
+#               (elf, ihex, s19, bin).
+#
+# debug:        debug <elfile>
+#               starts OpenOCD as GDB server in the background and
 #               connects to the server with the GDB client specified by
 #               the board
 #
 #               options:
+#               <elffile>:      path to the file to debug, must be in a format
+#                               recognized by GDB (preferably ELF, it will not
+#                               work with .bin, .hex or .s19 because they lack
+#                               symbol information)
 #               GDB_PORT:       port opened for GDB connections
 #               TCL_PORT:       port opened for TCL connections
 #               TELNET_PORT:    port opened for telnet connections
 #               DBG:            debugger client command, default: 'gdb -q'
 #               TUI:            if TUI!=null, the -tui option will be used
-#               ELFFILE:        path to the file to debug, must be in a format
-#                               recognized by GDB (preferably ELF, it will not
-#                               work with .bin, .hex or .s19 because they lack
-#                               symbol information)
 #
 # debug-server: starts OpenOCD as GDB server, but does not connect to
 #               to it with any frontend. This might be useful when using
@@ -93,10 +96,6 @@
 # Default offset is 0, meaning the image will be flashed at the address that it
 # was linked at.
 : ${IMAGE_OFFSET:=0}
-# Image file used for flashing. Must be in a format that OpenOCD can handle (ELF,
-# Intel hex, S19, or raw binary)
-# Default is to use $ELFFILE
-: ${IMAGE_FILE:=${ELFFILE}}
 # Type of image, leave empty to let OpenOCD automatically detect the type from
 # the file (default).
 # Valid values: elf, hex, s19, bin (see OpenOCD manual for more information)
@@ -210,6 +209,7 @@ _flash_address() {
 # now comes the actual actions
 #
 do_flash() {
+    IMAGE_FILE=$1
     test_config
     test_imagefile
     if [ -n "${PRE_FLASH_CHECK_SCRIPT}" ]; then
@@ -256,6 +256,7 @@ do_flash() {
 }
 
 do_debug() {
+    ELFFILE=$1
     test_config
     test_elffile
     # temporary file that saves OpenOCD pid
@@ -330,15 +331,16 @@ do_reset() {
 # parameter dispatching
 #
 ACTION="$1"
+shift # pop $1 from $@
 
 case "${ACTION}" in
   flash)
     echo "### Flashing Target ###"
-    do_flash
+    do_flash "$@"
     ;;
   debug)
     echo "### Starting Debugging ###"
-    do_debug
+    do_debug "$@"
     ;;
   debug-server)
     echo "### Starting GDB Server ###"
@@ -350,6 +352,8 @@ case "${ACTION}" in
     ;;
   *)
     echo "Usage: $0 {flash|debug|debug-server|reset}"
+    echo "          flash <flash_file>"
+    echo "          debug <elffile>"
     exit 2
     ;;
 esac

--- a/makefiles/tools/jlink.inc.mk
+++ b/makefiles/tools/jlink.inc.mk
@@ -5,7 +5,7 @@ export RESET = $(RIOTTOOLS)/jlink/jlink.sh
 
 HEXFILE = $(BINFILE)
 
-export FFLAGS ?= flash
-export DEBUGGER_FLAGS ?= debug
+export FFLAGS ?= flash $(HEXFILE)
+export DEBUGGER_FLAGS ?= debug $(ELFFILE)
 export DEBUGSERVER_FLAGS ?= debug-server
 export RESET_FLAGS ?= reset

--- a/makefiles/tools/openocd.inc.mk
+++ b/makefiles/tools/openocd.inc.mk
@@ -3,8 +3,8 @@ export DEBUGGER = $(RIOTTOOLS)/openocd/openocd.sh
 export DEBUGSERVER = $(RIOTTOOLS)/openocd/openocd.sh
 export RESET ?= $(RIOTTOOLS)/openocd/openocd.sh
 
-export FFLAGS ?= flash
-export DEBUGGER_FLAGS ?= debug
+export FFLAGS ?= flash $(ELFFILE)
+export DEBUGGER_FLAGS ?= debug $(ELFFILE)
 export DEBUGSERVER_FLAGS ?= debug-server
 export RESET_FLAGS ?= reset
 


### PR DESCRIPTION
### Contribution description

This makes most of the boards get the file used for flashing from command line arguments instead of environment variables. This prevents using arbitrary "HEXFILE" or "BINFILE".

This is a split of https://github.com/RIOT-OS/RIOT/pull/8838 that already have been tested.

I split it to allow only fixing newly added boards before adding the `FLASHFILE` variable.


### Issues/PRs references

Split of https://github.com/RIOT-OS/RIOT/pull/8838