### PR TITLE
boards/stm32l0538-disco: add initial support

### DIFF
--- a/boards/stm32l0538-disco/Makefile
+++ b/boards/stm32l0538-disco/Makefile
@@ -1,0 +1,3 @@
+MODULE = board
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/stm32l0538-disco/Makefile.dep
+++ b/boards/stm32l0538-disco/Makefile.dep
@@ -1,0 +1,3 @@
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += saul_gpio
+endif

--- a/boards/stm32l0538-disco/Makefile.features
+++ b/boards/stm32l0538-disco/Makefile.features
@@ -1,0 +1,7 @@
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_rtc
+FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart
+
+-include $(RIOTCPU)/stm32l0/Makefile.features

--- a/boards/stm32l0538-disco/Makefile.features
+++ b/boards/stm32l0538-disco/Makefile.features
@@ -4,4 +4,4 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
--include $(RIOTCPU)/stm32l0/Makefile.features
+include $(RIOTCPU)/stm32l0/Makefile.features

--- a/boards/stm32l0538-disco/Makefile.include
+++ b/boards/stm32l0538-disco/Makefile.include
@@ -1,0 +1,18 @@
+# define the cpu used by the stm32l0538-disco board
+export CPU = stm32l0
+export CPU_MODEL = stm32l053c8
+
+# we use shared STM32 configuration snippets
+INCLUDES += -I$(RIOTBOARD)/common/stm32/include
+
+# define the default port depending on the host OS
+PORT_LINUX ?= /dev/ttyUSB0
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
+
+# setup serial terminal
+include $(RIOTMAKE)/tools/serial.inc.mk
+
+DEBUG_ADAPTER ?= stlink
+
+# this board uses openocd
+include $(RIOTMAKE)/tools/openocd.inc.mk

--- a/boards/stm32l0538-disco/board.c
+++ b/boards/stm32l0538-disco/board.c
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2018 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     boards_stm32l0538-disco
+ * @{
+ *
+ * @file
+ * @brief       Board specific implementations for the STM32L0538-DISCO evaluation board
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ * @}
+ */
+
+#include "board.h"
+#include "periph/gpio.h"
+
+void board_init(void)
+{
+    /* initialize the boards LEDs */
+    gpio_init(LED0_PIN, GPIO_OUT);
+    gpio_init(LED1_PIN, GPIO_OUT);
+
+    /* initialize the CPU */
+    cpu_init();
+}

--- a/boards/stm32l0538-disco/doc.txt
+++ b/boards/stm32l0538-disco/doc.txt
@@ -1,0 +1,41 @@
+/**
+ * @defgroup    boards_stm32l0538-disco STM32L0538-DISCO
+ * @ingroup     boards
+ * @brief       Support for the STM32L0538-DISCO board
+
+### Introduction
+
+The
+[STM32L0538-DISCO](https://www.st.com/en/evaluation-tools/32l0538discovery.html)
+discovery kit features an ultra low-power stm32l053c8t6 microcontroller with
+64KB of FLASH and 8KB of RAM.
+The board also provides an on-board 2.04" E-paper display (not supported yet).
+
+![STM32L0538-DISCO](https://www.st.com/content/ccc/fragment/product_related/rpn_information/board_photo/group0/67/a2/3f/98/6b/24/4a/27/stm32l0538-discovery.jpg/files/stm32l0538-disco.jpg/_jcr_content/translations/en.stm32l0538-disco.jpg)
+
+### Supported features
+
+| Peripheral            | Configuration                                                                             |
+|:--------------------- |:----------------------------------------------------------------------------------------- |
+| TIMs                  | TIM2                                                                                      |
+| UARTs                 | USART1 on PA10 (RX), PA9 (TX)                                                             |
+| SPIs                  | SPI1 on PB5 (MOSI), PB4 (MISO), PB3 (SCLK); SPI2 on PB15 (MOSI), PB14 (MISO), PB13 (SCLK) |
+
+### Flashing the board
+
+The board can be flashed using OpenOCD via the on-board ST-Link adapter.
+Then use the following command:
+
+    make BOARD=stm32l0538-disco -C examples/hello-world flash
+
+### STDIO
+
+STDIO is connected to pins PA9 (TX) and PA10 (RX) so an USB to UART adapter is
+required. Use the `term` targed to open a terminal:
+
+    make BOARD=stm32l0538-disco -C examples/hello-world term
+
+If an external ST-Link adapter is used, RX and TX pins can be directly connected
+to it. In this case, STDIO is available on /dev/ttyACMx (Linux case).
+
+ */

--- a/boards/stm32l0538-disco/include/board.h
+++ b/boards/stm32l0538-disco/include/board.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2018 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     boards_stm32l0538-disco
+ * @{
+ *
+ * @file
+ * @brief       Board specific definitions for the STM32L0538-DISCO evaluation board.
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include "cpu.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Xtimer configuration
+ * @{
+ */
+#define XTIMER_WIDTH                (16)
+/** @} */
+
+/**
+ * @name Macros for controlling the on-board LEDs.
+ * @{
+ */
+#define LED0_PIN            GPIO_PIN(PORT_B, 4)
+#define LED0_PORT           GPIOB
+#define LED0_MASK           (1 << 4)
+
+#define LED0_ON             (LED0_PORT->BSRR = LED0_MASK)
+#define LED0_OFF            (LED0_PORT->BRR  = LED0_MASK)
+#define LED0_TOGGLE         (LED0_PORT->ODR ^= LED0_MASK)
+
+#define LED1_PIN            GPIO_PIN(PORT_A, 5)
+#define LED1_PORT           GPIOA
+#define LED1_MASK           (1 << 5)
+
+#define LED1_ON             (LED1_PORT->BSRR = LED1_MASK)
+#define LED1_OFF            (LED1_PORT->BRR  = LED1_MASK)
+#define LED1_TOGGLE         (LED1_PORT->ODR ^= LED1_MASK)
+/** @} */
+
+/**
+ * @name User button
+ * @{
+ */
+#define BTN0_PIN            GPIO_PIN(PORT_A, 0)
+#define BTN0_PORT           GPIOA
+#define BTN0_MODE           GPIO_IN
+/** @} */
+
+/**
+ * @brief Initialize board specific hardware, including clock, LEDs and std-IO
+ */
+void board_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/stm32l0538-disco/include/gpio_params.h
+++ b/boards/stm32l0538-disco/include/gpio_params.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2018 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup   boards_stm32l0538-disco
+ * @{
+ *
+ * @file
+ * @brief     Board specific configuration of direct mapped GPIOs
+ *
+ * @author    Alexandre Abadie <alexandre.abadie@inria.fr>
+ */
+
+#ifndef GPIO_PARAMS_H
+#define GPIO_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    GPIO pin configuration
+ */
+static const  saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name = "LD3",
+        .pin = LED0_PIN,
+        .mode = GPIO_OUT
+    },
+    {
+        .name = "LD4",
+        .pin = LED1_PIN,
+        .mode = GPIO_OUT
+    },
+    {
+        .name = "BTN USER",
+        .pin  = BTN0_PIN,
+        .mode = BTN0_MODE
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_PARAMS_H */
+/** @} */

--- a/boards/stm32l0538-disco/include/periph_conf.h
+++ b/boards/stm32l0538-disco/include/periph_conf.h
@@ -1,0 +1,150 @@
+/*
+ * Copyright (C) 2018 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     boards_stm32l0538-disco
+ * @{
+ *
+ * @file
+ * @brief       Peripheral MCU configuration for the STM32L0538-DISCO board
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+#include "periph_cpu.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Clock system configuration
+ * @{
+ */
+#define CLOCK_HSI           (16000000U)         /* internal oscillator */
+#define CLOCK_CORECLOCK     (32000000U)         /* desired core clock frequency */
+#define CLOCK_LSE           (0)                 /* enable low speed external oscillator */
+
+/* configuration of PLL prescaler and multiply values */
+/* CORECLOCK := HSI / CLOCK_PLL_DIV * CLOCK_PLL_MUL */
+#define CLOCK_PLL_DIV       RCC_CFGR_PLLDIV2
+#define CLOCK_PLL_MUL       RCC_CFGR_PLLMUL4
+/* configuration of peripheral bus clock prescalers */
+#define CLOCK_AHB_DIV       RCC_CFGR_HPRE_DIV1      /* AHB clock -> 32MHz */
+#define CLOCK_APB2_DIV      RCC_CFGR_PPRE2_DIV1     /* APB2 clock -> 32MHz */
+#define CLOCK_APB1_DIV      RCC_CFGR_PPRE1_DIV1     /* APB1 clock -> 32MHz */
+/* configuration of flash access cycles */
+#define CLOCK_FLASH_LATENCY FLASH_ACR_LATENCY
+
+/* bus clocks for simplified peripheral initialization, UPDATE MANUALLY! */
+#define CLOCK_AHB           (CLOCK_CORECLOCK / 1)
+#define CLOCK_APB2          (CLOCK_CORECLOCK / 1)
+#define CLOCK_APB1          (CLOCK_CORECLOCK / 1)
+/** @} */
+
+/**
+ * @name    Timer configuration
+ * @{
+ */
+static const timer_conf_t timer_config[] = {
+    {
+        .dev      = TIM2,
+        .max      = 0x0000ffff,
+        .rcc_mask = RCC_APB1ENR_TIM2EN,
+        .bus      = APB1,
+        .irqn     = TIM2_IRQn
+    }
+};
+
+#define TIMER_0_ISR         isr_tim2
+
+#define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
+/** @} */
+
+/**
+ * @name    UART configuration
+ * @{
+ */
+static const uart_conf_t uart_config[] = {
+    {
+        .dev        = USART1,
+        .rcc_mask   = RCC_APB2ENR_USART1EN,
+        .rx_pin     = GPIO_PIN(PORT_A, 10),
+        .tx_pin     = GPIO_PIN(PORT_A, 9),
+        .rx_af      = GPIO_AF4,
+        .tx_af      = GPIO_AF4,
+        .bus        = APB2,
+        .irqn       = USART1_IRQn,
+        .type       = STM32_USART,
+        .clk_src    = 0, /* Use APB clock */
+    }
+};
+
+#define UART_0_ISR          (isr_usart1)
+
+#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+/** @} */
+
+/**
+ * @name    SPI configuration
+ *
+ * @note    The spi_divtable is auto-generated from
+ *          `cpu/stm32_common/dist/spi_divtable/spi_divtable.c`
+ * @{
+ */
+static const uint8_t spi_divtable[2][5] = {
+    {       /* for APB1 @ 32000000Hz */
+        7,  /* -> 125000Hz */
+        5,  /* -> 500000Hz */
+        4,  /* -> 1000000Hz */
+        2,  /* -> 4000000Hz */
+        1   /* -> 8000000Hz */
+    },
+    {       /* for APB2 @ 32000000Hz */
+        7,  /* -> 125000Hz */
+        5,  /* -> 500000Hz */
+        4,  /* -> 1000000Hz */
+        2,  /* -> 4000000Hz */
+        1   /* -> 8000000Hz */
+    }
+};
+
+static const spi_conf_t spi_config[] = {
+    {
+        .dev      = SPI1,
+        .mosi_pin = GPIO_PIN(PORT_B, 5),
+        .miso_pin = GPIO_PIN(PORT_B, 4),
+        .sclk_pin = GPIO_PIN(PORT_B, 3),
+        .cs_pin   = GPIO_UNDEF,
+        .af       = GPIO_AF0,
+        .rccmask  = RCC_APB2ENR_SPI1EN,
+        .apbbus   = APB2
+    },
+    {
+        .dev      = SPI2,
+        .mosi_pin = GPIO_PIN(PORT_B, 15),
+        .miso_pin = GPIO_PIN(PORT_B, 14),
+        .sclk_pin = GPIO_PIN(PORT_B, 13),
+        .cs_pin   = GPIO_PIN(PORT_B, 12),
+        .af       = GPIO_AF0,
+        .rccmask  = RCC_APB1ENR_SPI2EN,
+        .apbbus   = APB1
+    },
+};
+
+#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_CONF_H */

--- a/examples/asymcute_mqttsn/Makefile
+++ b/examples/asymcute_mqttsn/Makefile
@@ -17,7 +17,7 @@ BOARD_INSUFFICIENT_MEMORY := airfy-beacon arduino-duemilanove arduino-leonardo \
                              nucleo-f070rb nucleo-f072rb nucleo-f303k8 \
                              nucleo-f334r8 nucleo-l031k6 nucleo-l053r8 \
                              saml10-xpro saml11-xpro  \
-                             stm32f0discovery telosb waspmote-pro \
+                             stm32f0discovery stm32l0538-disco telosb waspmote-pro \
                              wsn430-v1_3b wsn430-v1_4 yunjia-nrf51822 z1
 
 # Include packages that pull up and auto-init the link layer.

--- a/examples/cord_ep/Makefile
+++ b/examples/cord_ep/Makefile
@@ -13,7 +13,8 @@ BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-leonardo \
                              msb-430h nucleo-f030r8 nucleo-l053r8 \
                              nucleo-f031k6 nucleo-f042k6 nucleo-f303k8 \
                              nucleo-f334r8 nucleo-l031k6 stm32f0discovery \
-                             telosb waspmote-pro wsn430-v1_3b wsn430-v1_4 z1
+                             stm32l0538-disco telosb waspmote-pro \
+                             wsn430-v1_3b wsn430-v1_4 z1
 
 USEMODULE += gnrc_netdev_default
 USEMODULE += auto_init_gnrc_netif

--- a/examples/cord_epsim/Makefile
+++ b/examples/cord_epsim/Makefile
@@ -13,7 +13,8 @@ BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-leonardo \
                              nucleo-f030r8 nucleo-l053r8 nucleo-f031k6 \
                              nucleo-f042k6 nucleo-f303k8 nucleo-f334r8 \
                              nucleo-l031k6 mega-xplained stm32f0discovery \
-                             telosb waspmote-pro wsn430-v1_3b wsn430-v1_4 z1
+                             stm32l0538-disco telosb waspmote-pro \
+                             wsn430-v1_3b wsn430-v1_4 z1
 
 # Enable GNRC networking
 USEMODULE += gnrc_netdev_default

--- a/examples/dtls-echo/Makefile
+++ b/examples/dtls-echo/Makefile
@@ -20,7 +20,7 @@ BOARD_INSUFFICIENT_MEMORY := airfy-beacon b-l072z-lrwan1 blackpill bluepill call
                              nucleo-f042k6 nucleo-f303k8 nucleo-l031k6 nucleo-f030r8 \
                              nucleo-f070rb nucleo-f072rb nucleo-f103rb nucleo-f302r8 nucleo-f334r8 \
                              nucleo-l053r8 nucleo-l073rz opencm904 saml10-xpro \
-                             saml11-xpro spark-core stm32f0discovery yunjia-nrf51822
+                             saml11-xpro spark-core stm32f0discovery stm32l0538-disco yunjia-nrf51822
 
 # Include packages that pull up and auto-init the link layer.
 # NOTE: 6LoWPAN will be included if IEEE802.15.4 devices are present

--- a/examples/emcute_mqttsn/Makefile
+++ b/examples/emcute_mqttsn/Makefile
@@ -13,8 +13,8 @@ BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-leonardo \
                              nucleo-f031k6 nucleo-f042k6 nucleo-f303k8 \
                              nucleo-l031k6 nucleo-f030r8 nucleo-f070rb \
                              nucleo-f072rb nucleo-f302r8 nucleo-f334r8 \
-                             nucleo-l053r8 stm32f0discovery telosb \
-                             waspmote-pro wsn430-v1_3b \
+                             nucleo-l053r8 stm32f0discovery stm32l0538-disco \
+                             telosb waspmote-pro wsn430-v1_3b \
                              wsn430-v1_4 z1 mega-xplained
 
 # Include packages that pull up and auto-init the link layer.

--- a/examples/gcoap/Makefile
+++ b/examples/gcoap/Makefile
@@ -15,7 +15,8 @@ BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-leonardo \
                              msb-430h nucleo-f031k6 nucleo-f042k6 \
                              nucleo-l031k6 nucleo-f030r8 nucleo-f303k8 \
                              nucleo-f334r8 nucleo-l053r8 stm32f0discovery \
-                             telosb waspmote-pro wsn430-v1_3b wsn430-v1_4 z1
+                             stm32l0538-disco telosb waspmote-pro \
+                             wsn430-v1_3b wsn430-v1_4 z1
 
 ## Uncomment to redefine port, for example use 61616 for RFC 6282 UDP compression.
 #GCOAP_PORT = 5683

--- a/examples/gnrc_border_router/Makefile
+++ b/examples/gnrc_border_router/Makefile
@@ -18,7 +18,8 @@ BOARD_INSUFFICIENT_MEMORY := airfy-beacon arduino-duemilanove arduino-leonardo \
                              nucleo-f070rb nucleo-f072rb nucleo-f103rb \
                              nucleo-f302r8 nucleo-f334r8 nucleo-l053r8 \
                              nucleo-l073rz opencm904 saml10-xpro saml11-xpro \
-                             spark-core stm32f0discovery telosb waspmote-pro \
+                             spark-core stm32f0discovery stm32l0538-disco \
+                             telosb waspmote-pro \
                              weio wsn430-v1_3b wsn430-v1_4 yunjia-nrf51822 z1
 
 # The following boards do not have an available UART

--- a/examples/gnrc_networking/Makefile
+++ b/examples/gnrc_networking/Makefile
@@ -16,7 +16,8 @@ BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-leonardo \
                              nucleo-l031k6 nucleo-f030r8 nucleo-f070rb \
                              nucleo-f072rb nucleo-f103rb nucleo-f302r8 \
                              nucleo-f334r8 nucleo-l053r8 saml10-xpro \
-                             saml11-xpro spark-core stm32f0discovery telosb \
+                             saml11-xpro spark-core stm32f0discovery \
+                             stm32l0538-disco telosb \
                              waspmote-pro wsn430-v1_3b wsn430-v1_4 z1
 
 # Include packages that pull up and auto-init the link layer.

--- a/examples/gnrc_tftp/Makefile
+++ b/examples/gnrc_tftp/Makefile
@@ -17,7 +17,8 @@ BOARD_INSUFFICIENT_MEMORY := airfy-beacon arduino-duemilanove arduino-leonardo \
                              nucleo-f030r8 nucleo-f070rb nucleo-f072rb \
                              nucleo-f103rb nucleo-f302r8 nucleo-f334r8 \
                              nucleo-l053r8 saml10-xpro saml11-xpro spark-core \
-                             stm32f0discovery telosb waspmote-pro wsn430-v1_3b \
+                             stm32f0discovery stm32l0538-disco telosb \
+                             waspmote-pro wsn430-v1_3b \
                              wsn430-v1_4 yunjia-nrf51822 z1
 
 # Include packages that pull up and auto-init the link layer.

--- a/examples/javascript/Makefile
+++ b/examples/javascript/Makefile
@@ -15,7 +15,8 @@ BOARD_INSUFFICIENT_MEMORY := airfy-beacon b-l072z-lrwan1 blackpill bluepill call
                              nucleo-f410rb nucleo-l053r8 nucleo-l073rz \
                              nucleo-f031k6 nucleo-f042k6 nucleo-f303k8 \
                              nucleo-l031k6 opencm904 saml10-xpro saml11-xpro \
-                             spark-core stm32f0discovery yunjia-nrf51822
+                             spark-core stm32f0discovery stm32l0538-disco \
+                             yunjia-nrf51822
 
 BOARD_BLACKLIST := arduino-duemilanove arduino-leonardo arduino-mega2560 \
                    arduino-nano arduino-uno chronos \

--- a/examples/lua_REPL/Makefile
+++ b/examples/lua_REPL/Makefile
@@ -25,7 +25,8 @@ BOARD_INSUFFICIENT_MEMORY := blackpill bluepill calliope-mini cc2650-launchpad \
                              samr30-xpro seeeduino_arch-pro sensebox_samd21 slstk3401a \
                              sltb001a slwstk6220a sodaq-autonomo sodaq-explorer \
                              sodaq-one sodaq-sara-aff stk3600 stm32f3discovery \
-                             yunjia-nrf51822 esp8266-esp-12x esp8266-olimex-mod \
+                             stm32l0538-disco yunjia-nrf51822 \
+                             esp8266-esp-12x esp8266-olimex-mod \
                              esp8266-sparkfun-thing firefly
 
 BOARD_BLACKLIST := arduino-duemilanove arduino-leonardo \

--- a/examples/lua_basic/Makefile
+++ b/examples/lua_basic/Makefile
@@ -14,7 +14,7 @@ BOARD_INSUFFICIENT_MEMORY := blackpill bluepill calliope-mini cc2650-launchpad \
                              nucleo-f103rb nucleo-f302r8 nucleo-f303k8 \
                              nucleo-f334r8 nucleo-f410rb nucleo-l031k6 \
                              nucleo-l053r8 opencm904 saml10-xpro saml11-xpro \
-                             spark-core stm32f0discovery
+                             spark-core stm32f0discovery stm32l0538-disco
 
 BOARD_BLACKLIST := arduino-duemilanove arduino-leonardo \
                    arduino-mega2560 arduino-nano \

--- a/examples/nanocoap_server/Makefile
+++ b/examples/nanocoap_server/Makefile
@@ -12,7 +12,8 @@ BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-leonardo \
                              chronos i-nucleo-lrwan1 msb-430 msb-430h \
                              nucleo-f031k6 nucleo-f042k6 nucleo-l031k6 \
                              nucleo-f030r8 nucleo-f303k8 nucleo-l053r8 \
-                             stm32f0discovery telosb waspmote-pro wsn430-v1_3b \
+                             stm32f0discovery stm32l0538-disco telosb \
+                             waspmote-pro wsn430-v1_3b \
                              wsn430-v1_4 z1
 
 # Include packages that pull up and auto-init the link layer.

--- a/examples/ndn-ping/Makefile
+++ b/examples/ndn-ping/Makefile
@@ -12,7 +12,8 @@ BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-leonardo \
                              arduino-uno chronos i-nucleo-lrwan1 mega-xplained \
                              msb-430 msb-430h nucleo-f042k6 nucleo-f031k6 \
                              nucleo-l031k6 nucleo-f030r8 nucleo-l053r8 \
-                             stm32f0discovery telosb waspmote-pro weio \
+                             stm32f0discovery stm32l0538-disco telosb \
+                             waspmote-pro weio \
                              wsn430-v1_3b wsn430-v1_4 z1
 
 # Include packages that pull up and auto-init the link layer.

--- a/examples/posix_sockets/Makefile
+++ b/examples/posix_sockets/Makefile
@@ -14,7 +14,8 @@ BOARD_INSUFFICIENT_MEMORY := airfy-beacon arduino-duemilanove arduino-leonardo \
                              nucleo-f031k6 nucleo-f042k6 nucleo-l031k6 \
                              nucleo-f030r8 nucleo-f070rb nucleo-f072rb \
                              nucleo-f334r8 nucleo-f303k8 nucleo-l053r8 \
-                             stm32f0discovery telosb wsn430-v1_3b wsn430-v1_4 \
+                             stm32f0discovery stm32l0538-disco telosb \
+                             wsn430-v1_3b wsn430-v1_4 \
                              yunjia-nrf51822 waspmote-pro z1
 
 # Include packages that pull up and auto-init the link layer.

--- a/tests/cond_order/Makefile
+++ b/tests/cond_order/Makefile
@@ -5,6 +5,6 @@ BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-leonardo arduino-nano \
                              nucleo32-f042 nucleo32-l031 nucleo-f030 \
                              nucleo-f030r8 nucleo-f031k6 nucleo-f042k6 \
                              nucleo-l031k6 nucleo-l053 nucleo-l053r8 \
-                             stm32f0discovery
+                             stm32f0discovery stm32l0538-disco
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/conn_can/Makefile
+++ b/tests/conn_can/Makefile
@@ -8,7 +8,8 @@ BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-leonardo \
                              nucleo-l031k6 nucleo-f030r8 nucleo-f070rb \
                              nucleo-f072rb nucleo-f302r8 nucleo-f303re \
                              nucleo-f334r8 nucleo-l053r8 saml10-xpro \
-                             saml11-xpro stm32f0discovery telosb waspmote-pro \
+                             saml11-xpro stm32f0discovery stm32l0538-disco \
+                             telosb waspmote-pro \
                              wsn430-v1_3b wsn430-v1_4 z1
 
 USEMODULE += shell

--- a/tests/cpp11_condition_variable/Makefile
+++ b/tests/cpp11_condition_variable/Makefile
@@ -6,7 +6,8 @@ include ../Makefile.tests_common
 # Debian jessie libstdc++-arm-none-eabi-newlib-4.8.3-9+4 works fine, though.
 # Remove this line if Travis is upgraded to a different toolchain which does
 # not pull in all C++ locale code whenever exceptions are used.
-BOARD_INSUFFICIENT_MEMORY := i-nucleo-lrwan1 nucleo-f334r8 spark-core stm32f0discovery
+BOARD_INSUFFICIENT_MEMORY := i-nucleo-lrwan1 nucleo-f334r8 spark-core \
+                             stm32f0discovery stm32l0538-disco
 
 # If you want to add some extra flags when compile c++ files, add these flags
 # to CXXEXFLAGS variable

--- a/tests/cpp11_mutex/Makefile
+++ b/tests/cpp11_mutex/Makefile
@@ -6,7 +6,8 @@ include ../Makefile.tests_common
 # Debian jessie libstdc++-arm-none-eabi-newlib-4.8.3-9+4 works fine, though.
 # Remove this line if Travis is upgraded to a different toolchain which does
 # not pull in all C++ locale code whenever exceptions are used.
-BOARD_INSUFFICIENT_MEMORY := i-nucleo-lrwan1 nucleo-f334r8 spark-core stm32f0discovery
+BOARD_INSUFFICIENT_MEMORY := i-nucleo-lrwan1 nucleo-f334r8 spark-core \
+                             stm32f0discovery stm32l0538-disco
 
 # If you want to add some extra flags when compile c++ files, add these flags
 # to CXXEXFLAGS variable

--- a/tests/cpp11_thread/Makefile
+++ b/tests/cpp11_thread/Makefile
@@ -6,7 +6,8 @@ include ../Makefile.tests_common
 # Debian jessie libstdc++-arm-none-eabi-newlib-4.8.3-9+4 works fine, though.
 # Remove this line if Travis is upgraded to a different toolchain which does
 # not pull in all C++ locale code whenever exceptions are used.
-BOARD_INSUFFICIENT_MEMORY := i-nucleo-lrwan1 nucleo-f334r8 spark-core stm32f0discovery
+BOARD_INSUFFICIENT_MEMORY := i-nucleo-lrwan1 nucleo-f334r8 spark-core \
+                             stm32f0discovery stm32l0538-disco
 
 # If you want to add some extra flags when compile c++ files, add these flags
 # to CXXEXFLAGS variable

--- a/tests/driver_enc28j60/Makefile
+++ b/tests/driver_enc28j60/Makefile
@@ -5,7 +5,8 @@ BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-leonardo \
                              arduino-uno i-nucleo-lrwan1 msb-430 msb-430h \
                              nucleo-f334r8 nucleo-l053r8 nucleo-f031k6 \
                              nucleo-f042k6 nucleo-f303k8 nucleo-l031k6 \
-                             mega-xplained stm32f0discovery telosb \
+                             mega-xplained stm32f0discovery \
+                             stm32l0538-disco telosb \
                              waspmote-pro wsn430-v1_3b wsn430-v1_4 z1
 
 USEMODULE += auto_init_gnrc_netif

--- a/tests/driver_encx24j600/Makefile
+++ b/tests/driver_encx24j600/Makefile
@@ -4,7 +4,8 @@ BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-leonardo \
                              arduino-mega2560 arduino-nano \
                              arduino-uno i-nucleo-lrwan1 msb-430 msb-430h \
                              nucleo-l053r8 nucleo-f031k6 nucleo-f042k6 \
-                             nucleo-l031k6 stm32f0discovery telosb \
+                             nucleo-l031k6 stm32f0discovery \
+                             stm32l0538-disco telosb \
                              waspmote-pro wsn430-v1_3b wsn430-v1_4 z1
 
 USEMODULE += auto_init_gnrc_netif

--- a/tests/driver_kw2xrf/Makefile
+++ b/tests/driver_kw2xrf/Makefile
@@ -4,7 +4,7 @@ BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-leonardo \
                              arduino-mega2560 arduino-nano arduino-uno \
                              i-nucleo-lrwan1 nucleo-f031k6 nucleo-f042k6 \
                              nucleo-l031k6 nucleo-f334r8 nucleo-l053r8 \
-                             stm32f0discovery waspmote-pro
+                             stm32f0discovery stm32l0538-disco waspmote-pro
 
 USEMODULE += auto_init_gnrc_netif
 USEMODULE += gnrc_netdev_default

--- a/tests/emb6/Makefile
+++ b/tests/emb6/Makefile
@@ -10,8 +10,8 @@ BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-leonardo \
                              arduino-mega2560 arduino-nano arduino-uno \
                              i-nucleo-lrwan1 msb-430 msb-430h nucleo-l031k6 \
                              nucleo-f031k6 nucleo-f042k6 nucleo-l053r8 \
-                             stm32f0discovery telosb waspmote-pro wsn430-v1_3b \
-                             wsn430-v1_4 z1
+                             stm32f0discovery stm32l0538-disco telosb \
+                             waspmote-pro wsn430-v1_3b wsn430-v1_4 z1
 
 USEPKG += emb6
 

--- a/tests/gnrc_ipv6_ext/Makefile
+++ b/tests/gnrc_ipv6_ext/Makefile
@@ -8,7 +8,8 @@ BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-leonardo \
                              msb-430 msb-430h nucleo-f030r8 nucleo-f031k6 \
                              nucleo-f042k6 nucleo-f070rb nucleo-f072rb \
                              nucleo-f303k8 nucleo-f334r8 nucleo-l031k6 \
-                             nucleo-l053r8 stm32f0discovery telosb thingy52 \
+                             nucleo-l053r8 stm32f0discovery stm32l0538-disco \
+                             telosb thingy52 \
                              waspmote-pro wsn430-v1_3b wsn430-v1_4 z1
 # chronos, hamilton, mips-malta, and ruuvitag boards don't support ethos
 BOARD_BLACKLIST := chronos hamilton mips-malta ruuvitag

--- a/tests/gnrc_ipv6_fwd_w_sub/Makefile
+++ b/tests/gnrc_ipv6_fwd_w_sub/Makefile
@@ -5,7 +5,7 @@ BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-leonardo \
                              arduino-mega2560 arduino-nano arduino-uno chronos \
                              i-nucleo-lrwan1 msb-430 msb-430h nucleo-f030r8 \
                              nucleo-f031k6 nucleo-f042k6 nucleo-l031k6 \
-                             nucleo-l053r8 stm32f0discovery telosb \
+                             nucleo-l053r8 stm32f0discovery stm32l0538-disco telosb \
                              waspmote-pro wsn430-v1_3b wsn430-v1_4 z1
 
 USEMODULE += gnrc_ipv6_router_default

--- a/tests/gnrc_ipv6_nib_6ln/Makefile
+++ b/tests/gnrc_ipv6_nib_6ln/Makefile
@@ -4,8 +4,8 @@ BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-leonardo \
                              arduino-mega2560 arduino-nano arduino-uno chronos \
                              i-nucleo-lrwan1 nucleo-f030r8 nucleo-l053r8 \
                              nucleo-f031k6 nucleo-l031k6 nucleo-f042k6 \
-                             stm32f0discovery telosb waspmote-pro wsn430-v1_3b \
-                             wsn430-v1_4
+                             stm32f0discovery stm32l0538-disco telosb \
+                             waspmote-pro wsn430-v1_3b wsn430-v1_4
 
 USEMODULE += gnrc_ipv6
 USEMODULE += gnrc_sixlowpan

--- a/tests/gnrc_mac_timeout/Makefile
+++ b/tests/gnrc_mac_timeout/Makefile
@@ -5,7 +5,8 @@ BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-leonardo \
                              arduino-mega2560 arduino-nano arduino-uno \
                              chronos i-nucleo-lrwan1 nucleo-f030r8 \
                              nucleo-f031k6 nucleo-f042k6 nucleo-l031k6 \
-                             nucleo-l053r8 stm32f0discovery waspmote-pro
+                             nucleo-l053r8 stm32f0discovery stm32l0538-disco \
+                             waspmote-pro
 
 USEMODULE += gnrc_mac
 

--- a/tests/gnrc_ndp/Makefile
+++ b/tests/gnrc_ndp/Makefile
@@ -4,8 +4,8 @@ BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-leonardo \
                              arduino-mega2560 arduino-nano arduino-uno chronos \
                              i-nucleo-lrwan1 nucleo-f030r8 nucleo-f031k6 \
                              nucleo-f042k6 nucleo-l031k6 nucleo-l053r8 \
-                             stm32f0discovery telosb waspmote-pro wsn430-v1_3b \
-                             wsn430-v1_4
+                             stm32f0discovery stm32l0538-disco telosb \
+                             waspmote-pro wsn430-v1_3b wsn430-v1_4
 
 USEMODULE += gnrc_ipv6_nib_router
 USEMODULE += gnrc_ndp

--- a/tests/gnrc_netif/Makefile
+++ b/tests/gnrc_netif/Makefile
@@ -12,8 +12,9 @@ BOARD_INSUFFICIENT_MEMORY := airfy-beacon arduino-duemilanove arduino-leonardo \
                              nucleo-l053r8 nucleo-l073rz nucleo-f031k6 \
                              nucleo-f042k6 nucleo-f303k8 nucleo-l031k6 \
                              opencm904 saml10-xpro saml11-xpro spark-core \
-                             stm32f0discovery telosb waspmote-pro \
-                             wsn430-v1_3b wsn430-v1_4 yunjia-nrf51822 z1
+                             stm32f0discovery stm32l0538-disco telosb \
+                             waspmote-pro wsn430-v1_3b wsn430-v1_4 \
+                             yunjia-nrf51822 z1
 
 USEMODULE += embunit
 USEMODULE += gnrc_netif

--- a/tests/gnrc_rpl_srh/Makefile
+++ b/tests/gnrc_rpl_srh/Makefile
@@ -9,8 +9,8 @@ BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-leonardo \
                              nucleo-f042k6 nucleo-f070rb nucleo-f072rb \
                              nucleo-f303k8 nucleo-f334r8 nucleo-l031k6 \
                              nucleo-l053r8 saml10-xpro saml11-xpro \
-                             stm32f0discovery telosb thingy52 waspmote-pro \
-                             wsn430-v1_3b wsn430-v1_4 z1
+                             stm32f0discovery stm32l0538-disco telosb thingy52 \
+                             waspmote-pro wsn430-v1_3b wsn430-v1_4 z1
 # chronos, hamilton mips-malta, and ruuvitag boards don't support ethos
 BOARD_BLACKLIST := chronos hamilton mips-malta ruuvitag
 

--- a/tests/gnrc_sixlowpan/Makefile
+++ b/tests/gnrc_sixlowpan/Makefile
@@ -8,7 +8,8 @@ BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-leonardo \
                              nucleo-f070rb nucleo-f070rb nucleo-f072rb \
                              nucleo-f303k8 nucleo-f334r8 nucleo-l031k6 \
                              nucleo-l053r8 saml10-xpro saml11-xpro \
-                             stm32f0discovery telosb waspmote-pro wsn430-v1_3b \
+                             stm32f0discovery stm32l0538-disco telosb \
+                             waspmote-pro wsn430-v1_3b \
                              wsn430-v1_4 z1
 
 # use IEEE 802.15.4 as link-layer protocol

--- a/tests/gnrc_sock_dns/Makefile
+++ b/tests/gnrc_sock_dns/Makefile
@@ -8,7 +8,8 @@ BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-leonardo \
                              mega-xplained msb-430 msb-430h \
                              nucleo-f042k6 nucleo-f031k6 \
                              nucleo-f030r8 nucleo-f303k8 nucleo-l053r8 \
-                             nucleo-l031k6 stm32f0discovery thingy52 telosb \
+                             nucleo-l031k6 stm32f0discovery stm32l0538-disco \
+                             thingy52 telosb \
                              waspmote-pro wsn430-v1_3b wsn430-v1_4 z1
 # chronos, hamilton mips-malta, and ruuvitag boards don't support ethos
 BOARD_BLACKLIST := chronos hamilton mips-malta ruuvitag

--- a/tests/gnrc_tcp_client/Makefile
+++ b/tests/gnrc_tcp_client/Makefile
@@ -22,7 +22,8 @@ BOARD_INSUFFICIENT_MEMORY := airfy-beacon arduino-duemilanove \
                              nucleo-l031k6 nucleo-f030r8 nucleo-f070rb \
                              nucleo-f072rb nucleo-f302r8 nucleo-f334r8 \
                              nucleo-l053r8 saml10-xpro saml11-xpro sb-430 sb-430h \
-                             stm32f0discovery telosb waspmote-pro wsn430-v1_3b \
+                             stm32f0discovery stm32l0538-disco telosb \
+                             waspmote-pro wsn430-v1_3b \
                              wsn430-v1_4 yunjia-nrf51822 z1
 
 # Target Address, Target Port and number of Test Cycles

--- a/tests/gnrc_tcp_server/Makefile
+++ b/tests/gnrc_tcp_server/Makefile
@@ -22,7 +22,8 @@ BOARD_INSUFFICIENT_MEMORY := airfy-beacon arduino-duemilanove \
                              nucleo-f030r8 nucleo-f070rb nucleo-f072rb \
                              nucleo-f302r8 nucleo-f334r8 nucleo-l053r8 \
                              saml10-xpro saml11-xpro sb-430 sb-430h \
-                             stm32f0discovery telosb waspmote-pro wsn430-v1_3b \
+                             stm32f0discovery stm32l0538-disco telosb \
+                             waspmote-pro wsn430-v1_3b \
                              wsn430-v1_4 yunjia-nrf51822 z1
 
 # Local Address, Local Port and number of Test Cycles

--- a/tests/gnrc_udp/Makefile
+++ b/tests/gnrc_udp/Makefile
@@ -9,7 +9,8 @@ BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-leonardo \
                              nucleo-l031k6 nucleo-f030r8 nucleo-f070rb \
                              nucleo-f072rb nucleo-f103rb nucleo-f302r8 \
                              nucleo-f334r8 nucleo-l053r8 spark-core \
-                             stm32f0discovery telosb waspmote-pro wsn430-v1_3b \
+                             stm32f0discovery stm32l0538-disco telosb \
+                             waspmote-pro wsn430-v1_3b \
                              wsn430-v1_4 z1
 
 USEMODULE += gnrc_netdev_default

--- a/tests/lwip/Makefile
+++ b/tests/lwip/Makefile
@@ -12,7 +12,7 @@ BOARD_INSUFFICIENT_MEMORY := airfy-beacon hifive1 i-nucleo-lrwan1 nrf6310 \
                              nucleo-f031k6 nucleo-f042k6 \
                              nucleo-l031k6 nucleo-f030r8 nucleo-f303k8 \
                              nucleo-f334r8 nucleo-l053r8 stm32f0discovery \
-                             yunjia-nrf51822
+                             stm32l0538-disco yunjia-nrf51822
 
 # including lwip_ipv6_mld would currently break this test on at86rf2xx radios
 USEMODULE += lwip lwip_ipv6_autoconfig lwip_sock_ip lwip_netdev

--- a/tests/lwip_sock_ip/Makefile
+++ b/tests/lwip_sock_ip/Makefile
@@ -10,7 +10,8 @@ BOARD_BLACKLIST := arduino-duemilanove arduino-leonardo \
                    wsn430-v1_3b wsn430-v1_4 z1
 BOARD_INSUFFICIENT_MEMORY = i-nucleo-lrwan1 nucleo-f031k6 nucleo-f042k6 \
                             nucleo-l031k6 nucleo-f030r8 nucleo-f303k8 \
-                            nucleo-f334r8 nucleo-l053r8 stm32f0discovery
+                            nucleo-f334r8 nucleo-l053r8 stm32f0discovery \
+                            stm32l0538-disco
 
 LWIP_IPV4 ?= 0
 

--- a/tests/lwip_sock_tcp/Makefile
+++ b/tests/lwip_sock_tcp/Makefile
@@ -12,7 +12,8 @@ BOARD_INSUFFICIENT_MEMORY = blackpill bluepill i-nucleo-lrwan1 \
                             nucleo-f031k6 nucleo-f042k6 \
                             nucleo-l031k6 nucleo-f030r8 nucleo-f302r8 \
                             nucleo-f303k8 nucleo-f334r8 nucleo-l053r8 \
-                            saml10-xpro saml11-xpro stm32f0discovery
+                            saml10-xpro saml11-xpro stm32f0discovery \
+                            stm32l0538-disco
 
 LWIP_IPV4 ?= 0
 

--- a/tests/lwip_sock_udp/Makefile
+++ b/tests/lwip_sock_udp/Makefile
@@ -11,7 +11,7 @@ BOARD_BLACKLIST := arduino-duemilanove arduino-leonardo \
 BOARD_INSUFFICIENT_MEMORY = i-nucleo-lrwan1 nucleo-f031k6 nucleo-f042k6 \
                             nucleo-l031k6 nucleo-f030r8 \
                             nucleo-f303k8 nucleo-f334r8 nucleo-l053r8 \
-                            stm32f0discovery
+                            stm32f0discovery stm32l0538-disco
 
 LWIP_IPV4 ?= 0
 

--- a/tests/mutex_order/Makefile
+++ b/tests/mutex_order/Makefile
@@ -3,7 +3,8 @@ include ../Makefile.tests_common
 BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-leonardo arduino-nano \
                              arduino-uno i-nucleo-lrwan1 \
                              nucleo-f031k6 nucleo-f042k6 nucleo-l031k6 \
-                             nucleo-f030r8 nucleo-l053r8 stm32f0discovery
+                             nucleo-f030r8 nucleo-l053r8 stm32f0discovery \
+                             stm32l0538-disco
 
 # list of boards to run CI tests on
 TEST_ON_CI_WHITELIST += all

--- a/tests/nanocoap_cli/Makefile
+++ b/tests/nanocoap_cli/Makefile
@@ -6,7 +6,8 @@ BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-leonardo \
                              msb-430 msb-430h nucleo-f030r8 \
                              nucleo-f031k6 nucleo-f042k6 nucleo-f303k8 \
                              nucleo-f334r8 nucleo-l031k6 nucleo-l053r8 \
-                             stm32f0discovery telosb waspmote-pro z1
+                             stm32f0discovery stm32l0538-disco telosb \
+                             waspmote-pro z1
 
 # Include packages that pull up and auto-init the link layer.
 # NOTE: 6LoWPAN will be included if IEEE802.15.4 devices are present

--- a/tests/nhdp/Makefile
+++ b/tests/nhdp/Makefile
@@ -8,7 +8,7 @@ BOARD_BLACKLIST := arduino-duemilanove arduino-leonardo \
 BOARD_INSUFFICIENT_MEMORY := i-nucleo-lrwan1 nucleo-f031k6 nucleo-f042k6 \
                              nucleo-l031k6 nucleo-f030r8 \
                              nucleo-f303k8 nucleo-f334r8 nucleo-l053r8 \
-                             stm32f0discovery
+                             stm32f0discovery stm32l0538-disco
 
 USEMODULE += gnrc_ipv6
 USEMODULE += gnrc_sock_udp

--- a/tests/pkg_fatfs/Makefile
+++ b/tests/pkg_fatfs/Makefile
@@ -24,8 +24,8 @@ BOARD_WHITELIST := airfy-beacon arduino-due arduino-duemilanove \
                    remote-revb samd21-xpro saml21-xpro samr21-xpro \
                    sensebox_samd21 sltb001a sodaq-autonomo \
                    sodaq-explorer spark-core stm32f0discovery stm32f3discovery \
-                   stm32f4discovery telosb udoo waspmote-pro wsn430-v1_3b \
-                   wsn430-v1_4 yunjia-nrf51822 z1 native
+                   stm32f4discovery stm32l0538-disco telosb udoo waspmote-pro \
+                   wsn430-v1_3b wsn430-v1_4 yunjia-nrf51822 z1 native
 
 USEMODULE += shell
 USEMODULE += fatfs_diskio_mtd

--- a/tests/pkg_fatfs_vfs/Makefile
+++ b/tests/pkg_fatfs_vfs/Makefile
@@ -46,7 +46,8 @@ BOARD_WHITELIST := airfy-beacon arduino-due arduino-duemilanove \
                    remote-revb samd21-xpro saml21-xpro samr21-xpro \
                    sensebox_samd21 sltb001a sodaq-autonomo sodaq-explorer \
                    spark-core stm32f0discovery stm32f3discovery \
-                   stm32f4discovery udoo waspmote-pro yunjia-nrf51822 native
+                   stm32f4discovery stm32l0538-disco udoo waspmote-pro \
+                   yunjia-nrf51822 native
 
 TEST_DEPS += image
 

--- a/tests/pkg_libcoap/Makefile
+++ b/tests/pkg_libcoap/Makefile
@@ -9,8 +9,8 @@ BOARD_INSUFFICIENT_MEMORY := chronos i-nucleo-lrwan1 msb-430 msb-430h \
                              nucleo-f031k6 nucleo-f042k6 \
                              nucleo-l031k6 nucleo-f030r8 nucleo-f070rb \
                              nucleo-f303k8 nucleo-f334r8 nucleo-l053r8 \
-                             stm32f0discovery telosb wsn430-v1_3b wsn430-v1_4 \
-                             z1
+                             stm32f0discovery stm32l0538-disco telosb wsn430-v1_3b \
+                             wsn430-v1_4 z1
 
 USEMODULE += gnrc_ipv6
 USEMODULE += gnrc_sock_udp

--- a/tests/pkg_libcose/Makefile
+++ b/tests/pkg_libcose/Makefile
@@ -9,7 +9,8 @@ BOARD_BLACKLIST := arduino-duemilanove arduino-leonardo \
 
 BOARD_INSUFFICIENT_MEMORY := i-nucleo-lrwan1 \
                              nucleo-f030r8 nucleo-f031k6 nucleo-f042k6 \
-                             nucleo-l031k6 nucleo-l053r8 stm32f0discovery
+                             nucleo-l031k6 nucleo-l053r8 stm32f0discovery \
+                             stm32l0538-disco
 
 TEST_ON_CI_WHITELIST += native
 

--- a/tests/pkg_littlefs/Makefile
+++ b/tests/pkg_littlefs/Makefile
@@ -11,6 +11,7 @@ BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove \
                              nucleo-l053r8 \
                              nucleo-f030r8 \
                              stm32f0discovery \
+                             stm32l0538-disco \
 
 BOARD_BLACKLIST := chronos \
                    msb-430 \

--- a/tests/pkg_microcoap/Makefile
+++ b/tests/pkg_microcoap/Makefile
@@ -5,7 +5,8 @@ BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-leonardo \
                              i-nucleo-lrwan1 msb-430 msb-430h \
                              nucleo-f031k6 nucleo-f042k6 nucleo-f303k8 \
                              nucleo-l031k6 nucleo-f030r8 nucleo-l053r8 \
-                             stm32f0discovery telosb waspmote-pro z1
+                             stm32f0discovery stm32l0538-disco telosb \
+                             waspmote-pro z1
 
 # Include packages that pull up and auto-init the link layer.
 # NOTE: 6LoWPAN will be included if IEEE802.15.4 devices are present

--- a/tests/pkg_relic/Makefile
+++ b/tests/pkg_relic/Makefile
@@ -30,6 +30,7 @@ BOARD_INSUFFICIENT_MEMORY :=    i-nucleo-lrwan1 \
                                 nucleo-f042k6 \
                                 nucleo-l031k6 \
                                 nucleo-l053r8 \
+                                stm32l0538-disco \
                                 #
 
 CFLAGS += -DTHREAD_STACKSIZE_MAIN=\(5*THREAD_STACKSIZE_DEFAULT\)

--- a/tests/pkg_spiffs/Makefile
+++ b/tests/pkg_spiffs/Makefile
@@ -11,6 +11,7 @@ BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove \
                              nucleo-l053r8 \
                              nucleo-f030r8 \
                              stm32f0discovery \
+                             stm32l0538-disco \
 
 BOARD_BLACKLIST := chronos \
                    msb-430 \

--- a/tests/posix_semaphore/Makefile
+++ b/tests/posix_semaphore/Makefile
@@ -6,7 +6,7 @@ BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-leonardo arduino-nano \
                              nucleo-f031k6 nucleo-f042k6 nucleo-l031k6 \
                              nucleo-f030r8 nucleo-f303k8 nucleo-f334r8 \
                              nucleo-l053r8 spark-core stm32f0discovery \
-                             yunjia-nrf51822
+                             stm32l0538-disco yunjia-nrf51822
 
 USEMODULE += fmt
 USEMODULE += posix_semaphore

--- a/tests/ps_schedstatistics/Makefile
+++ b/tests/ps_schedstatistics/Makefile
@@ -4,8 +4,8 @@ BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-leonardo arduino-nano \
                              arduino-uno chronos i-nucleo-lrwan1 \
                              msb-430 msb-430h nucleo-f030r8 \
                              nucleo-l053r8 nucleo-f031k6 nucleo-f042k6 \
-                             nucleo-l031k6 stm32f0discovery telosb \
-                             wsn430-v1_3b wsn430-v1_4 z1
+                             nucleo-l031k6 stm32f0discovery stm32l0538-disco \
+                             telosb wsn430-v1_3b wsn430-v1_4 z1
 
 USEMODULE += shell
 USEMODULE += shell_commands

--- a/tests/pthread_barrier/Makefile
+++ b/tests/pthread_barrier/Makefile
@@ -2,7 +2,7 @@ include ../Makefile.tests_common
 
 BOARD_BLACKLIST := arduino-duemilanove arduino-leonardo arduino-mega2560 \
                    arduino-nano arduino-uno i-nucleo-lrwan1 jiminy-mega256rfr2 \
-                   mega-xplained waspmote-pro
+                   mega-xplained stm32l0538-disco waspmote-pro
 # AVR platform: unknown type name: clockid_t
 
 # exclude boards with insufficient memory

--- a/tests/pthread_cooperation/Makefile
+++ b/tests/pthread_cooperation/Makefile
@@ -2,7 +2,7 @@ include ../Makefile.tests_common
 
 BOARD_BLACKLIST := arduino-duemilanove arduino-leonardo arduino-mega2560 \
                    arduino-nano arduino-uno hifive1 i-nucleo-lrwan1 \
-                   jiminy-mega256rfr2 mega-xplained waspmote-pro
+                   jiminy-mega256rfr2 mega-xplained stm32l0538-disco waspmote-pro
 
 # AVR platform: unknown type name: clockid_t
 # hifive1: not enough memory for thread stacks

--- a/tests/pthread_rwlock/Makefile
+++ b/tests/pthread_rwlock/Makefile
@@ -15,6 +15,6 @@ BOARD_INSUFFICIENT_MEMORY += chronos i-nucleo-lrwan1 \
                              msb-430 msb-430h nucleo-f031k6 \
                              nucleo-f042k6 nucleo-l031k6 nucleo-f030r8 \
                              nucleo-f303k8 nucleo-f334r8 nucleo-l053r8 \
-                             stm32f0discovery
+                             stm32f0discovery stm32l0538-disco
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/rmutex/Makefile
+++ b/tests/rmutex/Makefile
@@ -3,7 +3,8 @@ include ../Makefile.tests_common
 BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-leonardo arduino-nano \
                              arduino-uno i-nucleo-lrwan1 \
                              nucleo-f031k6 nucleo-f042k6 nucleo-l031k6 \
-                             nucleo-f030r8 nucleo-l053r8 stm32f0discovery
+                             nucleo-f030r8 nucleo-l053r8 stm32f0discovery \
+                             stm32l0538-disco
 
 TEST_ON_CI_WHITELIST += all
 

--- a/tests/slip/Makefile
+++ b/tests/slip/Makefile
@@ -6,7 +6,7 @@ BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-leonardo \
                              msb-430 msb-430h nucleo-f031k6 \
                              nucleo-f042k6 nucleo-l031k6 nucleo-f030r8 \
                              nucleo-f303k8 nucleo-f334r8 nucleo-l053r8 \
-                             stm32f0discovery waspmote-pro
+                             stm32f0discovery stm32l0538-disco waspmote-pro
 
 BOARD_BLACKLIST += mips-malta
 

--- a/tests/sntp/Makefile
+++ b/tests/sntp/Makefile
@@ -5,8 +5,8 @@ BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-leonardo \
                              chronos i-nucleo-lrwan1 msb-430 msb-430h \
                              nucleo-f031k6 nucleo-f042k6 nucleo-l031k6 \
                              nucleo-f030r8 nucleo-f303k8 nucleo-f334r8 \
-                             nucleo-l053r8 stm32f0discovery telosb \
-                             waspmote-pro wsn430-v1_3b wsn430-v1_4 z1
+                             nucleo-l053r8 stm32f0discovery stm32l0538-disco \
+                             telosb waspmote-pro wsn430-v1_3b wsn430-v1_4 z1
 
 USEMODULE += sntp
 USEMODULE += gnrc_sock_udp

--- a/tests/thread_cooperation/Makefile
+++ b/tests/thread_cooperation/Makefile
@@ -2,14 +2,14 @@ include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-leonardo arduino-nano \
                              arduino-uno chronos i-nucleo-lrwan1 msb-430 \
-                             msb-430h nucleo-f031k6 nucleo-f303k8
+                             msb-430h nucleo-f031k6 nucleo-f303k8 stm32l0538-disco
 
 DISABLE_MODULE += auto_init
 
 ifneq (,$(filter nucleo-f042k6,$(BOARD)))
   PROBLEM ?= 3
 endif
-ifneq (,$(filter nucleo-f030r8 nucleo-l031k6 nucleo-l053r8 stm32f0discovery,$(BOARD)))
+ifneq (,$(filter nucleo-f030r8 nucleo-l031k6 nucleo-l053r8 stm32f0discovery stm32l0538-disco,$(BOARD)))
   PROBLEM ?= 5
 endif
 ifneq (,$(filter nucleo-f334r8,$(BOARD)))

--- a/tests/unittests/Makefile
+++ b/tests/unittests/Makefile
@@ -70,6 +70,7 @@ BOARD_INSUFFICIENT_MEMORY := airfy-beacon \
                              stk3600 \
                              stm32f0discovery \
                              stm32f3discovery \
+                             stm32l0538-disco \
                              teensy31 \
                              telosb \
                              waspmote-pro \
@@ -189,6 +190,7 @@ ARM_CORTEX_M_BOARDS := airfy-beacon \
                        stm32f3discovery \
                        stm32f4discovery \
                        stm32f769i-disco \
+                       stm32l0538-disco \
                        udoo \
                        usb-kw41z \
                        yunjia-nrf51822 \


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR adds an initial support for the [stm32l0538-disco](https://www.st.com/en/evaluation-tools/32l0538discovery.html) board.

This board embeds an epaper ink display and I could use it with the U8G2 package.

The board can be flashed via st-link but no UART is directly usable via st-link, so a serial to USB adapter is required for stdio.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->