### PR TITLE
cpu/stm32f4: use CPU_LINE in stm32f410-specific code

### DIFF
--- a/cpu/stm32_common/cpu_common.c
+++ b/cpu/stm32_common/cpu_common.c
@@ -92,7 +92,7 @@ void periph_clk_en(bus_t bus, uint32_t mask)
             RCC->AHB1ENR |= mask;
             break;
 /* STM32F410 RCC doesn't provide AHB2 and AHB3 */
-#if !defined(CPU_MODEL_STM32F410RB)
+#if !defined(CPU_LINE_STM32F410Rx)
         case AHB2:
             RCC->AHB2ENR |= mask;
             break;
@@ -140,7 +140,7 @@ void periph_clk_dis(bus_t bus, uint32_t mask)
             RCC->AHB1ENR &= ~(mask);
             break;
 /* STM32F410 RCC doesn't provide AHB2 and AHB3 */
-#if !defined(CPU_MODEL_STM32F410RB)
+#if !defined(CPU_LINE_STM32F410Rx)
         case AHB2:
             RCC->AHB2ENR &= ~(mask);
             break;

--- a/cpu/stm32_common/periph/hwrng.c
+++ b/cpu/stm32_common/periph/hwrng.c
@@ -39,7 +39,7 @@ void hwrng_read(void *buf, unsigned int num)
     uint8_t *b = (uint8_t *)buf;
 
     /* power on and enable the device */
-#if defined(CPU_MODEL_STM32F410RB)
+#if defined(CPU_LINE_STM32F410Rx)
     periph_clk_en(AHB1, RCC_AHB1ENR_RNGEN);
 #elif defined(CPU_FAM_STM32L0)
     periph_clk_en(AHB, RCC_AHBENR_RNGEN);
@@ -63,7 +63,7 @@ void hwrng_read(void *buf, unsigned int num)
 
     /* finally disable the device again */
     RNG->CR = 0;
-#if defined(CPU_MODEL_STM32F410RB)
+#if defined(CPU_LINE_STM32F410Rx)
     periph_clk_dis(AHB1, RCC_AHB1ENR_RNGEN);
 #elif defined(CPU_FAM_STM32L0)
     periph_clk_dis(AHB, RCC_AHBENR_RNGEN);


### PR DESCRIPTION
### Contribution description

Some common code has not been correctly adapted after #9096. stm32f410 has some specific clock management which needed adaptation.

### Issues/PRs references

Follow-up #9096 