### PR TITLE
pkg/semtech-loramac: use random_uint32() to generate random integer

### DIFF
--- a/pkg/semtech-loramac/patches/0003-adapt-utilities-functions.patch
+++ b/pkg/semtech-loramac/patches/0003-adapt-utilities-functions.patch
@@ -1,14 +1,14 @@
-From 406e1900f38e6ca43e74c98a5de0c1ec0f3e3213 Mon Sep 17 00:00:00 2001
+From 1143af922083090a08761ab1a871c7922962218f Mon Sep 17 00:00:00 2001
 From: Alexandre Abadie <alexandre.abadie@inria.fr>
 Date: Tue, 16 Jan 2018 15:04:09 +0100
 Subject: [PATCH] patch utilities functions
 
 ---
- src/boards/mcu/stm32/utilities.c | 48 +++++++++++-----------------------------
- 1 file changed, 13 insertions(+), 35 deletions(-)
+ src/boards/mcu/stm32/utilities.c | 46 +++++++++-----------------------
+ 1 file changed, 12 insertions(+), 34 deletions(-)
 
 diff --git a/src/boards/mcu/stm32/utilities.c b/src/boards/mcu/stm32/utilities.c
-index 8861235..583cae1 100644
+index 8861235..e339ba5 100644
 --- a/src/boards/mcu/stm32/utilities.c
 +++ b/src/boards/mcu/stm32/utilities.c
 @@ -14,8 +14,10 @@ Maintainer: Miguel Luis and Gregory Cristian
@@ -37,7 +37,7 @@ index 8861235..583cae1 100644
  {
 -    return ( int32_t )rand1( ) % ( max - min + 1 ) + min;
 -}
-+    return random_uint32_range(min, max + 1);
++    return (int32_t)random_uint32() % (max - min + 1) + min;
 +};
  
  void memcpy1( uint8_t *dst, const uint8_t *src, uint16_t size )
@@ -83,10 +83,8 @@ index 8861235..583cae1 100644
 -    {
 -        return '?';
 -    }
--}
 +    memset(dst, value, size);
-+}
-\ No newline at end of file
+ }
 -- 
-2.14.1
+2.17.1
 


### PR DESCRIPTION
Then the patched srand1 function used by loramac is closer to the original code and won't crash because of negative values

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is an attempt to fix #9526 issue. As @jia200x pointed out, there's a problem with negative values used by loramac and the `random_uint32_range` function that only expects unsigned value as input parameter.

The actual fix is just to keep the same code that is used in the original semtech code and just replace `rand1()` with `random_uin32()`.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

Fixes #9526

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->