### PR TITLE
sys: xtimer concurrency/robustness improvement

### DIFF
--- a/boards/common/esp8266/include/board_common.h
+++ b/boards/common/esp8266/include/board_common.h
@@ -73,8 +73,6 @@ extern "C" {
  * @name    XTimer configuration
  * @{
  */
-#define XTIMER_OVERHEAD             (0U)
-
 #if defined(MODULE_ESP_SW_TIMER)
 #define XTIMER_BACKOFF              (100U)
 #define XTIMER_ISR_BACKOFF          (100U)

--- a/boards/common/iotlab/include/board_common.h
+++ b/boards/common/iotlab/include/board_common.h
@@ -50,7 +50,6 @@ extern "C" {
  * @{
  */
 #define XTIMER_WIDTH        (16U)
-#define XTIMER_OVERHEAD     (6U)
 /** @} */
 
 /**

--- a/boards/common/nucleo/include/board_nucleo.h
+++ b/boards/common/nucleo/include/board_nucleo.h
@@ -37,10 +37,6 @@ extern "C" {
 #define XTIMER_WIDTH                (16)
 #endif
 
-#if defined(CPU_MODEL_STM32F334R8)
-#define XTIMER_OVERHEAD             (5)
-#endif
-
 #if defined(CPU_FAM_STM32F1)
 #define XTIMER_WIDTH                (16)
 #define XTIMER_BACKOFF              (19)
@@ -48,12 +44,10 @@ extern "C" {
 
 #if defined(CPU_FAM_STM32L1)
 #define XTIMER_BACKOFF              (11)
-#define XTIMER_OVERHEAD             (6)
 #endif
 
 #if defined(CPU_FAM_STM32F4) || defined(CPU_MODEL_STM32F303ZE)
 #define XTIMER_BACKOFF              (8)
-#define XTIMER_OVERHEAD             (6)
 #endif
 /** @} */
 

--- a/boards/frdm-kw41z/include/board.h
+++ b/boards/frdm-kw41z/include/board.h
@@ -85,7 +85,6 @@ extern "C"
 #define XTIMER_WIDTH                (16)
 #define XTIMER_BACKOFF              (5)
 #define XTIMER_ISR_BACKOFF          (5)
-#define XTIMER_OVERHEAD             (4)
 #define XTIMER_HZ                   (32768ul)
 #endif
 /** @} */

--- a/boards/hamilton/include/board.h
+++ b/boards/hamilton/include/board.h
@@ -36,7 +36,6 @@ extern "C" {
  */
 #define XTIMER_DEV          TIMER_DEV(1)
 #define XTIMER_CHAN         (0)
-#define XTIMER_OVERHEAD     (0)
 /** @} */
 
 /**

--- a/boards/msba2/include/board.h
+++ b/boards/msba2/include/board.h
@@ -45,13 +45,6 @@ extern "C" {
 #define LED1_TOGGLE         (FIO3PIN ^= LED1_MASK)
 /** @} */
 
-/**
- * @name    xtimer tuning values
- * @{
- */
-#define XTIMER_OVERHEAD     7
-/** @} */
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/mulle/include/board.h
+++ b/boards/mulle/include/board.h
@@ -49,7 +49,6 @@
 #define XTIMER_WIDTH                (16)
 #define XTIMER_BACKOFF              (4)
 #define XTIMER_ISR_BACKOFF          (4)
-#define XTIMER_OVERHEAD             (3)
 #define XTIMER_HZ                   (32768ul)
 #else
 /* PIT xtimer configuration */
@@ -57,7 +56,6 @@
 #define XTIMER_CHAN                 (0)
 #define XTIMER_BACKOFF              (40)
 #define XTIMER_ISR_BACKOFF          (40)
-#define XTIMER_OVERHEAD             (30)
 #endif
 /** @} */
 

--- a/boards/phynode-kw41z/include/board.h
+++ b/boards/phynode-kw41z/include/board.h
@@ -100,7 +100,6 @@ extern "C"
 #define XTIMER_WIDTH                (16)
 #define XTIMER_BACKOFF              (5)
 #define XTIMER_ISR_BACKOFF          (5)
-#define XTIMER_OVERHEAD             (4)
 #define XTIMER_HZ                   (32768ul)
 #endif
 /** @} */

--- a/boards/stm32f4discovery/include/board.h
+++ b/boards/stm32f4discovery/include/board.h
@@ -31,7 +31,6 @@ extern "C" {
  * @name xtimer configuration
  * @{
  */
-#define XTIMER_OVERHEAD     (6)
 #define XTIMER_BACKOFF      (10)
 /** @} */
 

--- a/boards/teensy31/include/board.h
+++ b/boards/teensy31/include/board.h
@@ -43,7 +43,6 @@ extern "C" {
 #define XTIMER_CHAN                 (0)
 #define XTIMER_BACKOFF              (40)
 #define XTIMER_ISR_BACKOFF          (40)
-#define XTIMER_OVERHEAD             (30)
 /** @} */
 
 /**

--- a/boards/usb-kw41z/include/board.h
+++ b/boards/usb-kw41z/include/board.h
@@ -96,7 +96,6 @@ extern "C"
 #define XTIMER_WIDTH                (16)
 #define XTIMER_BACKOFF              (5)
 #define XTIMER_ISR_BACKOFF          (5)
-#define XTIMER_OVERHEAD             (4)
 #define XTIMER_HZ                   (32768ul)
 #endif
 /** @} */

--- a/cpu/esp32/esp_xtimer.c
+++ b/cpu/esp32/esp_xtimer.c
@@ -148,7 +148,7 @@ void ets_timer_arm_us(ETSTimer *timer, uint32_t tmout, bool repeat)
 
     xtimer_set(&e2xt->xtimer, tmout);
 
-    e2xt->ets_timer->timer_expire = e2xt->xtimer.target;
+    e2xt->ets_timer->timer_expire = e2xt->xtimer.start_time + e2xt->xtimer.offset;
     e2xt->ets_timer->timer_period = repeat ? tmout : 0;
 }
 

--- a/cpu/native/include/periph_conf.h
+++ b/cpu/native/include/periph_conf.h
@@ -44,8 +44,6 @@ extern "C" {
 /**
  * @brief xtimer configuration
  */
-#define XTIMER_OVERHEAD 14
-
 /* timer_set_absolute() has a high margin for possible underflow if set with
  * value not far in the future. To prevent this, we set high backoff values
  * here.

--- a/drivers/dose/dose.c
+++ b/drivers/dose/dose.c
@@ -534,7 +534,7 @@ static const netdev_driver_t netdev_driver_dose = {
 
 void dose_setup(dose_t *ctx, const dose_params_t *params)
 {
-    static const xtimer_ticks32_t min_timeout = {.ticks32 = XTIMER_BACKOFF + XTIMER_OVERHEAD};
+    static const xtimer_ticks32_t min_timeout = {.ticks32 = XTIMER_BACKOFF};
 
     ctx->netdev.driver = &netdev_driver_dose;
 

--- a/pkg/ndn-riot/patches/0001-update-xtimer_member_names.patch
+++ b/pkg/ndn-riot/patches/0001-update-xtimer_member_names.patch
@@ -1,0 +1,52 @@
+From 22f5984e32bec116e3449ebad1b29b2a18f4d93e Mon Sep 17 00:00:00 2001
+From: Michel Rottleuthner <michel.rottleuthner@haw-hamburg.de>
+Date: Thu, 9 Jan 2020 11:16:38 +0100
+Subject: [PATCH] update xtimer_t member names
+
+---
+ app.c | 2 +-
+ l2.c  | 2 +-
+ pit.c | 2 +-
+ 3 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/app.c b/app.c
+index 8d37bd9..da9fc3c 100644
+--- a/app.c
++++ b/app.c
+@@ -380,7 +380,7 @@ int ndn_app_schedule(ndn_app_t* handle, ndn_app_sched_cb_t cb, void* context,
+     if (entry == NULL) return -1;
+
+     // initialize the timer
+-    entry->timer.target = entry->timer.long_target = 0;
++    entry->timer.offset = entry->timer.long_offset = 0;
+
+     // initialize the msg struct
+     entry->timer_msg.type = MSG_XTIMER;
+diff --git a/l2.c b/l2.c
+index 77d6be4..b64b9df 100644
+--- a/l2.c
++++ b/l2.c
+@@ -155,7 +155,7 @@ ndn_shared_block_t* ndn_l2_frag_receive(kernel_pid_t iface,
+         entry->id = id;
+
+         // initialize timer
+-        entry->timer.target = entry->timer.long_target = 0;
++        entry->timer.offset = entry->timer.long_offset = 0;
+         entry->timer_msg.type = NDN_L2_FRAG_MSG_TYPE_TIMEOUT;
+         entry->timer_msg.content.ptr = (char*)(&entry->timer_msg);
+
+diff --git a/pit.c b/pit.c
+index 644cf08..944a07c 100644
+--- a/pit.c
++++ b/pit.c
+@@ -155,7 +155,7 @@ int ndn_pit_add(kernel_pid_t face_id, int face_type, ndn_shared_block_t* si,
+ 	*pit_entry = entry;
+
+     /* initialize the timer */
+-    entry->timer.target = entry->timer.long_target = 0;
++    entry->timer.offset = entry->timer.long_offset = 0;
+
+     /* initialize the msg struct */
+     entry->timer_msg.type = NDN_PIT_MSG_TYPE_TIMEOUT;
+-- 
+2.24.1

--- a/pkg/nimble/patches/0001-xtimer_member_names.patch
+++ b/pkg/nimble/patches/0001-xtimer_member_names.patch
@@ -1,0 +1,24 @@
+From 6b1223df6884bcfd00f4ecc8918b790baf041021 Mon Sep 17 00:00:00 2001
+From: Michel Rottleuthner <michel.rottleuthner@haw-hamburg.de>
+Date: Wed, 8 Jan 2020 19:50:48 +0100
+Subject: [PATCH] update xtimer_t member names
+
+---
+ porting/npl/riot/include/nimble/nimble_npl_os.h | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/porting/npl/riot/include/nimble/nimble_npl_os.h b/porting/npl/riot/include/nimble/nimble_npl_os.h
+index 67eb74e1..61c1ea8a 100644
+--- a/porting/npl/riot/include/nimble/nimble_npl_os.h
++++ b/porting/npl/riot/include/nimble/nimble_npl_os.h
+@@ -209,7 +209,7 @@ ble_npl_callout_stop(struct ble_npl_callout *co)
+ static inline bool
+ ble_npl_callout_is_active(struct ble_npl_callout *c)
+ {
+-    return (c->timer.target || c->timer.long_target);
++    return (c->timer.offset || c->timer.long_offset);
+ }
+
+ static inline ble_npl_time_t
+--
+2.24.1

--- a/pkg/semtech-loramac/contrib/semtech_loramac_timer.c
+++ b/pkg/semtech-loramac/contrib/semtech_loramac_timer.c
@@ -27,7 +27,10 @@ extern kernel_pid_t semtech_loramac_pid;
 
 void TimerInit(TimerEvent_t *obj, void (*cb)(void))
 {
-    obj->dev.target = 0;
+    obj->dev.start_time = 0;
+    obj->dev.long_start_time = 0;
+    obj->dev.offset = 0;
+    obj->dev.long_offset = 0;
     obj->running = 0;
     obj->cb = cb;
 }

--- a/sys/evtimer/evtimer.c
+++ b/sys/evtimer/evtimer.c
@@ -115,8 +115,10 @@ static void _update_timer(evtimer_t *evtimer)
 static uint32_t _get_offset(xtimer_t *timer)
 {
     uint64_t now_us = xtimer_now_usec64();
-    uint64_t target_us = _xtimer_usec_from_ticks64(
-                        ((uint64_t)timer->long_target) << 32 | timer->target);
+    uint64_t start_us = _xtimer_usec_from_ticks64(
+                        ((uint64_t)timer->long_start_time << 32) | timer->start_time);
+    uint64_t target_us = start_us + _xtimer_usec_from_ticks64(
+                        ((uint64_t)timer->long_offset) << 32 | timer->offset);
 
     if (target_us <= now_us) {
         return 0;

--- a/sys/shell/commands/sc_gnrc_rpl.c
+++ b/sys/shell/commands/sc_gnrc_rpl.c
@@ -292,8 +292,10 @@ int _gnrc_rpl_dodag_show(void)
                 gnrc_rpl_instances[i].mop, gnrc_rpl_instances[i].of->ocp,
                 gnrc_rpl_instances[i].min_hop_rank_inc, gnrc_rpl_instances[i].max_rank_inc);
 
-        tc = (((uint64_t) dodag->trickle.msg_timer.long_target << 32)
-                | dodag->trickle.msg_timer.target) - xnow;
+        tc = _xtimer_usec_from_ticks64(((uint64_t) dodag->trickle.msg_timer.long_offset << 32)
+                                       | dodag->trickle.msg_timer.offset)
+             - (xnow - _xtimer_usec_from_ticks64(
+                         (uint64_t)dodag->trickle.msg_timer.long_start_time << 32 | dodag->trickle.msg_timer.start_time));
         tc = (int64_t) tc < 0 ? 0 : tc / US_PER_SEC;
 
         printf("\tdodag [%s | R: %d | OP: %s | PIO: %s | "

--- a/tests/bench_timers/main.c
+++ b/tests/bench_timers/main.c
@@ -374,14 +374,18 @@ static void run_test(test_ctx_t *ctx, uint32_t interval, unsigned int variant)
     interval += TEST_MIN;
     unsigned int interval_ref = TIM_TEST_TO_REF(interval);
     xtimer_t xt = {
-        .target = 0,
-        .long_target = 0,
+        .start_time = 0,
+        .long_start_time = 0,
+        .offset = 0,
+        .long_offset = 0,
         .callback = cb,
         .arg = ctx,
     };
     xtimer_t xt_parallel = {
-        .target = 0,
-        .long_target = 0,
+        .start_time = 0,
+        .long_start_time = 0,
+        .offset = 0,
+        .long_offset = 0,
         .callback = nop,
         .arg = NULL,
     };

--- a/tests/pkg_semtech-loramac/Makefile
+++ b/tests/pkg_semtech-loramac/Makefile
@@ -2,9 +2,11 @@ BOARD ?= b-l072z-lrwan1
 
 include ../Makefile.tests_common
 
-# waspmote-pro and arduino-meag2560 don't have enough RAM to support another
-# thread dedicated to RX messages
-BOARD_WITHOUT_LORAMAC_RX := arduino-mega2560 waspmote-pro
+BOARD_WITHOUT_LORAMAC_RX := \
+    arduino-mega2560 \
+    i-nuncleo-lrwan1 \
+    stm32f0discovery \
+    waspmote-pro \
 
 LORA_DRIVER ?= sx1276
 LORA_REGION ?= EU868

--- a/tests/rng/test.c
+++ b/tests/rng/test.c
@@ -412,8 +412,10 @@ void test_speed(uint32_t duration)
     /* collect samples as long as timer has not expired */
     unsigned running = 1;
     xtimer_t xt = {
-        .target = 0,
-        .long_target = 0,
+        .start_time = 0,
+        .long_start_time = 0,
+        .offset = 0,
+        .long_offset = 0,
         .callback = cb_speed_timeout,
         .arg = &running,
     };
@@ -444,8 +446,10 @@ void test_speed_range(uint32_t duration, uint32_t low_thresh, uint32_t high_thre
     /* collect samples as long as timer has not expired */
     unsigned running = 1;
     xtimer_t xt = {
-        .target = 0,
-        .long_target = 0,
+        .start_time = 0,
+        .long_start_time = 0,
+        .offset = 0,
+        .long_offset = 0,
         .callback = cb_speed_timeout,
         .arg = &running,
     };


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR tries to resolve concurrency/robustness problem of xtimer, an attempt to escape from long suffering of xtimer's unrobustness. I personally have experienced frequency system crash due to xtimer. As an embedded OS, RIOT can have a little timing error but **must avoid system crash** to enable long-term attended operation of embedded devices.
1. All time-sensitive sections are interrupt free.
2. Support various hardware timers including <32 bits  
3. Support overflow
 
The basic idea is to change xtimer operation from "absolute target-based" to "period-based", which is the case of TinyOS. Timer expiry and current time update are based on "offset" rather than "absolute target". An absolute target value is used only for sorting timers chronologically and setting a lltimer. I personally tested this PR with a Hamilton board and xtimer test applications in 'tests' folder. But further test might be needed.

I'm aware of other ongoing effort for fixing xtimer. I'm just throwing another option here since I have some time to focus on this issue now, and leave the decision whether to merge this PR with reviewers. @kaspar030, @gebart, This PR is the one I mentioned earlier about xtimer.

The next step would be reworking on #7053, with a simpler implementation.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references
#5428, #6937, #9211, #9491
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->