### PR TITLE
netdev_ieee802154: Add and use common reset function

### DIFF
--- a/drivers/at86rf2xx/at86rf2xx.c
+++ b/drivers/at86rf2xx/at86rf2xx.c
@@ -56,14 +56,12 @@ void at86rf2xx_reset(at86rf2xx_t *dev)
 
     at86rf2xx_hardware_reset(dev);
 
+    netdev_ieee802154_reset(&dev->netdev);
+
     /* Reset state machine to ensure a known state */
     if (dev->state == AT86RF2XX_STATE_P_ON) {
         at86rf2xx_set_state(dev, AT86RF2XX_STATE_FORCE_TRX_OFF);
     }
-
-    /* reset options and sequence number */
-    dev->netdev.seq = 0;
-    dev->netdev.flags = 0;
 
     /* get an 8-byte unique ID to use as hardware address */
     luid_get(addr_long.uint8, IEEE802154_LONG_ADDRESS_LEN);
@@ -88,12 +86,7 @@ void at86rf2xx_reset(at86rf2xx_t *dev)
 #ifdef MODULE_NETSTATS_L2
     at86rf2xx_set_option(dev, AT86RF2XX_OPT_TELL_TX_END, true);
 #endif
-    /* set default protocol */
-#ifdef MODULE_GNRC_SIXLOWPAN
-    dev->netdev.proto = GNRC_NETTYPE_SIXLOWPAN;
-#elif MODULE_GNRC
-    dev->netdev.proto = GNRC_NETTYPE_UNDEF;
-#endif
+
     /* enable safe mode (protect RX FIFO until reading data starts) */
     at86rf2xx_reg_write(dev, AT86RF2XX_REG__TRX_CTRL_2,
                         AT86RF2XX_TRX_CTRL_2_MASK__RX_SAFE_MODE);

--- a/drivers/cc2420/cc2420.c
+++ b/drivers/cc2420/cc2420.c
@@ -49,9 +49,7 @@ int cc2420_init(cc2420_t *dev)
     uint16_t reg;
     uint8_t addr[8];
 
-    /* reset options and sequence number */
-    dev->netdev.seq = 0;
-    dev->netdev.flags = 0;
+    netdev_ieee802154_reset(&dev->netdev);
 
     /* set default address, channel, PAN ID, and TX power */
     luid_get(addr, sizeof(addr));
@@ -72,12 +70,6 @@ int cc2420_init(cc2420_t *dev)
 
 #ifdef MODULE_NETSTATS_L2
     cc2420_set_option(dev, CC2420_OPT_TELL_RX_END, true);
-#endif
-    /* set default protocol*/
-#ifdef MODULE_GNRC_SIXLOWPAN
-    dev->netdev.proto = GNRC_NETTYPE_SIXLOWPAN;
-#elif MODULE_GNRC
-    dev->netdev.proto = GNRC_NETTYPE_UNDEF;
 #endif
 
     /* change default RX bandpass filter to 1.3uA (as recommended) */

--- a/drivers/include/net/netdev/ieee802154.h
+++ b/drivers/include/net/netdev/ieee802154.h
@@ -122,6 +122,17 @@ typedef struct {
 typedef struct netdev_radio_rx_info netdev_ieee802154_rx_info_t;
 
 /**
+ * @brief   Reset function for ieee802154 common fields
+ *
+ * Supposed to be used by netdev drivers to reset the ieee802154 fields when
+ * resetting the device
+ *
+ * @param[in]   dev     network device descriptor
+ */
+void netdev_ieee802154_reset(netdev_ieee802154_t *dev);
+
+
+/**
  * @brief   Fallback function for netdev IEEE 802.15.4 devices' _get function
  *
  * Supposed to be used by netdev drivers as default case.

--- a/drivers/kw2xrf/kw2xrf.c
+++ b/drivers/kw2xrf/kw2xrf.c
@@ -90,16 +90,7 @@ int kw2xrf_init(kw2xrf_t *dev, gpio_cb_t cb)
 
 void kw2xrf_reset_phy(kw2xrf_t *dev)
 {
-    /* reset options and sequence number */
-    dev->netdev.seq = 0;
-    dev->netdev.flags = 0;
-
-    /* set default protocol */
-#ifdef MODULE_GNRC_SIXLOWPAN
-    dev->netdev.proto = GNRC_NETTYPE_SIXLOWPAN;
-#elif MODULE_GNRC
-    dev->netdev.proto = GNRC_NETTYPE_UNDEF;
-#endif
+    netdev_ieee802154_reset(&dev->netdev);
 
     dev->tx_power = KW2XRF_DEFAULT_TX_POWER;
     kw2xrf_set_tx_power(dev, dev->tx_power);

--- a/drivers/mrf24j40/mrf24j40.c
+++ b/drivers/mrf24j40/mrf24j40.c
@@ -46,9 +46,7 @@ void mrf24j40_reset(mrf24j40_t *dev)
 
     mrf24j40_init(dev);
 
-    /* reset options and sequence number */
-    dev->netdev.seq = 0;
-    dev->netdev.flags = 0;
+    netdev_ieee802154_reset(&dev->netdev);
 
     /* get an 8-byte unique ID to use as hardware address */
     luid_get(addr_long.uint8, IEEE802154_LONG_ADDRESS_LEN);
@@ -74,13 +72,6 @@ void mrf24j40_reset(mrf24j40_t *dev)
     mrf24j40_set_option(dev, MRF24J40_OPT_TELL_RX_END, true);
 #ifdef MODULE_NETSTATS_L2
     mrf24j40_set_option(dev, MRF24J40_OPT_TELL_TX_END, true);
-#endif
-
-    /* set default protocol */
-#ifdef MODULE_GNRC_SIXLOWPAN
-    dev->netdev.proto = GNRC_NETTYPE_SIXLOWPAN;
-#elif MODULE_GNRC
-    dev->netdev.proto = GNRC_NETTYPE_UNDEF;
 #endif
 
     /* go into RX state */

--- a/drivers/netdev_ieee802154/netdev_ieee802154.c
+++ b/drivers/netdev_ieee802154/netdev_ieee802154.c
@@ -50,6 +50,19 @@ static int _get_iid(netdev_ieee802154_t *dev, eui64_t *value, size_t max_len)
     return sizeof(eui64_t);
 }
 
+void netdev_ieee802154_reset(netdev_ieee802154_t *dev)
+{
+    dev->seq = 0;
+    dev->flags = 0;
+
+    /* set default protocol */
+#ifdef MODULE_GNRC_SIXLOWPAN
+    dev->proto = GNRC_NETTYPE_SIXLOWPAN;
+#elif MODULE_GNRC
+    dev->proto = GNRC_NETTYPE_UNDEF;
+#endif
+}
+
 int netdev_ieee802154_get(netdev_ieee802154_t *dev, netopt_t opt, void *value,
                            size_t max_len)
 {


### PR DESCRIPTION
### Contribution description

Refactors the common part from the radio reset functions to a netdev function. 

### Issues/PRs references

None

### Other

When netdev is layered, the `netdev_ieee802154_reset` function can be called from netdev_ieee802154 in response to a `NETOPT_STATE_RESET` set call and removed from the device drivers.