### PR TITLE
netdev_ieee802154: Initialize sequence number to random value

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -59,6 +59,7 @@ endif
 
 ifneq (,$(filter netdev_ieee802154,$(USEMODULE)))
   USEMODULE += ieee802154
+  USEMODULE += random
 endif
 
 ifneq (,$(filter gnrc_uhcpc,$(USEMODULE)))

--- a/cpu/native/socket_zep/socket_zep.c
+++ b/cpu/native/socket_zep/socket_zep.c
@@ -293,15 +293,11 @@ static int _init(netdev_t *netdev)
 {
     socket_zep_t *dev = (socket_zep_t *)netdev;
 
+    netdev_ieee802154_reset(&dev->netdev);
+
     assert(dev != NULL);
     dev->netdev.chan = IEEE802154_DEFAULT_CHANNEL;
     dev->netdev.pan = IEEE802154_DEFAULT_PANID;
-#ifdef MODULE_GNRC_SIXLOWPAN
-    dev->netdev.proto = GNRC_NETTYPE_SIXLOWPAN;
-#elif MODULE_GNRC
-    dev->netdev.proto = GNRC_NETTYPE_UNDEF;
-#endif
-    dev->seq = random_uint32();
 
     return 0;
 }

--- a/drivers/netdev_ieee802154/netdev_ieee802154.c
+++ b/drivers/netdev_ieee802154/netdev_ieee802154.c
@@ -22,6 +22,7 @@
 #include "net/eui64.h"
 #include "net/ieee802154.h"
 #include "net/netdev.h"
+#include "random.h"
 
 #include "net/netdev/ieee802154.h"
 
@@ -52,7 +53,8 @@ static int _get_iid(netdev_ieee802154_t *dev, eui64_t *value, size_t max_len)
 
 void netdev_ieee802154_reset(netdev_ieee802154_t *dev)
 {
-    dev->seq = 0;
+    /* Only the least significant byte of the random value is used */
+    dev->seq = random_uint32();
     dev->flags = 0;
 
     /* set default protocol */


### PR DESCRIPTION
### Contribution description

As discussed in #9531, this changes the sequence number to a random value on reset

I'm piggybacking a commit to make socket_zep also use the common reset function in its initialization. If somebody minds, I can split it out to a separate PR.

### Issues/PRs references

depends on #9531 