### PR TITLE
Makefile.include: remove debug '$(info)'

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -323,7 +323,6 @@ include $(RIOTBASE)/drivers/Makefile.include
 $(RIOTPKG)/%/Makefile.include::
 	$(Q)"$(MAKE)" -C $(RIOTPKG)/$* Makefile.include
 
-$(info $(USEPKG:%=$(RIOTPKG)/%/Makefile.include))
 .PHONY: $(USEPKG:%=$(RIOTPKG)/%/Makefile.include)
 -include $(USEPKG:%=$(RIOTPKG)/%/Makefile.include)
 


### PR DESCRIPTION
### Contribution description

Remove debug '$(info)' added by https://github.com/RIOT-OS/RIOT/pull/9451


I was wondering why I was getting an empty line when doing `make -C examples/hello-world info-debug-variable-INCLUDES`. It was because of a debug info I forgot to remove and got through.


### Issues/PRs references

Introduced by https://github.com/RIOT-OS/RIOT/pull/9451