### PR TITLE
cc2538: use netdev reset

### DIFF
--- a/cpu/cc2538/radio/cc2538_rf_netdev.c
+++ b/cpu/cc2538/radio/cc2538_rf_netdev.c
@@ -367,6 +367,8 @@ static int _init(netdev_t *netdev)
     uint16_t addr_short = cc2538_get_addr_short();
     uint64_t addr_long = cc2538_get_addr_long();
 
+    netdev_ieee802154_reset(&dev->netdev);
+
     /* Initialise netdev_ieee802154_t struct */
     netdev_ieee802154_set((netdev_ieee802154_t *)netdev, NETOPT_NID, &pan,
                           sizeof(pan));
@@ -379,12 +381,6 @@ static int _init(netdev_t *netdev)
 
     cc2538_set_state(dev, NETOPT_STATE_IDLE);
 
-    /* set default protocol */
-#ifdef MODULE_GNRC_SIXLOWPAN
-    dev->netdev.proto = GNRC_NETTYPE_SIXLOWPAN;
-#elif MODULE_GNRC
-    dev->netdev.proto = GNRC_NETTYPE_UNDEF;
-#endif
 #ifdef MODULE_NETSTATS_L2
     memset(&netdev->stats, 0, sizeof(netstats_t));
 #endif

--- a/cpu/cc2538/radio/cc2538_rf_netdev.c
+++ b/cpu/cc2538/radio/cc2538_rf_netdev.c
@@ -370,13 +370,13 @@ static int _init(netdev_t *netdev)
     netdev_ieee802154_reset(&dev->netdev);
 
     /* Initialise netdev_ieee802154_t struct */
-    netdev_ieee802154_set((netdev_ieee802154_t *)netdev, NETOPT_NID, &pan,
-                          sizeof(pan));
-    netdev_ieee802154_set((netdev_ieee802154_t *)netdev, NETOPT_CHANNEL, &chan,
-                          sizeof(chan));
-    netdev_ieee802154_set((netdev_ieee802154_t *)netdev, NETOPT_ADDRESS,
+    netdev_ieee802154_set(&dev->netdev, NETOPT_NID,
+                          &pan, sizeof(pan));
+    netdev_ieee802154_set(&dev->netdev, NETOPT_CHANNEL,
+                          &chan, sizeof(chan));
+    netdev_ieee802154_set(&dev->netdev, NETOPT_ADDRESS,
                           &addr_short, sizeof(addr_short));
-    netdev_ieee802154_set((netdev_ieee802154_t *)netdev, NETOPT_ADDRESS_LONG,
+    netdev_ieee802154_set(&dev->netdev, NETOPT_ADDRESS_LONG,
                           &addr_long, sizeof(addr_long));
 
     cc2538_set_state(dev, NETOPT_STATE_IDLE);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Cleanup of the cc2538 radio driver using the new netdev_ieee802154_reset function, and some minor cleanup.


### Issues/PRs references

based on and followup to #9531