### PR TITLE
cflags: use gnu99 only if nothing else is specified (mips, msp430, native)

### DIFF
--- a/boards/native/Makefile.include
+++ b/boards/native/Makefile.include
@@ -47,7 +47,11 @@ export CGANNOTATE ?= cg_annotate
 export GPROF ?= gprof
 
 # basic cflags:
-export CFLAGS += -Wall -Wextra -pedantic -std=gnu99
+export CFLAGS += -Wall -Wextra -pedantic
+# default std set to gnu99 of not overwritten by user
+ifeq (,$(filter -std=%, $(CFLAGS)))
+  export CFLAGS += -std=gnu99
+endif
 
 ifeq ($(shell uname -m),x86_64)
   export CFLAGS += -m32

--- a/makefiles/arch/mips.inc.mk
+++ b/makefiles/arch/mips.inc.mk
@@ -32,7 +32,9 @@ endif
 # newlib commit 81c17949f0419d1c4fee421c60987ea1149522ae
 # https://cygwin.com/git/gitweb.cgi?p=newlib-cygwin.git;a=commitdiff;h=81c17949f0419d1c4fee421c60987ea1149522ae
 # Otherwise we get an error about a missing declaration of strnlen in some parts.
-export CFLAGS += -std=gnu99
+ifeq (, $(filter -std=%, $(CFLAGS)))
+  export CFLAGS += -std=gnu99
+endif
 export CFLAGS_CPU   = -EL -mabi=$(ABI)
 export CFLAGS_LINK  = -ffunction-sections -fno-builtin -fshort-enums -fdata-sections
 export CFLAGS_DBG   = -g3

--- a/makefiles/arch/msp430.inc.mk
+++ b/makefiles/arch/msp430.inc.mk
@@ -2,7 +2,11 @@
 export TARGET_ARCH ?= msp430
 
 # define build specific options
-CFLAGS_CPU   = -mmcu=$(CPU_MODEL) -std=gnu99
+CFLAGS_CPU   = -mmcu=$(CPU_MODEL)
+# default std set to gnu99 of not overwritten by user
+ifeq (, $(filter -std=%, $(CFLAGS)))
+  export CFLAGS += -std=gnu99
+endif
 CFLAGS_LINK  = -ffunction-sections -fdata-sections
 CFLAGS_DBG  ?= -gdwarf-2
 CFLAGS_OPT  ?= -Os


### PR DESCRIPTION
### Contribution description

On mips, msp430 and native, the `-std` option was forced to `gnu99` even though the user changed it.
This propose to change it only if nothing else is passed in the `CFLAGS` by adding a makefile variable and use it in the central cflags.inc.mk

### Issues/PRs references

Workaround #9371 by allowing a user to switch to c11.
First gnu99 changes were introduced in #5824
