### PR TITLE
stm32: fix vendor header conflicting enum

### DIFF
--- a/cpu/stm32f0/include/vendor/stm32f0xx.h
+++ b/cpu/stm32f0/include/vendor/stm32f0xx.h
@@ -169,32 +169,6 @@
   * @}
   */
 
-/** @addtogroup Exported_types
-  * @{
-  */
-typedef enum
-{
-  RESET = 0,
-  SET = !RESET
-} FlagStatus, ITStatus;
-
-typedef enum
-{
-  DISABLE = 0,
-  ENABLE = !DISABLE
-} FunctionalState;
-#define IS_FUNCTIONAL_STATE(STATE) (((STATE) == DISABLE) || ((STATE) == ENABLE))
-
-typedef enum
-{
-  ERROR = 0,
-  SUCCESS = !ERROR
-} ErrorStatus;
-
-/**
-  * @}
-  */
-
 
 /** @addtogroup Exported_macros
   * @{

--- a/cpu/stm32f2/include/vendor/stm32f2xx.h
+++ b/cpu/stm32f2/include/vendor/stm32f2xx.h
@@ -134,32 +134,6 @@
   * @}
   */
 
-/** @addtogroup Exported_types
-  * @{
-  */
-typedef enum
-{
-  RESET = 0,
-  SET = !RESET
-} FlagStatus, ITStatus;
-
-typedef enum
-{
-  DISABLE = 0,
-  ENABLE = !DISABLE
-} FunctionalState;
-#define IS_FUNCTIONAL_STATE(STATE) (((STATE) == DISABLE) || ((STATE) == ENABLE))
-
-typedef enum
-{
-  ERROR = 0,
-  SUCCESS = !ERROR
-} ErrorStatus;
-
-/**
-  * @}
-  */
-
 
 /** @addtogroup Exported_macro
   * @{

--- a/cpu/stm32f3/include/vendor/stm32f3xx.h
+++ b/cpu/stm32f3/include/vendor/stm32f3xx.h
@@ -174,32 +174,6 @@
   * @}
   */
 
-/** @addtogroup Exported_types
-  * @{
-  */
-typedef enum
-{
-  RESET = 0,
-  SET = !RESET
-} FlagStatus, ITStatus;
-
-typedef enum
-{
-  DISABLE = 0,
-  ENABLE = !DISABLE
-} FunctionalState;
-#define IS_FUNCTIONAL_STATE(STATE) (((STATE) == DISABLE) || ((STATE) == ENABLE))
-
-typedef enum
-{
-  ERROR = 0,
-  SUCCESS = !ERROR
-} ErrorStatus;
-
-/**
-  * @}
-  */
-
 
 /** @addtogroup Exported_macros
   * @{

--- a/cpu/stm32f4/include/vendor/stm32f4xx.h
+++ b/cpu/stm32f4/include/vendor/stm32f4xx.h
@@ -197,32 +197,6 @@
   * @}
   */
 
-/** @addtogroup Exported_types
-  * @{
-  */
-typedef enum
-{
-  RESET = 0U,
-  SET = !RESET
-} FlagStatus, ITStatus;
-
-typedef enum
-{
-  DISABLE = 0U,
-  ENABLE = !DISABLE
-} FunctionalState;
-#define IS_FUNCTIONAL_STATE(STATE) (((STATE) == DISABLE) || ((STATE) == ENABLE))
-
-typedef enum
-{
-  ERROR = 0U,
-  SUCCESS = !ERROR
-} ErrorStatus;
-
-/**
-  * @}
-  */
-
 
 /** @addtogroup Exported_macro
   * @{

--- a/cpu/stm32f7/include/vendor/stm32f7xx.h
+++ b/cpu/stm32f7/include/vendor/stm32f7xx.h
@@ -160,31 +160,6 @@
   * @}
   */
 
-/** @addtogroup Exported_types
-  * @{
-  */
-typedef enum
-{
-  RESET = 0,
-  SET = !RESET
-} FlagStatus, ITStatus;
-
-typedef enum
-{
-  DISABLE = 0,
-  ENABLE = !DISABLE
-} FunctionalState;
-#define IS_FUNCTIONAL_STATE(STATE) (((STATE) == DISABLE) || ((STATE) == ENABLE))
-
-typedef enum
-{
-  ERROR = 0,
-  SUCCESS = !ERROR
-} ErrorStatus;
-
-/**
-  * @}
-  */
 
 /** @addtogroup Exported_macro
   * @{


### PR DESCRIPTION
### Contribution description

New stm32 vendor headers define some enum which can conflict with packages.
This remove the enum declarations.

### Issues/PRs references

Follow-up #9096 #9435 #9439 #9441
To adapt #9436 #9443