### PR TITLE
boards: add missing new I2C periph_conf implementation

### DIFF
--- a/boards/limifrog-v1/include/periph_conf.h
+++ b/boards/limifrog-v1/include/periph_conf.h
@@ -155,28 +155,37 @@ static const spi_conf_t spi_config[] = {
  * @name    I2C configuration
   * @{
  */
-#define I2C_0_EN            1
-#define I2C_1_EN            1
-#define I2C_NUMOF           (I2C_0_EN + I2C_1_EN)
-#define I2C_IRQ_PRIO        1
-#define I2C_APBCLK          (CLOCK_APB1)
-
-/* I2C 0 device configuration */
-#define I2C_0_EVT_ISR       isr_i2c1_ev
-#define I2C_0_ERR_ISR       isr_i2c1_er
-
-/* I2C 1 device configuration */
-#define I2C_1_EVT_ISR       isr_i2c2_ev
-#define I2C_1_ERR_ISR       isr_i2c2_er
-
 static const i2c_conf_t i2c_config[] = {
-    /* device, port, scl-, sda-pin-number, I2C-AF, ER-IRQn, EV-IRQn */
-    {I2C1, GPIO_PIN(PORT_B,  8), GPIO_PIN(PORT_B,  9),
-     GPIO_OD_PU, GPIO_AF4, I2C1_ER_IRQn, I2C1_EV_IRQn},
-    {I2C2, GPIO_PIN(PORT_B, 10), GPIO_PIN(PORT_B, 11),
-     GPIO_OD_PU, GPIO_AF4, I2C2_ER_IRQn, I2C2_EV_IRQn},
+    {
+        .dev            = I2C1,
+        .speed          = I2C_SPEED_NORMAL,
+        .scl_pin        = GPIO_PIN(PORT_B, 8),
+        .sda_pin        = GPIO_PIN(PORT_B, 9),
+        .scl_af         = GPIO_AF4,
+        .sda_af         = GPIO_AF4,
+        .bus            = APB1,
+        .rcc_mask       = RCC_APB1ENR_I2C1EN,
+        .clk            = CLOCK_APB1,
+        .irqn           = I2C1_EV_IRQn
+    },
+    {
+        .dev            = I2C2,
+        .speed          = I2C_SPEED_NORMAL,
+        .scl_pin        = GPIO_PIN(PORT_B, 10),
+        .sda_pin        = GPIO_PIN(PORT_B, 11),
+        .scl_af         = GPIO_AF4,
+        .sda_af         = GPIO_AF4,
+        .bus            = APB1,
+        .rcc_mask       = RCC_APB1ENR_I2C2EN,
+        .clk            = CLOCK_APB1,
+        .irqn           = I2C2_EV_IRQn
+    }
 };
 
+#define I2C_0_ISR           isr_i2c1_ev
+#define I2C_1_ISR           isr_i2c2_ev
+
+#define I2C_NUMOF           (sizeof(i2c_config) / sizeof(i2c_config[0]))
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/nz32-sc151/include/periph_conf.h
+++ b/boards/nz32-sc151/include/periph_conf.h
@@ -196,20 +196,24 @@ static const spi_conf_t spi_config[] = {
  * @name    I2C configuration
   * @{
  */
-#define I2C_NUMOF           (1)
-#define I2C_0_EN            1
-#define I2C_IRQ_PRIO        1
-#define I2C_APBCLK          (36000000U)  /* Configurable from 2MHz to 50Mhz, steps of 2Mhz */
-
-/* I2C 0 device configuration */
-#define I2C_0_EVT_ISR       isr_i2c1_ev
-#define I2C_0_ERR_ISR       isr_i2c1_er
-
 static const i2c_conf_t i2c_config[] = {
-    /* device, port, scl-, sda-pin-number, I2C-AF, ER-IRQn, EV-IRQn */
-    {I2C1, GPIO_PIN(PORT_B,  8), GPIO_PIN(PORT_B,  9),
-     GPIO_OD_PU, GPIO_AF4, I2C1_ER_IRQn, I2C1_EV_IRQn}
+    {
+        .dev            = I2C1,
+        .speed          = I2C_SPEED_NORMAL,
+        .scl_pin        = GPIO_PIN(PORT_B, 8),
+        .sda_pin        = GPIO_PIN(PORT_B, 9),
+        .scl_af         = GPIO_AF4,
+        .sda_af         = GPIO_AF4,
+        .bus            = APB1,
+        .rcc_mask       = RCC_APB1ENR_I2C1EN,
+        .clk            = CLOCK_APB1,
+        .irqn           = I2C1_EV_IRQn
+    }
 };
+
+#define I2C_0_ISR           isr_i2c1_ev
+
+#define I2C_NUMOF           (sizeof(i2c_config) / sizeof(i2c_config[0]))
 /** @} */
 
 /**


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR upadtes the periph_conf.h files of missing boards to the new I2C interface.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references
#9539 
#9548 
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->