### PR TITLE
tests/periph_i2c: fix unused variable in pythonlib

### DIFF
--- a/tests/periph_i2c/tests/tools/bpt_if.py
+++ b/tests/periph_i2c/tests/tools/bpt_if.py
@@ -523,7 +523,7 @@ def main():
     try:
         bpt = BptIf.from_autodetect(baud=9600)
     except Exception as ex:
-        pass
+        logging.debug("Failed to autodetect BptIf: " + str(ex))
     bpt = BptIf.from_autodetect()
     bpt2 = BptIf.copy_driver(bpt)
     bpt.execute_changes()


### PR DESCRIPTION
    flake8 reported an error with an unused variable in a python
    library used by the automated I2C testing script, which is
    fix here.

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Fixes flake8 error reported by murdock when running static-tests, i.e., the variable `ex` wasn't used.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->