### PR TITLE
cpu/sam0_common/i2c: fix ambiguous reg assignment

### DIFF
--- a/cpu/sam0_common/periph/i2c.c
+++ b/cpu/sam0_common/periph/i2c.c
@@ -127,8 +127,8 @@ void i2c_init(i2c_t dev)
     /* Set sercom module to operate in I2C master mode and run in Standby
     if user requests it */
     bus(dev)->CTRLA.reg = SERCOM_I2CM_CTRLA_MODE_I2C_MASTER |
-                          (i2c_config[dev].flags & I2C_FLAG_RUN_STANDBY ?
-                              SERCOM_I2CM_CTRLA_RUNSTDBY : 0);
+                          ((i2c_config[dev].flags & I2C_FLAG_RUN_STANDBY) ?
+                           SERCOM_I2CM_CTRLA_RUNSTDBY : 0);
 
     /* Enable Smart Mode (ACK is sent when DATA.DATA is read) */
     bus(dev)->CTRLB.reg = SERCOM_I2CM_CTRLB_SMEN;


### PR DESCRIPTION
    The value assigned to the register was unclear due to usage
    of bit-comparison and ternary operator, added parentheses to
    make it explicit.

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->