### PR TITLE
doc: fix several doxygen issue from I2C rework

### DIFF
--- a/cpu/sam0_common/include/periph_cpu_common.h
+++ b/cpu/sam0_common/include/periph_cpu_common.h
@@ -253,7 +253,8 @@ typedef enum {
 } i2c_flag_t;
 
 /**
- * @brief   Override I2C clock speed values
+ * @name    Override I2C clock speed values
+ * @{
  */
 #define HAVE_I2C_SPEED_T
 typedef enum {
@@ -263,6 +264,7 @@ typedef enum {
     I2C_SPEED_FAST_PLUS = 1000000U,    /**< fast plus mode:    ~1Mbit/s */
     I2C_SPEED_HIGH      = 3400000U,    /**< high speed mode:   ~3.4Mbit/s */
 } i2c_speed_t;
+/** @} */
 
 /**
  * @brief   I2C device configuration

--- a/drivers/include/periph/i2c.h
+++ b/drivers/include/periph/i2c.h
@@ -16,7 +16,7 @@
  * different kind of register addressing schemes.
  *
  *
- * @section   sec_usage Usage
+ * @section   sec_i2c_usage Usage
  *
  * Example for reading a 8-bit register on a device, using a 10-bit device
  * address and 8-bit register addresses and using a RESTART condition (CAUTION:
@@ -54,7 +54,7 @@
  * @endcode
  *
  *
- * @section   sec_pull Pull Resistors
+ * @section   sec_i2c_pull Pull Resistors
  *
  * The I2C signal lines SDA/SCL need external pull-up resistors which connect
  * the lines to the positive voltage supply Vcc. The I2C driver implementation
@@ -86,7 +86,7 @@
  * http://www.nxp.com/documents/user_manual/UM10204.pdf
  *
  *
- * @section   sec_pm (Low-) power implications
+ * @section   sec_i2c_pm (Low-) power implications
  *
  * The I2C interface realizes a transaction-based access scheme to the bus. From
  * a power management perspective, we can leverage this by only powering on the

--- a/drivers/include/srf08.h
+++ b/drivers/include/srf08.h
@@ -91,11 +91,8 @@ typedef enum {
  * @param[in] dev           device descriptor of an SRF08 sensor
  * @param[in] i2c           I2C device the sensor is connected to
  * @param[in] addr          I2C address of the sensor
- * @param[in] speed         I2C speed mode
  *
  * @return                  0 on successful initialization
- * @return                  -1 on undefined device given
- * @return                  -2 on unsupported speed value
  * @return                  -3 on max. range error
  * @return                  -4 on max. gain error
  *


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR fixes some leftover doxygen issues from the I2C rework.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->