### PR TITLE
cpu/kinetis: suppress selfAssignement warning by cppcheck

### DIFF
--- a/cpu/kinetis/periph/i2c.c
+++ b/cpu/kinetis/periph/i2c.c
@@ -169,6 +169,8 @@ static uint8_t i2c_find_divider(unsigned freq, unsigned speed)
 
 static inline void i2c_clear_irq_flags(I2C_Type *i2c)
 {
+    /* cppcheck-suppress selfAssignment
+     * reason: intentional self assignment to clear all pending IRQs */
     i2c->S = i2c->S;
 }
 


### PR DESCRIPTION
    cppcheck raises a warning due to self assignment. As this is
    intentional to clear all IRQ on register status flags, this
    warning is suppressed now.

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->