### PR TITLE
openthread: Enable RX complete netdev event

### DIFF
--- a/pkg/openthread/contrib/netdev/openthread_netdev.c
+++ b/pkg/openthread/contrib/netdev/openthread_netdev.c
@@ -174,6 +174,7 @@ int openthread_netdev_init(char *stack, int stacksize, char priority,
 
     netopt_enable_t enable = NETOPT_ENABLE;
     netdev->driver->set(netdev, NETOPT_TX_END_IRQ, &enable, sizeof(enable));
+    netdev->driver->set(netdev, NETOPT_RX_END_IRQ, &enable, sizeof(enable));
 
     _pid = thread_create(stack, stacksize,
                          priority, THREAD_CREATE_STACKTEST,


### PR DESCRIPTION
Fixes "issue" where openthread assumed that this flag was enabled by
default with netdev devices. Most, if not all devices enable this flag by default so the problem did not show itself.

### Issues/PRs references

None