### PR TITLE
boards/ublox-c030-u201: adapt to new I2C interface

### DIFF
--- a/boards/ublox-c030-u201/include/periph_conf.h
+++ b/boards/ublox-c030-u201/include/periph_conf.h
@@ -198,47 +198,37 @@ static const spi_conf_t spi_config[] = {
  * @name I2C configuration
  * @{
  */
-#define I2C_0_EN            1
-#define I2C_1_EN            1
-#define I2C_NUMOF           2
-#define I2C_IRQ_PRIO        1
-#define I2C_APBCLK          (CLOCK_APB1)
+static const i2c_conf_t i2c_config[] = {
+    {
+        .dev            = I2C1,
+        .speed          = I2C_SPEED_NORMAL,
+        .scl_pin        = GPIO_PIN(PORT_B, 6),
+        .sda_pin        = GPIO_PIN(PORT_B, 7),
+        .scl_af         = GPIO_AF4,
+        .sda_af         = GPIO_AF4,
+        .bus            = APB1,
+        .rcc_mask       = RCC_APB1ENR_I2C1EN,
+        .clk            = CLOCK_APB1,
+        .irqn           = I2C1_EV_IRQn
+    },
+    {
+        .dev            = I2C3,
+        .speed          = I2C_SPEED_NORMAL,
+        .scl_pin        = GPIO_PIN(PORT_A, 8),
+        .sda_pin        = GPIO_PIN(PORT_C, 9),
+        .scl_af         = GPIO_AF4,
+        .sda_af         = GPIO_AF4,
+        .bus            = APB1,
+        .rcc_mask       = RCC_APB1ENR_I2C3EN,
+        .clk            = CLOCK_APB1,
+        .irqn           = I2C3_EV_IRQn
+    }
+};
 
-/* I2C 0 device configuration */
-#define I2C_0_DEV           I2C1
-#define I2C_0_CLKEN()       (periph_clk_en(APB1, RCC_APB1ENR_I2C1EN))
-#define I2C_0_CLKDIS()      (periph_clk_dis(APB1, RCC_APB1ENR_I2C1EN))
-#define I2C_0_EVT_IRQ       I2C1_EV_IRQn
-#define I2C_0_EVT_ISR       isr_i2c1_ev
-#define I2C_0_ERR_IRQ       I2C1_ER_IRQn
-#define I2C_0_ERR_ISR       isr_i2c1_er
-/* I2C 0 pin configuration */
-#define I2C_0_SCL_PORT      GPIOB
-#define I2C_0_SCL_PIN       6
-#define I2C_0_SCL_AF        4
-#define I2C_0_SCL_CLKEN()   (periph_clk_en(AHB1, RCC_AHB1ENR_GPIOBEN))
-#define I2C_0_SDA_PORT      GPIOB
-#define I2C_0_SDA_PIN       7
-#define I2C_0_SDA_AF        4
-#define I2C_0_SDA_CLKEN()   (periph_clk_en(AHB1, RCC_AHB1ENR_GPIOBEN))
+#define I2C_0_ISR           isr_i2c1_ev
+#define I2C_1_ISR           isr_i2c3_ev
 
-/* I2C 1 device configuration */
-#define I2C_1_DEV           I2C3
-#define I2C_1_CLKEN()       (periph_clk_en(APB1, RCC_APB1ENR_I2C3EN))
-#define I2C_1_CLKDIS()      (periph_clk_dis(APB1, RCC_APB1ENR_I2C3EN))
-#define I2C_1_EVT_IRQ       I2C3_EV_IRQn
-#define I2C_1_EVT_ISR       isr_i2c3_ev
-#define I2C_1_ERR_IRQ       I2C3_ER_IRQn
-#define I2C_1_ERR_ISR       isr_i2c3_er
-/* I2C 1 pin configuration */
-#define I2C_1_SCL_PORT      GPIOA
-#define I2C_1_SCL_PIN       8
-#define I2C_1_SCL_AF        4
-#define I2C_1_SCL_CLKEN()   (periph_clk_en(AHB1, RCC_AHB1ENR_GPIOAEN))
-#define I2C_1_SDA_PORT      GPIOC
-#define I2C_1_SDA_PIN       9
-#define I2C_1_SDA_AF        4
-#define I2C_1_SDA_CLKEN()   (periph_clk_en(AHB1, RCC_AHB1ENR_GPIOCEN))
+#define I2C_NUMOF (sizeof(i2c_config) / sizeof(i2c_config[0]))
 /** @} */
 
 /**


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR intends to repair a break from the ongoing I2C embargo.
I cherry-picked the Ublox commit from #8769 then I adapt the periph_conf to the new i2C interface.
Ublox board will still not compiles on this branch because I did not cherry-pick the commit that add support for the STM32 CPU (cause a merge conflict) but it will compiles once the branch get rebased into master (tested locally)
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references
see #8769 which breaks the embargo 
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->