### PR TITLE
gnrc_netif_ieee802154: drop frame on buffer error

### DIFF
--- a/sys/net/gnrc/netif/gnrc_netif_ieee802154.c
+++ b/sys/net/gnrc/netif/gnrc_netif_ieee802154.c
@@ -88,6 +88,8 @@ static gnrc_pktsnip_t *_recv(gnrc_netif_t *netif)
         pkt = gnrc_pktbuf_add(NULL, NULL, bytes_expected, GNRC_NETTYPE_UNDEF);
         if (pkt == NULL) {
             DEBUG("_recv_ieee802154: cannot allocate pktsnip.\n");
+            /* Discard packet on netdev device */
+            dev->driver->recv(dev, NULL, bytes_expected, NULL);
             return NULL;
         }
         nread = dev->driver->recv(dev, pkt->data, bytes_expected, &rx_info);


### PR DESCRIPTION
### Contribution description

This adds a netdev recv call to indicate that the received frame should be
dropped when there is no buffer space available to store the frame.

`gnrc_netif_ethernet.c` already has this call [here](https://github.com/RIOT-OS/RIOT/blob/master/sys/net/gnrc/netif/gnrc_netif_ethernet.c#L175)

### Issues/PRs references

None