### PR TITLE
gnrc_netif_ieee802154: rework `netif->state` to getter and flag

### DIFF
--- a/sys/include/net/gnrc/netif/flags.h
+++ b/sys/include/net/gnrc/netif/flags.h
@@ -130,6 +130,12 @@ enum {
 #define GNRC_NETIF_FLAGS_MAC_RX_STARTED            (0x00008000U)
 /** @} */
 
+/**
+ * @brief   Network interface is configured in raw mode
+ */
+#define GNRC_NETIF_FLAGS_RAWMODE                   (0x00010000U)
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -315,6 +315,18 @@ int gnrc_netif_set_from_netdev(gnrc_netif_t *netif,
             res = sizeof(netopt_enable_t);
             break;
 #endif  /* MODULE_GNRC_SIXLOWPAN_IPHC */
+        case NETOPT_RAWMODE:
+            if (*(((netopt_enable_t *)opt->data)) == NETOPT_ENABLE) {
+                netif->flags |= GNRC_NETIF_FLAGS_RAWMODE;
+            }
+            else {
+                netif->flags &= ~GNRC_NETIF_FLAGS_RAWMODE;
+            }
+            /* Also propagate to the netdev device */
+            netif->dev->driver->set(netif->dev, NETOPT_RAWMODE, opt->data,
+                                      opt->data_len);
+            res = sizeof(netopt_enable_t);
+            break;
         default:
             break;
     }

--- a/sys/net/gnrc/netif/gnrc_netif_ieee802154.c
+++ b/sys/net/gnrc/netif/gnrc_netif_ieee802154.c
@@ -78,7 +78,6 @@ static gnrc_pktsnip_t *_recv(gnrc_netif_t *netif)
 {
     netdev_t *dev = netif->dev;
     netdev_ieee802154_rx_info_t rx_info;
-    netdev_ieee802154_t *state = (netdev_ieee802154_t *)netif->dev;
     gnrc_pktsnip_t *pkt = NULL;
     int bytes_expected = dev->driver->recv(dev, NULL, 0, NULL);
 
@@ -97,7 +96,7 @@ static gnrc_pktsnip_t *_recv(gnrc_netif_t *netif)
             gnrc_pktbuf_release(pkt);
             return NULL;
         }
-        if (!(state->flags & NETDEV_IEEE802154_RAW)) {
+        if (!(netif->flags & GNRC_NETIF_FLAGS_RAWMODE)) {
             gnrc_pktsnip_t *ieee802154_hdr, *netif_hdr;
             gnrc_netif_hdr_t *hdr;
 #if ENABLE_DEBUG
@@ -140,7 +139,7 @@ static gnrc_pktsnip_t *_recv(gnrc_netif_t *netif)
             hdr->lqi = rx_info.lqi;
             hdr->rssi = rx_info.rssi;
             hdr->if_pid = thread_getpid();
-            pkt->type = state->proto;
+            dev->driver->get(dev, NETOPT_PROTO, &pkt->type, sizeof(pkt->type));
 #if ENABLE_DEBUG
             DEBUG("_recv_ieee802154: received packet from %s of length %u\n",
                   gnrc_netif_addr_to_str(gnrc_netif_hdr_get_src_addr(hdr),


### PR DESCRIPTION
### Contribution description

Low hanging fruit in the recv function. Removes direct access to the
netdev struct in favor of netdev API get calls. Reworking the access to the netdev struct in the send function requires a bit more work.

Impact on flash usage is 48 bytes on the samr21-xpro

### Issues/PRs references

Required for the changes proposed in #7736 
