### PR TITLE
nrf52xxxdk: match i2c pins with arduino layout

### DIFF
--- a/boards/common/nrf52xxxdk/include/periph_conf.h
+++ b/boards/common/nrf52xxxdk/include/periph_conf.h
@@ -100,8 +100,8 @@ static const spi_conf_t spi_config[] = {
 static const i2c_conf_t i2c_config[] = {
     {
         .dev = NRF_TWIM1,
-        .scl = 28,
-        .sda = 29
+        .scl = 27,
+        .sda = 26
     }
 };
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
While experimenting with the X-NUCLEO-IKS01A1, I realised that the I2C pins were not mapped to the Arduino shield. I don't know if this has a reason but for me it seems legit to make it match, since it allows the use of Arduino shields using I2C.

I think this doesn't touch any of the files for the I2C refactoring.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references
None.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->