### PR TITLE
boards/nucleo-f070: drop periph_i2c

### DIFF
--- a/boards/nucleo-f070/Makefile.features
+++ b/boards/nucleo-f070/Makefile.features
@@ -1,7 +1,6 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_gpio
-FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_timer


### PR DESCRIPTION
    This drops the I2C feature for the nucleo-f070. Note: this is
    only temporarily, to get the new I2C API merged into master.
    Hence, will be re-introduces and fixed later on, sorry for any
    inconvenience.

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Git rebase of the I2C branch onto master introduces a bug to due failed merge, this PR "helps" git to merge correctly, will be reverted as soon as things are in master.


### Issues/PRs references

