### PR TITLE
asymcute: clear request context on request timeout

### DIFF
--- a/sys/net/application_layer/asymcute/asymcute.c
+++ b/sys/net/application_layer/asymcute/asymcute.c
@@ -256,6 +256,8 @@ static void _on_req_timeout(void *arg)
         mutex_unlock(&req->lock);
         mutex_unlock(&con->lock);
         con->user_cb(req, ret);
+        /* clear request for further use */
+        req->con = NULL;
     }
 }
 


### PR DESCRIPTION
### Contribution description
When a message times out the request context isn't cleared, so it can be used for later messages.

### Issues/PRs references
-