### PR TITLE
drivers/radios: remove default event reporting flags

### DIFF
--- a/drivers/at86rf2xx/at86rf2xx.c
+++ b/drivers/at86rf2xx/at86rf2xx.c
@@ -81,11 +81,6 @@ void at86rf2xx_reset(at86rf2xx_t *dev)
     /* set default options */
     at86rf2xx_set_option(dev, AT86RF2XX_OPT_AUTOACK, true);
     at86rf2xx_set_option(dev, AT86RF2XX_OPT_CSMA, true);
-    at86rf2xx_set_option(dev, AT86RF2XX_OPT_TELL_RX_START, false);
-    at86rf2xx_set_option(dev, AT86RF2XX_OPT_TELL_RX_END, true);
-#ifdef MODULE_NETSTATS_L2
-    at86rf2xx_set_option(dev, AT86RF2XX_OPT_TELL_TX_END, true);
-#endif
 
     /* enable safe mode (protect RX FIFO until reading data starts) */
     at86rf2xx_reg_write(dev, AT86RF2XX_REG__TRX_CTRL_2,

--- a/drivers/cc2420/cc2420.c
+++ b/drivers/cc2420/cc2420.c
@@ -65,12 +65,6 @@ int cc2420_init(cc2420_t *dev)
     /* set default options */
     cc2420_set_option(dev, CC2420_OPT_AUTOACK, true);
     cc2420_set_option(dev, CC2420_OPT_CSMA, true);
-    cc2420_set_option(dev, CC2420_OPT_TELL_TX_START, true);
-    cc2420_set_option(dev, CC2420_OPT_TELL_RX_END, true);
-
-#ifdef MODULE_NETSTATS_L2
-    cc2420_set_option(dev, CC2420_OPT_TELL_RX_END, true);
-#endif
 
     /* change default RX bandpass filter to 1.3uA (as recommended) */
     reg = cc2420_reg_read(dev, CC2420_REG_RXCTRL1);

--- a/drivers/kw2xrf/kw2xrf.c
+++ b/drivers/kw2xrf/kw2xrf.c
@@ -111,9 +111,6 @@ void kw2xrf_reset_phy(kw2xrf_t *dev)
     kw2xrf_set_power_mode(dev, KW2XRF_AUTODOZE);
     kw2xrf_set_sequence(dev, dev->idle_state);
 
-    kw2xrf_set_option(dev, KW2XRF_OPT_TELL_RX_START, true);
-    kw2xrf_set_option(dev, KW2XRF_OPT_TELL_RX_END, true);
-    kw2xrf_set_option(dev, KW2XRF_OPT_TELL_TX_END, true);
     kw2xrf_clear_dreg_bit(dev, MKW2XDM_PHY_CTRL2, MKW2XDM_PHY_CTRL2_SEQMSK);
 
     kw2xrf_enable_irq_b(dev);

--- a/drivers/mrf24j40/mrf24j40.c
+++ b/drivers/mrf24j40/mrf24j40.c
@@ -68,11 +68,6 @@ void mrf24j40_reset(mrf24j40_t *dev)
     mrf24j40_set_option(dev, NETDEV_IEEE802154_SRC_MODE_LONG, true);
     mrf24j40_set_option(dev, NETDEV_IEEE802154_ACK_REQ, true);
     mrf24j40_set_option(dev, MRF24J40_OPT_CSMA, true);
-    mrf24j40_set_option(dev, MRF24J40_OPT_TELL_RX_START, false);
-    mrf24j40_set_option(dev, MRF24J40_OPT_TELL_RX_END, true);
-#ifdef MODULE_NETSTATS_L2
-    mrf24j40_set_option(dev, MRF24J40_OPT_TELL_TX_END, true);
-#endif
 
     /* go into RX state */
     mrf24j40_reset_tasks(dev);


### PR DESCRIPTION
### Contribution description

Now that all network stacks set the required netdev event flags on init, these defaults can be removed from the radios. This prevents the radios from reporting events that are not handled by the network stack anyway.

### Issues/PRs references

#9467, #9553, #9555, #9556

### Testing

All current network stacks should be tested with at least one of the changed drivers to ensure that all required events for that network stack still work (testing on native (with socket_zep) is not enough).

- [x] GNRC
    - [x] cc2420: tested with *examples/default* and `txtsnd` between 2 z1 nodes
    - [x] at86rf2xx <-> kw2x: tested with *examples/gnrc_networking* and `ping6` between samr21-xpro and pba-d-01-kw2x
    - [x] at86rf2xx <-> mrf24j40: tested with *examples/gnrc_networking* and `ping6` between samr21-xpro and nucleo-l476rg+mrf24j40
- [x] LwIP, tested with *tests/lwip*, `ip` and `udp` commands and 4 samr21-xpro nodes
- [x] emb6, tested with *tests/emb6*, `ping6` and `udp` commands and 4 iotlab-m3 nodes
- [x] openthread

@miri64 Did I miss a network stack that uses one of the modified 802.15.4 radios in this list?
