### PR TITLE
make: make BUILDRELPATH dependent on selected path

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -65,7 +65,7 @@ endif
 MAKEOVERRIDES += $(foreach v,$(__DIRECTORY_VARIABLES),$(v)=$($(v)))
 
 # Path to the current directory relative to RIOTPROJECT
-BUILDRELPATH ?= $(PWD:$(RIOTPROJECT)/%=%)/
+BUILDRELPATH ?= $(CURDIR:$(RIOTPROJECT)/%=%)/
 
 # get host operating system
 OS := $(shell uname)


### PR DESCRIPTION
### Contribution description
When selecting a directory to build using `-C` with make
`BUILD_IN_DOCKER` will fail, because the `BUILDRELPATH` chooses the path
`make` is executed in, not the path selected by `-C`. This fixes this
bug by replacing `PWD` in the macro's definition with `CURDIR`.

### Issues/PRs references
None