### PR TITLE
drivers/at: add poweron/off functions

### DIFF
--- a/drivers/at/at.c
+++ b/drivers/at/at.c
@@ -315,3 +315,13 @@ void at_process_urc(at_dev_t *dev, uint32_t timeout)
     clist_foreach(&dev->urc_list, _check_urc, buf);
 }
 #endif
+
+void at_dev_poweron(at_dev_t *dev)
+{
+    uart_poweron(dev->uart);
+}
+
+void at_dev_poweroff(at_dev_t *dev)
+{
+    uart_poweroff(dev->uart);
+}

--- a/drivers/include/at.h
+++ b/drivers/include/at.h
@@ -256,6 +256,20 @@ ssize_t at_readline(at_dev_t *dev, char *resp_buf, size_t len, bool keep_eol, ui
  */
 void at_drain(at_dev_t *dev);
 
+/**
+ * @brief   Power device on
+ *
+ * @param[in]   dev     device to power on
+ */
+void at_dev_poweron(at_dev_t *dev);
+
+/**
+ * @brief   Power device off
+ *
+ * @param[in]   dev     device to power off
+ */
+void at_dev_poweroff(at_dev_t *dev);
+
 #if defined(MODULE_AT_URC) || DOXYGEN
 /**
  * @brief   Add a callback for an unsolicited response code

--- a/tests/driver_at/main.c
+++ b/tests/driver_at/main.c
@@ -115,6 +115,30 @@ static int drain(int argc, char **argv)
     return 0;
 }
 
+static int power_on(int argc, char **argv)
+{
+    (void)argc;
+    (void)argv;
+
+    at_dev_poweron(&at_dev);
+
+    puts("Powered on");
+
+    return 0;
+}
+
+static int power_off(int argc, char **argv)
+{
+    (void)argc;
+    (void)argv;
+
+    at_dev_poweroff(&at_dev);
+
+    puts("Powered off");
+
+    return 0;
+}
+
 #ifdef MODULE_AT_URC
 #ifndef MAX_URC_NB
 #define MAX_URC_NB  5
@@ -205,6 +229,8 @@ static const shell_command_t shell_commands[] = {
     { "send_ok", "Send a command and wait OK", send_ok },
     { "send_lines", "Send a command and wait lines", send_lines },
     { "drain", "Drain AT device", drain },
+    { "power_on", "Power on AT device", power_on },
+    { "power_off", "Power off AT device", power_off },
 #ifdef MODULE_AT_URC
     { "add_urc", "Register an URC", add_urc },
     { "remove_urc", "De-register an URC", remove_urc },


### PR DESCRIPTION
### Contribution description

Add `at_poweron` and `at_poweroff` functions to enable/disable underlying uart and enable low power.
