### PR TITLE
at86rf2xx: Move flags from netdev to radio

### DIFF
--- a/drivers/at86rf2xx/at86rf2xx.c
+++ b/drivers/at86rf2xx/at86rf2xx.c
@@ -161,7 +161,7 @@ void at86rf2xx_tx_exec(const at86rf2xx_t *dev)
     at86rf2xx_reg_write(dev, AT86RF2XX_REG__TRX_STATE,
                         AT86RF2XX_TRX_STATE__TX_START);
     if (netdev->event_callback &&
-        (dev->netdev.flags & AT86RF2XX_OPT_TELL_TX_START)) {
+        (dev->flags & AT86RF2XX_OPT_TELL_TX_START)) {
         netdev->event_callback(netdev, NETDEV_EVENT_TX_STARTED);
     }
 }

--- a/drivers/at86rf2xx/at86rf2xx_getset.c
+++ b/drivers/at86rf2xx/at86rf2xx_getset.c
@@ -337,8 +337,8 @@ void at86rf2xx_set_option(at86rf2xx_t *dev, uint16_t option, bool state)
     DEBUG("set option %i to %i\n", option, state);
 
     /* set option field */
-    dev->netdev.flags = (state) ? (dev->netdev.flags |  option)
-                                : (dev->netdev.flags & ~option);
+    dev->flags = (state) ? (dev->flags |  option)
+                         : (dev->flags & ~option);
     /* trigger option specific actions */
     switch (option) {
         case AT86RF2XX_OPT_CSMA:

--- a/drivers/at86rf2xx/at86rf2xx_netdev.c
+++ b/drivers/at86rf2xx/at86rf2xx_netdev.c
@@ -119,7 +119,7 @@ static int _send(netdev_t *netdev, const iolist_t *iolist)
     }
 
     /* send data out directly if pre-loading id disabled */
-    if (!(dev->netdev.flags & AT86RF2XX_OPT_PRELOADING)) {
+    if (!(dev->flags & AT86RF2XX_OPT_PRELOADING)) {
         at86rf2xx_tx_exec(dev);
     }
     /* return the number of bytes that were actually loaded into the frame
@@ -199,7 +199,7 @@ static int _set_state(at86rf2xx_t *dev, netopt_state_t state)
             at86rf2xx_set_state(dev, AT86RF2XX_STATE_RX_AACK_ON);
             break;
         case NETOPT_STATE_TX:
-            if (dev->netdev.flags & AT86RF2XX_OPT_PRELOADING) {
+            if (dev->flags & AT86RF2XX_OPT_PRELOADING) {
                 /* The netdev driver ISR switches the transceiver back to the
                  * previous idle state after a completed TX. If the user tries
                  * to initiate another transmission (retransmitting the same data)
@@ -274,7 +274,7 @@ static int _get(netdev_t *netdev, netopt_t opt, void *val, size_t max_len)
             return sizeof(netopt_state_t);
 
         case NETOPT_PRELOADING:
-            if (dev->netdev.flags & AT86RF2XX_OPT_PRELOADING) {
+            if (dev->flags & AT86RF2XX_OPT_PRELOADING) {
                 *((netopt_enable_t *)val) = NETOPT_ENABLE;
             }
             else {
@@ -283,7 +283,7 @@ static int _get(netdev_t *netdev, netopt_t opt, void *val, size_t max_len)
             return sizeof(netopt_enable_t);
 
         case NETOPT_PROMISCUOUSMODE:
-            if (dev->netdev.flags & AT86RF2XX_OPT_PROMISCUOUS) {
+            if (dev->flags & AT86RF2XX_OPT_PROMISCUOUS) {
                 *((netopt_enable_t *)val) = NETOPT_ENABLE;
             }
             else {
@@ -293,27 +293,27 @@ static int _get(netdev_t *netdev, netopt_t opt, void *val, size_t max_len)
 
         case NETOPT_RX_START_IRQ:
             *((netopt_enable_t *)val) =
-                !!(dev->netdev.flags & AT86RF2XX_OPT_TELL_RX_START);
+                !!(dev->flags & AT86RF2XX_OPT_TELL_RX_START);
             return sizeof(netopt_enable_t);
 
         case NETOPT_RX_END_IRQ:
             *((netopt_enable_t *)val) =
-                !!(dev->netdev.flags & AT86RF2XX_OPT_TELL_RX_END);
+                !!(dev->flags & AT86RF2XX_OPT_TELL_RX_END);
             return sizeof(netopt_enable_t);
 
         case NETOPT_TX_START_IRQ:
             *((netopt_enable_t *)val) =
-                !!(dev->netdev.flags & AT86RF2XX_OPT_TELL_TX_START);
+                !!(dev->flags & AT86RF2XX_OPT_TELL_TX_START);
             return sizeof(netopt_enable_t);
 
         case NETOPT_TX_END_IRQ:
             *((netopt_enable_t *)val) =
-                !!(dev->netdev.flags & AT86RF2XX_OPT_TELL_TX_END);
+                !!(dev->flags & AT86RF2XX_OPT_TELL_TX_END);
             return sizeof(netopt_enable_t);
 
         case NETOPT_CSMA:
             *((netopt_enable_t *)val) =
-                !!(dev->netdev.flags & AT86RF2XX_OPT_CSMA);
+                !!(dev->flags & AT86RF2XX_OPT_CSMA);
             return sizeof(netopt_enable_t);
 
 /* Only radios with the XAH_CTRL_2 register support frame retry reporting */
@@ -545,7 +545,7 @@ static int _set(netdev_t *netdev, netopt_t opt, const void *val, size_t len)
 
         case NETOPT_CSMA_RETRIES:
             assert(len <= sizeof(uint8_t));
-            if (!(dev->netdev.flags & AT86RF2XX_OPT_CSMA) ||
+            if (!(dev->flags & AT86RF2XX_OPT_CSMA) ||
                 (*((uint8_t *)val) > 5)) {
                 /* If CSMA is disabled, don't allow setting retries */
                 res = -EINVAL;
@@ -609,7 +609,7 @@ static void _isr(netdev_t *netdev)
         if ((state == AT86RF2XX_STATE_RX_AACK_ON)
             || (state == AT86RF2XX_STATE_BUSY_RX_AACK)) {
             DEBUG("[at86rf2xx] EVT - RX_END\n");
-            if (!(dev->netdev.flags & AT86RF2XX_OPT_TELL_RX_END)) {
+            if (!(dev->flags & AT86RF2XX_OPT_TELL_RX_END)) {
                 return;
             }
             netdev->event_callback(netdev, NETDEV_EVENT_RX_COMPLETE);
@@ -632,7 +632,7 @@ static void _isr(netdev_t *netdev)
 
             DEBUG("[at86rf2xx] EVT - TX_END\n");
 
-            if (netdev->event_callback && (dev->netdev.flags & AT86RF2XX_OPT_TELL_TX_END)) {
+            if (netdev->event_callback && (dev->flags & AT86RF2XX_OPT_TELL_TX_END)) {
                 switch (trac_status) {
 #ifdef MODULE_OPENTHREAD
                     case AT86RF2XX_TRX_STATE__TRAC_SUCCESS:

--- a/drivers/include/at86rf2xx.h
+++ b/drivers/include/at86rf2xx.h
@@ -129,29 +129,24 @@ extern "C" {
 
 /**
  * @name    Internal device option flags
- *
- * `0x00ff` is reserved for general IEEE 802.15.4 flags
- * (see @ref netdev_ieee802154_t)
- *
  * @{
  */
-#define AT86RF2XX_OPT_SRC_ADDR_LONG  (NETDEV_IEEE802154_SRC_MODE_LONG)  /**< legacy define */
-#define AT86RF2XX_OPT_RAWDUMP        (NETDEV_IEEE802154_RAW)            /**< legacy define */
-#define AT86RF2XX_OPT_AUTOACK        (NETDEV_IEEE802154_ACK_REQ)        /**< legacy define */
-#define AT86RF2XX_OPT_ACK_PENDING    (NETDEV_IEEE802154_FRAME_PEND)     /**< legacy define */
-
-#define AT86RF2XX_OPT_CSMA           (0x0100)       /**< CSMA active */
-#define AT86RF2XX_OPT_PROMISCUOUS    (0x0200)       /**< promiscuous mode
+#define AT86RF2XX_OPT_TELL_TX_START  (0x0001)       /**< notify MAC layer on TX
+                                                     *   start */
+#define AT86RF2XX_OPT_TELL_TX_END    (0x0002)       /**< notify MAC layer on TX
+                                                     *   finished */
+#define AT86RF2XX_OPT_TELL_RX_START  (0x0004)       /**< notify MAC layer on RX
+                                                     *   start */
+#define AT86RF2XX_OPT_TELL_RX_END    (0x0008)       /**< notify MAC layer on RX
+                                                     *   finished */
+#define AT86RF2XX_OPT_CSMA           (0x0010)       /**< CSMA active */
+#define AT86RF2XX_OPT_PROMISCUOUS    (0x0020)       /**< promiscuous mode
                                                      *   active */
-#define AT86RF2XX_OPT_PRELOADING     (0x0400)       /**< preloading enabled */
-#define AT86RF2XX_OPT_TELL_TX_START  (0x0800)       /**< notify MAC layer on TX
-                                                     *   start */
-#define AT86RF2XX_OPT_TELL_TX_END    (0x1000)       /**< notify MAC layer on TX
-                                                     *   finished */
-#define AT86RF2XX_OPT_TELL_RX_START  (0x2000)       /**< notify MAC layer on RX
-                                                     *   start */
-#define AT86RF2XX_OPT_TELL_RX_END    (0x4000)       /**< notify MAC layer on RX
-                                                     *   finished */
+#define AT86RF2XX_OPT_PRELOADING     (0x0040)       /**< preloading enabled */
+#define AT86RF2XX_OPT_AUTOACK        (0x0080)       /**< Auto ACK active */
+#define AT86RF2XX_OPT_ACK_PENDING    (0x0100)       /**< ACK frames with data
+                                                     *   pending */
+
 /** @} */
 
 /**
@@ -175,6 +170,7 @@ typedef struct {
     netdev_ieee802154_t netdev;             /**< netdev parent struct */
     /* device specific fields */
     at86rf2xx_params_t params;              /**< parameters for initialization */
+    uint16_t flags;                         /**< Device specific flags */
     uint8_t state;                          /**< current state of the radio */
     uint8_t tx_frame_len;                   /**< length of the current TX frame */
 #ifdef MODULE_AT86RF212B


### PR DESCRIPTION
### Contribution description

The flags from the ieee802154 struct are only used in the radio code, there is no advantage of having make sense to have them in the netdev struct if their meaning is different per radio driver.

Also fixes a bug where (un)setting the `AUTOACK` flag would (un)set the `ACK_REQ` flag.

### Issues/PRs references

Minor cleanup preparing for #7736 

Similar PRs are required for the other radio drivers using flags.