### PR TITLE
mrf24j40: Move flags from netdev to radio

### DIFF
--- a/drivers/include/mrf24j40.h
+++ b/drivers/include/mrf24j40.h
@@ -104,8 +104,7 @@ extern "C" {
                                                      *   start */
 #define MRF24J40_OPT_TELL_RX_END        (0x4000)    /**< notify MAC layer on RX
                                                      *   finished */
-#define MRF24J40_OPT_REQ_AUTO_ACK       (0x8000)    /**< notify MAC layer on RX
-                                                     *   finished */
+#define MRF24J40_OPT_AUTOACK            (0x8000)    /**< Auto ack RX frames */
 /** @} */
 
 

--- a/drivers/include/mrf24j40.h
+++ b/drivers/include/mrf24j40.h
@@ -92,19 +92,19 @@ extern "C" {
  *
  * @{
  */
-#define MRF24J40_OPT_CSMA               (0x0100)    /**< CSMA active */
-#define MRF24J40_OPT_PROMISCUOUS        (0x0200)    /**< promiscuous mode
+#define MRF24J40_OPT_CSMA               (0x01)      /**< CSMA active */
+#define MRF24J40_OPT_PROMISCUOUS        (0x02)      /**< promiscuous mode
                                                      *   active */
-#define MRF24J40_OPT_PRELOADING         (0x0400)    /**< preloading enabled */
-#define MRF24J40_OPT_TELL_TX_START      (0x0800)    /**< notify MAC layer on TX
+#define MRF24J40_OPT_PRELOADING         (0x04)      /**< preloading enabled */
+#define MRF24J40_OPT_TELL_TX_START      (0x08)      /**< notify MAC layer on TX
                                                      *   start */
-#define MRF24J40_OPT_TELL_TX_END        (0x1000)    /**< notify MAC layer on TX
+#define MRF24J40_OPT_TELL_TX_END        (0x10)      /**< notify MAC layer on TX
                                                      *   finished */
-#define MRF24J40_OPT_TELL_RX_START      (0x2000)    /**< notify MAC layer on RX
+#define MRF24J40_OPT_TELL_RX_START      (0x20)      /**< notify MAC layer on RX
                                                      *   start */
-#define MRF24J40_OPT_TELL_RX_END        (0x4000)    /**< notify MAC layer on RX
+#define MRF24J40_OPT_TELL_RX_END        (0x40)      /**< notify MAC layer on RX
                                                      *   finished */
-#define MRF24J40_OPT_AUTOACK            (0x8000)    /**< Auto ack RX frames */
+#define MRF24J40_OPT_AUTOACK            (0x80)      /**< Auto ack RX frames */
 /** @} */
 
 
@@ -132,7 +132,7 @@ typedef struct {
     netdev_ieee802154_t netdev;             /**< netdev parent struct */
     /*  device specific fields  */
     mrf24j40_params_t params;               /**< parameters for initialization */
-    uint16_t flags;                         /**< Internal device flags */
+    uint8_t flags;                          /**< Internal device flags */
     uint8_t state;                          /**< current state of the radio */
     uint8_t idle_state;                     /**< state to return to after sending */
     uint8_t tx_frame_len;                   /**< length of the current TX frame */

--- a/drivers/include/mrf24j40.h
+++ b/drivers/include/mrf24j40.h
@@ -132,6 +132,7 @@ typedef struct {
     netdev_ieee802154_t netdev;             /**< netdev parent struct */
     /*  device specific fields  */
     mrf24j40_params_t params;               /**< parameters for initialization */
+    uint16_t flags;                         /**< Internal device flags */
     uint8_t state;                          /**< current state of the radio */
     uint8_t idle_state;                     /**< state to return to after sending */
     uint8_t tx_frame_len;                   /**< length of the current TX frame */

--- a/drivers/mrf24j40/mrf24j40.c
+++ b/drivers/mrf24j40/mrf24j40.c
@@ -66,7 +66,7 @@ void mrf24j40_reset(mrf24j40_t *dev)
     /* set default options */
     mrf24j40_set_option(dev, IEEE802154_FCF_PAN_COMP, true);
     mrf24j40_set_option(dev, NETDEV_IEEE802154_SRC_MODE_LONG, true);
-    mrf24j40_set_option(dev, NETDEV_IEEE802154_ACK_REQ, true);
+    mrf24j40_set_option(dev, MRF24J40_OPT_AUTOACK, true);
     mrf24j40_set_option(dev, MRF24J40_OPT_CSMA, true);
 
     /* go into RX state */

--- a/drivers/mrf24j40/mrf24j40.c
+++ b/drivers/mrf24j40/mrf24j40.c
@@ -48,6 +48,7 @@ void mrf24j40_reset(mrf24j40_t *dev)
 
     netdev_ieee802154_reset(&dev->netdev);
 
+    dev->flags = 0;
     /* get an 8-byte unique ID to use as hardware address */
     luid_get(addr_long.uint8, IEEE802154_LONG_ADDRESS_LEN);
     addr_long.uint8[0] &= ~(0x01);
@@ -148,7 +149,7 @@ void mrf24j40_tx_exec(mrf24j40_t *dev)
     else {
         mrf24j40_reg_write_short(dev, MRF24J40_REG_TXNCON, MRF24J40_TXNCON_TXNTRIG);
     }
-    if (netdev->event_callback && (dev->netdev.flags & MRF24J40_OPT_TELL_TX_START)) {
+    if (netdev->event_callback && (dev->flags & MRF24J40_OPT_TELL_TX_START)) {
         netdev->event_callback(netdev, NETDEV_EVENT_TX_STARTED);
     }
 }

--- a/drivers/mrf24j40/mrf24j40.c
+++ b/drivers/mrf24j40/mrf24j40.c
@@ -65,8 +65,6 @@ void mrf24j40_reset(mrf24j40_t *dev)
     mrf24j40_reg_write_short(dev, MRF24J40_REG_WAKECON, MRF24J40_WAKECON_IMMWAKE);
 
     /* set default options */
-    mrf24j40_set_option(dev, IEEE802154_FCF_PAN_COMP, true);
-    mrf24j40_set_option(dev, NETDEV_IEEE802154_SRC_MODE_LONG, true);
     mrf24j40_set_option(dev, MRF24J40_OPT_AUTOACK, true);
     mrf24j40_set_option(dev, MRF24J40_OPT_CSMA, true);
 

--- a/drivers/mrf24j40/mrf24j40_getset.c
+++ b/drivers/mrf24j40/mrf24j40_getset.c
@@ -331,7 +331,7 @@ void mrf24j40_set_option(mrf24j40_t *dev, uint16_t option, bool state)
 
     /* set option field */
     if (state) {
-        dev->netdev.flags |= option;
+        dev->flags |= option;
         /* trigger option specific actions */
         switch (option) {
             case MRF24J40_OPT_CSMA:
@@ -364,7 +364,7 @@ void mrf24j40_set_option(mrf24j40_t *dev, uint16_t option, bool state)
     }
     /* clear option field */
     else {
-        dev->netdev.flags &= ~(option);
+        dev->flags &= ~(option);
         /* trigger option specific actions */
         switch (option) {
             case MRF24J40_OPT_CSMA:

--- a/drivers/mrf24j40/mrf24j40_getset.c
+++ b/drivers/mrf24j40/mrf24j40_getset.c
@@ -351,7 +351,7 @@ void mrf24j40_set_option(mrf24j40_t *dev, uint16_t option, bool state)
                 tmp &= ~MRF24J40_RXMCR_ERRPKT;
                 mrf24j40_reg_write_short(dev, MRF24J40_REG_RXMCR, tmp);
                 break;
-            case NETDEV_IEEE802154_ACK_REQ:
+            case MRF24J40_OPT_AUTOACK:
                 DEBUG("[mrf24j40] opt: enabling auto ACKs\n");
                 tmp = mrf24j40_reg_read_short(dev, MRF24J40_REG_RXMCR);
                 tmp &= ~MRF24J40_RXMCR_NOACKRSP;
@@ -383,12 +383,12 @@ void mrf24j40_set_option(mrf24j40_t *dev, uint16_t option, bool state)
                 tmp &= ~MRF24J40_RXMCR_PROMI;
                 tmp &= ~MRF24J40_RXMCR_ERRPKT;
                 /* re-enable AUTOACK only if the option is set */
-                if (dev->netdev.flags & NETDEV_IEEE802154_ACK_REQ) {
+                if (dev->flags & MRF24J40_OPT_AUTOACK) {
                     tmp &= ~(MRF24J40_RXMCR_NOACKRSP);
                     mrf24j40_reg_write_short(dev, MRF24J40_REG_RXMCR, tmp);
                 }
                 break;
-            case NETDEV_IEEE802154_ACK_REQ:
+            case MRF24J40_OPT_AUTOACK:
                 DEBUG("[mrf24j40] opt: disabling auto ACKs\n");
                 tmp = mrf24j40_reg_read_short(dev, MRF24J40_REG_RXMCR);
                 tmp |= MRF24J40_RXMCR_NOACKRSP;

--- a/drivers/mrf24j40/mrf24j40_netdev.c
+++ b/drivers/mrf24j40/mrf24j40_netdev.c
@@ -207,6 +207,16 @@ static int _get(netdev_t *netdev, netopt_t opt, void *val, size_t max_len)
             }
             break;
 
+        case NETOPT_AUTOACK:
+            if (dev->netdev.flags & MRF24J40_OPT_AUTOACK) {
+                *((netopt_enable_t *)val) = NETOPT_ENABLE;
+            }
+            else {
+                *((netopt_enable_t *)val) = NETOPT_DISABLE;
+            }
+            res = sizeof(netopt_enable_t);
+            break;
+
         case NETOPT_PRELOADING:
             if (dev->netdev.flags & MRF24J40_OPT_PRELOADING) {
                 *((netopt_enable_t *)val) = NETOPT_ENABLE;
@@ -441,9 +451,9 @@ static int _set(netdev_t *netdev, netopt_t opt, const void *val, size_t len)
             break;
 
         case NETOPT_AUTOACK:
-            mrf24j40_set_option(dev, NETDEV_IEEE802154_ACK_REQ,
+            mrf24j40_set_option(dev, MRF24J40_OPT_AUTOACK,
                                 ((const bool *)val)[0]);
-            /* don't set res to set netdev_ieee802154_t::flags */
+            res = sizeof(netopt_enable_t);
             break;
 
         case NETOPT_PRELOADING:

--- a/drivers/mrf24j40/mrf24j40_netdev.c
+++ b/drivers/mrf24j40/mrf24j40_netdev.c
@@ -97,7 +97,7 @@ static int _send(netdev_t *netdev, const iolist_t *iolist)
     }
 
     /* send data out directly if pre-loading is disabled */
-    if (!(dev->netdev.flags & MRF24J40_OPT_PRELOADING)) {
+    if (!(dev->flags & MRF24J40_OPT_PRELOADING)) {
         mrf24j40_tx_exec(dev);
     }
     /* return the number of bytes that were actually send out */
@@ -208,7 +208,7 @@ static int _get(netdev_t *netdev, netopt_t opt, void *val, size_t max_len)
             break;
 
         case NETOPT_AUTOACK:
-            if (dev->netdev.flags & MRF24J40_OPT_AUTOACK) {
+            if (dev->flags & MRF24J40_OPT_AUTOACK) {
                 *((netopt_enable_t *)val) = NETOPT_ENABLE;
             }
             else {
@@ -218,7 +218,7 @@ static int _get(netdev_t *netdev, netopt_t opt, void *val, size_t max_len)
             break;
 
         case NETOPT_PRELOADING:
-            if (dev->netdev.flags & MRF24J40_OPT_PRELOADING) {
+            if (dev->flags & MRF24J40_OPT_PRELOADING) {
                 *((netopt_enable_t *)val) = NETOPT_ENABLE;
             }
             else {
@@ -228,7 +228,7 @@ static int _get(netdev_t *netdev, netopt_t opt, void *val, size_t max_len)
             break;
 
         case NETOPT_PROMISCUOUSMODE:
-            if (dev->netdev.flags & MRF24J40_OPT_PROMISCUOUS) {
+            if (dev->flags & MRF24J40_OPT_PROMISCUOUS) {
                 *((netopt_enable_t *)val) = NETOPT_ENABLE;
             }
             else {
@@ -239,31 +239,31 @@ static int _get(netdev_t *netdev, netopt_t opt, void *val, size_t max_len)
 
         case NETOPT_RX_START_IRQ:
             *((netopt_enable_t *)val) =
-                !!(dev->netdev.flags & MRF24J40_OPT_TELL_RX_START);
+                !!(dev->flags & MRF24J40_OPT_TELL_RX_START);
             res = sizeof(netopt_enable_t);
             break;
 
         case NETOPT_RX_END_IRQ:
             *((netopt_enable_t *)val) =
-                !!(dev->netdev.flags & MRF24J40_OPT_TELL_RX_END);
+                !!(dev->flags & MRF24J40_OPT_TELL_RX_END);
             res = sizeof(netopt_enable_t);
             break;
 
         case NETOPT_TX_START_IRQ:
             *((netopt_enable_t *)val) =
-                !!(dev->netdev.flags & MRF24J40_OPT_TELL_TX_START);
+                !!(dev->flags & MRF24J40_OPT_TELL_TX_START);
             res = sizeof(netopt_enable_t);
             break;
 
         case NETOPT_TX_END_IRQ:
             *((netopt_enable_t *)val) =
-                !!(dev->netdev.flags & MRF24J40_OPT_TELL_TX_END);
+                !!(dev->flags & MRF24J40_OPT_TELL_TX_END);
             res = sizeof(netopt_enable_t);
             break;
 
         case NETOPT_CSMA:
             *((netopt_enable_t *)val) =
-                !!(dev->netdev.flags & MRF24J40_OPT_CSMA);
+                !!(dev->flags & MRF24J40_OPT_CSMA);
             res = sizeof(netopt_enable_t);
             break;
 
@@ -344,7 +344,7 @@ static int _set_state(mrf24j40_t *dev, netopt_state_t state)
             mrf24j40_set_state(dev, MRF24J40_PSEUDO_STATE_IDLE);
             break;
         case NETOPT_STATE_TX:
-            if (dev->netdev.flags & MRF24J40_OPT_PRELOADING) {
+            if (dev->flags & MRF24J40_OPT_PRELOADING) {
                 mrf24j40_tx_exec(dev);
             }
             break;
@@ -503,7 +503,7 @@ static int _set(netdev_t *netdev, netopt_t opt, const void *val, size_t len)
                 (*((const uint8_t *)val) > 5)) {
                 res = -EOVERFLOW;
             }
-            else if (dev->netdev.flags & MRF24J40_OPT_CSMA) {
+            else if (dev->flags & MRF24J40_OPT_CSMA) {
                 /* only set if CSMA is enabled */
                 mrf24j40_set_csma_max_retries(dev, *((const uint8_t *)val));
                 res = sizeof(uint8_t);
@@ -542,7 +542,7 @@ static void _isr(netdev_t *netdev)
         dev->pending &= ~(MRF24J40_TASK_TX_READY);
         DEBUG("[mrf24j40] EVT - TX_END\n");
 #ifdef MODULE_NETSTATS_L2
-        if (netdev->event_callback && (dev->netdev.flags & MRF24J40_OPT_TELL_TX_END)) {
+        if (netdev->event_callback && (dev->flags & MRF24J40_OPT_TELL_TX_END)) {
             uint8_t txstat = mrf24j40_reg_read_short(dev, MRF24J40_REG_TXSTAT);
             dev->tx_retries = (txstat >> MRF24J40_TXSTAT_MAX_FRAME_RETRIES_SHIFT);
             /* transmision failed */
@@ -567,7 +567,7 @@ static void _isr(netdev_t *netdev)
     /* Receive interrupt occured */
     if (dev->pending & MRF24J40_TASK_RX_READY) {
         DEBUG("[mrf24j40] EVT - RX_END\n");
-        if ((dev->netdev.flags & MRF24J40_OPT_TELL_RX_END)) {
+        if ((dev->flags & MRF24J40_OPT_TELL_RX_END)) {
             netdev->event_callback(netdev, NETDEV_EVENT_RX_COMPLETE);
         }
         dev->pending &= ~(MRF24J40_TASK_RX_READY);


### PR DESCRIPTION
### Contribution description

The flags from the ieee802154 struct are only used in the radio code, there is no advantage of having make sense to have them in the netdev struct if their meaning is different per radio driver.

Also fixes a bug where the `NETOPT_AUTOACK` doesn't work, but is dis/enabled with the `NETOPT_ACK_REQ` setting.

### Issues/PRs references

Minor cleanup preparing for #7736

Similar PRs are required for the other radio drivers using flags.