### PR TITLE
drivers/cc2420: add netopt NETOPT_MAX_PACKET_SIZE

### DIFF
--- a/drivers/cc2420/cc2420_netdev.c
+++ b/drivers/cc2420/cc2420_netdev.c
@@ -38,6 +38,7 @@
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
 
+#define _MAX_MHR_OVERHEAD   (25)
 
 static int _send(netdev_t *netdev, const iolist_t *iolist);
 static int _recv(netdev_t *netdev, void *buf, size_t len, void *info);
@@ -186,6 +187,11 @@ static int _get(netdev_t *netdev, netopt_t opt, void *val, size_t max_len)
             assert(max_len >= 8);
             cc2420_get_addr_long(dev, val);
             return 8;
+
+        case NETOPT_MAX_PACKET_SIZE:
+            assert(max_len >= sizeof(int16_t));
+            *((uint16_t *)val) = CC2420_PKT_MAXLEN - _MAX_MHR_OVERHEAD;
+            return sizeof(int16_t);
 
         case NETOPT_NID:
             assert(max_len >= sizeof(uint16_t));


### PR DESCRIPTION
### Contribution description

This PR adds the netopt get option `NETOPT_MAX_PACKET_SIZE` to the cc2420 radio driver. Without this fix, running *examples/gnrc_minimal* on a z1 board (for example) asserts [here](https://github.com/RIOT-OS/RIOT/blob/master/sys/net/gnrc/netif/gnrc_netif.c#L1188)

### Issues/PRs references
Somehow relates to #3086