### PR TITLE
iotlab-support: use iotlab command to check credentials

### DIFF
--- a/dist/testbed-support/Makefile.iotlab
+++ b/dist/testbed-support/Makefile.iotlab
@@ -72,7 +72,8 @@ iotlab-stop: $(IOTLAB_AUTH) iotlab-check-exp
 	$(Q)iotlab-experiment stop -i $(IOTLAB_EXP_ID)
 
 iotlab-term: iotlab-check-exp
-	$(Q)ssh -t $(IOTLAB_AUTHORITY) "test -f ~/.iotlabrc || iotlab-auth -u $(IOTLAB_USER)"
+	$(Q)ssh -t $(IOTLAB_AUTHORITY) "iotlab-experiment get -r > /dev/null || \
+	                                iotlab-auth -u $(IOTLAB_USER)"
 
 	$(Q)ssh -t $(IOTLAB_AUTHORITY) \
 	"tmux attach -t riot-$(IOTLAB_EXP_ID) || tmux new -s riot-$(IOTLAB_EXP_ID) \


### PR DESCRIPTION
### Contribution description
Since the `iotlab-term` target uses `tmux` error messages are not really printed, so it took me a while to find out why at some sites this target wasn't working for me anymore.

If the IoT-LAB password was changed, just checking if `.iotlabrc` exists isn't enough, so I use `iotlab-experiment` to check if I'm logged in properly to prompt the password input in case I'm not.

### Issues/PRs references
None