### PR TITLE
unittests: increase test timeout

### DIFF
--- a/tests/unittests/tests/01-run.py
+++ b/tests/unittests/tests/01-run.py
@@ -17,4 +17,4 @@ def testfunc(child):
 if __name__ == "__main__":
     sys.path.append(os.path.join(os.environ['RIOTTOOLS'], 'testrunner'))
     from testrunner import run
-    sys.exit(run(testfunc, timeout=60))
+    sys.exit(run(testfunc, timeout=120))


### PR DESCRIPTION
### Contribution description

It currently takes 1m30 to run on iotlab-m3 which is more than the 60s configured.


### Issues/PRs references

Found for release testing: https://github.com/RIOT-OS/Release-Specs/issues/65#issuecomment-405606724