### PR TITLE
kw2xrf: Fix ack flag handling [backport 2018.07]

### DIFF
--- a/drivers/kw2xrf/kw2xrf_netdev.c
+++ b/drivers/kw2xrf/kw2xrf_netdev.c
@@ -275,6 +275,16 @@ int _get(netdev_t *netdev, netopt_t opt, void *value, size_t len)
             *((netopt_state_t *)value) = _get_state(dev);
             return sizeof(netopt_state_t);
 
+        case NETOPT_AUTOACK:
+            if (dev->netdev.flags & KW2XRF_OPT_AUTOACK) {
+                *((netopt_enable_t *)value) = NETOPT_ENABLE;
+            }
+            else {
+                *((netopt_enable_t *)value) = NETOPT_DISABLE;
+            }
+            return sizeof(netopt_enable_t);
+
+
         case NETOPT_PRELOADING:
             if (dev->netdev.flags & KW2XRF_OPT_PRELOADING) {
                 *((netopt_enable_t *)value) = NETOPT_ENABLE;
@@ -452,6 +462,7 @@ static int _set(netdev_t *netdev, netopt_t opt, const void *value, size_t len)
             /* Set up HW generated automatic ACK after Receive */
             kw2xrf_set_option(dev, KW2XRF_OPT_AUTOACK,
                               ((bool *)value)[0]);
+            res = sizeof(netopt_enable_t);
             break;
 
         case NETOPT_ACK_REQ:

--- a/drivers/kw2xrf/kw2xrf_netdev.c
+++ b/drivers/kw2xrf/kw2xrf_netdev.c
@@ -103,7 +103,7 @@ static size_t kw2xrf_tx_load(uint8_t *pkt_buf, uint8_t *buf, size_t len, size_t 
 
 static void kw2xrf_tx_exec(kw2xrf_t *dev)
 {
-    if ((dev->netdev.flags & KW2XRF_OPT_AUTOACK) &&
+    if ((dev->netdev.flags & KW2XRF_OPT_ACK_REQ) &&
         (_send_last_fcf & IEEE802154_FCF_ACK_REQ)) {
         kw2xrf_set_sequence(dev, XCVSEQ_TX_RX);
     }


### PR DESCRIPTION
# Backport of #9587

### Contribution description

Missing getter for `NETOPT_AUTOACK` and tx_exec used `AUTOACK` flag instead of `ACK_REQ` flag.

### Issues/PRs references

None