### PR TITLE
tests/xtimer_drift: added test

### DIFF
--- a/tests/xtimer_drift/Makefile
+++ b/tests/xtimer_drift/Makefile
@@ -2,6 +2,10 @@ include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_MEMORY := nucleo-f031k6 nucleo-f042k6
 
+FEATURES_REQUIRED += periph_gpio
 USEMODULE += xtimer
 
 include $(RIOTBASE)/Makefile.include
+
+test:
+	tests/01-run.py

--- a/tests/xtimer_drift/main.c
+++ b/tests/xtimer_drift/main.c
@@ -116,9 +116,9 @@ void *worker_thread(void *arg)
             expected = last + TEST_HZ * TEST_INTERVAL;
             int32_t jitter = now - expected;
             printf("now=%" PRIu32 ".%06" PRIu32 " (0x%08" PRIx32 " ticks), ",
-                    sec, us, ticks.ticks32);
+                   sec, us, ticks.ticks32);
             printf("drift=%" PRId32 " us, jitter=%" PRId32 " us\n",
-                    drift, jitter);
+                   drift, jitter);
             last = now;
         }
         ++loop_counter;

--- a/tests/xtimer_drift/tests/01-run.py
+++ b/tests/xtimer_drift/tests/01-run.py
@@ -1,0 +1,50 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2017 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import os
+import sys
+import time
+
+HOST_JITTER = 0.1
+TEST_INTERVAL_LOWER = 1 - HOST_JITTER
+TEST_INTERVAL_UPPER = 1 + HOST_JITTER
+
+
+class InvalidTimeout(Exception):
+    pass
+
+
+def testfunc(child):
+    error = 0
+
+    child.expect_exact(u"[START]")
+    child.expect(u"\r\n")
+    child.expect(u"now=(([0-9]*[.])?[0-9]+) .+ us\r\n")
+    start = time.time()
+    try:
+        while 1:
+            child.expect(u"now=(([0-9]*[.])?[0-9]+) .+ us\r\n")
+            end = time.time()
+            delta = end - start
+            start = time.time()
+            timestamp = float(child.match.group(1))
+            if (delta < TEST_INTERVAL_LOWER) or (delta > TEST_INTERVAL_UPPER):
+                error = error + 1
+                print("{}: Invalid timebetween messages, expected {} < {} < {}"
+                      .format(timestamp, TEST_INTERVAL_LOWER, delta, TEST_INTERVAL_UPPER))
+            # if error > 20:
+            #    raise InvalidTimeout("20 times Invalid time between messages")
+    except InvalidTimeout as e:
+        print(e)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    sys.path.append(os.path.join(os.environ['RIOTTOOLS'], 'testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc))


### PR DESCRIPTION
Added a test to be able to investigate problems like stated in https://github.com/RIOT-OS/RIOT/issues/5103.

Problems arising with this PR can be solved with
https://github.com/RIOT-OS/RIOT/pull/9211
https://github.com/RIOT-OS/RIOT/pull/9595

This PRs have to be merged before this problem is solved.

Additional https://github.com/RIOT-OS/RIOT/pull/8990 can be applied.

This test compares the timing between received messages with the host clock and prints when an error occured.

```
2018-07-18 13:41:16,388 - INFO # main(): This is RIOT! (Version: 2018.10)
2018-07-18 13:41:16,389 - INFO # [START]
2018-07-18 13:41:16,389 - INFO # 
2018-07-18 13:41:17,394 - INFO # now=1.046264 (0x0001fedf ticks), drift=552 us, jitter=552 us
2018-07-18 13:41:19,967 - INFO # now=2.045584 (0x0003e6d2 ticks), drift=-128 us, jitter=-680 us
2.045584: Invalid timebetween messages, expected 0.9 < 1.9108633995056152 < 1.1
2018-07-18 13:41:23,067 - INFO # now=3.045520 (0x0005cf12 ticks), drift=-192 us, jitter=-64 us
3.04552: Invalid timebetween messages, expected 0.9 < 3.1008362770080566 < 1.1
2018-07-18 13:41:25,642 - INFO # now=4.045456 (0x0007b752 ticks), drift=-256 us, jitter=-64 us
4.045456: Invalid timebetween messages, expected 0.9 < 2.5776400566101074 < 1.1
2018-07-18 13:41:27,164 - INFO # now=5.045392 (0x00099f92 ticks), drift=-320 us, jitter=-64 us
5.045392: Invalid timebetween messages, expected 0.9 < 1.517474889755249 < 1.1
2018-07-18 13:41:29,741 - INFO # now=6.045328 (0x000b87d2 ticks), drift=-384 us, jitter=-64 us
6.045328: Invalid timebetween messages, expected 0.9 < 2.6143975257873535 < 1.1
2018-07-18 13:41:31,791 - INFO # now=7.045264 (0x000d7012 ticks), drift=-448 us, jitter=-64 us
```