### PR TITLE
stm32_common: fix ram length for MCUs with non-contiguous ram regions [backport 2018.07]

### DIFF
--- a/cpu/stm32_common/stm32_mem_lengths.mk
+++ b/cpu/stm32_common/stm32_mem_lengths.mk
@@ -235,6 +235,7 @@ else ifeq ($(STM32_TYPE), L)
       RAM_LEN = 64K
     else ifeq ($(STM32_MODEL2), 7)
       RAM_LEN = 96K
+      RAM2_LEN = 32K
     else ifeq ($(STM32_MODEL2), 5)
       RAM_LEN = 160K
     else ifeq ($(STM32_MODEL2), 9)

--- a/cpu/stm32_common/stm32_mem_lengths.mk
+++ b/cpu/stm32_common/stm32_mem_lengths.mk
@@ -120,19 +120,20 @@ ifeq ($(STM32_TYPE), F)
       endif
     else ifeq ($(STM32_MODEL), 303)
       ifneq (, $(filter $(STM32_ROMSIZE), 6 8))
-        RAM_LEN = 16K
+        RAM_LEN = 12K
         CCMRAM_LEN = 4K
       else ifeq ($(STM32_ROMSIZE), B)
         RAM_LEN = 40K
         CCMRAM_LEN = 8K
       else ifeq ($(STM32_ROMSIZE), C)
-        RAM_LEN = 48K
+        RAM_LEN = 40K
         CCMRAM_LEN = 8K
       else ifneq (, $(filter $(STM32_ROMSIZE), D E))
-        RAM_LEN = 80K
+        RAM_LEN = 64K
+        CCMRAM_LEN = 16K
       endif
     else ifeq ($(STM32_MODEL3), 4)
-      RAM_LEN = 16K
+      RAM_LEN = 12K
       CCMRAM_LEN = 4K
     else ifeq ($(STM32_MODEL), 373)
       RAM_LEN = 32K
@@ -233,7 +234,7 @@ else ifeq ($(STM32_TYPE), L)
     ifeq ($(STM32_MODEL2), 3)
       RAM_LEN = 64K
     else ifeq ($(STM32_MODEL2), 7)
-      RAM_LEN = 128K
+      RAM_LEN = 96K
     else ifeq ($(STM32_MODEL2), 5)
       RAM_LEN = 160K
     else ifeq ($(STM32_MODEL2), 9)

--- a/examples/gcoap/Makefile
+++ b/examples/gcoap/Makefile
@@ -11,7 +11,8 @@ RIOTBASE ?= $(CURDIR)/../..
 
 BOARD_INSUFFICIENT_MEMORY := chronos msb-430 msb-430h nucleo-f031k6 nucleo-f042k6 \
                              nucleo-l031k6 nucleo-f030r8 nucleo-f334r8 nucleo-l053r8 \
-                             stm32f0discovery telosb wsn430-v1_3b wsn430-v1_4 z1
+                             stm32f0discovery telosb wsn430-v1_3b wsn430-v1_4 z1 \
+                             nucleo-f303k8
 
 ## Uncomment to redefine port, for example use 61616 for RFC 6282 UDP compression.
 #GCOAP_PORT = 5683

--- a/examples/nanocoap_server/Makefile
+++ b/examples/nanocoap_server/Makefile
@@ -9,7 +9,7 @@ RIOTBASE ?= $(CURDIR)/../..
 
 BOARD_INSUFFICIENT_MEMORY := chronos msb-430 msb-430h nucleo-f031k6 nucleo-f042k6 \
                              nucleo-l031k6 nucleo-f030r8 nucleo-l053r8 stm32f0discovery \
-                             telosb z1
+                             telosb z1 nucleo-f303k8
 
 # Include packages that pull up and auto-init the link layer.
 # NOTE: 6LoWPAN will be included if IEEE802.15.4 devices are present

--- a/examples/posix_sockets/Makefile
+++ b/examples/posix_sockets/Makefile
@@ -10,8 +10,8 @@ RIOTBASE ?= $(CURDIR)/../..
 BOARD_INSUFFICIENT_MEMORY := airfy-beacon chronos msb-430 msb-430h nrf51dongle \
                              nrf6310 nucleo-f031k6 nucleo-f042k6 nucleo-l031k6 \
                              nucleo-f030r8 nucleo-f070rb nucleo-f072rb nucleo-f334r8 \
-                             nucleo-l053r8 stm32f0discovery telosb \
-                             wsn430-v1_3b wsn430-v1_4 yunjia-nrf51822 z1
+                             nucleo-l053r8 stm32f0discovery telosb wsn430-v1_3b \
+                             wsn430-v1_4 yunjia-nrf51822 z1 nucleo-f303k8
 
 # Include packages that pull up and auto-init the link layer.
 # NOTE: 6LoWPAN will be included if IEEE802.15.4 devices are present

--- a/examples/rdcli_simple/Makefile
+++ b/examples/rdcli_simple/Makefile
@@ -10,7 +10,7 @@ RIOTBASE ?= $(CURDIR)/../..
 BOARD_INSUFFICIENT_MEMORY := chronos hifive1 msb-430 msb-430h nucleo-f030r8 nucleo-l053r8 \
                              nucleo-f031k6 nucleo-f042k6 nucleo-l031k6 \
                              stm32f0discovery telosb wsn430-v1_3b wsn430-v1_4 \
-                             z1 nucleo-f303k8
+                             z1 nucleo-f303k8 nucleo-f334r8
 
 # Enable GNRC networking
 USEMODULE += gnrc_netdev_default

--- a/examples/rdcli_simple/Makefile
+++ b/examples/rdcli_simple/Makefile
@@ -10,7 +10,7 @@ RIOTBASE ?= $(CURDIR)/../..
 BOARD_INSUFFICIENT_MEMORY := chronos hifive1 msb-430 msb-430h nucleo-f030r8 nucleo-l053r8 \
                              nucleo-f031k6 nucleo-f042k6 nucleo-l031k6 \
                              stm32f0discovery telosb wsn430-v1_3b wsn430-v1_4 \
-                             z1
+                             z1 nucleo-f303k8
 
 # Enable GNRC networking
 USEMODULE += gnrc_netdev_default

--- a/tests/driver_enc28j60/Makefile
+++ b/tests/driver_enc28j60/Makefile
@@ -1,9 +1,9 @@
 include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_MEMORY := msb-430 msb-430h nucleo-f334r8 nucleo-l053r8 \
-                             nucleo-f031k6 nucleo-f042k6 nucleo-l031k6 \
-                             stm32f0discovery telosb wsn430-v1_3b wsn430-v1_4 \
-                             z1
+                             nucleo-f031k6 nucleo-f042k6 nucleo-f303k8 \
+                             nucleo-l031k6 stm32f0discovery telosb \
+                             wsn430-v1_3b wsn430-v1_4 z1
 
 USEMODULE += auto_init_gnrc_netif
 USEMODULE += enc28j60

--- a/tests/gnrc_ipv6_ext/Makefile
+++ b/tests/gnrc_ipv6_ext/Makefile
@@ -3,7 +3,8 @@ include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_MEMORY := airfy-beacon chronos maple-mini msb-430 msb-430h \
                              nrf51dongle nrf6310 nucleo-f031k6 nucleo-f042k6 \
-                             nucleo-l031k6 nucleo-f030r8 nucleo-f103rb nucleo-f334r8 nucleo-l053r8 \
+                             nucleo-l031k6 nucleo-f030r8 nucleo-f103rb \
+                             nucleo-f303k8 nucleo-f334r8 nucleo-l053r8 \
                              spark-core stm32f0discovery telosb \
                              wsn430-v1_3b wsn430-v1_4 yunjia-nrf51822 z1
 

--- a/tests/gnrc_sixlowpan/Makefile
+++ b/tests/gnrc_sixlowpan/Makefile
@@ -4,9 +4,9 @@ include ../Makefile.tests_common
 BOARD_INSUFFICIENT_MEMORY := airfy-beacon chronos maple-mini msb-430 msb-430h \
                              nrf51dongle nrf6310 nucleo-f031k6 nucleo-f042k6 \
                              nucleo-l031k6 nucleo-f030r8 nucleo-f070rb nucleo-f103rb \
-                             nucleo-f334r8 nucleo-l053r8 spark-core \
-                             stm32f0discovery telosb wsn430-v1_3b wsn430-v1_4 \
-                             yunjia-nrf51822 z1
+                             nucleo-f303k8 nucleo-f334r8 nucleo-l053r8 \
+                             spark-core stm32f0discovery telosb wsn430-v1_3b \
+                             wsn430-v1_4 yunjia-nrf51822 z1
 
 # Include packages that pull up and auto-init the link layer.
 # NOTE: 6LoWPAN will be included if IEEE802.15.4 devices are present

--- a/tests/gnrc_sock_dns/Makefile
+++ b/tests/gnrc_sock_dns/Makefile
@@ -3,8 +3,8 @@ include ../Makefile.tests_common
 RIOTBASE ?= $(CURDIR)/../..
 
 BOARD_INSUFFICIENT_MEMORY := chronos telosb nucleo-f042k6 nucleo-f031k6 \
-                             nucleo-f030r8 nucleo-l053r8 nucleo-l031k6 \
-                             stm32f0discovery z1
+                             nucleo-f030r8 nucleo-f303k8 nucleo-l053r8 \
+                             nucleo-l031k6 stm32f0discovery z1
 
 USEMODULE += sock_dns
 USEMODULE += gnrc_sock_udp

--- a/tests/lwip/Makefile
+++ b/tests/lwip/Makefile
@@ -6,8 +6,9 @@ BOARD_BLACKLIST := arduino-uno arduino-duemilanove arduino-mega2560 chronos \
                    msb-430 msb-430h telosb waspmote-pro wsn430-v1_3b \
                    wsn430-v1_4 z1 jiminy-mega256rfr2 mega-xplained
 BOARD_INSUFFICIENT_MEMORY := airfy-beacon hifive1 nrf6310 nucleo-f031k6 nucleo-f042k6 \
-                             nucleo-l031k6 nucleo-f030r8 nucleo-f334r8 nucleo-l053r8 \
-                             stm32f0discovery yunjia-nrf51822
+                             nucleo-l031k6 nucleo-f030r8 nucleo-f303k8 \
+                             nucleo-f334r8 nucleo-l053r8 stm32f0discovery \
+                             yunjia-nrf51822
 
 # including lwip_ipv6_mld would currently break this test on at86rf2xx radios
 USEMODULE += lwip lwip_ipv6_autoconfig lwip_sock_ip lwip_netdev

--- a/tests/lwip_sock_ip/Makefile
+++ b/tests/lwip_sock_ip/Makefile
@@ -6,7 +6,8 @@ BOARD_BLACKLIST := arduino-uno arduino-duemilanove arduino-mega2560 chronos \
                    msb-430 msb-430h telosb waspmote-pro wsn430-v1_3b \
                    wsn430-v1_4 z1 jiminy-mega256rfr2 mega-xplained
 BOARD_INSUFFICIENT_MEMORY = nucleo-f031k6 nucleo-f042k6 nucleo-l031k6 nucleo-f030r8 \
-                            nucleo-f334r8 nucleo-l053r8 stm32f0discovery
+                            nucleo-f303k8 nucleo-f334r8 nucleo-l053r8 \
+                            stm32f0discovery
 
 LWIP_IPV4 ?= 0
 

--- a/tests/lwip_sock_tcp/Makefile
+++ b/tests/lwip_sock_tcp/Makefile
@@ -6,7 +6,8 @@ BOARD_BLACKLIST := arduino-uno arduino-duemilanove arduino-mega2560 chronos \
                    msb-430 msb-430h telosb waspmote-pro wsn430-v1_3b \
                    wsn430-v1_4 z1 jiminy-mega256rfr2 mega-xplained
 BOARD_INSUFFICIENT_MEMORY = nucleo-f031k6 nucleo-f042k6 nucleo-l031k6 nucleo-f030r8 \
-                            nucleo-f334r8 nucleo-l053r8 stm32f0discovery
+                            nucleo-f303k8 nucleo-f334r8 nucleo-l053r8 \
+                            stm32f0discovery
 
 LWIP_IPV4 ?= 0
 

--- a/tests/lwip_sock_udp/Makefile
+++ b/tests/lwip_sock_udp/Makefile
@@ -6,7 +6,8 @@ BOARD_BLACKLIST := arduino-uno arduino-duemilanove arduino-mega2560 chronos \
                    msb-430 msb-430h telosb waspmote-pro wsn430-v1_3b \
                    wsn430-v1_4 z1 jiminy-mega256rfr2 mega-xplained
 BOARD_INSUFFICIENT_MEMORY = nucleo-f031k6 nucleo-f042k6 nucleo-l031k6 nucleo-f030r8 \
-                            nucleo-f334r8 nucleo-l053r8 stm32f0discovery
+                            nucleo-f303k8 nucleo-f334r8 nucleo-l053r8 \
+                            stm32f0discovery
 
 LWIP_IPV4 ?= 0
 

--- a/tests/nhdp/Makefile
+++ b/tests/nhdp/Makefile
@@ -4,7 +4,8 @@ BOARD_BLACKLIST := arduino-mega2560 chronos msb-430 msb-430h telosb \
                    wsn430-v1_3b wsn430-v1_4 z1 waspmote-pro arduino-uno \
                    arduino-duemilanove jiminy-mega256rfr2 mega-xplained
 BOARD_INSUFFICIENT_MEMORY := nucleo-f031k6 nucleo-f042k6 nucleo-l031k6 nucleo-f030r8 \
-                             nucleo-f334r8 nucleo-l053r8 stm32f0discovery
+                             nucleo-f303k8 nucleo-f334r8 nucleo-l053r8 \
+                             stm32f0discovery
 
 USEMODULE += gnrc_ipv6
 USEMODULE += gnrc_sock_udp

--- a/tests/pkg_libcoap/Makefile
+++ b/tests/pkg_libcoap/Makefile
@@ -5,7 +5,8 @@ BOARD_BLACKLIST := arduino-mega2560 chronos msb-430 msb-430h telosb wsn430-v1_3b
                    wsn430-v1_4 z1 waspmote-pro arduino-uno arduino-duemilanove \
                    jiminy-mega256rfr2 mega-xplained
 BOARD_INSUFFICIENT_MEMORY := chronos msb-430 msb-430h nucleo-f031k6 nucleo-f042k6 \
-                             nucleo-l031k6 nucleo-f030r8 nucleo-f070rb nucleo-f334r8 nucleo-l053r8 \
+                             nucleo-l031k6 nucleo-f030r8 nucleo-f070rb \
+                             nucleo-f303k8 nucleo-f334r8 nucleo-l053r8 \
                              stm32f0discovery telosb wsn430-v1_3b wsn430-v1_4 \
                              z1
 

--- a/tests/pkg_microcoap/Makefile
+++ b/tests/pkg_microcoap/Makefile
@@ -1,8 +1,8 @@
 include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_MEMORY := chronos msb-430 msb-430h nucleo-f031k6 nucleo-f042k6 \
-                             nucleo-l031k6 nucleo-f030r8 nucleo-l053r8 \
-                             stm32f0discovery telosb z1
+                             nucleo-f303k8 nucleo-l031k6 nucleo-f030r8 \
+                             nucleo-l053r8 stm32f0discovery telosb z1
 
 # Include packages that pull up and auto-init the link layer.
 # NOTE: 6LoWPAN will be included if IEEE802.15.4 devices are present

--- a/tests/posix_semaphore/Makefile
+++ b/tests/posix_semaphore/Makefile
@@ -2,8 +2,8 @@ include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_MEMORY := chronos mbed_lpc1768 msb-430 msb-430h nrf6310 \
                              nucleo-f031k6 nucleo-f042k6 nucleo-l031k6 nucleo-f030r8 \
-                             nucleo-f334r8 nucleo-l053r8 spark-core \
-                             stm32f0discovery yunjia-nrf51822
+                             nucleo-f303k8 nucleo-f334r8 nucleo-l053r8 \
+                             spark-core stm32f0discovery yunjia-nrf51822
 
 USEMODULE += fmt
 USEMODULE += posix_semaphore

--- a/tests/pthread_rwlock/Makefile
+++ b/tests/pthread_rwlock/Makefile
@@ -12,7 +12,8 @@ USEMODULE += random
 
 BOARD_INSUFFICIENT_MEMORY += chronos msb-430 msb-430h nucleo-f031k6 \
                              nucleo-f042k6 nucleo-l031k6 nucleo-f030r8 \
-                             nucleo-f334r8 nucleo-l053r8 stm32f0discovery
+                             nucleo-f303k8 nucleo-f334r8 nucleo-l053r8 \
+                             stm32f0discovery
 
 include $(RIOTBASE)/Makefile.include
 

--- a/tests/slip/Makefile
+++ b/tests/slip/Makefile
@@ -1,8 +1,8 @@
 include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_MEMORY := msb-430 msb-430h nucleo-f031k6 nucleo-f042k6 \
-                             nucleo-l031k6 nucleo-f030r8 nucleo-f334r8 nucleo-l053r8 \
-                             stm32f0discovery
+                             nucleo-l031k6 nucleo-f030r8 nucleo-f303k8 \
+                             nucleo-f334r8 nucleo-l053r8 stm32f0discovery
 
 BOARD_BLACKLIST += mips-malta
 

--- a/tests/sntp/Makefile
+++ b/tests/sntp/Makefile
@@ -2,8 +2,8 @@ include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_MEMORY := chronos msb-430 msb-430h nucleo-f031k6 \
                              nucleo-f042k6 nucleo-l031k6 nucleo-f030r8 \
-                             nucleo-f334r8 nucleo-l053r8 stm32f0discovery \
-                             telosb wsn430-v1_3b wsn430-v1_4 z1
+                             nucleo-f303k8 nucleo-f334r8 nucleo-l053r8 \
+                             stm32f0discovery telosb wsn430-v1_3b wsn430-v1_4 z1
 
 USEMODULE += sntp
 USEMODULE += gnrc_sock_udp

--- a/tests/thread_cooperation/Makefile
+++ b/tests/thread_cooperation/Makefile
@@ -1,9 +1,7 @@
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY :=    chronos \
-                                msb-430 \
-                                msb-430h \
-                                nucleo-f031k6
+BOARD_INSUFFICIENT_MEMORY := chronos msb-430 msb-430h nucleo-f031k6 \
+                             nucleo-f303k8
 
 DISABLE_MODULE += auto_init
 


### PR DESCRIPTION
# Backport of #9579

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
On some MCUs the ram sizes specified in stm32_mem_lengths.mk are based on the sum of available ram, while it is physically not mapped to a contiguous ram region. This will make the linker place data/code in unmapped address space if enough ram is used. See #9534 for details.
This PR fixes the problem by decreasing the ram sizes to the size of the "primary" ram region.

For testing the following snippet may be helpful:

```c
extern uint32_t _sram;
extern uint32_t _eram;

int main(void)
{
    printf("ram start @0x%p\n", &_sram);
    printf("ram end   @0x%p\n", &_eram);

    printf("last value in ram @0x%p: 0x%08lX\n", &_eram - 1, *(&_eram - 1));

    return 0;
}
```

On stm32-l476rg without the fix the above code crashes:
```
ram start @0x0x20000000
ram end   @0x0x20020000

Context before hardfault:
   r0: 0x00000018
   r1: 0x20000d18
   r2: 0xa0000000
   r3: 0x12000000
  r12: 0x08002102
   lr: 0x08000cd1
   pc: 0x08000cd0
  psr: 0x21000000

FSR/FAR:
 CFSR: 0x00008200
 HFSR: 0x40000000
 DFSR: 0x00000008
 AFSR: 0x00000000
 BFAR: 0x2001fffc
Misc
EXC_RET: 0xfffffffd
Attempting to reconstruct state for debugging...
In GDB:
  set $pc=0x8000cd0
  frame 0
  bt

ISR stack overflowed by at least 16 bytes.
```

with the fix it works as expected:

```
ram start @0x0x20000000
ram end   @0x0x20018000
last value in ram @0x0x20017ffc: 0x99E5B210
```

A thing for future PRs: the currently unused ram regions (i.e. SRAM2 on L4 and CCMRAM on F3) should be properly added to the linker to allow using them in applications. Also a test to verify ram sizes may be a good thing.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references
Fixes #9534
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->