### PR TITLE
core/mutex: docs: clarify usage of mutex_unlock().

### DIFF
--- a/core/include/mutex.h
+++ b/core/include/mutex.h
@@ -106,6 +106,10 @@ static inline int mutex_trylock(mutex_t *mutex)
 /**
  * @brief Locks a mutex, blocking.
  *
+ * Mutexes are served in FIFO order. This ensures that, as long as no thread
+ * holds the mutex indefinitely and as long as there are no deadlocks,
+ * all threads blocked on mutex_lock() should eventually unblock.
+ *
  * @param[in] mutex Mutex object to lock. Has to be initialized first. Must not be NULL.
  */
 static inline void mutex_lock(mutex_t *mutex)
@@ -115,6 +119,13 @@ static inline void mutex_lock(mutex_t *mutex)
 
 /**
  * @brief Unlocks the mutex.
+ *
+ * If there is more than one thread waiting for the mutex, the first one that
+ * requested the mutex will be unlocked (i.e. first come, first serve).
+ *
+ * In contrast with other systems, a mutex in RIOT can be unlocked by a thread
+ * that is not holding the mutex. This can be used to construct other
+ * synchronization devices.
  *
  * @param[in] mutex Mutex object to unlock, must not be NULL.
  */

--- a/core/include/mutex.h
+++ b/core/include/mutex.h
@@ -106,9 +106,11 @@ static inline int mutex_trylock(mutex_t *mutex)
 /**
  * @brief Locks a mutex, blocking.
  *
- * Mutexes are served in FIFO order. This ensures that, as long as no thread
- * holds the mutex indefinitely and as long as there are no deadlocks,
- * all threads blocked on mutex_lock() should eventually unblock.
+ * Mutexes are served in FIFO order while respecting thread priority (i.e. a higher
+ * priority thread will be unlocked before a lower priority one even if it arrived
+ * later). As long as no thread holds the mutex indefinitely and as long as there
+ * are no deadlocks, all same-priority threads blocked on mutex_lock() should
+ * eventually unblock.
  *
  * @param[in] mutex Mutex object to lock. Has to be initialized first. Must not be NULL.
  */
@@ -120,12 +122,11 @@ static inline void mutex_lock(mutex_t *mutex)
 /**
  * @brief Unlocks the mutex.
  *
- * If there is more than one thread waiting for the mutex, the first one that
- * requested the mutex will be unlocked (i.e. first come, first serve).
+ * One of the threads waiting on the mutex will be unblocked. For details on the
+ * order in which mutexes are served see mutex_lock().
  *
- * In contrast with other systems, a mutex in RIOT can be unlocked by a thread
- * that is not holding the mutex. This can be used to construct other
- * synchronization devices.
+ * A mutex in RIOT can be unlocked by any thread and not just the one that is
+ * holding the mutex. This can be used to construct other synchronization devices.
  *
  * @param[in] mutex Mutex object to unlock, must not be NULL.
  */


### PR DESCRIPTION
### Contribution description

Mutexes in RIOT can be locked by a thread an unlocked by other. This is not a very common feature and, given the lack of other synchronization primitives in `core`, a very useful one.

This change documents the behaviour. Additionally, now that it is written we are bound to respect this API.

### Issues/PRs references

Fixes #9594.