### PR TITLE
lwip: fix parentheses equality issue

### DIFF
--- a/pkg/lwip/Makefile
+++ b/pkg/lwip/Makefile
@@ -9,3 +9,7 @@ all: git-download
 	"$(MAKE)" -C $(PKG_BUILDDIR)
 
 include $(RIOTBASE)/pkg/pkg.mk
+
+ifeq (llvm,$(TOOLCHAIN))
+  CFLAGS += -Wno-parentheses-equality
+endif


### PR DESCRIPTION
### Contribution description
Another issue revealed by `llvm`. Since this is caused by the resolution
of a macro in lwIP this can't be solved as a patch, so we just ignore
the warning.

### Issues/PRs references
Fixes an issue revealed by #9398.