### PR TITLE
lua: remove unsupported flags for llvm [backport 2018.07]

### DIFF
--- a/pkg/lua/Makefile.lua
+++ b/pkg/lua/Makefile.lua
@@ -1,8 +1,11 @@
 SRC := $(filter-out loadlib.c lua.c luac.c,$(wildcard *.c))
 
-CFLAGS += -fstack-usage -fconserve-stack \
-          -DLUA_MAXCAPTURES=16 \
-          -DL_MAXLENNUM=50
+ifneq (llvm, $(TOOLCHAIN))
+  CFLAGS += -fstack-usage -fconserve-stack
+endif
+
+CFLAGS += -DLUA_MAXCAPTURES=16 -DL_MAXLENNUM=50
+
 #    Enable these options to debug stack usage
 #          -Wstack-usage=128 -Wno-error=stack-usage=128
 


### PR DESCRIPTION
# Backport of #9604

### Contribution description

Prevents error:

  clang: error: unknown argument: '-fstack-usage'
  clang: error: unknown argument: '-fconserve-stack'

The flags are here to print debug information and try to optimize stack but are
not required.


### Testing

Both compiling with llvm and gcc works

    make -C examples/lua_basic BOARD=samr21-xpro  TOOLCHAIN=llvm clean all
    make -C examples/lua_basic BOARD=samr21-xpro  TOOLCHAIN=gnu clean all

### Issues/PRs references

Detected by https://github.com/RIOT-OS/RIOT/pull/9398