### PR TITLE
cflags: add -Wformat=2 -Wformat-overflow -Wformat-truncation [backport 2018.07]

### DIFF
--- a/makefiles/cflags.inc.mk
+++ b/makefiles/cflags.inc.mk
@@ -59,6 +59,8 @@ CFLAGS += -fno-common
 
 # Enable all default warnings and all extra warnings
 CFLAGS += -Wall -Wextra
+# Enable additional checks for printf/scanf format strings
+$(foreach flag,-Wformat=2 -Wformat-overflow -Wformat-truncation,$(eval $(call cflags_test_and_add,$(flag))))
 
 # Warn if a user-supplied include directory does not exist.
 CFLAGS += -Wmissing-include-dirs

--- a/pkg/ccn-lite/Makefile
+++ b/pkg/ccn-lite/Makefile
@@ -22,3 +22,6 @@ $(TOOLCHAIN_FILE): git-download
 	$(RIOTTOOLS)/cmake/generate-xcompile-toolchain.sh > $(TOOLCHAIN_FILE)
 
 include $(RIOTBASE)/pkg/pkg.mk
+ifneq (,$(filter -Wformat-nonliteral -Wformat=2, $(CFLAGS)))
+  CFLAGS += -Wno-format-nonliteral
+endif

--- a/pkg/lua/Makefile.lua
+++ b/pkg/lua/Makefile.lua
@@ -7,3 +7,6 @@ CFLAGS += -fstack-usage -fconserve-stack \
 #          -Wstack-usage=128 -Wno-error=stack-usage=128
 
 include $(RIOTBASE)/Makefile.base
+ifneq (,$(filter -Wformat-nonliteral -Wformat=2, $(CFLAGS)))
+  CFLAGS += -Wno-format-nonliteral
+endif

--- a/pkg/oonf_api/Makefile
+++ b/pkg/oonf_api/Makefile
@@ -18,3 +18,6 @@ $(BINDIR)/$(MODULE).a: $(BINDIR)/oonf_*.a
 	mkdir -p $(BINDIR)/$(MODULE); cd $(BINDIR)/$(MODULE); for var in $?; do ar -x $$var; done; ar -r -c -s $(BINDIR)/$(MODULE).a *.o
 
 include $(RIOTBASE)/pkg/pkg.mk
+ifneq (,$(filter -Wformat-nonliteral -Wformat=2, $(CFLAGS)))
+  CFLAGS += -Wno-format-nonliteral
+endif

--- a/sys/cbor/cbor.c
+++ b/sys/cbor/cbor.c
@@ -87,6 +87,7 @@
 
 /* Array size */
 #define MAX_TIMESTRING_LENGTH   (21)
+#define TIMESTRING_FORMAT "%Y-%m-%dT%H:%M:%SZ"
 
 #ifndef INFINITY
 #define INFINITY (1.0/0.0)
@@ -767,9 +768,8 @@ size_t cbor_deserialize_date_time(const cbor_stream_t *stream, size_t offset, st
     char buffer[21];
     offset++;  /* skip tag byte to decode date_time */
     size_t read_bytes = cbor_deserialize_unicode_string(stream, offset, buffer, sizeof(buffer));
-    const char *format = "%Y-%m-%dT%H:%M:%SZ";
 
-    if (strptime(buffer, format, val) == 0) {
+    if (strptime(buffer, TIMESTRING_FORMAT, val) == 0) {
         return 0;
     }
 
@@ -787,9 +787,8 @@ size_t cbor_serialize_date_time(cbor_stream_t *stream, struct tm *val)
     CBOR_ENSURE_SIZE(stream, MAX_TIMESTRING_LENGTH + 1); /* + 1 tag byte */
 
     char time_str[MAX_TIMESTRING_LENGTH];
-    const char *format = "%Y-%m-%dT%H:%M:%SZ";
 
-    if (strftime(time_str, sizeof(time_str), format, val) == 0) { /* struct tm to string */
+    if (strftime(time_str, sizeof(time_str), TIMESTRING_FORMAT, val) == 0) { /* struct tm to string */
         return 0;
     }
 
@@ -1017,7 +1016,7 @@ static size_t cbor_stream_decode_at(cbor_stream_t *stream, size_t offset, int in
                     char buf[64];
                     struct tm timeinfo;
                     size_t read_bytes = cbor_deserialize_date_time(stream, offset, &timeinfo);
-                    strftime(buf, sizeof(buf), "%c", &timeinfo);
+                    strftime(buf, sizeof(buf), TIMESTRING_FORMAT, &timeinfo);
                     printf("(tag: %u, date/time string: \"%s\")\n", tag, buf);
                     return read_bytes;
                 }


### PR DESCRIPTION
# Backport of #9355

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Enables additional compile time checks for format strings used by printf, scanf, strftime.
Includes a fix for warnings in the (deprecated) sys/cbor module 

### Issues/PRs references

Related: #9243 
Depends on: #9358, ~#9357~