### PR TITLE
emb6: llvm fixes

### DIFF
--- a/pkg/emb6/Makefile
+++ b/pkg/emb6/Makefile
@@ -26,3 +26,8 @@ emb6_%: git-download
 	"$(MAKE)" -C $(dir $(shell grep -lR "MODULE.*=.*\<$@\>" $(PKG_BUILDDIR)))
 
 include $(RIOTBASE)/pkg/pkg.mk
+
+ifeq (llvm,$(TOOLCHAIN))
+  CFLAGS += -Wno-tautological-compare
+  CFLAGS += -Wno-parentheses-equality
+endif

--- a/pkg/emb6/contrib/sock/udp/emb6_sock_udp.c
+++ b/pkg/emb6/contrib/sock/udp/emb6_sock_udp.c
@@ -91,7 +91,7 @@ int sock_udp_create(sock_udp_t *sock, const sock_udp_ep_t *local,
     mutex_init(&sock->mutex);
     mutex_lock(&sock->mutex);
     mbox_init(&sock->mbox, sock->mbox_queue, SOCK_MBOX_SIZE);
-    atomic_flag_clear(&sock->receivers);
+    atomic_init(&sock->receivers, 0);
     if ((res = _reg(&sock->sock, sock, _input_callback, local, remote)) < 0) {
         sock->sock.input_callback = NULL;
     }


### PR DESCRIPTION
### Contribution description
Another set of warnings fixed, again mostly caused by weird macro definitions/usages.

### Issues/PRs references
Detected in #9398.