### PR TITLE
tests: ignore infinite recursion for mpu_stack_test with clang [backport 2018.07]

### DIFF
--- a/tests/mpu_stack_guard/Makefile
+++ b/tests/mpu_stack_guard/Makefile
@@ -42,3 +42,7 @@ BOARD_WHITELIST += udoo             # cortex-m3
 USEMODULE += mpu_stack_guard
 
 include $(RIOTBASE)/Makefile.include
+
+ifeq (llvm,$(TOOLCHAIN))
+  CFLAGS += -Wno-infinite-recursion
+endif


### PR DESCRIPTION
# Backport of #9597

### Contribution description
One of the many errors #9398 revealed. I don't intend to fix all of them, but this one was a simple one to snipe ;-)

### Issues/PRs references
None