### PR TITLE
cflags.inc.mk: fix cflags test for llvm

### DIFF
--- a/makefiles/cflags.inc.mk
+++ b/makefiles/cflags.inc.mk
@@ -28,7 +28,7 @@ endif
 # Template for testing a compiler flag and adding it to CFLAGS (errors usually
 # happens when using older toolchains which do not support the given flags)
 define cflags_test_and_add
-  ifeq ($(shell $(CC) $(1) -E - 2>/dev/null >/dev/null </dev/null ; echo $$?),0)
+  ifeq ($(shell $(CC) -Werror $(1) -E - 2>/dev/null >/dev/null </dev/null ; echo $$?),0)
     CFLAGS += $(1)
   endif
 endef


### PR DESCRIPTION
### Contribution description

gcc does an error but not clang, so add -Werror

Previous from https://github.com/RIOT-OS/RIOT/pull/9355 llvm was handling all flags that are now with the `cflags_test_and_add` check.

### Testing

This now fails in master but works with this PR

```
make BOARD=samr21-xpro TOOLCHAIN=clang -C examples/hello-world/ clean all
error: unknown warning option '-Wformat-overflow'; did you mean '-Wshift-overflow'? [-Werror,-Wunknown-warning-option]
error: unknown warning option '-Wformat-truncation' [-Werror,-Wunknown-warning-option]
```

### Further work

I think it could even be applied to the other checks that currently use `grep warning:`.
But would be for another PR.


### Issues/PRs references

Found for llvm support in murdock: https://github.com/RIOT-OS/RIOT/pull/9398