### PR TITLE
tests: use literal string instead of format string for interval

### DIFF
--- a/tests/periph_pwm/main.c
+++ b/tests/periph_pwm/main.c
@@ -64,7 +64,7 @@ static int _init(int argc, char** argv)
         puts("\t\t1: right aligned\n");
         puts("\t\t2: center aligned\n");
         puts("\tfrequency: desired frequency in Hz\n");
-        printf("\tresolution: number between 2 and %" PRIu16 "\n", UINT16_MAX);
+        puts("\tresolution: number between 2 and 65535");
         return 1;
     }
 


### PR DESCRIPTION
### Contribution description
`UINT16_MAX` should be the same value on all platforms, so why not use
`puts` instead of `printf` here instead. Also, `llvm` detects an issue
with using the `UINT16_MAX` macro with `PRIu16` here.

### Issues/PRs references
Detected in #9398.