### PR TITLE
at86rf2xx: Always set channel on device

### DIFF
--- a/drivers/at86rf2xx/at86rf2xx_getset.c
+++ b/drivers/at86rf2xx/at86rf2xx_getset.c
@@ -140,11 +140,11 @@ uint8_t at86rf2xx_get_chan(const at86rf2xx_t *dev)
 
 void at86rf2xx_set_chan(at86rf2xx_t *dev, uint8_t channel)
 {
-    if ((channel > AT86RF2XX_MAX_CHANNEL) ||
+    if ((channel > AT86RF2XX_MAX_CHANNEL)
 #if AT86RF2XX_MIN_CHANNEL /* is zero for sub-GHz */
-        (channel < AT86RF2XX_MIN_CHANNEL) ||
+       || (channel < AT86RF2XX_MIN_CHANNEL)
 #endif
-        (dev->netdev.chan == channel)) {
+        ) {
         return;
     }
 


### PR DESCRIPTION
### Contribution description

This removes the check if the current configured channel equals the new
channel. This check prevents the at86rf2xx channel to be configured
after a reset which causes the radio to be non-functional after a
NETOPT_STATE_RESET.

### Issues/PRs references

fixes #8118

### Testing

Branch is intentionally not based on the latest master to prevent #9577/#9606 from causing issues.

The issue that causes gnrc_netif to switch to short source MAC addresses is not resolved here.