### PR TITLE
semtech-loramac: fix wrong behavior with RX windows

### DIFF
--- a/pkg/semtech-loramac/contrib/semtech_loramac_radio.c
+++ b/pkg/semtech-loramac/contrib/semtech_loramac_radio.c
@@ -96,7 +96,11 @@ void SX127XSetRxConfig(RadioModems_t modem, uint32_t bandwidth,
     sx127x_set_freq_hop(&sx127x, freqHopOn);
     sx127x_set_hop_period(&sx127x, hopPeriod);
     sx127x_set_iq_invert(&sx127x, iqInverted);
-    sx127x_set_symbol_timeout(&sx127x, 2 * symbTimeout);
+
+    /* for dealing with timing issues, we set twice 
+     * the symbol timeout */
+    sx127x_set_symbol_timeout(&sx127x, symbTimeout*2);
+
     sx127x_set_rx_single(&sx127x, !rxContinuous);
 }
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Sometimes when receiving ACK (confirmed messages) with the Semtech LoRaMAC pkg, the RX_TIMEOUT event is called twice (one from [this timer](https://github.com/RIOT-OS/RIOT/blob/master/drivers/sx127x/sx127x.c#L251) and also from [this interrupt](https://github.com/RIOT-OS/RIOT/blob/master/drivers/sx127x/sx127x.c#L195)). 

The reason is because the timer is used as an escape route if the longest possible LoRaWAN packet is not received  in the whole process (around 3 seconds in EU868), and not for RX window timeout. This is not intended by the original LoRaMAC implementation (as seen [here](https://github.com/Lora-net/LoRaMac-node/blob/develop/src/mac/region/RegionEU868.h#L140)) and sometimes produces a wrong behavior in the MAC internal states. 

This PR fixes that issue. 

~Also, another bug appeared when using the proper RX Symbol Timeout mechanism. The `randr` function from `0003-adapt-utilities-functions.patch` had a wrong behavior due to int32_t casting and gave several numbers out of the given range, which caused unexpected behaviors in LoRaMAC. This is also addressed here~ (already fixed in #8864 )
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references
None so far
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->