### PR TITLE
cpu/cortexm_common/cortexm_init: Allow piecewise calling

### DIFF
--- a/cpu/cortexm_common/cortexm_init.c
+++ b/cpu/cortexm_common/cortexm_init.c
@@ -21,31 +21,18 @@
 #include "cpu.h"
 
 /**
- * @name   Pattern to write into the co-processor Access Control Register to
- *         allow full FPU access
- */
-#define FULL_FPU_ACCESS         (0x00f00000)
-
-/**
  * Interrupt vector base address, defined by the linker
  */
 extern const void *_isr_vectors;
 
-void cortexm_init(void)
+#if defined(CPU_CORTEXM_INIT_SUBFUNCTIONS)
+#define CORTEXM_STATIC_INLINE /*empty*/
+#else
+#define CORTEXM_STATIC_INLINE static inline
+#endif
+
+CORTEXM_STATIC_INLINE void cortexm_init_isr_priorities(void)
 {
-    /* initialize the FPU on Cortex-M4F CPUs */
-#if defined(CPU_ARCH_CORTEX_M4F) || defined(CPU_ARCH_CORTEX_M7)
-    /* give full access to the FPU */
-    SCB->CPACR |= (uint32_t)FULL_FPU_ACCESS;
-#endif
-
-    /* configure the vector table location to internal flash */
-#if defined(CPU_ARCH_CORTEX_M3) || defined(CPU_ARCH_CORTEX_M4) || \
-    defined(CPU_ARCH_CORTEX_M4F) || defined(CPU_ARCH_CORTEX_M7) || \
-    (defined(CPU_ARCH_CORTEX_M0PLUS) && (__VTOR_PRESENT == 1))
-    SCB->VTOR = (uint32_t)&_isr_vectors;
-#endif
-
     /* initialize the interrupt priorities */
     /* set pendSV interrupt to same priority as the rest */
     NVIC_SetPriority(PendSV_IRQn, CPU_DEFAULT_IRQ_PRIO);
@@ -55,7 +42,10 @@ void cortexm_init(void)
     for (unsigned i = 0; i < CPU_IRQ_NUMOF; i++) {
         NVIC_SetPriority((IRQn_Type) i, CPU_DEFAULT_IRQ_PRIO);
     }
+}
 
+CORTEXM_STATIC_INLINE void cortexm_init_misc(void)
+{
     /* enable wake up on events for __WFE CPU sleep */
     SCB->SCR |= SCB_SCR_SEVONPEND_Msk;
 
@@ -66,4 +56,19 @@ void cortexm_init(void)
 #ifdef SCB_CCR_STKALIGN_Msk
     SCB->CCR |= SCB_CCR_STKALIGN_Msk;
 #endif
+}
+
+void cortexm_init(void)
+{
+    cortexm_init_fpu();
+
+    /* configure the vector table location to internal flash */
+#if defined(CPU_ARCH_CORTEX_M3) || defined(CPU_ARCH_CORTEX_M4) || \
+    defined(CPU_ARCH_CORTEX_M4F) || defined(CPU_ARCH_CORTEX_M7) || \
+    (defined(CPU_ARCH_CORTEX_M0PLUS) && (__VTOR_PRESENT == 1))
+    SCB->VTOR = (uint32_t)&_isr_vectors;
+#endif
+
+    cortexm_init_isr_priorities();
+    cortexm_init_misc();
 }


### PR DESCRIPTION
   Refactor cortexm_init to allow bits an pieces of
   it to be called separately, while retaining the
   current API, too.  Needed for non-standard
   Cortex-M initialisation, such as with nRF52
   SoftDevice.

### Contribution description

#9473 updates the Nordic nRF52 SoftDevice support to the 
latest API.  As a part of that, instead of copying bits and parts
of `cortexm_init()` function into a corresponding nRF52 SD
specific function, it is useful to refer to the relevant parts
of `cortexm_init`.  To allow that, this PR adds a piecewise
API to `cortexm_init` while retaining the current API.

### Issues/PRs references

Split out from #9473 into a separate PR.