### PR TITLE
Makefile.include: Replace PHONY by FORCE

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -323,7 +323,7 @@ include $(RIOTBASE)/drivers/Makefile.include
 $(RIOTPKG)/%/Makefile.include::
 	$(Q)"$(MAKE)" -C $(RIOTPKG)/$* Makefile.include
 
-.PHONY: $(USEPKG:%=$(RIOTPKG)/%/Makefile.include)
+$(USEPKG:%=$(RIOTPKG)/%/Makefile.include): FORCE
 -include $(USEPKG:%=$(RIOTPKG)/%/Makefile.include)
 
 # Deduplicate includes without sorting them

--- a/Makefile.include
+++ b/Makefile.include
@@ -349,9 +349,13 @@ include $(RIOTMAKE)/modules.inc.mk
 .PHONY: all link clean flash flash-only term doc debug debug-server reset objdump help info-modules
 .PHONY: print-size elffile binfile hexfile
 .PHONY: ..in-docker-container
-# Target can depend on FORCE to always rebuild but still let make use file
-# modification timestamp (contrary to .PHONY).
-# Use it for goals that may keep outputs unchanged when executed.
+# Targets that depend on FORCE will always be rebuilt. Use it for recipes that
+# may change the output even if prerequisites don't change (for example, if
+# it depends on configuration variables.)
+# For targets that are not a file, and only for that, use .PHONY. For more
+# information, see:
+# https://www.gnu.org/software/make/manual/html_node/Phony-Targets.html
+# https://www.gnu.org/software/make/manual/html_node/Force-Targets.html
 .PHONY: FORCE
 
 ELFFILE ?= $(BINDIR)/$(APPLICATION).elf

--- a/Makefile.include
+++ b/Makefile.include
@@ -444,11 +444,11 @@ ifneq (, $(filter clean, $(MAKECMDGOALS)))
     all $(BASELIBS) $(USEPKG:%=$(RIOTPKG)/%/Makefile.include) $(BUILDDEPS): clean
 endif
 
-.PHONY: pkg-prepare $(USEPKG:%=$(BINDIR)/%.a)
+.PHONY: pkg-prepare
 pkg-prepare:
 	-@for i in $(USEPKG) ; do "$(MAKE)" -C $(RIOTPKG)/$$i prepare ; done
 
-$(USEPKG:%=$(BINDIR)/%.a): $(BUILDDEPS)
+$(USEPKG:%=$(BINDIR)/%.a): $(BUILDDEPS) FORCE
 	@mkdir -p $(BINDIR)
 	$(QQ)"$(MAKE)" -C $(RIOTPKG)/$(patsubst $(BINDIR)/%.a,%,$@)
 

--- a/Makefile.include
+++ b/Makefile.include
@@ -635,10 +635,9 @@ endif
 include $(RIOTTOOLS)/desvirt/Makefile.desvirt
 
 # Build a header file with all common macro definitions and undefinitions
-# make it phony to force re-run of the script every time even if the file exists
+# make it depend on FORCE to re-run of the script every time even if the file exists
 # The script will only touch the file if anything has changed since last time.
-.PHONY: $(RIOTBUILD_CONFIG_HEADER_C)
-$(RIOTBUILD_CONFIG_HEADER_C):
+$(RIOTBUILD_CONFIG_HEADER_C): FORCE
 	@mkdir -p '$(dir $@)'
 	$(Q)'$(RIOTTOOLS)/genconfigheader/genconfigheader.sh' '$@' $(CFLAGS_WITH_MACROS)
 

--- a/Makefile.include
+++ b/Makefile.include
@@ -518,11 +518,11 @@ objdump:
 
 # Generate an XML file containing all macro definitions and include paths for
 # use in Eclipse CDT
-.PHONY: eclipsesym eclipsesym.xml $(CURDIR)/eclipsesym.xml
+.PHONY: eclipsesym eclipsesym.xml
 eclipsesym: $(CURDIR)/eclipsesym.xml
 eclipsesym.xml: $(CURDIR)/eclipsesym.xml
 
-$(CURDIR)/eclipsesym.xml:
+$(CURDIR)/eclipsesym.xml: FORCE
 	$(Q)printf "%s\n" $(CC) $(CFLAGS_WITH_MACROS) $(INCLUDES) | \
 		$(RIOTTOOLS)/eclipsesym/cmdline2xml.sh > $@
 


### PR DESCRIPTION
### Contribution description

Makefile.include abuses PHONY targets. These should be used for non-file targets, but they are currently being used to force re-running of the recipe.

This PR replaces PHONY targets by FORCE and clarifies when they should be used.

### References

See the GNU Make manual:

* https://www.gnu.org/software/make/manual/html_node/Phony-Targets.html
* https://www.gnu.org/software/make/manual/html_node/Force-Targets.html
