### PR TITLE
semtech-loramac: fix uninitialized datarate

### DIFF
--- a/pkg/semtech-loramac/patches/0004-fix-uninitialized-variable.patch
+++ b/pkg/semtech-loramac/patches/0004-fix-uninitialized-variable.patch
@@ -1,0 +1,25 @@
+From 9bf864033dfe765f0e06603e273c4665af777a1a Mon Sep 17 00:00:00 2001
+From: Jose Alamos <jose.alamos@haw-hamburg.de>
+Date: Tue, 24 Jul 2018 11:47:59 +0200
+Subject: [PATCH] fix uninitialized variable
+
+---
+ src/mac/LoRaMac.c | 2 ++
+ 1 file changed, 2 insertions(+)
+
+diff --git a/src/mac/LoRaMac.c b/src/mac/LoRaMac.c
+index 4cb2c50..46f7661 100644
+--- a/src/mac/LoRaMac.c
++++ b/src/mac/LoRaMac.c
+@@ -3266,6 +3266,8 @@ LoRaMacStatus_t LoRaMacMcpsRequest( McpsReq_t *mcpsRequest )
+             break;
+         }
+         default:
++            /* Shouldn't happen */
++            datarate = 0;
+             break;
+     }
+ 
+-- 
+2.16.0
+


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->
### Contribution description

This PR fixes an uninitialized variable in the LoRaMAC pkg, as shown in #9398. This seems to be fixed in the LoRaMAC upstream but updating the pkg might take some time.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references
#9398
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->