### PR TITLE
shell/sc_can: fix uninitialized warning

### DIFF
--- a/sys/shell/commands/sc_can.c
+++ b/sys/shell/commands/sc_can.c
@@ -83,7 +83,7 @@ static int _dump(int argc, char **argv)
         return 0;
     }
 
-    int ret;
+    int ret = -1;
     struct can_filter filters[SC_CAN_MAX_FILTERS];
     conn_can_raw_t conn;
     struct can_frame frame;


### PR DESCRIPTION
### Contribution description

When compiled for `hifive1` board with `gcc-7.2.0` this warning was raised:

'ret' may be used uninitialized in this function [-Werror=maybe-uninitialized]

This was first mentioned in https://github.com/RIOT-OS/riotdocker/pull/42#issuecomment-402240772

### Testing

The board does not have enough memory but the error is triggered when compiling with a `gcc` version `7.2.0`:

```
make -C tests/conn_can/ BOARD=hifive1 RIOT_CI_BUILD=1
```

Warning is dismissed, it was just a testing procedure error.

> ### Warning
> 
> Currently when compiling with `riscv-none-embed-gcc (GNU MCU Eclipse RISC-V Embedded GCC, 64-bits) 7.2.0` a linker error is raised 
>
>
> ```
>make -C tests/conn_can/ BOARD=hifive1
>...
>/opt/gnu-mcu-eclipse/riscv-none-gcc/7.2.0-2-20180111-2230/bin/../lib/gcc/riscv-none-embed/7.2.0/../../../../riscv-none-embed/bin/ld: section .stack VMA [0000000080003c00,0000000080003fff] overlaps section .bss VMA [00000000800001f8,0000000080003eaf]
> collect2: error: ld returned 1 exit status
> /data/riotbuild/riotbase/Makefile.include:356: recipe for target '/data/riotbuild/riotproject/tests/conn_can/bin/hifive1/tests_conn_can.elf' failed
> make: *** [/data/riotbuild/riotproject/tests/conn_can/bin/hifive1/tests_conn_can.elf] Error 1
> /home/user/Desktop/RIOT_master_old/makefiles/docker.inc.mk:90: recipe for target '..in-docker-container' failed
> make: *** [..in-docker-container] Error 2
> ```
>
> The goal of this PR is to resolve the linking bug and merge this.

### Issues/PRs references

https://github.com/RIOT-OS/RIOT/issues/9405
https://github.com/RIOT-OS/riotdocker/pull/42
Found it during release testing