### PR TITLE
toolchain/gnu: also define NM [backport 2018.07]

### DIFF
--- a/makefiles/toolchain/gnu.inc.mk
+++ b/makefiles/toolchain/gnu.inc.mk
@@ -9,6 +9,7 @@ export AR         = $(PREFIX)ar
 export RANLIB     = $(PREFIX)ranlib
 endif
 export AS         = $(PREFIX)as
+export NM         = $(PREFIX)nm
 export LINK       = $(PREFIX)gcc
 export LINKXX     = $(PREFIX)g++
 export SIZE       = $(PREFIX)size


### PR DESCRIPTION
# Backport of #9624

### Contribution description

Define NM when TOOLCHAIN=gnu

llvm is defining NM already and `openthread` is using the symbol.

### Testing

With this PR you correctly have an output for `info-debug-variable-NM` with `TOOLCHAIN=gnu`

```
make --no-print-directory -C examples/hello-world/ BOARD=samr21-xpro info-debug-variable-NM TOOLCHAIN=gnu
arm-none-eabi-nm

make --no-print-directory -C examples/hello-world/ BOARD=samr21-xpro info-debug-variable-NM TOOLCHAIN=llvm
llvm-nm

make --no-print-directory -C examples/hello-world/ BOARD=native info-debug-variable-NM TOOLCHAIN=gnu 
nm

make --no-print-directory -C examples/hello-world/ BOARD=native info-debug-variable-NM TOOLCHAIN=llvm
llvm-nm
```

### Issues/PRs references

Used in https://github.com/RIOT-OS/RIOT/pull/9599