### PR TITLE
makefiles/docker.inc.mk: allow using sudo for docker

### DIFF
--- a/makefiles/docker.inc.mk
+++ b/makefiles/docker.inc.mk
@@ -79,6 +79,9 @@ DOCKER_OVERRIDE_CMDLINE := $(foreach varname,$(DOCKER_ENV_VARS), \
     ))
 DOCKER_OVERRIDE_CMDLINE := $(strip $(DOCKER_OVERRIDE_CMDLINE))
 
+# Overwrite if you want to use `docker` with sudo
+DOCKER ?= docker
+
 # This will execute `make $(DOCKER_MAKECMDGOALS)` inside a Docker container.
 # We do not push the regular $(MAKECMDGOALS) to the container's make command in
 # order to only perform building inside the container and defer executing any
@@ -88,7 +91,7 @@ DOCKER_OVERRIDE_CMDLINE := $(strip $(DOCKER_OVERRIDE_CMDLINE))
 # hardware which may not be reachable from inside the container.
 ..in-docker-container:
 	@$(COLOR_ECHO) '$(COLOR_GREEN)Launching build container using image "$(DOCKER_IMAGE)".$(COLOR_RESET)'
-	docker run $(DOCKER_FLAGS) -t -u "$$(id -u)" \
+	$(DOCKER) run $(DOCKER_FLAGS) -t -u "$$(id -u)" \
 	    -v '$(RIOTBASE):$(DOCKER_BUILD_ROOT)/riotbase' \
 	    -v '$(RIOTCPU):$(DOCKER_BUILD_ROOT)/riotcpu' \
 	    -v '$(RIOTBOARD):$(DOCKER_BUILD_ROOT)/riotboard' \


### PR DESCRIPTION
When testing `llvm` support I often try running with murdock `docker` image to get the same environment but I do not have my user in the `docker` group.
This add a solution for this.

### Contribution description

~Add `DOCKER_WITH_SUDO` variable that runs docker using `sudo` when set to 1.~
Allow overwriting `DOCKER` command with for example `DOCKER="sudo docker"`.

Not all users register their user in the docker group and should not run the
whole make process as root to use docker.
Creating files as a user is correctly handled as `id -u` is still run as the
original user.

The variable name was chosen in 5 seconds and can be changed.

### Testing

```
make -C examples/hello-world BUILD_IN_DOCKER=1 DOCKER="sudo docker"
make: Entering directory '/home/harter/work/git/RIOT/examples/hello-world'
Launching build container using image "riot/riotbuild:latest".
sudo docker run --rm -t -u "$(id -u)" \
...

make -C examples/hello-world/ BUILD_IN_DOCKER=1
make: Entering directory '/home/harter/work/git/RIOT/examples/hello-world'
Launching build container using image "riot/riotbuild:latest".
docker run --rm -t -u "$(id -u)" \
...
```

### Issues/PRs references

https://github.com/RIOT-OS/RIOT/issues/9460
Testing llvm with docker https://github.com/RIOT-OS/RIOT/pull/9398/