### PR TITLE
gnrc_sixlowpan: remove assertion on multiple_by_size function

### DIFF
--- a/sys/include/net/gnrc/sixlowpan/internal.h
+++ b/sys/include/net/gnrc/sixlowpan/internal.h
@@ -54,9 +54,6 @@ void gnrc_sixlowpan_dispatch_send(gnrc_pktsnip_t *pkt, void *context,
  *
  * @param[in] pkt                   The packet to fit. Must not be NULL.
  * @param[in] orig_datagram_size    The original (uncompressed) datagram size.
- *                                  Must be greater or equal to the length of
- *                                  @p pkt as of `pkt->next` (i.e. without
- *                                  the @ref gnrc_netif_hdr_t).
  * @param[in] netif                 The interface to fit @p pkt over. Must not
  *                                  be NULL.
  * @param[in] page                  Current 6Lo dispatch parsing page


### PR DESCRIPTION
### Contribution description
During the review of #9485 [we found out][1] that an assertion in this
function was invalid. However, the documentation on this assertion
wasn't removed on that. This fixes that.

[1]: https://github.com/RIOT-OS/RIOT/pull/9485#issuecomment-407794280

### Issues/PRs references
Documentation follow-up to #9485.