### PR TITLE
pkg/pkg.mk: allow overwriting GITAMFLAGS from environment var [backport 2018.07]

### DIFF
--- a/pkg/pkg.mk
+++ b/pkg/pkg.mk
@@ -19,7 +19,7 @@ else
 git-download: $(PKG_BUILDDIR)/.git-downloaded
 endif
 
-GITAMFLAGS = --no-gpg-sign --ignore-whitespace
+GITAMFLAGS ?= --no-gpg-sign --ignore-whitespace
 
 ifneq (,$(wildcard $(PKG_DIR)/patches))
 $(PKG_BUILDDIR)/.git-patched: $(PKG_BUILDDIR)/.git-downloaded $(PKG_DIR)/Makefile $(PKG_DIR)/patches/*.patch


### PR DESCRIPTION
# Backport of #9637

I missed to make it overwrite-able when I introduced the variable. This fixes it.

### Contribution description

On IoT-LAB the git version does not support `--no-gpg-sign` so I would like a
way to overwrite `GITAMFLAGS` from environment variable.

### Issues/PRs references

Release testing on IoT-LAB.