### PR TITLE
tests/gnrc_sixlowpan: enable test on murdock

### DIFF
--- a/tests/gnrc_sixlowpan/Makefile
+++ b/tests/gnrc_sixlowpan/Makefile
@@ -19,6 +19,8 @@ USEMODULE += gnrc_udp
 # Dumps packets
 USEMODULE += gnrc_pktdump
 
+TEST_ON_CI_WHITELIST += all
+
 include $(RIOTBASE)/Makefile.include
 
 test:


### PR DESCRIPTION
### Contribution description

Enable testing `gnrc_sixlowpan` on murdock.

This should normally fail according to the release tests.

### Issues/PRs references

Would help testing https://github.com/RIOT-OS/RIOT/pull/9649 and https://github.com/RIOT-OS/RIOT/pull/9648