### PR TITLE
docker: Use system GIT_CACHE_DIR if available

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -14,6 +14,7 @@ RIOTPKG        ?= $(RIOTBASE)/pkg
 RIOTTOOLS      ?= $(RIOTBASE)/dist/tools
 RIOTPROJECT    ?= $(shell git rev-parse --show-toplevel 2>/dev/null || pwd)
 GITCACHE       ?= $(RIOTTOOLS)/git/git-cache
+GIT_CACHE_DIR  ?= $(HOME)/.gitcache
 APPDIR         ?= $(CURDIR)
 BINDIRBASE     ?= $(APPDIR)/bin
 BINDIR         ?= $(BINDIRBASE)/$(BOARD)

--- a/makefiles/docker.inc.mk
+++ b/makefiles/docker.inc.mk
@@ -82,6 +82,12 @@ DOCKER_OVERRIDE_CMDLINE := $(strip $(DOCKER_OVERRIDE_CMDLINE))
 # Overwrite if you want to use `docker` with sudo
 DOCKER ?= docker
 
+# Mounted volumes and exported environment variables
+
+# Add GIT_CACHE_DIR if the direcotry exists
+DOCKER_VOLUMES_AND_ENV += $(if $(wildcard $(GIT_CACHE_DIR)/),-v $(GIT_CACHE_DIR):$(DOCKER_BUILD_ROOT)/gitcache)
+DOCKER_VOLUMES_AND_ENV += $(if $(wildcard $(GIT_CACHE_DIR)/),-e GIT_CACHE_DIR=$(DOCKER_BUILD_ROOT)/gitcache)
+
 # This will execute `make $(DOCKER_MAKECMDGOALS)` inside a Docker container.
 # We do not push the regular $(MAKECMDGOALS) to the container's make command in
 # order to only perform building inside the container and defer executing any
@@ -104,6 +110,7 @@ DOCKER ?= docker
 	    -e 'RIOTBOARD=$(DOCKER_BUILD_ROOT)/riotboard' \
 	    -e 'RIOTMAKE=$(DOCKER_BUILD_ROOT)/riotmake' \
 	    -e 'RIOTPROJECT=$(DOCKER_BUILD_ROOT)/riotproject' \
+	    $(DOCKER_VOLUMES_AND_ENV) \
 	    $(DOCKER_ENVIRONMENT_CMDLINE) \
 	    -w '$(DOCKER_BUILD_ROOT)/riotproject/$(BUILDRELPATH)' \
 	    '$(DOCKER_IMAGE)' make $(DOCKER_MAKECMDGOALS) $(DOCKER_OVERRIDE_CMDLINE)

--- a/makefiles/vars.inc.mk
+++ b/makefiles/vars.inc.mk
@@ -62,6 +62,7 @@ export UNDEF                 # Object files that the linker must include in the 
 export WERROR                # Treat all compiler warnings as errors if set to 1 (see -Werror flag in GCC manual)
 
 export GITCACHE              # path to git-cache executable
+export GIT_CACHE_DIR         # path to git-cache cache directory
 export FLASHER               # The command to call on "make flash".
 export FFLAGS                # The parameters to supply to FLASHER.
 export FLASH_ADDR            # Define an offset to flash code into ROM memory.

--- a/pkg/pkg.mk
+++ b/pkg/pkg.mk
@@ -31,7 +31,7 @@ endif
 $(PKG_BUILDDIR)/.git-downloaded:
 	rm -Rf $(PKG_BUILDDIR)
 	mkdir -p $(PKG_BUILDDIR)
-	$(GITCACHE) clone "$(PKG_URL)" "$(PKG_VERSION)" "$(PKG_BUILDDIR)"
+	GIT_CACHE_DIR=$(GIT_CACHE_DIR) $(GITCACHE) clone "$(PKG_URL)" "$(PKG_VERSION)" "$(PKG_BUILDDIR)"
 	touch $@
 
 clean::


### PR DESCRIPTION
### Contribution description

If GIT_CACHE_DIR is a directory make it available to docker.

I used the same naming convention I used in https://github.com/RIOT-OS/RIOT/pull/9646

### Optional

I did not remove the default value for `GIT_CACHE_DIR` from `dist/tools/git/git-cache` but duplicated it in the build system to minimize changes to the script. I could do it in this PR or another if wanted.

### Testing

You must have `${HOME}/.gitcache` directory created to use git-cache.

```
# initialize the package if it is not in git-cache
make BOARD=native -C examples/ccn-lite-relay/ clean all
...
# Then build in docker
make BOARD=native -C examples/ccn-lite-relay/ BUILD_IN_DOCKER=1 DOCKER="sudo docker"  clean all`
make: Entering directory '/home/harter/work/git/RIOT/examples/ccn-lite-relay'
make[1]: Nothing to be done for 'Makefile.include'.
make[1]: Nothing to be done for 'Makefile.include'.
Launching build container using image "riot/riotbuild:latest".
sudo docker run --rm -t -u "$(id -u)" \
    -v '/home/harter/work/git/RIOT:/data/riotbuild/riotbase' \
    -v '/home/harter/work/git/RIOT/cpu:/data/riotbuild/riotcpu' \
    -v '/home/harter/work/git/RIOT/boards:/data/riotbuild/riotboard' \
    -v '/home/harter/work/git/RIOT/makefiles:/data/riotbuild/riotmake' \
    -v '/home/harter/work/git/RIOT:/data/riotbuild/riotproject' \
    -v /etc/localtime:/etc/localtime:ro \
    -e 'RIOTBASE=/data/riotbuild/riotbase' \
    -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' \
    -e 'RIOTCPU=/data/riotbuild/riotcpu' \
    -e 'RIOTBOARD=/data/riotbuild/riotboard' \
    -e 'RIOTMAKE=/data/riotbuild/riotmake' \
    -e 'RIOTPROJECT=/data/riotbuild/riotproject' \
    -v /home/harter/.gitcache:/data/riotbuild/gitcache -e GIT_CACHE_DIR=/data/riotbuild/gitcache \
    -e 'BOARD=native' \
    -w '/data/riotbuild/riotproject/examples/ccn-lite-relay/' \
    'riot/riotbuild:latest' make  'BOARD=native'
...
GIT_CACHE_DIR=/data/riotbuild/gitcache /data/riotbuild/riotbase/dist/tools/git/git-cache clone "https://github.com/cn-uofbasel/ccn-lite/" "48b17ebee7600b2e79b3acf0728217473d7a4ee8" "/data/riotbuild/riotproject/examples/ccn-lite-relay/bin/pkg/native/ccn-lite"
git-cache: cloning from cache. tag=commit48b17ebee7600b2e79b3acf0728217473d7a4ee8
...
```

You can notice the `-e GIT_CACHE_DIR=/data/riotbuild/gitcache` and `git-cache: cloning from cache`.

### Issues/PRs references

Fixes https://github.com/RIOT-OS/RIOT/issues/8267