### PR TITLE
drivers: Add driver for the LTC4150 coulomb counter

### DIFF
--- a/boards/msba2/Makefile.dep
+++ b/boards/msba2/Makefile.dep
@@ -5,5 +5,6 @@ ifneq (,$(filter netdev_default gnrc_netdev_default,$(USEMODULE)))
 endif
 
 ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += ltc4150
   USEMODULE += sht11
 endif

--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -262,6 +262,16 @@ ifneq (,$(filter lsm6dsl,$(USEMODULE)))
   USEMODULE += xtimer
 endif
 
+ifneq (,$(filter ltc4150_bidirectional,$(USEMODULE)))
+  USEMODULE += ltc4150
+endif
+
+ifneq (,$(filter ltc4150,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_gpio
+  FEATURES_REQUIRED += periph_gpio_irq
+  USEMODULE += xtimer
+endif
+
 ifneq (,$(filter mag3110,$(USEMODULE)))
   FEATURES_REQUIRED += periph_i2c
 endif

--- a/drivers/Makefile.include
+++ b/drivers/Makefile.include
@@ -158,6 +158,10 @@ ifneq (,$(filter lsm6dsl,$(USEMODULE)))
   USEMODULE_INCLUDES += $(RIOTBASE)/drivers/lsm6dsl/include
 endif
 
+ifneq (,$(filter ltc4150,$(USEMODULE)))
+  USEMODULE_INCLUDES += $(RIOTBASE)/drivers/ltc4150/include
+endif
+
 ifneq (,$(filter mag3110,$(USEMODULE)))
   USEMODULE_INCLUDES += $(RIOTBASE)/drivers/mag3110/include
 endif

--- a/drivers/include/ltc4150.h
+++ b/drivers/include/ltc4150.h
@@ -1,0 +1,234 @@
+/*
+ * Copyright 2018 Otto-von-Guericke-Universität Magdeburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    drivers_ltc4150 LTC4150 coulomb counter
+ * @ingroup     drivers_sensors
+ * @brief       Driver for LTC4150 coulomb counter
+ * @{
+ *
+ * @file
+ * @brief       LTC4150 coulomb counter
+ *
+ * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+ *
+ * # Wiring the LTC4150
+ * Hint: M Grusin thankfully created an
+ * [open hardware breakout board](https://cdn.sparkfun.com/datasheets/BreakoutBoards/LTC4150_BOB_v10.pdf).
+ * As a result, virtually all LTC4150 breakout boards are using this schematic.
+ * Whenever this documentation refers to a breakout board, this open hardware
+ * board is meant. Of course, this driver works with the "bare" LTC4150 as well.
+ *
+ * Please note that this driver works interrupt driven and does not clear the
+ * signal. Thus, the /CLR and /INT pins on the LTC4150 need to be connected
+ * (in case of the breakout board: close solder jumper SJ1), so that the signal
+ * is automatically cleared.
+ *
+ * Hint: The breakout board uses external pull up resistors on /INT, POL and
+ * /SHDN. Therefore /SHDN can be left unconnected and no internal pull ups are
+ * required for /INT and POL. In case your board uses 3.3V logic the solder
+ * jumpers SJ2 and SJ3 have to be closed, in case of 5V they have to remain
+ * open. Connect the VIO pin to the logic level, GND to ground, IN+ and IN- to
+ * the power supply and use OUT+ and OUT- to power your board.
+ *
+ * In the easiest case only the /INT pin needs to be connected to a GPIO,
+ * and (in case of external pull ups) /SHDN and POL can be left unconnected.
+ * The GPIO /INT is connected to support for interrupts, /SHDN and POL
+ * (if connected) do not require interrupt support.
+ *
+ * In case a battery is used, the module `ltc4150_bidirectional` should also be
+ * added and the POL pin connected to another GPIO. This allows to distinguish
+ * between charge drawn from the battery and charge transferred into the battery
+ * (used to load it).
+ *
+ * In case support to power off the LTC4150 is desired, the /SHDN pin needs to
+ * be connected to a third GPIO.
+ *
+ * # Things to keep in mind
+ * The LTC4150 creates pulses with a frequency depending on the current drawn.
+ * Thus, more interrupts need to be handled when more current is drawn, which
+ * in turn increases system load (and power consumption). The interrupt service
+ * routing is quite short and even when used outside of specification less than
+ * 20 ticks per second will occur. Hence, this effect should hopefully be
+ * negligible.
+ */
+
+#ifndef LTC4150_H
+#define LTC4150_H
+
+#include <mutex.h>
+#include <periph/gpio.h>
+#include <ringbuffer.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Configuration flags of the LTC4150 coulomb counter
+ */
+enum {
+    /**
+     * @brief External pull on the /INT pin is present
+     */
+    LTC4150_INT_EXT_PULL_UP = 0x01,
+    /**
+     * @brief External pull on the /POL pin is present
+     */
+    LTC4150_POL_EXT_PULL_UP = 0x02,
+    /**
+     * @brief External pull on the /INT *and* the /POL pin is present
+     */
+    LTC4150_EXT_PULL_UP = LTC4150_INT_EXT_PULL_UP | LTC4150_POL_EXT_PULL_UP,
+};
+
+/**
+ * @brief Parameters required to set up the LTC4150 coulomb counter
+ */
+typedef struct {
+    /**
+     * @brief Pin going LOW every time a specific charge is drawn, labeled INT
+     */
+    gpio_t interrupt;
+    /**
+     * @brief Pin indicating (dis-)charging, labeled POL
+     *
+     * Set this pin to `GPIO_UNDEF` to tread every pulse as discharging. This
+     * pin is pulled low by the LTC4150 in case the battery is discharging.
+     */
+    gpio_t polarity;
+    /**
+     * @brief Pin to power off the LTC4150 coulomb counter, labeled SHDN
+     *
+     * Set this pin to `GPIO_UNDEF` if the SHDN pin is not connected to the MCU
+     */
+    gpio_t shutdown;
+    /**
+     * @brief Pulse per ampere hour of charge
+     *
+     * pulses = 3600 * 32.55 * R
+     *
+     * Where R is the resistance (in Ohm) between the SENSE+ and SENSE- pins.
+     * E.g. the MSBA2 has 0.390 Ohm (==> 45700 pulses), while most breakout
+     * boards for the LTC4150 have 0.050 Ohm (==> 5859 pulses).
+     */
+    uint16_t pulses_per_ah;
+    /**
+     * @brief Configuration flags controlling if inter pull ups are required
+     *
+     * Most [breakout boards](https://cdn.sparkfun.com/datasheets/BreakoutBoards/LTC4150_BOB_v10.pdf)
+     * and the MSBA2 board use external pull up resistors, so no internal pull
+     * ups are required. Clear the flags to use internal pull ups instead.
+     */
+    uint16_t flags;
+} ltc4150_params_t;
+
+/**
+ * @brief Data structure storing the number of pulses for (dis-)charging
+ *
+ * In addition to the total number of pulses the accumulated pulses are stored
+ * for:
+ * - Every second in the last minute
+ * - The last minute
+ */
+typedef struct {
+    uint32_t total;         /**< Total number of pulses */
+    uint8_t ringbuf[6];     /**< Ring buffer to allow O(1) update of the `last_min` */
+    uint16_t last_min;      /**< Charge transferred in the last minute */
+    uint8_t counter;        /**< Temporary counter used as source for the ring buffer */
+} ltc4150_data_t;
+
+/**
+ * @brief LTC4150 coulomb counter
+ */
+typedef struct {
+    ltc4150_params_t params;    /**< Parameter of the LTC4150 coulomb counter */
+    uint32_t start_sec;         /**< Time stamp when started counting */
+    uint32_t last_update_sec;   /**< Time stamp of last pulse */
+#ifdef MODULE_LTC4150_BIDIRECTIONAL
+    ltc4150_data_t charged;     /**< # of pulses for charging (POL=high) */
+#endif
+    ltc4150_data_t discharged;  /**< # of pulses for discharging (POL=low) */
+    uint8_t position;           /**< Offset of the first element in the ring buf */
+} ltc4150_dev_t;
+
+/**
+ * @brief             Initialize the LTC4150 driver
+ *
+ * @param  dev        Device to initialize
+ * @param  params     Information on how the LTC4150 is conntected
+ *
+ * @retval  0         Success
+ * @retval -EINVAL    Called with invalid argument(s)
+ * @retval -EIO       IO failure (`gpio_init()`/`gpio_init_int()` failed)
+ */
+int ltc4150_init(ltc4150_dev_t *dev, const ltc4150_params_t *params);
+
+/**
+ * @brief             Disable the interrupt handler and turn the chip off
+ *
+ * @param  dev        Previously initialized device to power off
+ *
+ * @retval  0         Success
+ * @retval -EINVAL    Called with invalid argument(s)
+ *
+ * The driver can be reinitialized to power on the LTC4150 chip again
+ */
+int ltc4150_shutdown(ltc4150_dev_t *dev);
+
+/**
+ * @brief                  Get the measured charge since boot in millicoulomb
+ *
+ * @param dev              The LTC4150 device to read data from
+ * @param[out] charged     The charge transferred in charging direction
+ * @param[out] discharged  The charge transferred in discharging direction
+ *
+ * @retval 0                Success
+ * @retval -EINVAL          Called with an invalid argument
+ *
+ * Passing `NULL` for `charged` or `discharged` is allowed, if only one
+ * information is of interest.
+ */
+int ltc4150_total_charge(ltc4150_dev_t *dev,
+                         int32_t *charged, int32_t *discharged);
+
+/**
+ * @brief                  Get the accumulated charge of the last minute in
+ *                         millicoulomb
+ *
+ * @param dev              The LTC4150 device to read data from
+ * @param[out] charged     The charge transferred in charging direction
+ * @param[out] discharged  The charge transferred in discharging direction
+ *
+ * @retval 0               Success
+ * @retval -EINVAL         Called with an invalid argument
+ *
+ * Passing `NULL` for `charged` or `discharged` is allowed, if only one
+ * information is of interest. Divide the result by 60 to get the average
+ * current in milliampere.
+ */
+int ltc4150_last_minute_charge(ltc4150_dev_t *dev, int32_t *charged,
+                               int32_t *discharged);
+
+/**
+ * @brief             Get the average current drawn in E-01 milliampere
+ *
+ * @param dev         The LTC4150 device to read data from
+ * @param[out] dest   The result is stored here
+ *
+ * @retval 0          Success
+ * @retval -EINVAL    Called with an invalid argument
+ */
+int ltc4150_avg_current(ltc4150_dev_t *dev, int16_t *dest);
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* LTC4150_H */
+/** @} */

--- a/drivers/include/ltc4150.h
+++ b/drivers/include/ltc4150.h
@@ -9,13 +9,8 @@
 /**
  * @defgroup    drivers_ltc4150 LTC4150 coulomb counter
  * @ingroup     drivers_sensors
- * @brief       Driver for LTC4150 coulomb counter
- * @{
- *
- * @file
- * @brief       LTC4150 coulomb counter
- *
- * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+ * @brief       Driver for the Linear Tech LTC4150 Coulomb Counter
+ *              (a.k.a. battery gauge sensor or power consumption sensor)
  *
  * # Wiring the LTC4150
  * Hint: M Grusin thankfully created an
@@ -56,15 +51,22 @@
  * routing is quite short and even when used outside of specification less than
  * 20 ticks per second will occur. Hence, this effect should hopefully be
  * negligible.
+ *
+ * @{
+ *
+ * @file
+ * @brief       LTC4150 coulomb counter
+ *
+ * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
  */
 
 #ifndef LTC4150_H
 #define LTC4150_H
 
-#include <mutex.h>
-#include <periph/gpio.h>
-#include <ringbuffer.h>
 #include <stdint.h>
+
+#include "mutex.h"
+#include "periph/gpio.h"
 
 #ifdef __cplusplus
 extern "C" {

--- a/drivers/include/saul.h
+++ b/drivers/include/saul.h
@@ -99,6 +99,8 @@ enum {
     SAUL_SENSE_OCCUP    = 0x91,     /**< sensor: occupancy */
     SAUL_SENSE_PROXIMITY= 0x92,     /**< sensor: proximity */
     SAUL_SENSE_RSSI     = 0x93,     /**< sensor: RSSI */
+    SAUL_SENSE_CHARGE   = 0x94,     /**< sensor: coulomb counter */
+    SAUL_SENSE_CURRENT  = 0x95,     /**< sensor: ammeter */
     SAUL_CLASS_ANY      = 0xff      /**< any device - wildcard */
     /* extend this list as needed... */
 };

--- a/drivers/ltc4150/Makefile
+++ b/drivers/ltc4150/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/drivers/ltc4150/include/ltc4150_params.h
+++ b/drivers/ltc4150/include/ltc4150_params.h
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2018 Otto-von-Guericke-Universität Magdeburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_ltc4150
+ *
+ * @{
+ * @file
+ * @brief       Default configuration for LTC4150 coulomb counters
+ *
+ * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+ */
+
+#ifndef LTC4150_PARAMS_H
+#define LTC4150_PARAMS_H
+
+#include "board.h"
+#include "ltc4150.h"
+#include "saul_reg.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Set default configuration parameters for the LTC4150
+ * @{
+ */
+#ifndef LTC4150_PARAM_INT
+#define LTC4150_PARAM_INT             (GPIO_PIN(0, 4))
+#endif
+#ifndef LTC4150_PARAM_POL
+#define LTC4150_PARAM_POL             (GPIO_UNDEF)
+#endif
+#ifndef LTC4150_PARAM_SHUTDOWN
+#define LTC4150_PARAM_SHUTDOWN        (GPIO_PIN(0, 5))
+#endif
+#ifndef LTC4150_PARAM_PULSES
+#define LTC4150_PARAM_PULSES          (45700)
+#endif
+#ifndef LTC4150_PARAM_FLAGS
+#define LTC4150_PARAM_FLAGS           LTC4150_EXT_PULL_UP
+#endif
+#ifndef LTC4150_PARAMS
+#define LTC4150_PARAMS                { .interrupt = LTC4150_PARAM_INT,  \
+                                        .polarity = LTC4150_PARAM_POL, \
+                                        .shutdown = LTC4150_PARAM_SHUTDOWN, \
+                                        .pulses_per_ah = LTC4150_PARAM_PULSES, \
+                                        .flags = LTC4150_PARAM_FLAGS }
+#endif
+/**@}*/
+
+/**
+ * @name    Set default SAUL info text for the LTC4150
+ * @{
+ */
+#ifndef LTC4150_SAULINFO
+#define LTC4150_SAULINFO              { .name = "LTC4150 total charge" }, \
+                                      { .name = "LTC4150 last minute charge" }, \
+                                      { .name = "LTC4150 average current" }
+#endif
+
+/**@}*/
+
+/**
+ * @brief   Configure LTC4150 devices
+ */
+static const ltc4150_params_t ltc4150_params[] =
+{
+    LTC4150_PARAMS
+};
+
+/**
+ * @brief   Allocate and configure entries to the SAUL registry
+ */
+static const saul_reg_info_t ltc4150_saul_info[] =
+{
+    LTC4150_SAULINFO
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* LTC4150_PARAMS_H */
+/** @} */

--- a/drivers/ltc4150/include/ltc4150_params.h
+++ b/drivers/ltc4150/include/ltc4150_params.h
@@ -8,8 +8,8 @@
 
 /**
  * @ingroup     drivers_ltc4150
- *
  * @{
+ *
  * @file
  * @brief       Default configuration for LTC4150 coulomb counters
  *
@@ -53,7 +53,7 @@ extern "C" {
                                         .pulses_per_ah = LTC4150_PARAM_PULSES, \
                                         .flags = LTC4150_PARAM_FLAGS }
 #endif
-/**@}*/
+/** @} */
 
 /**
  * @name    Set default SAUL info text for the LTC4150
@@ -64,8 +64,7 @@ extern "C" {
                                       { .name = "LTC4150 last minute charge" }, \
                                       { .name = "LTC4150 average current" }
 #endif
-
-/**@}*/
+/** @} */
 
 /**
  * @brief   Configure LTC4150 devices

--- a/drivers/ltc4150/ltc4150.c
+++ b/drivers/ltc4150/ltc4150.c
@@ -154,22 +154,25 @@ static void get_coulomb(const ltc4150_dev_t *dev,
 #endif
                         uint32_t raw_discharged)
 {
+    uint64_t tmp;
     if (charged != NULL) {
 #ifdef MODULE_LTC4150_BIDIRECTIONAL
-        *charged = raw_charged;
-        *charged *= 3600000;
-        *charged += dev->params.pulses_per_ah >> 1;
-        *charged /= dev->params.pulses_per_ah;
+        tmp = raw_charged;
+        tmp *= 3600000;
+        tmp += dev->params.pulses_per_ah >> 1;
+        tmp /= dev->params.pulses_per_ah;
+        *charged = tmp;
 #else
         *charged = 0;
 #endif
     }
 
     if (discharged != NULL) {
-        *discharged = raw_discharged;
-        *discharged *= 3600000;
-        *discharged += dev->params.pulses_per_ah >> 1;
-        *discharged /= dev->params.pulses_per_ah;
+        tmp = raw_discharged;
+        tmp *= 3600000;
+        tmp += dev->params.pulses_per_ah >> 1;
+        tmp /= dev->params.pulses_per_ah;
+        *discharged = tmp;
     }
 }
 

--- a/drivers/ltc4150/ltc4150.c
+++ b/drivers/ltc4150/ltc4150.c
@@ -1,0 +1,245 @@
+/*
+ * Copyright 2018 Otto-von-Guericke-Universität Magdeburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_ltc4150
+ * @brief       Driver for the Linear Tech LTC4150 Coulomb Counter
+ *              (a.k.a. battery gauge sensor or power consumption sensor)
+ * @{
+ *
+ * @file
+ * @brief       LTC4150 Device Driver
+ * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+ *
+ * @}
+ */
+#include <errno.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "ltc4150.h"
+#include "xtimer.h"
+
+#define ENABLE_DEBUG (0)
+#include "debug.h"
+
+static void update_data(ltc4150_dev_t *dev)
+{
+    timex_t now;
+
+    xtimer_now_timex(&now);
+    /* For every ten seconds passed since last update: */
+    while (dev->last_update_sec + 10 < now.seconds) {
+        /* Update charged transferred last minute */
+#ifdef MODULE_LTC4150_BIDIRECTIONAL
+        dev->charged.last_min += dev->charged.counter;
+        dev->charged.last_min -= dev->charged.ringbuf[dev->position];
+        dev->charged.ringbuf[dev->position] = dev->charged.counter;
+        dev->charged.counter = 0;
+#endif
+
+        dev->discharged.last_min += dev->discharged.counter;
+        dev->discharged.last_min -= dev->discharged.ringbuf[dev->position];
+        dev->discharged.ringbuf[dev->position] = dev->discharged.counter;
+        dev->discharged.counter = 0;
+
+        dev->position++;
+
+        if (dev->position >= 6) {
+            dev->position = 0;
+        }
+
+        dev->last_update_sec += 10;
+    }
+}
+
+static void pulse_cb(void *_dev)
+{
+    ltc4150_dev_t *dev = _dev;
+
+    update_data(dev);
+#ifdef MODULE_LTC4150_BIDIRECTIONAL
+    if (
+        (dev->params.polarity == GPIO_UNDEF) ||
+        (!gpio_read(dev->params.polarity))
+        ) {
+        dev->discharged.counter++;
+        dev->discharged.total++;
+    }
+    else {
+        dev->charged.counter++;
+        dev->charged.total++;
+    }
+#else
+    dev->discharged.counter++;
+    dev->discharged.total++;
+#endif
+}
+
+int ltc4150_init(ltc4150_dev_t *dev, const ltc4150_params_t *params)
+{
+    timex_t now;
+
+    if (!dev || !params) {
+        return -EINVAL;
+    }
+
+    memset(dev, 0x00, sizeof(ltc4150_dev_t));
+    dev->params = *params;
+
+    if (dev->params.shutdown != GPIO_UNDEF) {
+        /* Activate LTC4150 */
+        if (gpio_init(dev->params.shutdown, GPIO_OUT)) {
+            DEBUG("[ltc4150] Failed to initialize shutdown pin");
+            return -EIO;
+        }
+        gpio_set(dev->params.shutdown);
+    }
+
+#ifdef MODULE_LTC4150_BIDIRECTIONAL
+    if (dev->params.polarity != GPIO_UNDEF) {
+        gpio_mode_t mode = (dev->params.flags & LTC4150_POL_EXT_PULL_UP) ?
+                           GPIO_IN : GPIO_IN_PU;
+        if (gpio_init(dev->params.polarity, mode)) {
+            DEBUG("[ltc4150] Failed to initialize polarity pin");
+            return -EIO;
+        }
+    }
+#endif
+
+    gpio_mode_t mode = (dev->params.flags & LTC4150_INT_EXT_PULL_UP) ?
+                       GPIO_IN : GPIO_IN_PU;
+    if (gpio_init_int(dev->params.interrupt, mode, GPIO_FALLING,
+                      pulse_cb, dev)
+        ) {
+        DEBUG("[ltc4150] Failed to initialize interrupt pin");
+        return -EIO;
+    }
+
+    xtimer_now_timex(&now);
+    dev->last_update_sec = now.seconds;
+    dev->start_sec = now.seconds;
+
+    DEBUG("[ltc4150] Initialized successfully");
+    return 0;
+}
+
+int ltc4150_shutdown(ltc4150_dev_t *dev)
+{
+    if (!dev) {
+        return -EINVAL;
+    }
+
+    gpio_irq_disable(dev->params.interrupt);
+
+    if (dev->params.shutdown != GPIO_UNDEF) {
+        gpio_clear(dev->params.shutdown);
+    }
+
+    return 0;
+}
+
+/**
+ * @brief Convert the raw data (# pulses) acquired by the LTC4150 device to
+ *        charge information in millicoulomb
+ *
+ * @param dev                 LTC4150 device the data was received from
+ * @param[out] charged        Charge in charging direction is stored here
+ * @param[out] discharged     Charge in discharging direction is stored here
+ * @param[in] raw_charged     Number of pulses in charging direction
+ * @param[in] raw_discharged  Number of pulses in discharging direction
+ */
+static void get_coulomb(const ltc4150_dev_t *dev,
+                        int32_t *charged, int32_t *discharged,
+#ifdef MODULE_LTC4150_BIDIRECTIONAL
+                        uint32_t raw_charged,
+#endif
+                        uint32_t raw_discharged)
+{
+    if (charged != NULL) {
+#ifdef MODULE_LTC4150_BIDIRECTIONAL
+        *charged = raw_charged;
+        *charged *= 3600000;
+        *charged += dev->params.pulses_per_ah >> 1;
+        *charged /= dev->params.pulses_per_ah;
+#else
+        *charged = 0;
+#endif
+    }
+
+    if (discharged != NULL) {
+        *discharged = raw_discharged;
+        *discharged *= 3600000;
+        *discharged += dev->params.pulses_per_ah >> 1;
+        *discharged /= dev->params.pulses_per_ah;
+    }
+}
+
+int ltc4150_total_charge(ltc4150_dev_t *dev,
+                         int32_t *charged, int32_t *discharged)
+{
+    if (!dev) {
+        return -EINVAL;
+    }
+
+    gpio_irq_disable(dev->params.interrupt);
+    update_data(dev);
+#ifdef MODULE_LTC4150_BIDIRECTIONAL
+    get_coulomb(dev, charged, discharged,
+                dev->charged.total, dev->discharged.total);
+#else
+    get_coulomb(dev, charged, discharged, dev->discharged.total);
+#endif
+    gpio_irq_enable(dev->params.interrupt);
+    return 0;
+}
+
+int ltc4150_last_minute_charge(ltc4150_dev_t *dev, int32_t *charged,
+                               int32_t *discharged)
+{
+    if (!dev) {
+        return -EINVAL;
+    }
+
+    gpio_irq_disable(dev->params.interrupt);
+    update_data(dev);
+#ifdef MODULE_LTC4150_BIDIRECTIONAL
+    get_coulomb(dev, charged, discharged,
+                dev->charged.last_min, dev->discharged.last_min);
+#else
+    get_coulomb(dev, charged, discharged, dev->discharged.last_min);
+#endif
+    gpio_irq_enable(dev->params.interrupt);
+    return 0;
+}
+
+int ltc4150_avg_current(ltc4150_dev_t *dev, int16_t *dest)
+{
+    timex_t now;
+    int32_t duration, charged, discharged;;
+    int retval;
+
+    retval = ltc4150_total_charge(dev, &charged, &discharged);
+    if (retval) {
+        return retval;
+    }
+
+    xtimer_now_timex(&now);
+    duration = now.seconds - dev->start_sec;
+    if (!duration) {
+        /* Called before at least one second of data acquired. Prevent division
+         * by zero by returning -EAGAIN.
+         */
+        return -EAGAIN;
+    }
+
+    /* From millicoloumb (=mAs) to E-01 mA */
+    *dest = ((discharged - charged) * 10) / duration;
+
+    return 0;
+}

--- a/drivers/ltc4150/ltc4150_saul.c
+++ b/drivers/ltc4150/ltc4150_saul.c
@@ -1,0 +1,100 @@
+/*
+ * Copyright 2018 Otto-von-Guericke-Universität Magdeburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_ltc4150
+ * @{
+ *
+ * @file
+ * @brief       SAUL adaption for LTC4150 devices
+ *
+ * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+ *
+ * @}
+ */
+
+#include <errno.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "phydat.h"
+#include "saul.h"
+#include "ltc4150.h"
+
+static int read_total_charge(const void *_dev, phydat_t *res)
+{
+    ltc4150_dev_t *dev = (ltc4150_dev_t *)_dev;
+    int32_t temp[3];
+
+    if (ltc4150_total_charge(dev, &temp[1], &temp[2]) == 0) {
+        res->scale = -3;
+        res->unit = UNIT_COULOMB;
+#ifdef MODULE_LTC4150_BIDIRECTIONAL
+        temp[0] = temp[2] - temp[1];
+        int dim = (dev->params.polarity != GPIO_UNDEF) ? 3 : 1;
+        phydat_fit(res, temp, (unsigned int)dim);
+        return dim;
+#else
+        phydat_fit(res, &temp[2], 1);
+        return 1;
+#endif
+    }
+
+    return -ECANCELED;
+}
+
+static int read_last_minute_charge(const void *_dev, phydat_t *res)
+{
+    ltc4150_dev_t *dev = (ltc4150_dev_t *)_dev;
+    int32_t temp[3];
+
+    if (ltc4150_last_minute_charge(dev, &temp[1], &temp[2]) == 0) {
+        res->unit = UNIT_COULOMB;
+        res->scale = -3;
+#ifdef MODULE_LTC4150_BIDIRECTIONAL
+        temp[0] = temp[2] - temp[1];
+        int dim = (dev->params.polarity != GPIO_UNDEF) ? 3 : 1;
+        phydat_fit(res, temp, (unsigned int)dim);
+        return dim;
+#else
+        phydat_fit(res, &temp[2], 1);
+        return 1;
+#endif
+    }
+
+    return -ECANCELED;
+}
+
+static int read_current(const void *dev, phydat_t *res)
+{
+    if (ltc4150_avg_current((ltc4150_dev_t *)dev, res->val) == 0) {
+        res->unit = UNIT_A;
+        res->scale = -4;
+        return 1;
+    }
+
+    return -ECANCELED;
+}
+
+const saul_driver_t ltc4150_saul_total_charge_driver = {
+    .read = read_total_charge,
+    .write = saul_notsup,
+    .type = SAUL_SENSE_CHARGE
+};
+
+const saul_driver_t ltc4150_saul_last_minute_charge_driver = {
+    .read = read_last_minute_charge,
+    .write = saul_notsup,
+    .type = SAUL_SENSE_CHARGE
+};
+
+const saul_driver_t ltc4150_saul_current_driver = {
+    .read = read_current,
+    .write = saul_notsup,
+    .type = SAUL_SENSE_CURRENT
+};

--- a/drivers/saul/saul_str.c
+++ b/drivers/saul/saul_str.c
@@ -55,6 +55,8 @@ const char *saul_class_to_str(const uint8_t class_id)
         case SAUL_SENSE_TVOC:      return "SENSE_TVOC";
         case SAUL_SENSE_PROXIMITY: return "SENSE_PROXIMITY";
         case SAUL_SENSE_RSSI:      return "SENSE_RSSI";
+        case SAUL_SENSE_CHARGE:    return "SENSE_CHARGE";
+        case SAUL_SENSE_CURRENT:   return "SENSE_CURRENT";
         case SAUL_CLASS_ANY:       return "CLASS_ANY";
         case SAUL_SENSE_OCCUP:     return "SENSE_OCCUP";
         default:                   return "CLASS_UNKNOWN";

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -38,6 +38,7 @@ PSEUDOMODULES += lis2dh12_spi
 PSEUDOMODULES += log
 PSEUDOMODULES += log_printfnoformat
 PSEUDOMODULES += lora
+PSEUDOMODULES += ltc4150_bidirectional
 PSEUDOMODULES += mpu_stack_guard
 PSEUDOMODULES += nanocoap_%
 PSEUDOMODULES += netdev_default

--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -409,6 +409,10 @@ void auto_init(void)
     extern void auto_init_lsm6dsl(void);
     auto_init_lsm6dsl();
 #endif
+#ifdef MODULE_LTC4150
+    extern void auto_init_ltc4150(void);
+    auto_init_ltc4150();
+ #endif
 #ifdef MODULE_MAG3110
     extern void auto_init_mag3110(void);
     auto_init_mag3110();

--- a/sys/auto_init/saul/auto_init_ltc4150.c
+++ b/sys/auto_init/saul/auto_init_ltc4150.c
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2018 Otto-von-Guericke-Universität Magdeburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ *
+ */
+
+/*
+ * @ingroup     sys_auto_init_saul
+ * @{
+ *
+ * @file
+ * @brief       Auto initialization for LTC4150 coulomb counter
+ *
+ * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+ *
+ * @}
+ */
+
+#ifdef MODULE_LTC4150
+
+#include "assert.h"
+#include "log.h"
+#include "saul_reg.h"
+#include "ltc4150_params.h"
+#include "ltc4150.h"
+
+/**
+ * @brief   Define the number of configured sensors
+ */
+#define LTC4150_NUM     (sizeof(ltc4150_params) / sizeof(ltc4150_params[0]))
+
+/**
+ * @brief   Allocate memory for the device descriptors
+ */
+static ltc4150_dev_t ltc4150_devs[LTC4150_NUM];
+
+/**
+ * @brief   Memory for the SAUL registry entries
+ */
+static saul_reg_t saul_entries[LTC4150_NUM * 3];
+
+/**
+ * @brief   Define the number of saul info
+ */
+#define LTC4150_INFO_NUM (sizeof(ltc4150_saul_info) / sizeof(ltc4150_saul_info[0]))
+
+/**
+ * @name    Import SAUL endpoints
+ * @{
+ */
+extern const saul_driver_t ltc4150_saul_total_charge_driver;
+extern const saul_driver_t ltc4150_saul_last_minute_charge_driver;
+extern const saul_driver_t ltc4150_saul_current_driver;
+/** @} */
+
+void auto_init_ltc4150(void)
+{
+    assert(LTC4150_INFO_NUM == 3 * LTC4150_NUM);
+
+    for (unsigned int i = 0; i < LTC4150_NUM; i++) {
+        LOG_DEBUG("[auto_init_saul] initializing ltc4150 #%u\n", i);
+
+        if (ltc4150_init(&ltc4150_devs[i], &ltc4150_params[i])) {
+            LOG_ERROR("[auto_init_saul] error initializing ltc4150 #%u\n", i);
+            continue;
+        }
+
+        saul_entries[i * 3    ].dev = &(ltc4150_devs[i]);
+        saul_entries[i * 3    ].name = ltc4150_saul_info[3 * i    ].name;
+        saul_entries[i * 3    ].driver = &ltc4150_saul_total_charge_driver;
+        saul_entries[i * 3 + 1].dev = &(ltc4150_devs[i]);
+        saul_entries[i * 3 + 1].name = ltc4150_saul_info[3 * i + 1].name;
+        saul_entries[i * 3 + 1].driver = &ltc4150_saul_last_minute_charge_driver;
+        saul_entries[i * 3 + 2].dev = &(ltc4150_devs[i]);
+        saul_entries[i * 3 + 2].name = ltc4150_saul_info[3 * i + 2].name;
+        saul_entries[i * 3 + 2].driver = &ltc4150_saul_current_driver;
+        saul_reg_add(&(saul_entries[i * 3    ]));
+        saul_reg_add(&(saul_entries[i * 3 + 1]));
+        saul_reg_add(&(saul_entries[i * 3 + 2]));
+    }
+}
+
+#else
+typedef int dont_be_pedantic;
+#endif /* MODULE_LTC4150 */

--- a/sys/include/phydat.h
+++ b/sys/include/phydat.h
@@ -95,6 +95,7 @@ enum {
     UNIT_V,         /**< Volts */
     UNIT_GS,        /**< gauss */
     UNIT_DBM,       /**< decibel-milliwatts */
+    UNIT_COULOMB,   /**< coulomb */
     /* pressure */
     UNIT_BAR,       /**< Beer? */
     UNIT_PA,        /**< Pascal */

--- a/sys/phydat/phydat_str.c
+++ b/sys/phydat/phydat_str.c
@@ -101,6 +101,7 @@ const char *phydat_unit_to_str(uint8_t unit)
         case UNIT_CD:       return "cd";
         case UNIT_PERCENT:  return "%";
         case UNIT_CTS:      return "cts";
+        case UNIT_COULOMB:  return "C";
         default:            return "";
     }
 }

--- a/sys/shell/commands/shell_commands.c
+++ b/sys/shell/commands/shell_commands.c
@@ -44,11 +44,6 @@ extern int _get_weather_handler(int argc, char **argv);
 extern int _sht_config_handler(int argc, char **argv);
 #endif
 
-#ifdef MODULE_LTC4150
-extern int _get_current_handler(int argc, char **argv);
-extern int _reset_current_handler(int argc, char **argv);
-#endif
-
 #ifdef MODULE_AT30TSE75X
 extern int _at30tse75x_handler(int argc, char **argv);
 #endif
@@ -162,10 +157,6 @@ const shell_command_t _shell_command_list[] = {
     {"hum", "Prints measured humidity.", _get_humidity_handler},
     {"weather", "Prints measured humidity and temperature.", _get_weather_handler},
     {"sht-config", "Get/set SHT10/11/15 sensor configuration.", _sht_config_handler},
-#endif
-#ifdef MODULE_LTC4150
-    {"cur", "Prints current and average power consumption.", _get_current_handler},
-    {"rstcur", "Resets coulomb counter.", _reset_current_handler},
 #endif
 #ifdef MODULE_AT30TSE75X
     {"at30tse75x", "Test AT30TSE75X temperature sensor", _at30tse75x_handler},

--- a/tests/saul/Makefile
+++ b/tests/saul/Makefile
@@ -5,4 +5,7 @@ USEMODULE += saul_default
 
 USEMODULE += xtimer
 
+# Too little flash:
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno
+
 include $(RIOTBASE)/Makefile.include


### PR DESCRIPTION
This PR adds support for the LTC4150 coulomb counter (a.k.a. bidirectional current sensor or battery gauge) and integrates this driver into SAUL.

On the MSBA2 this driver can be easily tested using the saul shell command in the default example. There is also an [open hardware breakout board](https://cdn.sparkfun.com/datasheets/BreakoutBoards/LTC4150_BOB_v10.pdf) that can be easily [attached](https://learn.sparkfun.com/tutorials/ltc4150-coulomb-counter-hookup-guide) to any 3.3V or 5V board.

This driver is implemented in interrupt driven mode. Thus, only 1 GPIO (with interrupt support) is needed in case the user does not want to power down the LTC4150 and no battery is connected. (In case a battery is connected one GPIO is required to detect if the battery is charged or discharged. Another GPIO is required if the LTC4150 should be powered off.)

Note: An LTC4150 driver was already part of RIOT, but was dropped. This driver does not inherit any code from the depreciated and removed driver.