### PR TITLE
tests: gnrc_ipv6_ext: replace default netif with dummy

### DIFF
--- a/tests/gnrc_ipv6_ext/Makefile
+++ b/tests/gnrc_ipv6_ext/Makefile
@@ -1,17 +1,14 @@
 # name of your application
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := airfy-beacon chronos maple-mini msb-430 msb-430h \
-                             nrf51dongle nrf6310 nucleo-f031k6 nucleo-f042k6 \
-                             nucleo-l031k6 nucleo-f030r8 nucleo-f103rb \
-                             nucleo-f303k8 nucleo-f334r8 nucleo-l053r8 \
-                             spark-core stm32f0discovery telosb \
-                             wsn430-v1_3b wsn430-v1_4 yunjia-nrf51822 z1
+BOARD_INSUFFICIENT_MEMORY := chronos msb-430 msb-430h nucleo-f030r8 \
+                             nucleo-f031k6 nucleo-f042k6 nucleo-f303k8 \
+                             nucleo-f334r8 nucleo-l031k6 nucleo-l053r8 \
+                             stm32f0discovery
 
-# Include packages that pull up and auto-init the link layer.
-# NOTE: 6LoWPAN will be included if IEEE802.15.4 devices are present
-USEMODULE += gnrc_netdev_default
-USEMODULE += auto_init_gnrc_netif
+# use Ethernet as link-layer protocol
+USEMODULE += netdev_eth
+USEMODULE += netdev_test
 # Specify the mandatory networking modules for IPv6
 USEMODULE += gnrc_ipv6_router_default
 # IPv6 extension headers
@@ -24,6 +21,8 @@ USEMODULE += gnrc_udp
 USEMODULE += ps
 
 CFLAGS += -DGNRC_NETIF_IPV6_ADDRS_NUMOF=3
+
+TEST_ON_CI_WHITELIST += all
 
 include $(RIOTBASE)/Makefile.include
 

--- a/tests/gnrc_ipv6_ext/main.c
+++ b/tests/gnrc_ipv6_ext/main.c
@@ -23,31 +23,66 @@
 
 #include "shell.h"
 #include "msg.h"
+#include "net/ethernet.h"
 #include "net/ipv6/addr.h"
 #include "net/gnrc/pkt.h"
 #include "net/gnrc/pktbuf.h"
 #include "net/gnrc/netreg.h"
 #include "net/gnrc/netapi.h"
 #include "net/gnrc/netif.h"
+#include "net/gnrc/netif/conf.h"
+#include "net/gnrc/netif/ethernet.h"
 #include "net/gnrc/netif/hdr.h"
+#include "net/netdev_test.h"
+
+static char _netif_stack[THREAD_STACKSIZE_SMALL];
+static netdev_test_t _dev;
+
+static int _get_netdev_device_type(netdev_t *netdev, void *value, size_t max_len)
+{
+    assert(max_len == sizeof(uint16_t));
+    (void)netdev;
+
+    *((uint16_t *)value) = NETDEV_TYPE_ETHERNET;
+    return sizeof(uint16_t);
+}
+
+static int _get_netdev_max_packet_size(netdev_t *netdev, void *value,
+                                       size_t max_len)
+{
+    assert(max_len == sizeof(uint16_t));
+    (void)netdev;
+
+    *((uint16_t *)value) = ETHERNET_DATA_LEN;
+    return sizeof(uint16_t);
+}
 
 static void _init_interface(void)
 {
-    gnrc_netif_t *iface;
+    gnrc_netif_t *netif;
     ipv6_addr_t addr = IPV6_ADDR_UNSPECIFIED;
 
-    iface = gnrc_netif_iter(NULL);
+    netdev_test_setup(&_dev, NULL);
+    netdev_test_set_get_cb(&_dev, NETOPT_DEVICE_TYPE,
+                           _get_netdev_device_type);
+    netdev_test_set_get_cb(&_dev, NETOPT_MAX_PACKET_SIZE,
+                           _get_netdev_max_packet_size);
+    netif = gnrc_netif_ethernet_create(
+            _netif_stack, THREAD_STACKSIZE_SMALL, GNRC_NETIF_PRIO,
+            "dummy_netif", (netdev_t *)&_dev);
 
     addr.u8[0] = 0xfd;
     addr.u8[1] = 0x01;
     addr.u8[15] = 0x02;
+
+    xtimer_usleep(500); /* wait for thread to start */
     /* add addresses fd01::02/64 and fd01::3/64 to interface */
     for (uint8_t i = 0x2; i <= 0x3; i++) {
         addr.u8[15] = i;
-        if (gnrc_netapi_set(iface->pid, NETOPT_IPV6_ADDR, 64U << 8U, &addr,
+        if (gnrc_netapi_set(netif->pid, NETOPT_IPV6_ADDR, 64U << 8U, &addr,
                             sizeof(addr)) < 0) {
             printf("error: unable to add IPv6 address fd01::%x/64 to interface %u\n",
-                   addr.u8[15], iface->pid);
+                   addr.u8[15], netif->pid);
         }
     }
 }


### PR DESCRIPTION
### Contribution description
Use a minimalistic dummy instead of the default interface for testing
the `gnrc_ipv6_ext` module

Currently the default interface is used which leads to problems with
this test, since random traffic on the medium or a missing default
interface might lead to failed results.

### Issues/PRs references
Similar issue as with #9648 