### PR TITLE
boards: Add support for KEA128LEDLIGHTRD

### DIFF
--- a/boards/kea128ledlightrd/Makefile
+++ b/boards/kea128ledlightrd/Makefile
@@ -1,0 +1,3 @@
+MODULE = board
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/kea128ledlightrd/Makefile.dep
+++ b/boards/kea128ledlightrd/Makefile.dep
@@ -1,0 +1,6 @@
+USEMODULE += stdio_rtt
+
+# setup clock to run at 40MHz
+CFLAGS += -DCLOCK_SETUP=1
+
+include $(RIOTCPU)/kinetis/Makefile.dep

--- a/boards/kea128ledlightrd/Makefile.features
+++ b/boards/kea128ledlightrd/Makefile.features
@@ -1,0 +1,7 @@
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_timer
+
+# The board MPU family (used for grouping by the CI system)
+FEATURES_MCU_GROUP = cortex_m0+
+
+include $(RIOTCPU)/kinetis/Makefile.features

--- a/boards/kea128ledlightrd/Makefile.include
+++ b/boards/kea128ledlightrd/Makefile.include
@@ -1,0 +1,8 @@
+# define the cpu used by the KEA128LEDLIGHTRD board
+export CPU = kinetis
+export CPU_MODEL = s9keaz128aclh48
+
+DEBUG_ADAPTER ?= arm-jtag-swd
+OPENOCD_CONFIG ?= ${RIOTBOARD}/kea128ledlightrd/dist/openocd.cfg
+
+include ${RIOTMAKE}/tools/openocd.inc.mk

--- a/boards/kea128ledlightrd/board.c
+++ b/boards/kea128ledlightrd/board.c
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2014 Freie Universität Berlin
+ * Copyright (C) 2014 PHYTEC Messtechnik GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     boards_kea128ledlightrd
+ * @{
+ *
+ * @file
+ * @brief       Board specific implementations for the KEA128LEDLIGHTRD
+ *
+ * @author      Johann Fischer <j.fischer@phytec.de>
+ * @author      Anton Gerasimov <anton.gerasimov@here.com>
+ *
+ * @}
+ */
+
+#include "board.h"
+#include "periph/gpio.h"
+#include "tja1042.h"
+
+extern void SystemInit(void);
+
+void board_init(void)
+{
+    /* initialize clocks */
+    SystemInit();
+
+    /* initialize the CPU core */
+    cpu_init();
+
+    /* disable NMI on the pin used for LED2 */
+    SIM->SOPT0 &= (~SIM_SOPT0_NMIE_MASK);
+
+    /* initialize and turn off the on-board RGB-LED */
+    gpio_init(LED0_PIN, GPIO_OUT);
+    gpio_init(LED1_PIN, GPIO_OUT);
+    gpio_init(LED2_PIN, GPIO_OUT);
+    gpio_init(LED3_PIN, GPIO_OUT);
+    gpio_set(LED0_PIN);
+    gpio_set(LED1_PIN);
+    gpio_set(LED2_PIN);
+    gpio_set(LED3_PIN);
+}

--- a/boards/kea128ledlightrd/dist/openocd.cfg
+++ b/boards/kea128ledlightrd/dist/openocd.cfg
@@ -1,0 +1,2 @@
+# Kinetis KE series CPUs
+source [find target/ke0x.cfg]

--- a/boards/kea128ledlightrd/include/board.h
+++ b/boards/kea128ledlightrd/include/board.h
@@ -1,0 +1,84 @@
+/*
+ * Copyright (C) 2014 Freie Universität Berlin
+ * Copyright (C) 2015 PHYTEC Messtechnik GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @defgroup    boards_kea128ledlightrd NXP/Freescale KEA128LEDLIGHTRD Board
+ * @ingroup     boards
+ * @brief       Support for the NXP KEA128LEDLIGHTRD
+ * @{
+ *
+ * @file
+ * @brief       Board specific definitions for the KEA128LEDLIGHTRD
+ *
+ * @author      Johann Fischer <j.fischer@phytec.de>
+ * @author      Anton Gerasimov <anton.gerasimov@here.com>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include "cpu.h"
+#include "periph_conf.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/**
+ * @name    LED pin definitions and handlers
+ * @{
+ */
+#define LED0_PIN            GPIO_PIN(PORT_A, 10)
+#define LED1_PIN            GPIO_PIN(PORT_A, 11)
+#define LED2_PIN            GPIO_PIN(PORT_A, 12)
+#define LED3_PIN            GPIO_PIN(PORT_A, 13)
+
+#define LED0_MASK           (1 << 10)
+#define LED1_MASK           (1 << 11)
+#define LED2_MASK           (1 << 12)
+#define LED3_MASK           (1 << 13)
+
+#define LED0_ON            (GPIOA->PCOR = LED0_MASK)
+#define LED0_OFF           (GPIOA->PSOR = LED0_MASK)
+#define LED0_TOGGLE        (GPIOA->PTOR = LED0_MASK)
+
+#define LED1_ON            (GPIOA->PCOR = LED1_MASK)
+#define LED1_OFF           (GPIOA->PSOR = LED1_MASK)
+#define LED1_TOGGLE        (GPIOA->PTOR = LED1_MASK)
+
+#define LED2_ON            (GPIOA->PCOR = LED2_MASK)
+#define LED2_OFF           (GPIOA->PSOR = LED2_MASK)
+#define LED2_TOGGLE        (GPIOA->PTOR = LED2_MASK)
+
+#define LED3_ON            (GPIOA->PCOR = LED3_MASK)
+#define LED3_OFF           (GPIOA->PSOR = LED3_MASK)
+#define LED3_TOGGLE        (GPIOA->PTOR = LED3_MASK)
+
+/** @} */
+
+/**
+ * @name    xtimer configuration
+ * @{
+ */
+#define XTIMER_DEV                  (TIMER_PIT_DEV(0))
+#define XTIMER_CHAN                 (0)
+/** @} */
+
+/**
+ * @brief   Initialize board specific hardware, including clock, LEDs and std-IO
+ */
+void board_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/kea128ledlightrd/include/periph_conf.h
+++ b/boards/kea128ledlightrd/include/periph_conf.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2014 Freie Universität Berlin
+ * Copyright (C) 2015 PHYTEC Messtechnik GmbH
+ * Copyright (C) 2018 HERE Deutschland GmbH
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     boards_kea128ledlightrd
+ * @{
+ *
+ * @file
+ * @name        Peripheral MCU configuration for KEA128LEDLIGHTRD
+ *
+ * @author      Johann Fischer <j.fischer@phytec.de>
+ * @author      Anton Gerasimov <anton.gerasimov@here.com>
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+#include "periph_cpu.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#define CLOCK_CORECLOCK              (40000000ul)
+#define CLOCK_BUSCLOCK               (CLOCK_CORECLOCK / 1)
+/** @} */
+
+/**
+ * @name Timer configuration
+ * @{
+ */
+#define PIT_NUMOF               (2U)
+#define LPTMR_NUMOF             (0U)
+#define PIT_CONFIG {                 \
+        {                            \
+            .prescaler_ch = 0,       \
+            .count_ch = 1,           \
+        },                           \
+        {                            \
+            .prescaler_ch = 2,       \
+            .count_ch = 3,           \
+        },                           \
+}
+#define TIMER_NUMOF             ((PIT_NUMOF))
+
+#define PIT_BASECLOCK           (CLOCK_BUSCLOCK)
+#define PIT_ISR_0               isr_pit1
+#define PIT_ISR_1               isr_pit3
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_CONF_H */
+/** @} */

--- a/makefiles/tools/openocd-adapters/arm-jtag-swd.inc.mk
+++ b/makefiles/tools/openocd-adapters/arm-jtag-swd.inc.mk
@@ -1,0 +1,7 @@
+# Olimex ARM-USB-OCD-H with ARM-JTAG-SWD adapter
+OPENOCD_ADAPTER_INIT ?= -c 'source [find interface/ftdi/olimex-arm-usb-ocd-h.cfg]' -c 'source [find interface/ftdi/olimex-arm-jtag-swd.cfg]'
+# Add serial matching command, only if DEBUG_ADAPTER_ID was specified
+ifneq (,$(DEBUG_ADAPTER_ID))
+  OPENOCD_ADAPTER_INIT += -c 'ftdi_serial $(DEBUG_ADAPTER_ID)'
+endif
+export OPENOCD_ADAPTER_INIT

--- a/makefiles/tools/openocd-adapters/arm-usb-ocd-h.inc.mk
+++ b/makefiles/tools/openocd-adapters/arm-usb-ocd-h.inc.mk
@@ -1,0 +1,7 @@
+# Olimex ARM-USB-OCD-H debug adapter
+OPENOCD_ADAPTER_INIT ?= -c 'source [find interface/ftdi/olimex-arm-usb-ocd-h.cfg]'
+# Add serial matching command, only if DEBUG_ADAPTER_ID was specified
+ifneq (,$(DEBUG_ADAPTER_ID))
+  OPENOCD_ADAPTER_INIT += -c 'ftdi_serial $(DEBUG_ADAPTER_ID)'
+endif
+export OPENOCD_ADAPTER_INIT


### PR DESCRIPTION
The PR includes support for S9KEA128 MCU with a limited set of peripherals (LEDs, GPIOs, PIT timer and CAN) and support for the board.
I had to add some conditional compilation to kinetis codebase, because KEA family has significant differences from what was supported so far (different clock generation/distribution, different pin multiplexing).
I've also run into some issues with CAN subsystem and added some hacks to my driver as a workaround, but it's worth debugging these problems to the cause.