### PR TITLE
tlsf: fix for llvm

### DIFF
--- a/pkg/tlsf/contrib/tlsf-malloc.c
+++ b/pkg/tlsf/contrib/tlsf-malloc.c
@@ -31,7 +31,9 @@
 static tlsf_t gheap = NULL;
 
 /* TODO: Add defines for other compilers */
-#ifdef __GNUC__
+#if defined(__GNUC__) && !defined(__clang__)    /* Clang supports __GNUC__ but
+                                                 * not the alloc_size()
+                                                 * attribute */
 
 #define ATTR_MALLOC  __attribute__((malloc, alloc_size(1)))
 #define ATTR_CALLOC  __attribute__((malloc, alloc_size(1,2)))


### PR DESCRIPTION
### Contribution description
The `__GNUC__` is also available in `clang` as is just used to provide
the major version of a GNU-C compatible compiler [[1]]. So I check for
`tlsf` if the `alloc_size()` is available by using the combination of
macros as proposed here: https://stackoverflow.com/a/43205345/395687

[1]: https://gcc.gnu.org/onlinedocs/cpp/Common-Predefined-Macros.html

### Issues/PRs references
Detected in #9398.