### PR TITLE
native: ignore -Wformat-nonliteral for formatting syscalls [backport 2018.07]

### DIFF
--- a/cpu/native/syscalls.c
+++ b/cpu/native/syscalls.c
@@ -265,6 +265,9 @@ int puts(const char *s)
     return r;
 }
 
+/* Solve 'format string is not a string literal' as it is validly used in this
+ * function */
+__attribute__((__format__ (__printf__, 1, 0)))
 char *make_message(const char *format, va_list argp)
 {
     int size = 100;


### PR DESCRIPTION
# Backport of #9661

### Contribution description
The point of that call is to wrap the actual host system's formatting
functions, so the non-literal formatting string is alright here.

### Issues/PRs references
Cherry-picked and detected in #9398, alternative to #9660.