### PR TITLE
examples/lua_REPL: cast pointer to void in printf

### DIFF
--- a/examples/lua_REPL/main.c
+++ b/examples/lua_REPL/main.c
@@ -46,7 +46,7 @@ const size_t lua_riot_builtin_lua_table_len = 1;
 int main(void)
 {
     printf("Using memory range for Lua heap: %p - %p, %zu bytes\n",
-           lua_memory, lua_memory + MAIN_LUA_MEM_SIZE, sizeof(void *));
+           (void *)lua_memory, (void *)(lua_memory + MAIN_LUA_MEM_SIZE), sizeof(void *));
 
     while (1) {
         int status, value;


### PR DESCRIPTION
### Contribution description

Fix an error/warning caused by using "%p" with a char pointer.

```
/home/jcarrano/source/masterRIOT/examples/lua_REPL/main.c:49:12: error: format specifies type 'void *' but the argument has type
      'char *' [-Werror,-Wformat-pedantic]
           lua_memory, lua_memory + MAIN_LUA_MEM_SIZE, sizeof(void *));
           ^~~~~~~~~~
/home/jcarrano/source/masterRIOT/examples/lua_REPL/main.c:49:24: error: format specifies type 'void *' but the argument has type
      'char *' [-Werror,-Wformat-pedantic]
           lua_memory, lua_memory + MAIN_LUA_MEM_SIZE, sizeof(void *));
                       ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```

### Issues/PRs references

This was the only problem I found when compiling with LLVM. See  #9398.