### PR TITLE
gnrc_ipv6: fix regression from #8215

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
+++ b/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
@@ -437,6 +437,7 @@ static int _fill_ipv6_hdr(gnrc_netif_t *netif, gnrc_pktsnip_t *ipv6)
              * original packet by other subscriber */
             return -ENOMEM;
         }
+        payload = tmp;
         prev->next = payload;
         prev = payload;
     } while (_is_ipv6_hdr(payload));

--- a/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
+++ b/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
@@ -426,18 +426,14 @@ static int _fill_ipv6_hdr(gnrc_netif_t *netif, gnrc_pktsnip_t *ipv6)
     payload = ipv6;
     prev = ipv6;
     do {
-        gnrc_pktsnip_t *tmp;
         /* IPv6 header itself was already write-protected in caller function,
          * just write protect extension headers and payload header */
-        payload = payload->next;
-        tmp = gnrc_pktbuf_start_write(payload);
-        if (tmp == NULL) {
+        if ((payload = gnrc_pktbuf_start_write(payload->next)) == NULL) {
             DEBUG("ipv6: unable to get write access to IPv6 extension or payload header\n");
             /* packet duplicated to this point will be released by caller,
              * original packet by other subscriber */
             return -ENOMEM;
         }
-        payload = tmp;
         prev->next = payload;
         prev = payload;
     } while (_is_ipv6_hdr(payload));

--- a/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
+++ b/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
@@ -433,7 +433,8 @@ static int _fill_ipv6_hdr(gnrc_netif_t *netif, gnrc_pktsnip_t *ipv6)
         tmp = gnrc_pktbuf_start_write(payload);
         if (tmp == NULL) {
             DEBUG("ipv6: unable to get write access to IPv6 extension or payload header\n");
-            gnrc_pktbuf_release(ipv6);
+            /* packet duplicated to this point will be released by caller,
+             * original packet by other subscriber */
             return -ENOMEM;
         }
         prev->next = payload;
@@ -443,6 +444,7 @@ static int _fill_ipv6_hdr(gnrc_netif_t *netif, gnrc_pktsnip_t *ipv6)
     if ((res = gnrc_netreg_calc_csum(payload, ipv6)) < 0) {
         if (res != -ENOENT) {   /* if there is no checksum we are okay */
             DEBUG("ipv6: checksum calculation failed.\n");
+            /* packet will be released by caller */
             return res;
         }
     }


### PR DESCRIPTION
### Contribution description
While `tmp` in the loop for write-protection for the check-sum calculation is used to check the return value of `gnrc_pktbuf_start_write()`, it never overwrites `payload` causing the original snip to be used in the following iteration `prev` when duplicated, and destroying the sanity of `ipv6`. However, since no
release in this function is required anyways, we can just use `payload` to check the return value directly.

### Issues/PRs references
Detected via #9669.