### PR TITLE
tests/gnrc_sixlowpan: enable test on murdock [backport 2018.07]

### DIFF
--- a/tests/gnrc_sixlowpan/Makefile
+++ b/tests/gnrc_sixlowpan/Makefile
@@ -17,6 +17,8 @@ USEMODULE += gnrc_udp
 # Dumps packets
 USEMODULE += gnrc_pktdump
 
+TEST_ON_CI_WHITELIST += all
+
 include $(RIOTBASE)/Makefile.include
 
 test:


### PR DESCRIPTION
# Backport of #9650

### Contribution description

Enable testing `gnrc_sixlowpan` on murdock.

~This should normally fail according to the release tests.~
Should be fixed.

### Issues/PRs references

Would help testing ~https://github.com/RIOT-OS/RIOT/pull/9649~ and ~https://github.com/RIOT-OS/RIOT/pull/9648~