### PR TITLE
tests: gnrc_netif: fix group join iteration macro

### DIFF
--- a/tests/gnrc_netif/main.c
+++ b/tests/gnrc_netif/main.c
@@ -523,7 +523,7 @@ static void test_ipv6_group_join__ENOMEM(void)
 {
     ipv6_addr_t addr = IPV6_ADDR_ALL_NODES_LINK_LOCAL;
 
-    for (unsigned i = 0; i < GNRC_NETIF_IPV6_ADDRS_NUMOF;
+    for (unsigned i = 0; i < GNRC_NETIF_IPV6_GROUPS_NUMOF;
          i++, addr.u16[7].u16++) {
         TEST_ASSERT(0 <= gnrc_netif_ipv6_group_join_internal(netifs[0], &addr));
     }


### PR DESCRIPTION
### Contribution description
The `test_ipv6_group_join__ENOMEM()` tests joining multicast groups,
so we need to iterate `GNRC_NETIF_IPV6_GROUPS_NUMOF` times to fill up
all addresses, not `GNRC_NETIF_IPV6_ADDRS_NUMOF`.

### Issues/PRs references
Detected when reviewing #9669.