### PR TITLE
tests: gnrc_sixlowpan: replace default netif with dummy [backport 2018.07]

### DIFF
--- a/tests/gnrc_sixlowpan/Makefile
+++ b/tests/gnrc_sixlowpan/Makefile
@@ -1,17 +1,15 @@
 # name of your application
 include ../Makefile.tests_common
 
-BOARD_INSUFFICIENT_MEMORY := airfy-beacon chronos maple-mini msb-430 msb-430h \
-                             nrf51dongle nrf6310 nucleo-f031k6 nucleo-f042k6 \
-                             nucleo-l031k6 nucleo-f030r8 nucleo-f070rb nucleo-f103rb \
-                             nucleo-f303k8 nucleo-f334r8 nucleo-l053r8 \
-                             spark-core stm32f0discovery telosb wsn430-v1_3b \
-                             wsn430-v1_4 yunjia-nrf51822 z1
+BOARD_INSUFFICIENT_MEMORY := chronos hifive1 msb-430 msb-430h nucleo-f030r8 \
+                             nucleo-f031k6 nucleo-f042k6 nucleo-f070rb \
+                             nucleo-f070rb nucleo-f072rb nucleo-f303k8 \
+                             nucleo-f334r8 nucleo-l031k6 nucleo-l053r8 \
+                             stm32f0discovery telosb wsn430-v1_3b wsn430-v1_4 z1
 
-# Include packages that pull up and auto-init the link layer.
-# NOTE: 6LoWPAN will be included if IEEE802.15.4 devices are present
-USEMODULE += gnrc_netdev_default
-USEMODULE += auto_init_gnrc_netif
+# use IEEE 802.15.4 as link-layer protocol
+USEMODULE += netdev_ieee802154
+USEMODULE += netdev_test
 # 6LoWPAN and its extensions
 USEMODULE += gnrc_sixlowpan_default
 # UDP

--- a/tests/gnrc_sixlowpan/main.c
+++ b/tests/gnrc_sixlowpan/main.c
@@ -29,12 +29,59 @@
 #include "net/gnrc/netreg.h"
 #include "net/gnrc/netapi.h"
 #include "net/gnrc/netif.h"
+#include "net/gnrc/netif/conf.h"
+#include "net/gnrc/netif/ieee802154.h"
 #include "net/gnrc/netif/hdr.h"
 #include "net/gnrc/pktdump.h"
+#include "net/netdev_test.h"
+#include "xtimer.h"
+
+#define IEEE802154_MAX_FRAG_SIZE    (102)
+
+static char _netif_stack[THREAD_STACKSIZE_SMALL];
+static netdev_test_t _ieee802154_dev;
+
+static int _get_netdev_device_type(netdev_t *netdev, void *value, size_t max_len)
+{
+    assert(max_len == sizeof(uint16_t));
+    (void)netdev;
+
+    *((uint16_t *)value) = NETDEV_TYPE_IEEE802154;
+    return sizeof(uint16_t);
+}
+
+static int _get_netdev_max_packet_size(netdev_t *netdev, void *value,
+                                       size_t max_len)
+{
+    assert(max_len == sizeof(uint16_t));
+    (void)netdev;
+
+    *((uint16_t *)value) = IEEE802154_MAX_FRAG_SIZE;
+    return sizeof(uint16_t);
+}
+
+static int _get_netdev_src_len(netdev_t *netdev, void *value, size_t max_len)
+{
+    (void)netdev;
+    assert(max_len == sizeof(uint16_t));
+    *((uint16_t *)value) = sizeof(eui64_t);
+    return sizeof(uint16_t);
+}
 
 static void _init_interface(void)
 {
-    gnrc_netif_t *netif = gnrc_netif_iter(NULL);
+    gnrc_netif_t *netif;
+
+    netdev_test_setup(&_ieee802154_dev, NULL);
+    netdev_test_set_get_cb(&_ieee802154_dev, NETOPT_DEVICE_TYPE,
+                           _get_netdev_device_type);
+    netdev_test_set_get_cb(&_ieee802154_dev, NETOPT_MAX_PACKET_SIZE,
+                           _get_netdev_max_packet_size);
+    netdev_test_set_get_cb(&_ieee802154_dev, NETOPT_SRC_LEN,
+                           _get_netdev_src_len);
+    netif = gnrc_netif_ieee802154_create(
+            _netif_stack, THREAD_STACKSIZE_SMALL, GNRC_NETIF_PRIO,
+            "dummy_netif", (netdev_t *)&_ieee802154_dev);
     ipv6_addr_t addr = IPV6_ADDR_UNSPECIFIED;
 
     /* fd01::01 */
@@ -42,6 +89,7 @@ static void _init_interface(void)
     addr.u8[1] = 0x01;
     addr.u8[15] = 0x01;
 
+    xtimer_usleep(500); /* wait for thread to start */
     if (gnrc_netapi_set(netif->pid, NETOPT_IPV6_ADDR, 64U << 8U, &addr,
                         sizeof(addr)) < 0) {
         printf("error: unable to add IPv6 address fd01::1/64 to interface %u\n",


### PR DESCRIPTION
# Backport of #9648

### Contribution description
Use a minimalistic dummy instead of the default interface for testing
the `gnrc_sixlowpan` module

Currently the default interface is used which leads to problems with
this test, since random traffic on the medium might lead to failed
results.


### Issues/PRs references
None