### PR TITLE
*: fix formatting errors with llvm

### DIFF
--- a/drivers/mtd_sdcard/mtd_sdcard.c
+++ b/drivers/mtd_sdcard/mtd_sdcard.c
@@ -25,7 +25,7 @@
 #include "sdcard_spi.h"
 #include "sdcard_spi_internal.h"
 
-#include <stdint.h>
+#include <inttypes.h>
 #include <errno.h>
 
 static int mtd_sdcard_init(mtd_dev_t *mtd);
@@ -65,7 +65,7 @@ static int mtd_sdcard_init(mtd_dev_t *dev)
 static int mtd_sdcard_read(mtd_dev_t *dev, void *buff, uint32_t addr,
                            uint32_t size)
 {
-    DEBUG("mtd_sdcard_read: addr:%lu size:%lu\n", addr, size);
+    DEBUG("mtd_sdcard_read: addr:%" PRIu32 " size:%" PRIu32 "\n", addr, size);
     mtd_sdcard_t *mtd_sd = (mtd_sdcard_t*)dev;
     sd_rw_response_t err;
     int res = sdcard_spi_read_blocks(mtd_sd->sd_card, addr / SD_HC_BLOCK_SIZE,
@@ -81,7 +81,7 @@ static int mtd_sdcard_read(mtd_dev_t *dev, void *buff, uint32_t addr,
 static int mtd_sdcard_write(mtd_dev_t *dev, const void *buff, uint32_t addr,
                             uint32_t size)
 {
-    DEBUG("mtd_sdcard_write: addr:%lu size:%lu\n", addr, size);
+    DEBUG("mtd_sdcard_write: addr:%" PRIu32 " size:%" PRIu32 "\n", addr, size);
     mtd_sdcard_t *mtd_sd = (mtd_sdcard_t*)dev;
     sd_rw_response_t err;
     int res = sdcard_spi_write_blocks(mtd_sd->sd_card, addr / SD_HC_BLOCK_SIZE,
@@ -98,7 +98,7 @@ static int mtd_sdcard_erase(mtd_dev_t *dev,
                             uint32_t addr,
                             uint32_t size)
 {
-    DEBUG("mtd_sdcard_erase: addr:%lu size:%lu\n", addr, size);
+    DEBUG("mtd_sdcard_erase: addr:%" PRIu32 " size:%" PRIu32 "\n", addr, size);
     (void)dev;
     (void)addr;
     (void)size;

--- a/tests/driver_io1_xplained/main.c
+++ b/tests/driver_io1_xplained/main.c
@@ -43,10 +43,10 @@ static void _sd_card_cid(void)
     printf("PNM: %c%c%c%c%c\n",
            dev.sdcard.cid.PNM[0], dev.sdcard.cid.PNM[1], dev.sdcard.cid.PNM[2],
            dev.sdcard.cid.PNM[3], dev.sdcard.cid.PNM[4]);
-    printf("PRV: %d\n", dev.sdcard.cid.PRV);
-    printf("PSN: %lu\n", dev.sdcard.cid.PSN);
-    printf("MDT: %d\n", dev.sdcard.cid.MDT);
-    printf("CRC: %d\n", dev.sdcard.cid.CID_CRC);
+    printf("PRV: %u\n", dev.sdcard.cid.PRV);
+    printf("PSN: %" PRIu32 "\n", dev.sdcard.cid.PSN);
+    printf("MDT: %u\n", dev.sdcard.cid.MDT);
+    printf("CRC: %u\n", dev.sdcard.cid.CID_CRC);
     puts("+----------------------------------------+\n");
 }
 

--- a/tests/driver_sdcard_spi/main.c
+++ b/tests/driver_sdcard_spi/main.c
@@ -22,6 +22,7 @@
 #include "sdcard_spi_internal.h"
 #include "sdcard_spi_params.h"
 #include "fmt.h"
+#include <inttypes.h>
 #include <stdlib.h>
 #include <string.h>
 #include <stdio.h>
@@ -68,10 +69,10 @@ static int _cid(int argc, char **argv)
     printf("OID: %c%c\n", card->cid.OID[0], card->cid.OID[1]);
     printf("PNM: %c%c%c%c%c\n", card->cid.PNM[0], card->cid.PNM[1], card->cid.PNM[2],
                                 card->cid.PNM[3], card->cid.PNM[4]);
-    printf("PRV: %d\n", card->cid.PRV);
-    printf("PSN: %lu\n", card->cid.PSN);
-    printf("MDT: %d\n", card->cid.MDT);
-    printf("CRC: %d\n", card->cid.CID_CRC);
+    printf("PRV: %u\n", card->cid.PRV);
+    printf("PSN: %" PRIu32 "\n", card->cid.PSN);
+    printf("MDT: %u\n", card->cid.MDT);
+    printf("CRC: %u\n", card->cid.CID_CRC);
     puts("----------------------------------------");
     return 0;
 }
@@ -192,7 +193,8 @@ static int _size(int argc, char **argv)
 
     puts("\nCard size: ");
     print_u64_dec( bytes );
-    printf(" bytes (%lu,%03lu GiB | %lu,%03lu GB)\n", gib_int, gib_frac, gb_int, gb_frac);
+    printf(" bytes (%" PRIu32 ",%03" PRIu32 " GiB | %" PRIu32 ",%03" PRIu32 " GB)\n", gib_int,
+           gib_frac, gb_int, gb_frac);
     return 0;
 }
 
@@ -352,7 +354,8 @@ static int _sector_count(int argc, char **argv)
     (void)argc;
     (void)argv;
 
-    printf("available sectors on card: %li\n", sdcard_spi_get_sector_count(card));
+    printf("available sectors on card: %" PRIu32 "\n",
+           sdcard_spi_get_sector_count(card));
     return 0;
 }
 

--- a/tests/periph_flashpage/main.c
+++ b/tests/periph_flashpage/main.c
@@ -18,6 +18,7 @@
  * @}
  */
 
+#include <inttypes.h>
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>
@@ -195,7 +196,7 @@ static int cmd_write_raw(int argc, char **argv)
 
     flashpage_write_raw((void*)addr, raw_buf, strlen(raw_buf));
 
-    printf("wrote local data to flash address %#lx of len %u\n",
+    printf("wrote local data to flash address %#" PRIx32 " of len %u\n",
            addr, strlen(raw_buf));
     return 0;
 }

--- a/tests/puf_sram/main.c
+++ b/tests/puf_sram/main.c
@@ -17,6 +17,7 @@
  *
  * @}
  */
+#include <inttypes.h>
 #include <stdio.h>
 #include "puf_sram.h"
 
@@ -24,7 +25,7 @@ int main(void)
 {
     puts("Start: Test random number generator");
 
-    printf("Success: Data for puf_sram_seed: [0x%08lX]", puf_sram_seed);
+    printf("Success: Data for puf_sram_seed: [0x%08" PRIX32 "]", puf_sram_seed);
 
     puts("End: Test finished");
     return 0;


### PR DESCRIPTION
### Contribution description
This fixes a bunch of formatting errors picked up by compiling with `llvm`

### Issues/PRs references
Detected in #9398.