### PR TITLE
gnrc netif: cleanup and code deduplication

### DIFF
--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -456,6 +456,7 @@ void gnrc_netif_release(gnrc_netif_t *netif)
 #ifdef MODULE_GNRC_IPV6
 static inline bool _addr_anycast(const gnrc_netif_t *netif, unsigned idx);
 static int _addr_idx(const gnrc_netif_t *netif, const ipv6_addr_t *addr);
+static int _group_idx(const gnrc_netif_t *netif, const ipv6_addr_t *addr);
 
 static char addr_str[IPV6_ADDR_MAX_STR_LEN];
 
@@ -547,7 +548,6 @@ static int _create_candidate_set(const gnrc_netif_t *netif,
 static ipv6_addr_t *_src_addr_selection(gnrc_netif_t *netif,
                                         const ipv6_addr_t *dst,
                                         uint8_t *candidate_set);
-static int _group_idx(const gnrc_netif_t *netif, const ipv6_addr_t *addr);
 
 int gnrc_netif_ipv6_addr_add_internal(gnrc_netif_t *netif,
                                       const ipv6_addr_t *addr,
@@ -875,16 +875,28 @@ static inline bool _addr_anycast(const gnrc_netif_t *netif, unsigned idx)
     return (netif->ipv6.addrs_flags[idx] & GNRC_NETIF_IPV6_ADDRS_FLAGS_ANYCAST);
 }
 
-static int _addr_idx(const gnrc_netif_t *netif, const ipv6_addr_t *addr)
+static int _idx(const gnrc_netif_t *netif, const ipv6_addr_t *addr, bool mcast)
 {
     if (!ipv6_addr_is_unspecified(addr)) {
-        for (unsigned i = 0; i < GNRC_NETIF_IPV6_ADDRS_NUMOF; i++) {
-            if (ipv6_addr_equal(&netif->ipv6.addrs[i], addr)) {
+        const ipv6_addr_t *iplist = (mcast) ? netif->ipv6.groups : netif->ipv6.addrs;
+        unsigned ipmax = (mcast) ? GNRC_NETIF_IPV6_GROUPS_NUMOF : GNRC_NETIF_IPV6_ADDRS_NUMOF;
+        for (unsigned i = 0; i < ipmax; i++) {
+            if (ipv6_addr_equal(&iplist[i], addr)) {
                 return i;
             }
         }
     }
     return -1;
+}
+
+static inline int _addr_idx(const gnrc_netif_t *netif, const ipv6_addr_t *addr)
+{
+    return _idx(netif, addr, false);
+}
+
+static inline int _group_idx(const gnrc_netif_t *netif, const ipv6_addr_t *addr)
+{
+    return _idx(netif, addr, true);
 }
 
 static unsigned _match_to_len(const gnrc_netif_t *netif,
@@ -1130,18 +1142,6 @@ static ipv6_addr_t *_src_addr_selection(gnrc_netif_t *netif,
     /* otherwise apply rule 8: Use longest matching prefix. */
     int idx = _match_to_idx(netif, dst, candidate_set);
     return (idx < 0) ? NULL : &netif->ipv6.addrs[idx];
-}
-
-static int _group_idx(const gnrc_netif_t *netif, const ipv6_addr_t *addr)
-{
-    if (!ipv6_addr_is_unspecified(addr)) {
-        for (unsigned i = 0; i < GNRC_NETIF_IPV6_GROUPS_NUMOF; i++) {
-            if (ipv6_addr_equal(&netif->ipv6.groups[i], addr)) {
-                return i;
-            }
-        }
-    }
-    return -1;
 }
 #endif  /* MODULE_GNRC_IPV6 */
 

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -588,7 +588,7 @@ int gnrc_netif_ipv6_addr_add_internal(gnrc_netif_t *netif,
     ipv6_addr_set_solicited_nodes(&sol_nodes, addr);
     res = gnrc_netif_ipv6_group_join_internal(netif, &sol_nodes);
     if (res < 0) {
-        DEBUG("nib: Can't join solicited-nodes of %s on interface %u\n",
+        DEBUG("gnrc_netif: Can't join solicited-nodes of %s on interface %" PRIkernel_pid "\n",
               ipv6_addr_to_str(addr_str, addr, sizeof(addr_str)),
               netif->pid);
         return res;
@@ -666,7 +666,7 @@ int gnrc_netif_ipv6_addr_idx(gnrc_netif_t *netif,
     int idx;
 
     assert((netif != NULL) && (addr != NULL));
-    DEBUG("gnrc_netif: get index of %s from inteface %i\n",
+    DEBUG("gnrc_netif: get index of %s from interface %" PRIkernel_pid "\n",
           ipv6_addr_to_str(addr_str, addr, sizeof(addr_str)),
           netif->pid);
     gnrc_netif_acquire(netif);
@@ -694,6 +694,8 @@ ipv6_addr_t *gnrc_netif_ipv6_addr_best_src(gnrc_netif_t *netif,
     BITFIELD(candidate_set, GNRC_NETIF_IPV6_ADDRS_NUMOF);
 
     assert((netif != NULL) && (dst != NULL));
+    DEBUG("gnrc_netif: get best source address for %s\n",
+          ipv6_addr_to_str(addr_str, dst, sizeof(addr_str)));
     memset(candidate_set, 0, sizeof(candidate_set));
     gnrc_netif_acquire(netif);
     int first_candidate = _create_candidate_set(netif, dst, ll_only,
@@ -981,7 +983,7 @@ static int _create_candidate_set(const gnrc_netif_t *netif,
 {
     int res = -1;
 
-    DEBUG("gathering candidates\n");
+    DEBUG("gathering source address candidates\n");
     /* currently this implementation supports only addresses as source address
      * candidates assigned to this interface. Thus we assume all addresses to be
      * on interface @p netif */

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -460,21 +460,38 @@ static int _addr_idx(const gnrc_netif_t *netif, const ipv6_addr_t *addr);
 static char addr_str[IPV6_ADDR_MAX_STR_LEN];
 
 /**
- * @brief   Matches an address by prefix to an address on the interface
+ * @brief   Matches an address by prefix to an address on the interface and
+ *          return length of the best match
+ *
+ * @param[in] netif     the network interface
+ * @param[in] addr      the address to match
+ *
+ * @return  bits up to which the best match matches @p addr
+ * @return  0, if no match was found
+ *
+ * @pre `netif != NULL` and `addr != NULL`
+ */
+static unsigned _match_to_len(const gnrc_netif_t *netif,
+                              const ipv6_addr_t *addr);
+
+/**
+ * @brief   Matches an address by prefix to an address on the interface and
+ *          return index of the best match
  *
  * @param[in] netif     the network interface
  * @param[in] addr      the address to match
  * @param[in] filter    a bitfield with the bits at the position equal to the
  *                      indexes of the addresses you want to include in the
  *                      search set to one. NULL for all addresses
- * @param[out] idx      index of the best match. -1 if no match was found.
  *
- * @return  bits up to which the best match matches @p addr
- * @return  0, if no match was found
+ * @return  index of the best match for @p addr
+ * @return  -1 if no match was found
+ *
+ * @pre `netif != NULL` and `addr != NULL`
  */
-static unsigned _match(const gnrc_netif_t *netif, const ipv6_addr_t *addr,
-                       const uint8_t *filter, int *idx);
-
+static int _match_to_idx(const gnrc_netif_t *netif,
+                        const ipv6_addr_t *addr,
+                        const uint8_t *filter);
 /**
  * @brief Determines the scope of the given address.
  *
@@ -661,11 +678,9 @@ int gnrc_netif_ipv6_addr_idx(gnrc_netif_t *netif,
 int gnrc_netif_ipv6_addr_match(gnrc_netif_t *netif,
                                const ipv6_addr_t *addr)
 {
-    int idx;
-
     assert((netif != NULL) && (addr != NULL));
     gnrc_netif_acquire(netif);
-    _match(netif, addr, NULL, &idx);
+    int idx = _match_to_idx(netif, addr, NULL);
     gnrc_netif_release(netif);
     return idx;
 }
@@ -717,9 +732,8 @@ gnrc_netif_t *gnrc_netif_get_by_prefix(const ipv6_addr_t *prefix)
 
     while ((netif = gnrc_netif_iter(netif))) {
         unsigned match;
-        int idx;
 
-        if (((match = _match(netif, prefix, NULL, &idx)) > 0) &&
+        if (((match = _match_to_len(netif, prefix)) > 0) &&
             (match > best_match)) {
             best_match = match;
             best_netif = netif;
@@ -871,13 +885,23 @@ static int _addr_idx(const gnrc_netif_t *netif, const ipv6_addr_t *addr)
     return -1;
 }
 
-static unsigned _match(const gnrc_netif_t *netif, const ipv6_addr_t *addr,
-                       const uint8_t *filter, int *idx)
+static unsigned _match_to_len(const gnrc_netif_t *netif,
+                              const ipv6_addr_t *addr)
 {
-    unsigned best_match = 0;
+    assert((netif != NULL) && (addr != NULL));
 
-    assert(idx != NULL);
-    *idx = -1;
+    int n = _match_to_idx(netif, addr, NULL);
+    return (n >= 0) ? ipv6_addr_match_prefix(&(netif->ipv6.addrs[n]), addr) : 0;
+}
+
+static int _match_to_idx(const gnrc_netif_t *netif,
+                         const ipv6_addr_t *addr,
+                         const uint8_t *filter)
+{
+    assert((netif != NULL) && (addr != NULL));
+
+    int idx = -1;
+    unsigned best_match = 0;
     for (int i = 0; i < GNRC_NETIF_IPV6_ADDRS_NUMOF; i++) {
         unsigned match;
 
@@ -890,15 +914,13 @@ static unsigned _match(const gnrc_netif_t *netif, const ipv6_addr_t *addr,
         match = ipv6_addr_match_prefix(&(netif->ipv6.addrs[i]), addr);
         if (((match > 64U) || !ipv6_addr_is_link_local(&(netif->ipv6.addrs[i]))) &&
             (match >= best_match)) {
-            if (idx != NULL) {
-                *idx = i;
-            }
+            idx = i;
             best_match = match;
         }
     }
-    if (*idx >= 0) {
+    if (idx != -1) {
         DEBUG("gnrc_netif: Found %s on interface %" PRIkernel_pid " matching ",
-              ipv6_addr_to_str(addr_str, &netif->ipv6.addrs[*idx],
+              ipv6_addr_to_str(addr_str, &netif->ipv6.addrs[idx],
                                sizeof(addr_str)),
               netif->pid);
         DEBUG("%s by %u bits (used as source address = %s)\n",
@@ -913,7 +935,7 @@ static unsigned _match(const gnrc_netif_t *netif, const ipv6_addr_t *addr,
               ipv6_addr_to_str(addr_str, addr, sizeof(addr_str)),
               (filter != NULL) ? "true" : "false");
     }
-    return best_match;
+    return idx;
 }
 
 static uint8_t _get_scope(const ipv6_addr_t *addr)
@@ -1104,9 +1126,8 @@ static ipv6_addr_t *_src_addr_selection(gnrc_netif_t *netif,
         }
     }
     /* otherwise apply rule 8: Use longest matching prefix. */
-    int res;
-    _match(netif, dst, candidate_set, &res);
-    return (res < 0) ? NULL : &netif->ipv6.addrs[res];
+    int idx = _match_to_idx(netif, dst, candidate_set);
+    return (idx < 0) ? NULL : &netif->ipv6.addrs[idx];
 }
 
 static int _group_idx(const gnrc_netif_t *netif, const ipv6_addr_t *addr)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR make some enhancements on debug output and simplifies internal helper
function to reduce code duplication and (hopefully) increase readability.

It also saves 36B in binary size as a goody.


### Issues/PRs references

depends on #9672