### PR TITLE
newlib.mk: llvm, fix newlib-nano header not used  [backport 2018.07]

### DIFF
--- a/makefiles/libc/newlib.mk
+++ b/makefiles/libc/newlib.mk
@@ -69,6 +69,13 @@ ifeq ($(TOOLCHAIN),llvm)
   # in case some header is missing from the cross tool chain
   NEWLIB_INCLUDES := -isystem $(NEWLIB_INCLUDE_DIR) -nostdinc
   NEWLIB_INCLUDES += $(addprefix -isystem ,$(abspath $(wildcard $(dir $(NEWLIB_INCLUDE_DIR))/usr/include)))
+
+  # Newlib includes should go before GCC includes. This is especially important
+  # when using Clang, because Clang will yield compilation errors on some GCC-
+  # bundled headers. Clang compatible versions of those headers are already
+  # provided by Newlib, so placing this directory first will eliminate those problems.
+  # The above problem was observed with LLVM 3.9.1 when building against GCC 6.3.0 headers.
+  INCLUDES := $(NEWLIB_INCLUDES) $(INCLUDES)
 endif
 
 ifeq (1,$(USE_NEWLIB_NANO))
@@ -79,10 +86,3 @@ ifeq (1,$(USE_NEWLIB_NANO))
   # the regular system include dirs.
   INCLUDES := -isystem $(NEWLIB_NANO_INCLUDE_DIR) $(INCLUDES)
 endif
-
-# Newlib includes should go before GCC includes. This is especially important
-# when using Clang, because Clang will yield compilation errors on some GCC-
-# bundled headers. Clang compatible versions of those headers are already
-# provided by Newlib, so placing this directory first will eliminate those problems.
-# The above problem was observed with LLVM 3.9.1 when building against GCC 6.3.0 headers.
-export INCLUDES := $(NEWLIB_INCLUDES) $(INCLUDES)


### PR DESCRIPTION
# Backport of #9513

### Contribution description

This fixes building with llvm where newlib-nano header is not used.

Basically, the default newlib directory was put before newlib-nano include directory.

### Test command

The first commit can be tested to show it is broken and that the second fixes it

    make TOOLCHAIN=llvm BOARD=samr21-xpro ASSERT_NEWLIB_NANO_HEADER=1 -C examples/hello-world/

### Output

Without patch:

    make TOOLCHAIN=llvm BOARD=samr21-xpro -C examples/hello-world/ info-debug-variable-INCLUDES

    -isystem /usr/bin/../lib/gcc/arm-none-eabi/7.2.1/../../../../arm-none-eabi/include/ -nostdinc -isystem /usr/bin/../lib/gcc/arm-none-eabi/7.2.1/../../../../arm-none-eabi/include/newlib-nano -I/home/harter/work/git/RIOT/core/include -I/home/harter/work/git/RIOT/drivers/include -I/home/harter/work/git/RIOT/sys/include -I/home/harter/work/git/RIOT/boards/samr21-xpro/include -I/home/harter/work/git/RIOT/cpu/samd21/include -I/home/harter/work/git/RIOT/cpu/sam0_common/include -I/home/harter/work/git/RIOT/cpu/cortexm_common/include -I/home/harter/work/git/RIOT/cpu/cortexm_common/include/vendor -isystem /usr/bin/../lib/gcc/arm-none-eabi/7.2.1/include -isystem /usr/bin/../lib/gcc/arm-none-eabi/7.2.1/include-fixed -I/home/harter/work/git/RIOT/sys/libc/include


You can notive that 'newlib-nano' is not in front

With the fix, newlib-nano directory is in front.

    -isystem /usr/bin/../lib/gcc/arm-none-eabi/7.2.1/../../../../arm-none-eabi/include/newlib-nano -isystem /usr/bin/../lib/gcc/arm-none-eabi/7.2.1/../../../../arm-none-eabi/include/ -nostdinc -I/home/harter/work/git/RIOT/core/include -I/home/harter/work/git/RIOT/drivers/include -I/home/harter/work/git/RIOT/sys/include -I/home/harter/work/git/RIOT/boards/samr21-xpro/include -I/home/harter/work/git/RIOT/cpu/samd21/include -I/home/harter/work/git/RIOT/cpu/sam0_common/include -I/home/harter/work/git/RIOT/cpu/cortexm_common/include -I/home/harter/work/git/RIOT/cpu/cortexm_common/include/vendor -isystem /usr/bin/../lib/gcc/arm-none-eabi/7.2.1/include -isystem /usr/bin/../lib/gcc/arm-none-eabi/7.2.1/include-fixed -I/home/harter/work/git/RIOT/sys/libc/include

> ### Remove first commit before merge
> 
> Rebase before merging: This PR includes an arbitrary test for newlib-nano that I do not > want to include in this PR at the end but is required for testing.

Replaced by https://github.com/RIOT-OS/RIOT/pull/9599

### Issues/PRs references

Split from https://github.com/RIOT-OS/RIOT/pull/9512