### PR TITLE
sx127x: fix -Wformat llvm warning

### DIFF
--- a/drivers/sx127x/sx127x_getset.c
+++ b/drivers/sx127x/sx127x_getset.c
@@ -123,7 +123,7 @@ uint32_t sx127x_get_channel(const sx127x_t *dev)
 
 void sx127x_set_channel(sx127x_t *dev, uint32_t channel)
 {
-    DEBUG("[sx127x] Set channel: %lu\n", channel);
+    DEBUG("[sx127x] Set channel: %" PRIu32 "\n", channel);
 
     /* Save current operating mode */
     dev->settings.channel = channel;
@@ -814,14 +814,14 @@ void sx127x_set_preamble_length(sx127x_t *dev, uint16_t preamble)
 
 void sx127x_set_rx_timeout(sx127x_t *dev, uint32_t timeout)
 {
-    DEBUG("[sx127x] Set RX timeout: %lu\n", timeout);
+    DEBUG("[sx127x] Set RX timeout: %" PRIu32 "\n", timeout);
 
     dev->settings.lora.rx_timeout = timeout;
 }
 
 void sx127x_set_tx_timeout(sx127x_t *dev, uint32_t timeout)
 {
-    DEBUG("[sx127x] Set TX timeout: %lu\n", timeout);
+    DEBUG("[sx127x] Set TX timeout: %" PRIu32 "\n", timeout);
 
     dev->settings.lora.tx_timeout = timeout;
 }

--- a/pkg/semtech-loramac/contrib/semtech_loramac_getset.c
+++ b/pkg/semtech-loramac/contrib/semtech_loramac_getset.c
@@ -18,6 +18,7 @@
  */
 
 #include <string.h>
+#include <inttypes.h>
 
 #include "mutex.h"
 
@@ -188,7 +189,7 @@ bool semtech_loramac_get_public_network(semtech_loramac_t *mac)
 void semtech_loramac_set_netid(semtech_loramac_t *mac, uint32_t netid)
 {
     mutex_lock(&mac->lock);
-    DEBUG("[semtech-loramac] set NetID %lu\n", netid);
+    DEBUG("[semtech-loramac] set NetID %" PRIu32 "\n", netid);
     MibRequestConfirm_t mibReq;
     mibReq.Type = MIB_NET_ID;
     mibReq.Param.NetID = netid;
@@ -272,7 +273,7 @@ static void _semtech_loramac_set_rx2_params(semtech_loramac_channel_params_t par
 void semtech_loramac_set_rx2_freq(semtech_loramac_t *mac, uint32_t freq)
 {
     mutex_lock(&mac->lock);
-    DEBUG("[semtech-loramac] setting RX2 freq to %lu\n", freq);
+    DEBUG("[semtech-loramac] setting RX2 freq to %" PRIu32" \n", freq);
     Rx2ChannelParams_t p;
     MibRequestConfirm_t mibReq;
     mibReq.Type = MIB_RX2_DEFAULT_CHANNEL;

--- a/tests/driver_sx127x/main.c
+++ b/tests/driver_sx127x/main.c
@@ -24,6 +24,7 @@
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
+#include <inttypes.h>
 
 #include "thread.h"
 #include "xtimer.h"
@@ -328,7 +329,7 @@ static void _event_cb(netdev_t *dev, netdev_event_t event)
             case NETDEV_EVENT_RX_COMPLETE:
                 len = dev->driver->recv(dev, NULL, 0, 0);
                 dev->driver->recv(dev, message, len, &packet_info);
-                printf("{Payload: \"%s\" (%d bytes), RSSI: %i, SNR: %i, TOA: %lu}\n",
+                printf("{Payload: \"%s\" (%d bytes), RSSI: %i, SNR: %i, TOA: %" PRIu32 "}\n",
                        message, (int)len,
                        packet_info.rssi, (int)packet_info.snr,
                        sx127x_get_time_on_air((const sx127x_t*)dev, len));

--- a/tests/pkg_semtech-loramac/main.c
+++ b/tests/pkg_semtech-loramac/main.c
@@ -18,6 +18,7 @@
  */
 
 #include <string.h>
+#include <inttypes.h>
 
 #include "msg.h"
 #include "shell.h"
@@ -144,13 +145,13 @@ static int _cmd_loramac(int argc, char **argv)
                    semtech_loramac_get_public_network(&loramac) ? "on" : "off");
         }
         else if (strcmp("netid", argv[2]) == 0) {
-            printf("NetID: %lu\n", semtech_loramac_get_netid(&loramac));
+            printf("NetID: %" PRIu32 "\n", semtech_loramac_get_netid(&loramac));
         }
         else if (strcmp("tx_power", argv[2]) == 0) {
             printf("TX power index: %d\n", semtech_loramac_get_tx_power(&loramac));
         }
         else if (strcmp("rx2_freq", argv[2]) == 0) {
-            printf("RX2 freq: %lu\n", semtech_loramac_get_rx2_freq(&loramac));
+            printf("RX2 freq: %" PRIu32 "\n", semtech_loramac_get_rx2_freq(&loramac));
         }
         else if (strcmp("rx2_dr", argv[2]) == 0) {
             printf("RX2 dr: %d\n", semtech_loramac_get_rx2_dr(&loramac));


### PR DESCRIPTION
### Contribution description

Fix -Wformat llvm issues in `sx127x` related tests and code.

Fixed warning

    format specifies type 'unsigned long' but the argument has type 'uint32_t' (aka 'unsigned int')

### Testing

I tested by compiling `tests/driver_sx127x` and `tests/pkg_semtech-loramac`.

```
make -C tests/driver_sx127x BOARD=samr21-xpro distclean all
make -C tests/driver_sx127x BOARD=samr21-xpro distclean all TOOLCHAIN=llvm
make -C tests/pkg_semtech-loramac/ BOARD=samr21-xpro distclean all
make -C tests/pkg_semtech-loramac/ BOARD=samr21-xpro distclean all TOOLCHAIN=llvm
```


### Issues/PRs references

Found in https://github.com/RIOT-OS/RIOT/pull/9398 and split out from https://github.com/RIOT-OS/RIOT/pull/9626 addressing `PRI` comment.