### PR TITLE
newlib.mk: fix regressions [backport 2018.07]

### DIFF
--- a/makefiles/libc/newlib.mk
+++ b/makefiles/libc/newlib.mk
@@ -23,7 +23,11 @@ export LINKFLAGS += -lc
 
 # Try to search for newlib in the standard search path of the compiler for includes
 ifeq (,$(NEWLIB_INCLUDE_DIR))
-  COMPILER_INCLUDE_PATHS := $(shell $(PREFIX)gcc -v -x c -E /dev/null 2>&1 | grep '^\s' | tr -d '\n')
+  COMPILER_INCLUDE_PATHS := $(shell $(PREFIX)gcc -v -x c -E /dev/null 2>&1 | \
+                              sed \
+                              -e '1,/\#include <...> search starts here:/d' \
+                              -e '/End of search list./,$$d' \
+                              -e 's/^ *//')
   NEWLIB_INCLUDE_DIR := $(firstword $(dir $(wildcard $(addsuffix /newlib.h, $(COMPILER_INCLUDE_PATHS)))))
 endif
 

--- a/makefiles/libc/newlib.mk
+++ b/makefiles/libc/newlib.mk
@@ -39,30 +39,30 @@ ifeq (,$(NEWLIB_INCLUDE_DIR))
 endif
 
 ifeq (,$(NEWLIB_INCLUDE_DIR))
-# Since Clang is not installed as a separate instance for each crossdev target
-# we need to tell it where to look for platform specific includes (Newlib
-# headers instead of Linux/Glibc headers.)
-# On GCC this is done when building the cross compiler toolchain so we do not
-# actually need to specify the include paths for system includes.
-# Ubuntu gcc-arm-embedded toolchain (https://launchpad.net/gcc-arm-embedded)
-# places newlib headers in several places, but the primary source seem to be
-# /etc/alternatives/gcc-arm-none-eabi-include
-# Gentoo Linux crossdev place the newlib headers in /usr/arm-none-eabi/include
-# Arch Linux also place the newlib headers in /usr/arm-none-eabi/include
-# Ubuntu seem to put a copy of the newlib headers in the same place as
-# Gentoo crossdev, but we prefer to look at /etc/alternatives first.
-# On OSX, newlib includes are possibly located in
-# /usr/local/opt/arm-none-eabi*/arm-none-eabi/include or /usr/local/opt/gcc-arm/arm-none-eabi/include
+  # Since Clang is not installed as a separate instance for each crossdev target
+  # we need to tell it where to look for platform specific includes (Newlib
+  # headers instead of Linux/Glibc headers.)
+  # On GCC this is done when building the cross compiler toolchain so we do not
+  # actually need to specify the include paths for system includes.
+  # Ubuntu gcc-arm-embedded toolchain (https://launchpad.net/gcc-arm-embedded)
+  # places newlib headers in several places, but the primary source seem to be
+  # /etc/alternatives/gcc-arm-none-eabi-include
+  # Gentoo Linux crossdev place the newlib headers in /usr/arm-none-eabi/include
+  # Arch Linux also place the newlib headers in /usr/arm-none-eabi/include
+  # Ubuntu seem to put a copy of the newlib headers in the same place as
+  # Gentoo crossdev, but we prefer to look at /etc/alternatives first.
+  # On OSX, newlib includes are possibly located in
+  # /usr/local/opt/arm-none-eabi*/arm-none-eabi/include or /usr/local/opt/gcc-arm/arm-none-eabi/include
   NEWLIB_INCLUDE_PATTERNS ?= \
     /etc/alternatives/gcc-$(TARGET_ARCH)-include \
     /usr/$(TARGET_ARCH)/include \
     /usr/local/opt/$(TARGET_ARCH)*/$(TARGET_ARCH)/include \
     /usr/local/opt/gcc-*/$(TARGET_ARCH)/include \
     #
-# Use the wildcard Makefile function to search for existing directories matching
-# the patterns above. We use the -isystem gcc/clang argument to add the include
-# directories as system include directories, which means they will not be
-# searched until after all the project specific include directories (-I/path)
+  # Use the wildcard Makefile function to search for existing directories matching
+  # the patterns above. We use the -isystem gcc/clang argument to add the include
+  # directories as system include directories, which means they will not be
+  # searched until after all the project specific include directories (-I/path)
   NEWLIB_INCLUDE_DIR := $(firstword $(realpath $(dir $(wildcard $(addsuffix /newlib.h, $(NEWLIB_INCLUDE_PATTERNS))))))
 endif
 

--- a/makefiles/libc/newlib.mk
+++ b/makefiles/libc/newlib.mk
@@ -52,7 +52,7 @@ ifeq (,$(NEWLIB_INCLUDE_DIR))
 # the patterns above. We use the -isystem gcc/clang argument to add the include
 # directories as system include directories, which means they will not be
 # searched until after all the project specific include directories (-I/path)
-  NEWLIB_INCLUDE_DIR ?= $(firstword $(dir $(wildcard $(addsuffix /newlib.h, $(NEWLIB_INCLUDE_PATTERNS)))))
+  NEWLIB_INCLUDE_DIR := $(firstword $(dir $(wildcard $(addsuffix /newlib.h, $(NEWLIB_INCLUDE_PATTERNS)))))
 endif
 
 # If nothing was found we will try to fall back to searching for a cross-gcc in

--- a/makefiles/libc/newlib.mk
+++ b/makefiles/libc/newlib.mk
@@ -19,6 +19,13 @@ endif
 
 export LINKFLAGS += -lc
 
+# Note on `realpath` vs `abspath`
+#
+# `realpath` is used instead of `abspath` to support Mingw32
+# It fixes issues when using windows formatted paths like in the gcc output
+# It does leave the trailing `/` on windows though
+
+
 # Search for Newlib include directories
 
 # Try to search for newlib in the standard search path of the compiler for includes
@@ -62,7 +69,7 @@ endif
 # If nothing was found we will try to fall back to searching for a cross-gcc in
 # the current PATH and use a relative path for the includes
 ifeq (,$(NEWLIB_INCLUDE_DIR))
-  NEWLIB_INCLUDE_DIR := $(abspath $(wildcard $(dir $(shell command -v $(PREFIX)gcc 2>/dev/null))/../$(TARGET_ARCH)/include))
+  NEWLIB_INCLUDE_DIR := $(realpath $(wildcard $(dir $(shell command -v $(PREFIX)gcc 2>/dev/null))/../$(TARGET_ARCH)/include))
 endif
 
 ifeq ($(TOOLCHAIN),llvm)
@@ -72,7 +79,7 @@ ifeq ($(TOOLCHAIN),llvm)
   # We also add -nostdinc to avoid including the host system headers by mistake
   # in case some header is missing from the cross tool chain
   NEWLIB_INCLUDES := -isystem $(NEWLIB_INCLUDE_DIR) -nostdinc
-  NEWLIB_INCLUDES += $(addprefix -isystem ,$(abspath $(wildcard $(dir $(NEWLIB_INCLUDE_DIR))/usr/include)))
+  NEWLIB_INCLUDES += $(addprefix -isystem ,$(realpath $(wildcard $(dir $(NEWLIB_INCLUDE_DIR))/usr/include)))
 
   # Newlib includes should go before GCC includes. This is especially important
   # when using Clang, because Clang will yield compilation errors on some GCC-

--- a/makefiles/libc/newlib.mk
+++ b/makefiles/libc/newlib.mk
@@ -79,9 +79,9 @@ ifeq ($(TOOLCHAIN),llvm)
 endif
 
 ifeq (1,$(USE_NEWLIB_NANO))
-  NEWLIB_NANO_INCLUDE_DIR ?= $(firstword $(wildcard $(NEWLIB_INCLUDE_DIR)newlib-nano \
-                                                    $(NEWLIB_INCLUDE_DIR)newlib/nano \
-                                                    $(NEWLIB_INCLUDE_DIR)nano))
+  NEWLIB_NANO_INCLUDE_DIR ?= $(firstword $(wildcard $(NEWLIB_INCLUDE_DIR)/newlib-nano \
+                                                    $(NEWLIB_INCLUDE_DIR)/newlib/nano \
+                                                    $(NEWLIB_INCLUDE_DIR)/nano))
   # newlib-nano overrides newlib.h and its include dir should therefore go before
   # the regular system include dirs.
   INCLUDES := -isystem $(NEWLIB_NANO_INCLUDE_DIR) $(INCLUDES)

--- a/makefiles/libc/newlib.mk
+++ b/makefiles/libc/newlib.mk
@@ -35,7 +35,7 @@ ifeq (,$(NEWLIB_INCLUDE_DIR))
                               -e '1,/\#include <...> search starts here:/d' \
                               -e '/End of search list./,$$d' \
                               -e 's/^ *//')
-  NEWLIB_INCLUDE_DIR := $(firstword $(dir $(wildcard $(addsuffix /newlib.h, $(COMPILER_INCLUDE_PATHS)))))
+  NEWLIB_INCLUDE_DIR := $(firstword $(realpath $(dir $(wildcard $(addsuffix /newlib.h, $(COMPILER_INCLUDE_PATHS))))))
 endif
 
 ifeq (,$(NEWLIB_INCLUDE_DIR))
@@ -63,7 +63,7 @@ ifeq (,$(NEWLIB_INCLUDE_DIR))
 # the patterns above. We use the -isystem gcc/clang argument to add the include
 # directories as system include directories, which means they will not be
 # searched until after all the project specific include directories (-I/path)
-  NEWLIB_INCLUDE_DIR := $(firstword $(dir $(wildcard $(addsuffix /newlib.h, $(NEWLIB_INCLUDE_PATTERNS)))))
+  NEWLIB_INCLUDE_DIR := $(firstword $(realpath $(dir $(wildcard $(addsuffix /newlib.h, $(NEWLIB_INCLUDE_PATTERNS))))))
 endif
 
 # If nothing was found we will try to fall back to searching for a cross-gcc in


### PR DESCRIPTION
# Backport of #9515

### Contribution description

Fixes:

* clean the output of gcc to get compiler includes
* Non indented comments
* Patterns not taken into account
* The need to have a trailing slash in NEWLIB_INCLUDE_DIR

### Testing

Can be tested by compiling `tests/libc_newlib`:

```
make -C tests/libc_newlib/ BOARD=samr21-xpro clean all
make -C tests/libc_newlib/ BOARD=samr21-xpro clean all TOOLCHAIN=llvm # this should also work.
```

### Issues/PRs references

Fixes for https://github.com/RIOT-OS/RIOT/pull/9394

Split from https://github.com/RIOT-OS/RIOT/pull/9512