### PR TITLE
cpu/cc2538: add TI vendor headers

### DIFF
--- a/cpu/cc2538/include/vendor/hw_aes.h
+++ b/cpu/cc2538/include/vendor/hw_aes.h
@@ -1,0 +1,4379 @@
+/******************************************************************************
+*  Filename:       hw_aes.h
+*  Revised:        $Date: 2013-04-12 15:10:54 +0200 (Fri, 12 Apr 2013) $
+*  Revision:       $Revision: 9735 $
+*
+*  Copyright (C) 2013 Texas Instruments Incorporated - http://www.ti.com/
+*
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*    Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+*
+*    Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+*
+*    Neither the name of Texas Instruments Incorporated nor the names of
+*    its contributors may be used to endorse or promote products derived
+*    from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+*  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+*  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+*  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+*  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+*  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+*  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+*  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+*  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+******************************************************************************/
+
+#ifndef __HW_AES_H__
+#define __HW_AES_H__
+
+//*****************************************************************************
+//
+// The following are defines for the AES register offsets.
+//
+//*****************************************************************************
+#define AES_DMAC_CH0_CTRL       0x4008B000  // Channel control This register 
+                                            // is used for channel enabling and 
+                                            // priority selection. When a 
+                                            // channel is disabled, it becomes 
+                                            // inactive only when all ongoing 
+                                            // requests are finished. 
+#define AES_DMAC_CH0_EXTADDR    0x4008B004  // Channel external address 
+#define AES_DMAC_CH0_DMALENGTH \
+                                0x4008B00C  // Channel DMA length 
+
+#define AES_DMAC_STATUS         0x4008B018  // DMAC status This register 
+                                            // provides the actual state of 
+                                            // each DMA channel. It also 
+                                            // reports port errors in case 
+                                            // these were received by the 
+                                            // master interface module during 
+                                            // the data transfer. 
+#define AES_DMAC_SWRES          0x4008B01C  // DMAC software reset register 
+                                            // Software reset is used to reset 
+                                            // the DMAC to stop all transfers 
+                                            // and clears the port error status 
+                                            // register. After the software 
+                                            // reset is performed, all the 
+                                            // channels are disabled and no new 
+                                            // requests are performed by the 
+                                            // channels. The DMAC waits for the 
+                                            // existing (active) requests to 
+                                            // finish and accordingly sets the 
+                                            // DMAC status registers. 
+#define AES_DMAC_CH1_CTRL       0x4008B020  // Channel control This register 
+                                            // is used for channel enabling and 
+                                            // priority selection. When a 
+                                            // channel is disabled, it becomes 
+                                            // inactive only when all ongoing 
+                                            // requests are finished. 
+#define AES_DMAC_CH1_EXTADDR    0x4008B024  // Channel external address 
+#define AES_DMAC_CH1_DMALENGTH \
+                                0x4008B02C  // Channel DMA length 
+
+#define AES_DMAC_MST_RUNPARAMS \
+                                0x4008B078  // DMAC master run-time parameters 
+                                            // This register defines all the 
+                                            // run-time parameters for the AHB 
+                                            // master interface port. These 
+                                            // parameters are required for the 
+                                            // proper functioning of the 
+                                            // EIP-101m AHB master adapter. 
+
+#define AES_DMAC_PERSR          0x4008B07C  // DMAC port error raw status 
+                                            // register This register provides 
+                                            // the actual status of individual 
+                                            // port errors. It also indicates 
+                                            // which channel is serviced by an 
+                                            // external AHB port (which is 
+                                            // frozen by a port error). A port 
+                                            // error aborts operations on all 
+                                            // serviced channels (channel 
+                                            // enable bit is forced to 0) and 
+                                            // prevents further transfers via 
+                                            // that port until the error is 
+                                            // cleared by writing to the 
+                                            // DMAC_SWRES register. 
+#define AES_DMAC_OPTIONS        0x4008B0F8  // DMAC options register These 
+                                            // registers contain information 
+                                            // regarding the different options 
+                                            // configured in this DMAC. 
+#define AES_DMAC_VERSION        0x4008B0FC  // DMAC version register This 
+                                            // register contains an indication 
+                                            // (or signature) of the EIP type 
+                                            // of this DMAC, as well as the 
+                                            // hardware version/patch numbers. 
+#define AES_KEY_STORE_WRITE_AREA \
+                                0x4008B400  // Key store write area register 
+                                            // This register defines where the 
+                                            // keys should be written in the 
+                                            // key store RAM. After writing 
+                                            // this register, the key store 
+                                            // module is ready to receive the 
+                                            // keys through a DMA operation. In 
+                                            // case the key data transfer 
+                                            // triggered an error in the key 
+                                            // store, the error will be 
+                                            // available in the interrupt 
+                                            // status register after the DMA is 
+                                            // finished. The key store 
+                                            // write-error is asserted when the 
+                                            // programmed/selected area is not 
+                                            // completely written. This error 
+                                            // is also asserted when the DMA 
+                                            // operation writes to ram areas 
+                                            // that are not selected. The key 
+                                            // store RAM is divided into 8 
+                                            // areas of 128 bits. 192-bit keys 
+                                            // written in the key store RAM 
+                                            // should start on boundaries of 
+                                            // 256 bits. This means that 
+                                            // writing a 192-bit key to the key 
+                                            // store RAM must be done by 
+                                            // writing 256 bits of data with 
+                                            // the 64 most-significant bits set 
+                                            // to 0. These bits are ignored by 
+                                            // the AES engine. 
+
+#define AES_KEY_STORE_WRITTEN_AREA \
+                                0x4008B404  // Key store written area register 
+                                            // This register shows which areas 
+                                            // of the key store RAM contain 
+                                            // valid written keys. When a new 
+                                            // key needs to be written to the 
+                                            // key store, on a location that is 
+                                            // already occupied by a valid key, 
+                                            // this key area must be cleared 
+                                            // first. This can be done by 
+                                            // writing this register before the 
+                                            // new key is written to the key 
+                                            // store memory. Attempting to 
+                                            // write to a key area that already 
+                                            // contains a valid key is not 
+                                            // allowed and results in an error. 
+
+#define AES_KEY_STORE_SIZE      0x4008B408  // Key store size register This 
+                                            // register defines the size of the 
+                                            // keys that are written with DMA. 
+                                            // This register should be 
+                                            // configured before writing to the 
+                                            // KEY_STORE_WRITE_AREA register. 
+#define AES_KEY_STORE_READ_AREA \
+                                0x4008B40C  // Key store read area register 
+                                            // This register selects the key 
+                                            // store RAM area from where the 
+                                            // key needs to be read that will 
+                                            // be used for an AES operation. 
+                                            // The operation directly starts 
+                                            // after writing this register. 
+                                            // When the operation is finished, 
+                                            // the status of the key store read 
+                                            // operation is available in the 
+                                            // interrupt status register. Key 
+                                            // store read error is asserted 
+                                            // when a RAM area is selected 
+                                            // which does not contain valid 
+                                            // written key. 
+
+#define AES_AES_KEY2_0          0x4008B500  // AES_KEY2_0 / AES_GHASH_H_IN_0 
+                                            // Second Key / GHASH Key 
+                                            // (internal, but clearable) The 
+                                            // following registers are not 
+                                            // accessible through the host for 
+                                            // reading and writing. They are 
+                                            // used to store internally 
+                                            // calculated key information and 
+                                            // intermediate results. However, 
+                                            // when the host performs a write 
+                                            // to the any of the respective 
+                                            // AES_KEY2_n or AES_KEY3_n 
+                                            // addresses, respectively the 
+                                            // whole 128-bit AES_KEY2_n or 
+                                            // AES_KEY3_n register is cleared 
+                                            // to 0s. The AES_GHASH_H_IN_n 
+                                            // registers (required for GHASH, 
+                                            // which is part of GCM) are mapped 
+                                            // to the AES_KEY2_n registers. The 
+                                            // (intermediate) authentication 
+                                            // result for GCM and CCM is stored 
+                                            // in the AES_KEY3_n register. 
+#define AES_AES_KEY2_1          0x4008B504  // AES_KEY2_1 / AES_GHASH_H_IN_1 
+                                            // Second Key / GHASH Key 
+                                            // (internal, but clearable) The 
+                                            // following registers are not 
+                                            // accessible through the host for 
+                                            // reading and writing. They are 
+                                            // used to store internally 
+                                            // calculated key information and 
+                                            // intermediate results. However, 
+                                            // when the host performs a write 
+                                            // to the any of the respective 
+                                            // AES_KEY2_n or AES_KEY3_n 
+                                            // addresses, respectively the 
+                                            // whole 128-bit AES_KEY2_n or 
+                                            // AES_KEY3_n register is cleared 
+                                            // to 0s. The AES_GHASH_H_IN_n 
+                                            // registers (required for GHASH, 
+                                            // which is part of GCM) are mapped 
+                                            // to the AES_KEY2_n registers. The 
+                                            // (intermediate) authentication 
+                                            // result for GCM and CCM is stored 
+                                            // in the AES_KEY3_n register. 
+#define AES_AES_KEY2_2          0x4008B508  // AES_KEY2_2 / AES_GHASH_H_IN_2 
+                                            // Second Key / GHASH Key 
+                                            // (internal, but clearable) The 
+                                            // following registers are not 
+                                            // accessible through the host for 
+                                            // reading and writing. They are 
+                                            // used to store internally 
+                                            // calculated key information and 
+                                            // intermediate results. However, 
+                                            // when the host performs a write 
+                                            // to the any of the respective 
+                                            // AES_KEY2_n or AES_KEY3_n 
+                                            // addresses, respectively the 
+                                            // whole 128-bit AES_KEY2_n or 
+                                            // AES_KEY3_n register is cleared 
+                                            // to 0s. The AES_GHASH_H_IN_n 
+                                            // registers (required for GHASH, 
+                                            // which is part of GCM) are mapped 
+                                            // to the AES_KEY2_n registers. The 
+                                            // (intermediate) authentication 
+                                            // result for GCM and CCM is stored 
+                                            // in the AES_KEY3_n register. 
+#define AES_AES_KEY2_3          0x4008B50C  // AES_KEY2_3 / AES_GHASH_H_IN_3 
+                                            // Second Key / GHASH Key 
+                                            // (internal, but clearable) The 
+                                            // following registers are not 
+                                            // accessible through the host for 
+                                            // reading and writing. They are 
+                                            // used to store internally 
+                                            // calculated key information and 
+                                            // intermediate results. However, 
+                                            // when the host performs a write 
+                                            // to the any of the respective 
+                                            // AES_KEY2_n or AES_KEY3_n 
+                                            // addresses, respectively the 
+                                            // whole 128-bit AES_KEY2_n or 
+                                            // AES_KEY3_n register is cleared 
+                                            // to 0s. The AES_GHASH_H_IN_n 
+                                            // registers (required for GHASH, 
+                                            // which is part of GCM) are mapped 
+                                            // to the AES_KEY2_n registers. The 
+                                            // (intermediate) authentication 
+                                            // result for GCM and CCM is stored 
+                                            // in the AES_KEY3_n register. 
+#define AES_AES_KEY3_0          0x4008B510  // AES_KEY3_0 / AES_KEY2_4 Third 
+                                            // Key / Second Key (internal, but 
+                                            // clearable) The following 
+                                            // registers are not accessible 
+                                            // through the host for reading and 
+                                            // writing. They are used to store 
+                                            // internally calculated key 
+                                            // information and intermediate 
+                                            // results. However, when the host 
+                                            // performs a write to the any of 
+                                            // the respective AES_KEY2_n or 
+                                            // AES_KEY3_n addresses, 
+                                            // respectively the whole 128-bit 
+                                            // AES_KEY2_n or AES_KEY3_n 
+                                            // register is cleared to 0s. The 
+                                            // AES_GHASH_H_IN_n registers 
+                                            // (required for GHASH, which is 
+                                            // part of GCM) are mapped to the 
+                                            // AES_KEY2_n registers. The 
+                                            // (intermediate) authentication 
+                                            // result for GCM and CCM is stored 
+                                            // in the AES_KEY3_n register. 
+#define AES_AES_KEY3_1          0x4008B514  // AES_KEY3_1 / AES_KEY2_5 Third 
+                                            // Key / Second Key (internal, but 
+                                            // clearable) The following 
+                                            // registers are not accessible 
+                                            // through the host for reading and 
+                                            // writing. They are used to store 
+                                            // internally calculated key 
+                                            // information and intermediate 
+                                            // results. However, when the host 
+                                            // performs a write to the any of 
+                                            // the respective AES_KEY2_n or 
+                                            // AES_KEY3_n addresses, 
+                                            // respectively the whole 128-bit 
+                                            // AES_KEY2_n or AES_KEY3_n 
+                                            // register is cleared to 0s. The 
+                                            // AES_GHASH_H_IN_n registers 
+                                            // (required for GHASH, which is 
+                                            // part of GCM) are mapped to the 
+                                            // AES_KEY2_n registers. The 
+                                            // (intermediate) authentication 
+                                            // result for GCM and CCM is stored 
+                                            // in the AES_KEY3_n register. 
+#define AES_AES_KEY3_2          0x4008B518  // AES_KEY3_2 / AES_KEY2_6 Third 
+                                            // Key / Second Key (internal, but 
+                                            // clearable) The following 
+                                            // registers are not accessible 
+                                            // through the host for reading and 
+                                            // writing. They are used to store 
+                                            // internally calculated key 
+                                            // information and intermediate 
+                                            // results. However, when the host 
+                                            // performs a write to the any of 
+                                            // the respective AES_KEY2_n or 
+                                            // AES_KEY3_n addresses, 
+                                            // respectively the whole 128-bit 
+                                            // AES_KEY2_n or AES_KEY3_n 
+                                            // register is cleared to 0s. The 
+                                            // AES_GHASH_H_IN_n registers 
+                                            // (required for GHASH, which is 
+                                            // part of GCM) are mapped to the 
+                                            // AES_KEY2_n registers. The 
+                                            // (intermediate) authentication 
+                                            // result for GCM and CCM is stored 
+                                            // in the AES_KEY3_n register. 
+#define AES_AES_KEY3_3          0x4008B51C  // AES_KEY3_3 / AES_KEY2_7 Third 
+                                            // Key / Second Key (internal, but 
+                                            // clearable) The following 
+                                            // registers are not accessible 
+                                            // through the host for reading and 
+                                            // writing. They are used to store 
+                                            // internally calculated key 
+                                            // information and intermediate 
+                                            // results. However, when the host 
+                                            // performs a write to the any of 
+                                            // the respective AES_KEY2_n or 
+                                            // AES_KEY3_n addresses, 
+                                            // respectively the whole 128-bit 
+                                            // AES_KEY2_n or AES_KEY3_n 
+                                            // register is cleared to 0s. The 
+                                            // AES_GHASH_H_IN_n registers 
+                                            // (required for GHASH, which is 
+                                            // part of GCM) are mapped to the 
+                                            // AES_KEY2_n registers. The 
+                                            // (intermediate) authentication 
+                                            // result for GCM and CCM is stored 
+                                            // in the AES_KEY3_n register. 
+#define AES_AES_IV_0            0x4008B540  // AES initialization vector 
+                                            // registers These registers are 
+                                            // used to provide and read the IV 
+                                            // from the AES engine. 
+#define AES_AES_IV_1            0x4008B544  // AES initialization vector 
+                                            // registers These registers are 
+                                            // used to provide and read the IV 
+                                            // from the AES engine. 
+#define AES_AES_IV_2            0x4008B548  // AES initialization vector 
+                                            // registers These registers are 
+                                            // used to provide and read the IV 
+                                            // from the AES engine. 
+#define AES_AES_IV_3            0x4008B54C  // AES initialization vector 
+                                            // registers These registers are 
+                                            // used to provide and read the IV 
+                                            // from the AES engine. 
+#define AES_AES_CTRL            0x4008B550  // AES input/output buffer control 
+                                            // and mode register This register 
+                                            // specifies the AES mode of 
+                                            // operation for the EIP-120t. 
+                                            // Electronic codebook (ECB) mode 
+                                            // is automatically selected if 
+                                            // bits [28:5] of this register are 
+                                            // all 0. 
+#define AES_AES_C_LENGTH_0      0x4008B554  // AES crypto length registers 
+                                            // (LSW) These registers are used 
+                                            // to write the Length values to 
+                                            // the EIP-120t. While processing, 
+                                            // the length values decrement to 
+                                            // 0. If both lengths are 0, the 
+                                            // data stream is finished and a 
+                                            // new context is requested. For 
+                                            // basic AES modes (ECB, CBC, and 
+                                            // CTR), a crypto length of 0 can 
+                                            // be written if multiple streams 
+                                            // need to be processed with the 
+                                            // same key. Writing 0 length 
+                                            // results in continued data 
+                                            // requests until a new context is 
+                                            // written. For the other modes 
+                                            // (CBC-MAC, GCM, and CCM) no (new) 
+                                            // data requests are done if the 
+                                            // length decrements to or equals 
+                                            // 0. It is advised to write a new 
+                                            // length per packet. If the length 
+                                            // registers decrement to 0, no new 
+                                            // data is processed until a new 
+                                            // context or length value is 
+                                            // written. When writing a new mode 
+                                            // without writing the length 
+                                            // registers, the length register 
+                                            // values from the previous context 
+                                            // is reused. 
+#define AES_AES_C_LENGTH_1      0x4008B558  // AES crypto length registers 
+                                            // (MSW) These registers are used 
+                                            // to write the Length values to 
+                                            // the EIP-120t. While processing, 
+                                            // the length values decrement to 
+                                            // 0. If both lengths are 0, the 
+                                            // data stream is finished and a 
+                                            // new context is requested. For 
+                                            // basic AES modes (ECB, CBC, and 
+                                            // CTR), a crypto length of 0 can 
+                                            // be written if multiple streams 
+                                            // need to be processed with the 
+                                            // same key. Writing 0 length 
+                                            // results in continued data 
+                                            // requests until a new context is 
+                                            // written. For the other modes 
+                                            // (CBC-MAC, GCM and CCM) no (new) 
+                                            // data requests are done if the 
+                                            // length decrements to or equals 
+                                            // 0. It is advised to write a new 
+                                            // length per packet. If the length 
+                                            // registers decrement to 0, no new 
+                                            // data is processed until a new 
+                                            // context or length value is 
+                                            // written. When writing a new mode 
+                                            // without writing the length 
+                                            // registers, the length register 
+                                            // values from the previous context 
+                                            // is reused. 
+#define AES_AES_AUTH_LENGTH     0x4008B55C  // Authentication length register 
+#define AES_AES_DATA_IN_OUT_0   0x4008B560  // Data input/output registers The 
+                                            // data registers are typically 
+                                            // accessed through the DMA and not 
+                                            // with host writes and/or reads. 
+                                            // However, for debugging purposes 
+                                            // the data input/output registers 
+                                            // can be accessed via host write 
+                                            // and read operations. The 
+                                            // registers are used to buffer the 
+                                            // input/output data blocks to/from 
+                                            // the EIP-120t. Note: The data 
+                                            // input buffer (AES_DATA_IN_n) and 
+                                            // data output buffer 
+                                            // (AES_DATA_OUT_n) are mapped to 
+                                            // the same address locations. 
+                                            // Writes (both DMA and host) to 
+                                            // these addresses load the Input 
+                                            // Buffer while reads pull from the 
+                                            // Output Buffer. Therefore, for 
+                                            // write access, the data input 
+                                            // buffer is written; for read 
+                                            // access, the data output buffer 
+                                            // is read. The data input buffer 
+                                            // must be written before starting 
+                                            // an operation. The data output 
+                                            // buffer contains valid data on 
+                                            // completion of an operation. 
+                                            // Therefore, any 128-bit data 
+                                            // block can be split over multiple 
+                                            // 32-bit word transfers; these can 
+                                            // be mixed with other host 
+                                            // transfers over the external 
+                                            // interface. 
+#define AES_AES_DATA_IN_OUT_1   0x4008B564  // Data Input/Output Registers The 
+                                            // data registers are typically 
+                                            // accessed via DMA and not with 
+                                            // host writes and/or reads. 
+                                            // However, for debugging purposes 
+                                            // the Data Input/Output Registers 
+                                            // can be accessed via host write 
+                                            // and read operations. The 
+                                            // registers are used to buffer the 
+                                            // input/output data blocks to/from 
+                                            // the EIP-120t. Note: The data 
+                                            // input buffer (AES_DATA_IN_n) and 
+                                            // data output buffer 
+                                            // (AES_DATA_OUT_n) are mapped to 
+                                            // the same address locations. 
+                                            // Writes (both DMA and host) to 
+                                            // these addresses load the Input 
+                                            // Buffer while reads pull from the 
+                                            // Output Buffer. Therefore, for 
+                                            // write access, the data input 
+                                            // buffer is written; for read 
+                                            // access, the data output buffer 
+                                            // is read. The data input buffer 
+                                            // must be written before starting 
+                                            // an operation. The data output 
+                                            // buffer contains valid data on 
+                                            // completion of an operation. 
+                                            // Therefore, any 128-bit data 
+                                            // block can be split over multiple 
+                                            // 32-bit word transfers; these can 
+                                            // be mixed with other host 
+                                            // transfers over the external 
+                                            // interface. 
+#define AES_AES_DATA_IN_OUT_2   0x4008B568  // Data Input/Output Registers The 
+                                            // data registers are typically 
+                                            // accessed via DMA and not with 
+                                            // host writes and/or reads. 
+                                            // However, for debugging purposes 
+                                            // the Data Input/Output Registers 
+                                            // can be accessed via host write 
+                                            // and read operations. The 
+                                            // registers are used to buffer the 
+                                            // input/output data blocks to/from 
+                                            // the EIP-120t. Note: The data 
+                                            // input buffer (AES_DATA_IN_n) and 
+                                            // data output buffer 
+                                            // (AES_DATA_OUT_n) are mapped to 
+                                            // the same address locations. 
+                                            // Writes (both DMA and host) to 
+                                            // these addresses load the Input 
+                                            // Buffer while reads pull from the 
+                                            // Output Buffer. Therefore, for 
+                                            // write access, the data input 
+                                            // buffer is written; for read 
+                                            // access, the data output buffer 
+                                            // is read. The data input buffer 
+                                            // must be written before starting 
+                                            // an operation. The data output 
+                                            // buffer contains valid data on 
+                                            // completion of an operation. 
+                                            // Therefore, any 128-bit data 
+                                            // block can be split over multiple 
+                                            // 32-bit word transfers; these can 
+                                            // be mixed with other host 
+                                            // transfers over the external 
+                                            // interface. 
+#define AES_AES_DATA_IN_OUT_3   0x4008B56C  // Data Input/Output Registers The 
+                                            // data registers are typically 
+                                            // accessed via DMA and not with 
+                                            // host writes and/or reads. 
+                                            // However, for debugging purposes 
+                                            // the Data Input/Output Registers 
+                                            // can be accessed via host write 
+                                            // and read operations. The 
+                                            // registers are used to buffer the 
+                                            // input/output data blocks to/from 
+                                            // the EIP-120t. Note: The data 
+                                            // input buffer (AES_DATA_IN_n) and 
+                                            // data output buffer 
+                                            // (AES_DATA_OUT_n) are mapped to 
+                                            // the same address locations. 
+                                            // Writes (both DMA and host) to 
+                                            // these addresses load the Input 
+                                            // Buffer while reads pull from the 
+                                            // Output Buffer. Therefore, for 
+                                            // write access, the data input 
+                                            // buffer is written; for read 
+                                            // access, the data output buffer 
+                                            // is read. The data input buffer 
+                                            // must be written before starting 
+                                            // an operation. The data output 
+                                            // buffer contains valid data on 
+                                            // completion of an operation. 
+                                            // Therefore, any 128-bit data 
+                                            // block can be split over multiple 
+                                            // 32-bit word transfers; these can 
+                                            // be mixed with other host 
+                                            // transfers over the external 
+                                            // interface. 
+#define AES_AES_TAG_OUT_0       0x4008B570  // TAG registers The tag registers 
+                                            // can be accessed via DMA or 
+                                            // directly with host reads. These 
+                                            // registers buffer the TAG from 
+                                            // the EIP-120t. The registers are 
+                                            // shared with the intermediate 
+                                            // authentication result registers, 
+                                            // but cannot be read until the 
+                                            // processing is finished. While 
+                                            // processing, a read from these 
+                                            // registers returns 0s. If an 
+                                            // operation does not return a TAG, 
+                                            // reading from these registers 
+                                            // returns an IV. If an operation 
+                                            // returns a TAG plus an IV and 
+                                            // both need to be read by the 
+                                            // host, the host must first read 
+                                            // the TAG followed by the IV. 
+                                            // Reading these in reverse order 
+                                            // will return the IV twice. 
+#define AES_AES_TAG_OUT_1       0x4008B574  // TAG registers The tag registers 
+                                            // can be accessed via DMA or 
+                                            // directly with host reads. These 
+                                            // registers buffer the TAG from 
+                                            // the EIP-120t. The registers are 
+                                            // shared with the intermediate 
+                                            // authentication result registers, 
+                                            // but cannot be read until the 
+                                            // processing is finished. While 
+                                            // processing, a read from these 
+                                            // registers returns 0s. If an 
+                                            // operation does not return a TAG, 
+                                            // reading from these registers 
+                                            // returns an IV. If an operation 
+                                            // returns a TAG plus an IV and 
+                                            // both need to be read by the 
+                                            // host, the host must first read 
+                                            // the TAG followed by the IV. 
+                                            // Reading these in reverse order 
+                                            // returns the IV twice. 
+#define AES_AES_TAG_OUT_2       0x4008B578  // TAG registers The tag registers 
+                                            // can be accessed via DMA or 
+                                            // directly with host reads. These 
+                                            // registers buffer the TAG from 
+                                            // the EIP-120t. The registers are 
+                                            // shared with the intermediate 
+                                            // authentication result registers, 
+                                            // but cannot be read until the 
+                                            // processing is finished. While 
+                                            // processing, a read from these 
+                                            // registers returns 0s. If an 
+                                            // operation does not return a TAG, 
+                                            // reading from these registers 
+                                            // returns an IV. If an operation 
+                                            // returns a TAG plus an IV and 
+                                            // both need to be read by the 
+                                            // host, the host must first read 
+                                            // the TAG followed by the IV. 
+                                            // Reading these in reverse order 
+                                            // returns the IV twice. 
+#define AES_AES_TAG_OUT_3       0x4008B57C  // TAG registers The tag registers 
+                                            // can be accessed via DMA or 
+                                            // directly with host reads. These 
+                                            // registers buffer the TAG from 
+                                            // the EIP-120t. The registers are 
+                                            // shared with the intermediate 
+                                            // authentication result registers, 
+                                            // but cannot be read until the 
+                                            // processing is finished. While 
+                                            // processing, a read from these 
+                                            // registers returns 0s. If an 
+                                            // operation does not return a TAG, 
+                                            // reading from these registers 
+                                            // returns an IV. If an operation 
+                                            // returns a TAG plus an IV and 
+                                            // both need to be read by the 
+                                            // host, the host must first read 
+                                            // the TAG followed by the IV. 
+                                            // Reading these in reverse order 
+                                            // returns the IV twice. 
+#define AES_HASH_DATA_IN_0      0x4008B600  // HASH data input registers The 
+                                            // data input registers should be 
+                                            // used to provide input data to 
+                                            // the hash module through the 
+                                            // slave interface. 
+#define AES_HASH_DATA_IN_1      0x4008B604  // HASH data input registers The 
+                                            // data input registers should be 
+                                            // used to provide input data to 
+                                            // the hash module through the 
+                                            // slave interface. 
+#define AES_HASH_DATA_IN_2      0x4008B608  // HASH data input registers The 
+                                            // data input registers should be 
+                                            // used to provide input data to 
+                                            // the hash module through the 
+                                            // slave interface. 
+#define AES_HASH_DATA_IN_3      0x4008B60C  // HASH data input registers The 
+                                            // data input registers should be 
+                                            // used to provide input data to 
+                                            // the hash module through the 
+                                            // slave interface. 
+#define AES_HASH_DATA_IN_4      0x4008B610  // HASH data input registers The 
+                                            // data input registers should be 
+                                            // used to provide input data to 
+                                            // the hash module through the 
+                                            // slave interface. 
+#define AES_HASH_DATA_IN_5      0x4008B614  // HASH data input registers The 
+                                            // data input registers should be 
+                                            // used to provide input data to 
+                                            // the hash module through the 
+                                            // slave interface. 
+#define AES_HASH_DATA_IN_6      0x4008B618  // HASH data input registers The 
+                                            // data input registers should be 
+                                            // used to provide input data to 
+                                            // the hash module through the 
+                                            // slave interface. 
+#define AES_HASH_DATA_IN_7      0x4008B61C  // HASH data input registers The 
+                                            // data input registers should be 
+                                            // used to provide input data to 
+                                            // the hash module through the 
+                                            // slave interface. 
+#define AES_HASH_DATA_IN_8      0x4008B620  // HASH data input registers The 
+                                            // data input registers should be 
+                                            // used to provide input data to 
+                                            // the hash module through the 
+                                            // slave interface. 
+#define AES_HASH_DATA_IN_9      0x4008B624  // HASH data input registers The 
+                                            // data input registers should be 
+                                            // used to provide input data to 
+                                            // the hash module through the 
+                                            // slave interface. 
+#define AES_HASH_DATA_IN_10     0x4008B628  // HASH data input registers The 
+                                            // data input registers should be 
+                                            // used to provide input data to 
+                                            // the hash module through the 
+                                            // slave interface. 
+#define AES_HASH_DATA_IN_11     0x4008B62C  // HASH data input registers The 
+                                            // data input registers should be 
+                                            // used to provide input data to 
+                                            // the hash module through the 
+                                            // slave interface. 
+#define AES_HASH_DATA_IN_12     0x4008B630  // HASH data input registers The 
+                                            // data input registers should be 
+                                            // used to provide input data to 
+                                            // the hash module through the 
+                                            // slave interface. 
+#define AES_HASH_DATA_IN_13     0x4008B634  // HASH data input registers The 
+                                            // data input registers should be 
+                                            // used to provide input data to 
+                                            // the hash module through the 
+                                            // slave interface. 
+#define AES_HASH_DATA_IN_14     0x4008B638  // HASH data input registers The 
+                                            // data input registers should be 
+                                            // used to provide input data to 
+                                            // the hash module through the 
+                                            // slave interface. 
+#define AES_HASH_DATA_IN_15     0x4008B63C  // HASH data input registers The 
+                                            // data input registers should be 
+                                            // used to provide input data to 
+                                            // the hash module through the 
+                                            // slave interface. 
+#define AES_HASH_IO_BUF_CTRL    0x4008B640  // Input/output buffer control and 
+                                            // status register This register 
+                                            // pair shares a single address 
+                                            // location and contains bits that 
+                                            // control and monitor the data 
+                                            // flow between the host and the 
+                                            // hash engine. 
+#define AES_HASH_MODE_IN        0x4008B644  // Hash mode register 
+#define AES_HASH_LENGTH_IN_L    0x4008B648  // Hash length register 
+#define AES_HASH_LENGTH_IN_H    0x4008B64C  // Hash length register 
+#define AES_HASH_DIGEST_A       0x4008B650  // Hash digest registers The hash 
+                                            // digest registers consist of 
+                                            // eight 32-bit registers, named 
+                                            // HASH_DIGEST_A to HASH_DIGEST_H. 
+                                            // After processing a message, the 
+                                            // output digest can be read from 
+                                            // these registers. These registers 
+                                            // can be written with an 
+                                            // intermediate hash result for 
+                                            // continued hash operations. 
+#define AES_HASH_DIGEST_B       0x4008B654  // Hash digest registers The hash 
+                                            // digest registers consist of 
+                                            // eight 32-bit registers, named 
+                                            // HASH_DIGEST_A to HASH_DIGEST_H. 
+                                            // After processing a message, the 
+                                            // output digest can be read from 
+                                            // these registers. These registers 
+                                            // can be written with an 
+                                            // intermediate hash result for 
+                                            // continued hash operations. 
+#define AES_HASH_DIGEST_C       0x4008B658  // Hash digest registers The hash 
+                                            // digest registers consist of 
+                                            // eight 32-bit registers, named 
+                                            // HASH_DIGEST_A to HASH_DIGEST_H. 
+                                            // After processing a message, the 
+                                            // output digest can be read from 
+                                            // these registers. These registers 
+                                            // can be written with an 
+                                            // intermediate hash result for 
+                                            // continued hash operations. 
+#define AES_HASH_DIGEST_D       0x4008B65C  // Hash digest registers The hash 
+                                            // digest registers consist of 
+                                            // eight 32-bit registers, named 
+                                            // HASH_DIGEST_A to HASH_DIGEST_H. 
+                                            // After processing a message, the 
+                                            // output digest can be read from 
+                                            // these registers. These registers 
+                                            // can be written with an 
+                                            // intermediate hash result for 
+                                            // continued hash operations. 
+#define AES_HASH_DIGEST_E       0x4008B660  // Hash digest registers The hash 
+                                            // digest registers consist of 
+                                            // eight 32-bit registers, named 
+                                            // HASH_DIGEST_A to HASH_DIGEST_H. 
+                                            // After processing a message, the 
+                                            // output digest can be read from 
+                                            // these registers. These registers 
+                                            // can be written with an 
+                                            // intermediate hash result for 
+                                            // continued hash operations. 
+#define AES_HASH_DIGEST_F       0x4008B664  // Hash digest registers The hash 
+                                            // digest registers consist of 
+                                            // eight 32-bit registers, named 
+                                            // HASH_DIGEST_A to HASH_DIGEST_H. 
+                                            // After processing a message, the 
+                                            // output digest can be read from 
+                                            // these registers. These registers 
+                                            // can be written with an 
+                                            // intermediate hash result for 
+                                            // continued hash operations. 
+#define AES_HASH_DIGEST_G       0x4008B668  // Hash digest registers The hash 
+                                            // digest registers consist of 
+                                            // eight 32-bit registers, named 
+                                            // HASH_DIGEST_A to HASH_DIGEST_H. 
+                                            // After processing a message, the 
+                                            // output digest can be read from 
+                                            // these registers. These registers 
+                                            // can be written with an 
+                                            // intermediate hash result for 
+                                            // continued hash operations. 
+#define AES_HASH_DIGEST_H       0x4008B66C  // Hash digest registers The hash 
+                                            // digest registers consist of 
+                                            // eight 32-bit registers, named 
+                                            // HASH_DIGEST_A to HASH_DIGEST_H. 
+                                            // After processing a message, the 
+                                            // output digest can be read from 
+                                            // these registers. These registers 
+                                            // can be written with an 
+                                            // intermediate hash result for 
+                                            // continued hash operations. 
+#define AES_CTRL_ALG_SEL        0x4008B700  // Algorithm select This algorithm 
+                                            // selection register configures 
+                                            // the internal destination of the 
+                                            // DMA controller. 
+#define AES_CTRL_PROT_EN        0x4008B704  // Master PROT privileged access 
+                                            // enable This register enables the 
+                                            // second bit (bit [1]) of the AHB 
+                                            // HPROT bus of the AHB master 
+                                            // interface when a read action of 
+                                            // key(s) is performed on the AHB 
+                                            // master interface for writing 
+                                            // keys into the store module. 
+#define AES_CTRL_SW_RESET       0x4008B740  // Software reset 
+#define AES_CTRL_INT_CFG        0x4008B780  // Interrupt configuration 
+#define AES_CTRL_INT_EN         0x4008B784  // Interrupt enable 
+#define AES_CTRL_INT_CLR        0x4008B788  // Interrupt clear 
+#define AES_CTRL_INT_SET        0x4008B78C  // Interrupt set 
+#define AES_CTRL_INT_STAT       0x4008B790  // Interrupt status 
+#define AES_CTRL_OPTIONS        0x4008B7F8  // Options register 
+#define AES_CTRL_VERSION        0x4008B7FC  // Version register 
+
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// AES_DMAC_CH0_CTRL register.
+//
+//*****************************************************************************
+#define AES_DMAC_CH0_CTRL_PRIO  0x00000002  // Channel priority 0: Low 1: High 
+                                            // If both channels have the same 
+                                            // priority, access of the channels 
+                                            // to the external port is 
+                                            // arbitrated using the round robin 
+                                            // scheme. If one channel has a 
+                                            // high priority and another one 
+                                            // low, the channel with the high 
+                                            // priority is served first, in 
+                                            // case of simultaneous access 
+                                            // requests. 
+#define AES_DMAC_CH0_CTRL_PRIO_M \
+                                0x00000002
+#define AES_DMAC_CH0_CTRL_PRIO_S 1
+#define AES_DMAC_CH0_CTRL_EN    0x00000001  // Channel enable 0: Disabled 1: 
+                                            // Enable Note: Disabling an active 
+                                            // channel interrupts the DMA 
+                                            // operation. The ongoing block 
+                                            // transfer completes, but no new 
+                                            // transfers are requested. 
+#define AES_DMAC_CH0_CTRL_EN_M  0x00000001
+#define AES_DMAC_CH0_CTRL_EN_S  0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// AES_DMAC_CH0_EXTADDR register.
+//
+//*****************************************************************************
+#define AES_DMAC_CH0_EXTADDR_ADDR_M \
+                                0xFFFFFFFF  // Channel external address value 
+                                            // When read during operation, it 
+                                            // holds the last updated external 
+                                            // address after being sent to the 
+                                            // master interface. 
+
+#define AES_DMAC_CH0_EXTADDR_ADDR_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// AES_DMAC_CH0_DMALENGTH register.
+//
+//*****************************************************************************
+#define AES_DMAC_CH0_DMALENGTH_DMALEN_M \
+                                0x0000FFFF  // Channel DMA length in bytes 
+                                            // During configuration, this 
+                                            // register contains the DMA 
+                                            // transfer length in bytes. During 
+                                            // operation, it contains the last 
+                                            // updated value of the DMA 
+                                            // transfer length after being sent 
+                                            // to the master interface. Note: 
+                                            // Setting this register to a 
+                                            // nonzero value starts the 
+                                            // transfer if the channel is 
+                                            // enabled. Therefore, this 
+                                            // register must be written last 
+                                            // when setting up a DMA channel. 
+
+#define AES_DMAC_CH0_DMALENGTH_DMALEN_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// AES_DMAC_STATUS register.
+//
+//*****************************************************************************
+#define AES_DMAC_STATUS_PORT_ERR \
+                                0x00020000  // Reflects possible transfer 
+                                            // errors on the AHB port. 
+
+#define AES_DMAC_STATUS_PORT_ERR_M \
+                                0x00020000
+#define AES_DMAC_STATUS_PORT_ERR_S 17
+#define AES_DMAC_STATUS_CH1_ACT 0x00000002  // A value of 1 indicates that 
+                                            // channel 1 is active (DMA 
+                                            // transfer on-going). 
+#define AES_DMAC_STATUS_CH1_ACT_M \
+                                0x00000002
+#define AES_DMAC_STATUS_CH1_ACT_S 1
+#define AES_DMAC_STATUS_CH0_ACT 0x00000001  // A value of 1 indicates that 
+                                            // channel 0 is active (DMA 
+                                            // transfer on-going). 
+#define AES_DMAC_STATUS_CH0_ACT_M \
+                                0x00000001
+#define AES_DMAC_STATUS_CH0_ACT_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// AES_DMAC_SWRES register.
+//
+//*****************************************************************************
+#define AES_DMAC_SWRES_SWRES    0x00000001  // Software reset enable 0 = 
+                                            // Disabled 1 = Enabled 
+                                            // (self-cleared to 0) Completion 
+                                            // of the software reset must be 
+                                            // checked through the DMAC_STATUS 
+                                            // register. 
+#define AES_DMAC_SWRES_SWRES_M  0x00000001
+#define AES_DMAC_SWRES_SWRES_S  0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// AES_DMAC_CH1_CTRL register.
+//
+//*****************************************************************************
+#define AES_DMAC_CH1_CTRL_PRIO  0x00000002  // Channel priority 0: Low 1: High 
+                                            // If both channels have the same 
+                                            // priority, access of the channels 
+                                            // to the external port is 
+                                            // arbitrated using the round robin 
+                                            // scheme. If one channel has a 
+                                            // high priority and another one 
+                                            // low, the channel with the high 
+                                            // priority is served first, in 
+                                            // case of simultaneous access 
+                                            // requests. 
+#define AES_DMAC_CH1_CTRL_PRIO_M \
+                                0x00000002
+#define AES_DMAC_CH1_CTRL_PRIO_S 1
+#define AES_DMAC_CH1_CTRL_EN    0x00000001  // Channel enable 0: Disabled 1: 
+                                            // Enable Note: Disabling an active 
+                                            // channel interrupts the DMA 
+                                            // operation. The ongoing block 
+                                            // transfer completes, but no new 
+                                            // transfers are requested. 
+#define AES_DMAC_CH1_CTRL_EN_M  0x00000001
+#define AES_DMAC_CH1_CTRL_EN_S  0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// AES_DMAC_CH1_EXTADDR register.
+//
+//*****************************************************************************
+#define AES_DMAC_CH1_EXTADDR_ADDR_M \
+                                0xFFFFFFFF  // Channel external address value. 
+                                            // When read during operation, it 
+                                            // holds the last updated external 
+                                            // address after being sent to the 
+                                            // master interface. 
+
+#define AES_DMAC_CH1_EXTADDR_ADDR_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// AES_DMAC_CH1_DMALENGTH register.
+//
+//*****************************************************************************
+#define AES_DMAC_CH1_DMALENGTH_DMALEN_M \
+                                0x0000FFFF  // Channel DMA length in bytes. 
+                                            // During configuration, this 
+                                            // register contains the DMA 
+                                            // transfer length in bytes. During 
+                                            // operation, it contains the last 
+                                            // updated value of the DMA 
+                                            // transfer length after being sent 
+                                            // to the master interface. Note: 
+                                            // Setting this register to a 
+                                            // nonzero value starts the 
+                                            // transfer if the channel is 
+                                            // enabled. Therefore, this 
+                                            // register must be written last 
+                                            // when setting up a DMA channel. 
+
+#define AES_DMAC_CH1_DMALENGTH_DMALEN_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// AES_DMAC_MST_RUNPARAMS register.
+//
+//*****************************************************************************
+#define AES_DMAC_MST_RUNPARAMS_AHB_MST1_BURST_SIZE_M \
+                                0x0000F000  // Maximum burst size that can be 
+                                            // performed on the AHB bus 0010b = 
+                                            // 4 bytes (default) 0011b = 8 
+                                            // bytes 0100b = 16 bytes 0101b = 
+                                            // 32 bytes 0110b = 64 bytes Others 
+                                            // = Reserved 
+
+#define AES_DMAC_MST_RUNPARAMS_AHB_MST1_BURST_SIZE_S 12
+#define AES_DMAC_MST_RUNPARAMS_AHB_MST1_IDLE_EN \
+                                0x00000800  // Idle insertion between 
+                                            // consecutive burst transfers on 
+                                            // AHB 0: No Idle insertion 1: Idle 
+                                            // insertion 
+
+#define AES_DMAC_MST_RUNPARAMS_AHB_MST1_IDLE_EN_M \
+                                0x00000800
+#define AES_DMAC_MST_RUNPARAMS_AHB_MST1_IDLE_EN_S 11
+#define AES_DMAC_MST_RUNPARAMS_AHB_MST1_INCR_EN \
+                                0x00000400  // Burst length type of AHB 
+                                            // transfer 0: Unspecified length 
+                                            // burst transfers 1: Fixed length 
+                                            // burst or single transfers 
+
+#define AES_DMAC_MST_RUNPARAMS_AHB_MST1_INCR_EN_M \
+                                0x00000400
+#define AES_DMAC_MST_RUNPARAMS_AHB_MST1_INCR_EN_S 10
+#define AES_DMAC_MST_RUNPARAMS_AHB_MST1_LOCK_EN \
+                                0x00000200  // Locked transform on AHB 0: 
+                                            // Transfers are not locked 1: 
+                                            // Transfers are locked 
+
+#define AES_DMAC_MST_RUNPARAMS_AHB_MST1_LOCK_EN_M \
+                                0x00000200
+#define AES_DMAC_MST_RUNPARAMS_AHB_MST1_LOCK_EN_S 9
+#define AES_DMAC_MST_RUNPARAMS_AHB_MST1_BIGEND \
+                                0x00000100  // Endianess for the AHB master 0: 
+                                            // Little endian 1: Big endian 
+
+#define AES_DMAC_MST_RUNPARAMS_AHB_MST1_BIGEND_M \
+                                0x00000100
+#define AES_DMAC_MST_RUNPARAMS_AHB_MST1_BIGEND_S 8
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// AES_DMAC_PERSR register.
+//
+//*****************************************************************************
+#define AES_DMAC_PERSR_PORT1_AHB_ERROR \
+                                0x00001000  // A value of 1 indicates that the 
+                                            // EIP-101 has detected an AHB bus 
+                                            // error 
+
+#define AES_DMAC_PERSR_PORT1_AHB_ERROR_M \
+                                0x00001000
+#define AES_DMAC_PERSR_PORT1_AHB_ERROR_S 12
+#define AES_DMAC_PERSR_PORT1_CHANNEL \
+                                0x00000200  // Indicates which channel has 
+                                            // serviced last (channel 0 or 
+                                            // channel 1) by AHB master port. 
+
+#define AES_DMAC_PERSR_PORT1_CHANNEL_M \
+                                0x00000200
+#define AES_DMAC_PERSR_PORT1_CHANNEL_S 9
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// AES_DMAC_OPTIONS register.
+//
+//*****************************************************************************
+#define AES_DMAC_OPTIONS_NR_OF_CHANNELS_M \
+                                0x00000F00  // Number of channels implemented, 
+                                            // value in the range 1-8. 
+
+#define AES_DMAC_OPTIONS_NR_OF_CHANNELS_S 8
+#define AES_DMAC_OPTIONS_NR_OF_PORTS_M \
+                                0x00000007  // Number of ports implemented, 
+                                            // value in range 1-4. 
+
+#define AES_DMAC_OPTIONS_NR_OF_PORTS_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// AES_DMAC_VERSION register.
+//
+//*****************************************************************************
+#define AES_DMAC_VERSION_HW_MAJOR_VERSION_M \
+                                0x0F000000  // Major version number 
+
+#define AES_DMAC_VERSION_HW_MAJOR_VERSION_S 24
+#define AES_DMAC_VERSION_HW_MINOR_VERSION_M \
+                                0x00F00000  // Minor version number 
+
+#define AES_DMAC_VERSION_HW_MINOR_VERSION_S 20
+#define AES_DMAC_VERSION_HW_PATCH_LEVEL_M \
+                                0x000F0000  // Patch level Starts at 0 at 
+                                            // first delivery of this version 
+
+#define AES_DMAC_VERSION_HW_PATCH_LEVEL_S 16
+#define AES_DMAC_VERSION_EIP_NUMBER_COMPL_M \
+                                0x0000FF00  // Bit-by-bit complement of the 
+                                            // EIP_NUMBER field bits. 
+
+#define AES_DMAC_VERSION_EIP_NUMBER_COMPL_S 8
+#define AES_DMAC_VERSION_EIP_NUMBER_M \
+                                0x000000FF  // Binary encoding of the 
+                                            // EIP-number of this DMA 
+                                            // controller (209) 
+
+#define AES_DMAC_VERSION_EIP_NUMBER_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// AES_KEY_STORE_WRITE_AREA register.
+//
+//*****************************************************************************
+#define AES_KEY_STORE_WRITE_AREA_RAM_AREA7 \
+                                0x00000080  // Each RAM_AREAx represents an 
+                                            // area of 128 bits. Select the key 
+                                            // store RAM area(s) where the 
+                                            // key(s) needs to be written 0: 
+                                            // RAM_AREA7 is not selected to be 
+                                            // written. 1: RAM_AREA7 is 
+                                            // selected to be written. Writing 
+                                            // to multiple RAM locations is 
+                                            // possible only when the selected 
+                                            // RAM areas are sequential. Keys 
+                                            // that require more than one RAM 
+                                            // locations (key size is 192 or 
+                                            // 256 bits), must start at one of 
+                                            // the following areas: RAM_AREA0, 
+                                            // RAM_AREA2, RAM_AREA4, or 
+                                            // RAM_AREA6. 
+
+#define AES_KEY_STORE_WRITE_AREA_RAM_AREA7_M \
+                                0x00000080
+#define AES_KEY_STORE_WRITE_AREA_RAM_AREA7_S 7
+#define AES_KEY_STORE_WRITE_AREA_RAM_AREA6 \
+                                0x00000040  // Each RAM_AREAx represents an 
+                                            // area of 128 bits. Select the key 
+                                            // store RAM area(s) where the 
+                                            // key(s) needs to be written 0: 
+                                            // RAM_AREA6 is not selected to be 
+                                            // written. 1: RAM_AREA6 is 
+                                            // selected to be written. Writing 
+                                            // to multiple RAM locations is 
+                                            // possible only when the selected 
+                                            // RAM areas are sequential. Keys 
+                                            // that require more than one RAM 
+                                            // locations (key size is 192 or 
+                                            // 256 bits), must start at one of 
+                                            // the following areas: RAM_AREA0, 
+                                            // RAM_AREA2, RAM_AREA4, or 
+                                            // RAM_AREA6. 
+
+#define AES_KEY_STORE_WRITE_AREA_RAM_AREA6_M \
+                                0x00000040
+#define AES_KEY_STORE_WRITE_AREA_RAM_AREA6_S 6
+#define AES_KEY_STORE_WRITE_AREA_RAM_AREA5 \
+                                0x00000020  // Each RAM_AREAx represents an 
+                                            // area of 128 bits. Select the key 
+                                            // store RAM area(s) where the 
+                                            // key(s) needs to be written 0: 
+                                            // RAM_AREA5 is not selected to be 
+                                            // written. 1: RAM_AREA5 is 
+                                            // selected to be written. Writing 
+                                            // to multiple RAM locations is 
+                                            // possible only when the selected 
+                                            // RAM areas are sequential. Keys 
+                                            // that require more than one RAM 
+                                            // locations (key size is 192 or 
+                                            // 256 bits), must start at one of 
+                                            // the following areas: RAM_AREA0, 
+                                            // RAM_AREA2, RAM_AREA4, or 
+                                            // RAM_AREA6. 
+
+#define AES_KEY_STORE_WRITE_AREA_RAM_AREA5_M \
+                                0x00000020
+#define AES_KEY_STORE_WRITE_AREA_RAM_AREA5_S 5
+#define AES_KEY_STORE_WRITE_AREA_RAM_AREA4 \
+                                0x00000010  // Each RAM_AREAx represents an 
+                                            // area of 128 bits. Select the key 
+                                            // store RAM area(s) where the 
+                                            // key(s) needs to be written 0: 
+                                            // RAM_AREA4 is not selected to be 
+                                            // written. 1: RAM_AREA4 is 
+                                            // selected to be written. Writing 
+                                            // to multiple RAM locations is 
+                                            // possible only when the selected 
+                                            // RAM areas are sequential. Keys 
+                                            // that require more than one RAM 
+                                            // locations (key size is 192 or 
+                                            // 256 bits), must start at one of 
+                                            // the following areas: RAM_AREA0, 
+                                            // RAM_AREA2, RAM_AREA4, or 
+                                            // RAM_AREA6. 
+
+#define AES_KEY_STORE_WRITE_AREA_RAM_AREA4_M \
+                                0x00000010
+#define AES_KEY_STORE_WRITE_AREA_RAM_AREA4_S 4
+#define AES_KEY_STORE_WRITE_AREA_RAM_AREA3 \
+                                0x00000008  // Each RAM_AREAx represents an 
+                                            // area of 128 bits. Select the key 
+                                            // store RAM area(s) where the 
+                                            // key(s) needs to be written 0: 
+                                            // RAM_AREA3 is not selected to be 
+                                            // written. 1: RAM_AREA3 is 
+                                            // selected to be written. Writing 
+                                            // to multiple RAM locations is 
+                                            // possible only when the selected 
+                                            // RAM areas are sequential. Keys 
+                                            // that require more than one RAM 
+                                            // locations (key size is 192 or 
+                                            // 256 bits), must start at one of 
+                                            // the following areas: RAM_AREA0, 
+                                            // RAM_AREA2, RAM_AREA4, or 
+                                            // RAM_AREA6. 
+
+#define AES_KEY_STORE_WRITE_AREA_RAM_AREA3_M \
+                                0x00000008
+#define AES_KEY_STORE_WRITE_AREA_RAM_AREA3_S 3
+#define AES_KEY_STORE_WRITE_AREA_RAM_AREA2 \
+                                0x00000004  // Each RAM_AREAx represents an 
+                                            // area of 128 bits. Select the key 
+                                            // store RAM area(s) where the 
+                                            // key(s) needs to be written 0: 
+                                            // RAM_AREA2 is not selected to be 
+                                            // written. 1: RAM_AREA2 is 
+                                            // selected to be written. Writing 
+                                            // to multiple RAM locations is 
+                                            // possible only when the selected 
+                                            // RAM areas are sequential. Keys 
+                                            // that require more than one RAM 
+                                            // locations (key size is 192 or 
+                                            // 256 bits), must start at one of 
+                                            // the following areas: RAM_AREA0, 
+                                            // RAM_AREA2, RAM_AREA4, or 
+                                            // RAM_AREA6. 
+
+#define AES_KEY_STORE_WRITE_AREA_RAM_AREA2_M \
+                                0x00000004
+#define AES_KEY_STORE_WRITE_AREA_RAM_AREA2_S 2
+#define AES_KEY_STORE_WRITE_AREA_RAM_AREA1 \
+                                0x00000002  // Each RAM_AREAx represents an 
+                                            // area of 128 bits. Select the key 
+                                            // store RAM area(s) where the 
+                                            // key(s) needs to be written 0: 
+                                            // RAM_AREA1 is not selected to be 
+                                            // written. 1: RAM_AREA1 is 
+                                            // selected to be written. Writing 
+                                            // to multiple RAM locations is 
+                                            // possible only when the selected 
+                                            // RAM areas are sequential. Keys 
+                                            // that require more than one RAM 
+                                            // locations (key size is 192 or 
+                                            // 256 bits), must start at one of 
+                                            // the following areas: RAM_AREA0, 
+                                            // RAM_AREA2, RAM_AREA4, or 
+                                            // RAM_AREA6. 
+
+#define AES_KEY_STORE_WRITE_AREA_RAM_AREA1_M \
+                                0x00000002
+#define AES_KEY_STORE_WRITE_AREA_RAM_AREA1_S 1
+#define AES_KEY_STORE_WRITE_AREA_RAM_AREA0 \
+                                0x00000001  // Each RAM_AREAx represents an 
+                                            // area of 128 bits. Select the key 
+                                            // store RAM area(s) where the 
+                                            // key(s) needs to be written 0: 
+                                            // RAM_AREA0 is not selected to be 
+                                            // written. 1: RAM_AREA0 is 
+                                            // selected to be written. Writing 
+                                            // to multiple RAM locations is 
+                                            // possible only when the selected 
+                                            // RAM areas are sequential. Keys 
+                                            // that require more than one RAM 
+                                            // locations (key size is 192 or 
+                                            // 256 bits), must start at one of 
+                                            // the following areas: RAM_AREA0, 
+                                            // RAM_AREA2, RAM_AREA4, or 
+                                            // RAM_AREA6. 
+
+#define AES_KEY_STORE_WRITE_AREA_RAM_AREA0_M \
+                                0x00000001
+#define AES_KEY_STORE_WRITE_AREA_RAM_AREA0_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// AES_KEY_STORE_WRITTEN_AREA register.
+//
+//*****************************************************************************
+#define AES_KEY_STORE_WRITTEN_AREA_RAM_AREA_WRITTEN7 \
+                                0x00000080  // Read operation: 0: This RAM 
+                                            // area is not written with valid 
+                                            // key information. 1: This RAM 
+                                            // area is written with valid key 
+                                            // information. Each individual 
+                                            // ram_area_writtenx bit can be 
+                                            // reset by writing 1. Note: This 
+                                            // register is reset on a soft 
+                                            // reset from the master control 
+                                            // module. After a soft reset, all 
+                                            // keys must be rewritten to the 
+                                            // key store memory. 
+
+#define AES_KEY_STORE_WRITTEN_AREA_RAM_AREA_WRITTEN7_M \
+                                0x00000080
+#define AES_KEY_STORE_WRITTEN_AREA_RAM_AREA_WRITTEN7_S 7
+#define AES_KEY_STORE_WRITTEN_AREA_RAM_AREA_WRITTEN6 \
+                                0x00000040  // Read operation: 0: This RAM 
+                                            // area is not written with valid 
+                                            // key information. 1: This RAM 
+                                            // area is written with valid key 
+                                            // information. Each individual 
+                                            // ram_area_writtenx bit can be 
+                                            // reset by writing 1. Note: This 
+                                            // register is reset on a soft 
+                                            // reset from the master control 
+                                            // module. After a soft reset, all 
+                                            // keys must be rewritten to the 
+                                            // key store memory. 
+
+#define AES_KEY_STORE_WRITTEN_AREA_RAM_AREA_WRITTEN6_M \
+                                0x00000040
+#define AES_KEY_STORE_WRITTEN_AREA_RAM_AREA_WRITTEN6_S 6
+#define AES_KEY_STORE_WRITTEN_AREA_RAM_AREA_WRITTEN5 \
+                                0x00000020  // Read operation: 0: This RAM 
+                                            // area is not written with valid 
+                                            // key information. 1: This RAM 
+                                            // area is written with valid key 
+                                            // information. Each individual 
+                                            // ram_area_writtenx bit can be 
+                                            // reset by writing 1. Note: This 
+                                            // register is reset on a soft 
+                                            // reset from the master control 
+                                            // module. After a soft reset, all 
+                                            // keys must be rewritten to the 
+                                            // key store memory. 
+
+#define AES_KEY_STORE_WRITTEN_AREA_RAM_AREA_WRITTEN5_M \
+                                0x00000020
+#define AES_KEY_STORE_WRITTEN_AREA_RAM_AREA_WRITTEN5_S 5
+#define AES_KEY_STORE_WRITTEN_AREA_RAM_AREA_WRITTEN4 \
+                                0x00000010  // Read operation: 0: This RAM 
+                                            // area is not written with valid 
+                                            // key information. 1: This RAM 
+                                            // area is written with valid key 
+                                            // information. Each individual 
+                                            // ram_area_writtenx bit can be 
+                                            // reset by writing 1. Note: This 
+                                            // register is reset on a soft 
+                                            // reset from the master control 
+                                            // module. After a soft reset, all 
+                                            // keys must be rewritten to the 
+                                            // key store memory. 
+
+#define AES_KEY_STORE_WRITTEN_AREA_RAM_AREA_WRITTEN4_M \
+                                0x00000010
+#define AES_KEY_STORE_WRITTEN_AREA_RAM_AREA_WRITTEN4_S 4
+#define AES_KEY_STORE_WRITTEN_AREA_RAM_AREA_WRITTEN3 \
+                                0x00000008  // Read operation: 0: This RAM 
+                                            // area is not written with valid 
+                                            // key information. 1: This RAM 
+                                            // area is written with valid key 
+                                            // information. Each individual 
+                                            // ram_area_writtenx bit can be 
+                                            // reset by writing 1. Note: This 
+                                            // register is reset on a soft 
+                                            // reset from the master control 
+                                            // module. After a soft reset, all 
+                                            // keys must be rewritten to the 
+                                            // key store memory. 
+
+#define AES_KEY_STORE_WRITTEN_AREA_RAM_AREA_WRITTEN3_M \
+                                0x00000008
+#define AES_KEY_STORE_WRITTEN_AREA_RAM_AREA_WRITTEN3_S 3
+#define AES_KEY_STORE_WRITTEN_AREA_RAM_AREA_WRITTEN2 \
+                                0x00000004  // Read operation: 0: This RAM 
+                                            // area is not written with valid 
+                                            // key information. 1: This RAM 
+                                            // area is written with valid key 
+                                            // information. Each individual 
+                                            // ram_area_writtenx bit can be 
+                                            // reset by writing 1. Note: This 
+                                            // register is reset on a soft 
+                                            // reset from the master control 
+                                            // module. After a soft reset, all 
+                                            // keys must be rewritten to the 
+                                            // key store memory. 
+
+#define AES_KEY_STORE_WRITTEN_AREA_RAM_AREA_WRITTEN2_M \
+                                0x00000004
+#define AES_KEY_STORE_WRITTEN_AREA_RAM_AREA_WRITTEN2_S 2
+#define AES_KEY_STORE_WRITTEN_AREA_RAM_AREA_WRITTEN1 \
+                                0x00000002  // Read operation: 0: This RAM 
+                                            // area is not written with valid 
+                                            // key information. 1: This RAM 
+                                            // area is written with valid key 
+                                            // information. Each individual 
+                                            // ram_area_writtenx bit can be 
+                                            // reset by writing 1. Note: This 
+                                            // register is reset on a soft 
+                                            // reset from the master control 
+                                            // module. After a soft reset, all 
+                                            // keys must be rewritten to the 
+                                            // key store memory. 
+
+#define AES_KEY_STORE_WRITTEN_AREA_RAM_AREA_WRITTEN1_M \
+                                0x00000002
+#define AES_KEY_STORE_WRITTEN_AREA_RAM_AREA_WRITTEN1_S 1
+#define AES_KEY_STORE_WRITTEN_AREA_RAM_AREA_WRITTEN0 \
+                                0x00000001  // Read operation: 0: This RAM 
+                                            // area is not written with valid 
+                                            // key information. 1: This RAM 
+                                            // area is written with valid key 
+                                            // information. Each individual 
+                                            // ram_area_writtenx bit can be 
+                                            // reset by writing 1. Note: This 
+                                            // register is reset on a soft 
+                                            // reset from the master control 
+                                            // module. After a soft reset, all 
+                                            // keys must be rewritten to the 
+                                            // key store memory. 
+
+#define AES_KEY_STORE_WRITTEN_AREA_RAM_AREA_WRITTEN0_M \
+                                0x00000001
+#define AES_KEY_STORE_WRITTEN_AREA_RAM_AREA_WRITTEN0_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// AES_KEY_STORE_SIZE register.
+//
+//*****************************************************************************
+#define AES_KEY_STORE_SIZE_KEY_SIZE_M \
+                                0x00000003  // Key size: 00: Reserved 01: 128 
+                                            // bits 10: 192 bits 11: 256 bits 
+                                            // When writing this to this 
+                                            // register, the 
+                                            // KEY_STORE_WRITTEN_AREA register 
+                                            // is reset. 
+
+#define AES_KEY_STORE_SIZE_KEY_SIZE_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// AES_KEY_STORE_READ_AREA register.
+//
+//*****************************************************************************
+#define AES_KEY_STORE_READ_AREA_BUSY \
+                                0x80000000  // Key store operation busy status 
+                                            // flag (read only): 0: Operation 
+                                            // is complete. 1: Operation is not 
+                                            // completed and the key store is 
+                                            // busy. 
+
+#define AES_KEY_STORE_READ_AREA_BUSY_M \
+                                0x80000000
+#define AES_KEY_STORE_READ_AREA_BUSY_S 31
+#define AES_KEY_STORE_READ_AREA_RAM_AREA_M \
+                                0x0000000F  // Selects the area of the key 
+                                            // store RAM from where the key 
+                                            // needs to be read that will be 
+                                            // writen to the AES engine 
+                                            // RAM_AREA: 0000: RAM_AREA0 0001: 
+                                            // RAM_AREA1 0010: RAM_AREA2 0011: 
+                                            // RAM_AREA3 0100: RAM_AREA4 0101: 
+                                            // RAM_AREA5 0110: RAM_AREA6 0111: 
+                                            // RAM_AREA7 1000: no RAM area 
+                                            // selected 1001-1111: Reserved RAM 
+                                            // areas RAM_AREA0, RAM_AREA2, 
+                                            // RAM_AREA4 and RAM_AREA6 are the 
+                                            // only valid read areas for 192 
+                                            // and 256 bits key sizes. Only RAM 
+                                            // areas that contain valid written 
+                                            // keys can be selected. 
+
+#define AES_KEY_STORE_READ_AREA_RAM_AREA_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// AES_AES_KEY2_0 register.
+//
+//*****************************************************************************
+#define AES_AES_KEY2_0_AES_KEY2_M \
+                                0xFFFFFFFF  // AES_KEY2/AES_GHASH_H[31:0] For 
+                                            // GCM: -[127:0] - GHASH_H - The 
+                                            // internally calculated GHASH key 
+                                            // is stored in these registers. 
+                                            // Only used for modes that use the 
+                                            // GHASH function (GCM). -[255:128] 
+                                            // - This register is used to store 
+                                            // intermediate values and is 
+                                            // initialized with 0s when loading 
+                                            // a new key. For CCM: -[255:0] - 
+                                            // This register is used to store 
+                                            // intermediate values. For 
+                                            // CBC-MAC: -[255:0] - ZEROES - 
+                                            // This register must remain 0. 
+
+#define AES_AES_KEY2_0_AES_KEY2_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// AES_AES_KEY2_1 register.
+//
+//*****************************************************************************
+#define AES_AES_KEY2_1_AES_KEY2_M \
+                                0xFFFFFFFF  // AES_KEY2/AES_GHASH_H[63:32] For 
+                                            // GCM: -[127:0] - GHASH_H - The 
+                                            // internally calculated GHASH key 
+                                            // is stored in these registers. 
+                                            // Only used for modes that use the 
+                                            // GHASH function (GCM). -[255:128] 
+                                            // - This register is used to store 
+                                            // intermediate values and is 
+                                            // initialized with 0s when loading 
+                                            // a new key. For CCM: -[255:0] - 
+                                            // This register is used to store 
+                                            // intermediate values. For 
+                                            // CBC-MAC: -[255:0] - ZEROES - 
+                                            // This register must remain 0. 
+
+#define AES_AES_KEY2_1_AES_KEY2_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// AES_AES_KEY2_2 register.
+//
+//*****************************************************************************
+#define AES_AES_KEY2_2_AES_KEY2_M \
+                                0xFFFFFFFF  // AES_KEY2/AES_GHASH_H[95:64] For 
+                                            // GCM: -[127:0] - GHASH_H - The 
+                                            // internally calculated GHASH key 
+                                            // is stored in these registers. 
+                                            // Only used for modes that use the 
+                                            // GHASH function (GCM). -[255:128] 
+                                            // - This register is used to store 
+                                            // intermediate values and is 
+                                            // initialized with 0s when loading 
+                                            // a new key. For CCM: -[255:0] - 
+                                            // This register is used to store 
+                                            // intermediate values. For 
+                                            // CBC-MAC: -[255:0] - ZEROES - 
+                                            // This register must remain 0. 
+
+#define AES_AES_KEY2_2_AES_KEY2_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// AES_AES_KEY2_3 register.
+//
+//*****************************************************************************
+#define AES_AES_KEY2_3_AES_KEY2_M \
+                                0xFFFFFFFF  // AES_KEY2/AES_GHASH_H[127:96] 
+                                            // For GCM: -[127:0] - GHASH_H - 
+                                            // The internally calculated GHASH 
+                                            // key is stored in these 
+                                            // registers. Only used for modes 
+                                            // that use the GHASH function 
+                                            // (GCM). -[255:128] - This 
+                                            // register is used to store 
+                                            // intermediate values and is 
+                                            // initialized with 0s when loading 
+                                            // a new key. For CCM: -[255:0] - 
+                                            // This register is used to store 
+                                            // intermediate values. For 
+                                            // CBC-MAC: -[255:0] - ZEROES - 
+                                            // This register must remain 0. 
+
+#define AES_AES_KEY2_3_AES_KEY2_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// AES_AES_KEY3_0 register.
+//
+//*****************************************************************************
+#define AES_AES_KEY3_0_AES_KEY3_M \
+                                0xFFFFFFFF  // 
+                                            // AES_KEY3[31:0]/AES_KEY2[159:128] 
+                                            // For GCM: -[127:0] - GHASH_H - 
+                                            // The internally calculated GHASH 
+                                            // key is stored in these 
+                                            // registers. Only used for modes 
+                                            // that use the GHASH function 
+                                            // (GCM). -[255:128] - This 
+                                            // register is used to store 
+                                            // intermediate values and is 
+                                            // initialized with 0s when loading 
+                                            // a new key. For CCM: -[255:0] - 
+                                            // This register is used to store 
+                                            // intermediate values. For 
+                                            // CBC-MAC: -[255:0] - ZEROES - 
+                                            // This register must remain 0. 
+
+#define AES_AES_KEY3_0_AES_KEY3_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// AES_AES_KEY3_1 register.
+//
+//*****************************************************************************
+#define AES_AES_KEY3_1_AES_KEY3_M \
+                                0xFFFFFFFF  // 
+                                            // AES_KEY3[63:32]/AES_KEY2[191:160] 
+                                            // For GCM: -[127:0] - GHASH_H - 
+                                            // The internally calculated GHASH 
+                                            // key is stored in these 
+                                            // registers. Only used for modes 
+                                            // that use the GHASH function 
+                                            // (GCM). -[255:128] - This 
+                                            // register is used to store 
+                                            // intermediate values and is 
+                                            // initialized with 0s when loading 
+                                            // a new key. For CCM: -[255:0] - 
+                                            // This register is used to store 
+                                            // intermediate values. For 
+                                            // CBC-MAC: -[255:0] - ZEROES - 
+                                            // This register must remain 0. 
+
+#define AES_AES_KEY3_1_AES_KEY3_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// AES_AES_KEY3_2 register.
+//
+//*****************************************************************************
+#define AES_AES_KEY3_2_AES_KEY3_M \
+                                0xFFFFFFFF  // 
+                                            // AES_KEY3[95:64]/AES_KEY2[223:192] 
+                                            // For GCM: -[127:0] - GHASH_H - 
+                                            // The internally calculated GHASH 
+                                            // key is stored in these 
+                                            // registers. Only used for modes 
+                                            // that use the GHASH function 
+                                            // (GCM). -[255:128] - This 
+                                            // register is used to store 
+                                            // intermediate values and is 
+                                            // initialized with 0s when loading 
+                                            // a new key. For CCM: -[255:0] - 
+                                            // This register is used to store 
+                                            // intermediate values. For 
+                                            // CBC-MAC: -[255:0] - ZEROES - 
+                                            // This register must remain 0. 
+
+#define AES_AES_KEY3_2_AES_KEY3_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// AES_AES_KEY3_3 register.
+//
+//*****************************************************************************
+#define AES_AES_KEY3_3_AES_KEY3_M \
+                                0xFFFFFFFF  // 
+                                            // AES_KEY3[127:96]/AES_KEY2[255:224] 
+                                            // For GCM: -[127:0] - GHASH_H - 
+                                            // The internally calculated GHASH 
+                                            // key is stored in these 
+                                            // registers. Only used for modes 
+                                            // that use the GHASH function 
+                                            // (GCM). -[255:128] - This 
+                                            // register is used to store 
+                                            // intermediate values and is 
+                                            // initialized with 0s when loading 
+                                            // a new key. For CCM: -[255:0] - 
+                                            // This register is used to store 
+                                            // intermediate values. For 
+                                            // CBC-MAC: -[255:0] - ZEROES - 
+                                            // This register must remain 0. 
+
+#define AES_AES_KEY3_3_AES_KEY3_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the AES_AES_IV_0 register.
+//
+//*****************************************************************************
+#define AES_AES_IV_0_AES_IV_M   0xFFFFFFFF  // AES_IV[31:0] Initialization 
+                                            // vector Used for regular non-ECB 
+                                            // modes (CBC/CTR): -[127:0] - 
+                                            // AES_IV - For regular AES 
+                                            // operations (CBC and CTR) these 
+                                            // registers must be written with a 
+                                            // new 128-bit IV. After an 
+                                            // operation, these registers 
+                                            // contain the latest 128-bit 
+                                            // result IV, generated by the 
+                                            // EIP-120t. If CTR mode is 
+                                            // selected, this value is 
+                                            // incremented with 0x1: After 
+                                            // first use - When a new data 
+                                            // block is submitted to the engine 
+                                            // For GCM: -[127:0] - AES_IV - For 
+                                            // GCM operations, these registers 
+                                            // must be written with a new 
+                                            // 128-bit IV. After an operation, 
+                                            // these registers contain the 
+                                            // updated 128-bit result IV, 
+                                            // generated by the EIP-120t. Note 
+                                            // that bits [127:96] of the IV 
+                                            // represent the initial counter 
+                                            // value (which is 1 for GCM) and 
+                                            // must therefore be initialized to 
+                                            // 0x01000000. This value is 
+                                            // incremented with 0x1: After 
+                                            // first use - When a new data 
+                                            // block is submitted to the 
+                                            // engine. For CCM: -[127:0] - A0: 
+                                            // For CCM this field must be 
+                                            // written with value A0, this 
+                                            // value is the concatenation of: 
+                                            // A0-flags (5-bits of 0 and 3-bits 
+                                            // 'L'), Nonce and counter value. 
+                                            // 'L' must be a copy from the 'L' 
+                                            // value of the AES_CTRL register. 
+                                            // This 'L' indicates the width of 
+                                            // the Nonce and counter. The 
+                                            // loaded counter must be 
+                                            // initialized to 0. The total 
+                                            // width of A0 is 128-bit. For 
+                                            // CBC-MAC: -[127:0] - Zeroes - For 
+                                            // CBC-MAC this register must be 
+                                            // written with 0s at the start of 
+                                            // each operation. After an 
+                                            // operation, these registers 
+                                            // contain the 128-bit TAG output, 
+                                            // generated by the EIP-120t. 
+#define AES_AES_IV_0_AES_IV_S   0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the AES_AES_IV_1 register.
+//
+//*****************************************************************************
+#define AES_AES_IV_1_AES_IV_M   0xFFFFFFFF  // AES_IV[63:32] Initialization 
+                                            // vector Used for regular non-ECB 
+                                            // modes (CBC/CTR): -[127:0] - 
+                                            // AES_IV - For regular AES 
+                                            // operations (CBC and CTR) these 
+                                            // registers must be written with a 
+                                            // new 128-bit IV. After an 
+                                            // operation, these registers 
+                                            // contain the latest 128-bit 
+                                            // result IV, generated by the 
+                                            // EIP-120t. If CTR mode is 
+                                            // selected, this value is 
+                                            // incremented with 0x1: After 
+                                            // first use - When a new data 
+                                            // block is submitted to the engine 
+                                            // For GCM: -[127:0] - AES_IV - For 
+                                            // GCM operations, these registers 
+                                            // must be written with a new 
+                                            // 128-bit IV. After an operation, 
+                                            // these registers contain the 
+                                            // updated 128-bit result IV, 
+                                            // generated by the EIP-120t. Note 
+                                            // that bits [127:96] of the IV 
+                                            // represent the initial counter 
+                                            // value (which is 1 for GCM) and 
+                                            // must therefore be initialized to 
+                                            // 0x01000000. This value is 
+                                            // incremented with 0x1: After 
+                                            // first use - When a new data 
+                                            // block is submitted to the 
+                                            // engine. For CCM: -[127:0] - A0: 
+                                            // For CCM this field must be 
+                                            // written with value A0, this 
+                                            // value is the concatenation of: 
+                                            // A0-flags (5-bits of 0 and 3-bits 
+                                            // 'L'), Nonce and counter value. 
+                                            // 'L' must be a copy from the 'L' 
+                                            // value of the AES_CTRL register. 
+                                            // This 'L' indicates the width of 
+                                            // the Nonce and counter. The 
+                                            // loaded counter must be 
+                                            // initialized to 0. The total 
+                                            // width of A0 is 128-bit. For 
+                                            // CBC-MAC: -[127:0] - Zeroes - For 
+                                            // CBC-MAC this register must be 
+                                            // written with 0s at the start of 
+                                            // each operation. After an 
+                                            // operation, these registers 
+                                            // contain the 128-bit TAG output, 
+                                            // generated by the EIP-120t. 
+#define AES_AES_IV_1_AES_IV_S   0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the AES_AES_IV_2 register.
+//
+//*****************************************************************************
+#define AES_AES_IV_2_AES_IV_M   0xFFFFFFFF  // AES_IV[95:64] Initialization 
+                                            // vector Used for regular non-ECB 
+                                            // modes (CBC/CTR): -[127:0] - 
+                                            // AES_IV - For regular AES 
+                                            // operations (CBC and CTR) these 
+                                            // registers must be written with a 
+                                            // new 128-bit IV. After an 
+                                            // operation, these registers 
+                                            // contain the latest 128-bit 
+                                            // result IV, generated by the 
+                                            // EIP-120t. If CTR mode is 
+                                            // selected, this value is 
+                                            // incremented with 0x1: After 
+                                            // first use - When a new data 
+                                            // block is submitted to the engine 
+                                            // For GCM: -[127:0] - AES_IV - For 
+                                            // GCM operations, these registers 
+                                            // must be written with a new 
+                                            // 128-bit IV. After an operation, 
+                                            // these registers contain the 
+                                            // updated 128-bit result IV, 
+                                            // generated by the EIP-120t. Note 
+                                            // that bits [127:96] of the IV 
+                                            // represent the initial counter 
+                                            // value (which is 1 for GCM) and 
+                                            // must therefore be initialized to 
+                                            // 0x01000000. This value is 
+                                            // incremented with 0x1: After 
+                                            // first use - When a new data 
+                                            // block is submitted to the 
+                                            // engine. For CCM: -[127:0] - A0: 
+                                            // For CCM this field must be 
+                                            // written with value A0, this 
+                                            // value is the concatenation of: 
+                                            // A0-flags (5-bits of 0 and 3-bits 
+                                            // 'L'), Nonce and counter value. 
+                                            // 'L' must be a copy from the 'L' 
+                                            // value of the AES_CTRL register. 
+                                            // This 'L' indicates the width of 
+                                            // the Nonce and counter. The 
+                                            // loaded counter must be 
+                                            // initialized to 0. The total 
+                                            // width of A0 is 128-bit. For 
+                                            // CBC-MAC: -[127:0] - Zeroes - For 
+                                            // CBC-MAC this register must be 
+                                            // written with 0s at the start of 
+                                            // each operation. After an 
+                                            // operation, these registers 
+                                            // contain the 128-bit TAG output, 
+                                            // generated by the EIP-120t. 
+#define AES_AES_IV_2_AES_IV_S   0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the AES_AES_IV_3 register.
+//
+//*****************************************************************************
+#define AES_AES_IV_3_AES_IV_M   0xFFFFFFFF  // AES_IV[127:96] Initialization 
+                                            // vector Used for regular non-ECB 
+                                            // modes (CBC/CTR): -[127:0] - 
+                                            // AES_IV - For regular AES 
+                                            // operations (CBC and CTR) these 
+                                            // registers must be written with a 
+                                            // new 128-bit IV. After an 
+                                            // operation, these registers 
+                                            // contain the latest 128-bit 
+                                            // result IV, generated by the 
+                                            // EIP-120t. If CTR mode is 
+                                            // selected, this value is 
+                                            // incremented with 0x1: After 
+                                            // first use - When a new data 
+                                            // block is submitted to the engine 
+                                            // For GCM: -[127:0] - AES_IV - For 
+                                            // GCM operations, these registers 
+                                            // must be written with a new 
+                                            // 128-bit IV. After an operation, 
+                                            // these registers contain the 
+                                            // updated 128-bit result IV, 
+                                            // generated by the EIP-120t. Note 
+                                            // that bits [127:96] of the IV 
+                                            // represent the initial counter 
+                                            // value (which is 1 for GCM) and 
+                                            // must therefore be initialized to 
+                                            // 0x01000000. This value is 
+                                            // incremented with 0x1: After 
+                                            // first use - When a new data 
+                                            // block is submitted to the 
+                                            // engine. For CCM: -[127:0] - A0: 
+                                            // For CCM this field must be 
+                                            // written with value A0, this 
+                                            // value is the concatenation of: 
+                                            // A0-flags (5-bits of 0 and 3-bits 
+                                            // 'L'), Nonce and counter value. 
+                                            // 'L' must be a copy from the 'L' 
+                                            // value of the AES_CTRL register. 
+                                            // This 'L' indicates the width of 
+                                            // the Nonce and counter. The 
+                                            // loaded counter must be 
+                                            // initialized to 0. The total 
+                                            // width of A0 is 128-bit. For 
+                                            // CBC-MAC: -[127:0] - Zeroes - For 
+                                            // CBC-MAC this register must be 
+                                            // written with 0s at the start of 
+                                            // each operation. After an 
+                                            // operation, these registers 
+                                            // contain the 128-bit TAG output, 
+                                            // generated by the EIP-120t. 
+#define AES_AES_IV_3_AES_IV_S   0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the AES_AES_CTRL register.
+//
+//*****************************************************************************
+#define AES_AES_CTRL_context_ready \
+                                0x80000000  // If 1, this read-only status bit 
+                                            // indicates that the context data 
+                                            // registers can be overwritten and 
+                                            // the host is permitted to write 
+                                            // the next context. 
+
+#define AES_AES_CTRL_context_ready_M \
+                                0x80000000
+#define AES_AES_CTRL_context_ready_S 31
+#define AES_AES_CTRL_saved_context_ready \
+                                0x40000000  // If 1, this status bit indicates 
+                                            // that an AES authentication TAG 
+                                            // and/or IV block(s) is/are 
+                                            // available for the host to 
+                                            // retrieve. This bit is only 
+                                            // asserted if the save_context bit 
+                                            // is set to 1. The bit is mutual 
+                                            // exclusive with the context_ready 
+                                            // bit. Writing one clears the bit 
+                                            // to 0, indicating the AES core 
+                                            // can start its next operation. 
+                                            // This bit is also cleared when 
+                                            // the 4th word of the output TAG 
+                                            // and/or IV is read. Note: All 
+                                            // other mode bit writes are 
+                                            // ignored when this mode bit is 
+                                            // written with 1. Note: This bit 
+                                            // is controlled automatically by 
+                                            // the EIP-120t for TAG read DMA 
+                                            // operations. 
+
+#define AES_AES_CTRL_saved_context_ready_M \
+                                0x40000000
+#define AES_AES_CTRL_saved_context_ready_S 30
+#define AES_AES_CTRL_save_context \
+                                0x20000000  // This bit indicates that an 
+                                            // authentication TAG or result IV 
+                                            // needs to be stored as a result 
+                                            // context. Typically this bit must 
+                                            // be set for authentication modes 
+                                            // returning a TAG (CBC-MAC, GCM 
+                                            // and CCM), or for basic 
+                                            // encryption modes that require 
+                                            // future continuation with the 
+                                            // current result IV. If this bit 
+                                            // is set, the engine retains its 
+                                            // full context until the TAG 
+                                            // and/or IV registers are read. 
+                                            // The TAG or IV must be read 
+                                            // before the AES engine can start 
+                                            // a new operation. 
+
+#define AES_AES_CTRL_save_context_M \
+                                0x20000000
+#define AES_AES_CTRL_save_context_S 29
+#define AES_AES_CTRL_CCM_M_M    0x01C00000  // Defines M, which indicates the 
+                                            // length of the authentication 
+                                            // field for CCM operations; the 
+                                            // authentication field length 
+                                            // equals two times (the value of 
+                                            // CCM-M plus one). Note: The 
+                                            // EIP-120t always returns a 
+                                            // 128-bit authentication field, of 
+                                            // which the M least significant 
+                                            // bytes are valid. All values are 
+                                            // supported. 
+#define AES_AES_CTRL_CCM_M_S    22
+#define AES_AES_CTRL_CCM_L_M    0x00380000  // Defines L, which indicates the 
+                                            // width of the length field for 
+                                            // CCM operations; the length field 
+                                            // in bytes equals the value of 
+                                            // CMM-L plus one. All values are 
+                                            // supported. 
+#define AES_AES_CTRL_CCM_L_S    19
+#define AES_AES_CTRL_CCM        0x00040000  // If set to 1, AES-CCM is 
+                                            // selected AES-CCM is a combined 
+                                            // mode, using AES for 
+                                            // authentication and encryption. 
+                                            // Note: Selecting AES-CCM mode 
+                                            // requires writing of the AAD 
+                                            // length register after all other 
+                                            // registers. Note: The CTR mode 
+                                            // bit in this register must also 
+                                            // be set to 1 to enable AES-CTR; 
+                                            // selecting other AES modes than 
+                                            // CTR mode is invalid. 
+#define AES_AES_CTRL_CCM_M      0x00040000
+#define AES_AES_CTRL_CCM_S      18
+#define AES_AES_CTRL_GCM_M      0x00030000  // Set these bits to 11 to select 
+                                            // AES-GCM mode. AES-GCM is a 
+                                            // combined mode, using the Galois 
+                                            // field multiplier GF(2 to the 
+                                            // power of 128) for authentication 
+                                            // and AES-CTR mode for encryption. 
+                                            // Note: The CTR mode bit in this 
+                                            // register must also be set to 1 
+                                            // to enable AES-CTR Bit 
+                                            // combination description: 00 = No 
+                                            // GCM mode 01 = Reserved, do not 
+                                            // select 10 = Reserved, do not 
+                                            // select 11 = Autonomous GHASH 
+                                            // (both H- and Y0-encrypted 
+                                            // calculated internally) Note: The 
+                                            // EIP-120t-1 configuration only 
+                                            // supports mode 11 (autonomous 
+                                            // GHASH), other GCM modes are not 
+                                            // allowed. 
+#define AES_AES_CTRL_GCM_S      16
+#define AES_AES_CTRL_CBC_MAC    0x00008000  // Set to 1 to select AES-CBC MAC 
+                                            // mode. The direction bit must be 
+                                            // set to 1 for this mode. 
+                                            // Selecting this mode requires 
+                                            // writing the length register 
+                                            // after all other registers. 
+#define AES_AES_CTRL_CBC_MAC_M  0x00008000
+#define AES_AES_CTRL_CBC_MAC_S  15
+#define AES_AES_CTRL_ctr_width_M \
+                                0x00000180  // Specifies the counter width for 
+                                            // AES-CTR mode 00 = 32-bit counter 
+                                            // 01 = 64-bit counter 10 = 96-bit 
+                                            // counter 11 = 128-bit counter 
+
+#define AES_AES_CTRL_ctr_width_S 7
+#define AES_AES_CTRL_CTR        0x00000040  // If set to 1, AES counter mode 
+                                            // (CTR) is selected. Note: This 
+                                            // bit must also be set for GCM and 
+                                            // CCM, when encryption/decryption 
+                                            // is required. 
+#define AES_AES_CTRL_CTR_M      0x00000040
+#define AES_AES_CTRL_CTR_S      6
+#define AES_AES_CTRL_CBC        0x00000020  // If set to 1, 
+                                            // cipher-block-chaining (CBC) mode 
+                                            // is selected. 
+#define AES_AES_CTRL_CBC_M      0x00000020
+#define AES_AES_CTRL_CBC_S      5
+#define AES_AES_CTRL_key_size_M 0x00000018  // This read-only field specifies 
+                                            // the key size. The key size is 
+                                            // automatically configured when a 
+                                            // new key is loaded through the 
+                                            // key store module. 00 = N/A - 
+                                            // Reserved 01 = 128-bit 10 = 
+                                            // 192-bit 11 = 256-bit 
+#define AES_AES_CTRL_key_size_S 3
+#define AES_AES_CTRL_direction  0x00000004  // If set to 1 an encrypt 
+                                            // operation is performed. If set 
+                                            // to 0 a decrypt operation is 
+                                            // performed. This bit must be 
+                                            // written with a 1 when CBC-MAC is 
+                                            // selected. 
+#define AES_AES_CTRL_direction_M \
+                                0x00000004
+#define AES_AES_CTRL_direction_S 2
+#define AES_AES_CTRL_input_ready \
+                                0x00000002  // If 1, this status bit indicates 
+                                            // that the 16-byte AES input 
+                                            // buffer is empty. The host is 
+                                            // permitted to write the next 
+                                            // block of data. Writing 0 clears 
+                                            // the bit to 0 and indicates that 
+                                            // the AES core can use the 
+                                            // provided input data block. 
+                                            // Writing 1 to this bit is 
+                                            // ignored. Note: For DMA 
+                                            // operations, this bit is 
+                                            // automatically controlled by the 
+                                            // EIP-120t. After reset, this bit 
+                                            // is 0. After writing a context, 
+                                            // this bit becomes 1. 
+
+#define AES_AES_CTRL_input_ready_M \
+                                0x00000002
+#define AES_AES_CTRL_input_ready_S 1
+#define AES_AES_CTRL_output_ready \
+                                0x00000001  // If 1, this status bit indicates 
+                                            // that an AES output block is 
+                                            // available to be retrieved by the 
+                                            // host. Writing 0 clears the bit 
+                                            // to 0 and indicates that output 
+                                            // data is read by the host. The 
+                                            // AES core can provide a next 
+                                            // output data block. Writing 1 to 
+                                            // this bit is ignored. Note: For 
+                                            // DMA operations, this bit is 
+                                            // automatically controlled by the 
+                                            // EIP-120t. 
+
+#define AES_AES_CTRL_output_ready_M \
+                                0x00000001
+#define AES_AES_CTRL_output_ready_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// AES_AES_C_LENGTH_0 register.
+//
+//*****************************************************************************
+#define AES_AES_C_LENGTH_0_C_LENGTH_M \
+                                0xFFFFFFFF  // C_LENGTH[31:0] Bits [60:0] of 
+                                            // the crypto length registers (LSW 
+                                            // and MSW) store the cryptographic 
+                                            // data length in bytes for all 
+                                            // modes. Once processing with this 
+                                            // context is started, this length 
+                                            // decrements to 0. Data lengths up 
+                                            // to (261: 1) bytes are allowed. 
+                                            // For GCM, any value up to 236 - 
+                                            // 32 bytes can be used. This is 
+                                            // because a 32-bit counter mode is 
+                                            // used; the maximum number of 
+                                            // 128-bit blocks is 232 - 2, 
+                                            // resulting in a maximum number of 
+                                            // bytes of 236 - 32. A write to 
+                                            // this register triggers the 
+                                            // engine to start using this 
+                                            // context. This is valid for all 
+                                            // modes except GCM and CCM. Note: 
+                                            // For the combined modes (GCM and 
+                                            // CCM), this length does not 
+                                            // include the authentication only 
+                                            // data; the authentication length 
+                                            // is specified in the 
+                                            // AES_AUTH_LENGTH register below. 
+                                            // All modes must have a length 
+                                            // greater than 0. For the combined 
+                                            // modes, it is allowed to have one 
+                                            // of the lengths equal to 0. For 
+                                            // the basic encryption modes (ECB, 
+                                            // CBC, and CTR) it is allowed to 
+                                            // program zero to the length 
+                                            // field; in that case the length 
+                                            // is assumed infinite. All data 
+                                            // must be byte (8-bit) aligned for 
+                                            // stream cipher modes; bit aligned 
+                                            // data streams are not supported 
+                                            // by the EIP-120t. For block 
+                                            // cipher modes, the data length 
+                                            // must be programmed in multiples 
+                                            // of the block cipher size, 16 
+                                            // bytes. For a host read 
+                                            // operation, these registers 
+                                            // return all-0s. 
+
+#define AES_AES_C_LENGTH_0_C_LENGTH_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// AES_AES_C_LENGTH_1 register.
+//
+//*****************************************************************************
+#define AES_AES_C_LENGTH_1_C_LENGTH_M \
+                                0x1FFFFFFF  // C_LENGTH[60:32] Bits [60:0] of 
+                                            // the crypto length registers (LSW 
+                                            // and MSW) store the cryptographic 
+                                            // data length in bytes for all 
+                                            // modes. Once processing with this 
+                                            // context is started, this length 
+                                            // decrements to 0. Data lengths up 
+                                            // to (261: 1) bytes are allowed. 
+                                            // For GCM, any value up to 236 - 
+                                            // 32 bytes can be used. This is 
+                                            // because a 32-bit counter mode is 
+                                            // used; the maximum number of 
+                                            // 128-bit blocks is 232 - 2, 
+                                            // resulting in a maximum number of 
+                                            // bytes of 236 - 32. A write to 
+                                            // this register triggers the 
+                                            // engine to start using this 
+                                            // context. This is valid for all 
+                                            // modes except GCM and CCM. Note: 
+                                            // For the combined modes (GCM and 
+                                            // CCM), this length does not 
+                                            // include the authentication only 
+                                            // data; the authentication length 
+                                            // is specified in the 
+                                            // AES_AUTH_LENGTH register below. 
+                                            // All modes must have a length 
+                                            // greater than 0. For the combined 
+                                            // modes, it is allowed to have one 
+                                            // of the lengths equal to 0. For 
+                                            // the basic encryption modes (ECB, 
+                                            // CBC, and CTR) it is allowed to 
+                                            // program zero to the length 
+                                            // field; in that case the length 
+                                            // is assumed infinite. All data 
+                                            // must be byte (8-bit) aligned for 
+                                            // stream cipher modes; bit aligned 
+                                            // data streams are not supported 
+                                            // by the EIP-120t. For block 
+                                            // cipher modes, the data length 
+                                            // must be programmed in multiples 
+                                            // of the block cipher size, 16 
+                                            // bytes. For a host read 
+                                            // operation, these registers 
+                                            // return all-0s. 
+
+#define AES_AES_C_LENGTH_1_C_LENGTH_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// AES_AES_AUTH_LENGTH register.
+//
+//*****************************************************************************
+#define AES_AES_AUTH_LENGTH_AUTH_LENGTH_M \
+                                0xFFFFFFFF  // Bits [31:0] of the 
+                                            // authentication length register 
+                                            // store the authentication data 
+                                            // length in bytes for combined 
+                                            // modes only (GCM or CCM). 
+                                            // Supported AAD-lengths for CCM 
+                                            // are from 0 to (2^16 - 2^8) 
+                                            // bytes. For GCM any value up to 
+                                            // (2^32 - 1) bytes can be used. 
+                                            // Once processing with this 
+                                            // context is started, this length 
+                                            // decrements to 0. A write to this 
+                                            // register triggers the engine to 
+                                            // start using this context for GCM 
+                                            // and CCM. For a host read 
+                                            // operation, these registers 
+                                            // return all-0s. 
+
+#define AES_AES_AUTH_LENGTH_AUTH_LENGTH_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// AES_AES_DATA_IN_OUT_0 register.
+//
+//*****************************************************************************
+#define AES_AES_DATA_IN_OUT_0_AES_DATA_IN_OUT_M \
+                                0xFFFFFFFF  // AES input data[31:0] / AES 
+                                            // output data[31:0] Data registers 
+                                            // for input/output block data 
+                                            // to/from the EIP-120t. For normal 
+                                            // operations, this register is not 
+                                            // used, since data input and 
+                                            // output is transferred from and 
+                                            // to the AES core via DMA. For a 
+                                            // host write operation, these 
+                                            // registers must be written with 
+                                            // the 128-bit input block for the 
+                                            // next AES operation. Writing at a 
+                                            // word-aligned offset within this 
+                                            // address range stores the word (4 
+                                            // bytes) of data into the 
+                                            // corresponding position of 4-word 
+                                            // deep (16 bytes = 128-bit AES 
+                                            // block) data input buffer. This 
+                                            // buffer is used for the next AES 
+                                            // operation. If the last data 
+                                            // block is not completely filled 
+                                            // with valid data (see notes 
+                                            // below), it is allowed to write 
+                                            // only the words with valid data. 
+                                            // Next AES operation is triggered 
+                                            // by writing to the input_ready 
+                                            // flag of the AES_CTRL register. 
+                                            // For a host read operation, these 
+                                            // registers contain the 128-bit 
+                                            // output block from the latest AES 
+                                            // operation. Reading from a 
+                                            // word-aligned offset within this 
+                                            // address range reads one word (4 
+                                            // bytes) of data out the 4-word 
+                                            // deep (16 bytes = 128-bits AES 
+                                            // block) data output buffer. The 
+                                            // words (4 words, one full block) 
+                                            // should be read before the core 
+                                            // will move the next block to the 
+                                            // data output buffer. To empty the 
+                                            // data output buffer, the 
+                                            // output_ready flag of the 
+                                            // AES_CTRL register must be 
+                                            // written. For the modes with 
+                                            // authentication (CBC-MAC, GCM and 
+                                            // CCM), the invalid (message) 
+                                            // bytes/words can be written with 
+                                            // any data. Note: AES typically 
+                                            // operates on 128 bits block 
+                                            // multiple input data. The CTR, 
+                                            // GCM and CCM modes form an 
+                                            // exception. The last block of a 
+                                            // CTR-mode message may contain 
+                                            // less than 128 bits (refer to 
+                                            // [NIST 800-38A]). For GCM/CCM, 
+                                            // the last block of both AAD and 
+                                            // message data may contain less 
+                                            // than 128 bits (refer to [NIST 
+                                            // 800-38D]). The EIP-120t 
+                                            // automatically pads or masks 
+                                            // misaligned ending data blocks 
+                                            // with 0s for GCM, CCM and 
+                                            // CBC-MAC. For CTR mode, the 
+                                            // remaining data in an unaligned 
+                                            // data block is ignored. Note: The 
+                                            // AAD / authentication only data 
+                                            // is not copied to the output 
+                                            // buffer but only used for 
+                                            // authentication. 
+
+#define AES_AES_DATA_IN_OUT_0_AES_DATA_IN_OUT_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// AES_AES_DATA_IN_OUT_1 register.
+//
+//*****************************************************************************
+#define AES_AES_DATA_IN_OUT_1_AES_DATA_IN_OUT_M \
+                                0xFFFFFFFF  // AES input data[63:32] / AES 
+                                            // output data[63:32] Data 
+                                            // registers for input/output block 
+                                            // data to/from the EIP-120t. For 
+                                            // normal operations, this register 
+                                            // is not used, since data input 
+                                            // and output is transferred from 
+                                            // and to the AES core via DMA. For 
+                                            // a host write operation, these 
+                                            // registers must be written with 
+                                            // the 128-bit input block for the 
+                                            // next AES operation. Writing at a 
+                                            // word-aligned offset within this 
+                                            // address range stores the word (4 
+                                            // bytes) of data into the 
+                                            // corresponding position of 4-word 
+                                            // deep (16 bytes = 128-bit AES 
+                                            // block) data input buffer. This 
+                                            // buffer is used for the next AES 
+                                            // operation. If the last data 
+                                            // block is not completely filled 
+                                            // with valid data (see notes 
+                                            // below), it is allowed to write 
+                                            // only the words with valid data. 
+                                            // Next AES operation is triggered 
+                                            // by writing to the input_ready 
+                                            // flag of the AES_CTRL register. 
+                                            // For a host read operation, these 
+                                            // registers contain the 128-bit 
+                                            // output block from the latest AES 
+                                            // operation. Reading from a 
+                                            // word-aligned offset within this 
+                                            // address range reads one word (4 
+                                            // bytes) of data out the 4-word 
+                                            // deep (16 bytes = 128-bits AES 
+                                            // block) data output buffer. The 
+                                            // words (4 words, one full block) 
+                                            // should be read before the core 
+                                            // will move the next block to the 
+                                            // data output buffer. To empty the 
+                                            // data output buffer, the 
+                                            // output_ready flag of the 
+                                            // AES_CTRL register must be 
+                                            // written. For the modes with 
+                                            // authentication (CBC-MAC, GCM and 
+                                            // CCM), the invalid (message) 
+                                            // bytes/words can be written with 
+                                            // any data. Note: AES typically 
+                                            // operates on 128 bits block 
+                                            // multiple input data. The CTR, 
+                                            // GCM and CCM modes form an 
+                                            // exception. The last block of a 
+                                            // CTR-mode message may contain 
+                                            // less than 128 bits (refer to 
+                                            // [NIST 800-38A]). For GCM/CCM, 
+                                            // the last block of both AAD and 
+                                            // message data may contain less 
+                                            // than 128 bits (refer to [NIST 
+                                            // 800-38D]). The EIP-120t 
+                                            // automatically pads or masks 
+                                            // misaligned ending data blocks 
+                                            // with 0s for GCM, CCM and 
+                                            // CBC-MAC. For CTR mode, the 
+                                            // remaining data in an unaligned 
+                                            // data block is ignored. Note: The 
+                                            // AAD / authentication only data 
+                                            // is not copied to the output 
+                                            // buffer but only used for 
+                                            // authentication. 
+
+#define AES_AES_DATA_IN_OUT_1_AES_DATA_IN_OUT_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// AES_AES_DATA_IN_OUT_2 register.
+//
+//*****************************************************************************
+#define AES_AES_DATA_IN_OUT_2_AES_DATA_IN_OUT_M \
+                                0xFFFFFFFF  // AES input data[95:64] / AES 
+                                            // output data[95:64] Data 
+                                            // registers for input/output block 
+                                            // data to/from the EIP-120t. For 
+                                            // normal operations, this register 
+                                            // is not used, since data input 
+                                            // and output is transferred from 
+                                            // and to the AES core via DMA. For 
+                                            // a host write operation, these 
+                                            // registers must be written with 
+                                            // the 128-bit input block for the 
+                                            // next AES operation. Writing at a 
+                                            // word-aligned offset within this 
+                                            // address range stores the word (4 
+                                            // bytes) of data into the 
+                                            // corresponding position of 4-word 
+                                            // deep (16 bytes = 128-bit AES 
+                                            // block) data input buffer. This 
+                                            // buffer is used for the next AES 
+                                            // operation. If the last data 
+                                            // block is not completely filled 
+                                            // with valid data (see notes 
+                                            // below), it is allowed to write 
+                                            // only the words with valid data. 
+                                            // Next AES operation is triggered 
+                                            // by writing to the input_ready 
+                                            // flag of the AES_CTRL register. 
+                                            // For a host read operation, these 
+                                            // registers contain the 128-bit 
+                                            // output block from the latest AES 
+                                            // operation. Reading from a 
+                                            // word-aligned offset within this 
+                                            // address range reads one word (4 
+                                            // bytes) of data out the 4-word 
+                                            // deep (16 bytes = 128-bits AES 
+                                            // block) data output buffer. The 
+                                            // words (4 words, one full block) 
+                                            // should be read before the core 
+                                            // will move the next block to the 
+                                            // data output buffer. To empty the 
+                                            // data output buffer, the 
+                                            // output_ready flag of the 
+                                            // AES_CTRL register must be 
+                                            // written. For the modes with 
+                                            // authentication (CBC-MAC, GCM and 
+                                            // CCM), the invalid (message) 
+                                            // bytes/words can be written with 
+                                            // any data. Note: AES typically 
+                                            // operates on 128 bits block 
+                                            // multiple input data. The CTR, 
+                                            // GCM and CCM modes form an 
+                                            // exception. The last block of a 
+                                            // CTR-mode message may contain 
+                                            // less than 128 bits (refer to 
+                                            // [NIST 800-38A]). For GCM/CCM, 
+                                            // the last block of both AAD and 
+                                            // message data may contain less 
+                                            // than 128 bits (refer to [NIST 
+                                            // 800-38D]). The EIP-120t 
+                                            // automatically pads or masks 
+                                            // misaligned ending data blocks 
+                                            // with 0s for GCM, CCM and 
+                                            // CBC-MAC. For CTR mode, the 
+                                            // remaining data in an unaligned 
+                                            // data block is ignored. Note: The 
+                                            // AAD / authentication only data 
+                                            // is not copied to the output 
+                                            // buffer but only used for 
+                                            // authentication. 
+
+#define AES_AES_DATA_IN_OUT_2_AES_DATA_IN_OUT_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// AES_AES_DATA_IN_OUT_3 register.
+//
+//*****************************************************************************
+#define AES_AES_DATA_IN_OUT_3_AES_DATA_IN_OUT_M \
+                                0xFFFFFFFF  // AES input data[127:96] / AES 
+                                            // output data[127:96] Data 
+                                            // registers for input/output block 
+                                            // data to/from the EIP-120t. For 
+                                            // normal operations, this register 
+                                            // is not used, since data input 
+                                            // and output is transferred from 
+                                            // and to the AES core via DMA. For 
+                                            // a host write operation, these 
+                                            // registers must be written with 
+                                            // the 128-bit input block for the 
+                                            // next AES operation. Writing at a 
+                                            // word-aligned offset within this 
+                                            // address range stores the word (4 
+                                            // bytes) of data into the 
+                                            // corresponding position of 4-word 
+                                            // deep (16 bytes = 128-bit AES 
+                                            // block) data input buffer. This 
+                                            // buffer is used for the next AES 
+                                            // operation. If the last data 
+                                            // block is not completely filled 
+                                            // with valid data (see notes 
+                                            // below), it is allowed to write 
+                                            // only the words with valid data. 
+                                            // Next AES operation is triggered 
+                                            // by writing to the input_ready 
+                                            // flag of the AES_CTRL register. 
+                                            // For a host read operation, these 
+                                            // registers contain the 128-bit 
+                                            // output block from the latest AES 
+                                            // operation. Reading from a 
+                                            // word-aligned offset within this 
+                                            // address range reads one word (4 
+                                            // bytes) of data out the 4-word 
+                                            // deep (16 bytes = 128-bits AES 
+                                            // block) data output buffer. The 
+                                            // words (4 words, one full block) 
+                                            // should be read before the core 
+                                            // will move the next block to the 
+                                            // data output buffer. To empty the 
+                                            // data output buffer, the 
+                                            // output_ready flag of the 
+                                            // AES_CTRL register must be 
+                                            // written. For the modes with 
+                                            // authentication (CBC-MAC, GCM and 
+                                            // CCM), the invalid (message) 
+                                            // bytes/words can be written with 
+                                            // any data. Note: AES typically 
+                                            // operates on 128 bits block 
+                                            // multiple input data. The CTR, 
+                                            // GCM and CCM modes form an 
+                                            // exception. The last block of a 
+                                            // CTR-mode message may contain 
+                                            // less than 128 bits (refer to 
+                                            // [NIST 800-38A]). For GCM/CCM, 
+                                            // the last block of both AAD and 
+                                            // message data may contain less 
+                                            // than 128 bits (refer to [NIST 
+                                            // 800-38D]). The EIP-120t 
+                                            // automatically pads or masks 
+                                            // misaligned ending data blocks 
+                                            // with 0s for GCM, CCM and 
+                                            // CBC-MAC. For CTR mode, the 
+                                            // remaining data in an unaligned 
+                                            // data block is ignored. Note: The 
+                                            // AAD / authentication only data 
+                                            // is not copied to the output 
+                                            // buffer but only used for 
+                                            // authentication. 
+
+#define AES_AES_DATA_IN_OUT_3_AES_DATA_IN_OUT_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// AES_AES_TAG_OUT_0 register.
+//
+//*****************************************************************************
+#define AES_AES_TAG_OUT_0_AES_TAG_M \
+                                0xFFFFFFFF  // AES_TAG[31:0] Bits [31:0] of 
+                                            // the AES_TAG registers store the 
+                                            // authentication value for the 
+                                            // combined and authentication only 
+                                            // modes. For a host read 
+                                            // operation, these registers 
+                                            // contain the last 128-bit TAG 
+                                            // output of the EIP-120t; the TAG 
+                                            // is available until the next 
+                                            // context is written. This 
+                                            // register will only contain valid 
+                                            // data if the TAG is available and 
+                                            // when the store_ready bit from 
+                                            // AES_CTRL register is set. During 
+                                            // processing or for 
+                                            // operations/modes that do not 
+                                            // return a TAG, reads from this 
+                                            // register return data from the IV 
+                                            // register. 
+
+#define AES_AES_TAG_OUT_0_AES_TAG_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// AES_AES_TAG_OUT_1 register.
+//
+//*****************************************************************************
+#define AES_AES_TAG_OUT_1_AES_TAG_M \
+                                0xFFFFFFFF  // AES_TAG[63:32] For a host read 
+                                            // operation, these registers 
+                                            // contain the last 128-bit TAG 
+                                            // output of the EIP-120t; the TAG 
+                                            // is available until the next 
+                                            // context is written. This 
+                                            // register contains valid data 
+                                            // only if the TAG is available and 
+                                            // when the store_ready bit from 
+                                            // AES_CTRL register is set. During 
+                                            // processing or for 
+                                            // operations/modes that do not 
+                                            // return a TAG, reads from this 
+                                            // register return data from the IV 
+                                            // register. 
+
+#define AES_AES_TAG_OUT_1_AES_TAG_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// AES_AES_TAG_OUT_2 register.
+//
+//*****************************************************************************
+#define AES_AES_TAG_OUT_2_AES_TAG_M \
+                                0xFFFFFFFF  // AES_TAG[95:64] For a host read 
+                                            // operation, these registers 
+                                            // contain the last 128-bit TAG 
+                                            // output of the EIP-120t; the TAG 
+                                            // is available until the next 
+                                            // context is written. This 
+                                            // register contains valid data 
+                                            // only if the TAG is available and 
+                                            // when the store_ready bit from 
+                                            // AES_CTRL register is set. During 
+                                            // processing or for 
+                                            // operations/modes that do not 
+                                            // return a TAG, reads from this 
+                                            // register return data from the IV 
+                                            // register. 
+
+#define AES_AES_TAG_OUT_2_AES_TAG_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// AES_AES_TAG_OUT_3 register.
+//
+//*****************************************************************************
+#define AES_AES_TAG_OUT_3_AES_TAG_M \
+                                0xFFFFFFFF  // AES_TAG[127:96] For a host read 
+                                            // operation, these registers 
+                                            // contain the last 128-bit TAG 
+                                            // output of the EIP-120t; the TAG 
+                                            // is available until the next 
+                                            // context is written. This 
+                                            // register contains valid data 
+                                            // only if the TAG is available and 
+                                            // when the store_ready bit from 
+                                            // AES_CTRL register is set. During 
+                                            // processing or for 
+                                            // operations/modes that do not 
+                                            // return a TAG, reads from this 
+                                            // register return data from the IV 
+                                            // register. 
+
+#define AES_AES_TAG_OUT_3_AES_TAG_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// AES_HASH_DATA_IN_0 register.
+//
+//*****************************************************************************
+#define AES_HASH_DATA_IN_0_HASH_DATA_IN_M \
+                                0xFFFFFFFF  // HASH_DATA_IN[31:0] These 
+                                            // registers must be written with 
+                                            // the 512-bit input data. The data 
+                                            // lines are connected directly to 
+                                            // the data input of the hash 
+                                            // module and hence into the 
+                                            // engine's internal data buffer. 
+                                            // Writing to each of the registers 
+                                            // triggers a corresponding 32-bit 
+                                            // write enable to the internal 
+                                            // buffer. Note: The host may only 
+                                            // write the input data buffer when 
+                                            // the rfd_in bit of the 
+                                            // HASH_IO_BUF_CTRL register is 
+                                            // high. If the rfd_in bit is 0, 
+                                            // the engine is busy with 
+                                            // processing. During processing, 
+                                            // it is not allowed to write new 
+                                            // input data. For message lengths 
+                                            // larger than 64 bytes, multiple 
+                                            // blocks of data are written to 
+                                            // this input buffer using a 
+                                            // handshake through flags of the 
+                                            // HASH_IO_BUF_CTRL register. All 
+                                            // blocks except the last are 
+                                            // required to be 512 bits in size. 
+                                            // If the last block is not 512 
+                                            // bits long, only the least 
+                                            // significant bits of data must be 
+                                            // written, but they must be padded 
+                                            // with 0s to the next 32-bit 
+                                            // boundary. Host read operations 
+                                            // from these register addresses 
+                                            // return 0s. 
+
+#define AES_HASH_DATA_IN_0_HASH_DATA_IN_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// AES_HASH_DATA_IN_1 register.
+//
+//*****************************************************************************
+#define AES_HASH_DATA_IN_1_HASH_DATA_IN_M \
+                                0xFFFFFFFF  // HASH_DATA_IN[63:32] These 
+                                            // registers must be written with 
+                                            // the 512-bit input data. The data 
+                                            // lines are connected directly to 
+                                            // the data input of the hash 
+                                            // module and hence into the 
+                                            // engine's internal data buffer. 
+                                            // Writing to each of the registers 
+                                            // triggers a corresponding 32-bit 
+                                            // write enable to the internal 
+                                            // buffer. Note: The host may only 
+                                            // write the input data buffer when 
+                                            // the rfd_in bit of the 
+                                            // HASH_IO_BUF_CTRL register is 
+                                            // high. If the rfd_in bit is 0, 
+                                            // the engine is busy with 
+                                            // processing. During processing, 
+                                            // it is not allowed to write new 
+                                            // input data. For message lengths 
+                                            // larger than 64 bytes, multiple 
+                                            // blocks of data are written to 
+                                            // this input buffer using a 
+                                            // handshake through flags of the 
+                                            // HASH_IO_BUF_CTRL register. All 
+                                            // blocks except the last are 
+                                            // required to be 512 bits in size. 
+                                            // If the last block is not 512 
+                                            // bits long, only the least 
+                                            // significant bits of data must be 
+                                            // written, but they must be padded 
+                                            // with 0s to the next 32-bit 
+                                            // boundary. Host read operations 
+                                            // from these register addresses 
+                                            // return 0s. 
+
+#define AES_HASH_DATA_IN_1_HASH_DATA_IN_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// AES_HASH_DATA_IN_2 register.
+//
+//*****************************************************************************
+#define AES_HASH_DATA_IN_2_HASH_DATA_IN_M \
+                                0xFFFFFFFF  // HASH_DATA_IN[95:64] These 
+                                            // registers must be written with 
+                                            // the 512-bit input data. The data 
+                                            // lines are connected directly to 
+                                            // the data input of the hash 
+                                            // module and hence into the 
+                                            // engine's internal data buffer. 
+                                            // Writing to each of the registers 
+                                            // triggers a corresponding 32-bit 
+                                            // write enable to the internal 
+                                            // buffer. Note: The host may only 
+                                            // write the input data buffer when 
+                                            // the rfd_in bit of the 
+                                            // HASH_IO_BUF_CTRL register is 
+                                            // high. If the rfd_in bit is 0, 
+                                            // the engine is busy with 
+                                            // processing. During processing, 
+                                            // it is not allowed to write new 
+                                            // input data. For message lengths 
+                                            // larger than 64 bytes, multiple 
+                                            // blocks of data are written to 
+                                            // this input buffer using a 
+                                            // handshake through flags of the 
+                                            // HASH_IO_BUF_CTRL register. All 
+                                            // blocks except the last are 
+                                            // required to be 512 bits in size. 
+                                            // If the last block is not 512 
+                                            // bits long, only the least 
+                                            // significant bits of data must be 
+                                            // written, but they must be padded 
+                                            // with 0s to the next 32-bit 
+                                            // boundary. Host read operations 
+                                            // from these register addresses 
+                                            // return 0s. 
+
+#define AES_HASH_DATA_IN_2_HASH_DATA_IN_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// AES_HASH_DATA_IN_3 register.
+//
+//*****************************************************************************
+#define AES_HASH_DATA_IN_3_HASH_DATA_IN_M \
+                                0xFFFFFFFF  // HASH_DATA_IN[127:96] These 
+                                            // registers must be written with 
+                                            // the 512-bit input data. The data 
+                                            // lines are connected directly to 
+                                            // the data input of the hash 
+                                            // module and hence into the 
+                                            // engine's internal data buffer. 
+                                            // Writing to each of the registers 
+                                            // triggers a corresponding 32-bit 
+                                            // write enable to the internal 
+                                            // buffer. Note: The host may only 
+                                            // write the input data buffer when 
+                                            // the rfd_in bit of the 
+                                            // HASH_IO_BUF_CTRL register is 
+                                            // high. If the rfd_in bit is 0, 
+                                            // the engine is busy with 
+                                            // processing. During processing, 
+                                            // it is not allowed to write new 
+                                            // input data. For message lengths 
+                                            // larger than 64 bytes, multiple 
+                                            // blocks of data are written to 
+                                            // this input buffer using a 
+                                            // handshake through flags of the 
+                                            // HASH_IO_BUF_CTRL register. All 
+                                            // blocks except the last are 
+                                            // required to be 512 bits in size. 
+                                            // If the last block is not 512 
+                                            // bits long, only the least 
+                                            // significant bits of data must be 
+                                            // written, but they must be padded 
+                                            // with 0s to the next 32-bit 
+                                            // boundary. Host read operations 
+                                            // from these register addresses 
+                                            // return 0s. 
+
+#define AES_HASH_DATA_IN_3_HASH_DATA_IN_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// AES_HASH_DATA_IN_4 register.
+//
+//*****************************************************************************
+#define AES_HASH_DATA_IN_4_HASH_DATA_IN_M \
+                                0xFFFFFFFF  // HASH_DATA_IN[159:128] These 
+                                            // registers must be written with 
+                                            // the 512-bit input data. The data 
+                                            // lines are connected directly to 
+                                            // the data input of the hash 
+                                            // module and hence into the 
+                                            // engine's internal data buffer. 
+                                            // Writing to each of the registers 
+                                            // triggers a corresponding 32-bit 
+                                            // write enable to the internal 
+                                            // buffer. Note: The host may only 
+                                            // write the input data buffer when 
+                                            // the rfd_in bit of the 
+                                            // HASH_IO_BUF_CTRL register is 
+                                            // high. If the rfd_in bit is 0, 
+                                            // the engine is busy with 
+                                            // processing. During processing, 
+                                            // it is not allowed to write new 
+                                            // input data. For message lengths 
+                                            // larger than 64 bytes, multiple 
+                                            // blocks of data are written to 
+                                            // this input buffer using a 
+                                            // handshake through flags of the 
+                                            // HASH_IO_BUF_CTRL register. All 
+                                            // blocks except the last are 
+                                            // required to be 512 bits in size. 
+                                            // If the last block is not 512 
+                                            // bits long, only the least 
+                                            // significant bits of data must be 
+                                            // written, but they must be padded 
+                                            // with 0s to the next 32-bit 
+                                            // boundary. Host read operations 
+                                            // from these register addresses 
+                                            // return 0s. 
+
+#define AES_HASH_DATA_IN_4_HASH_DATA_IN_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// AES_HASH_DATA_IN_5 register.
+//
+//*****************************************************************************
+#define AES_HASH_DATA_IN_5_HASH_DATA_IN_M \
+                                0xFFFFFFFF  // HASH_DATA_IN[191:160] These 
+                                            // registers must be written with 
+                                            // the 512-bit input data. The data 
+                                            // lines are connected directly to 
+                                            // the data input of the hash 
+                                            // module and hence into the 
+                                            // engine's internal data buffer. 
+                                            // Writing to each of the registers 
+                                            // triggers a corresponding 32-bit 
+                                            // write enable to the internal 
+                                            // buffer. Note: The host may only 
+                                            // write the input data buffer when 
+                                            // the rfd_in bit of the 
+                                            // HASH_IO_BUF_CTRL register is 
+                                            // high. If the rfd_in bit is 0, 
+                                            // the engine is busy with 
+                                            // processing. During processing, 
+                                            // it is not allowed to write new 
+                                            // input data. For message lengths 
+                                            // larger than 64 bytes, multiple 
+                                            // blocks of data are written to 
+                                            // this input buffer using a 
+                                            // handshake through flags of the 
+                                            // HASH_IO_BUF_CTRL register. All 
+                                            // blocks except the last are 
+                                            // required to be 512 bits in size. 
+                                            // If the last block is not 512 
+                                            // bits long, only the least 
+                                            // significant bits of data must be 
+                                            // written, but they must be padded 
+                                            // with 0s to the next 32-bit 
+                                            // boundary. Host read operations 
+                                            // from these register addresses 
+                                            // return 0s. 
+
+#define AES_HASH_DATA_IN_5_HASH_DATA_IN_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// AES_HASH_DATA_IN_6 register.
+//
+//*****************************************************************************
+#define AES_HASH_DATA_IN_6_HASH_DATA_IN_M \
+                                0xFFFFFFFF  // HASH_DATA_IN[223:192] These 
+                                            // registers must be written with 
+                                            // the 512-bit input data. The data 
+                                            // lines are connected directly to 
+                                            // the data input of the hash 
+                                            // module and hence into the 
+                                            // engine's internal data buffer. 
+                                            // Writing to each of the registers 
+                                            // triggers a corresponding 32-bit 
+                                            // write enable to the internal 
+                                            // buffer. Note: The host may only 
+                                            // write the input data buffer when 
+                                            // the rfd_in bit of the 
+                                            // HASH_IO_BUF_CTRL register is 
+                                            // high. If the rfd_in bit is 0, 
+                                            // the engine is busy with 
+                                            // processing. During processing, 
+                                            // it is not allowed to write new 
+                                            // input data. For message lengths 
+                                            // larger than 64 bytes, multiple 
+                                            // blocks of data are written to 
+                                            // this input buffer using a 
+                                            // handshake through flags of the 
+                                            // HASH_IO_BUF_CTRL register. All 
+                                            // blocks except the last are 
+                                            // required to be 512 bits in size. 
+                                            // If the last block is not 512 
+                                            // bits long, only the least 
+                                            // significant bits of data must be 
+                                            // written, but they must be padded 
+                                            // with 0s to the next 32-bit 
+                                            // boundary. Host read operations 
+                                            // from these register addresses 
+                                            // return 0s. 
+
+#define AES_HASH_DATA_IN_6_HASH_DATA_IN_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// AES_HASH_DATA_IN_7 register.
+//
+//*****************************************************************************
+#define AES_HASH_DATA_IN_7_HASH_DATA_IN_M \
+                                0xFFFFFFFF  // HASH_DATA_IN[255:224] These 
+                                            // registers must be written with 
+                                            // the 512-bit input data. The data 
+                                            // lines are connected directly to 
+                                            // the data input of the hash 
+                                            // module and hence into the 
+                                            // engine's internal data buffer. 
+                                            // Writing to each of the registers 
+                                            // triggers a corresponding 32-bit 
+                                            // write enable to the internal 
+                                            // buffer. Note: The host may only 
+                                            // write the input data buffer when 
+                                            // the rfd_in bit of the 
+                                            // HASH_IO_BUF_CTRL register is 
+                                            // high. If the rfd_in bit is 0, 
+                                            // the engine is busy with 
+                                            // processing. During processing, 
+                                            // it is not allowed to write new 
+                                            // input data. For message lengths 
+                                            // larger than 64 bytes, multiple 
+                                            // blocks of data are written to 
+                                            // this input buffer using a 
+                                            // handshake through flags of the 
+                                            // HASH_IO_BUF_CTRL register. All 
+                                            // blocks except the last are 
+                                            // required to be 512 bits in size. 
+                                            // If the last block is not 512 
+                                            // bits long, only the least 
+                                            // significant bits of data must be 
+                                            // written, but they must be padded 
+                                            // with 0s to the next 32-bit 
+                                            // boundary. Host read operations 
+                                            // from these register addresses 
+                                            // return 0s. 
+
+#define AES_HASH_DATA_IN_7_HASH_DATA_IN_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// AES_HASH_DATA_IN_8 register.
+//
+//*****************************************************************************
+#define AES_HASH_DATA_IN_8_HASH_DATA_IN_M \
+                                0xFFFFFFFF  // HASH_DATA_IN[287:256] These 
+                                            // registers must be written with 
+                                            // the 512-bit input data. The data 
+                                            // lines are connected directly to 
+                                            // the data input of the hash 
+                                            // module and hence into the 
+                                            // engine's internal data buffer. 
+                                            // Writing to each of the registers 
+                                            // triggers a corresponding 32-bit 
+                                            // write enable to the internal 
+                                            // buffer. Note: The host may only 
+                                            // write the input data buffer when 
+                                            // the rfd_in bit of the 
+                                            // HASH_IO_BUF_CTRL register is 
+                                            // high. If the rfd_in bit is 0, 
+                                            // the engine is busy with 
+                                            // processing. During processing, 
+                                            // it is not allowed to write new 
+                                            // input data. For message lengths 
+                                            // larger than 64 bytes, multiple 
+                                            // blocks of data are written to 
+                                            // this input buffer using a 
+                                            // handshake through flags of the 
+                                            // HASH_IO_BUF_CTRL register. All 
+                                            // blocks except the last are 
+                                            // required to be 512 bits in size. 
+                                            // If the last block is not 512 
+                                            // bits long, only the least 
+                                            // significant bits of data must be 
+                                            // written, but they must be padded 
+                                            // with 0s to the next 32-bit 
+                                            // boundary. Host read operations 
+                                            // from these register addresses 
+                                            // return 0s. 
+
+#define AES_HASH_DATA_IN_8_HASH_DATA_IN_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// AES_HASH_DATA_IN_9 register.
+//
+//*****************************************************************************
+#define AES_HASH_DATA_IN_9_HASH_DATA_IN_M \
+                                0xFFFFFFFF  // HASH_DATA_IN[319:288] These 
+                                            // registers must be written with 
+                                            // the 512-bit input data. The data 
+                                            // lines are connected directly to 
+                                            // the data input of the hash 
+                                            // module and hence into the 
+                                            // engine's internal data buffer. 
+                                            // Writing to each of the registers 
+                                            // triggers a corresponding 32-bit 
+                                            // write enable to the internal 
+                                            // buffer. Note: The host may only 
+                                            // write the input data buffer when 
+                                            // the rfd_in bit of the 
+                                            // HASH_IO_BUF_CTRL register is 
+                                            // high. If the rfd_in bit is 0, 
+                                            // the engine is busy with 
+                                            // processing. During processing, 
+                                            // it is not allowed to write new 
+                                            // input data. For message lengths 
+                                            // larger than 64 bytes, multiple 
+                                            // blocks of data are written to 
+                                            // this input buffer using a 
+                                            // handshake through flags of the 
+                                            // HASH_IO_BUF_CTRL register. All 
+                                            // blocks except the last are 
+                                            // required to be 512 bits in size. 
+                                            // If the last block is not 512 
+                                            // bits long, only the least 
+                                            // significant bits of data must be 
+                                            // written, but they must be padded 
+                                            // with 0s to the next 32-bit 
+                                            // boundary. Host read operations 
+                                            // from these register addresses 
+                                            // return 0s. 
+
+#define AES_HASH_DATA_IN_9_HASH_DATA_IN_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// AES_HASH_DATA_IN_10 register.
+//
+//*****************************************************************************
+#define AES_HASH_DATA_IN_10_HASH_DATA_IN_M \
+                                0xFFFFFFFF  // HASH_DATA_IN[351:320] These 
+                                            // registers must be written with 
+                                            // the 512-bit input data. The data 
+                                            // lines are connected directly to 
+                                            // the data input of the hash 
+                                            // module and hence into the 
+                                            // engine's internal data buffer. 
+                                            // Writing to each of the registers 
+                                            // triggers a corresponding 32-bit 
+                                            // write enable to the internal 
+                                            // buffer. Note: The host may only 
+                                            // write the input data buffer when 
+                                            // the rfd_in bit of the 
+                                            // HASH_IO_BUF_CTRL register is 
+                                            // high. If the rfd_in bit is 0, 
+                                            // the engine is busy with 
+                                            // processing. During processing, 
+                                            // it is not allowed to write new 
+                                            // input data. For message lengths 
+                                            // larger than 64 bytes, multiple 
+                                            // blocks of data are written to 
+                                            // this input buffer using a 
+                                            // handshake through flags of the 
+                                            // HASH_IO_BUF_CTRL register. All 
+                                            // blocks except the last are 
+                                            // required to be 512 bits in size. 
+                                            // If the last block is not 512 
+                                            // bits long, only the least 
+                                            // significant bits of data must be 
+                                            // written, but they must be padded 
+                                            // with 0s to the next 32-bit 
+                                            // boundary. Host read operations 
+                                            // from these register addresses 
+                                            // return 0s. 
+
+#define AES_HASH_DATA_IN_10_HASH_DATA_IN_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// AES_HASH_DATA_IN_11 register.
+//
+//*****************************************************************************
+#define AES_HASH_DATA_IN_11_HASH_DATA_IN_M \
+                                0xFFFFFFFF  // HASH_DATA_IN[383:352] These 
+                                            // registers must be written with 
+                                            // the 512-bit input data. The data 
+                                            // lines are connected directly to 
+                                            // the data input of the hash 
+                                            // module and hence into the 
+                                            // engine's internal data buffer. 
+                                            // Writing to each of the registers 
+                                            // triggers a corresponding 32-bit 
+                                            // write enable to the internal 
+                                            // buffer. Note: The host may only 
+                                            // write the input data buffer when 
+                                            // the rfd_in bit of the 
+                                            // HASH_IO_BUF_CTRL register is 
+                                            // high. If the rfd_in bit is 0, 
+                                            // the engine is busy with 
+                                            // processing. During processing, 
+                                            // it is not allowed to write new 
+                                            // input data. For message lengths 
+                                            // larger than 64 bytes, multiple 
+                                            // blocks of data are written to 
+                                            // this input buffer using a 
+                                            // handshake through flags of the 
+                                            // HASH_IO_BUF_CTRL register. All 
+                                            // blocks except the last are 
+                                            // required to be 512 bits in size. 
+                                            // If the last block is not 512 
+                                            // bits long, only the least 
+                                            // significant bits of data must be 
+                                            // written, but they must be padded 
+                                            // with 0s to the next 32-bit 
+                                            // boundary. Host read operations 
+                                            // from these register addresses 
+                                            // return 0s. 
+
+#define AES_HASH_DATA_IN_11_HASH_DATA_IN_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// AES_HASH_DATA_IN_12 register.
+//
+//*****************************************************************************
+#define AES_HASH_DATA_IN_12_HASH_DATA_IN_M \
+                                0xFFFFFFFF  // HASH_DATA_IN[415:384] These 
+                                            // registers must be written with 
+                                            // the 512-bit input data. The data 
+                                            // lines are connected directly to 
+                                            // the data input of the hash 
+                                            // module and hence into the 
+                                            // engine's internal data buffer. 
+                                            // Writing to each of the registers 
+                                            // triggers a corresponding 32-bit 
+                                            // write enable to the internal 
+                                            // buffer. Note: The host may only 
+                                            // write the input data buffer when 
+                                            // the rfd_in bit of the 
+                                            // HASH_IO_BUF_CTRL register is 
+                                            // high. If the rfd_in bit is 0, 
+                                            // the engine is busy with 
+                                            // processing. During processing, 
+                                            // it is not allowed to write new 
+                                            // input data. For message lengths 
+                                            // larger than 64 bytes, multiple 
+                                            // blocks of data are written to 
+                                            // this input buffer using a 
+                                            // handshake through flags of the 
+                                            // HASH_IO_BUF_CTRL register. All 
+                                            // blocks except the last are 
+                                            // required to be 512 bits in size. 
+                                            // If the last block is not 512 
+                                            // bits long, only the least 
+                                            // significant bits of data must be 
+                                            // written, but they must be padded 
+                                            // with 0s to the next 32-bit 
+                                            // boundary. Host read operations 
+                                            // from these register addresses 
+                                            // return 0s. 
+
+#define AES_HASH_DATA_IN_12_HASH_DATA_IN_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// AES_HASH_DATA_IN_13 register.
+//
+//*****************************************************************************
+#define AES_HASH_DATA_IN_13_HASH_DATA_IN_M \
+                                0xFFFFFFFF  // HASH_DATA_IN[447:416] These 
+                                            // registers must be written with 
+                                            // the 512-bit input data. The data 
+                                            // lines are connected directly to 
+                                            // the data input of the hash 
+                                            // module and hence into the 
+                                            // engine's internal data buffer. 
+                                            // Writing to each of the registers 
+                                            // triggers a corresponding 32-bit 
+                                            // write enable to the internal 
+                                            // buffer. Note: The host may only 
+                                            // write the input data buffer when 
+                                            // the rfd_in bit of the 
+                                            // HASH_IO_BUF_CTRL register is 
+                                            // high. If the rfd_in bit is 0, 
+                                            // the engine is busy with 
+                                            // processing. During processing, 
+                                            // it is not allowed to write new 
+                                            // input data. For message lengths 
+                                            // larger than 64 bytes, multiple 
+                                            // blocks of data are written to 
+                                            // this input buffer using a 
+                                            // handshake through flags of the 
+                                            // HASH_IO_BUF_CTRL register. All 
+                                            // blocks except the last are 
+                                            // required to be 512 bits in size. 
+                                            // If the last block is not 512 
+                                            // bits long, only the least 
+                                            // significant bits of data must be 
+                                            // written, but they must be padded 
+                                            // with 0s to the next 32-bit 
+                                            // boundary. Host read operations 
+                                            // from these register addresses 
+                                            // return 0s. 
+
+#define AES_HASH_DATA_IN_13_HASH_DATA_IN_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// AES_HASH_DATA_IN_14 register.
+//
+//*****************************************************************************
+#define AES_HASH_DATA_IN_14_HASH_DATA_IN_M \
+                                0xFFFFFFFF  // HASH_DATA_IN[479:448] These 
+                                            // registers must be written with 
+                                            // the 512-bit input data. The data 
+                                            // lines are connected directly to 
+                                            // the data input of the hash 
+                                            // module and hence into the 
+                                            // engine's internal data buffer. 
+                                            // Writing to each of the registers 
+                                            // triggers a corresponding 32-bit 
+                                            // write enable to the internal 
+                                            // buffer. Note: The host may only 
+                                            // write the input data buffer when 
+                                            // the rfd_in bit of the 
+                                            // HASH_IO_BUF_CTRL register is 
+                                            // high. If the rfd_in bit is 0, 
+                                            // the engine is busy with 
+                                            // processing. During processing, 
+                                            // it is not allowed to write new 
+                                            // input data. For message lengths 
+                                            // larger than 64 bytes, multiple 
+                                            // blocks of data are written to 
+                                            // this input buffer using a 
+                                            // handshake through flags of the 
+                                            // HASH_IO_BUF_CTRL register. All 
+                                            // blocks except the last are 
+                                            // required to be 512 bits in size. 
+                                            // If the last block is not 512 
+                                            // bits long, only the least 
+                                            // significant bits of data must be 
+                                            // written, but they must be padded 
+                                            // with 0s to the next 32-bit 
+                                            // boundary. Host read operations 
+                                            // from these register addresses 
+                                            // return 0s. 
+
+#define AES_HASH_DATA_IN_14_HASH_DATA_IN_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// AES_HASH_DATA_IN_15 register.
+//
+//*****************************************************************************
+#define AES_HASH_DATA_IN_15_HASH_DATA_IN_M \
+                                0xFFFFFFFF  // HASH_DATA_IN[511:480] These 
+                                            // registers must be written with 
+                                            // the 512-bit input data. The data 
+                                            // lines are connected directly to 
+                                            // the data input of the hash 
+                                            // module and hence into the 
+                                            // engine's internal data buffer. 
+                                            // Writing to each of the registers 
+                                            // triggers a corresponding 32-bit 
+                                            // write enable to the internal 
+                                            // buffer. Note: The host may only 
+                                            // write the input data buffer when 
+                                            // the rfd_in bit of the 
+                                            // HASH_IO_BUF_CTRL register is 
+                                            // high. If the rfd_in bit is 0, 
+                                            // the engine is busy with 
+                                            // processing. During processing, 
+                                            // it is not allowed to write new 
+                                            // input data. For message lengths 
+                                            // larger than 64 bytes, multiple 
+                                            // blocks of data are written to 
+                                            // this input buffer using a 
+                                            // handshake through flags of the 
+                                            // HASH_IO_BUF_CTRL register. All 
+                                            // blocks except the last are 
+                                            // required to be 512 bits in size. 
+                                            // If the last block is not 512 
+                                            // bits long, only the least 
+                                            // significant bits of data must be 
+                                            // written, but they must be padded 
+                                            // with 0s to the next 32-bit 
+                                            // boundary. Host read operations 
+                                            // from these register addresses 
+                                            // return 0s. 
+
+#define AES_HASH_DATA_IN_15_HASH_DATA_IN_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// AES_HASH_IO_BUF_CTRL register.
+//
+//*****************************************************************************
+#define AES_HASH_IO_BUF_CTRL_PAD_DMA_MESSAGE \
+                                0x00000080  // Note: This bit must only be 
+                                            // used when data is supplied 
+                                            // through the DMA. It should not 
+                                            // be used when data is supplied 
+                                            // through the slave interface. 
+                                            // This bit indicates whether the 
+                                            // hash engine has to pad the 
+                                            // message, received through the 
+                                            // DMA and finalize the hash. When 
+                                            // set to 1, the hash engine pads 
+                                            // the last block using the 
+                                            // programmed length. After 
+                                            // padding, the final hash result 
+                                            // is calculated. When set to 0, 
+                                            // the hash engine treats the last 
+                                            // written block as block-size 
+                                            // aligned and calculates the 
+                                            // intermediate digest. This bit is 
+                                            // automatically cleared when the 
+                                            // last DMA data block is arrived 
+                                            // in the hash engine. 
+
+#define AES_HASH_IO_BUF_CTRL_PAD_DMA_MESSAGE_M \
+                                0x00000080
+#define AES_HASH_IO_BUF_CTRL_PAD_DMA_MESSAGE_S 7
+#define AES_HASH_IO_BUF_CTRL_GET_DIGEST \
+                                0x00000040  // Note: The bit description below 
+                                            // is only applicable when data is 
+                                            // sent through the slave 
+                                            // interface. This bit must be set 
+                                            // to 0 when data is received 
+                                            // through the DMA. This bit 
+                                            // indicates whether the hash 
+                                            // engine should provide the hash 
+                                            // digest. When provided 
+                                            // simultaneously with data_in_av, 
+                                            // the hash digest is provided 
+                                            // after processing the data that 
+                                            // is currently in the HASH_DATA_IN 
+                                            // register. When provided without 
+                                            // data_in_av, the current internal 
+                                            // digest buffer value is copied to 
+                                            // the HASH_DIGEST_n registers. The 
+                                            // host must write a 1 to this bit 
+                                            // to make the intermediate hash 
+                                            // digest available. Writing 0 to 
+                                            // this bit has no effect. This bit 
+                                            // is automatically cleared (that 
+                                            // is, reads 0) when the hash 
+                                            // engine has processed the 
+                                            // contents of the HASH_DATA_IN 
+                                            // register. In the period between 
+                                            // this bit is set by the host and 
+                                            // the actual HASH_DATA_IN 
+                                            // processing, this bit reads 1. 
+
+#define AES_HASH_IO_BUF_CTRL_GET_DIGEST_M \
+                                0x00000040
+#define AES_HASH_IO_BUF_CTRL_GET_DIGEST_S 6
+#define AES_HASH_IO_BUF_CTRL_PAD_MESSAGE \
+                                0x00000020  // Note: The bit description below 
+                                            // is only applicable when data is 
+                                            // sent through the slave 
+                                            // interface. This bit must be set 
+                                            // to 0 when data is received 
+                                            // through the DMA. This bit 
+                                            // indicates that the HASH_DATA_IN 
+                                            // registers hold the last data of 
+                                            // the message and hash padding 
+                                            // must be applied. The host must 
+                                            // write this bit to 1 in order to 
+                                            // indicate to the hash engine that 
+                                            // the HASH_DATA_IN register 
+                                            // currently holds the last data of 
+                                            // the message. When pad_message is 
+                                            // set to 1, the hash engine will 
+                                            // add padding bits to the data 
+                                            // currently in the HASH_DATA_IN 
+                                            // register. When the last message 
+                                            // block is smaller than 512 bits, 
+                                            // the pad_message bit must be set 
+                                            // to 1 together with the 
+                                            // data_in_av bit. When the last 
+                                            // message block is equal to 512 
+                                            // bits, pad_message may be set 
+                                            // together with data_in_av. In 
+                                            // this case the pad_message bit 
+                                            // may also be set after the last 
+                                            // data block has been written to 
+                                            // the hash engine (so when the 
+                                            // rfd_in bit has become 1 again 
+                                            // after writing the last data 
+                                            // block). Writing 0 to this bit 
+                                            // has no effect. This bit is 
+                                            // automatically cleared (i.e. 
+                                            // reads 0) by the hash engine. 
+                                            // This bit reads 1 between the 
+                                            // time it was set by the host and 
+                                            // the hash engine interpreted its 
+                                            // value. 
+
+#define AES_HASH_IO_BUF_CTRL_PAD_MESSAGE_M \
+                                0x00000020
+#define AES_HASH_IO_BUF_CTRL_PAD_MESSAGE_S 5
+#define AES_HASH_IO_BUF_CTRL_RFD_IN \
+                                0x00000004  // Note: The bit description below 
+                                            // is only applicable when data is 
+                                            // sent through the slave 
+                                            // interface. This bit can be 
+                                            // ignored when data is received 
+                                            // through the DMA. Read-only 
+                                            // status of the input buffer of 
+                                            // the hash engine. When 1, the 
+                                            // input buffer of the hash engine 
+                                            // can accept new data; the 
+                                            // HASH_DATA_IN registers can 
+                                            // safely be populated with new 
+                                            // data. When 0, the input buffer 
+                                            // of the hash engine is processing 
+                                            // the data that is currently in 
+                                            // HASH_DATA_IN; writing new data 
+                                            // to these registers is not 
+                                            // allowed. 
+
+#define AES_HASH_IO_BUF_CTRL_RFD_IN_M \
+                                0x00000004
+#define AES_HASH_IO_BUF_CTRL_RFD_IN_S 2
+#define AES_HASH_IO_BUF_CTRL_DATA_IN_AV \
+                                0x00000002  // Note: The bit description below 
+                                            // is only applicable when data is 
+                                            // sent through the slave 
+                                            // interface. This bit must be set 
+                                            // to 0 when data is received 
+                                            // through the DMA. This bit 
+                                            // indicates that the HASH_DATA_IN 
+                                            // registers contain new input data 
+                                            // for processing. The host must 
+                                            // write a 1 to this bit to start 
+                                            // processing the data in 
+                                            // HASH_DATA_IN; the hash engine 
+                                            // will process the new data as 
+                                            // soon as it is ready for it 
+                                            // (rfd_in bit is 1). Writing 0 to 
+                                            // this bit has no effect. This bit 
+                                            // is automatically cleared (i.e. 
+                                            // reads as 0) when the hash engine 
+                                            // starts processing the 
+                                            // HASH_DATA_IN contents. This bit 
+                                            // reads 1 between the time it was 
+                                            // set by the host and the hash 
+                                            // engine actually starts 
+                                            // processing the input data block. 
+
+#define AES_HASH_IO_BUF_CTRL_DATA_IN_AV_M \
+                                0x00000002
+#define AES_HASH_IO_BUF_CTRL_DATA_IN_AV_S 1
+#define AES_HASH_IO_BUF_CTRL_OUTPUT_FULL \
+                                0x00000001  // Indicates that the output 
+                                            // buffer registers (HASH_DIGEST_n) 
+                                            // are available for reading by the 
+                                            // host. When this bit reads 0, the 
+                                            // output buffer registers are 
+                                            // released; the hash engine is 
+                                            // allowed to write new data to it. 
+                                            // In this case, the registers 
+                                            // should not be read by the host. 
+                                            // When this bit reads 1, the hash 
+                                            // engine has stored the result of 
+                                            // the latest hash operation in the 
+                                            // output buffer registers. As long 
+                                            // as this bit reads 1, the host 
+                                            // may read output buffer registers 
+                                            // and the hash engine is prevented 
+                                            // from writing new data to the 
+                                            // output buffer. After retrieving 
+                                            // the hash result data from the 
+                                            // output buffer, the host must 
+                                            // write a 1 to this bit to clear 
+                                            // it. This makes the digest output 
+                                            // buffer available for the hash 
+                                            // engine to store new hash 
+                                            // results. Writing 0 to this bit 
+                                            // has no effect. Note: If this bit 
+                                            // is asserted (1) no new operation 
+                                            // should be started before the 
+                                            // digest is retrieved from the 
+                                            // hash engine and this bit is 
+                                            // cleared (0). 
+
+#define AES_HASH_IO_BUF_CTRL_OUTPUT_FULL_M \
+                                0x00000001
+#define AES_HASH_IO_BUF_CTRL_OUTPUT_FULL_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// AES_HASH_MODE_IN register.
+//
+//*****************************************************************************
+#define AES_HASH_MODE_IN_SHA256_MODE \
+                                0x00000008  // The host must write this bit 
+                                            // with 1 before processing a hash 
+                                            // session. 
+
+#define AES_HASH_MODE_IN_SHA256_MODE_M \
+                                0x00000008
+#define AES_HASH_MODE_IN_SHA256_MODE_S 3
+#define AES_HASH_MODE_IN_NEW_HASH \
+                                0x00000001  // When set to 1, it indicates 
+                                            // that the hash engine must start 
+                                            // processing a new hash session. 
+                                            // The HASH_DIGEST_n registers will 
+                                            // automatically be loaded with the 
+                                            // initial hash algorithm constants 
+                                            // of the selected hash algorithm. 
+                                            // When this bit is 0 while the 
+                                            // hash processing is started, the 
+                                            // initial hash algorithm constants 
+                                            // are not loaded in the 
+                                            // HASH_DIGEST_n registers. The 
+                                            // hash engine will start 
+                                            // processing with the digest that 
+                                            // is currently in its internal 
+                                            // HASH_DIGEST_n registers. This 
+                                            // bit is automatically cleared 
+                                            // when hash processing is started. 
+
+#define AES_HASH_MODE_IN_NEW_HASH_M \
+                                0x00000001
+#define AES_HASH_MODE_IN_NEW_HASH_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// AES_HASH_LENGTH_IN_L register.
+//
+//*****************************************************************************
+#define AES_HASH_LENGTH_IN_L_LENGTH_IN_M \
+                                0xFFFFFFFF  // LENGTH_IN[31:0] Message length 
+                                            // registers. The content of these 
+                                            // registers is used by the hash 
+                                            // engine during the message 
+                                            // padding phase of the hash 
+                                            // session. The data lines of this 
+                                            // registers are directly connected 
+                                            // to the interface of the hash 
+                                            // engine. For a write operation by 
+                                            // the host, these registers should 
+                                            // be written with the message 
+                                            // length in bits. Final hash 
+                                            // operations: The total input data 
+                                            // length must be programmed for 
+                                            // new hash operations that require 
+                                            // finalization (padding). The 
+                                            // input data must be provided 
+                                            // through the slave or DMA 
+                                            // interface. Continued hash 
+                                            // operations (finalized): For 
+                                            // continued hash operations that 
+                                            // require finalization, the total 
+                                            // message length must be 
+                                            // programmed, including the length 
+                                            // of previously hashed data that 
+                                            // corresponds to the written input 
+                                            // digest. Non-final hash 
+                                            // operations: For hash operations 
+                                            // that do not require finalization 
+                                            // (input data length is multiple 
+                                            // of 512-bits which is SHA-256 
+                                            // data block size), the length 
+                                            // field does not need to be 
+                                            // programmed since not used by the 
+                                            // operation. If the message length 
+                                            // in bits is below (2^32-1), then 
+                                            // only HASH_LENGTH_IN_L needs to 
+                                            // be written. The hardware 
+                                            // automatically sets 
+                                            // HASH_LENGTH_IN_H to 0s in this 
+                                            // case. The host may write the 
+                                            // length register at any time 
+                                            // during the hash session when the 
+                                            // rfd_in bit of the 
+                                            // HASH_IO_BUF_CTRL is high. The 
+                                            // length register must be written 
+                                            // before the last data of the 
+                                            // active hash session is written 
+                                            // into the hash engine. host read 
+                                            // operations from these register 
+                                            // locations will return 0s. Note: 
+                                            // When getting data from DMA, this 
+                                            // register must be programmed 
+                                            // before DMA is programmed to 
+                                            // start. 
+
+#define AES_HASH_LENGTH_IN_L_LENGTH_IN_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// AES_HASH_LENGTH_IN_H register.
+//
+//*****************************************************************************
+#define AES_HASH_LENGTH_IN_H_LENGTH_IN_M \
+                                0xFFFFFFFF  // LENGTH_IN[63:32] Message length 
+                                            // registers. The content of these 
+                                            // registers is used by the hash 
+                                            // engine during the message 
+                                            // padding phase of the hash 
+                                            // session. The data lines of this 
+                                            // registers are directly connected 
+                                            // to the interface of the hash 
+                                            // engine. For a write operation by 
+                                            // the host, these registers should 
+                                            // be written with the message 
+                                            // length in bits. Final hash 
+                                            // operations: The total input data 
+                                            // length must be programmed for 
+                                            // new hash operations that require 
+                                            // finalization (padding). The 
+                                            // input data must be provided 
+                                            // through the slave or DMA 
+                                            // interface. Continued hash 
+                                            // operations (finalized): For 
+                                            // continued hash operations that 
+                                            // require finalization, the total 
+                                            // message length must be 
+                                            // programmed, including the length 
+                                            // of previously hashed data that 
+                                            // corresponds to the written input 
+                                            // digest. Non-final hash 
+                                            // operations: For hash operations 
+                                            // that do not require finalization 
+                                            // (input data length is multiple 
+                                            // of 512-bits which is SHA-256 
+                                            // data block size), the length 
+                                            // field does not need to be 
+                                            // programmed since not used by the 
+                                            // operation. If the message length 
+                                            // in bits is below (2^32-1), then 
+                                            // only HASH_LENGTH_IN_L needs to 
+                                            // be written. The hardware 
+                                            // automatically sets 
+                                            // HASH_LENGTH_IN_H to 0s in this 
+                                            // case. The host may write the 
+                                            // length register at any time 
+                                            // during the hash session when the 
+                                            // rfd_in bit of the 
+                                            // HASH_IO_BUF_CTRL is high. The 
+                                            // length register must be written 
+                                            // before the last data of the 
+                                            // active hash session is written 
+                                            // into the hash engine. host read 
+                                            // operations from these register 
+                                            // locations will return 0s. Note: 
+                                            // When getting data from DMA, this 
+                                            // register must be programmed 
+                                            // before DMA is programmed to 
+                                            // start. 
+
+#define AES_HASH_LENGTH_IN_H_LENGTH_IN_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// AES_HASH_DIGEST_A register.
+//
+//*****************************************************************************
+#define AES_HASH_DIGEST_A_HASH_DIGEST_M \
+                                0xFFFFFFFF  // HASH_DIGEST[31:0] Hash digest 
+                                            // registers Write operation: 
+                                            // Continued hash: These registers 
+                                            // should be written with the 
+                                            // context data, before the start 
+                                            // of a resumed hash session (the 
+                                            // new_hash bit in the HASH_MODE 
+                                            // register is 0 when starting a 
+                                            // hash session). New hash: When 
+                                            // initiating a new hash session 
+                                            // (the new_hash bit in the 
+                                            // HASH_MODE register is high), the 
+                                            // internal digest registers are 
+                                            // automatically set to the SHA-256 
+                                            // algorithm constant and these 
+                                            // register should not be written. 
+                                            // Reading from these registers 
+                                            // provides the intermediate hash 
+                                            // result (non-final hash 
+                                            // operation) or the final hash 
+                                            // result (final hash operation) 
+                                            // after data processing. 
+
+#define AES_HASH_DIGEST_A_HASH_DIGEST_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// AES_HASH_DIGEST_B register.
+//
+//*****************************************************************************
+#define AES_HASH_DIGEST_B_HASH_DIGEST_M \
+                                0xFFFFFFFF  // HASH_DIGEST[63:32] Hash digest 
+                                            // registers Write operation: 
+                                            // Continued hash: These registers 
+                                            // should be written with the 
+                                            // context data, before the start 
+                                            // of a resumed hash session (the 
+                                            // new_hash bit in the HASH_MODE 
+                                            // register is 0 when starting a 
+                                            // hash session). New hash: When 
+                                            // initiating a new hash session 
+                                            // (the new_hash bit in the 
+                                            // HASH_MODE register is high), the 
+                                            // internal digest registers are 
+                                            // automatically set to the SHA-256 
+                                            // algorithm constant and these 
+                                            // register should not be written. 
+                                            // Reading from these registers 
+                                            // provides the intermediate hash 
+                                            // result (non-final hash 
+                                            // operation) or the final hash 
+                                            // result (final hash operation) 
+                                            // after data processing. 
+
+#define AES_HASH_DIGEST_B_HASH_DIGEST_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// AES_HASH_DIGEST_C register.
+//
+//*****************************************************************************
+#define AES_HASH_DIGEST_C_HASH_DIGEST_M \
+                                0xFFFFFFFF  // HASH_DIGEST[95:64] Hash digest 
+                                            // registers Write operation: 
+                                            // Continued hash: These registers 
+                                            // should be written with the 
+                                            // context data, before the start 
+                                            // of a resumed hash session (the 
+                                            // new_hash bit in the HASH_MODE 
+                                            // register is 0 when starting a 
+                                            // hash session). New hash: When 
+                                            // initiating a new hash session 
+                                            // (the new_hash bit in the 
+                                            // HASH_MODE register is high), the 
+                                            // internal digest registers are 
+                                            // automatically set to the SHA-256 
+                                            // algorithm constant and these 
+                                            // register should not be written. 
+                                            // Reading from these registers 
+                                            // provides the intermediate hash 
+                                            // result (non-final hash 
+                                            // operation) or the final hash 
+                                            // result (final hash operation) 
+                                            // after data processing. 
+
+#define AES_HASH_DIGEST_C_HASH_DIGEST_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// AES_HASH_DIGEST_D register.
+//
+//*****************************************************************************
+#define AES_HASH_DIGEST_D_HASH_DIGEST_M \
+                                0xFFFFFFFF  // HASH_DIGEST[127:96] Hash digest 
+                                            // registers Write operation: 
+                                            // Continued hash: These registers 
+                                            // should be written with the 
+                                            // context data, before the start 
+                                            // of a resumed hash session (the 
+                                            // new_hash bit in the HASH_MODE 
+                                            // register is 0 when starting a 
+                                            // hash session). New hash: When 
+                                            // initiating a new hash session 
+                                            // (the new_hash bit in the 
+                                            // HASH_MODE register is high), the 
+                                            // internal digest registers are 
+                                            // automatically set to the SHA-256 
+                                            // algorithm constant and these 
+                                            // register should not be written. 
+                                            // Reading from these registers 
+                                            // provides the intermediate hash 
+                                            // result (non-final hash 
+                                            // operation) or the final hash 
+                                            // result (final hash operation) 
+                                            // after data processing. 
+
+#define AES_HASH_DIGEST_D_HASH_DIGEST_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// AES_HASH_DIGEST_E register.
+//
+//*****************************************************************************
+#define AES_HASH_DIGEST_E_HASH_DIGEST_M \
+                                0xFFFFFFFF  // HASH_DIGEST[159:128] Hash 
+                                            // digest registers Write 
+                                            // operation: Continued hash: These 
+                                            // registers should be written with 
+                                            // the context data, before the 
+                                            // start of a resumed hash session 
+                                            // (the new_hash bit in the 
+                                            // HASH_MODE register is 0 when 
+                                            // starting a hash session). New 
+                                            // hash: When initiating a new hash 
+                                            // session (the new_hash bit in the 
+                                            // HASH_MODE register is high), the 
+                                            // internal digest registers are 
+                                            // automatically set to the SHA-256 
+                                            // algorithm constant and these 
+                                            // register should not be written. 
+                                            // Reading from these registers 
+                                            // provides the intermediate hash 
+                                            // result (non-final hash 
+                                            // operation) or the final hash 
+                                            // result (final hash operation) 
+                                            // after data processing. 
+
+#define AES_HASH_DIGEST_E_HASH_DIGEST_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// AES_HASH_DIGEST_F register.
+//
+//*****************************************************************************
+#define AES_HASH_DIGEST_F_HASH_DIGEST_M \
+                                0xFFFFFFFF  // HASH_DIGEST[191:160] Hash 
+                                            // digest registers Write 
+                                            // operation: Continued hash: These 
+                                            // registers should be written with 
+                                            // the context data, before the 
+                                            // start of a resumed hash session 
+                                            // (the new_hash bit in the 
+                                            // HASH_MODE register is 0 when 
+                                            // starting a hash session). New 
+                                            // hash: When initiating a new hash 
+                                            // session (the new_hash bit in the 
+                                            // HASH_MODE register is high), the 
+                                            // internal digest registers are 
+                                            // automatically set to the SHA-256 
+                                            // algorithm constant and these 
+                                            // register should not be written. 
+                                            // Reading from these registers 
+                                            // provides the intermediate hash 
+                                            // result (non-final hash 
+                                            // operation) or the final hash 
+                                            // result (final hash operation) 
+                                            // after data processing. 
+
+#define AES_HASH_DIGEST_F_HASH_DIGEST_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// AES_HASH_DIGEST_G register.
+//
+//*****************************************************************************
+#define AES_HASH_DIGEST_G_HASH_DIGEST_M \
+                                0xFFFFFFFF  // HASH_DIGEST[223:192] Hash 
+                                            // digest registers Write 
+                                            // operation: Continued hash: These 
+                                            // registers should be written with 
+                                            // the context data, before the 
+                                            // start of a resumed hash session 
+                                            // (the new_hash bit in the 
+                                            // HASH_MODE register is 0 when 
+                                            // starting a hash session). New 
+                                            // hash: When initiating a new hash 
+                                            // session (the new_hash bit in the 
+                                            // HASH_MODE register is high), the 
+                                            // internal digest registers are 
+                                            // automatically set to the SHA-256 
+                                            // algorithm constant and these 
+                                            // register should not be written. 
+                                            // Reading from these registers 
+                                            // provides the intermediate hash 
+                                            // result (non-final hash 
+                                            // operation) or the final hash 
+                                            // result (final hash operation) 
+                                            // after data processing. 
+
+#define AES_HASH_DIGEST_G_HASH_DIGEST_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// AES_HASH_DIGEST_H register.
+//
+//*****************************************************************************
+#define AES_HASH_DIGEST_H_HASH_DIGEST_M \
+                                0xFFFFFFFF  // HASH_DIGEST[255:224] Hash 
+                                            // digest registers Write 
+                                            // operation: Continued hash: These 
+                                            // registers should be written with 
+                                            // the context data, before the 
+                                            // start of a resumed hash session 
+                                            // (the new_hash bit in the 
+                                            // HASH_MODE register is 0 when 
+                                            // starting a hash session). New 
+                                            // hash: When initiating a new hash 
+                                            // session (the new_hash bit in the 
+                                            // HASH_MODE register is high), the 
+                                            // internal digest registers are 
+                                            // automatically set to the SHA-256 
+                                            // algorithm constant and these 
+                                            // register should not be written. 
+                                            // Reading from these registers 
+                                            // provides the intermediate hash 
+                                            // result (non-final hash 
+                                            // operation) or the final hash 
+                                            // result (final hash operation) 
+                                            // after data processing. 
+
+#define AES_HASH_DIGEST_H_HASH_DIGEST_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// AES_CTRL_ALG_SEL register.
+//
+//*****************************************************************************
+#define AES_CTRL_ALG_SEL_TAG    0x80000000  // If this bit is cleared to 0, 
+                                            // the DMA operation involves only 
+                                            // data. If this bit is set, the 
+                                            // DMA operation includes a TAG 
+                                            // (Authentication Result / 
+                                            // Digest). For SHA-256 operation, 
+                                            // a DMA must be set up for both 
+                                            // input data and TAG. For any 
+                                            // other selected module, setting 
+                                            // this bit only allows a DMA that 
+                                            // reads the TAG. No data allowed 
+                                            // to be transferred to or from the 
+                                            // selected module via the DMA. 
+#define AES_CTRL_ALG_SEL_TAG_M  0x80000000
+#define AES_CTRL_ALG_SEL_TAG_S  31
+#define AES_CTRL_ALG_SEL_HASH   0x00000004  // If set to one, selects the hash 
+                                            // engine as destination for the 
+                                            // DMA The maximum transfer size to 
+                                            // DMA engine is set to 64 bytes 
+                                            // for reading and 32 bytes for 
+                                            // writing (the latter is only 
+                                            // applicable if the hash result is 
+                                            // written out through the DMA). 
+#define AES_CTRL_ALG_SEL_HASH_M 0x00000004
+#define AES_CTRL_ALG_SEL_HASH_S 2
+#define AES_CTRL_ALG_SEL_AES    0x00000002  // If set to one, selects the AES 
+                                            // engine as source/destination for 
+                                            // the DMA The read and write 
+                                            // maximum transfer size to the DMA 
+                                            // engine is set to 16 bytes. 
+#define AES_CTRL_ALG_SEL_AES_M  0x00000002
+#define AES_CTRL_ALG_SEL_AES_S  1
+#define AES_CTRL_ALG_SEL_KEYSTORE \
+                                0x00000001  // If set to one, selects the Key 
+                                            // Store as destination for the DMA 
+                                            // The maximum transfer size to DMA 
+                                            // engine is set to 32 bytes 
+                                            // (however transfers of 16, 24 and 
+                                            // 32 bytes are allowed) 
+
+#define AES_CTRL_ALG_SEL_KEYSTORE_M \
+                                0x00000001
+#define AES_CTRL_ALG_SEL_KEYSTORE_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// AES_CTRL_PROT_EN register.
+//
+//*****************************************************************************
+#define AES_CTRL_PROT_EN_PROT_EN \
+                                0x00000001  // If this bit is cleared to 0, 
+                                            // m_h_prot[1] on the AHB mater 
+                                            // interface always remains 0. If 
+                                            // this bit is set to one, the 
+                                            // m_h_prot[1] signal on the master 
+                                            // AHB bus is asserted to 1 if an 
+                                            // AHB read operation is performed, 
+                                            // using DMA, with the key store 
+                                            // module as destination. 
+
+#define AES_CTRL_PROT_EN_PROT_EN_M \
+                                0x00000001
+#define AES_CTRL_PROT_EN_PROT_EN_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// AES_CTRL_SW_RESET register.
+//
+//*****************************************************************************
+#define AES_CTRL_SW_RESET_SW_RESET \
+                                0x00000001  // If this bit is set to 1, the 
+                                            // following modules are reset: - 
+                                            // Master control internal state is 
+                                            // reset. That includes interrupt, 
+                                            // error status register, and 
+                                            // result available interrupt 
+                                            // generation FSM. - Key store 
+                                            // module state is reset. That 
+                                            // includes clearing the written 
+                                            // area flags; therefore, the keys 
+                                            // must be reloaded to the key 
+                                            // store module. Writing 0 has no 
+                                            // effect. The bit is self cleared 
+                                            // after executing the reset. 
+
+#define AES_CTRL_SW_RESET_SW_RESET_M \
+                                0x00000001
+#define AES_CTRL_SW_RESET_SW_RESET_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// AES_CTRL_INT_CFG register.
+//
+//*****************************************************************************
+#define AES_CTRL_INT_CFG_LEVEL  0x00000001  // If this bit is 0, the interrupt 
+                                            // output is a pulse. If this bit 
+                                            // is set to 1, the interrupt is a 
+                                            // level interrupt that must be 
+                                            // cleared by writing the interrupt 
+                                            // clear register. This bit is 
+                                            // applicable for both interrupt 
+                                            // output signals. 
+#define AES_CTRL_INT_CFG_LEVEL_M \
+                                0x00000001
+#define AES_CTRL_INT_CFG_LEVEL_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// AES_CTRL_INT_EN register.
+//
+//*****************************************************************************
+#define AES_CTRL_INT_EN_DMA_IN_DONE \
+                                0x00000002  // If this bit is set to 0, the 
+                                            // DMA input done (irq_dma_in_done) 
+                                            // interrupt output is disabled and 
+                                            // remains 0. If this bit is set to 
+                                            // 1, the DMA input done interrupt 
+                                            // output is enabled. 
+
+#define AES_CTRL_INT_EN_DMA_IN_DONE_M \
+                                0x00000002
+#define AES_CTRL_INT_EN_DMA_IN_DONE_S 1
+#define AES_CTRL_INT_EN_RESULT_AV \
+                                0x00000001  // If this bit is set to 0, the 
+                                            // result available (irq_result_av) 
+                                            // interrupt output is disabled and 
+                                            // remains 0. If this bit is set to 
+                                            // 1, the result available 
+                                            // interrupt output is enabled. 
+
+#define AES_CTRL_INT_EN_RESULT_AV_M \
+                                0x00000001
+#define AES_CTRL_INT_EN_RESULT_AV_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// AES_CTRL_INT_CLR register.
+//
+//*****************************************************************************
+#define AES_CTRL_INT_CLR_DMA_BUS_ERR \
+                                0x80000000  // If 1 is written to this bit, 
+                                            // the DMA bus error status is 
+                                            // cleared. Writing 0 has no 
+                                            // effect. 
+
+#define AES_CTRL_INT_CLR_DMA_BUS_ERR_M \
+                                0x80000000
+#define AES_CTRL_INT_CLR_DMA_BUS_ERR_S 31
+#define AES_CTRL_INT_CLR_KEY_ST_WR_ERR \
+                                0x40000000  // If 1 is written to this bit, 
+                                            // the key store write error status 
+                                            // is cleared. Writing 0 has no 
+                                            // effect. 
+
+#define AES_CTRL_INT_CLR_KEY_ST_WR_ERR_M \
+                                0x40000000
+#define AES_CTRL_INT_CLR_KEY_ST_WR_ERR_S 30
+#define AES_CTRL_INT_CLR_KEY_ST_RD_ERR \
+                                0x20000000  // If 1 is written to this bit, 
+                                            // the key store read error status 
+                                            // is cleared. Writing 0 has no 
+                                            // effect. 
+
+#define AES_CTRL_INT_CLR_KEY_ST_RD_ERR_M \
+                                0x20000000
+#define AES_CTRL_INT_CLR_KEY_ST_RD_ERR_S 29
+#define AES_CTRL_INT_CLR_DMA_IN_DONE \
+                                0x00000002  // If 1 is written to this bit, 
+                                            // the DMA in done 
+                                            // (irq_dma_in_done) interrupt 
+                                            // output is cleared. Writing 0 has 
+                                            // no effect. Note that clearing an 
+                                            // interrupt makes sense only if 
+                                            // the interrupt output is 
+                                            // programmed as level (refer to 
+                                            // CTRL_INT_CFG). 
+
+#define AES_CTRL_INT_CLR_DMA_IN_DONE_M \
+                                0x00000002
+#define AES_CTRL_INT_CLR_DMA_IN_DONE_S 1
+#define AES_CTRL_INT_CLR_RESULT_AV \
+                                0x00000001  // If 1 is written to this bit, 
+                                            // the result available 
+                                            // (irq_result_av) interrupt output 
+                                            // is cleared. Writing 0 has no 
+                                            // effect. Note that clearing an 
+                                            // interrupt makes sense only if 
+                                            // the interrupt output is 
+                                            // programmed as level (refer to 
+                                            // CTRL_INT_CFG). 
+
+#define AES_CTRL_INT_CLR_RESULT_AV_M \
+                                0x00000001
+#define AES_CTRL_INT_CLR_RESULT_AV_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// AES_CTRL_INT_SET register.
+//
+//*****************************************************************************
+#define AES_CTRL_INT_SET_DMA_IN_DONE \
+                                0x00000002  // If 1 is written to this bit, 
+                                            // the DMA data in done 
+                                            // (irq_dma_in_done) interrupt 
+                                            // output is set to one. Writing 0 
+                                            // has no effect. If the interrupt 
+                                            // configuration register is 
+                                            // programmed to pulse, clearing 
+                                            // the DMA data in done 
+                                            // (irq_dma_in_done) interrupt is 
+                                            // not needed. If it is programmed 
+                                            // to level, clearing the interrupt 
+                                            // output should be done by writing 
+                                            // the interrupt clear register 
+                                            // (CTRL_INT_CLR). 
+
+#define AES_CTRL_INT_SET_DMA_IN_DONE_M \
+                                0x00000002
+#define AES_CTRL_INT_SET_DMA_IN_DONE_S 1
+#define AES_CTRL_INT_SET_RESULT_AV \
+                                0x00000001  // If 1 is written to this bit, 
+                                            // the result available 
+                                            // (irq_result_av) interrupt output 
+                                            // is set to one. Writing 0 has no 
+                                            // effect. If the interrupt 
+                                            // configuration register is 
+                                            // programmed to pulse, clearing 
+                                            // the result available 
+                                            // (irq_result_av) interrupt is not 
+                                            // needed. If it is programmed to 
+                                            // level, clearing the interrupt 
+                                            // output should be done by writing 
+                                            // the interrupt clear register 
+                                            // (CTRL_INT_CLR). 
+
+#define AES_CTRL_INT_SET_RESULT_AV_M \
+                                0x00000001
+#define AES_CTRL_INT_SET_RESULT_AV_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// AES_CTRL_INT_STAT register.
+//
+//*****************************************************************************
+#define AES_CTRL_INT_STAT_DMA_BUS_ERR \
+                                0x80000000  // This bit is set when a DMA bus 
+                                            // error is detected during a DMA 
+                                            // operation. The value of this 
+                                            // register is held until it is 
+                                            // cleared through the CTRL_INT_CLR 
+                                            // register. Note: This error is 
+                                            // asserted if an error is detected 
+                                            // on the AHB master interface 
+                                            // during a DMA operation. 
+
+#define AES_CTRL_INT_STAT_DMA_BUS_ERR_M \
+                                0x80000000
+#define AES_CTRL_INT_STAT_DMA_BUS_ERR_S 31
+#define AES_CTRL_INT_STAT_KEY_ST_WR_ERR \
+                                0x40000000  // This bit is set when a write 
+                                            // error is detected during the DMA 
+                                            // write operation to the key store 
+                                            // memory. The value of this 
+                                            // register is held until it is 
+                                            // cleared through the CTRL_INT_CLR 
+                                            // register. Note: This error is 
+                                            // asserted if a DMA operation does 
+                                            // not cover a full key area or 
+                                            // more areas are written than 
+                                            // expected. 
+
+#define AES_CTRL_INT_STAT_KEY_ST_WR_ERR_M \
+                                0x40000000
+#define AES_CTRL_INT_STAT_KEY_ST_WR_ERR_S 30
+#define AES_CTRL_INT_STAT_KEY_ST_RD_ERR \
+                                0x20000000  // This bit is set when a read 
+                                            // error is detected during the 
+                                            // read of a key from the key 
+                                            // store, while copying it to the 
+                                            // AES core. The value of this 
+                                            // register is held until it is 
+                                            // cleared through the CTRL_INT_CLR 
+                                            // register. Note: This error is 
+                                            // asserted if a key location is 
+                                            // selected in the key store that 
+                                            // is not available. 
+
+#define AES_CTRL_INT_STAT_KEY_ST_RD_ERR_M \
+                                0x20000000
+#define AES_CTRL_INT_STAT_KEY_ST_RD_ERR_S 29
+#define AES_CTRL_INT_STAT_DMA_IN_DONE \
+                                0x00000002  // This read only bit returns the 
+                                            // actual DMA data in done 
+                                            // (irq_data_in_done) interrupt 
+                                            // status of the DMA data in done 
+                                            // interrupt output pin 
+                                            // (irq_data_in_done). 
+
+#define AES_CTRL_INT_STAT_DMA_IN_DONE_M \
+                                0x00000002
+#define AES_CTRL_INT_STAT_DMA_IN_DONE_S 1
+#define AES_CTRL_INT_STAT_RESULT_AV \
+                                0x00000001  // This read only bit returns the 
+                                            // actual result available 
+                                            // (irq_result_av) interrupt status 
+                                            // of the result available 
+                                            // interrupt output pin 
+                                            // (irq_result_av). 
+
+#define AES_CTRL_INT_STAT_RESULT_AV_M \
+                                0x00000001
+#define AES_CTRL_INT_STAT_RESULT_AV_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// AES_CTRL_OPTIONS register.
+//
+//*****************************************************************************
+#define AES_CTRL_OPTIONS_TYPE_M 0xFF000000  // This field is 0x01 for the 
+                                            // TYPE1 device. 
+#define AES_CTRL_OPTIONS_TYPE_S 24
+#define AES_CTRL_OPTIONS_AHBINTERFACE \
+                                0x00010000  // AHB interface is available If 
+                                            // this bit is 0, the EIP-120t has 
+                                            // a TCM interface. 
+
+#define AES_CTRL_OPTIONS_AHBINTERFACE_M \
+                                0x00010000
+#define AES_CTRL_OPTIONS_AHBINTERFACE_S 16
+#define AES_CTRL_OPTIONS_SHA_256 \
+                                0x00000100  // The HASH core supports SHA-256. 
+
+#define AES_CTRL_OPTIONS_SHA_256_M \
+                                0x00000100
+#define AES_CTRL_OPTIONS_SHA_256_S 8
+#define AES_CTRL_OPTIONS_AES_CCM \
+                                0x00000080  // AES-CCM is available as a 
+                                            // single operation. 
+
+#define AES_CTRL_OPTIONS_AES_CCM_M \
+                                0x00000080
+#define AES_CTRL_OPTIONS_AES_CCM_S 7
+#define AES_CTRL_OPTIONS_AES_GCM \
+                                0x00000040  // AES-GCM is available as a 
+                                            // single operation. 
+
+#define AES_CTRL_OPTIONS_AES_GCM_M \
+                                0x00000040
+#define AES_CTRL_OPTIONS_AES_GCM_S 6
+#define AES_CTRL_OPTIONS_AES_256 \
+                                0x00000020  // AES core supports 256-bit keys 
+                                            // Note: If both AES-128 and 
+                                            // AES-256 are set to one, the AES 
+                                            // core supports 192-bit keys as 
+                                            // well. 
+
+#define AES_CTRL_OPTIONS_AES_256_M \
+                                0x00000020
+#define AES_CTRL_OPTIONS_AES_256_S 5
+#define AES_CTRL_OPTIONS_AES_128 \
+                                0x00000010  // AES core supports 128-bit keys. 
+
+#define AES_CTRL_OPTIONS_AES_128_M \
+                                0x00000010
+#define AES_CTRL_OPTIONS_AES_128_S 4
+#define AES_CTRL_OPTIONS_HASH   0x00000004  // HASH Core is available. 
+#define AES_CTRL_OPTIONS_HASH_M 0x00000004
+#define AES_CTRL_OPTIONS_HASH_S 2
+#define AES_CTRL_OPTIONS_AES    0x00000002  // AES core is available. 
+#define AES_CTRL_OPTIONS_AES_M  0x00000002
+#define AES_CTRL_OPTIONS_AES_S  1
+#define AES_CTRL_OPTIONS_KEYSTORE \
+                                0x00000001  // KEY STORE is available. 
+
+#define AES_CTRL_OPTIONS_KEYSTORE_M \
+                                0x00000001
+#define AES_CTRL_OPTIONS_KEYSTORE_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// AES_CTRL_VERSION register.
+//
+//*****************************************************************************
+#define AES_CTRL_VERSION_MAJOR_VERSION_M \
+                                0x0F000000  // Major version number 
+
+#define AES_CTRL_VERSION_MAJOR_VERSION_S 24
+#define AES_CTRL_VERSION_MINOR_VERSION_M \
+                                0x00F00000  // Minor version number 
+
+#define AES_CTRL_VERSION_MINOR_VERSION_S 20
+#define AES_CTRL_VERSION_PATCH_LEVEL_M \
+                                0x000F0000  // Patch level Starts at 0 at 
+                                            // first delivery of this version 
+
+#define AES_CTRL_VERSION_PATCH_LEVEL_S 16
+#define AES_CTRL_VERSION_EIP_NUMBER_COMPL_M \
+                                0x0000FF00  // These bits simply contain the 
+                                            // complement of bits [7:0] (0x87), 
+                                            // used by a driver to ascertain 
+                                            // that the EIP-120t register is 
+                                            // indeed read. 
+
+#define AES_CTRL_VERSION_EIP_NUMBER_COMPL_S 8
+#define AES_CTRL_VERSION_EIP_NUMBER_M \
+                                0x000000FF  // These bits encode the EIP 
+                                            // number for the EIP-120t, this 
+                                            // field contains the value 120 
+                                            // (decimal) or 0x78. 
+
+#define AES_CTRL_VERSION_EIP_NUMBER_S 0
+
+
+#endif // __HW_AES_H__
+

--- a/cpu/cc2538/include/vendor/hw_ana_regs.h
+++ b/cpu/cc2538/include/vendor/hw_ana_regs.h
@@ -1,0 +1,86 @@
+/******************************************************************************
+*  Filename:       hw_ana_regs.h
+*  Revised:        $Date: 2013-04-30 17:13:44 +0200 (Tue, 30 Apr 2013) $
+*  Revision:       $Revision: 9943 $
+*
+*  Copyright (C) 2013 Texas Instruments Incorporated - http://www.ti.com/
+*
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*    Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+*
+*    Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+*
+*    Neither the name of Texas Instruments Incorporated nor the names of
+*    its contributors may be used to endorse or promote products derived
+*    from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+*  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+*  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+*  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+*  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+*  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+*  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+*  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+*  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+******************************************************************************/
+
+#ifndef __HW_ANA_REGS_H__
+#define __HW_ANA_REGS_H__
+
+//*****************************************************************************
+//
+// The following are defines for the ANA_REGS register offsets.
+//
+//*****************************************************************************
+#define ANA_REGS_O_IVCTRL       0x00000004  // Analog control register 
+
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// ANA_REGS_O_IVCTRL register.
+//
+//*****************************************************************************
+#define ANA_REGS_IVCTRL_DAC_CURR_CTRL_M \
+                                0x00000030  // Controls bias current to DAC 
+                                            // 00: 100% IVREF, 0% IREF bias 01: 
+                                            // 60% IVREF, 40% IREF bias 10: 40% 
+                                            // IVREF, 60% IREF bias 11: 0% 
+                                            // IVREF, 100% IREF bias 
+
+#define ANA_REGS_IVCTRL_DAC_CURR_CTRL_S 4
+#define ANA_REGS_IVCTRL_LODIV_BIAS_CTRL \
+                                0x00000008  // Controls bias current to LODIV 
+                                            // 1: PTAT bias 0: IVREF bias 
+
+#define ANA_REGS_IVCTRL_LODIV_BIAS_CTRL_M \
+                                0x00000008
+#define ANA_REGS_IVCTRL_LODIV_BIAS_CTRL_S 3
+#define ANA_REGS_IVCTRL_TXMIX_DC_CTRL \
+                                0x00000004  // Controls DC bias in TXMIX 
+
+#define ANA_REGS_IVCTRL_TXMIX_DC_CTRL_M \
+                                0x00000004
+#define ANA_REGS_IVCTRL_TXMIX_DC_CTRL_S 2
+#define ANA_REGS_IVCTRL_PA_BIAS_CTRL_M \
+                                0x00000003  // Controls bias current to PA 00: 
+                                            // IREF bias 01: IREF and IVREF 
+                                            // bias (CC2530 mode) 10: PTAT bias 
+                                            // 11: Increased PTAT slope bias 
+
+#define ANA_REGS_IVCTRL_PA_BIAS_CTRL_S 0
+
+
+#endif // __HW_ANA_REGS_H__
+

--- a/cpu/cc2538/include/vendor/hw_cctest.h
+++ b/cpu/cc2538/include/vendor/hw_cctest.h
@@ -1,0 +1,266 @@
+/******************************************************************************
+*  Filename:       hw_cctest.h
+*  Revised:        $Date: 2013-04-30 17:13:44 +0200 (Tue, 30 Apr 2013) $
+*  Revision:       $Revision: 9943 $
+*
+*  Copyright (C) 2013 Texas Instruments Incorporated - http://www.ti.com/
+*
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*    Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+*
+*    Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+*
+*    Neither the name of Texas Instruments Incorporated nor the names of
+*    its contributors may be used to endorse or promote products derived
+*    from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+*  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+*  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+*  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+*  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+*  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+*  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+*  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+*  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+******************************************************************************/
+
+#ifndef __HW_CCTEST_H__
+#define __HW_CCTEST_H__
+
+//*****************************************************************************
+//
+// The following are defines for the CCTEST register offsets.
+//
+//*****************************************************************************
+#define CCTEST_IO               0x44010000  // Output strength control 
+#define CCTEST_OBSSEL0          0x44010014  // Select output signal on 
+                                            // observation output 0 
+#define CCTEST_OBSSEL1          0x44010018  // Select output signal on 
+                                            // observation output 1 
+#define CCTEST_OBSSEL2          0x4401001C  // Select output signal on 
+                                            // observation output 2 
+#define CCTEST_OBSSEL3          0x44010020  // Select output signal on 
+                                            // observation output 3 
+#define CCTEST_OBSSEL4          0x44010024  // Select output signal on 
+                                            // observation output 4 
+#define CCTEST_OBSSEL5          0x44010028  // Select output signal on 
+                                            // observation output 5 
+#define CCTEST_OBSSEL6          0x4401002C  // Select output signal on 
+                                            // observation output 6 
+#define CCTEST_OBSSEL7          0x44010030  // Select output signal on 
+                                            // observation output 7 
+#define CCTEST_TR0              0x44010034  // Test register 0 
+#define CCTEST_USBCTRL          0x44010050  // USB PHY stand-by control 
+
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the CCTEST_IO register.
+//
+//*****************************************************************************
+#define CCTEST_IO_SC            0x00000001  // I/O strength control bit Common 
+                                            // to all digital output pads 
+                                            // Should be set when unregulated 
+                                            // voltage is below approximately 
+                                            // 2.6 V. 
+#define CCTEST_IO_SC_M          0x00000001
+#define CCTEST_IO_SC_S          0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// CCTEST_OBSSEL0 register.
+//
+//*****************************************************************************
+#define CCTEST_OBSSEL0_EN       0x00000080  // Observation output 0 enable 
+                                            // control for PC0 0: Observation 
+                                            // output disabled 1: Observation 
+                                            // output enabled Note: If enabled, 
+                                            // this overwrites the standard 
+                                            // GPIO behavior of PC0. 
+#define CCTEST_OBSSEL0_EN_M     0x00000080
+#define CCTEST_OBSSEL0_EN_S     7
+#define CCTEST_OBSSEL0_SEL_M    0x0000007F  // n - obs_sigs[n] output on 
+                                            // output 0: 0: rfc_obs_sig0 1: 
+                                            // rfc_obs_sig1 2: rfc_obs_sig2 
+                                            // Others: Reserved 
+#define CCTEST_OBSSEL0_SEL_S    0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// CCTEST_OBSSEL1 register.
+//
+//*****************************************************************************
+#define CCTEST_OBSSEL1_EN       0x00000080  // Observation output 1 enable 
+                                            // control for PC1 0: Observation 
+                                            // output disabled 1: Observation 
+                                            // output enabled Note: If enabled, 
+                                            // this overwrites the standard 
+                                            // GPIO behavior of PC1. 
+#define CCTEST_OBSSEL1_EN_M     0x00000080
+#define CCTEST_OBSSEL1_EN_S     7
+#define CCTEST_OBSSEL1_SEL_M    0x0000007F  // n - obs_sigs[n] output on 
+                                            // output 1: 0: rfc_obs_sig0 1: 
+                                            // rfc_obs_sig1 2: rfc_obs_sig2 
+                                            // Others: Reserved 
+#define CCTEST_OBSSEL1_SEL_S    0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// CCTEST_OBSSEL2 register.
+//
+//*****************************************************************************
+#define CCTEST_OBSSEL2_EN       0x00000080  // Observation output 2 enable 
+                                            // control for PC2 0: Observation 
+                                            // output disabled 1: Observation 
+                                            // output enabled Note: If enabled, 
+                                            // this overwrites the standard 
+                                            // GPIO behavior of PC2. 
+#define CCTEST_OBSSEL2_EN_M     0x00000080
+#define CCTEST_OBSSEL2_EN_S     7
+#define CCTEST_OBSSEL2_SEL_M    0x0000007F  // n - obs_sigs[n] output on 
+                                            // output 2: 0: rfc_obs_sig0 1: 
+                                            // rfc_obs_sig1 2: rfc_obs_sig2 
+                                            // Others: Reserved 
+#define CCTEST_OBSSEL2_SEL_S    0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// CCTEST_OBSSEL3 register.
+//
+//*****************************************************************************
+#define CCTEST_OBSSEL3_EN       0x00000080  // Observation output 3 enable 
+                                            // control for PC3 0: Observation 
+                                            // output disabled 1: Observation 
+                                            // output enabled Note: If enabled, 
+                                            // this overwrites the standard 
+                                            // GPIO behavior of PC3. 
+#define CCTEST_OBSSEL3_EN_M     0x00000080
+#define CCTEST_OBSSEL3_EN_S     7
+#define CCTEST_OBSSEL3_SEL_M    0x0000007F  // n - obs_sigs[n] output on 
+                                            // output 3: 0: rfc_obs_sig0 1: 
+                                            // rfc_obs_sig1 2: rfc_obs_sig2 
+                                            // Others: Reserved 
+#define CCTEST_OBSSEL3_SEL_S    0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// CCTEST_OBSSEL4 register.
+//
+//*****************************************************************************
+#define CCTEST_OBSSEL4_EN       0x00000080  // Observation output 4 enable 
+                                            // control for PC4 0: Observation 
+                                            // output disabled 1: Observation 
+                                            // output enabled Note: If enabled, 
+                                            // this overwrites the standard 
+                                            // GPIO behavior of PC4. 
+#define CCTEST_OBSSEL4_EN_M     0x00000080
+#define CCTEST_OBSSEL4_EN_S     7
+#define CCTEST_OBSSEL4_SEL_M    0x0000007F  // n - obs_sigs[n] output on 
+                                            // output 4: 0: rfc_obs_sig0 1: 
+                                            // rfc_obs_sig1 2: rfc_obs_sig2 
+                                            // Others: Reserved 
+#define CCTEST_OBSSEL4_SEL_S    0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// CCTEST_OBSSEL5 register.
+//
+//*****************************************************************************
+#define CCTEST_OBSSEL5_EN       0x00000080  // Observation output 5 enable 
+                                            // control for PC5 0: Observation 
+                                            // output disabled 1: Observation 
+                                            // output enabled Note: If enabled, 
+                                            // this overwrites the standard 
+                                            // GPIO behavior of PC5. 
+#define CCTEST_OBSSEL5_EN_M     0x00000080
+#define CCTEST_OBSSEL5_EN_S     7
+#define CCTEST_OBSSEL5_SEL_M    0x0000007F  // n - obs_sigs[n] output on 
+                                            // output 5: 0: rfc_obs_sig0 1: 
+                                            // rfc_obs_sig1 2: rfc_obs_sig2 
+                                            // Others: Reserved 
+#define CCTEST_OBSSEL5_SEL_S    0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// CCTEST_OBSSEL6 register.
+//
+//*****************************************************************************
+#define CCTEST_OBSSEL6_EN       0x00000080  // Observation output 6 enable 
+                                            // control for PC6 0: Observation 
+                                            // output disabled 1: Observation 
+                                            // output enabled Note: If enabled, 
+                                            // this overwrites the standard 
+                                            // GPIO behavior of PC6. 
+#define CCTEST_OBSSEL6_EN_M     0x00000080
+#define CCTEST_OBSSEL6_EN_S     7
+#define CCTEST_OBSSEL6_SEL_M    0x0000007F  // n - obs_sigs[n] output on 
+                                            // output 6: 0: rfc_obs_sig0 1: 
+                                            // rfc_obs_sig1 2: rfc_obs_sig2 
+                                            // Others: Reserved 
+#define CCTEST_OBSSEL6_SEL_S    0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// CCTEST_OBSSEL7 register.
+//
+//*****************************************************************************
+#define CCTEST_OBSSEL7_EN       0x00000080  // Observation output 7 enable 
+                                            // control for PC7 0: Observation 
+                                            // output disabled 1: Observation 
+                                            // output enabled Note: If enabled, 
+                                            // this overwrites the standard 
+                                            // GPIO behavior of PC7. 
+#define CCTEST_OBSSEL7_EN_M     0x00000080
+#define CCTEST_OBSSEL7_EN_S     7
+#define CCTEST_OBSSEL7_SEL_M    0x0000007F  // n - obs_sigs[n] output on 
+                                            // output 7: 0: rfc_obs_sig0 1: 
+                                            // rfc_obs_sig1 2: rfc_obs_sig2 
+                                            // Others: Reserved 
+#define CCTEST_OBSSEL7_SEL_S    0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the CCTEST_TR0 register.
+//
+//*****************************************************************************
+#define CCTEST_TR0_ADCTM        0x00000002  // Set to 1 to connect the 
+                                            // temperature sensor to the 
+                                            // SOC_ADC. See also 
+                                            // RFCORE_XREG_ATEST register 
+                                            // description to enable the 
+                                            // temperature sensor. 
+#define CCTEST_TR0_ADCTM_M      0x00000002
+#define CCTEST_TR0_ADCTM_S      1
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// CCTEST_USBCTRL register.
+//
+//*****************************************************************************
+#define CCTEST_USBCTRL_USB_STB  0x00000001  // USB PHY stand-by override bit 
+                                            // When this bit is cleared to 0 
+                                            // (default state) the USB module 
+                                            // cannot change the stand-by mode 
+                                            // of the PHY (USB pads) and the 
+                                            // PHY is forced out of stand-by 
+                                            // mode. This bit must be 1 as well 
+                                            // as the stand-by control from the 
+                                            // USB controller, before the mode 
+                                            // of the PHY is stand-by. 
+#define CCTEST_USBCTRL_USB_STB_M \
+                                0x00000001
+#define CCTEST_USBCTRL_USB_STB_S 0
+
+
+#endif // __HW_CCTEST_H__
+

--- a/cpu/cc2538/include/vendor/hw_flash_ctrl.h
+++ b/cpu/cc2538/include/vendor/hw_flash_ctrl.h
@@ -1,0 +1,449 @@
+/******************************************************************************
+*  Filename:       hw_flash_ctrl.h
+*  Revised:        $Date: 2013-04-30 17:13:44 +0200 (Tue, 30 Apr 2013) $
+*  Revision:       $Revision: 9943 $
+*
+*  Copyright (C) 2013 Texas Instruments Incorporated - http://www.ti.com/
+*
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*    Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+*
+*    Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+*
+*    Neither the name of Texas Instruments Incorporated nor the names of
+*    its contributors may be used to endorse or promote products derived
+*    from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+*  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+*  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+*  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+*  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+*  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+*  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+*  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+*  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+******************************************************************************/
+
+#ifndef __HW_FLASH_CTRL_H__
+#define __HW_FLASH_CTRL_H__
+
+//*****************************************************************************
+//
+// The following are defines for the FLASH_CTRL register offsets.
+//
+//*****************************************************************************
+#define FLASH_CTRL_FCTL         0x400D3008  // Flash control This register 
+                                            // provides control and monitoring 
+                                            // functions for the flash module. 
+#define FLASH_CTRL_FADDR        0x400D300C  // Flash address The register sets 
+                                            // the address to be written in 
+                                            // flash memory. See the bitfield 
+                                            // descriptions for formatting 
+                                            // information. 
+#define FLASH_CTRL_FWDATA       0x400D3010  // Flash data This register 
+                                            // contains the 32-bits of data to 
+                                            // be written to the flash location 
+                                            // selected in FADDR. 
+#define FLASH_CTRL_DIECFG0      0x400D3014  // These settings are a function 
+                                            // of the FLASH information page 
+                                            // bit settings, which are 
+                                            // programmed during production 
+                                            // test, and are subject for 
+                                            // specific configuration for 
+                                            // multiple device flavors of 
+                                            // cc2538. 
+#define FLASH_CTRL_DIECFG1      0x400D3018  // These settings are a function 
+                                            // of the FLASH information page 
+                                            // bit settings, which are 
+                                            // programmed during production 
+                                            // test, and are subject for 
+                                            // specific configuration for 
+                                            // multiple device flavors of 
+                                            // cc2538. 
+#define FLASH_CTRL_DIECFG2      0x400D301C  // These settings are a function 
+                                            // of the FLASH information page 
+                                            // bit settings, which are 
+                                            // programmed during production 
+                                            // test, and are subject for 
+                                            // specific configuration for 
+                                            // multiple device flavors of 
+                                            // cc2538. The DIE_*_REVISION 
+                                            // registers are an exeception to 
+                                            // this, as they are hardwired and 
+                                            // are not part of the FLASH 
+                                            // information page. 
+
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// FLASH_CTRL_FCTL register.
+//
+//*****************************************************************************
+#define FLASH_CTRL_FCTL_UPPER_PAGE_ACCESS \
+                                0x00000200  // Lock bit for lock bit page 0: 
+                                            // Neither write nor erase not 
+                                            // allowed 1: Both write and erase 
+                                            // allowed 
+
+#define FLASH_CTRL_FCTL_UPPER_PAGE_ACCESS_M \
+                                0x00000200
+#define FLASH_CTRL_FCTL_UPPER_PAGE_ACCESS_S 9
+#define FLASH_CTRL_FCTL_SEL_INFO_PAGE \
+                                0x00000100  // Flash erase or write operation 
+                                            // on APB bus must assert this when 
+                                            // accessing the information page 
+
+#define FLASH_CTRL_FCTL_SEL_INFO_PAGE_M \
+                                0x00000100
+#define FLASH_CTRL_FCTL_SEL_INFO_PAGE_S 8
+#define FLASH_CTRL_FCTL_BUSY    0x00000080  // Set when the WRITE or ERASE bit 
+                                            // is set; that is, when the flash 
+                                            // controller is busy 
+#define FLASH_CTRL_FCTL_BUSY_M  0x00000080
+#define FLASH_CTRL_FCTL_BUSY_S  7
+#define FLASH_CTRL_FCTL_FULL    0x00000040  // Write buffer full The CPU can 
+                                            // write to FWDATA when this bit is 
+                                            // 0 and WRITE is 1. This bit is 
+                                            // cleared when BUSY is cleared. 
+#define FLASH_CTRL_FCTL_FULL_M  0x00000040
+#define FLASH_CTRL_FCTL_FULL_S  6
+#define FLASH_CTRL_FCTL_ABORT   0x00000020  // Abort status This bit is set to 
+                                            // 1 when a write sequence or page 
+                                            // erase is aborted. An operation 
+                                            // is aborted when the accessed 
+                                            // page is locked. Cleared when a 
+                                            // write or page erase is started. 
+                                            // If a write operation times out 
+                                            // (because the FWDATA register is 
+                                            // not written fast enough), the 
+                                            // ABORT bit is not set even if the 
+                                            // page is locked. If a page erase 
+                                            // and a write operation are 
+                                            // started simultaneously, the 
+                                            // ABORT bit reflects the status of 
+                                            // the last write operation. For 
+                                            // example, if the page is locked 
+                                            // and the write times out, the 
+                                            // ABORT bit is not set because 
+                                            // only the write operation times 
+                                            // out. 
+#define FLASH_CTRL_FCTL_ABORT_M 0x00000020
+#define FLASH_CTRL_FCTL_ABORT_S 5
+#define FLASH_CTRL_FCTL_CM_M    0x0000000C  // Cache Mode Disabling the cache 
+                                            // increases the power consumption 
+                                            // and reduces performance. 
+                                            // Prefetching improves performance 
+                                            // at the expense of a potential 
+                                            // increase in power consumption. 
+                                            // Real-time mode provides 
+                                            // predictable flash read access 
+                                            // time, the execution time is 
+                                            // equal to cache disabled mode, 
+                                            // but the power consumption is 
+                                            // lower. 00: Cache disabled 01: 
+                                            // Cache enabled 10: Cache enabled, 
+                                            // with prefetch 11: Real-time mode 
+                                            // Note: The read value always 
+                                            // represents the current cache 
+                                            // mode. Writing a new cache mode 
+                                            // starts a cache mode change 
+                                            // request that does not take 
+                                            // effect until the controller is 
+                                            // ready. Writes to this register 
+                                            // are ignored if there is a 
+                                            // current cache change request in 
+                                            // progress. 
+#define FLASH_CTRL_FCTL_CM_S    2
+#define FLASH_CTRL_FCTL_WRITE   0x00000002  // Write bit Start a write 
+                                            // sequence by setting this bit to 
+                                            // 1. Cleared by hardware when the 
+                                            // operation completes. Writes to 
+                                            // this bit are ignored when 
+                                            // FCTL.BUSY is 1. If FCTL.ERASE is 
+                                            // set simultaneously with this 
+                                            // bit, the erase operation is 
+                                            // started first, then the write is 
+                                            // started. 
+#define FLASH_CTRL_FCTL_WRITE_M 0x00000002
+#define FLASH_CTRL_FCTL_WRITE_S 1
+#define FLASH_CTRL_FCTL_ERASE   0x00000001  // Erase bit Start an erase 
+                                            // operation by setting this bit to 
+                                            // 1. Cleared by hardware when the 
+                                            // operation completes. Writes to 
+                                            // this bit are ignored when 
+                                            // FCTL.BUSY is 1. If FCTL.WRITE is 
+                                            // set simultaneously with this 
+                                            // bit, the erase operation is 
+                                            // started first, then the write is 
+                                            // started. 
+#define FLASH_CTRL_FCTL_ERASE_M 0x00000001
+#define FLASH_CTRL_FCTL_ERASE_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// FLASH_CTRL_FADDR register.
+//
+//*****************************************************************************
+#define FLASH_CTRL_FADDR_FADDR_M \
+                                0x0001FFFF  // Bit number [16:9] selects one 
+                                            // of 256 pages for page erase. Bit 
+                                            // number [8:7] selects one of the 
+                                            // 4 row in a given page Bit number 
+                                            // [6:1] selects one of the 64-bit 
+                                            // wide locations in a give row. 
+                                            // Bit number [0] will select 
+                                            // upper/lower 32-bits in a given 
+                                            // 64-bit location - 64Kbytes --> 
+                                            // Bits [16:14] will always be 0. - 
+                                            // 128Kbytes --> Bits [16:15] will 
+                                            // always be 0. - 256Kbytes --> Bit 
+                                            // [16] will always be 0. - 
+                                            // 384/512Kbytes --> All bits 
+                                            // written and valid. Writes to 
+                                            // this register will be ignored 
+                                            // when any of FCTL.WRITE and 
+                                            // FCTL.ERASE is set. FADDR should 
+                                            // be written with byte addressable 
+                                            // location of the Flash to be 
+                                            // programmed. Read back value 
+                                            // always reflects a 32-bit aligned 
+                                            // address. When the register is 
+                                            // read back, the value that was 
+                                            // written to FADDR gets right 
+                                            // shift by 2 to indicate 32-bit 
+                                            // aligned address. In other words 
+                                            // lower 2 bits are discarded while 
+                                            // reading back the register. Out 
+                                            // of range address results in roll 
+                                            // over. There is no status signal 
+                                            // generated by flash controller to 
+                                            // indicate this. Firmware is 
+                                            // responsible to managing the 
+                                            // addresses correctly. 
+
+#define FLASH_CTRL_FADDR_FADDR_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// FLASH_CTRL_FWDATA register.
+//
+//*****************************************************************************
+#define FLASH_CTRL_FWDATA_FWDATA_M \
+                                0xFFFFFFFF  // 32-bit flash write data Writes 
+                                            // to this register are accepted 
+                                            // only during a flash write 
+                                            // sequence; that is, writes to 
+                                            // this register after having 
+                                            // written 1 to the FCTL.WRITE bit. 
+                                            // New 32-bit data is written only 
+                                            // if FCTL.FULL = 0. 
+
+#define FLASH_CTRL_FWDATA_FWDATA_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// FLASH_CTRL_DIECFG0 register.
+//
+//*****************************************************************************
+#define FLASH_CTRL_DIECFG0_CHIPID_M \
+                                0xFFFF0000  // Register copy of configuration 
+                                            // bits Three clock cycles after 
+                                            // reset is released, this bit 
+                                            // field is equal to the field with 
+                                            // the same name in the information 
+                                            // page. 
+
+#define FLASH_CTRL_DIECFG0_CHIPID_S 16
+#define FLASH_CTRL_DIECFG0_CLK_SEL_GATE_EN_N \
+                                0x00000400  // Register copy of configuration 
+                                            // bits Three clock cycles after 
+                                            // reset is released, this bit is 
+                                            // equal to the field with the same 
+                                            // name in the information page. 
+
+#define FLASH_CTRL_DIECFG0_CLK_SEL_GATE_EN_N_M \
+                                0x00000400
+#define FLASH_CTRL_DIECFG0_CLK_SEL_GATE_EN_N_S 10
+#define FLASH_CTRL_DIECFG0_SRAM_SIZE_M \
+                                0x00000380  // Register copy of configuration 
+                                            // bits Three clock cycles after 
+                                            // reset is released, this bit 
+                                            // field is equal to the field with 
+                                            // the same name in the information 
+                                            // page. 
+
+#define FLASH_CTRL_DIECFG0_SRAM_SIZE_S 7
+#define FLASH_CTRL_DIECFG0_FLASH_SIZE_M \
+                                0x00000070  // Register copy of configuration 
+                                            // bits Three clock cycles after 
+                                            // reset is released, this bit 
+                                            // field is equal to the field with 
+                                            // the same name in the information 
+                                            // page. 
+
+#define FLASH_CTRL_DIECFG0_FLASH_SIZE_S 4
+#define FLASH_CTRL_DIECFG0_USB_ENABLE \
+                                0x00000008  // Register copy of configuration 
+                                            // bits Three clock cycles after 
+                                            // reset is released, this bit is 
+                                            // equal to the field with the same 
+                                            // name in the information page. 
+
+#define FLASH_CTRL_DIECFG0_USB_ENABLE_M \
+                                0x00000008
+#define FLASH_CTRL_DIECFG0_USB_ENABLE_S 3
+#define FLASH_CTRL_DIECFG0_MASS_ERASE_ENABLE \
+                                0x00000004  // Register copy of configuration 
+                                            // bits Three clock cycles after 
+                                            // reset is released, this bit is 
+                                            // equal to the field with the same 
+                                            // name in the information page. 
+
+#define FLASH_CTRL_DIECFG0_MASS_ERASE_ENABLE_M \
+                                0x00000004
+#define FLASH_CTRL_DIECFG0_MASS_ERASE_ENABLE_S 2
+#define FLASH_CTRL_DIECFG0_LOCK_FWT_N \
+                                0x00000002  // Register copy of configuration 
+                                            // bits Three clock cycles after 
+                                            // reset is released, this bit is 
+                                            // equal to the field with the same 
+                                            // name in the information page. 
+
+#define FLASH_CTRL_DIECFG0_LOCK_FWT_N_M \
+                                0x00000002
+#define FLASH_CTRL_DIECFG0_LOCK_FWT_N_S 1
+#define FLASH_CTRL_DIECFG0_LOCK_IP_N \
+                                0x00000001  // Register copy of configuration 
+                                            // bits Three clock cycles after 
+                                            // reset is released, this bit is 
+                                            // equal to the field with the same 
+                                            // name in the information page. 
+
+#define FLASH_CTRL_DIECFG0_LOCK_IP_N_M \
+                                0x00000001
+#define FLASH_CTRL_DIECFG0_LOCK_IP_N_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// FLASH_CTRL_DIECFG1 register.
+//
+//*****************************************************************************
+#define FLASH_CTRL_DIECFG1_I2C_EN \
+                                0x01000000  // 1: I2C is enabled. 0: I2C is 
+                                            // permanently disabled. 
+
+#define FLASH_CTRL_DIECFG1_I2C_EN_M \
+                                0x01000000
+#define FLASH_CTRL_DIECFG1_I2C_EN_S 24
+#define FLASH_CTRL_DIECFG1_UART1_EN \
+                                0x00020000  // 1: UART1 is enabled. 0: UART1 
+                                            // is permanently disabled. 
+
+#define FLASH_CTRL_DIECFG1_UART1_EN_M \
+                                0x00020000
+#define FLASH_CTRL_DIECFG1_UART1_EN_S 17
+#define FLASH_CTRL_DIECFG1_UART0_EN \
+                                0x00010000  // 1: UART0 is enabled. 0: UART0 
+                                            // is permanently disabled. 
+
+#define FLASH_CTRL_DIECFG1_UART0_EN_M \
+                                0x00010000
+#define FLASH_CTRL_DIECFG1_UART0_EN_S 16
+#define FLASH_CTRL_DIECFG1_SSI1_EN \
+                                0x00000200  // 1: SSI1 is enabled. 0: SSI1 is 
+                                            // permanently disabled. 
+
+#define FLASH_CTRL_DIECFG1_SSI1_EN_M \
+                                0x00000200
+#define FLASH_CTRL_DIECFG1_SSI1_EN_S 9
+#define FLASH_CTRL_DIECFG1_SSI0_EN \
+                                0x00000100  // 1: SSI0 is enabled. 0: SSI0 is 
+                                            // permanently disabled. 
+
+#define FLASH_CTRL_DIECFG1_SSI0_EN_M \
+                                0x00000100
+#define FLASH_CTRL_DIECFG1_SSI0_EN_S 8
+#define FLASH_CTRL_DIECFG1_GPTM3_EN \
+                                0x00000008  // 1: GPTM3 is enabled. 0: GPTM3 
+                                            // is permanently disabled. 
+
+#define FLASH_CTRL_DIECFG1_GPTM3_EN_M \
+                                0x00000008
+#define FLASH_CTRL_DIECFG1_GPTM3_EN_S 3
+#define FLASH_CTRL_DIECFG1_GPTM2_EN \
+                                0x00000004  // 1: GPTM2 is enabled. 0: GPTM2 
+                                            // is permanently disabled. 
+
+#define FLASH_CTRL_DIECFG1_GPTM2_EN_M \
+                                0x00000004
+#define FLASH_CTRL_DIECFG1_GPTM2_EN_S 2
+#define FLASH_CTRL_DIECFG1_GPTM1_EN \
+                                0x00000002  // 1: GPTM1 is enabled. 0: GPTM1 
+                                            // is permanently disabled. 
+
+#define FLASH_CTRL_DIECFG1_GPTM1_EN_M \
+                                0x00000002
+#define FLASH_CTRL_DIECFG1_GPTM1_EN_S 1
+#define FLASH_CTRL_DIECFG1_GPTM0_EN \
+                                0x00000001  // 1: GPTM0 is enabled. 0: GPTM0 
+                                            // is permanently disabled. 
+
+#define FLASH_CTRL_DIECFG1_GPTM0_EN_M \
+                                0x00000001
+#define FLASH_CTRL_DIECFG1_GPTM0_EN_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// FLASH_CTRL_DIECFG2 register.
+//
+//*****************************************************************************
+#define FLASH_CTRL_DIECFG2_DIE_MAJOR_REVISION_M \
+                                0x0000F000  // Indicates the major revision 
+                                            // (all layer change) number for 
+                                            // the cc2538 0x0 - PG1.0 0x2 - 
+                                            // PG2.0 
+
+#define FLASH_CTRL_DIECFG2_DIE_MAJOR_REVISION_S 12
+#define FLASH_CTRL_DIECFG2_DIE_MINOR_REVISION_M \
+                                0x00000F00  // Indicates the minor revision 
+                                            // (metla layer only) number for 
+                                            // the cc2538 0x0 - PG1.0 or PG2.0 
+
+#define FLASH_CTRL_DIECFG2_DIE_MINOR_REVISION_S 8
+#define FLASH_CTRL_DIECFG2_RF_CORE_EN \
+                                0x00000004  // 1: RF_CORE is enabled. 0: 
+                                            // RF_CORE is permanently disabled. 
+
+#define FLASH_CTRL_DIECFG2_RF_CORE_EN_M \
+                                0x00000004
+#define FLASH_CTRL_DIECFG2_RF_CORE_EN_S 2
+#define FLASH_CTRL_DIECFG2_AES_EN \
+                                0x00000002  // 1: AES is enabled. 0: AES is 
+                                            // permanently disabled. 
+
+#define FLASH_CTRL_DIECFG2_AES_EN_M \
+                                0x00000002
+#define FLASH_CTRL_DIECFG2_AES_EN_S 1
+#define FLASH_CTRL_DIECFG2_PKA_EN \
+                                0x00000001  // 1: PKA is enabled. 0: PKA is 
+                                            // permanently disabled. 
+
+#define FLASH_CTRL_DIECFG2_PKA_EN_M \
+                                0x00000001
+#define FLASH_CTRL_DIECFG2_PKA_EN_S 0
+
+
+#endif // __HW_FLASH_CTRL_H__
+

--- a/cpu/cc2538/include/vendor/hw_gpio.h
+++ b/cpu/cc2538/include/vendor/hw_gpio.h
@@ -1,0 +1,1299 @@
+/******************************************************************************
+*  Filename:       hw_gpio.h
+*  Revised:        $Date: 2013-04-30 17:13:44 +0200 (Tue, 30 Apr 2013) $
+*  Revision:       $Revision: 9943 $
+*
+*  Copyright (C) 2013 Texas Instruments Incorporated - http://www.ti.com/
+*
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*    Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+*
+*    Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+*
+*    Neither the name of Texas Instruments Incorporated nor the names of
+*    its contributors may be used to endorse or promote products derived
+*    from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+*  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+*  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+*  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+*  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+*  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+*  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+*  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+*  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+******************************************************************************/
+
+#ifndef __HW_GPIO_H__
+#define __HW_GPIO_H__
+
+//*****************************************************************************
+//
+// The following are defines for the GPIO register offsets.
+//
+//*****************************************************************************
+#define GPIO_O_DATA             0x00000000  // This is the data register. In 
+                                            // software control mode, values 
+                                            // written in the GPIODATA register 
+                                            // are transferred onto the GPOUT 
+                                            // pins if the respective pins have 
+                                            // been configured as outputs 
+                                            // through the GPIODIR register. A 
+                                            // read from GPIODATA returns the 
+                                            // last bit value written if the 
+                                            // respective pins are configured 
+                                            // as output, or it returns the 
+                                            // value on the corresponding input 
+                                            // GPIN bit when these are 
+                                            // configured as inputs. 
+#define GPIO_O_DIR              0x00000400  // The DIR register is the data 
+                                            // direction register. All bits are 
+                                            // cleared by a reset; therefore, 
+                                            // the GPIO pins are input by 
+                                            // default. 
+#define GPIO_O_IS               0x00000404  // The IS register is the 
+                                            // interrupt sense register. 
+#define GPIO_O_IBE              0x00000408  // The IBE register is the 
+                                            // interrupt both-edges register. 
+                                            // When the corresponding bit in IS 
+                                            // is set to detect edges, bits set 
+                                            // to high in IBE configure the 
+                                            // corresponding pin to detect both 
+                                            // rising and falling edges, 
+                                            // regardless of the corresponding 
+                                            // bit in the IEV (interrupt event 
+                                            // register). Clearing a bit 
+                                            // configures the pin to be 
+                                            // controlled by IEV. 
+#define GPIO_O_IEV              0x0000040C  // The IEV register is the 
+                                            // interrupt event register. Bits 
+                                            // set to high in IEV configure the 
+                                            // corresponding pin to detect 
+                                            // rising edges or high levels, 
+                                            // depending on the corresponding 
+                                            // bit value in IS. Clearing a bit 
+                                            // configures the pin to detect 
+                                            // falling edges or low levels, 
+                                            // depending on the corresponding 
+                                            // bit value in IS. 
+#define GPIO_O_IE               0x00000410  // The IE register is the 
+                                            // interrupt mask register. Bits 
+                                            // set to high in IE allow the 
+                                            // corresponding pins to trigger 
+                                            // their individual interrupts and 
+                                            // the combined GPIOINTR line. 
+                                            // Clearing a bit disables 
+                                            // interrupt triggering on that 
+                                            // pin. 
+#define GPIO_O_RIS              0x00000414  // The RIS register is the raw 
+                                            // interrupt status register. Bits 
+                                            // read high in RIS reflect the 
+                                            // status of interrupts trigger 
+                                            // conditions detected (raw, before 
+                                            // masking), indicating that all 
+                                            // the requirements are met, before 
+                                            // they are finally allowed to 
+                                            // trigger by IE. Bits read as 0 
+                                            // indicate that corresponding 
+                                            // input pins have not initiated an 
+                                            // interrupt. 
+#define GPIO_O_MIS              0x00000418  // The MIS register is the masked 
+                                            // interrupt status register. Bits 
+                                            // read high in MIS reflect the 
+                                            // status of input lines triggering 
+                                            // an interrupt. Bits read as low 
+                                            // indicate that either no 
+                                            // interrupt has been generated, or 
+                                            // the interrupt is masked. MIS is 
+                                            // the state of the interrupt after 
+                                            // masking. 
+#define GPIO_O_IC               0x0000041C  // The IC register is the 
+                                            // interrupt clear register. 
+                                            // Writing 1 to a bit in this 
+                                            // register clears the 
+                                            // corresponding interrupt edge 
+                                            // detection logic register. 
+                                            // Writing 0 has no effect. 
+#define GPIO_O_AFSEL            0x00000420  // The AFSEL register is the mode 
+                                            // control select register. Writing 
+                                            // 1 to any bit in this register 
+                                            // selects the hardware 
+                                            // (peripheral) control for the 
+                                            // corresponding GPIO line. All 
+                                            // bits are cleared by a reset, 
+                                            // therefore no GPIO line is set to 
+                                            // hardware control by default. 
+#define GPIO_O_GPIOLOCK         0x00000520  // A write of the value 0x4C4F434B 
+                                            // to the GPIOLOCK register unlocks 
+                                            // the GPIO commit register 
+                                            // (GPIOCR) for write access. A 
+                                            // write of any other value 
+                                            // reapplies the lock, preventing 
+                                            // any register updates. Any write 
+                                            // to the commit register (GPIOCR) 
+                                            // causes the lock register to be 
+                                            // locked. 
+#define GPIO_O_GPIOCR           0x00000524  // The GPIOCR register is the 
+                                            // commit register. The value of 
+                                            // the GPIOCR register determines 
+                                            // which bits of the AFSEL register 
+                                            // is committed when a write to the 
+                                            // AFSEL register is performed. If 
+                                            // a bit in the GPIOCR register is 
+                                            // 0, the data being written to the 
+                                            // corresponding bit in the AFSEL 
+                                            // register is not committed and 
+                                            // retains its previous value. If a 
+                                            // bit in the GPIOCR register is 
+                                            // set to 1, the data being written 
+                                            // to the corresponding bit of the 
+                                            // AFSEL register is committed to 
+                                            // the register and will reflect 
+                                            // the new value. The contents of 
+                                            // the GPIOCR register can only be 
+                                            // modified if the GPIOLOCK 
+                                            // register is unlocked. Writes to 
+                                            // the GPIOCR register will be 
+                                            // ignored if the GPIOLOCK register 
+                                            // is locked. Any write to the 
+                                            // commit register causes the lock 
+                                            // register to be locked. 
+#define GPIO_O_PMUX             0x00000700  // The PMUX register can be used 
+                                            // to output external decouple 
+                                            // control and clock_32k on I/O 
+                                            // pins. Decouple control can be 
+                                            // output on specific PB pins and 
+                                            // clock_32k can be output on a 
+                                            // specific PA or PB pin. These 
+                                            // features override the current 
+                                            // setting of the selected pin when 
+                                            // enabled. The pin is set to 
+                                            // output, pull-up and -down 
+                                            // disabled, and analog mode 
+                                            // disabled. 
+#define GPIO_O_P_EDGE_CTRL      0x00000704  // The port edge control register 
+                                            // is used to control which edge of 
+                                            // each port input causes that port 
+                                            // to generate a power-up interrupt 
+                                            // to the system. 
+#define GPIO_O_USB_CTRL         0x00000708  // This register is used to 
+                                            // control which edge of the USB 
+                                            // controller input generates a 
+                                            // power-up interrupt to the 
+                                            // system. 
+#define GPIO_O_PI_IEN           0x00000710  // The power-up interrupt enable 
+                                            // register selects, for its 
+                                            // corresponding port A-D pin, 
+                                            // whether interrupts are enabled 
+                                            // or disabled. 
+#define GPIO_O_IRQ_DETECT_ACK   0x00000718  // If the IRQ detect ACK register 
+                                            // is read, the value returned can 
+                                            // be used to determine which 
+                                            // enabled I/O port is responsible 
+                                            // for creating a power-up 
+                                            // interrupt to the system. Writing 
+                                            // the IRQ detect ACK register is 
+                                            // used to clear any number of 
+                                            // individual port bits that may be 
+                                            // signaling that an edge was 
+                                            // detected as configured by the 
+                                            // port edge control register and 
+                                            // the interrupt control register. 
+                                            // There is a self-clearing 
+                                            // function to this register that 
+                                            // generates a reset pulse to clear 
+                                            // any interrupt which has its 
+                                            // corresponding bit set to 1. 
+#define GPIO_O_USB_IRQ_ACK      0x0000071C  // Same functionality as 
+                                            // IRQ_DETECT_ACK, but for USB 
+#define GPIO_O_IRQ_DETECT_UNMASK \
+                                0x00000720  // Same functionality as 
+                                            // IRQ_DETECT_ACK, but this 
+                                            // register handles masked 
+                                            // interrupts 
+
+
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the GPIO_O_DATA register.
+//
+//*****************************************************************************
+#define GPIO_DATA_DATA_M        0x000000FF  // Input and output data 
+#define GPIO_DATA_DATA_S        0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the GPIO_O_DIR register.
+//
+//*****************************************************************************
+#define GPIO_DIR_DIR_M          0x000000FF  // Bits set: Corresponding pin is 
+                                            // output Bits cleared: 
+                                            // Corresponding pin is input 
+#define GPIO_DIR_DIR_S          0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the GPIO_O_IS register.
+//
+//*****************************************************************************
+#define GPIO_IS_IS_M            0x000000FF  // Bits set: Level on 
+                                            // corresponding pin is detected 
+                                            // Bits cleared: Edge on 
+                                            // corresponding pin is detected 
+#define GPIO_IS_IS_S            0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the GPIO_O_IBE register.
+//
+//*****************************************************************************
+#define GPIO_IBE_IBE_M          0x000000FF  // Bits set: Both edges on 
+                                            // corresponding pin trigger an 
+                                            // interrupt Bits cleared: 
+                                            // Interrupt generation event is 
+                                            // controlled by GPIOIEV Single 
+                                            // edge: Determined by 
+                                            // corresponding bit in GPIOIEV 
+                                            // register 
+#define GPIO_IBE_IBE_S          0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the GPIO_O_IEV register.
+//
+//*****************************************************************************
+#define GPIO_IEV_IEV_M          0x000000FF  // Bits set: Rising edges or high 
+                                            // levels on corresponding pin 
+                                            // trigger interrupts Bits cleared: 
+                                            // Falling edges or low levels on 
+                                            // corresponding pin trigger 
+                                            // interrupts 
+#define GPIO_IEV_IEV_S          0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the GPIO_O_IE register.
+//
+//*****************************************************************************
+#define GPIO_IE_IE_M            0x000000FF  // Bits set: Corresponding pin is 
+                                            // not masked Bits cleared: 
+                                            // Corresponding pin is masked 
+#define GPIO_IE_IE_S            0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the GPIO_O_RIS register.
+//
+//*****************************************************************************
+#define GPIO_RIS_RIS_M          0x000000FF  // Reflects the status of 
+                                            // interrupts trigger conditions 
+                                            // detected on pins (raw, before 
+                                            // masking) Bits set: Requirements 
+                                            // met by corresponding pins Bits 
+                                            // clear: Requirements not met 
+#define GPIO_RIS_RIS_S          0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the GPIO_O_MIS register.
+//
+//*****************************************************************************
+#define GPIO_MIS_MIS_M          0x000000FF  // Masked value of interrupt due 
+                                            // to corresponding pin Bits clear: 
+                                            // GPIO line interrupt not active 
+                                            // Bits set: GPIO line asserting 
+                                            // interrupt 
+#define GPIO_MIS_MIS_S          0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the GPIO_O_IC register.
+//
+//*****************************************************************************
+#define GPIO_IC_IC_M            0x000000FF  // Bit written as 1: Clears edge 
+                                            // detection logic Bit written as 
+                                            // 0: Has no effect 
+#define GPIO_IC_IC_S            0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the GPIO_O_AFSEL register.
+//
+//*****************************************************************************
+#define GPIO_AFSEL_AFSEL_M      0x000000FF  // Bit set: Enables hardware 
+                                            // (peripheral) control mode Bit 
+                                            // cleared: Enables software 
+                                            // control mode 
+#define GPIO_AFSEL_AFSEL_S      0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// GPIO_O_GPIOLOCK register.
+//
+//*****************************************************************************
+#define GPIO_GPIOLOCK_LOCK_M    0xFFFFFFFF  // A read of this register returns 
+                                            // the following values: Locked: 
+                                            // 0x00000001 Unlocked: 0x00000000 
+#define GPIO_GPIOLOCK_LOCK_S    0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the GPIO_O_GPIOCR register.
+//
+//*****************************************************************************
+#define GPIO_GPIOCR_CR_M        0x000000FF  // On a bit-wise basis, any bit 
+                                            // set allows the corresponding 
+                                            // GPIOAFSEL bit to be set to its 
+                                            // alternate function. 
+#define GPIO_GPIOCR_CR_S        0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the GPIO_O_PMUX register.
+//
+//*****************************************************************************
+#define GPIO_PMUX_CKOEN         0x00000080  // Clock out enable When this bit 
+                                            // is set, the 32-kHz clock is 
+                                            // routed to either PA[0] or PB[7] 
+                                            // pins. PMUX.CKOPIN selects the 
+                                            // pin to use. This overrides the 
+                                            // current configuration setting 
+                                            // for this pin. The pullup or 
+                                            // pulldown is disabled and the 
+                                            // direction is set to output for 
+                                            // this pin. 
+#define GPIO_PMUX_CKOEN_M       0x00000080
+#define GPIO_PMUX_CKOEN_S       7
+#define GPIO_PMUX_CKOPIN        0x00000010  // Decouple control pin select 
+                                            // This control only has relevance 
+                                            // when CKOEN is set. When 0, PA[0] 
+                                            // becomes the 32-kHz clock output. 
+                                            // When 1, PB[7] becomes the 32-kHz 
+                                            // clock output. 
+#define GPIO_PMUX_CKOPIN_M      0x00000010
+#define GPIO_PMUX_CKOPIN_S      4
+#define GPIO_PMUX_DCEN          0x00000008  // Decouple control enable When 
+                                            // this bit is set, the on-die 
+                                            // digital regulator status is 
+                                            // routed to either PB[1] or PB[0] 
+                                            // pins. PMUX.DCPIN selects the pin 
+                                            // to use. This overrides the 
+                                            // current configuration setting 
+                                            // for this pin. The pullup or 
+                                            // pulldown is disabled and the 
+                                            // direction is set to output for 
+                                            // this pin. 
+#define GPIO_PMUX_DCEN_M        0x00000008
+#define GPIO_PMUX_DCEN_S        3
+#define GPIO_PMUX_DCPIN         0x00000001  // Decouple control pin select 
+                                            // This control has relevance only 
+                                            // when DCEN is set. When 0, PB[1] 
+                                            // becomes the on-die digital 
+                                            // regulator status (1 indicates 
+                                            // the on-die digital regulator is 
+                                            // active); when 1, PB[0] becomes 
+                                            // the on-die digital regulator 
+                                            // status. NOTE: PB[1] and PB[0] 
+                                            // can also be controlled with 
+                                            // other override features. In 
+                                            // priority order for PB[1]: When 
+                                            // POR/BOD test mode is active, 
+                                            // PB[1] becomes the active low 
+                                            // brown-out detected indicator. 
+                                            // When DCEN is set and DCPIN is 
+                                            // not set, PB[1] becomes the 
+                                            // on-dir digital regulator status. 
+                                            // In priority order for PB[0]: 
+                                            // When POR/BOD test mode is 
+                                            // active, PB[0] becomes the 
+                                            // power-on-reset indicator. When 
+                                            // DCEN and DCPIN are set, PB[0] 
+                                            // becomes the on-die digital 
+                                            // regulator status. 
+#define GPIO_PMUX_DCPIN_M       0x00000001
+#define GPIO_PMUX_DCPIN_S       0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// GPIO_O_P_EDGE_CTRL register.
+//
+//*****************************************************************************
+#define GPIO_P_EDGE_CTRL_PDIRC7 0x80000000  // Port D bit 7 interrupt request 
+                                            // condition: 0: Rising 1: Falling 
+                                            // edge 
+#define GPIO_P_EDGE_CTRL_PDIRC7_M \
+                                0x80000000
+#define GPIO_P_EDGE_CTRL_PDIRC7_S 31
+#define GPIO_P_EDGE_CTRL_PDIRC6 0x40000000  // Port D bit 6 interrupt request 
+                                            // condition: 0: Rising 1: Falling 
+                                            // edge 
+#define GPIO_P_EDGE_CTRL_PDIRC6_M \
+                                0x40000000
+#define GPIO_P_EDGE_CTRL_PDIRC6_S 30
+#define GPIO_P_EDGE_CTRL_PDIRC5 0x20000000  // Port D bit 5 interrupt request 
+                                            // condition: 0: Rising 1: Falling 
+                                            // edge 
+#define GPIO_P_EDGE_CTRL_PDIRC5_M \
+                                0x20000000
+#define GPIO_P_EDGE_CTRL_PDIRC5_S 29
+#define GPIO_P_EDGE_CTRL_PDIRC4 0x10000000  // Port D bit 4 interrupt request 
+                                            // condition: 0: Rising 1: Falling 
+                                            // edge 
+#define GPIO_P_EDGE_CTRL_PDIRC4_M \
+                                0x10000000
+#define GPIO_P_EDGE_CTRL_PDIRC4_S 28
+#define GPIO_P_EDGE_CTRL_PDIRC3 0x08000000  // Port D bit 3 interrupt request 
+                                            // condition: 0: Rising 1: Falling 
+                                            // edge 
+#define GPIO_P_EDGE_CTRL_PDIRC3_M \
+                                0x08000000
+#define GPIO_P_EDGE_CTRL_PDIRC3_S 27
+#define GPIO_P_EDGE_CTRL_PDIRC2 0x04000000  // Port D bit 2 interrupt request 
+                                            // condition: 0: Rising 1: Falling 
+                                            // edge 
+#define GPIO_P_EDGE_CTRL_PDIRC2_M \
+                                0x04000000
+#define GPIO_P_EDGE_CTRL_PDIRC2_S 26
+#define GPIO_P_EDGE_CTRL_PDIRC1 0x02000000  // Port D bit 1 interrupt request 
+                                            // condition: 0: Rising 1: Falling 
+                                            // edge 
+#define GPIO_P_EDGE_CTRL_PDIRC1_M \
+                                0x02000000
+#define GPIO_P_EDGE_CTRL_PDIRC1_S 25
+#define GPIO_P_EDGE_CTRL_PDIRC0 0x01000000  // Port D bit 0 interrupt request 
+                                            // condition: 0: Rising 1: Falling 
+                                            // edge 
+#define GPIO_P_EDGE_CTRL_PDIRC0_M \
+                                0x01000000
+#define GPIO_P_EDGE_CTRL_PDIRC0_S 24
+#define GPIO_P_EDGE_CTRL_PCIRC7 0x00800000  // Port C bit 7 interrupt request 
+                                            // condition: 0: Rising 1: Falling 
+                                            // edge 
+#define GPIO_P_EDGE_CTRL_PCIRC7_M \
+                                0x00800000
+#define GPIO_P_EDGE_CTRL_PCIRC7_S 23
+#define GPIO_P_EDGE_CTRL_PCIRC6 0x00400000  // Port C bit 6 interrupt request 
+                                            // condition: 0: Rising 1: Falling 
+                                            // edge 
+#define GPIO_P_EDGE_CTRL_PCIRC6_M \
+                                0x00400000
+#define GPIO_P_EDGE_CTRL_PCIRC6_S 22
+#define GPIO_P_EDGE_CTRL_PCIRC5 0x00200000  // Port C bit 5 interrupt request 
+                                            // condition: 0: Rising 1: Falling 
+                                            // edge 
+#define GPIO_P_EDGE_CTRL_PCIRC5_M \
+                                0x00200000
+#define GPIO_P_EDGE_CTRL_PCIRC5_S 21
+#define GPIO_P_EDGE_CTRL_PCIRC4 0x00100000  // Port C bit 4 interrupt request 
+                                            // condition: 0: Rising 1: Falling 
+                                            // edge 
+#define GPIO_P_EDGE_CTRL_PCIRC4_M \
+                                0x00100000
+#define GPIO_P_EDGE_CTRL_PCIRC4_S 20
+#define GPIO_P_EDGE_CTRL_PCIRC3 0x00080000  // Port C bit 3 interrupt request 
+                                            // condition: 0: Rising 1: Falling 
+                                            // edge 
+#define GPIO_P_EDGE_CTRL_PCIRC3_M \
+                                0x00080000
+#define GPIO_P_EDGE_CTRL_PCIRC3_S 19
+#define GPIO_P_EDGE_CTRL_PCIRC2 0x00040000  // Port C bit 2 interrupt request 
+                                            // condition: 0: Rising 1: Falling 
+                                            // edge 
+#define GPIO_P_EDGE_CTRL_PCIRC2_M \
+                                0x00040000
+#define GPIO_P_EDGE_CTRL_PCIRC2_S 18
+#define GPIO_P_EDGE_CTRL_PCIRC1 0x00020000  // Port C bit 1 interrupt request 
+                                            // condition: 0: Rising 1: Falling 
+                                            // edge 
+#define GPIO_P_EDGE_CTRL_PCIRC1_M \
+                                0x00020000
+#define GPIO_P_EDGE_CTRL_PCIRC1_S 17
+#define GPIO_P_EDGE_CTRL_PCIRC0 0x00010000  // Port C bit 0 interrupt request 
+                                            // condition: 0: Rising 1: Falling 
+                                            // edge 
+#define GPIO_P_EDGE_CTRL_PCIRC0_M \
+                                0x00010000
+#define GPIO_P_EDGE_CTRL_PCIRC0_S 16
+#define GPIO_P_EDGE_CTRL_PBIRC7 0x00008000  // Port B bit 7 interrupt request 
+                                            // condition: 0: Rising 1: Falling 
+                                            // edge 
+#define GPIO_P_EDGE_CTRL_PBIRC7_M \
+                                0x00008000
+#define GPIO_P_EDGE_CTRL_PBIRC7_S 15
+#define GPIO_P_EDGE_CTRL_PBIRC6 0x00004000  // Port B bit 6 interrupt request 
+                                            // condition: 0: Rising 1: Falling 
+                                            // edge 
+#define GPIO_P_EDGE_CTRL_PBIRC6_M \
+                                0x00004000
+#define GPIO_P_EDGE_CTRL_PBIRC6_S 14
+#define GPIO_P_EDGE_CTRL_PBIRC5 0x00002000  // Port B bit 5 interrupt request 
+                                            // condition: 0: Rising 1: Falling 
+                                            // edge 
+#define GPIO_P_EDGE_CTRL_PBIRC5_M \
+                                0x00002000
+#define GPIO_P_EDGE_CTRL_PBIRC5_S 13
+#define GPIO_P_EDGE_CTRL_PBIRC4 0x00001000  // Port B bit 4 interrupt request 
+                                            // condition: 0: Rising 1: Falling 
+                                            // edge 
+#define GPIO_P_EDGE_CTRL_PBIRC4_M \
+                                0x00001000
+#define GPIO_P_EDGE_CTRL_PBIRC4_S 12
+#define GPIO_P_EDGE_CTRL_PBIRC3 0x00000800  // Port B bit 3 interrupt request 
+                                            // condition: 0: Rising 1: Falling 
+                                            // edge 
+#define GPIO_P_EDGE_CTRL_PBIRC3_M \
+                                0x00000800
+#define GPIO_P_EDGE_CTRL_PBIRC3_S 11
+#define GPIO_P_EDGE_CTRL_PBIRC2 0x00000400  // Port B bit 2 interrupt request 
+                                            // condition: 0: Rising 1: Falling 
+                                            // edge 
+#define GPIO_P_EDGE_CTRL_PBIRC2_M \
+                                0x00000400
+#define GPIO_P_EDGE_CTRL_PBIRC2_S 10
+#define GPIO_P_EDGE_CTRL_PBIRC1 0x00000200  // Port B bit 1 interrupt request 
+                                            // condition: 0: Rising 1: Falling 
+                                            // edge 
+#define GPIO_P_EDGE_CTRL_PBIRC1_M \
+                                0x00000200
+#define GPIO_P_EDGE_CTRL_PBIRC1_S 9
+#define GPIO_P_EDGE_CTRL_PBIRC0 0x00000100  // Port B bit 0 interrupt request 
+                                            // condition: 0: Rising 1: Falling 
+                                            // edge 
+#define GPIO_P_EDGE_CTRL_PBIRC0_M \
+                                0x00000100
+#define GPIO_P_EDGE_CTRL_PBIRC0_S 8
+#define GPIO_P_EDGE_CTRL_PAIRC7 0x00000080  // Port A bit 7 interrupt request 
+                                            // condition: 0: Rising 1: Falling 
+                                            // edge 
+#define GPIO_P_EDGE_CTRL_PAIRC7_M \
+                                0x00000080
+#define GPIO_P_EDGE_CTRL_PAIRC7_S 7
+#define GPIO_P_EDGE_CTRL_PAIRC6 0x00000040  // Port A bit 6 interrupt request 
+                                            // condition: 0: Rising 1: Falling 
+                                            // edge 
+#define GPIO_P_EDGE_CTRL_PAIRC6_M \
+                                0x00000040
+#define GPIO_P_EDGE_CTRL_PAIRC6_S 6
+#define GPIO_P_EDGE_CTRL_PAIRC5 0x00000020  // Port A bit 5 interrupt request 
+                                            // condition: 0: Rising 1: Falling 
+                                            // edge 
+#define GPIO_P_EDGE_CTRL_PAIRC5_M \
+                                0x00000020
+#define GPIO_P_EDGE_CTRL_PAIRC5_S 5
+#define GPIO_P_EDGE_CTRL_PAIRC4 0x00000010  // Port A bit 4 interrupt request 
+                                            // condition: 0: Rising 1: Falling 
+                                            // edge 
+#define GPIO_P_EDGE_CTRL_PAIRC4_M \
+                                0x00000010
+#define GPIO_P_EDGE_CTRL_PAIRC4_S 4
+#define GPIO_P_EDGE_CTRL_PAIRC3 0x00000008  // Port A bit 3 interrupt request 
+                                            // condition: 0: Rising 1: Falling 
+                                            // edge 
+#define GPIO_P_EDGE_CTRL_PAIRC3_M \
+                                0x00000008
+#define GPIO_P_EDGE_CTRL_PAIRC3_S 3
+#define GPIO_P_EDGE_CTRL_PAIRC2 0x00000004  // Port A bit 2 interrupt request 
+                                            // condition: 0: Rising 1: Falling 
+                                            // edge 
+#define GPIO_P_EDGE_CTRL_PAIRC2_M \
+                                0x00000004
+#define GPIO_P_EDGE_CTRL_PAIRC2_S 2
+#define GPIO_P_EDGE_CTRL_PAIRC1 0x00000002  // Port A bit 1 interrupt request 
+                                            // condition: 0: Rising 1: Falling 
+                                            // edge 
+#define GPIO_P_EDGE_CTRL_PAIRC1_M \
+                                0x00000002
+#define GPIO_P_EDGE_CTRL_PAIRC1_S 1
+#define GPIO_P_EDGE_CTRL_PAIRC0 0x00000001  // Port A bit 0 interrupt request 
+                                            // condition: 0: Rising 1: Falling 
+                                            // edge 
+#define GPIO_P_EDGE_CTRL_PAIRC0_M \
+                                0x00000001
+#define GPIO_P_EDGE_CTRL_PAIRC0_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// GPIO_O_USB_CTRL register.
+//
+//*****************************************************************************
+#define GPIO_USB_CTRL_USB_EDGE_CTL \
+                                0x00000001  // Used to set the edge which 
+                                            // triggers the USB power up 
+                                            // interrupt 0: Rising 1: Falling 
+
+#define GPIO_USB_CTRL_USB_EDGE_CTL_M \
+                                0x00000001
+#define GPIO_USB_CTRL_USB_EDGE_CTL_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the GPIO_O_PI_IEN register.
+//
+//*****************************************************************************
+#define GPIO_PI_IEN_PDIEN7      0x80000000  // Port D bit 7 interrupt enable: 
+                                            // 1: Enabled 2: Disabled 
+#define GPIO_PI_IEN_PDIEN7_M    0x80000000
+#define GPIO_PI_IEN_PDIEN7_S    31
+#define GPIO_PI_IEN_PDIEN6      0x40000000  // Port D bit 6 interrupt enable: 
+                                            // 1: Enabled 2: Disabled 
+#define GPIO_PI_IEN_PDIEN6_M    0x40000000
+#define GPIO_PI_IEN_PDIEN6_S    30
+#define GPIO_PI_IEN_PDIEN5      0x20000000  // Port D bit 5 interrupt enable: 
+                                            // 1: Enabled 2: Disabled 
+#define GPIO_PI_IEN_PDIEN5_M    0x20000000
+#define GPIO_PI_IEN_PDIEN5_S    29
+#define GPIO_PI_IEN_PDIEN4      0x10000000  // Port D bit 4 interrupt enable: 
+                                            // 1: Enabled 2: Disabled 
+#define GPIO_PI_IEN_PDIEN4_M    0x10000000
+#define GPIO_PI_IEN_PDIEN4_S    28
+#define GPIO_PI_IEN_PDIEN3      0x08000000  // Port D bit 3 interrupt enable: 
+                                            // 1: Enabled 2: Disabled 
+#define GPIO_PI_IEN_PDIEN3_M    0x08000000
+#define GPIO_PI_IEN_PDIEN3_S    27
+#define GPIO_PI_IEN_PDIEN2      0x04000000  // Port D bit 2 interrupt enable: 
+                                            // 1: Enabled 2: Disabled 
+#define GPIO_PI_IEN_PDIEN2_M    0x04000000
+#define GPIO_PI_IEN_PDIEN2_S    26
+#define GPIO_PI_IEN_PDIEN1      0x02000000  // Port D bit 1 interrupt enable: 
+                                            // 1: Enabled 2: Disabled 
+#define GPIO_PI_IEN_PDIEN1_M    0x02000000
+#define GPIO_PI_IEN_PDIEN1_S    25
+#define GPIO_PI_IEN_PDIEN0      0x01000000  // Port D bit 0 interrupt enable: 
+                                            // 1: Enabled 2: Disabled 
+#define GPIO_PI_IEN_PDIEN0_M    0x01000000
+#define GPIO_PI_IEN_PDIEN0_S    24
+#define GPIO_PI_IEN_PCIEN7      0x00800000  // Port C bit 7 interrupt enable: 
+                                            // 1: Enabled 2: Disabled 
+#define GPIO_PI_IEN_PCIEN7_M    0x00800000
+#define GPIO_PI_IEN_PCIEN7_S    23
+#define GPIO_PI_IEN_PCIEN6      0x00400000  // Port C bit 6 interrupt enable: 
+                                            // 1: Enabled 2: Disabled 
+#define GPIO_PI_IEN_PCIEN6_M    0x00400000
+#define GPIO_PI_IEN_PCIEN6_S    22
+#define GPIO_PI_IEN_PCIEN5      0x00200000  // Port C bit 5 interrupt enable: 
+                                            // 1: Enabled 2: Disabled 
+#define GPIO_PI_IEN_PCIEN5_M    0x00200000
+#define GPIO_PI_IEN_PCIEN5_S    21
+#define GPIO_PI_IEN_PCIEN4      0x00100000  // Port C bit 4 interrupt enable: 
+                                            // 1: Enabled 2: Disabled 
+#define GPIO_PI_IEN_PCIEN4_M    0x00100000
+#define GPIO_PI_IEN_PCIEN4_S    20
+#define GPIO_PI_IEN_PCIEN3      0x00080000  // Port C bit 3 interrupt enable: 
+                                            // 1: Enabled 2: Disabled 
+#define GPIO_PI_IEN_PCIEN3_M    0x00080000
+#define GPIO_PI_IEN_PCIEN3_S    19
+#define GPIO_PI_IEN_PCIEN2      0x00040000  // Port C bit 2 interrupt enable: 
+                                            // 1: Enabled 2: Disabled 
+#define GPIO_PI_IEN_PCIEN2_M    0x00040000
+#define GPIO_PI_IEN_PCIEN2_S    18
+#define GPIO_PI_IEN_PCIEN1      0x00020000  // Port C bit 1 interrupt enable: 
+                                            // 1: Enabled 2: Disabled 
+#define GPIO_PI_IEN_PCIEN1_M    0x00020000
+#define GPIO_PI_IEN_PCIEN1_S    17
+#define GPIO_PI_IEN_PCIEN0      0x00010000  // Port C bit 0 interrupt enable: 
+                                            // 1: Enabled 2: Disabled 
+#define GPIO_PI_IEN_PCIEN0_M    0x00010000
+#define GPIO_PI_IEN_PCIEN0_S    16
+#define GPIO_PI_IEN_PBIEN7      0x00008000  // Port B bit 7 interrupt enable: 
+                                            // 1: Enabled 2: Disabled 
+#define GPIO_PI_IEN_PBIEN7_M    0x00008000
+#define GPIO_PI_IEN_PBIEN7_S    15
+#define GPIO_PI_IEN_PBIEN6      0x00004000  // Port B bit 6 interrupt enable: 
+                                            // 1: Enabled 2: Disabled 
+#define GPIO_PI_IEN_PBIEN6_M    0x00004000
+#define GPIO_PI_IEN_PBIEN6_S    14
+#define GPIO_PI_IEN_PBIEN5      0x00002000  // Port B bit 5 interrupt enable: 
+                                            // 1: Enabled 2: Disabled 
+#define GPIO_PI_IEN_PBIEN5_M    0x00002000
+#define GPIO_PI_IEN_PBIEN5_S    13
+#define GPIO_PI_IEN_PBIEN4      0x00001000  // Port B bit 4 interrupt enable: 
+                                            // 1: Enabled 2: Disabled 
+#define GPIO_PI_IEN_PBIEN4_M    0x00001000
+#define GPIO_PI_IEN_PBIEN4_S    12
+#define GPIO_PI_IEN_PBIEN3      0x00000800  // Port B bit 3 interrupt enable: 
+                                            // 1: Enabled 2: Disabled 
+#define GPIO_PI_IEN_PBIEN3_M    0x00000800
+#define GPIO_PI_IEN_PBIEN3_S    11
+#define GPIO_PI_IEN_PBIEN2      0x00000400  // Port B bit 2 interrupt enable: 
+                                            // 1: Enabled 2: Disabled 
+#define GPIO_PI_IEN_PBIEN2_M    0x00000400
+#define GPIO_PI_IEN_PBIEN2_S    10
+#define GPIO_PI_IEN_PBIEN1      0x00000200  // Port B bit 1 interrupt enable: 
+                                            // 1: Enabled 2: Disabled 
+#define GPIO_PI_IEN_PBIEN1_M    0x00000200
+#define GPIO_PI_IEN_PBIEN1_S    9
+#define GPIO_PI_IEN_PBIEN0      0x00000100  // Port B bit 0 interrupt enable: 
+                                            // 1: Enabled 2: Disabled 
+#define GPIO_PI_IEN_PBIEN0_M    0x00000100
+#define GPIO_PI_IEN_PBIEN0_S    8
+#define GPIO_PI_IEN_PAIEN7      0x00000080  // Port A bit 7 interrupt enable: 
+                                            // 1: Enabled 2: Disabled 
+#define GPIO_PI_IEN_PAIEN7_M    0x00000080
+#define GPIO_PI_IEN_PAIEN7_S    7
+#define GPIO_PI_IEN_PAIEN6      0x00000040  // Port A bit 6 interrupt enable: 
+                                            // 1: Enabled 2: Disabled 
+#define GPIO_PI_IEN_PAIEN6_M    0x00000040
+#define GPIO_PI_IEN_PAIEN6_S    6
+#define GPIO_PI_IEN_PAIEN5      0x00000020  // Port A bit 5 interrupt enable: 
+                                            // 1: Enabled 2: Disabled 
+#define GPIO_PI_IEN_PAIEN5_M    0x00000020
+#define GPIO_PI_IEN_PAIEN5_S    5
+#define GPIO_PI_IEN_PAIEN4      0x00000010  // Port A bit 4 interrupt enable: 
+                                            // 1: Enabled 2: Disabled 
+#define GPIO_PI_IEN_PAIEN4_M    0x00000010
+#define GPIO_PI_IEN_PAIEN4_S    4
+#define GPIO_PI_IEN_PAIEN3      0x00000008  // Port A bit 3 interrupt enable: 
+                                            // 1: Enabled 2: Disabled 
+#define GPIO_PI_IEN_PAIEN3_M    0x00000008
+#define GPIO_PI_IEN_PAIEN3_S    3
+#define GPIO_PI_IEN_PAIEN2      0x00000004  // Port A bit 2 interrupt enable: 
+                                            // 1: Enabled 2: Disabled 
+#define GPIO_PI_IEN_PAIEN2_M    0x00000004
+#define GPIO_PI_IEN_PAIEN2_S    2
+#define GPIO_PI_IEN_PAIEN1      0x00000002  // Port A bit 1 interrupt enable: 
+                                            // 1: Enabled 2: Disabled 
+#define GPIO_PI_IEN_PAIEN1_M    0x00000002
+#define GPIO_PI_IEN_PAIEN1_S    1
+#define GPIO_PI_IEN_PAIEN0      0x00000001  // Port A bit 0 interrupt enable: 
+                                            // 1: Enabled 2: Disabled 
+#define GPIO_PI_IEN_PAIEN0_M    0x00000001
+#define GPIO_PI_IEN_PAIEN0_S    0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// GPIO_O_IRQ_DETECT_ACK register.
+//
+//*****************************************************************************
+#define GPIO_IRQ_DETECT_ACK_PDIACK7 \
+                                0x80000000  // Port D bit 7 masked interrupt 
+                                            // status: 1: Detected 0: Not 
+                                            // detected 
+
+#define GPIO_IRQ_DETECT_ACK_PDIACK7_M \
+                                0x80000000
+#define GPIO_IRQ_DETECT_ACK_PDIACK7_S 31
+#define GPIO_IRQ_DETECT_ACK_PDIACK6 \
+                                0x40000000  // Port D bit 6 masked interrupt 
+                                            // status: 1: Detected 0: Not 
+                                            // detected 
+
+#define GPIO_IRQ_DETECT_ACK_PDIACK6_M \
+                                0x40000000
+#define GPIO_IRQ_DETECT_ACK_PDIACK6_S 30
+#define GPIO_IRQ_DETECT_ACK_PDIACK5 \
+                                0x20000000  // Port D bit 5 masked interrupt 
+                                            // status: 1: Detected 0: Not 
+                                            // detected 
+
+#define GPIO_IRQ_DETECT_ACK_PDIACK5_M \
+                                0x20000000
+#define GPIO_IRQ_DETECT_ACK_PDIACK5_S 29
+#define GPIO_IRQ_DETECT_ACK_PDIACK4 \
+                                0x10000000  // Port D bit 4 masked interrupt 
+                                            // status: 1: Detected 0: Not 
+                                            // detected 
+
+#define GPIO_IRQ_DETECT_ACK_PDIACK4_M \
+                                0x10000000
+#define GPIO_IRQ_DETECT_ACK_PDIACK4_S 28
+#define GPIO_IRQ_DETECT_ACK_PDIACK3 \
+                                0x08000000  // Port D bit 3 masked interrupt 
+                                            // status: 1: Detected 0: Not 
+                                            // detected 
+
+#define GPIO_IRQ_DETECT_ACK_PDIACK3_M \
+                                0x08000000
+#define GPIO_IRQ_DETECT_ACK_PDIACK3_S 27
+#define GPIO_IRQ_DETECT_ACK_PDIACK2 \
+                                0x04000000  // Port D bit 2 masked interrupt 
+                                            // status: 1: Detected 0: Not 
+                                            // detected 
+
+#define GPIO_IRQ_DETECT_ACK_PDIACK2_M \
+                                0x04000000
+#define GPIO_IRQ_DETECT_ACK_PDIACK2_S 26
+#define GPIO_IRQ_DETECT_ACK_PDIACK1 \
+                                0x02000000  // Port D bit 1 masked interrupt 
+                                            // status: 1: Detected0: Not 
+                                            // detected 
+
+#define GPIO_IRQ_DETECT_ACK_PDIACK1_M \
+                                0x02000000
+#define GPIO_IRQ_DETECT_ACK_PDIACK1_S 25
+#define GPIO_IRQ_DETECT_ACK_PDIACK0 \
+                                0x01000000  // Port D bit 0 masked interrupt 
+                                            // status: 1: Detected 0: Not 
+                                            // detected 
+
+#define GPIO_IRQ_DETECT_ACK_PDIACK0_M \
+                                0x01000000
+#define GPIO_IRQ_DETECT_ACK_PDIACK0_S 24
+#define GPIO_IRQ_DETECT_ACK_PCIACK7 \
+                                0x00800000  // Port C bit 7 masked interrupt 
+                                            // status: 1: Detected 0: Not 
+                                            // detected 
+
+#define GPIO_IRQ_DETECT_ACK_PCIACK7_M \
+                                0x00800000
+#define GPIO_IRQ_DETECT_ACK_PCIACK7_S 23
+#define GPIO_IRQ_DETECT_ACK_PCIACK6 \
+                                0x00400000  // Port C bit 6 masked interrupt 
+                                            // status: 1: Detected 0: Not 
+                                            // detected 
+
+#define GPIO_IRQ_DETECT_ACK_PCIACK6_M \
+                                0x00400000
+#define GPIO_IRQ_DETECT_ACK_PCIACK6_S 22
+#define GPIO_IRQ_DETECT_ACK_PCIACK5 \
+                                0x00200000  // Port C bit 5 masked interrupt 
+                                            // status: 1: Detected 0: Not 
+                                            // detected 
+
+#define GPIO_IRQ_DETECT_ACK_PCIACK5_M \
+                                0x00200000
+#define GPIO_IRQ_DETECT_ACK_PCIACK5_S 21
+#define GPIO_IRQ_DETECT_ACK_PCIACK4 \
+                                0x00100000  // Port C bit 4 masked interrupt 
+                                            // status: 1: Detected 0: Not 
+                                            // detected 
+
+#define GPIO_IRQ_DETECT_ACK_PCIACK4_M \
+                                0x00100000
+#define GPIO_IRQ_DETECT_ACK_PCIACK4_S 20
+#define GPIO_IRQ_DETECT_ACK_PCIACK3 \
+                                0x00080000  // Port C bit 3 masked interrupt 
+                                            // status: 1: Detected 0: Not 
+                                            // detected 
+
+#define GPIO_IRQ_DETECT_ACK_PCIACK3_M \
+                                0x00080000
+#define GPIO_IRQ_DETECT_ACK_PCIACK3_S 19
+#define GPIO_IRQ_DETECT_ACK_PCIACK2 \
+                                0x00040000  // Port C bit 2 masked interrupt 
+                                            // status: 1: Detected 0: Not 
+                                            // detected 
+
+#define GPIO_IRQ_DETECT_ACK_PCIACK2_M \
+                                0x00040000
+#define GPIO_IRQ_DETECT_ACK_PCIACK2_S 18
+#define GPIO_IRQ_DETECT_ACK_PCIACK1 \
+                                0x00020000  // Port C bit 1 masked interrupt 
+                                            // status: 1: Detected 0: Not 
+                                            // detected 
+
+#define GPIO_IRQ_DETECT_ACK_PCIACK1_M \
+                                0x00020000
+#define GPIO_IRQ_DETECT_ACK_PCIACK1_S 17
+#define GPIO_IRQ_DETECT_ACK_PCIACK0 \
+                                0x00010000  // Port C bit 0 masked interrupt 
+                                            // status: 1: Detected 0: Not 
+                                            // detected 
+
+#define GPIO_IRQ_DETECT_ACK_PCIACK0_M \
+                                0x00010000
+#define GPIO_IRQ_DETECT_ACK_PCIACK0_S 16
+#define GPIO_IRQ_DETECT_ACK_PBIACK7 \
+                                0x00008000  // Port B bit 7 masked interrupt 
+                                            // status: 1: Detected 0: Not 
+                                            // detected 
+
+#define GPIO_IRQ_DETECT_ACK_PBIACK7_M \
+                                0x00008000
+#define GPIO_IRQ_DETECT_ACK_PBIACK7_S 15
+#define GPIO_IRQ_DETECT_ACK_PBIACK6 \
+                                0x00004000  // Port B bit 6 masked interrupt 
+                                            // status: 1: Detected 0: Not 
+                                            // detected 
+
+#define GPIO_IRQ_DETECT_ACK_PBIACK6_M \
+                                0x00004000
+#define GPIO_IRQ_DETECT_ACK_PBIACK6_S 14
+#define GPIO_IRQ_DETECT_ACK_PBIACK5 \
+                                0x00002000  // Port B bit 5 masked interrupt 
+                                            // status: 1: Detected 0: Not 
+                                            // detected 
+
+#define GPIO_IRQ_DETECT_ACK_PBIACK5_M \
+                                0x00002000
+#define GPIO_IRQ_DETECT_ACK_PBIACK5_S 13
+#define GPIO_IRQ_DETECT_ACK_PBIACK4 \
+                                0x00001000  // Port B bit 4 masked interrupt 
+                                            // status: 1: Detected 0: Not 
+                                            // detected 
+
+#define GPIO_IRQ_DETECT_ACK_PBIACK4_M \
+                                0x00001000
+#define GPIO_IRQ_DETECT_ACK_PBIACK4_S 12
+#define GPIO_IRQ_DETECT_ACK_PBIACK3 \
+                                0x00000800  // Port B bit 3 masked interrupt 
+                                            // status: 1: Detected 0: Not 
+                                            // detected 
+
+#define GPIO_IRQ_DETECT_ACK_PBIACK3_M \
+                                0x00000800
+#define GPIO_IRQ_DETECT_ACK_PBIACK3_S 11
+#define GPIO_IRQ_DETECT_ACK_PBIACK2 \
+                                0x00000400  // Port B bit 2 masked interrupt 
+                                            // status: 1: Detected 0: Not 
+                                            // detected 
+
+#define GPIO_IRQ_DETECT_ACK_PBIACK2_M \
+                                0x00000400
+#define GPIO_IRQ_DETECT_ACK_PBIACK2_S 10
+#define GPIO_IRQ_DETECT_ACK_PBIACK1 \
+                                0x00000200  // Port B bit 1 masked interrupt 
+                                            // status: 1: Detected 0: Not 
+                                            // detected 
+
+#define GPIO_IRQ_DETECT_ACK_PBIACK1_M \
+                                0x00000200
+#define GPIO_IRQ_DETECT_ACK_PBIACK1_S 9
+#define GPIO_IRQ_DETECT_ACK_PBIACK0 \
+                                0x00000100  // Port B bit 0 masked interrupt 
+                                            // status: 1: Detected 0: Not 
+                                            // detected 
+
+#define GPIO_IRQ_DETECT_ACK_PBIACK0_M \
+                                0x00000100
+#define GPIO_IRQ_DETECT_ACK_PBIACK0_S 8
+#define GPIO_IRQ_DETECT_ACK_PAIACK7 \
+                                0x00000080  // Port A bit 7 masked interrupt 
+                                            // status: 1: Detected 0: Not 
+                                            // detected 
+
+#define GPIO_IRQ_DETECT_ACK_PAIACK7_M \
+                                0x00000080
+#define GPIO_IRQ_DETECT_ACK_PAIACK7_S 7
+#define GPIO_IRQ_DETECT_ACK_PAIACK6 \
+                                0x00000040  // Port A bit 6 masked interrupt 
+                                            // status: 1: Detected 0: Not 
+                                            // detected 
+
+#define GPIO_IRQ_DETECT_ACK_PAIACK6_M \
+                                0x00000040
+#define GPIO_IRQ_DETECT_ACK_PAIACK6_S 6
+#define GPIO_IRQ_DETECT_ACK_PAIACK5 \
+                                0x00000020  // Port A bit 5 masked interrupt 
+                                            // status: 1: Detected 0: Not 
+                                            // detected 
+
+#define GPIO_IRQ_DETECT_ACK_PAIACK5_M \
+                                0x00000020
+#define GPIO_IRQ_DETECT_ACK_PAIACK5_S 5
+#define GPIO_IRQ_DETECT_ACK_PAIACK4 \
+                                0x00000010  // Port A bit 4 masked interrupt 
+                                            // status: 1: Detected 0: Not 
+                                            // detected 
+
+#define GPIO_IRQ_DETECT_ACK_PAIACK4_M \
+                                0x00000010
+#define GPIO_IRQ_DETECT_ACK_PAIACK4_S 4
+#define GPIO_IRQ_DETECT_ACK_PAIACK3 \
+                                0x00000008  // Port A bit 3 masked interrupt 
+                                            // status: 1: Detected 0: Not 
+                                            // detected 
+
+#define GPIO_IRQ_DETECT_ACK_PAIACK3_M \
+                                0x00000008
+#define GPIO_IRQ_DETECT_ACK_PAIACK3_S 3
+#define GPIO_IRQ_DETECT_ACK_PAIACK2 \
+                                0x00000004  // Port A bit 2 masked interrupt 
+                                            // status: 1: Detected 0: Not 
+                                            // detected 
+
+#define GPIO_IRQ_DETECT_ACK_PAIACK2_M \
+                                0x00000004
+#define GPIO_IRQ_DETECT_ACK_PAIACK2_S 2
+#define GPIO_IRQ_DETECT_ACK_PAIACK1 \
+                                0x00000002  // Port A bit 1 masked interrupt 
+                                            // status: 1: Detected 0: Not 
+                                            // detected 
+
+#define GPIO_IRQ_DETECT_ACK_PAIACK1_M \
+                                0x00000002
+#define GPIO_IRQ_DETECT_ACK_PAIACK1_S 1
+#define GPIO_IRQ_DETECT_ACK_PAIACK0 \
+                                0x00000001  // Port A bit 0 masked interrupt 
+                                            // status: 1: Detected 0: Not 
+                                            // detected 
+
+#define GPIO_IRQ_DETECT_ACK_PAIACK0_M \
+                                0x00000001
+#define GPIO_IRQ_DETECT_ACK_PAIACK0_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// GPIO_O_USB_IRQ_ACK register.
+//
+//*****************************************************************************
+#define GPIO_USB_IRQ_ACK_USBACK 0x00000001  // USB masked interrupt status: 1: 
+                                            // Detected 0: Not detected 
+#define GPIO_USB_IRQ_ACK_USBACK_M \
+                                0x00000001
+#define GPIO_USB_IRQ_ACK_USBACK_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// GPIO_O_IRQ_DETECT_UNMASK register.
+//
+//*****************************************************************************
+#define GPIO_IRQ_DETECT_UNMASK_PDIACK7 \
+                                0x80000000  // Port D bit 7 unmasked interrupt 
+                                            // status: 1: Detected 0: 
+                                            // Undetected 
+
+#define GPIO_IRQ_DETECT_UNMASK_PDIACK7_M \
+                                0x80000000
+#define GPIO_IRQ_DETECT_UNMASK_PDIACK7_S 31
+#define GPIO_IRQ_DETECT_UNMASK_PDIACK6 \
+                                0x40000000  // Port D bit 6 unmasked interrupt 
+                                            // status: 1: Detected 0: 
+                                            // Undetected 
+
+#define GPIO_IRQ_DETECT_UNMASK_PDIACK6_M \
+                                0x40000000
+#define GPIO_IRQ_DETECT_UNMASK_PDIACK6_S 30
+#define GPIO_IRQ_DETECT_UNMASK_PDIACK5 \
+                                0x20000000  // Port D bit 5 unmasked interrupt 
+                                            // status: 1: Detected 0: 
+                                            // Undetected 
+
+#define GPIO_IRQ_DETECT_UNMASK_PDIACK5_M \
+                                0x20000000
+#define GPIO_IRQ_DETECT_UNMASK_PDIACK5_S 29
+#define GPIO_IRQ_DETECT_UNMASK_PDIACK4 \
+                                0x10000000  // Port D bit 4 unmasked interrupt 
+                                            // status: 1: Detected 0: 
+                                            // Undetected 
+
+#define GPIO_IRQ_DETECT_UNMASK_PDIACK4_M \
+                                0x10000000
+#define GPIO_IRQ_DETECT_UNMASK_PDIACK4_S 28
+#define GPIO_IRQ_DETECT_UNMASK_PDIACK3 \
+                                0x08000000  // Port D bit 3 unmasked interrupt 
+                                            // status: 1: Detected 0: 
+                                            // Undetected 
+
+#define GPIO_IRQ_DETECT_UNMASK_PDIACK3_M \
+                                0x08000000
+#define GPIO_IRQ_DETECT_UNMASK_PDIACK3_S 27
+#define GPIO_IRQ_DETECT_UNMASK_PDIACK2 \
+                                0x04000000  // Port D bit 2 unmasked interrupt 
+                                            // status: 1: Detected 0: 
+                                            // Undetected 
+
+#define GPIO_IRQ_DETECT_UNMASK_PDIACK2_M \
+                                0x04000000
+#define GPIO_IRQ_DETECT_UNMASK_PDIACK2_S 26
+#define GPIO_IRQ_DETECT_UNMASK_PDIACK1 \
+                                0x02000000  // Port D bit 1 unmasked interrupt 
+                                            // status: 1: Detected 0: 
+                                            // Undetected 
+
+#define GPIO_IRQ_DETECT_UNMASK_PDIACK1_M \
+                                0x02000000
+#define GPIO_IRQ_DETECT_UNMASK_PDIACK1_S 25
+#define GPIO_IRQ_DETECT_UNMASK_PDIACK0 \
+                                0x01000000  // Port D bit 0 unmasked interrupt 
+                                            // status: 1: Detected 0: 
+                                            // Undetected 
+
+#define GPIO_IRQ_DETECT_UNMASK_PDIACK0_M \
+                                0x01000000
+#define GPIO_IRQ_DETECT_UNMASK_PDIACK0_S 24
+#define GPIO_IRQ_DETECT_UNMASK_PCIACK7 \
+                                0x00800000  // Port C bit 7 unmasked interrupt 
+                                            // status: 1: Detected 0: 
+                                            // Undetected 
+
+#define GPIO_IRQ_DETECT_UNMASK_PCIACK7_M \
+                                0x00800000
+#define GPIO_IRQ_DETECT_UNMASK_PCIACK7_S 23
+#define GPIO_IRQ_DETECT_UNMASK_PCIACK6 \
+                                0x00400000  // Port C bit 6 unmasked interrupt 
+                                            // status: 1: Detected 0: 
+                                            // Undetected 
+
+#define GPIO_IRQ_DETECT_UNMASK_PCIACK6_M \
+                                0x00400000
+#define GPIO_IRQ_DETECT_UNMASK_PCIACK6_S 22
+#define GPIO_IRQ_DETECT_UNMASK_PCIACK5 \
+                                0x00200000  // Port C bit 5 unmasked interrupt 
+                                            // status: 1: Detected 0: 
+                                            // Undetected 
+
+#define GPIO_IRQ_DETECT_UNMASK_PCIACK5_M \
+                                0x00200000
+#define GPIO_IRQ_DETECT_UNMASK_PCIACK5_S 21
+#define GPIO_IRQ_DETECT_UNMASK_PCIACK4 \
+                                0x00100000  // Port C bit 4 unmasked interrupt 
+                                            // status: 1: Detected 0: 
+                                            // Undetected 
+
+#define GPIO_IRQ_DETECT_UNMASK_PCIACK4_M \
+                                0x00100000
+#define GPIO_IRQ_DETECT_UNMASK_PCIACK4_S 20
+#define GPIO_IRQ_DETECT_UNMASK_PCIACK3 \
+                                0x00080000  // Port C bit 3 unmasked interrupt 
+                                            // status: 1: Detected 0: 
+                                            // Undetected 
+
+#define GPIO_IRQ_DETECT_UNMASK_PCIACK3_M \
+                                0x00080000
+#define GPIO_IRQ_DETECT_UNMASK_PCIACK3_S 19
+#define GPIO_IRQ_DETECT_UNMASK_PCIACK2 \
+                                0x00040000  // Port C bit 2 unmasked interrupt 
+                                            // status: 1: Detected 0: 
+                                            // Undetected 
+
+#define GPIO_IRQ_DETECT_UNMASK_PCIACK2_M \
+                                0x00040000
+#define GPIO_IRQ_DETECT_UNMASK_PCIACK2_S 18
+#define GPIO_IRQ_DETECT_UNMASK_PCIACK1 \
+                                0x00020000  // Port C bit 1 unmasked interrupt 
+                                            // status: 1: Detected 0: 
+                                            // Undetected 
+
+#define GPIO_IRQ_DETECT_UNMASK_PCIACK1_M \
+                                0x00020000
+#define GPIO_IRQ_DETECT_UNMASK_PCIACK1_S 17
+#define GPIO_IRQ_DETECT_UNMASK_PCIACK0 \
+                                0x00010000  // Port C bit 0 unmasked interrupt 
+                                            // status: 1: Detected 0: 
+                                            // Undetected 
+
+#define GPIO_IRQ_DETECT_UNMASK_PCIACK0_M \
+                                0x00010000
+#define GPIO_IRQ_DETECT_UNMASK_PCIACK0_S 16
+#define GPIO_IRQ_DETECT_UNMASK_PBIACK7 \
+                                0x00008000  // Port B bit 7 unmasked interrupt 
+                                            // status: 1: Detected 0: 
+                                            // Undetected 
+
+#define GPIO_IRQ_DETECT_UNMASK_PBIACK7_M \
+                                0x00008000
+#define GPIO_IRQ_DETECT_UNMASK_PBIACK7_S 15
+#define GPIO_IRQ_DETECT_UNMASK_PBIACK6 \
+                                0x00004000  // Port B bit 6 unmasked interrupt 
+                                            // status: 1: Detected 0: 
+                                            // Undetected 
+
+#define GPIO_IRQ_DETECT_UNMASK_PBIACK6_M \
+                                0x00004000
+#define GPIO_IRQ_DETECT_UNMASK_PBIACK6_S 14
+#define GPIO_IRQ_DETECT_UNMASK_PBIACK5 \
+                                0x00002000  // Port B bit 5 unmasked interrupt 
+                                            // status: 1: Detected 0: 
+                                            // Undetected 
+
+#define GPIO_IRQ_DETECT_UNMASK_PBIACK5_M \
+                                0x00002000
+#define GPIO_IRQ_DETECT_UNMASK_PBIACK5_S 13
+#define GPIO_IRQ_DETECT_UNMASK_PBIACK4 \
+                                0x00001000  // Port B bit 4 unmasked interrupt 
+                                            // status: 1: Detected 0: 
+                                            // Undetected 
+
+#define GPIO_IRQ_DETECT_UNMASK_PBIACK4_M \
+                                0x00001000
+#define GPIO_IRQ_DETECT_UNMASK_PBIACK4_S 12
+#define GPIO_IRQ_DETECT_UNMASK_PBIACK3 \
+                                0x00000800  // Port B bit 3 unmasked interrupt 
+                                            // status: 1: Detected 0: 
+                                            // Undetected 
+
+#define GPIO_IRQ_DETECT_UNMASK_PBIACK3_M \
+                                0x00000800
+#define GPIO_IRQ_DETECT_UNMASK_PBIACK3_S 11
+#define GPIO_IRQ_DETECT_UNMASK_PBIACK2 \
+                                0x00000400  // Port B bit 2 unmasked interrupt 
+                                            // status: 1: Detected 0: 
+                                            // Undetected 
+
+#define GPIO_IRQ_DETECT_UNMASK_PBIACK2_M \
+                                0x00000400
+#define GPIO_IRQ_DETECT_UNMASK_PBIACK2_S 10
+#define GPIO_IRQ_DETECT_UNMASK_PBIACK1 \
+                                0x00000200  // Port B bit 1 unmasked interrupt 
+                                            // status: 1: Detected 0: 
+                                            // Undetected 
+
+#define GPIO_IRQ_DETECT_UNMASK_PBIACK1_M \
+                                0x00000200
+#define GPIO_IRQ_DETECT_UNMASK_PBIACK1_S 9
+#define GPIO_IRQ_DETECT_UNMASK_PBIACK0 \
+                                0x00000100  // Port B bit 0 unmasked interrupt 
+                                            // status: 1: Detected 0: 
+                                            // Undetected 
+
+#define GPIO_IRQ_DETECT_UNMASK_PBIACK0_M \
+                                0x00000100
+#define GPIO_IRQ_DETECT_UNMASK_PBIACK0_S 8
+#define GPIO_IRQ_DETECT_UNMASK_PAIACK7 \
+                                0x00000080  // Port A bit 7 unmasked interrupt 
+                                            // status: 1: Detected 0: 
+                                            // Undetected 
+
+#define GPIO_IRQ_DETECT_UNMASK_PAIACK7_M \
+                                0x00000080
+#define GPIO_IRQ_DETECT_UNMASK_PAIACK7_S 7
+#define GPIO_IRQ_DETECT_UNMASK_PAIACK6 \
+                                0x00000040  // Port A bit 6 unmasked interrupt 
+                                            // status: 1: Detected 0: 
+                                            // Undetected 
+
+#define GPIO_IRQ_DETECT_UNMASK_PAIACK6_M \
+                                0x00000040
+#define GPIO_IRQ_DETECT_UNMASK_PAIACK6_S 6
+#define GPIO_IRQ_DETECT_UNMASK_PAIACK5 \
+                                0x00000020  // Port A bit 5 unmasked interrupt 
+                                            // status: 1: Detected 0: 
+                                            // Undetected 
+
+#define GPIO_IRQ_DETECT_UNMASK_PAIACK5_M \
+                                0x00000020
+#define GPIO_IRQ_DETECT_UNMASK_PAIACK5_S 5
+#define GPIO_IRQ_DETECT_UNMASK_PAIACK4 \
+                                0x00000010  // Port A bit 4 unmasked interrupt 
+                                            // status: 1: Detected 0: 
+                                            // Undetected 
+
+#define GPIO_IRQ_DETECT_UNMASK_PAIACK4_M \
+                                0x00000010
+#define GPIO_IRQ_DETECT_UNMASK_PAIACK4_S 4
+#define GPIO_IRQ_DETECT_UNMASK_PAIACK3 \
+                                0x00000008  // Port A bit 3 unmasked interrupt 
+                                            // status: 1: Detected 0: 
+                                            // Undetected 
+
+#define GPIO_IRQ_DETECT_UNMASK_PAIACK3_M \
+                                0x00000008
+#define GPIO_IRQ_DETECT_UNMASK_PAIACK3_S 3
+#define GPIO_IRQ_DETECT_UNMASK_PAIACK2 \
+                                0x00000004  // Port A bit 2 unmasked interrupt 
+                                            // status: 1: Detected 0: 
+                                            // Undetected 
+
+#define GPIO_IRQ_DETECT_UNMASK_PAIACK2_M \
+                                0x00000004
+#define GPIO_IRQ_DETECT_UNMASK_PAIACK2_S 2
+#define GPIO_IRQ_DETECT_UNMASK_PAIACK1 \
+                                0x00000002  // Port A bit 1 unmasked interrupt 
+                                            // status: 1: Detected 0: 
+                                            // Undetected 
+
+#define GPIO_IRQ_DETECT_UNMASK_PAIACK1_M \
+                                0x00000002
+#define GPIO_IRQ_DETECT_UNMASK_PAIACK1_S 1
+#define GPIO_IRQ_DETECT_UNMASK_PAIACK0 \
+                                0x00000001  // Port A bit 0 unmasked interrupt 
+                                            // status: 1: Detected 0: 
+                                            // Undetected 
+
+#define GPIO_IRQ_DETECT_UNMASK_PAIACK0_M \
+                                0x00000001
+#define GPIO_IRQ_DETECT_UNMASK_PAIACK0_S 0
+
+
+#endif // __HW_GPIO_H__
+

--- a/cpu/cc2538/include/vendor/hw_gptimer.h
+++ b/cpu/cc2538/include/vendor/hw_gptimer.h
@@ -1,0 +1,1031 @@
+/******************************************************************************
+*  Filename:       hw_gptimer.h
+*  Revised:        $Date: 2013-04-12 15:10:54 +0200 (Fri, 12 Apr 2013) $
+*  Revision:       $Revision: 9735 $
+*
+*  Copyright (C) 2013 Texas Instruments Incorporated - http://www.ti.com/
+*
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*    Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+*
+*    Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+*
+*    Neither the name of Texas Instruments Incorporated nor the names of
+*    its contributors may be used to endorse or promote products derived
+*    from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+*  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+*  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+*  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+*  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+*  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+*  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+*  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+*  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+******************************************************************************/
+
+#ifndef __HW_GPTIMER_H__
+#define __HW_GPTIMER_H__
+
+//*****************************************************************************
+//
+// The following are defines for the GPTIMER register offsets.
+//
+//*****************************************************************************
+#define GPTIMER_O_CFG           0x00000000  // GPTM configuration This 
+                                            // register configures the global 
+                                            // operation of the GPTM. The value 
+                                            // written to this register 
+                                            // determines whether the GPTM is 
+                                            // in 32-bit mode (concatenated 
+                                            // timers) or in 16-bit mode 
+                                            // (individual, split timers). 
+#define GPTIMER_O_TAMR          0x00000004  // GPTM Timer A mode This register 
+                                            // configures the GPTM based on the 
+                                            // configuration selected in the 
+                                            // CFG register. This register 
+                                            // controls the modes for Timer A 
+                                            // when it is used individually. 
+                                            // When Timer A and Timer B are 
+                                            // concatenated, this register 
+                                            // controls the modes for both 
+                                            // Timer A and Timer B, and the 
+                                            // contents of TBMR are ignored. 
+#define GPTIMER_O_TBMR          0x00000008  // GPTM Timer B mode This register 
+                                            // configures the GPTM based on the 
+                                            // configuration selected in the 
+                                            // CFG register. This register 
+                                            // controls the modes for Timer B 
+                                            // when it is used individually. 
+                                            // When Timer A and Timer B are 
+                                            // concatenated, this register is 
+                                            // ignored and TBMR controls the 
+                                            // modes for both Timer A and Timer 
+                                            // B. 
+#define GPTIMER_O_CTL           0x0000000C  // GPTM control This register is 
+                                            // used alongside the CFG and TnMR 
+                                            // registers to fine-tune the timer 
+                                            // configuration, and to enable 
+                                            // other features such as timer 
+                                            // stall. 
+#define GPTIMER_O_SYNC          0x00000010  // GPTM synchronize Note: This 
+                                            // register is implemented on GPTM 
+                                            // 0 base address only. This 
+                                            // register does however, allow 
+                                            // software to synchronize a number 
+                                            // of timers. 
+#define GPTIMER_O_IMR           0x00000018  // GPTM interrupt mask This 
+                                            // register allows software to 
+                                            // enable and disable GPTM 
+                                            // controller-level interrupts. 
+                                            // Setting a bit enables the 
+                                            // corresponding interrupt, while 
+                                            // clearing a bit disables it. 
+#define GPTIMER_O_RIS           0x0000001C  // GPTM raw interrupt status This 
+                                            // register shows the state of the 
+                                            // GPTM internal interrupt signal. 
+                                            // These bits are set whether or 
+                                            // not the interrupt is masked in 
+                                            // the IMR register. Each bit can 
+                                            // be cleared by writing 1 to its 
+                                            // corresponding bit in ICR. 
+#define GPTIMER_O_MIS           0x00000020  // GPTM masked interrupt status 
+                                            // This register shows the state of 
+                                            // the GPTM controller-level 
+                                            // interrupt. If an interrupt is 
+                                            // unmasked in IMR, and there is an 
+                                            // event that causes the interrupt 
+                                            // to be asserted, the 
+                                            // corresponding bit is set in this 
+                                            // register. All bits are cleared 
+                                            // by writing 1 to the 
+                                            // corresponding bit in ICR. 
+#define GPTIMER_O_ICR           0x00000024  // GPTM interrupt clear This 
+                                            // register is used to clear the 
+                                            // status bits in the RIS and MIS 
+                                            // registers. Writing 1 to a bit 
+                                            // clears the corresponding bit in 
+                                            // the RIS and MIS registers. 
+#define GPTIMER_O_TAILR         0x00000028  // GPTM Timer A interval load When 
+                                            // the Timer is counting down, this 
+                                            // register is used to load the 
+                                            // starting count value into the 
+                                            // Timer. When the Timer is 
+                                            // counting up, this register sets 
+                                            // the upper bound for the timeout 
+                                            // event. When a GPTM is configured 
+                                            // to one of the 32-bit modes, 
+                                            // TAILR appears as a 32-bit 
+                                            // register (the upper 16-bits 
+                                            // correspond to the contents of 
+                                            // the GPTM Timer B Interval Load 
+                                            // (TBILR) register). In a 16-bit 
+                                            // mode, the upper 16 bits of this 
+                                            // register read as 0s and have no 
+                                            // effect on the state of TBILR. 
+#define GPTIMER_O_TBILR         0x0000002C  // GPTM Timer B interval load When 
+                                            // the Timer is counting down, this 
+                                            // register is used to load the 
+                                            // starting count value into the 
+                                            // Timer. When the Timer is 
+                                            // counting up, this register sets 
+                                            // the upper bound for the time-out 
+                                            // event. When a GPTM is configured 
+                                            // to one of the 32-bit modes, the 
+                                            // contents of bits [15:0] in this 
+                                            // register are loaded into the 
+                                            // upper 16 bits of the TAILR 
+                                            // register. Reads from this 
+                                            // register return the current 
+                                            // value of Timer B and writes are 
+                                            // ignored. In a 16-bit mode, bits 
+                                            // [15:0] are used for the load 
+                                            // value. Bits [31:16] are reserved 
+                                            // in both cases. 
+#define GPTIMER_O_TAMATCHR      0x00000030  // GPTM Timer A match This 
+                                            // register is loaded with a match 
+                                            // value. Interrupts can be 
+                                            // generated when the Timer value 
+                                            // is equal to the value in this 
+                                            // register in one-shot or periodic 
+                                            // mode. When a GPTM is configured 
+                                            // to one of the 32-bit modes, 
+                                            // TAMATCHR appears as a 32-bit 
+                                            // register (the upper 16-bits 
+                                            // correspond to the contents of 
+                                            // the GPTM Timer B match 
+                                            // (GPTMTBMATCHR) register). In a 
+                                            // 16-bit mode, the upper 16 bits 
+                                            // of this register read as 0s and 
+                                            // have no effect on the state of 
+                                            // TBMATCHR. 
+#define GPTIMER_O_TBMATCHR      0x00000034  // PTM Timer B match This register 
+                                            // is loaded with a match value. 
+                                            // Interrupts can be generated when 
+                                            // the Timer value is equal to the 
+                                            // value in this register in 
+                                            // one-shot or periodic mode. When 
+                                            // a GPTM is configured to one of 
+                                            // the 32-bit modes, the contents 
+                                            // of bits [15:0] in this register 
+                                            // are loaded into the upper 16 
+                                            // bits of the TAMATCHR register. 
+                                            // Reads from this register return 
+                                            // the current match value of Timer 
+                                            // B and writes are ignored. In a 
+                                            // 16-bit mode, bits [15:0] are 
+                                            // used for the match value. Bits 
+                                            // [31:16] are reserved in both 
+                                            // cases. 
+#define GPTIMER_O_TAPR          0x00000038  // GPTM Timer A prescale This 
+                                            // register allows software to 
+                                            // extend the range of the 16-bit 
+                                            // Timers in periodic and one-shot 
+                                            // modes. 
+#define GPTIMER_O_TBPR          0x0000003C  // GPTM Timer B prescale This 
+                                            // register allows software to 
+                                            // extend the range of the 16-bit 
+                                            // Timers in periodic and one-shot 
+                                            // modes. 
+#define GPTIMER_O_TAPMR         0x00000040  // GPTM Timer A prescale match 
+                                            // This register effectively 
+                                            // extends the range of TAMATCHR to 
+                                            // 24 bits when operating in 
+                                            // 16-bit, one-shot or periodic 
+                                            // mode. 
+#define GPTIMER_O_TBPMR         0x00000044  // GPTM Timer B prescale match 
+                                            // This register effectively 
+                                            // extends the range ofMTBMATCHR to 
+                                            // 24 bits when operating in 
+                                            // 16-bit, one-shot or periodic 
+                                            // mode. 
+#define GPTIMER_O_TAR           0x00000048  // GPTM Timer A This register 
+                                            // shows the current value of the 
+                                            // Timer A counter. When a GPTM is 
+                                            // configured to one of the 32-bit 
+                                            // modes, TAR appears as a 32-bit 
+                                            // register (the upper 16-bits 
+                                            // correspond to the contents of 
+                                            // the GPTM Timer B (TBR) 
+                                            // register). In the16-bit Input 
+                                            // edge count, input edge time, and 
+                                            // PWM modes, bits [15:0] contain 
+                                            // the value of the counter and 
+                                            // bits 23:16 contain the value of 
+                                            // the prescaler, which is the 
+                                            // upper 8 bits of the count. Bits 
+                                            // [31:24] always read as 0. To 
+                                            // read the value of the prescaler 
+                                            // in 16-bit, one-shot and periodic 
+                                            // modes, read bits [23:16] in the 
+                                            // TAV register. 
+#define GPTIMER_O_TBR           0x0000004C  // GPTM Timer B This register 
+                                            // shows the current value of the 
+                                            // Timer B counter. When a GPTM is 
+                                            // configured to one of the 32-bit 
+                                            // modes, the contents of bits 
+                                            // [15:0] in this register are 
+                                            // loaded into the upper 16 bits of 
+                                            // the TAR register. Reads from 
+                                            // this register return the current 
+                                            // value of Timer B. In a 16-bit 
+                                            // mode, bits 15:0 contain the 
+                                            // value of the counter and bits 
+                                            // [23:16] contain the value of the 
+                                            // prescaler in Input edge count, 
+                                            // input edge time, and PWM modes, 
+                                            // which is the upper 8 bits of the 
+                                            // count. Bits [31:24] always read 
+                                            // as 0. To read the value of the 
+                                            // prescaler in 16-bit, one-shot 
+                                            // and periodic modes, read bits 
+                                            // [23:16] in the TBV register. 
+#define GPTIMER_O_TAV           0x00000050  // GPTM Timer A value When read, 
+                                            // this register shows the current, 
+                                            // free-running value of Timer A in 
+                                            // all modes. Software can use this 
+                                            // value to determine the time 
+                                            // elapsed between an interrupt and 
+                                            // the ISR entry when using the 
+                                            // snapshot feature with the 
+                                            // periodic operating mode. When 
+                                            // written, the value written into 
+                                            // this register is loaded into the 
+                                            // TAR register on the next clock 
+                                            // cycle. When a GPTM is configured 
+                                            // to one of the 32-bit modes, TAV 
+                                            // appears as a 32-bit register 
+                                            // (the upper 16-bits correspond to 
+                                            // the contents of the GPTM Timer B 
+                                            // Value (TBV) register). In a 
+                                            // 16-bit mode, bits [15:0] contain 
+                                            // the value of the counter and 
+                                            // bits [23:16] contain the 
+                                            // current, free-running value of 
+                                            // the prescaler, which is the 
+                                            // upper 8 bits of the count in 
+                                            // input edge count, input edge 
+                                            // time, PWM and one-shot or 
+                                            // periodic up count modes. In 
+                                            // one-shot or periodic down count 
+                                            // modes, the prescaler stored in 
+                                            // [23:16] is a true prescaler, 
+                                            // meaning bits [23:16] count down 
+                                            // before decrementing the value in 
+                                            // bits [15:0]. The prescaler its 
+                                            // [31:24] always read as 0. 
+#define GPTIMER_O_TBV           0x00000054  // GPTM Timer B value When read, 
+                                            // this register shows the current, 
+                                            // free-running value of Timer B in 
+                                            // all modes. Software can use this 
+                                            // value to determine the time 
+                                            // elapsed between an interrupt and 
+                                            // the ISR entry. When written, the 
+                                            // value written into this register 
+                                            // is loaded into the TBR register 
+                                            // on the next clock cycle. When a 
+                                            // GPTM is configured to one of the 
+                                            // 32-bit modes, the contents of 
+                                            // bits 15:0 in this register are 
+                                            // loaded into the upper 16 bits of 
+                                            // the TAV register. Reads from 
+                                            // this register return the current 
+                                            // free-running value of Timer B. 
+                                            // In a 16-bit mode, bits [15:0] 
+                                            // contain the value of the counter 
+                                            // and bits [23:16] contain the 
+                                            // current, free-running value of 
+                                            // the prescaler, which is the 
+                                            // upper 8 bits of the count in 
+                                            // input edge count, input edge 
+                                            // time, PWM and one-shot or 
+                                            // periodic up count modes. In 
+                                            // one-shot or periodic down count 
+                                            // modes, the prescaler stored in 
+                                            // [23:16] is a true prescaler, 
+                                            // meaning bits [23:16] count down 
+                                            // before decrementing the value in 
+                                            // bits [15:0]. The prescaler its 
+                                            // [31:24] always read as 0. 
+#define GPTIMER_O_TAPS          0x0000005C  // GPTM Timer A prescale snapshot 
+                                            // For the 32-bit wide GPTM, this 
+                                            // register shows the current value 
+                                            // of the Timer A prescaler in the 
+                                            // 32-bit modes. This register is 
+                                            // ununsed in 16-bit GPTM mode. 
+#define GPTIMER_O_TBPS          0x00000060  // GPTM Timer B prescale snapshot 
+                                            // For the 32-bit wide GPTM, this 
+                                            // register shows the current value 
+                                            // of the Timer B prescaler in the 
+                                            // 32-bit modes. This register is 
+                                            // ununsed in 16-bit GPTM mode. 
+#define GPTIMER_O_TAPV          0x00000064  // GPTM Timer A prescale value For 
+                                            // the 32-bit wide GPTM, this 
+                                            // register shows the current 
+                                            // free-running value of the Timer 
+                                            // A prescaler in the 32-bit modes. 
+                                            // Software can use this value in 
+                                            // conjunction with the TAV 
+                                            // register to determine the time 
+                                            // elapsed between an interrupt and 
+                                            // the ISR entry. This register is 
+                                            // ununsed in 16- or 32-bit GPTM 
+                                            // mode. 
+#define GPTIMER_O_TBPV          0x00000068  // GPTM Timer B prescale value For 
+                                            // the 32-bit wide GPTM, this 
+                                            // register shows the current 
+                                            // free-running value of the Timer 
+                                            // B prescaler in the 32-bit modes. 
+                                            // Software can use this value in 
+                                            // conjunction with the TBV 
+                                            // register to determine the time 
+                                            // elapsed between an interrupt and 
+                                            // the ISR entry. This register is 
+                                            // ununsed in 16- or 32-bit GPTM 
+                                            // mode. 
+#define GPTIMER_O_PP            0x00000FC0  // GPTM peripheral properties The 
+                                            // PP register provides information 
+                                            // regarding the properties of the 
+                                            // general-purpose Timer module. 
+
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the GPTIMER_O_CFG register.
+//
+//*****************************************************************************
+#define GPTIMER_CFG_GPTMCFG_M   0x00000007  // GPTM configuration The GPTMCFG 
+                                            // values are defined as follows: 
+                                            // 0x0: 32-bit timer configuration. 
+                                            // 0x1: 32-bit real-time clock 0x2: 
+                                            // Reserved 0x3: Reserved 0x4: 
+                                            // 16-bit timer configuration. The 
+                                            // function is controlled by bits 
+                                            // [1:0] of GPTMTAMR and GPTMTBMR. 
+                                            // 0x5-0x7: Reserved 
+#define GPTIMER_CFG_GPTMCFG_S   0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the GPTIMER_O_TAMR register.
+//
+//*****************************************************************************
+#define GPTIMER_TAMR_TAPLO      0x00000800  // Legacy PWM operation 0: Legacy 
+                                            // operation 1: CCP is set to 1 on 
+                                            // time-out. 
+#define GPTIMER_TAMR_TAPLO_M    0x00000800
+#define GPTIMER_TAMR_TAPLO_S    11
+#define GPTIMER_TAMR_TAMRSU     0x00000400  // Timer A match register update 
+                                            // mode 0: Update GPTMAMATCHR and 
+                                            // GPTMAPR if used on the next 
+                                            // cycle. 1: Update GPTMAMATCHR and 
+                                            // GPTMAPR if used on the next 
+                                            // time-out. If the timer is 
+                                            // disabled (TAEN is clear) when 
+                                            // this bit is set, GPTMTAMATCHR 
+                                            // and GPTMTAPR are updated when 
+                                            // the timer is enabled. If the 
+                                            // timer is stalled (TASTALL is 
+                                            // set), GPTMTAMATCHR and GPTMTAPR 
+                                            // are updated according to the 
+                                            // configuration of this bit. 
+#define GPTIMER_TAMR_TAMRSU_M   0x00000400
+#define GPTIMER_TAMR_TAMRSU_S   10
+#define GPTIMER_TAMR_TAPWMIE    0x00000200  // GPTM Timer A PWM interrupt 
+                                            // enable This bit enables 
+                                            // interrupts in PWM mode on 
+                                            // rising, falling, or both edges 
+                                            // of the CCP output. 0: Interrupt 
+                                            // is disabled. 1: Interrupt is 
+                                            // enabled. This bit is valid only 
+                                            // in PWM mode. 
+#define GPTIMER_TAMR_TAPWMIE_M  0x00000200
+#define GPTIMER_TAMR_TAPWMIE_S  9
+#define GPTIMER_TAMR_TAILD      0x00000100  // GPTM Timer A PWM interval load 
+                                            // write 0: Update the GPTMTAR 
+                                            // register with the value in the 
+                                            // GPTMTAILR register on the next 
+                                            // cycle. If the prescaler is used, 
+                                            // update the GPTMTAPS register 
+                                            // with the value in the GPTMTAPR 
+                                            // register on the next cycle. 1: 
+                                            // Update the GPTMTAR register with 
+                                            // the value in the GPTMTAILR 
+                                            // register on the next cycle. If 
+                                            // the prescaler is used, update 
+                                            // the GPTMTAPS register with the 
+                                            // value in the GPTMTAPR register 
+                                            // on the next time-out. 
+#define GPTIMER_TAMR_TAILD_M    0x00000100
+#define GPTIMER_TAMR_TAILD_S    8
+#define GPTIMER_TAMR_TASNAPS    0x00000080  // GPTM Timer A snap-shot mode 0: 
+                                            // Snap-shot mode is disabled. 1: 
+                                            // If Timer A is configured in 
+                                            // periodic mode, the actual 
+                                            // free-running value of Timer A is 
+                                            // loaded at the time-out event 
+                                            // into the GPTM Timer A (GPTMTAR) 
+                                            // register. 
+#define GPTIMER_TAMR_TASNAPS_M  0x00000080
+#define GPTIMER_TAMR_TASNAPS_S  7
+#define GPTIMER_TAMR_TAWOT      0x00000040  // GPTM Timer A wait-on-trigger 0: 
+                                            // Timer A begins counting as soon 
+                                            // as it is enabled. 1: If Timer A 
+                                            // is enabled (TAEN is set in the 
+                                            // GPTMCTL register), Timer A does 
+                                            // not begin counting until it 
+                                            // receives a trigger from the 
+                                            // Timer in the previous position 
+                                            // in the daisy-chain. This bit 
+                                            // must be clear for GP Timer 
+                                            // module 0, Timer A. 
+#define GPTIMER_TAMR_TAWOT_M    0x00000040
+#define GPTIMER_TAMR_TAWOT_S    6
+#define GPTIMER_TAMR_TAMIE      0x00000020  // GPTM Timer A match interrupt 
+                                            // enable 0: The match interrupt is 
+                                            // disabled. 1: An interrupt is 
+                                            // generated when the match value 
+                                            // in the GPTMTAMATCHR register is 
+                                            // reached in the one-shot and 
+                                            // periodic modes. 
+#define GPTIMER_TAMR_TAMIE_M    0x00000020
+#define GPTIMER_TAMR_TAMIE_S    5
+#define GPTIMER_TAMR_TACDIR     0x00000010  // GPTM Timer A count direction 0: 
+                                            // The timer counts down. 1: The 
+                                            // timer counts up. When counting 
+                                            // up, the timer starts from a 
+                                            // value of 0x0. 
+#define GPTIMER_TAMR_TACDIR_M   0x00000010
+#define GPTIMER_TAMR_TACDIR_S   4
+#define GPTIMER_TAMR_TAAMS      0x00000008  // GPTM Timer A alternate mode 0: 
+                                            // Capture mode is enabled. 1: PWM 
+                                            // mode is enabled. Note: To enable 
+                                            // PWM mode, the TACM bit must be 
+                                            // cleared and the TAMR field must 
+                                            // be configured to 0x2. 
+#define GPTIMER_TAMR_TAAMS_M    0x00000008
+#define GPTIMER_TAMR_TAAMS_S    3
+#define GPTIMER_TAMR_TACMR      0x00000004  // GPTM Timer A capture mode 0: 
+                                            // Edge-count mode 1: Edge-time 
+                                            // mode 
+#define GPTIMER_TAMR_TACMR_M    0x00000004
+#define GPTIMER_TAMR_TACMR_S    2
+#define GPTIMER_TAMR_TAMR_M     0x00000003  // GPTM Timer A mode 0x0: Reserved 
+                                            // 0x1: One-shot mode 0x2: Periodic 
+                                            // mode 0x3: Capture mode The timer 
+                                            // mode is based on the timer 
+                                            // configuration defined by bits 
+                                            // [2:0] in the GPTMCFG register. 
+#define GPTIMER_TAMR_TAMR_S     0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the GPTIMER_O_TBMR register.
+//
+//*****************************************************************************
+#define GPTIMER_TBMR_TBPLO      0x00000800  // Legacy PWM operation 0: Legacy 
+                                            // operation 1: CCP is set to 1 on 
+                                            // time-out. 
+#define GPTIMER_TBMR_TBPLO_M    0x00000800
+#define GPTIMER_TBMR_TBPLO_S    11
+#define GPTIMER_TBMR_TBMRSU     0x00000400  // Timer B match register update 
+                                            // mode 0: Update the GPTMBMATCHR 
+                                            // and the GPTMBPR, if used on the 
+                                            // next cycle. 1: Update the 
+                                            // GPTMBMATCHR and the GPTMBPR, if 
+                                            // used on the next time-out. If 
+                                            // the timer is disabled (TAEN is 
+                                            // clear) when this bit is set, 
+                                            // GPTMTBMATCHR and GPTMTBPR are 
+                                            // updated when the timer is 
+                                            // enabled. If the timer is stalled 
+                                            // (TBSTALL is set), GPTMTBMATCHR 
+                                            // and GPTMTBPR are updated 
+                                            // according to the configuration 
+                                            // of this bit. 
+#define GPTIMER_TBMR_TBMRSU_M   0x00000400
+#define GPTIMER_TBMR_TBMRSU_S   10
+#define GPTIMER_TBMR_TBPWMIE    0x00000200  // GPTM Timer B PWM interrupt 
+                                            // enable This bit enables 
+                                            // interrupts in PWM mode on 
+                                            // rising, falling, or both edges 
+                                            // of the CCP output. 0: Interrupt 
+                                            // is disabled. 1: Interrupt is 
+                                            // enabled. This bit is valid only 
+                                            // in PWM mode. 
+#define GPTIMER_TBMR_TBPWMIE_M  0x00000200
+#define GPTIMER_TBMR_TBPWMIE_S  9
+#define GPTIMER_TBMR_TBILD      0x00000100  // GPTM Timer B PWM interval load 
+                                            // write 0: Update the GPTMTBR 
+                                            // register with the value in the 
+                                            // GPTMTBILR register on the next 
+                                            // cycle. If the prescaler is used, 
+                                            // update the GPTMTBPS register 
+                                            // with the value in the GPTMTBPR 
+                                            // register on the next cycle. 1: 
+                                            // Update the GPTMTBR register with 
+                                            // the value in the GPTMTBILR 
+                                            // register on the next cycle. If 
+                                            // the prescaler is used, update 
+                                            // the GPTMTBPS register with the 
+                                            // value in the GPTMTBPR register 
+                                            // on the next time-out. 
+#define GPTIMER_TBMR_TBILD_M    0x00000100
+#define GPTIMER_TBMR_TBILD_S    8
+#define GPTIMER_TBMR_TBSNAPS    0x00000080  // GPTM Timer B snap-shot mode 0: 
+                                            // Snap-shot mode is disabled. 1: 
+                                            // If Timer B is configured in the 
+                                            // periodic mode, the actual 
+                                            // free-running value of Timer A is 
+                                            // loaded into the GPTM Timer B 
+                                            // (GPTMTBR) register at the 
+                                            // time-out event. 
+#define GPTIMER_TBMR_TBSNAPS_M  0x00000080
+#define GPTIMER_TBMR_TBSNAPS_S  7
+#define GPTIMER_TBMR_TBWOT      0x00000040  // GPTM Timer B wait-on-trigger 0: 
+                                            // Timer B begins counting as soon 
+                                            // as it is enabled. 1: If Timer B 
+                                            // is enabled (TBEN is set in the 
+                                            // GPTMCTL register), Timer B does 
+                                            // not begin counting until it 
+                                            // receives a trigger from the 
+                                            // timer in the previous position 
+                                            // in the daisy-chain. 
+#define GPTIMER_TBMR_TBWOT_M    0x00000040
+#define GPTIMER_TBMR_TBWOT_S    6
+#define GPTIMER_TBMR_TBMIE      0x00000020  // GPTM Timer B match interrupt 
+                                            // enable 0: The match interrupt is 
+                                            // disabled. 1: An interrupt is 
+                                            // generated when the match value 
+                                            // in the GPTMTBMATCHR register is 
+                                            // reached in the one-shot and 
+                                            // periodic modes. 
+#define GPTIMER_TBMR_TBMIE_M    0x00000020
+#define GPTIMER_TBMR_TBMIE_S    5
+#define GPTIMER_TBMR_TBCDIR     0x00000010  // GPTM Timer B count direction 0: 
+                                            // The timer counts down. 1: The 
+                                            // timer counts up. When counting 
+                                            // up, the timer starts from a 
+                                            // value of 0x0. 
+#define GPTIMER_TBMR_TBCDIR_M   0x00000010
+#define GPTIMER_TBMR_TBCDIR_S   4
+#define GPTIMER_TBMR_TBAMS      0x00000008  // GPTM Timer B alternate mode 0: 
+                                            // Capture mode is enabled. 1: PWM 
+                                            // mode is enabled. Note: To enable 
+                                            // PWM mode, the TBCM bit must be 
+                                            // cleared and the TBMR field must 
+                                            // be configured to 0x2. 
+#define GPTIMER_TBMR_TBAMS_M    0x00000008
+#define GPTIMER_TBMR_TBAMS_S    3
+#define GPTIMER_TBMR_TBCMR      0x00000004  // GPTM Timer B capture mode 0: 
+                                            // Edge-count mode 1: Edge-time 
+                                            // mode 
+#define GPTIMER_TBMR_TBCMR_M    0x00000004
+#define GPTIMER_TBMR_TBCMR_S    2
+#define GPTIMER_TBMR_TBMR_M     0x00000003  // GPTM Timer B mode 0x0: Reserved 
+                                            // 0x1: One-shot timer mode 0x2: 
+                                            // Periodic timer mode 0x3: Capture 
+                                            // mode The timer mode is based on 
+                                            // the timer configuration defined 
+                                            // by bits [2:0] in the GPTMCFG 
+                                            // register. 
+#define GPTIMER_TBMR_TBMR_S     0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the GPTIMER_O_CTL register.
+//
+//*****************************************************************************
+#define GPTIMER_CTL_TBPWML      0x00004000  // GPTM Timer B PWM output level 
+                                            // 0: Output is unaffected. 1: 
+                                            // Output is inverted. 
+#define GPTIMER_CTL_TBPWML_M    0x00004000
+#define GPTIMER_CTL_TBPWML_S    14
+#define GPTIMER_CTL_TBOTE       0x00002000  // GPTM Timer B output trigger 
+                                            // enable 0: The ADC trigger of 
+                                            // output Timer B is disabled. 1: 
+                                            // The ADC trigger of output Timer 
+                                            // B is enabled. 
+#define GPTIMER_CTL_TBOTE_M     0x00002000
+#define GPTIMER_CTL_TBOTE_S     13
+#define GPTIMER_CTL_TBEVENT_M   0x00000C00  // GPTM Timer B event mode 0x0: 
+                                            // Positive edge 0x1: Negative edge 
+                                            // 0x2: Reserved 0x3: Both edges 
+#define GPTIMER_CTL_TBEVENT_S   10
+#define GPTIMER_CTL_TBSTALL     0x00000200  // GPTM Timer B stall enable 0: 
+                                            // Timer B continues counting while 
+                                            // the processor is halted by the 
+                                            // debugger. 1: Timer B freezes 
+                                            // counting while the processor is 
+                                            // halted by the debugger. 
+#define GPTIMER_CTL_TBSTALL_M   0x00000200
+#define GPTIMER_CTL_TBSTALL_S   9
+#define GPTIMER_CTL_TBEN        0x00000100  // GPTM Timer B enable 0: Timer B 
+                                            // is disabled. 1: Timer B is 
+                                            // enabled and begins counting or 
+                                            // the capture logic is enabled 
+                                            // based on the GPTMCFG register. 
+#define GPTIMER_CTL_TBEN_M      0x00000100
+#define GPTIMER_CTL_TBEN_S      8
+#define GPTIMER_CTL_TAPWML      0x00000040  // GPTM Timer A PWM output level 
+                                            // 0: Output is unaffected. 1: 
+                                            // Output is inverted. 
+#define GPTIMER_CTL_TAPWML_M    0x00000040
+#define GPTIMER_CTL_TAPWML_S    6
+#define GPTIMER_CTL_TAOTE       0x00000020  // GPTM Timer A output trigger 
+                                            // enable 0: The ADC trigger of 
+                                            // output Timer A is disabled. 1: 
+                                            // The ADC trigger of output Timer 
+                                            // A is enabled. 
+#define GPTIMER_CTL_TAOTE_M     0x00000020
+#define GPTIMER_CTL_TAOTE_S     5
+#define GPTIMER_CTL_TAEVENT_M   0x0000000C  // GPTM Timer A event mode 0x0: 
+                                            // Positive edge 0x1: Negative edge 
+                                            // 0x2: Reserved 0x3: Both edges 
+#define GPTIMER_CTL_TAEVENT_S   2
+#define GPTIMER_CTL_TASTALL     0x00000002  // GPTM Timer A stall enable 0: 
+                                            // Timer A continues counting while 
+                                            // the processor is halted by the 
+                                            // debugger. 1: Timer A freezes 
+                                            // counting while the processor is 
+                                            // halted by the debugger. 
+#define GPTIMER_CTL_TASTALL_M   0x00000002
+#define GPTIMER_CTL_TASTALL_S   1
+#define GPTIMER_CTL_TAEN        0x00000001  // GPTM Timer A enable 0: Timer A 
+                                            // is disabled. 1: Timer A is 
+                                            // enabled and begins counting or 
+                                            // the capture logic is enabled 
+                                            // based on the GPTMCFG register. 
+#define GPTIMER_CTL_TAEN_M      0x00000001
+#define GPTIMER_CTL_TAEN_S      0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the GPTIMER_O_SYNC register.
+//
+//*****************************************************************************
+#define GPTIMER_SYNC_SYNC3_M    0x000000C0  // Synchronize GPTM3 0x0: GPTM3 is 
+                                            // not affected. 0x1: A time-out 
+                                            // event for Timer A of GPTM3 is 
+                                            // triggered. 0x2: A time-out event 
+                                            // for Timer B of GPTM3 is 
+                                            // triggered. 0x3: A time-out event 
+                                            // for Timer A and Timer B of GPTM3 
+                                            // is triggered. 
+#define GPTIMER_SYNC_SYNC3_S    6
+#define GPTIMER_SYNC_SYNC2_M    0x00000030  // Synchronize GPTM2 0x0: GPTM2 is 
+                                            // not affected. 0x1: A time-out 
+                                            // event for Timer A of GPTM2 is 
+                                            // triggered. 0x2: A time-out event 
+                                            // for Timer B of GPTM2 is 
+                                            // triggered. 0x3: A time-out event 
+                                            // for Timer A and Timer B of GPTM2 
+                                            // is triggered. 
+#define GPTIMER_SYNC_SYNC2_S    4
+#define GPTIMER_SYNC_SYNC1_M    0x0000000C  // Synchronize GPTM1 0x0: GPTM1 is 
+                                            // not affected. 0x1: A time-out 
+                                            // event for Timer A of GPTM1 is 
+                                            // triggered. 0x2: A time-out event 
+                                            // for Timer B of GPTM1 is 
+                                            // triggered. 0x3: A time-out event 
+                                            // for Timer A and Timer B of GPTM1 
+                                            // is triggered. 
+#define GPTIMER_SYNC_SYNC1_S    2
+#define GPTIMER_SYNC_SYNC0_M    0x00000003  // Synchronize GPTM0 0x0: GPTM0 is 
+                                            // not affected. 0x1: A time-out 
+                                            // event for Timer A of GPTM0 is 
+                                            // triggered. 0x2: A time-out event 
+                                            // for Timer B of GPTM0 is 
+                                            // triggered. 0x3: A time-out event 
+                                            // for Timer A and Timer B of GPTM0 
+                                            // is triggered. 
+#define GPTIMER_SYNC_SYNC0_S    0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the GPTIMER_O_IMR register.
+//
+//*****************************************************************************
+#define GPTIMER_IMR_TBMIM       0x00000800  // GPTM Timer B match interrupt 
+                                            // mask 0: Interrupt is disabled. 
+                                            // 1: Interrupt is enabled. 
+#define GPTIMER_IMR_TBMIM_M     0x00000800
+#define GPTIMER_IMR_TBMIM_S     11
+#define GPTIMER_IMR_CBEIM       0x00000400  // GPTM Timer B capture event 
+                                            // interrupt mask 0: Interrupt is 
+                                            // disabled. 1: Interrupt is 
+                                            // enabled. 
+#define GPTIMER_IMR_CBEIM_M     0x00000400
+#define GPTIMER_IMR_CBEIM_S     10
+#define GPTIMER_IMR_CBMIM       0x00000200  // GPTM Timer B capture match 
+                                            // interrupt mask 0: Interrupt is 
+                                            // disabled. 1: Interrupt is 
+                                            // enabled. 
+#define GPTIMER_IMR_CBMIM_M     0x00000200
+#define GPTIMER_IMR_CBMIM_S     9
+#define GPTIMER_IMR_TBTOIM      0x00000100  // GPTM Timer B time-out interrupt 
+                                            // mask 0: Interrupt is disabled. 
+                                            // 1: Interrupt is enabled. 
+#define GPTIMER_IMR_TBTOIM_M    0x00000100
+#define GPTIMER_IMR_TBTOIM_S    8
+#define GPTIMER_IMR_TAMIM       0x00000010  // GPTM Timer A match interrupt 
+                                            // mask 0: Interrupt is disabled. 
+                                            // 1: Interrupt is enabled. 
+#define GPTIMER_IMR_TAMIM_M     0x00000010
+#define GPTIMER_IMR_TAMIM_S     4
+#define GPTIMER_IMR_CAEIM       0x00000004  // GPTM Timer A capture event 
+                                            // interrupt mask 0: Interrupt is 
+                                            // disabled. 1: Interrupt is 
+                                            // enabled. 
+#define GPTIMER_IMR_CAEIM_M     0x00000004
+#define GPTIMER_IMR_CAEIM_S     2
+#define GPTIMER_IMR_CAMIM       0x00000002  // GPTM Timer A capture match 
+                                            // interrupt mask 0: Interrupt is 
+                                            // disabled. 1: Interrupt is 
+                                            // enabled. 
+#define GPTIMER_IMR_CAMIM_M     0x00000002
+#define GPTIMER_IMR_CAMIM_S     1
+#define GPTIMER_IMR_TATOIM      0x00000001  // GPTM Timer A time-out interrupt 
+                                            // mask 0: Interrupt is disabled. 
+                                            // 1: Interrupt is enabled. 
+#define GPTIMER_IMR_TATOIM_M    0x00000001
+#define GPTIMER_IMR_TATOIM_S    0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the GPTIMER_O_RIS register.
+//
+//*****************************************************************************
+#define GPTIMER_RIS_TBMRIS      0x00000800  // GPTM Timer B match raw 
+                                            // interrupt 
+#define GPTIMER_RIS_TBMRIS_M    0x00000800
+#define GPTIMER_RIS_TBMRIS_S    11
+#define GPTIMER_RIS_CBERIS      0x00000400  // GPTM Timer B capture event raw 
+                                            // interrupt 
+#define GPTIMER_RIS_CBERIS_M    0x00000400
+#define GPTIMER_RIS_CBERIS_S    10
+#define GPTIMER_RIS_CBMRIS      0x00000200  // GPTM Timer B capture match raw 
+                                            // interrupt 
+#define GPTIMER_RIS_CBMRIS_M    0x00000200
+#define GPTIMER_RIS_CBMRIS_S    9
+#define GPTIMER_RIS_TBTORIS     0x00000100  // GPTM Timer B time-out raw 
+                                            // interrupt 
+#define GPTIMER_RIS_TBTORIS_M   0x00000100
+#define GPTIMER_RIS_TBTORIS_S   8
+#define GPTIMER_RIS_TAMRIS      0x00000010  // GPTM Timer A match raw 
+                                            // interrupt 
+#define GPTIMER_RIS_TAMRIS_M    0x00000010
+#define GPTIMER_RIS_TAMRIS_S    4
+#define GPTIMER_RIS_CAERIS      0x00000004  // GPTM Timer A capture event raw 
+                                            // interrupt 
+#define GPTIMER_RIS_CAERIS_M    0x00000004
+#define GPTIMER_RIS_CAERIS_S    2
+#define GPTIMER_RIS_CAMRIS      0x00000002  // GPTM Timer A capture match raw 
+                                            // interrupt 
+#define GPTIMER_RIS_CAMRIS_M    0x00000002
+#define GPTIMER_RIS_CAMRIS_S    1
+#define GPTIMER_RIS_TATORIS     0x00000001  // GPTM Timer A time-out raw 
+                                            // interrupt 
+#define GPTIMER_RIS_TATORIS_M   0x00000001
+#define GPTIMER_RIS_TATORIS_S   0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the GPTIMER_O_MIS register.
+//
+//*****************************************************************************
+#define GPTIMER_MIS_TBMMIS      0x00000800  // GPTM Timer B match masked 
+                                            // interrupt 
+#define GPTIMER_MIS_TBMMIS_M    0x00000800
+#define GPTIMER_MIS_TBMMIS_S    11
+#define GPTIMER_MIS_CBEMIS      0x00000400  // GPTM Timer B capture event 
+                                            // masked interrupt 
+#define GPTIMER_MIS_CBEMIS_M    0x00000400
+#define GPTIMER_MIS_CBEMIS_S    10
+#define GPTIMER_MIS_CBMMIS      0x00000200  // GPTM Timer B capture match 
+                                            // masked interrupt 
+#define GPTIMER_MIS_CBMMIS_M    0x00000200
+#define GPTIMER_MIS_CBMMIS_S    9
+#define GPTIMER_MIS_TBTOMIS     0x00000100  // GPTM Timer B time-out masked 
+                                            // interrupt 
+#define GPTIMER_MIS_TBTOMIS_M   0x00000100
+#define GPTIMER_MIS_TBTOMIS_S   8
+#define GPTIMER_MIS_TAMRIS      0x00000010  // GPTM Timer A match raw 
+                                            // interrupt 
+#define GPTIMER_MIS_TAMRIS_M    0x00000010
+#define GPTIMER_MIS_TAMRIS_S    4
+#define GPTIMER_MIS_CAEMIS      0x00000004  // GPTM Timer A capture event raw 
+                                            // interrupt 
+#define GPTIMER_MIS_CAEMIS_M    0x00000004
+#define GPTIMER_MIS_CAEMIS_S    2
+#define GPTIMER_MIS_CAMMIS      0x00000002  // GPTM Timer A capture match raw 
+                                            // interrupt 
+#define GPTIMER_MIS_CAMMIS_M    0x00000002
+#define GPTIMER_MIS_CAMMIS_S    1
+#define GPTIMER_MIS_TATOMIS     0x00000001  // GPTM Timer A time-out raw 
+                                            // interrupt 
+#define GPTIMER_MIS_TATOMIS_M   0x00000001
+#define GPTIMER_MIS_TATOMIS_S   0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the GPTIMER_O_ICR register.
+//
+//*****************************************************************************
+#define GPTIMER_ICR_WUECINT     0x00010000  // GPTM write update error 
+                                            // interrupt clear 
+#define GPTIMER_ICR_WUECINT_M   0x00010000
+#define GPTIMER_ICR_WUECINT_S   16
+#define GPTIMER_ICR_TBMCINT     0x00000800  // GPTM Timer B match interrupt 
+                                            // clear 
+#define GPTIMER_ICR_TBMCINT_M   0x00000800
+#define GPTIMER_ICR_TBMCINT_S   11
+#define GPTIMER_ICR_CBECINT     0x00000400  // GPTM Timer B capture event 
+                                            // Interrupt clear 
+#define GPTIMER_ICR_CBECINT_M   0x00000400
+#define GPTIMER_ICR_CBECINT_S   10
+#define GPTIMER_ICR_CBMCINT     0x00000200  // GPTM Timer B capture match 
+                                            // interrupt clear 
+#define GPTIMER_ICR_CBMCINT_M   0x00000200
+#define GPTIMER_ICR_CBMCINT_S   9
+#define GPTIMER_ICR_TBTOCINT    0x00000100  // GPTM Timer B time-out interrupt 
+                                            // clear 
+#define GPTIMER_ICR_TBTOCINT_M  0x00000100
+#define GPTIMER_ICR_TBTOCINT_S  8
+#define GPTIMER_ICR_TAMCINT     0x00000010  // GPTM Timer A match interrupt 
+                                            // clear 
+#define GPTIMER_ICR_TAMCINT_M   0x00000010
+#define GPTIMER_ICR_TAMCINT_S   4
+#define GPTIMER_ICR_CAECINT     0x00000004  // GPTM Timer A capture event 
+                                            // Interrupt clear 
+#define GPTIMER_ICR_CAECINT_M   0x00000004
+#define GPTIMER_ICR_CAECINT_S   2
+#define GPTIMER_ICR_CAMCINT     0x00000002  // GPTM Timer A capture match 
+                                            // interrupt clear 
+#define GPTIMER_ICR_CAMCINT_M   0x00000002
+#define GPTIMER_ICR_CAMCINT_S   1
+#define GPTIMER_ICR_TATOCINT    0x00000001  // GPTM Timer A time-out interrupt 
+                                            // clear 
+#define GPTIMER_ICR_TATOCINT_M  0x00000001
+#define GPTIMER_ICR_TATOCINT_S  0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// GPTIMER_O_TAILR register.
+//
+//*****************************************************************************
+#define GPTIMER_TAILR_TAILR_M   0xFFFFFFFF  // GPTM A interval load register 
+#define GPTIMER_TAILR_TAILR_S   0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// GPTIMER_O_TBILR register.
+//
+//*****************************************************************************
+#define GPTIMER_TBILR_TBILR_M   0x0000FFFF  // GPTM B interval load register 
+#define GPTIMER_TBILR_TBILR_S   0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// GPTIMER_O_TAMATCHR register.
+//
+//*****************************************************************************
+#define GPTIMER_TAMATCHR_TAMR_M 0xFFFFFFFF  // GPTM Timer A match register 
+#define GPTIMER_TAMATCHR_TAMR_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// GPTIMER_O_TBMATCHR register.
+//
+//*****************************************************************************
+#define GPTIMER_TBMATCHR_TBMR_M 0x0000FFFF  // GPTM Timer B match register 
+#define GPTIMER_TBMATCHR_TBMR_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the GPTIMER_O_TAPR register.
+//
+//*****************************************************************************
+#define GPTIMER_TAPR_TAPSR_M    0x000000FF  // GPTM Timer A prescale 
+#define GPTIMER_TAPR_TAPSR_S    0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the GPTIMER_O_TBPR register.
+//
+//*****************************************************************************
+#define GPTIMER_TBPR_TBPSR_M    0x000000FF  // GPTM Timer B prescale 
+#define GPTIMER_TBPR_TBPSR_S    0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// GPTIMER_O_TAPMR register.
+//
+//*****************************************************************************
+#define GPTIMER_TAPMR_TAPSR_M   0x000000FF  // GPTM Timer A prescale match 
+#define GPTIMER_TAPMR_TAPSR_S   0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// GPTIMER_O_TBPMR register.
+//
+//*****************************************************************************
+#define GPTIMER_TBPMR_TBPSR_M   0x000000FF  // GPTM Timer B prescale match 
+#define GPTIMER_TBPMR_TBPSR_S   0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the GPTIMER_O_TAR register.
+//
+//*****************************************************************************
+#define GPTIMER_TAR_TAR_M       0xFFFFFFFF  // GPTM Timer A register 
+#define GPTIMER_TAR_TAR_S       0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the GPTIMER_O_TBR register.
+//
+//*****************************************************************************
+#define GPTIMER_TBR_TBR_M       0x0000FFFF  // GPTM Timer B register 
+#define GPTIMER_TBR_TBR_S       0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the GPTIMER_O_TAV register.
+//
+//*****************************************************************************
+#define GPTIMER_TAV_TAV_M       0xFFFFFFFF  // GPTM Timer A register 
+#define GPTIMER_TAV_TAV_S       0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the GPTIMER_O_TBV register.
+//
+//*****************************************************************************
+#define GPTIMER_TBV_PRE_M       0x00FF0000  // GPTM Timer B prescale register 
+                                            // (16-bit mode) 
+#define GPTIMER_TBV_PRE_S       16
+#define GPTIMER_TBV_TBV_M       0x0000FFFF  // GPTM Timer B register 
+#define GPTIMER_TBV_TBV_S       0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the GPTIMER_O_TAPS register.
+//
+//*****************************************************************************
+#define GPTIMER_TAPS_PSS_M      0x0000FFFF  // GPTM Timer A prescaler 
+#define GPTIMER_TAPS_PSS_S      0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the GPTIMER_O_TBPS register.
+//
+//*****************************************************************************
+#define GPTIMER_TBPS_PSS_M      0x0000FFFF  // GPTM Timer B prescaler 
+#define GPTIMER_TBPS_PSS_S      0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the GPTIMER_O_TAPV register.
+//
+//*****************************************************************************
+#define GPTIMER_TAPV_PSV_M      0x0000FFFF  // GPTM Timer A prescaler value 
+#define GPTIMER_TAPV_PSV_S      0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the GPTIMER_O_TBPV register.
+//
+//*****************************************************************************
+#define GPTIMER_TBPV_PSV_M      0x0000FFFF  // GPTM Timer B prescaler value 
+#define GPTIMER_TBPV_PSV_S      0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the GPTIMER_O_PP register.
+//
+//*****************************************************************************
+#define GPTIMER_PP_ALTCLK       0x00000040  // Alternate clock source 0: Timer 
+                                            // is not capable of using an 
+                                            // alternate clock. 1: Timer is 
+                                            // capable of using an alternate 
+                                            // clock. 
+#define GPTIMER_PP_ALTCLK_M     0x00000040
+#define GPTIMER_PP_ALTCLK_S     6
+#define GPTIMER_PP_SYNCNT       0x00000020  // Synchronized start 0: Timer is 
+                                            // not capable of synchronizing the 
+                                            // count value with other timers. 
+                                            // 1: Timer is capable of 
+                                            // synchronizing the count value 
+                                            // with other timers. 
+#define GPTIMER_PP_SYNCNT_M     0x00000020
+#define GPTIMER_PP_SYNCNT_S     5
+#define GPTIMER_PP_CHAIN        0x00000010  // Chain with other timers 0: 
+                                            // Timer is not capable of chaining 
+                                            // with previously numbered Timers. 
+                                            // 1: Timer is capable of chaining 
+                                            // with previously numbered timers. 
+#define GPTIMER_PP_CHAIN_M      0x00000010
+#define GPTIMER_PP_CHAIN_S      4
+#define GPTIMER_PP_SIZE_M       0x0000000F  // Timer size 0: Timer A and Timer 
+                                            // B are 16 bits wide with 8-bit 
+                                            // prescale. 1: Timer A and Timer B 
+                                            // are 32 bits wide with 16-bit 
+                                            // prescale. 
+#define GPTIMER_PP_SIZE_S       0
+
+
+#endif // __HW_GPTIMER_H__
+

--- a/cpu/cc2538/include/vendor/hw_i2cm.h
+++ b/cpu/cc2538/include/vendor/hw_i2cm.h
@@ -1,0 +1,357 @@
+/******************************************************************************
+*  Filename:       hw_i2cm.h
+*  Revised:        $Date: 2013-04-30 17:13:44 +0200 (Tue, 30 Apr 2013) $
+*  Revision:       $Revision: 9943 $
+*
+*  Copyright (C) 2013 Texas Instruments Incorporated - http://www.ti.com/
+*
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*    Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+*
+*    Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+*
+*    Neither the name of Texas Instruments Incorporated nor the names of
+*    its contributors may be used to endorse or promote products derived
+*    from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+*  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+*  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+*  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+*  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+*  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+*  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+*  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+*  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+******************************************************************************/
+
+#ifndef __HW_I2CM_H__
+#define __HW_I2CM_H__
+
+//*****************************************************************************
+//
+// The following are defines for the I2CM register offsets.
+//
+//*****************************************************************************
+#define I2CM_SA                 0x40020000  // I2C master slave address This 
+                                            // register consists of eight bits, 
+                                            // seven address bits (A6-A0), and 
+                                            // a receive and send bit, which 
+                                            // determines if the next operation 
+                                            // is a receive (high) or transmit 
+                                            // (low). 
+#define I2CM_CTRL               0x40020004  // I2C master control and status 
+                                            // This register accesses status 
+                                            // bits when read and control bits 
+                                            // when written. When read, the 
+                                            // status register indicates the 
+                                            // state of the I2C bus controller. 
+                                            // When written, the control 
+                                            // register configures the I2C 
+                                            // controller operation. The START 
+                                            // bit generates the START or 
+                                            // REPEATED START condition. The 
+                                            // STOP bit determines if the cycle 
+                                            // stops at the end of the data 
+                                            // cycle or continues on to a 
+                                            // repeated START condition. To 
+                                            // generate a single transmit 
+                                            // cycle, the I2C master slave 
+                                            // address (I2CMSA) register is 
+                                            // written with the desired 
+                                            // address, the R/S bit is cleared, 
+                                            // and this register is written 
+                                            // with ACK = X (0 or 1), STOP = 1, 
+                                            // START = 1, and RUN = 1 to 
+                                            // perform the operation and stop. 
+                                            // When the operation is completed 
+                                            // (or aborted due an error), an 
+                                            // interrupt becomes active and the 
+                                            // data may be read from the I2CMDR 
+                                            // register. When the I2C module 
+                                            // operates in master receiver 
+                                            // mode, the ACK bit is normally 
+                                            // set, causing the I2C bus 
+                                            // controller to automatically 
+                                            // transmit an acknowledge after 
+                                            // each byte. This bit must be 
+                                            // cleared when the I2C bus 
+                                            // controller requires no further 
+                                            // data to be transmitted from the 
+                                            // slave transmitter. 
+#define I2CM_STAT               0x40020004  // I2C master control and status 
+                                            // This register accesses status 
+                                            // bits when read and control bits 
+                                            // when written. When read, the 
+                                            // status register indicates the 
+                                            // state of the I2C bus controller. 
+                                            // When written, the control 
+                                            // register configures the I2C 
+                                            // controller operation. The START 
+                                            // bit generates the START or 
+                                            // REPEATED START condition. The 
+                                            // STOP bit determines if the cycle 
+                                            // stops at the end of the data 
+                                            // cycle or continues on to a 
+                                            // repeated START condition. To 
+                                            // generate a single transmit 
+                                            // cycle, the I2C master slave 
+                                            // address (I2CMSA) register is 
+                                            // written with the desired 
+                                            // address, the R/S bit is cleared, 
+                                            // and this register is written 
+                                            // with ACK = X (0 or 1), STOP = 1, 
+                                            // START = 1, and RUN = 1 to 
+                                            // perform the operation and stop. 
+                                            // When the operation is completed 
+                                            // (or aborted due an error), an 
+                                            // interrupt becomes active and the 
+                                            // data may be read from the I2CMDR 
+                                            // register. When the I2C module 
+                                            // operates in master receiver 
+                                            // mode, the ACK bit is normally 
+                                            // set, causing the I2C bus 
+                                            // controller to automatically 
+                                            // transmit an acknowledge after 
+                                            // each byte. This bit must be 
+                                            // cleared when the I2C bus 
+                                            // controller requires no further 
+                                            // data to be transmitted from the 
+                                            // slave transmitter. 
+#define I2CM_DR                 0x40020008  // I2C master data This register 
+                                            // contains the data to be 
+                                            // transmitted when in the master 
+                                            // transmit state and the data 
+                                            // received when in the master 
+                                            // receive state. 
+#define I2CM_TPR                0x4002000C  // I2C master timer period This 
+                                            // register specifies the period of 
+                                            // the SCL clock. 
+#define I2CM_IMR                0x40020010  // I2C master interrupt mask This 
+                                            // register controls whether a raw 
+                                            // interrupt is promoted to a 
+                                            // controller interrupt. 
+#define I2CM_RIS                0x40020014  // I2C master raw interrupt status 
+                                            // This register specifies whether 
+                                            // an interrupt is pending. 
+#define I2CM_MIS                0x40020018  // I2C master masked interrupt 
+                                            // status This register specifies 
+                                            // whether an interrupt was 
+                                            // signaled. 
+#define I2CM_ICR                0x4002001C  // I2C master interrupt clear This 
+                                            // register clears the raw and 
+                                            // masked interrupts. 
+#define I2CM_CR                 0x40020020  // I2C master configuration This 
+                                            // register configures the mode 
+                                            // (master or slave) and sets the 
+                                            // interface for test mode 
+                                            // loopback. 
+
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the I2CM_SA register.
+//
+//*****************************************************************************
+#define I2CM_SA_SA_M            0x000000FE  // I2C slave address 
+#define I2CM_SA_SA_S            1
+#define I2CM_SA_RS              0x00000001  // Receive and send The R/S bit 
+                                            // specifies if the next operation 
+                                            // is a receive (high) or transmit 
+                                            // (low). 0: Transmit 1: Receive 
+#define I2CM_SA_RS_M            0x00000001
+#define I2CM_SA_RS_S            0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the I2CM_CTRL register.
+//
+//*****************************************************************************
+#define I2CM_CTRL_ACK           0x00000008  // Data acknowledge enable 0: The 
+                                            // received data byte is not 
+                                            // acknowledged automatically by 
+                                            // the master. 1: The received data 
+                                            // byte is acknowledged 
+                                            // automatically by the master. 
+#define I2CM_CTRL_ACK_M         0x00000008
+#define I2CM_CTRL_ACK_S         3
+#define I2CM_CTRL_STOP          0x00000004  // Generate STOP 0: The controller 
+                                            // does not generate the STOP 
+                                            // condition. 1: The controller 
+                                            // generates the STOP condition. 
+#define I2CM_CTRL_STOP_M        0x00000004
+#define I2CM_CTRL_STOP_S        2
+#define I2CM_CTRL_START         0x00000002  // Generate START 0: The 
+                                            // controller does not generate the 
+                                            // START condition. 1: The 
+                                            // controller generates the START 
+                                            // condition. 
+#define I2CM_CTRL_START_M       0x00000002
+#define I2CM_CTRL_START_S       1
+#define I2CM_CTRL_RUN           0x00000001  // I2C master enable 0: The master 
+                                            // is disabled. 1: The master is 
+                                            // enabled to transmit or receive 
+                                            // data. When the BUSY bit is set, 
+                                            // the other status bits are not 
+                                            // valid. 
+#define I2CM_CTRL_RUN_M         0x00000001
+#define I2CM_CTRL_RUN_S         0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the I2CM_STAT register.
+//
+//*****************************************************************************
+#define I2CM_STAT_BUSBSY        0x00000040  // Bus busy 0: The I2C bus is 
+                                            // idle. 1: The I2C bus is busy. 
+                                            // The bit changes based on the 
+                                            // START and STOP conditions. 
+#define I2CM_STAT_BUSBSY_M      0x00000040
+#define I2CM_STAT_BUSBSY_S      6
+#define I2CM_STAT_IDLE          0x00000020  // I2C idle 0: The I2C controller 
+                                            // is not idle. 1: The I2C 
+                                            // controller is idle. 
+#define I2CM_STAT_IDLE_M        0x00000020
+#define I2CM_STAT_IDLE_S        5
+#define I2CM_STAT_ARBLST        0x00000010  // Arbitration lost 0: The I2C 
+                                            // controller won arbitration. 1: 
+                                            // The I2C controller lost 
+                                            // arbitration. 
+#define I2CM_STAT_ARBLST_M      0x00000010
+#define I2CM_STAT_ARBLST_S      4
+#define I2CM_STAT_DATACK        0x00000008  // Acknowledge data 0: The 
+                                            // transmited data was 
+                                            // acknowledged. 1: The transmited 
+                                            // data was not acknowledged. 
+#define I2CM_STAT_DATACK_M      0x00000008
+#define I2CM_STAT_DATACK_S      3
+#define I2CM_STAT_ADRACK        0x00000004  // Acknowledge address 0: The 
+                                            // transmited address was 
+                                            // acknowledged. 1: The transmited 
+                                            // address was not acknowledged. 
+#define I2CM_STAT_ADRACK_M      0x00000004
+#define I2CM_STAT_ADRACK_S      2
+#define I2CM_STAT_ERROR         0x00000002  // Error 0: No error was detected 
+                                            // on the last operation. 1: An 
+                                            // error occurred on the last 
+                                            // operation. 
+#define I2CM_STAT_ERROR_M       0x00000002
+#define I2CM_STAT_ERROR_S       1
+#define I2CM_STAT_BUSY          0x00000001  // I2C busy 0: The controller is 
+                                            // idle. 1: The controller is busy. 
+                                            // When the BUSY bit is set, the 
+                                            // other status bits are not valid. 
+#define I2CM_STAT_BUSY_M        0x00000001
+#define I2CM_STAT_BUSY_S        0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the I2CM_DR register.
+//
+//*****************************************************************************
+#define I2CM_DR_DATA_M          0x000000FF  // Data transferred Data 
+                                            // transferred during transaction 
+#define I2CM_DR_DATA_S          0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the I2CM_TPR register.
+//
+//*****************************************************************************
+#define I2CM_TPR_TPR_M          0x0000007F  // SCL clock period This field 
+                                            // specifies the period of the SCL 
+                                            // clock. SCL_PRD = 2 * 
+                                            // (1+TPR)*(SCL_LP + 
+                                            // SCL_HP)*CLK_PRD where: SCL_PRD 
+                                            // is the SCL line period (I2C 
+                                            // clock). TPR is the timer period 
+                                            // register value (range of 1 to 
+                                            // 127) SCL_LP is the SCL low 
+                                            // period (fixed at 6). SCL_HP is 
+                                            // the SCL high period (fixed at 
+                                            // 4). CLK_PRD is the system clock 
+                                            // period in ns. 
+#define I2CM_TPR_TPR_S          0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the I2CM_IMR register.
+//
+//*****************************************************************************
+#define I2CM_IMR_IM             0x00000001  // Interrupt mask 1: The master 
+                                            // interrupt is sent to the 
+                                            // interrupt controller when the 
+                                            // RIS bit in the I2CMRIS register 
+                                            // is set. 0: The RIS interrupt is 
+                                            // suppressed and not sent to the 
+                                            // interrupt controller. 
+#define I2CM_IMR_IM_M           0x00000001
+#define I2CM_IMR_IM_S           0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the I2CM_RIS register.
+//
+//*****************************************************************************
+#define I2CM_RIS_RIS            0x00000001  // Raw interrupt status 1: A 
+                                            // master interrupt is pending. 0: 
+                                            // No interrupt This bit is cleared 
+                                            // by writing 1 to the IC bit in 
+                                            // the I2CMICR register. 
+#define I2CM_RIS_RIS_M          0x00000001
+#define I2CM_RIS_RIS_S          0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the I2CM_MIS register.
+//
+//*****************************************************************************
+#define I2CM_MIS_MIS            0x00000001  // Masked interrupt status 1: An 
+                                            // unmasked master interrupt is 
+                                            // pending. 0: An interrupt has not 
+                                            // occurred or is masked. This bit 
+                                            // is cleared by writing 1 to the 
+                                            // IC bit in the I2CMICR register. 
+#define I2CM_MIS_MIS_M          0x00000001
+#define I2CM_MIS_MIS_S          0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the I2CM_ICR register.
+//
+//*****************************************************************************
+#define I2CM_ICR_IC             0x00000001  // Interrupt clear Writing 1 to 
+                                            // this bit clears the RIS bit in 
+                                            // the I2CMRIS register and the MIS 
+                                            // bit in the I2CMMIS register. 
+                                            // Reading this register returns no 
+                                            // meaningful data. 
+#define I2CM_ICR_IC_M           0x00000001
+#define I2CM_ICR_IC_S           0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the I2CM_CR register.
+//
+//*****************************************************************************
+#define I2CM_CR_SFE             0x00000020  // I2C slave function enable 1: 
+                                            // Slave mode is enabled. 0: Slave 
+                                            // mode is disabled. 
+#define I2CM_CR_SFE_M           0x00000020
+#define I2CM_CR_SFE_S           5
+#define I2CM_CR_MFE             0x00000010  // I2C master function enable 1: 
+                                            // Master mode is enabled. 0: 
+                                            // Master mode is disabled. 
+#define I2CM_CR_MFE_M           0x00000010
+#define I2CM_CR_MFE_S           4
+#define I2CM_CR_LPBK            0x00000001  // I2C loopback 1: The controller 
+                                            // in a test mode loopback 
+                                            // configuration. 0: Normal 
+                                            // operation 
+#define I2CM_CR_LPBK_M          0x00000001
+#define I2CM_CR_LPBK_S          0
+
+
+#endif // __HW_I2CM_H__
+

--- a/cpu/cc2538/include/vendor/hw_i2cs.h
+++ b/cpu/cc2538/include/vendor/hw_i2cs.h
@@ -1,0 +1,285 @@
+/******************************************************************************
+*  Filename:       hw_i2cs.h
+*  Revised:        $Date: 2013-04-30 17:13:44 +0200 (Tue, 30 Apr 2013) $
+*  Revision:       $Revision: 9943 $
+*
+*  Copyright (C) 2013 Texas Instruments Incorporated - http://www.ti.com/
+*
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*    Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+*
+*    Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+*
+*    Neither the name of Texas Instruments Incorporated nor the names of
+*    its contributors may be used to endorse or promote products derived
+*    from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+*  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+*  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+*  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+*  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+*  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+*  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+*  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+*  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+******************************************************************************/
+
+#ifndef __HW_I2CS_H__
+#define __HW_I2CS_H__
+
+//*****************************************************************************
+//
+// The following are defines for the I2CS register offsets.
+//
+//*****************************************************************************
+#define I2CS_OAR                0x40020800  // I2C slave own address This 
+                                            // register consists of seven 
+                                            // address bits that identify the 
+                                            // CC2538 I2C device on the I2C 
+                                            // bus. 
+#define I2CS_STAT               0x40020804  // I2C slave control and status 
+                                            // This register functions as a 
+                                            // control register when written, 
+                                            // and a status register when read. 
+#define I2CS_CTRL               0x40020804  // I2C slave control and status 
+                                            // This register functions as a 
+                                            // control register when written, 
+                                            // and a status register when read. 
+#define I2CS_DR                 0x40020808  // I2C slave data This register 
+                                            // contains the data to be 
+                                            // transmitted when in the slave 
+                                            // transmit state, and the data 
+                                            // received when in the slave 
+                                            // receive state. 
+#define I2CS_IMR                0x4002080C  // I2C slave interrupt mask This 
+                                            // register controls whether a raw 
+                                            // interrupt is promoted to a 
+                                            // controller interrupt. 
+#define I2CS_RIS                0x40020810  // I2C slave raw interrupt status 
+                                            // This register specifies whether 
+                                            // an interrupt is pending. 
+#define I2CS_MIS                0x40020814  // I2C slave masked interrupt 
+                                            // status This register specifies 
+                                            // whether an interrupt was 
+                                            // signaled. 
+#define I2CS_ICR                0x40020818  // I2C slave interrupt clear This 
+                                            // register clears the raw 
+                                            // interrupt. A read of this 
+                                            // register returns no meaningful 
+                                            // data. 
+
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the I2CS_OAR register.
+//
+//*****************************************************************************
+#define I2CS_OAR_OAR_M          0x0000007F  // I2C slave own address This 
+                                            // field specifies bits A6 through 
+                                            // A0 of the slave address. 
+#define I2CS_OAR_OAR_S          0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the I2CS_STAT register.
+//
+//*****************************************************************************
+#define I2CS_STAT_FBR           0x00000004  // First byte received 1: The 
+                                            // first byte following the slave's 
+                                            // own address has been received. 
+                                            // 0: The first byte has not been 
+                                            // received. This bit is only valid 
+                                            // when the RREQ bit is set and is 
+                                            // automatically cleared when data 
+                                            // has been read from the I2CSDR 
+                                            // register. Note: This bit is not 
+                                            // used for slave transmit 
+                                            // operations. 
+#define I2CS_STAT_FBR_M         0x00000004
+#define I2CS_STAT_FBR_S         2
+#define I2CS_STAT_TREQ          0x00000002  // Transmit request 1: The I2C 
+                                            // controller has been addressed as 
+                                            // a slave transmitter and is using 
+                                            // clock stretching to delay the 
+                                            // master until data has been 
+                                            // written to the I2CSDR register. 
+                                            // 0: No outstanding transmit 
+                                            // request. 
+#define I2CS_STAT_TREQ_M        0x00000002
+#define I2CS_STAT_TREQ_S        1
+#define I2CS_STAT_RREQ          0x00000001  // Receive request 1: The I2C 
+                                            // controller has outstanding 
+                                            // receive data from the I2C master 
+                                            // and is using clock stretching to 
+                                            // delay the master until data has 
+                                            // been read from the I2CSDR 
+                                            // register. 0: No outstanding 
+                                            // receive data 
+#define I2CS_STAT_RREQ_M        0x00000001
+#define I2CS_STAT_RREQ_S        0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the I2CS_CTRL register.
+//
+//*****************************************************************************
+#define I2CS_CTRL_DA            0x00000001  // Device active 0: Disables the 
+                                            // I2C slave operation 1: Enables 
+                                            // the I2C slave operation 
+#define I2CS_CTRL_DA_M          0x00000001
+#define I2CS_CTRL_DA_S          0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the I2CS_DR register.
+//
+//*****************************************************************************
+#define I2CS_DR_DATA_M          0x000000FF  // Data for transfer This field 
+                                            // contains the data for transfer 
+                                            // during a slave receive or 
+                                            // transmit operation. 
+#define I2CS_DR_DATA_S          0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the I2CS_IMR register.
+//
+//*****************************************************************************
+#define I2CS_IMR_STOPIM         0x00000004  // Stop condition interrupt mask 
+                                            // 1: The STOP condition interrupt 
+                                            // is sent to the interrupt 
+                                            // controller when the STOPRIS bit 
+                                            // in the I2CSRIS register is set. 
+                                            // 0: The STOPRIS interrupt is 
+                                            // supressed and not sent to the 
+                                            // interrupt controller. 
+#define I2CS_IMR_STOPIM_M       0x00000004
+#define I2CS_IMR_STOPIM_S       2
+#define I2CS_IMR_STARTIM        0x00000002  // Start condition interrupt mask 
+                                            // 1: The START condition interrupt 
+                                            // is sent to the interrupt 
+                                            // controller when the STARTRIS bit 
+                                            // in the I2CSRIS register is set. 
+                                            // 0: The STARTRIS interrupt is 
+                                            // supressed and not sent to the 
+                                            // interrupt controller. 
+#define I2CS_IMR_STARTIM_M      0x00000002
+#define I2CS_IMR_STARTIM_S      1
+#define I2CS_IMR_DATAIM         0x00000001  // Data interrupt mask 1: The data 
+                                            // received or data requested 
+                                            // interrupt is sent to the 
+                                            // interrupt controller when the 
+                                            // DATARIS bit in the I2CSRIS 
+                                            // register is set. 0: The DATARIS 
+                                            // interrupt is surpressed and not 
+                                            // sent to the interrupt 
+                                            // controller. 
+#define I2CS_IMR_DATAIM_M       0x00000001
+#define I2CS_IMR_DATAIM_S       0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the I2CS_RIS register.
+//
+//*****************************************************************************
+#define I2CS_RIS_STOPRIS        0x00000004  // Stop condition raw interrupt 
+                                            // status 1: A STOP condition 
+                                            // interrupt is pending. 0: No 
+                                            // interrupt This bit is cleared by 
+                                            // writing 1 to the STOPIC bit in 
+                                            // the I2CSICR register. 
+#define I2CS_RIS_STOPRIS_M      0x00000004
+#define I2CS_RIS_STOPRIS_S      2
+#define I2CS_RIS_STARTRIS       0x00000002  // Start condition raw interrupt 
+                                            // status 1: A START condition 
+                                            // interrupt is pending. 0: No 
+                                            // interrupt This bit is cleared by 
+                                            // writing 1 to the STARTIC bit in 
+                                            // the I2CSICR register. 
+#define I2CS_RIS_STARTRIS_M     0x00000002
+#define I2CS_RIS_STARTRIS_S     1
+#define I2CS_RIS_DATARIS        0x00000001  // Data raw interrupt status 1: A 
+                                            // data received or data requested 
+                                            // interrupt is pending. 0: No 
+                                            // interrupt This bit is cleared by 
+                                            // writing 1 to the DATAIC bit in 
+                                            // the I2CSICR register. 
+#define I2CS_RIS_DATARIS_M      0x00000001
+#define I2CS_RIS_DATARIS_S      0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the I2CS_MIS register.
+//
+//*****************************************************************************
+#define I2CS_MIS_STOPMIS        0x00000004  // Stop condition masked interrupt 
+                                            // status 1: An unmasked STOP 
+                                            // condition interrupt is pending. 
+                                            // 0: An interrupt has not occurred 
+                                            // or is masked. This bit is 
+                                            // cleared by writing 1 to the 
+                                            // STOPIC bit in the I2CSICR 
+                                            // register. 
+#define I2CS_MIS_STOPMIS_M      0x00000004
+#define I2CS_MIS_STOPMIS_S      2
+#define I2CS_MIS_STARTMIS       0x00000002  // Start condition masked 
+                                            // interrupt status 1: An unmasked 
+                                            // START condition interrupt is 
+                                            // pending. 0: An interrupt has not 
+                                            // occurred or is masked. This bit 
+                                            // is cleared by writing 1 to the 
+                                            // STARTIC bit in the I2CSICR 
+                                            // register. 
+#define I2CS_MIS_STARTMIS_M     0x00000002
+#define I2CS_MIS_STARTMIS_S     1
+#define I2CS_MIS_DATAMIS        0x00000001  // Data masked interrupt status 1: 
+                                            // An unmasked data received or 
+                                            // data requested interrupt is 
+                                            // pending. 0: An interrupt has not 
+                                            // occurred or is masked. This bit 
+                                            // is cleared by writing 1 to the 
+                                            // DATAIC bit in the I2CSICR 
+                                            // register. 
+#define I2CS_MIS_DATAMIS_M      0x00000001
+#define I2CS_MIS_DATAMIS_S      0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the I2CS_ICR register.
+//
+//*****************************************************************************
+#define I2CS_ICR_STOPIC         0x00000004  // Stop condition interrupt clear 
+                                            // Writing 1 to this bit clears the 
+                                            // STOPRIS bit in the I2CSRIS 
+                                            // register and the STOPMIS bit in 
+                                            // the I2CSMIS register. A read of 
+                                            // this register returns no 
+                                            // meaningful data. 
+#define I2CS_ICR_STOPIC_M       0x00000004
+#define I2CS_ICR_STOPIC_S       2
+#define I2CS_ICR_STARTIC        0x00000002  // Start condition interrupt vlear 
+                                            // Writing 1 to this bit clears the 
+                                            // STARTRIS bit in the I2CSRIS 
+                                            // register and the STARTMIS bit in 
+                                            // the I2CSMIS register. A read of 
+                                            // this register returns no 
+                                            // meaningful data. 
+#define I2CS_ICR_STARTIC_M      0x00000002
+#define I2CS_ICR_STARTIC_S      1
+#define I2CS_ICR_DATAIC         0x00000001  // Data interrupt clear Writing 1 
+                                            // to this bit clears the DATARIS 
+                                            // bit in the I2CSRIS register and 
+                                            // the DATAMIS bit in the I2CSMIS 
+                                            // register. A read of this 
+                                            // register returns no meaningful 
+                                            // data. 
+#define I2CS_ICR_DATAIC_M       0x00000001
+#define I2CS_ICR_DATAIC_S       0
+
+
+#endif // __HW_I2CS_H__
+

--- a/cpu/cc2538/include/vendor/hw_ints.h
+++ b/cpu/cc2538/include/vendor/hw_ints.h
@@ -1,0 +1,153 @@
+/******************************************************************************
+*  Filename:       hw_ints.h
+*  Revised:        $Date: 2013-04-29 09:49:55 +0200 (Mon, 29 Apr 2013) $
+*  Revision:       $Revision: 9923 $
+*
+*  Description:    Macros that define the interrupt assignment on Stellaris.
+*
+*  Copyright (C) 2013 Texas Instruments Incorporated - http://www.ti.com/
+*
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*    Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+*
+*    Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+*
+*    Neither the name of Texas Instruments Incorporated nor the names of
+*    its contributors may be used to endorse or promote products derived
+*    from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+*  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+*  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+*  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+*  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+*  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+*  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+*  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+*  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+******************************************************************************/
+
+
+#ifndef __HW_INTS_H__
+#define __HW_INTS_H__
+
+// Note: Use the following define if alternate interrupt map is to be used.
+//       This map is smaller. The function IntAltMapEnable() must be called
+//       to enable The alternate map.
+// #define CC2538_USE_ALTERNATE_INTERRUPT_MAP 1
+
+//*****************************************************************************
+//
+// The following are defines for the fault assignments.
+//
+//*****************************************************************************
+#define FAULT_NMI               2           // NMI fault
+#define FAULT_HARD              3           // Hard fault
+#define FAULT_MPU               4           // MPU fault
+#define FAULT_BUS               5           // Bus fault
+#define FAULT_USAGE             6           // Usage fault
+#define FAULT_SVCALL            11          // SVCall
+#define FAULT_DEBUG             12          // Debug monitor
+#define FAULT_PENDSV            14          // PendSV
+#define FAULT_SYSTICK           15          // System Tick
+
+//*****************************************************************************
+//
+// The following are defines for the interrupt assignments.
+//
+//*****************************************************************************
+#define INT_GPIOA               16          // GPIO Port A
+#define INT_GPIOB               17          // GPIO Port B
+#define INT_GPIOC               18          // GPIO Port C
+#define INT_GPIOD               19          // GPIO Port D
+// 20 not in use
+#define INT_UART0               21          // UART0 Rx and Tx
+#define INT_UART1               22          // UART1 Rx and Tx
+#define INT_SSI0                23          // SSI0 Rx and Tx
+#define INT_I2C0                24          // I2C0 Master and Slave
+// 25 - 29 not in use
+#define INT_ADC0                30          // ADC0 Sequence 0
+// 31 - 33 not in use
+#define INT_WATCHDOG            34          // Watchdog timer
+#define INT_WATCHDOG0           34          // Watchdog Timer0
+#define INT_TIMER0A             35          // Timer 0 subtimer A
+#define INT_TIMER0B             36          // Timer 0 subtimer B
+#define INT_TIMER1A             37          // Timer 1 subtimer A
+#define INT_TIMER1B             38          // Timer 1 subtimer B
+#define INT_TIMER2A             39          // Timer 2 subtimer A
+#define INT_TIMER2B             40          // Timer 2 subtimer B
+#define INT_COMP0               41          // Analog Comparator 0
+
+// 42 - 44 only in use for alternate map
+#ifdef CC2538_USE_ALTERNATE_INTERRUPT_MAP
+#define INT_RFCORERTX           42           // RFCORE RX/TX
+#define INT_RFCOREERR           43           // RFCORE Error
+#define INT_ICEPICK             44           // Icepick
+#endif // CC2538_USE_ALTERNATE_INTERRUPT_MAP
+
+#define INT_FLASH               45          // FLASH Control
+
+// 46 - 49 only in use for alternate map
+#ifdef CC2538_USE_ALTERNATE_INTERRUPT_MAP
+#define INT_AES                 46           // AES
+#define INT_PKA                 47           // PKA
+#define INT_SMTIM               48           // SMTimer
+#define INT_MACTIMR             49           // MACTimer
+#endif // CC2538_USE_ALTERNATE_INTERRUPT_MAP
+
+#define INT_SSI1                50          // SSI1 Rx and Tx
+#define INT_TIMER3A             51          // Timer 3 subtimer A
+#define INT_TIMER3B             52          // Timer 3 subtimer B
+// 53 - 59 not in use
+// 60 only in use for alternate map
+#ifdef CC2538_USE_ALTERNATE_INTERRUPT_MAP
+#define INT_USB2538             60           // USB new for 2538
+#endif // CC2538_USE_ALTERNATE_INTERRUPT_MAP
+
+// 61 not in use
+#define INT_UDMA                62          // uDMA controller
+#define INT_UDMAERR             63          // uDMA Error
+
+// 64 - 155 not in use
+// 156-162 only in use in basic map
+#ifndef CC2538_USE_ALTERNATE_INTERRUPT_MAP
+#define INT_USB2538            156          // USB new for 2538
+#define INT_RFCORERTX          157          // RFCORE RX/TX
+#define INT_RFCOREERR          158          // RFCORE Error
+#define INT_AES                159          // AES
+#define INT_PKA                160          // PKA
+#define INT_SMTIM              161          // SMTimer
+#define INT_MACTIMR            162          // MACTimer
+#endif // not CC2538_USE_ALTERNATE_INTERRUPT_MAP
+
+//*****************************************************************************
+//
+// The following are defines for the total number of interrupts.
+//
+//*****************************************************************************
+
+#ifdef CC2538_USE_ALTERNATE_INTERRUPT_MAP
+#define NUM_INTERRUPTS          64
+#else
+#define NUM_INTERRUPTS          163
+#endif // CC2538_USE_ALTERNATE_INTERRUPT_MAP
+
+//*****************************************************************************
+//
+// The following are defines for the total number of priority levels.
+//
+//*****************************************************************************
+#define NUM_PRIORITY            8
+#define NUM_PRIORITY_BITS       3
+
+#endif // __HW_INTS_H__

--- a/cpu/cc2538/include/vendor/hw_ioc.h
+++ b/cpu/cc2538/include/vendor/hw_ioc.h
@@ -1,0 +1,1117 @@
+/******************************************************************************
+*  Filename:       hw_ioc.h
+*  Revised:        $Date: 2013-04-30 17:13:44 +0200 (Tue, 30 Apr 2013) $
+*  Revision:       $Revision: 9943 $
+*
+*  Copyright (C) 2013 Texas Instruments Incorporated - http://www.ti.com/
+*
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*    Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+*
+*    Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+*
+*    Neither the name of Texas Instruments Incorporated nor the names of
+*    its contributors may be used to endorse or promote products derived
+*    from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+*  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+*  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+*  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+*  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+*  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+*  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+*  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+*  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+******************************************************************************/
+
+#ifndef __HW_IOC_H__
+#define __HW_IOC_H__
+
+//*****************************************************************************
+//
+// The following are defines for the IOC register offsets.
+//
+//*****************************************************************************
+#define IOC_PA0_SEL             0x400D4000  // Peripheral select control for 
+                                            // PA0 
+#define IOC_PA1_SEL             0x400D4004  // Peripheral select control for 
+                                            // PA1 
+#define IOC_PA2_SEL             0x400D4008  // Peripheral select control for 
+                                            // PA2 
+#define IOC_PA3_SEL             0x400D400C  // Peripheral select control for 
+                                            // PA3 
+#define IOC_PA4_SEL             0x400D4010  // Peripheral select control for 
+                                            // PA4 
+#define IOC_PA5_SEL             0x400D4014  // Peripheral select control for 
+                                            // PA5 
+#define IOC_PA6_SEL             0x400D4018  // Peripheral select control for 
+                                            // PA6 
+#define IOC_PA7_SEL             0x400D401C  // Peripheral select control for 
+                                            // PA7 
+#define IOC_PB0_SEL             0x400D4020  // Peripheral select control for 
+                                            // PB0 
+#define IOC_PB1_SEL             0x400D4024  // Peripheral select control for 
+                                            // PB1 
+#define IOC_PB2_SEL             0x400D4028  // Peripheral select control for 
+                                            // PB2 
+#define IOC_PB3_SEL             0x400D402C  // Peripheral select control for 
+                                            // PB3 
+#define IOC_PB4_SEL             0x400D4030  // Peripheral select control for 
+                                            // PB4 
+#define IOC_PB5_SEL             0x400D4034  // Peripheral select control for 
+                                            // PB5 
+#define IOC_PB6_SEL             0x400D4038  // Peripheral select control for 
+                                            // PB6 
+#define IOC_PB7_SEL             0x400D403C  // Peripheral select control for 
+                                            // PB7 
+#define IOC_PC0_SEL             0x400D4040  // Peripheral select control for 
+                                            // PC0 
+#define IOC_PC1_SEL             0x400D4044  // Peripheral select control for 
+                                            // PC1 
+#define IOC_PC2_SEL             0x400D4048  // Peripheral select control for 
+                                            // PC2 
+#define IOC_PC3_SEL             0x400D404C  // Peripheral select control for 
+                                            // PC3 
+#define IOC_PC4_SEL             0x400D4050  // Peripheral select control for 
+                                            // PC4 
+#define IOC_PC5_SEL             0x400D4054  // Peripheral select control for 
+                                            // PC5 
+#define IOC_PC6_SEL             0x400D4058  // Peripheral select control for 
+                                            // PC6 
+#define IOC_PC7_SEL             0x400D405C  // Peripheral select control for 
+                                            // PC7 
+#define IOC_PD0_SEL             0x400D4060  // Peripheral select control for 
+                                            // PD0 
+#define IOC_PD1_SEL             0x400D4064  // Peripheral select control for 
+                                            // PD1 
+#define IOC_PD2_SEL             0x400D4068  // Peripheral select control for 
+                                            // PD2 
+#define IOC_PD3_SEL             0x400D406C  // Peripheral select control for 
+                                            // PD3 
+#define IOC_PD4_SEL             0x400D4070  // Peripheral select control for 
+                                            // PD4 
+#define IOC_PD5_SEL             0x400D4074  // Peripheral select control for 
+                                            // PD5 
+#define IOC_PD6_SEL             0x400D4078  // Peripheral select control for 
+                                            // PD6 
+#define IOC_PD7_SEL             0x400D407C  // Peripheral select control for 
+                                            // PD7 
+#define IOC_PA0_OVER            0x400D4080  // This is the overide 
+                                            // configuration register for each 
+                                            // pad. 
+#define IOC_PA1_OVER            0x400D4084  // This is the overide 
+                                            // configuration register for each 
+                                            // pad. 
+#define IOC_PA2_OVER            0x400D4088  // This is the overide 
+                                            // configuration register for each 
+                                            // pad. 
+#define IOC_PA3_OVER            0x400D408C  // This is the overide 
+                                            // configuration register for each 
+                                            // pad. 
+#define IOC_PA4_OVER            0x400D4090  // This is the overide 
+                                            // configuration register for each 
+                                            // pad. 
+#define IOC_PA5_OVER            0x400D4094  // This is the overide 
+                                            // configuration register for each 
+                                            // pad. 
+#define IOC_PA6_OVER            0x400D4098  // This is the overide 
+                                            // configuration register for each 
+                                            // pad. 
+#define IOC_PA7_OVER            0x400D409C  // This is the overide 
+                                            // configuration register for each 
+                                            // pad. 
+#define IOC_PB0_OVER            0x400D40A0  // This is the overide 
+                                            // configuration register for each 
+                                            // pad. 
+#define IOC_PB1_OVER            0x400D40A4  // This is the overide 
+                                            // configuration register for each 
+                                            // pad. 
+#define IOC_PB2_OVER            0x400D40A8  // This is the overide 
+                                            // configuration register for each 
+                                            // pad. 
+#define IOC_PB3_OVER            0x400D40AC  // This is the overide 
+                                            // configuration register for each 
+                                            // pad. 
+#define IOC_PB4_OVER            0x400D40B0  // This is the overide 
+                                            // configuration register for each 
+                                            // pad. 
+#define IOC_PB5_OVER            0x400D40B4  // This is the overide 
+                                            // configuration register for each 
+                                            // pad. 
+#define IOC_PB6_OVER            0x400D40B8  // This is the overide 
+                                            // configuration register for each 
+                                            // pad. 
+#define IOC_PB7_OVER            0x400D40BC  // This is the overide 
+                                            // configuration register for each 
+                                            // pad. 
+#define IOC_PC0_OVER            0x400D40C0  // This is the overide 
+                                            // configuration register for each 
+                                            // pad. PC0 has high drive 
+                                            // capability. 
+#define IOC_PC1_OVER            0x400D40C4  // This is the overide 
+                                            // configuration register for each 
+                                            // pad. PC1 has high drive 
+                                            // capability. 
+#define IOC_PC2_OVER            0x400D40C8  // This is the overide 
+                                            // configuration register for each 
+                                            // pad. PC2 has high drive 
+                                            // capability. 
+#define IOC_PC3_OVER            0x400D40CC  // This is the overide 
+                                            // configuration register for each 
+                                            // pad. PC3 has high drive 
+                                            // capability. 
+#define IOC_PC4_OVER            0x400D40D0  // This is the overide 
+                                            // configuration register for each 
+                                            // pad. 
+#define IOC_PC5_OVER            0x400D40D4  // This is the overide 
+                                            // configuration register for each 
+                                            // pad. 
+#define IOC_PC6_OVER            0x400D40D8  // This is the overide 
+                                            // configuration register for each 
+                                            // pad. 
+#define IOC_PC7_OVER            0x400D40DC  // This is the overide 
+                                            // configuration register for each 
+                                            // pad. 
+#define IOC_PD0_OVER            0x400D40E0  // This is the overide 
+                                            // configuration register for each 
+                                            // pad. 
+#define IOC_PD1_OVER            0x400D40E4  // This is the overide 
+                                            // configuration register for each 
+                                            // pad. 
+#define IOC_PD2_OVER            0x400D40E8  // This is the overide 
+                                            // configuration register for each 
+                                            // pad. 
+#define IOC_PD3_OVER            0x400D40EC  // This is the overide 
+                                            // configuration register for each 
+                                            // pad. 
+#define IOC_PD4_OVER            0x400D40F0  // This is the overide 
+                                            // configuration register for each 
+                                            // pad. 
+#define IOC_PD5_OVER            0x400D40F4  // This is the overide 
+                                            // configuration register for each 
+                                            // pad. 
+#define IOC_PD6_OVER            0x400D40F8  // This is the overide 
+                                            // configuration register for each 
+                                            // pad. 
+#define IOC_PD7_OVER            0x400D40FC  // This is the overide 
+                                            // configuration register for each 
+                                            // pad. 
+#define IOC_UARTRXD_UART0       0x400D4100  // Selects one of the 32 pins on 
+                                            // the four 8-pin I/O-ports (port 
+                                            // A, port B, port C, and port D) 
+                                            // to be the UART0 RX. 
+#define IOC_UARTCTS_UART1       0x400D4104  // Selects one of the 32 pins on 
+                                            // the four 8-pin I/O-ports (port 
+                                            // A, port B, port C, and port D) 
+                                            // to be the UART1 CTS. 
+#define IOC_UARTRXD_UART1       0x400D4108  // Selects one of the 32 pins on 
+                                            // the four 8-pin I/O-ports (port 
+                                            // A, port B, port C, and port D) 
+                                            // to be the UART1 RX. 
+#define IOC_CLK_SSI_SSI0        0x400D410C  // Selects one of the 32 pins on 
+                                            // the four 8-pin I/O-ports (port 
+                                            // A, port B, port C, and port D) 
+                                            // to be the SSI0 CLK. 
+#define IOC_SSIRXD_SSI0         0x400D4110  // Selects one of the 32 pins on 
+                                            // the four 8-pin I/O-ports (port 
+                                            // A, port B, port C, and port D) 
+                                            // to be the SSI0 RX. 
+#define IOC_SSIFSSIN_SSI0       0x400D4114  // Selects one of the 32 pins on 
+                                            // the four 8-pin I/O-ports (port 
+                                            // A, port B, port C, and port D) 
+                                            // to be the SSI0 FSSIN. 
+#define IOC_CLK_SSIIN_SSI0      0x400D4118  // Selects one of the 32 pins on 
+                                            // the four 8-pin I/O-ports (port 
+                                            // A, port B, port C, and port D) 
+                                            // to be the SSI0 CLK_SSIN. 
+#define IOC_CLK_SSI_SSI1        0x400D411C  // Selects one of the 32 pins on 
+                                            // the four 8-pin I/O-ports (port 
+                                            // A, port B, port C, and port D) 
+                                            // to be the SSI1 CLK. 
+#define IOC_SSIRXD_SSI1         0x400D4120  // Selects one of the 32 pins on 
+                                            // the four 8-pin I/O-ports (port 
+                                            // A, port B, port C, and port D) 
+                                            // to be the SSI1 RX. 
+#define IOC_SSIFSSIN_SSI1       0x400D4124  // Selects one of the 32 pins on 
+                                            // the four 8-pin I/O-ports (port 
+                                            // A, port B, port C, and port D) 
+                                            // to be the SSI1 FSSIN. 
+#define IOC_CLK_SSIIN_SSI1      0x400D4128  // Selects one of the 32 pins on 
+                                            // the four 8-pin I/O-ports (port 
+                                            // A, port B, port C, and port D) 
+                                            // to be the SSI1 CLK_SSIN. 
+#define IOC_I2CMSSDA            0x400D412C  // Selects one of the 32 pins on 
+                                            // the four 8-pin I/O-ports (port 
+                                            // A, port B, port C, and port D) 
+                                            // to be the I2C SDA. 
+#define IOC_I2CMSSCL            0x400D4130  // Selects one of the 32 pins on 
+                                            // the four 8-pin I/O-ports (port 
+                                            // A, port B, port C, and port D) 
+                                            // to be the I2C SCL. 
+#define IOC_GPT0OCP1            0x400D4134  // Selects one of the 32 pins on 
+                                            // the four 8-pin I/O-ports (port 
+                                            // A, port B, port C, and port D) 
+                                            // to be the GPT0OCP1. 
+#define IOC_GPT0OCP2            0x400D4138  // Selects one of the 32 pins on 
+                                            // the four 8-pin I/O-ports (port 
+                                            // A, port B, port C, and port D) 
+                                            // to be the GPT0OCP2. 
+#define IOC_GPT1OCP1            0x400D413C  // Selects one of the 32 pins on 
+                                            // the four 8-pin I/O-ports (port 
+                                            // A, port B, port C, and port D) 
+                                            // to be the GPT1OCP1. 
+#define IOC_GPT1OCP2            0x400D4140  // Selects one of the 32 pins on 
+                                            // the four 8-pin I/O-ports (port 
+                                            // A, port B, port C, and port D) 
+                                            // to be the GPT1OCP2. 
+#define IOC_GPT2OCP1            0x400D4144  // Selects one of the 32 pins on 
+                                            // the four 8-pin I/O-ports (port 
+                                            // A, port B, port C, and port D) 
+                                            // to be the GPT2OCP1. 
+#define IOC_GPT2OCP2            0x400D4148  // Selects one of the 32 pins on 
+                                            // the four 8-pin I/O-ports (port 
+                                            // A, port B, port C, and port D) 
+                                            // to be the GPT2OCP2. 
+#define IOC_GPT3OCP1            0x400D414C  // Selects one of the 32 pins on 
+                                            // the four 8-pin I/O-ports (port 
+                                            // A, port B, port C, and port D) 
+                                            // to be the GPT3OCP1. 
+#define IOC_GPT3OCP2            0x400D4150  // Selects one of the 32 pins on 
+                                            // the four 8-pin I/O-ports (port 
+                                            // A, port B, port C, and port D) 
+                                            // to be the GPT3OCP2. 
+
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the IOC_PA0_SEL register.
+//
+//*****************************************************************************
+#define IOC_PA0_SEL_PA0_sel_M   0x0000001F  // Select one peripheral signal 
+                                            // output for PA0. 
+#define IOC_PA0_SEL_PA0_sel_S   0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the IOC_PA1_SEL register.
+//
+//*****************************************************************************
+#define IOC_PA1_SEL_PA1_sel_M   0x0000001F  // Select one peripheral signal 
+                                            // output for PA1. 
+#define IOC_PA1_SEL_PA1_sel_S   0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the IOC_PA2_SEL register.
+//
+//*****************************************************************************
+#define IOC_PA2_SEL_PA2_sel_M   0x0000001F  // Select one peripheral signal 
+                                            // output for PA2. 
+#define IOC_PA2_SEL_PA2_sel_S   0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the IOC_PA3_SEL register.
+//
+//*****************************************************************************
+#define IOC_PA3_SEL_PA3_sel_M   0x0000001F  // Select one peripheral signal 
+                                            // output for PA3. 
+#define IOC_PA3_SEL_PA3_sel_S   0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the IOC_PA4_SEL register.
+//
+//*****************************************************************************
+#define IOC_PA4_SEL_PA4_sel_M   0x0000001F  // Select one peripheral signal 
+                                            // output for PA4. 
+#define IOC_PA4_SEL_PA4_sel_S   0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the IOC_PA5_SEL register.
+//
+//*****************************************************************************
+#define IOC_PA5_SEL_PA5_sel_M   0x0000001F  // Select one peripheral signal 
+                                            // output for PA5. 
+#define IOC_PA5_SEL_PA5_sel_S   0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the IOC_PA6_SEL register.
+//
+//*****************************************************************************
+#define IOC_PA6_SEL_PA6_sel_M   0x0000001F  // Select one peripheral signal 
+                                            // output for PA6. 
+#define IOC_PA6_SEL_PA6_sel_S   0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the IOC_PA7_SEL register.
+//
+//*****************************************************************************
+#define IOC_PA7_SEL_PA7_sel_M   0x0000001F  // Select one peripheral signal 
+                                            // output for PA7. 
+#define IOC_PA7_SEL_PA7_sel_S   0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the IOC_PB0_SEL register.
+//
+//*****************************************************************************
+#define IOC_PB0_SEL_PB0_sel_M   0x0000001F  // Select one peripheral signal 
+                                            // output for PB0. 
+#define IOC_PB0_SEL_PB0_sel_S   0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the IOC_PB1_SEL register.
+//
+//*****************************************************************************
+#define IOC_PB1_SEL_PB1_sel_M   0x0000001F  // Select one peripheral signal 
+                                            // output for PB1. 
+#define IOC_PB1_SEL_PB1_sel_S   0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the IOC_PB2_SEL register.
+//
+//*****************************************************************************
+#define IOC_PB2_SEL_PB2_sel_M   0x0000001F  // Select one peripheral signal 
+                                            // output for PB2. 
+#define IOC_PB2_SEL_PB2_sel_S   0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the IOC_PB3_SEL register.
+//
+//*****************************************************************************
+#define IOC_PB3_SEL_PB3_sel_M   0x0000001F  // Select one peripheral signal 
+                                            // output for PB3. 
+#define IOC_PB3_SEL_PB3_sel_S   0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the IOC_PB4_SEL register.
+//
+//*****************************************************************************
+#define IOC_PB4_SEL_PB4_sel_M   0x0000001F  // Select one peripheral signal 
+                                            // output for PB4. 
+#define IOC_PB4_SEL_PB4_sel_S   0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the IOC_PB5_SEL register.
+//
+//*****************************************************************************
+#define IOC_PB5_SEL_PB5_sel_M   0x0000001F  // Select one peripheral signal 
+                                            // output for PB5. 
+#define IOC_PB5_SEL_PB5_sel_S   0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the IOC_PB6_SEL register.
+//
+//*****************************************************************************
+#define IOC_PB6_SEL_PB6_sel_M   0x0000001F  // Select one peripheral signal 
+                                            // output for PB6. 
+#define IOC_PB6_SEL_PB6_sel_S   0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the IOC_PB7_SEL register.
+//
+//*****************************************************************************
+#define IOC_PB7_SEL_PB7_sel_M   0x0000001F  // Select one peripheral signal 
+                                            // output for PB7. 
+#define IOC_PB7_SEL_PB7_sel_S   0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the IOC_PC0_SEL register.
+//
+//*****************************************************************************
+#define IOC_PC0_SEL_PC0_sel_M   0x0000001F  // Select one peripheral signal 
+                                            // output for PC0. 
+#define IOC_PC0_SEL_PC0_sel_S   0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the IOC_PC1_SEL register.
+//
+//*****************************************************************************
+#define IOC_PC1_SEL_PC1_sel_M   0x0000001F  // Select one peripheral signal 
+                                            // output for PC1. 
+#define IOC_PC1_SEL_PC1_sel_S   0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the IOC_PC2_SEL register.
+//
+//*****************************************************************************
+#define IOC_PC2_SEL_PC2_sel_M   0x0000001F  // Select one peripheral signal 
+                                            // output for PC2. 
+#define IOC_PC2_SEL_PC2_sel_S   0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the IOC_PC3_SEL register.
+//
+//*****************************************************************************
+#define IOC_PC3_SEL_PC3_sel_M   0x0000001F  // Select one peripheral signal 
+                                            // output for PC3. 
+#define IOC_PC3_SEL_PC3_sel_S   0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the IOC_PC4_SEL register.
+//
+//*****************************************************************************
+#define IOC_PC4_SEL_PC4_sel_M   0x0000001F  // Select one peripheral signal 
+                                            // output for PC4. 
+#define IOC_PC4_SEL_PC4_sel_S   0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the IOC_PC5_SEL register.
+//
+//*****************************************************************************
+#define IOC_PC5_SEL_PC5_sel_M   0x0000001F  // Select one peripheral signal 
+                                            // output for PC5. 
+#define IOC_PC5_SEL_PC5_sel_S   0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the IOC_PC6_SEL register.
+//
+//*****************************************************************************
+#define IOC_PC6_SEL_PC6_sel_M   0x0000001F  // Select one peripheral signal 
+                                            // output for PC6. 
+#define IOC_PC6_SEL_PC6_sel_S   0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the IOC_PC7_SEL register.
+//
+//*****************************************************************************
+#define IOC_PC7_SEL_PC7_sel_M   0x0000001F  // Select one peripheral signal 
+                                            // output for PC7. 
+#define IOC_PC7_SEL_PC7_sel_S   0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the IOC_PD0_SEL register.
+//
+//*****************************************************************************
+#define IOC_PD0_SEL_PD0_sel_M   0x0000001F  // Select one peripheral signal 
+                                            // output for PD0. 
+#define IOC_PD0_SEL_PD0_sel_S   0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the IOC_PD1_SEL register.
+//
+//*****************************************************************************
+#define IOC_PD1_SEL_PD1_sel_M   0x0000001F  // Select one peripheral signal 
+                                            // output for PD1. 
+#define IOC_PD1_SEL_PD1_sel_S   0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the IOC_PD2_SEL register.
+//
+//*****************************************************************************
+#define IOC_PD2_SEL_PD2_sel_M   0x0000001F  // Select one peripheral signal 
+                                            // output for PD2. 
+#define IOC_PD2_SEL_PD2_sel_S   0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the IOC_PD3_SEL register.
+//
+//*****************************************************************************
+#define IOC_PD3_SEL_PD3_sel_M   0x0000001F  // Select one peripheral signal 
+                                            // output for PD3. 
+#define IOC_PD3_SEL_PD3_sel_S   0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the IOC_PD4_SEL register.
+//
+//*****************************************************************************
+#define IOC_PD4_SEL_PD4_sel_M   0x0000001F  // Select one peripheral signal 
+                                            // output for PD4. 
+#define IOC_PD4_SEL_PD4_sel_S   0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the IOC_PD5_SEL register.
+//
+//*****************************************************************************
+#define IOC_PD5_SEL_PD5_sel_M   0x0000001F  // Select one peripheral signal 
+                                            // output for PD5. 
+#define IOC_PD5_SEL_PD5_sel_S   0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the IOC_PD6_SEL register.
+//
+//*****************************************************************************
+#define IOC_PD6_SEL_PD6_sel_M   0x0000001F  // Select one peripheral signal 
+                                            // output for PD6. 
+#define IOC_PD6_SEL_PD6_sel_S   0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the IOC_PD7_SEL register.
+//
+//*****************************************************************************
+#define IOC_PD7_SEL_PD7_sel_M   0x0000001F  // Select one peripheral signal 
+                                            // output for PD7. 
+#define IOC_PD7_SEL_PD7_sel_S   0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the IOC_PA0_OVER register.
+//
+//*****************************************************************************
+#define IOC_PA0_OVER_PA0_over_M 0x0000000F  // 0x8: oe - output enable 0x4: 
+                                            // pue - pullup enable 0x2: pde - 
+                                            // pulldown enable 0x1: ana - 
+                                            // analog enable 
+#define IOC_PA0_OVER_PA0_over_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the IOC_PA1_OVER register.
+//
+//*****************************************************************************
+#define IOC_PA1_OVER_PA1_over_M 0x0000000F  // 0x8: oe - output enable 0x4: 
+                                            // pue - pullup enable 0x2: pde - 
+                                            // pulldown enable 0x1: ana - 
+                                            // analog enable 
+#define IOC_PA1_OVER_PA1_over_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the IOC_PA2_OVER register.
+//
+//*****************************************************************************
+#define IOC_PA2_OVER_PA2_over_M 0x0000000F  // 0x8: oe - output enable 0x4: 
+                                            // pue - pullup enable 0x2: pde - 
+                                            // pulldown enable 0x1: ana - 
+                                            // analog enable 
+#define IOC_PA2_OVER_PA2_over_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the IOC_PA3_OVER register.
+//
+//*****************************************************************************
+#define IOC_PA3_OVER_PA3_over_M 0x0000000F  // 0x8: oe - output enable 0x4: 
+                                            // pue - pullup enable 0x2: pde - 
+                                            // pulldown enable 0x1: ana - 
+                                            // analog enable 
+#define IOC_PA3_OVER_PA3_over_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the IOC_PA4_OVER register.
+//
+//*****************************************************************************
+#define IOC_PA4_OVER_PA4_over_M 0x0000000F  // 0x8: oe - output enable 0x4: 
+                                            // pue - pullup enable 0x2: pde - 
+                                            // pulldown enable 0x1: ana - 
+                                            // analog enable 
+#define IOC_PA4_OVER_PA4_over_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the IOC_PA5_OVER register.
+//
+//*****************************************************************************
+#define IOC_PA5_OVER_PA5_over_M 0x0000000F  // 0x8: oe - output enable 0x4: 
+                                            // pue - pullup enable 0x2: pde - 
+                                            // pulldown enable 0x1: ana - 
+                                            // analog enable 
+#define IOC_PA5_OVER_PA5_over_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the IOC_PA6_OVER register.
+//
+//*****************************************************************************
+#define IOC_PA6_OVER_PA6_over_M 0x0000000F  // 0x8: oe - output enable 0x4: 
+                                            // pue - pullup enable 0x2: pde - 
+                                            // pulldown enable 0x1: ana - 
+                                            // analog enable 
+#define IOC_PA6_OVER_PA6_over_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the IOC_PA7_OVER register.
+//
+//*****************************************************************************
+#define IOC_PA7_OVER_PA7_over_M 0x0000000F  // 0x8: oe - output enable 0x4: 
+                                            // pue - pullup enable 0x2: pde - 
+                                            // pulldown enable 0x1: ana - 
+                                            // analog enable 
+#define IOC_PA7_OVER_PA7_over_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the IOC_PB0_OVER register.
+//
+//*****************************************************************************
+#define IOC_PB0_OVER_PB0_over_M 0x0000000F  // 0x8: oe - output enable 0x4: 
+                                            // pue - pullup enable 0x2: pde - 
+                                            // pulldown enable 0x1: ana - 
+                                            // analog enable 
+#define IOC_PB0_OVER_PB0_over_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the IOC_PB1_OVER register.
+//
+//*****************************************************************************
+#define IOC_PB1_OVER_PB1_over_M 0x0000000F  // 0x8: oe - output enable 0x4: 
+                                            // pue - pullup enable 0x2: pde - 
+                                            // pulldown enable 0x1: ana - 
+                                            // analog enable 
+#define IOC_PB1_OVER_PB1_over_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the IOC_PB2_OVER register.
+//
+//*****************************************************************************
+#define IOC_PB2_OVER_PB2_over_M 0x0000000F  // 0x8: oe - output enable 0x4: 
+                                            // pue - pullup enable 0x2: pde - 
+                                            // pulldown enable 0x1: ana - 
+                                            // analog enable 
+#define IOC_PB2_OVER_PB2_over_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the IOC_PB3_OVER register.
+//
+//*****************************************************************************
+#define IOC_PB3_OVER_PB3_over_M 0x0000000F  // 0x8: oe - output enable 0x4: 
+                                            // pue - pullup enable 0x2: pde - 
+                                            // pulldown enable 0x1: ana - 
+                                            // analog enable 
+#define IOC_PB3_OVER_PB3_over_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the IOC_PB4_OVER register.
+//
+//*****************************************************************************
+#define IOC_PB4_OVER_PB4_over_M 0x0000000F  // 0x8: oe - output enable 0x4: 
+                                            // pue - pullup enable 0x2: pde - 
+                                            // pulldown enable 0x1: ana - 
+                                            // analog enable 
+#define IOC_PB4_OVER_PB4_over_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the IOC_PB5_OVER register.
+//
+//*****************************************************************************
+#define IOC_PB5_OVER_PB5_over_M 0x0000000F  // 0x8: oe - output enable 0x4: 
+                                            // pue - pullup enable 0x2: pde - 
+                                            // pulldown enable 0x1: ana - 
+                                            // analog enable 
+#define IOC_PB5_OVER_PB5_over_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the IOC_PB6_OVER register.
+//
+//*****************************************************************************
+#define IOC_PB6_OVER_PB6_over_M 0x0000000F  // 0x8: oe - output enable 0x4: 
+                                            // pue - pullup enable 0x2: pde - 
+                                            // pulldown enable 0x1: ana - 
+                                            // analog enable 
+#define IOC_PB6_OVER_PB6_over_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the IOC_PB7_OVER register.
+//
+//*****************************************************************************
+#define IOC_PB7_OVER_PB7_over_M 0x0000000F  // 0x8: oe - output enable 0x4: 
+                                            // pue - pullup enable 0x2: pde - 
+                                            // pulldown enable 0x1: ana - 
+                                            // analog enable 
+#define IOC_PB7_OVER_PB7_over_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the IOC_PC0_OVER register.
+//
+//*****************************************************************************
+#define IOC_PC0_OVER_PC0_over   0x00000008  // 0: output disable 1: oe - 
+                                            // output enable 
+#define IOC_PC0_OVER_PC0_over_M 0x00000008
+#define IOC_PC0_OVER_PC0_over_S 3
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the IOC_PC1_OVER register.
+//
+//*****************************************************************************
+#define IOC_PC1_OVER_PC1_over   0x00000008  // 0: output disable 1: oe - 
+                                            // output enable 
+#define IOC_PC1_OVER_PC1_over_M 0x00000008
+#define IOC_PC1_OVER_PC1_over_S 3
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the IOC_PC2_OVER register.
+//
+//*****************************************************************************
+#define IOC_PC2_OVER_PC2_over   0x00000008  // 0: output disable 1: oe - 
+                                            // output enable 
+#define IOC_PC2_OVER_PC2_over_M 0x00000008
+#define IOC_PC2_OVER_PC2_over_S 3
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the IOC_PC3_OVER register.
+//
+//*****************************************************************************
+#define IOC_PC3_OVER_PC3_over   0x00000008  // 0: output disable 1: oe - 
+                                            // output enable 
+#define IOC_PC3_OVER_PC3_over_M 0x00000008
+#define IOC_PC3_OVER_PC3_over_S 3
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the IOC_PC4_OVER register.
+//
+//*****************************************************************************
+#define IOC_PC4_OVER_PC4_over_M 0x0000000F  // 0x8: oe - output enable 0x4: 
+                                            // pue - pullup enable 0x2: pde - 
+                                            // pulldown enable 0x1: ana - 
+                                            // analog enable 
+#define IOC_PC4_OVER_PC4_over_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the IOC_PC5_OVER register.
+//
+//*****************************************************************************
+#define IOC_PC5_OVER_PC5_over_M 0x0000000F  // 0x8: oe - output enable 0x4: 
+                                            // pue - pullup enable 0x2: pde - 
+                                            // pulldown enable 0x1: ana - 
+                                            // analog enable 
+#define IOC_PC5_OVER_PC5_over_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the IOC_PC6_OVER register.
+//
+//*****************************************************************************
+#define IOC_PC6_OVER_PC6_over_M 0x0000000F  // 0x8: oe - output enable 0x4: 
+                                            // pue - pullup enable 0x2: pde - 
+                                            // pulldown enable 0x1: ana - 
+                                            // analog enable 
+#define IOC_PC6_OVER_PC6_over_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the IOC_PC7_OVER register.
+//
+//*****************************************************************************
+#define IOC_PC7_OVER_PC7_over_M 0x0000000F  // 0x8: oe - output enable 0x4: 
+                                            // pue - pullup enable 0x2: pde - 
+                                            // pulldown enable 0x1: ana - 
+                                            // analog enable 
+#define IOC_PC7_OVER_PC7_over_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the IOC_PD0_OVER register.
+//
+//*****************************************************************************
+#define IOC_PD0_OVER_PD0_over_M 0x0000000F  // 0x8: oe - output enable 0x4: 
+                                            // pue - pullup enable 0x2: pde - 
+                                            // pulldown enable 0x1: ana - 
+                                            // analog enable 
+#define IOC_PD0_OVER_PD0_over_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the IOC_PD1_OVER register.
+//
+//*****************************************************************************
+#define IOC_PD1_OVER_PD1_over_M 0x0000000F  // 0x8: oe - output enable 0x4: 
+                                            // pue - pullup enable 0x2: pde - 
+                                            // pulldown enable 0x1: ana - 
+                                            // analog enable 
+#define IOC_PD1_OVER_PD1_over_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the IOC_PD2_OVER register.
+//
+//*****************************************************************************
+#define IOC_PD2_OVER_PD2_over_M 0x0000000F  // 0x8: oe - output enable 0x4: 
+                                            // pue - pullup enable 0x2: pde - 
+                                            // pulldown enable 0x1: ana - 
+                                            // analog enable 
+#define IOC_PD2_OVER_PD2_over_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the IOC_PD3_OVER register.
+//
+//*****************************************************************************
+#define IOC_PD3_OVER_PD3_over_M 0x0000000F  // 0x8: oe - output enable 0x4: 
+                                            // pue - pullup enable 0x2: pde - 
+                                            // pulldown enable 0x1: ana - 
+                                            // analog enable 
+#define IOC_PD3_OVER_PD3_over_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the IOC_PD4_OVER register.
+//
+//*****************************************************************************
+#define IOC_PD4_OVER_PD4_over_M 0x0000000F  // 0x8: oe - output enable 0x4: 
+                                            // pue - pullup enable 0x2: pde - 
+                                            // pulldown enable 0x1: ana - 
+                                            // analog enable 
+#define IOC_PD4_OVER_PD4_over_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the IOC_PD5_OVER register.
+//
+//*****************************************************************************
+#define IOC_PD5_OVER_PD5_over_M 0x0000000F  // 0x8: oe - output enable 0x4: 
+                                            // pue - pullup enable 0x2: pde - 
+                                            // pulldown enable 0x1: ana - 
+                                            // analog enable 
+#define IOC_PD5_OVER_PD5_over_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the IOC_PD6_OVER register.
+//
+//*****************************************************************************
+#define IOC_PD6_OVER_PD6_over_M 0x0000000F  // 0x8: oe - output enable 0x4: 
+                                            // pue - pullup enable 0x2: pde - 
+                                            // pulldown enable 0x1: ana - 
+                                            // analog enable 
+#define IOC_PD6_OVER_PD6_over_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the IOC_PD7_OVER register.
+//
+//*****************************************************************************
+#define IOC_PD7_OVER_PD7_over_M 0x0000000F  // 0x8: oe - output enable 0x4: 
+                                            // pue - pullup enable 0x2: pde - 
+                                            // pulldown enable 0x1: ana - 
+                                            // analog enable 
+#define IOC_PD7_OVER_PD7_over_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// IOC_UARTRXD_UART0 register.
+//
+//*****************************************************************************
+#define IOC_UARTRXD_UART0_INPUT_SEL_M \
+                                0x0000001F  // 0: PA0 selected as UART0 RX 1: 
+                                            // PA1 selected as UART0 RX ... 31: 
+                                            // PD7 selected as UART0 RX 
+
+#define IOC_UARTRXD_UART0_INPUT_SEL_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// IOC_UARTCTS_UART1 register.
+//
+//*****************************************************************************
+#define IOC_UARTCTS_UART1_INPUT_SEL_M \
+                                0x0000001F  // 0: PA0 selected as UART1 CTS 1: 
+                                            // PA1 selected as UART1 CTS ... 
+                                            // 31: PD7 selected as UART1 CTS 
+
+#define IOC_UARTCTS_UART1_INPUT_SEL_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// IOC_UARTRXD_UART1 register.
+//
+//*****************************************************************************
+#define IOC_UARTRXD_UART1_INPUT_SEL_M \
+                                0x0000001F  // 0: PA0 selected as UART1 RX 1: 
+                                            // PA1 selected as UART1 RX ... 31: 
+                                            // PD7 selected as UART1 RX 
+
+#define IOC_UARTRXD_UART1_INPUT_SEL_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// IOC_CLK_SSI_SSI0 register.
+//
+//*****************************************************************************
+#define IOC_CLK_SSI_SSI0_INPUT_SEL_M \
+                                0x0000001F  // 0: PA0 selected as SSI0 CLK 1: 
+                                            // PA1 selected as SSI0 CLK ... 31: 
+                                            // PD7 selected as SSI0 CLK 
+
+#define IOC_CLK_SSI_SSI0_INPUT_SEL_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// IOC_SSIRXD_SSI0 register.
+//
+//*****************************************************************************
+#define IOC_SSIRXD_SSI0_INPUT_SEL_M \
+                                0x0000001F  // 0: PA0 selected as SSI0 RX 1: 
+                                            // PA1 selected as SSI0 RX ... 31: 
+                                            // PD7 selected as SSI0 RX 
+
+#define IOC_SSIRXD_SSI0_INPUT_SEL_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// IOC_SSIFSSIN_SSI0 register.
+//
+//*****************************************************************************
+#define IOC_SSIFSSIN_SSI0_INPUT_SEL_M \
+                                0x0000001F  // 0: PA0 selected as SSI0 FSSIN 
+                                            // 1: PA1 selected as SSI0 FSSIN 
+                                            // ... 31: PD7 selected as SSI0 
+                                            // FSSIN 
+
+#define IOC_SSIFSSIN_SSI0_INPUT_SEL_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// IOC_CLK_SSIIN_SSI0 register.
+//
+//*****************************************************************************
+#define IOC_CLK_SSIIN_SSI0_INPUT_SEL_M \
+                                0x0000001F  // 0: PA0 selected as SSI0 
+                                            // CLK_SSIN 1: PA1 selected as SSI0 
+                                            // CLK_SSIN ... 31: PD7 selected as 
+                                            // SSI0 CLK_SSIN 
+
+#define IOC_CLK_SSIIN_SSI0_INPUT_SEL_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// IOC_CLK_SSI_SSI1 register.
+//
+//*****************************************************************************
+#define IOC_CLK_SSI_SSI1_INPUT_SEL_M \
+                                0x0000001F  // 0: PA0 selected as SSI1 CLK 1: 
+                                            // PA1 selected as SSI1 CLK ... 31: 
+                                            // PD7 selected as SSI1 CLK 
+
+#define IOC_CLK_SSI_SSI1_INPUT_SEL_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// IOC_SSIRXD_SSI1 register.
+//
+//*****************************************************************************
+#define IOC_SSIRXD_SSI1_INPUT_SEL_M \
+                                0x0000001F  // 0: PA0 selected as SSI1 RX 1: 
+                                            // PA1 selected as SSI1 RX ... 31: 
+                                            // PD7 selected as SSI1 RX 
+
+#define IOC_SSIRXD_SSI1_INPUT_SEL_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// IOC_SSIFSSIN_SSI1 register.
+//
+//*****************************************************************************
+#define IOC_SSIFSSIN_SSI1_INPUT_SEL_M \
+                                0x0000001F  // 0: PA0 selected as SSI1 FSSIN 
+                                            // 1: PA1 selected as SSI1 FSSIN 
+                                            // ... 31: PD7 selected as SSI1 
+                                            // FSSIN 
+
+#define IOC_SSIFSSIN_SSI1_INPUT_SEL_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// IOC_CLK_SSIIN_SSI1 register.
+//
+//*****************************************************************************
+#define IOC_CLK_SSIIN_SSI1_INPUT_SEL_M \
+                                0x0000001F  // 0: PA0 selected as SSI1 
+                                            // CLK_SSIN 1: PA1 selected as SSI1 
+                                            // CLK_SSIN ... 31: PD7 selected as 
+                                            // SSI1 CLK_SSIN 
+
+#define IOC_CLK_SSIIN_SSI1_INPUT_SEL_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the IOC_I2CMSSDA register.
+//
+//*****************************************************************************
+#define IOC_I2CMSSDA_INPUT_SEL_M \
+                                0x0000001F  // 0: PA0 selected as I2C SDA 1: 
+                                            // PA1 selected as I2C SDA ... 31: 
+                                            // PD7 selected as I2C SDA 
+
+#define IOC_I2CMSSDA_INPUT_SEL_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the IOC_I2CMSSCL register.
+//
+//*****************************************************************************
+#define IOC_I2CMSSCL_INPUT_SEL_M \
+                                0x0000001F  // 0: PA0 selected as I2C SCL 1: 
+                                            // PA1 selected as I2C SCL ... 31: 
+                                            // PD7 selected as I2C SCL 
+
+#define IOC_I2CMSSCL_INPUT_SEL_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the IOC_GPT0OCP1 register.
+//
+//*****************************************************************************
+#define IOC_GPT0OCP1_INPUT_SEL_M \
+                                0x0000001F  // 0: PA0 selected as GPT0OCP1 1: 
+                                            // PA1 selected as GPT0OCP1 ... 31: 
+                                            // PD7 selected as GPT0OCP1 
+
+#define IOC_GPT0OCP1_INPUT_SEL_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the IOC_GPT0OCP2 register.
+//
+//*****************************************************************************
+#define IOC_GPT0OCP2_INPUT_SEL_M \
+                                0x0000001F  // 0: PA0 selected as GPT0OCP2 1: 
+                                            // PA1 selected as GPT0OCP2 ... 31: 
+                                            // PD7 selected as GPT0OCP2 
+
+#define IOC_GPT0OCP2_INPUT_SEL_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the IOC_GPT1OCP1 register.
+//
+//*****************************************************************************
+#define IOC_GPT1OCP1_INPUT_SEL_M \
+                                0x0000001F  // 0: PA0 selected as GPT1OCP1 1: 
+                                            // PA1 selected as GPT1OCP1 ... 31: 
+                                            // PD7 selected as GPT1OCP1 
+
+#define IOC_GPT1OCP1_INPUT_SEL_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the IOC_GPT1OCP2 register.
+//
+//*****************************************************************************
+#define IOC_GPT1OCP2_INPUT_SEL_M \
+                                0x0000001F  // 0: PA0 selected as GPT1OCP2 1: 
+                                            // PA1 selected as GPT1OCP2 ... 31: 
+                                            // PD7 selected as GPT1OCP2 
+
+#define IOC_GPT1OCP2_INPUT_SEL_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the IOC_GPT2OCP1 register.
+//
+//*****************************************************************************
+#define IOC_GPT2OCP1_INPUT_SEL_M \
+                                0x0000001F  // 0: PA0 selected as GPT2OCP1 1: 
+                                            // PA1 selected as GPT2OCP1 ... 31: 
+                                            // PD7 selected as GPT2OCP1 
+
+#define IOC_GPT2OCP1_INPUT_SEL_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the IOC_GPT2OCP2 register.
+//
+//*****************************************************************************
+#define IOC_GPT2OCP2_INPUT_SEL_M \
+                                0x0000001F  // 0: PA0 selected as GPT2OCP2 1: 
+                                            // PA1 selected as GPT2OCP2 ... 31: 
+                                            // PD7 selected as GPT2OCP2 
+
+#define IOC_GPT2OCP2_INPUT_SEL_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the IOC_GPT3OCP1 register.
+//
+//*****************************************************************************
+#define IOC_GPT3OCP1_INPUT_SEL_M \
+                                0x0000001F  // 0: PA0 selected as GPT3OCP1 1: 
+                                            // PA1 selected as GPT3OCP1 ... 31: 
+                                            // PD7 selected as GPT3OCP1 
+
+#define IOC_GPT3OCP1_INPUT_SEL_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the IOC_GPT3OCP2 register.
+//
+//*****************************************************************************
+#define IOC_GPT3OCP2_INPUT_SEL_M \
+                                0x0000001F  // 0: PA0 selected as GPT3OCP2 1: 
+                                            // PA1 selected as GPT3OCP2 ... 31: 
+                                            // PD7 selected as GPT3OCP2 
+
+#define IOC_GPT3OCP2_INPUT_SEL_S 0
+
+
+#endif // __HW_IOC_H__
+

--- a/cpu/cc2538/include/vendor/hw_memmap.h
+++ b/cpu/cc2538/include/vendor/hw_memmap.h
@@ -1,0 +1,85 @@
+/******************************************************************************
+*  Filename:       hw_memmap.h
+*  Revised:        $Date: 2013-04-12 15:10:54 +0200 (Fri, 12 Apr 2013) $
+*  Revision:       $Revision: 9735 $
+*
+*  Copyright (C) 2013 Texas Instruments Incorporated - http://www.ti.com/
+*
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*    Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+*
+*    Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+*
+*    Neither the name of Texas Instruments Incorporated nor the names of
+*    its contributors may be used to endorse or promote products derived
+*    from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+*  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+*  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+*  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+*  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+*  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+*  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+*  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+*  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+******************************************************************************/
+
+#ifndef __HW_MEMMAP_H__
+#define __HW_MEMMAP_H__
+
+//*****************************************************************************
+//
+// The following are defines for the base address of the memories and
+// peripherals on the top_s interface.
+//
+//*****************************************************************************
+#define ROM_BASE                0x00000000  // ROM 
+#define FLASH_BASE              0x00200000  // Flash 
+#define SRAM_BASE               0x20000000  // SRAM 
+#define SRAM_LL_BASE            0x20004000  // SRAM_LL 
+#define SSI0_BASE               0x40008000  // SSI 
+#define SSI1_BASE               0x40009000  // SSI 
+#define UART0_BASE              0x4000C000  // UART 
+#define UART1_BASE              0x4000D000  // UART 
+#define I2C_M0_BASE             0x40020000  // I2CM 
+#define I2C_S0_BASE             0x40020800  // I2CS 
+#define GPTIMER0_BASE           0x40030000  // GPTIMER 
+#define GPTIMER1_BASE           0x40031000  // GPTIMER 
+#define GPTIMER2_BASE           0x40032000  // GPTIMER 
+#define GPTIMER3_BASE           0x40033000  // GPTIMER 
+#define RFCORE_RAM_BASE         0x40088000  // SRAM_RFCORE 
+#define FRMF_SRCM_RAM_BASE      0x40088400  // SRAM_FRMF_SRCM 
+#define RFCORE_FFSM_BASE        0x40088500  // RFCORE_FFSM 
+#define RFCORE_XREG_BASE        0x40088600  // RFCORE_XREG 
+#define RFCORE_SFR_BASE         0x40088800  // RFCORE_SFR 
+#define USB_BASE                0x40089000  // USB 
+#define AES_BASE                0x4008B000  // AES 
+#define SYS_CTRL_BASE           0x400D2000  // SYS_CTRL 
+#define FLASH_CTRL_BASE         0x400D3000  // FLASH_CTRL 
+#define IOC_BASE                0x400D4000  // IOC 
+#define SMWDTHROSC_BASE         0x400D5000  // SMWDTHROSC 
+#define ANA_REGS_BASE           0x400D6000  // ANA_REGS 
+#define SOC_ADC_BASE            0x400D7000  // SOC_ADC 
+#define GPIO_A_BASE             0x400D9000  // GPIO 
+#define GPIO_B_BASE             0x400DA000  // GPIO 
+#define GPIO_C_BASE             0x400DB000  // GPIO 
+#define GPIO_D_BASE             0x400DC000  // GPIO 
+#define uDMA_BASE               0x400FF000  // UDMA 
+#define ST_TESTCTRL_BASE        0x40110000  // STTEST 
+#define PKA_BASE                0x44004000  // PKA 
+#define PKA_RAM_BASE            0x44006000  // SRAM_PKA 
+#define CC_TESTCTRL_BASE        0x44010000  // CCTEST 
+
+#endif // __HW_MEMMAP_H__
+

--- a/cpu/cc2538/include/vendor/hw_nvic.h
+++ b/cpu/cc2538/include/vendor/hw_nvic.h
@@ -1,0 +1,1767 @@
+/******************************************************************************
+*  Filename:       hw_nvic.h
+*  Revised:        $Date: 2013-04-29 09:49:55 +0200 (Mon, 29 Apr 2013) $
+*  Revision:       $Revision: 9923 $
+*
+*  Description:    Macros used when accessing the NVIC hardware.
+*
+*
+*  Copyright (C) 2013 Texas Instruments Incorporated - http://www.ti.com/
+*
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*    Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+*
+*    Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+*
+*    Neither the name of Texas Instruments Incorporated nor the names of
+*    its contributors may be used to endorse or promote products derived
+*    from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+*  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+*  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+*  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+*  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+*  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+*  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+*  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+*  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+******************************************************************************/
+
+#ifndef __HW_NVIC_H__
+#define __HW_NVIC_H__
+
+//*****************************************************************************
+//
+// The following are defines for the NVIC register addresses.
+//
+//*****************************************************************************
+#define NVIC_INT_TYPE           0xE000E004  // Interrupt Controller Type Reg
+#define NVIC_ACTLR              0xE000E008  // Auxiliary Control
+#define NVIC_ST_CTRL            0xE000E010  // SysTick Control and Status
+                                            // Register
+#define NVIC_ST_RELOAD          0xE000E014  // SysTick Reload Value Register
+#define NVIC_ST_CURRENT         0xE000E018  // SysTick Current Value Register
+#define NVIC_ST_CAL             0xE000E01C  // SysTick Calibration Value Reg
+#define NVIC_EN0                0xE000E100  // Interrupt 0-31 Set Enable
+#define NVIC_EN1                0xE000E104  // Interrupt 32-54 Set Enable
+#define NVIC_EN2                0xE000E108  // Interrupt 64-95 Set Enable
+#define NVIC_EN3                0xE000E10C  // Interrupt 96-127 Set Enable
+#define NVIC_EN4                0xE000E110  // Interrupt 128-131 Set Enable
+#define NVIC_DIS0               0xE000E180  // Interrupt 0-31 Clear Enable
+#define NVIC_DIS1               0xE000E184  // Interrupt 32-54 Clear Enable
+#define NVIC_DIS2               0xE000E188  // Interrupt 64-95 Clear Enable
+#define NVIC_DIS3               0xE000E18C  // Interrupt 96-127 Clear Enable
+#define NVIC_DIS4               0xE000E190  // Interrupt 128-131 Clear Enable
+#define NVIC_PEND0              0xE000E200  // Interrupt 0-31 Set Pending
+#define NVIC_PEND1              0xE000E204  // Interrupt 32-54 Set Pending
+#define NVIC_PEND2              0xE000E208  // Interrupt 64-95 Set Pending
+#define NVIC_PEND3              0xE000E20C  // Interrupt 96-127 Set Pending
+#define NVIC_PEND4              0xE000E210  // Interrupt 128-131 Set Pending
+#define NVIC_UNPEND0            0xE000E280  // Interrupt 0-31 Clear Pending
+#define NVIC_UNPEND1            0xE000E284  // Interrupt 32-54 Clear Pending
+#define NVIC_UNPEND2            0xE000E288  // Interrupt 64-95 Clear Pending
+#define NVIC_UNPEND3            0xE000E28C  // Interrupt 96-127 Clear Pending
+#define NVIC_UNPEND4            0xE000E290  // Interrupt 128-131 Clear Pending
+#define NVIC_ACTIVE0            0xE000E300  // Interrupt 0-31 Active Bit
+#define NVIC_ACTIVE1            0xE000E304  // Interrupt 32-54 Active Bit
+#define NVIC_ACTIVE2            0xE000E308  // Interrupt 64-95 Active Bit
+#define NVIC_ACTIVE3            0xE000E30C  // Interrupt 96-127 Active Bit
+#define NVIC_ACTIVE4            0xE000E310  // Interrupt 128-131 Active Bit
+#define NVIC_PRI0               0xE000E400  // Interrupt 0-3 Priority
+#define NVIC_PRI1               0xE000E404  // Interrupt 4-7 Priority
+#define NVIC_PRI2               0xE000E408  // Interrupt 8-11 Priority
+#define NVIC_PRI3               0xE000E40C  // Interrupt 12-15 Priority
+#define NVIC_PRI4               0xE000E410  // Interrupt 16-19 Priority
+#define NVIC_PRI5               0xE000E414  // Interrupt 20-23 Priority
+#define NVIC_PRI6               0xE000E418  // Interrupt 24-27 Priority
+#define NVIC_PRI7               0xE000E41C  // Interrupt 28-31 Priority
+#define NVIC_PRI8               0xE000E420  // Interrupt 32-35 Priority
+#define NVIC_PRI9               0xE000E424  // Interrupt 36-39 Priority
+#define NVIC_PRI10              0xE000E428  // Interrupt 40-43 Priority
+#define NVIC_PRI11              0xE000E42C  // Interrupt 44-47 Priority
+#define NVIC_PRI12              0xE000E430  // Interrupt 48-51 Priority
+#define NVIC_PRI13              0xE000E434  // Interrupt 52-53 Priority
+#define NVIC_PRI14              0xE000E438  // Interrupt 56-59 Priority
+#define NVIC_PRI15              0xE000E43C  // Interrupt 60-63 Priority
+#define NVIC_PRI16              0xE000E440  // Interrupt 64-67 Priority
+#define NVIC_PRI17              0xE000E444  // Interrupt 68-71 Priority
+#define NVIC_PRI18              0xE000E448  // Interrupt 72-75 Priority
+#define NVIC_PRI19              0xE000E44C  // Interrupt 76-79 Priority
+#define NVIC_PRI20              0xE000E450  // Interrupt 80-83 Priority
+#define NVIC_PRI21              0xE000E454  // Interrupt 84-87 Priority
+#define NVIC_PRI22              0xE000E458  // Interrupt 88-91 Priority
+#define NVIC_PRI23              0xE000E45C  // Interrupt 92-95 Priority
+#define NVIC_PRI24              0xE000E460  // Interrupt 96-99 Priority
+#define NVIC_PRI25              0xE000E464  // Interrupt 100-103 Priority
+#define NVIC_PRI26              0xE000E468  // Interrupt 104-107 Priority
+#define NVIC_PRI27              0xE000E46C  // Interrupt 108-111 Priority
+#define NVIC_PRI28              0xE000E470  // Interrupt 112-115 Priority
+#define NVIC_PRI29              0xE000E474  // Interrupt 116-119 Priority
+#define NVIC_PRI30              0xE000E478  // Interrupt 120-123 Priority
+#define NVIC_PRI31              0xE000E47C  // Interrupt 124-127 Priority
+#define NVIC_PRI32              0xE000E480  // Interrupt 128-131 Priority
+#define NVIC_PRI33              0xE000E484  // Interrupt 132-135 Priority
+#define NVIC_PRI34              0xE000E488  // Interrupt 136-139 Priority
+#define NVIC_PRI35              0xE000E48C  // Interrupt 140-143 Priority
+#define NVIC_PRI36              0xE000E490  // Interrupt 144-147 Priority
+#define NVIC_CPUID              0xE000ED00  // CPU ID Base
+#define NVIC_INT_CTRL           0xE000ED04  // Interrupt Control and State
+#define NVIC_VTABLE             0xE000ED08  // Vector Table Offset
+#define NVIC_APINT              0xE000ED0C  // Application Interrupt and Reset
+                                            // Control
+#define NVIC_SYS_CTRL           0xE000ED10  // System Control
+#define NVIC_CFG_CTRL           0xE000ED14  // Configuration and Control
+#define NVIC_SYS_PRI1           0xE000ED18  // System Handler Priority 1
+#define NVIC_SYS_PRI2           0xE000ED1C  // System Handler Priority 2
+#define NVIC_SYS_PRI3           0xE000ED20  // System Handler Priority 3
+#define NVIC_SYS_HND_CTRL       0xE000ED24  // System Handler Control and State
+#define NVIC_FAULT_STAT         0xE000ED28  // Configurable Fault Status
+#define NVIC_HFAULT_STAT        0xE000ED2C  // Hard Fault Status
+#define NVIC_DEBUG_STAT         0xE000ED30  // Debug Status Register
+#define NVIC_MM_ADDR            0xE000ED34  // Memory Management Fault Address
+#define NVIC_FAULT_ADDR         0xE000ED38  // Bus Fault Address
+#define NVIC_MPU_TYPE           0xE000ED90  // MPU Type
+#define NVIC_MPU_CTRL           0xE000ED94  // MPU Control
+#define NVIC_MPU_NUMBER         0xE000ED98  // MPU Region Number
+#define NVIC_MPU_BASE           0xE000ED9C  // MPU Region Base Address
+#define NVIC_MPU_ATTR           0xE000EDA0  // MPU Region Attribute and Size
+#define NVIC_MPU_BASE1          0xE000EDA4  // MPU Region Base Address Alias 1
+#define NVIC_MPU_ATTR1          0xE000EDA8  // MPU Region Attribute and Size
+                                            // Alias 1
+#define NVIC_MPU_BASE2          0xE000EDAC  // MPU Region Base Address Alias 2
+#define NVIC_MPU_ATTR2          0xE000EDB0  // MPU Region Attribute and Size
+                                            // Alias 2
+#define NVIC_MPU_BASE3          0xE000EDB4  // MPU Region Base Address Alias 3
+#define NVIC_MPU_ATTR3          0xE000EDB8  // MPU Region Attribute and Size
+                                            // Alias 3
+#define NVIC_DBG_CTRL           0xE000EDF0  // Debug Control and Status Reg
+#define NVIC_DBG_XFER           0xE000EDF4  // Debug Core Reg. Transfer Select
+#define NVIC_DBG_DATA           0xE000EDF8  // Debug Core Register Data
+#define NVIC_DBG_INT            0xE000EDFC  // Debug Reset Interrupt Control
+#define NVIC_SW_TRIG            0xE000EF00  // Software Trigger Interrupt
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_INT_TYPE register.
+//
+//*****************************************************************************
+#define NVIC_INT_TYPE_LINES_M   0x0000001F  // Number of interrupt lines (x32)
+#define NVIC_INT_TYPE_LINES_S   0
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_ACTLR register.
+//
+//*****************************************************************************
+#define NVIC_ACTLR_DISFOLD      0x00000004  // Disable IT Folding
+#define NVIC_ACTLR_DISWBUF      0x00000002  // Disable Write Buffer
+#define NVIC_ACTLR_DISMCYC      0x00000001  // Disable Interrupts of Multiple
+                                            // Cycle Instructions
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_ST_CTRL register.
+//
+//*****************************************************************************
+#define NVIC_ST_CTRL_COUNT      0x00010000  // Count Flag
+#define NVIC_ST_CTRL_CLK_SRC    0x00000004  // Clock Source
+#define NVIC_ST_CTRL_INTEN      0x00000002  // Interrupt Enable
+#define NVIC_ST_CTRL_ENABLE     0x00000001  // Enable
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_ST_RELOAD register.
+//
+//*****************************************************************************
+#define NVIC_ST_RELOAD_M        0x00FFFFFF  // Reload Value
+#define NVIC_ST_RELOAD_S        0
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_ST_CURRENT
+// register.
+//
+//*****************************************************************************
+#define NVIC_ST_CURRENT_M       0x00FFFFFF  // Current Value
+#define NVIC_ST_CURRENT_S       0
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_ST_CAL register.
+//
+//*****************************************************************************
+#define NVIC_ST_CAL_NOREF       0x80000000  // No reference clock
+#define NVIC_ST_CAL_SKEW        0x40000000  // Clock skew
+#define NVIC_ST_CAL_ONEMS_M     0x00FFFFFF  // 1ms reference value
+#define NVIC_ST_CAL_ONEMS_S     0
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_EN0 register.
+//
+//*****************************************************************************
+#define NVIC_EN0_INT_M          0xFFFFFFFF  // Interrupt Enable
+#define NVIC_EN0_INT0           0x00000001  // Interrupt 0 enable
+#define NVIC_EN0_INT1           0x00000002  // Interrupt 1 enable
+#define NVIC_EN0_INT2           0x00000004  // Interrupt 2 enable
+#define NVIC_EN0_INT3           0x00000008  // Interrupt 3 enable
+#define NVIC_EN0_INT4           0x00000010  // Interrupt 4 enable
+#define NVIC_EN0_INT5           0x00000020  // Interrupt 5 enable
+#define NVIC_EN0_INT6           0x00000040  // Interrupt 6 enable
+#define NVIC_EN0_INT7           0x00000080  // Interrupt 7 enable
+#define NVIC_EN0_INT8           0x00000100  // Interrupt 8 enable
+#define NVIC_EN0_INT9           0x00000200  // Interrupt 9 enable
+#define NVIC_EN0_INT10          0x00000400  // Interrupt 10 enable
+#define NVIC_EN0_INT11          0x00000800  // Interrupt 11 enable
+#define NVIC_EN0_INT12          0x00001000  // Interrupt 12 enable
+#define NVIC_EN0_INT13          0x00002000  // Interrupt 13 enable
+#define NVIC_EN0_INT14          0x00004000  // Interrupt 14 enable
+#define NVIC_EN0_INT15          0x00008000  // Interrupt 15 enable
+#define NVIC_EN0_INT16          0x00010000  // Interrupt 16 enable
+#define NVIC_EN0_INT17          0x00020000  // Interrupt 17 enable
+#define NVIC_EN0_INT18          0x00040000  // Interrupt 18 enable
+#define NVIC_EN0_INT19          0x00080000  // Interrupt 19 enable
+#define NVIC_EN0_INT20          0x00100000  // Interrupt 20 enable
+#define NVIC_EN0_INT21          0x00200000  // Interrupt 21 enable
+#define NVIC_EN0_INT22          0x00400000  // Interrupt 22 enable
+#define NVIC_EN0_INT23          0x00800000  // Interrupt 23 enable
+#define NVIC_EN0_INT24          0x01000000  // Interrupt 24 enable
+#define NVIC_EN0_INT25          0x02000000  // Interrupt 25 enable
+#define NVIC_EN0_INT26          0x04000000  // Interrupt 26 enable
+#define NVIC_EN0_INT27          0x08000000  // Interrupt 27 enable
+#define NVIC_EN0_INT28          0x10000000  // Interrupt 28 enable
+#define NVIC_EN0_INT29          0x20000000  // Interrupt 29 enable
+#define NVIC_EN0_INT30          0x40000000  // Interrupt 30 enable
+#define NVIC_EN0_INT31          0x80000000  // Interrupt 31 enable
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_EN1 register.
+//
+//*****************************************************************************
+#define NVIC_EN1_INT_M          0xFFFFFFFF  // Interrupt Enable
+#define NVIC_EN1_INT32          0x00000001  // Interrupt 32 enable
+#define NVIC_EN1_INT33          0x00000002  // Interrupt 33 enable
+#define NVIC_EN1_INT34          0x00000004  // Interrupt 34 enable
+#define NVIC_EN1_INT35          0x00000008  // Interrupt 35 enable
+#define NVIC_EN1_INT36          0x00000010  // Interrupt 36 enable
+#define NVIC_EN1_INT37          0x00000020  // Interrupt 37 enable
+#define NVIC_EN1_INT38          0x00000040  // Interrupt 38 enable
+#define NVIC_EN1_INT39          0x00000080  // Interrupt 39 enable
+#define NVIC_EN1_INT40          0x00000100  // Interrupt 40 enable
+#define NVIC_EN1_INT41          0x00000200  // Interrupt 41 enable
+#define NVIC_EN1_INT42          0x00000400  // Interrupt 42 enable
+#define NVIC_EN1_INT43          0x00000800  // Interrupt 43 enable
+#define NVIC_EN1_INT44          0x00001000  // Interrupt 44 enable
+#define NVIC_EN1_INT45          0x00002000  // Interrupt 45 enable
+#define NVIC_EN1_INT46          0x00004000  // Interrupt 46 enable
+#define NVIC_EN1_INT47          0x00008000  // Interrupt 47 enable
+#define NVIC_EN1_INT48          0x00010000  // Interrupt 48 enable
+#define NVIC_EN1_INT49          0x00020000  // Interrupt 49 enable
+#define NVIC_EN1_INT50          0x00040000  // Interrupt 50 enable
+#define NVIC_EN1_INT51          0x00080000  // Interrupt 51 enable
+#define NVIC_EN1_INT52          0x00100000  // Interrupt 52 enable
+#define NVIC_EN1_INT53          0x00200000  // Interrupt 53 enable
+#define NVIC_EN1_INT54          0x00400000  // Interrupt 54 enable
+#define NVIC_EN1_INT55          0x00800000  // Interrupt 55 enable
+#define NVIC_EN1_INT56          0x01000000  // Interrupt 56 enable
+#define NVIC_EN1_INT57          0x02000000  // Interrupt 57 enable
+#define NVIC_EN1_INT58          0x04000000  // Interrupt 58 enable
+#define NVIC_EN1_INT59          0x08000000  // Interrupt 59 enable
+#define NVIC_EN1_INT60          0x10000000  // Interrupt 60 enable
+#define NVIC_EN1_INT61          0x20000000  // Interrupt 61 enable
+#define NVIC_EN1_INT62          0x40000000  // Interrupt 62 enable
+#define NVIC_EN1_INT63          0x80000000  // Interrupt 63 enable
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_EN2 register.
+//
+//*****************************************************************************
+#define NVIC_EN2_INT_M          0xFFFFFFFF  // Interrupt Enable
+#define NVIC_EN2_INT64          0x00000001  // Interrupt 64 enable
+#define NVIC_EN2_INT65          0x00000002  // Interrupt 65 enable
+#define NVIC_EN2_INT66          0x00000004  // Interrupt 66 enable
+#define NVIC_EN2_INT67          0x00000008  // Interrupt 67 enable
+#define NVIC_EN2_INT68          0x00000010  // Interrupt 68 enable
+#define NVIC_EN2_INT69          0x00000020  // Interrupt 69 enable
+#define NVIC_EN2_INT70          0x00000040  // Interrupt 70 enable
+#define NVIC_EN2_INT71          0x00000080  // Interrupt 71 enable
+#define NVIC_EN2_INT72          0x00000100  // Interrupt 72 enable
+#define NVIC_EN2_INT73          0x00000200  // Interrupt 73 enable
+#define NVIC_EN2_INT74          0x00000400  // Interrupt 74 enable
+#define NVIC_EN2_INT75          0x00000800  // Interrupt 75 enable
+#define NVIC_EN2_INT76          0x00001000  // Interrupt 76 enable
+#define NVIC_EN2_INT77          0x00002000  // Interrupt 77 enable
+#define NVIC_EN2_INT78          0x00004000  // Interrupt 78 enable
+#define NVIC_EN2_INT79          0x00008000  // Interrupt 79 enable
+#define NVIC_EN2_INT80          0x00010000  // Interrupt 80 enable
+#define NVIC_EN2_INT81          0x00020000  // Interrupt 81 enable
+#define NVIC_EN2_INT82          0x00040000  // Interrupt 82 enable
+#define NVIC_EN2_INT83          0x00080000  // Interrupt 83 enable
+#define NVIC_EN2_INT84          0x00100000  // Interrupt 84 enable
+#define NVIC_EN2_INT85          0x00200000  // Interrupt 85 enable
+#define NVIC_EN2_INT86          0x00400000  // Interrupt 86 enable
+#define NVIC_EN2_INT87          0x00800000  // Interrupt 87 enable
+#define NVIC_EN2_INT88          0x01000000  // Interrupt 88 enable
+#define NVIC_EN2_INT89          0x02000000  // Interrupt 89 enable
+#define NVIC_EN2_INT90          0x04000000  // Interrupt 90 enable
+#define NVIC_EN2_INT91          0x08000000  // Interrupt 91 enable
+#define NVIC_EN2_INT92          0x10000000  // Interrupt 92 enable
+#define NVIC_EN2_INT93          0x20000000  // Interrupt 93 enable
+#define NVIC_EN2_INT94          0x40000000  // Interrupt 94 enable
+#define NVIC_EN2_INT95          0x80000000  // Interrupt 95 enable
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_EN3 register.
+//
+//*****************************************************************************
+#define NVIC_EN3_INT_M          0xFFFFFFFF  // Interrupt Enable
+#define NVIC_EN3_INT96          0x00000001  // Interrupt 96 enable
+#define NVIC_EN3_INT97          0x00000002  // Interrupt 97 enable
+#define NVIC_EN3_INT98          0x00000004  // Interrupt 98 enable
+#define NVIC_EN3_INT99          0x00000008  // Interrupt 99 enable
+#define NVIC_EN3_INT100         0x00000010  // Interrupt 100 enable
+#define NVIC_EN3_INT101         0x00000020  // Interrupt 101 enable
+#define NVIC_EN3_INT102         0x00000040  // Interrupt 102 enable
+#define NVIC_EN3_INT103         0x00000080  // Interrupt 103 enable
+#define NVIC_EN3_INT104         0x00000100  // Interrupt 104 enable
+#define NVIC_EN3_INT105         0x00000200  // Interrupt 105 enable
+#define NVIC_EN3_INT106         0x00000400  // Interrupt 106 enable
+#define NVIC_EN3_INT107         0x00000800  // Interrupt 107 enable
+#define NVIC_EN3_INT108         0x00001000  // Interrupt 108 enable
+#define NVIC_EN3_INT109         0x00002000  // Interrupt 109 enable
+#define NVIC_EN3_INT110         0x00004000  // Interrupt 110 enable
+#define NVIC_EN3_INT111         0x00008000  // Interrupt 111 enable
+#define NVIC_EN3_INT112         0x00010000  // Interrupt 112 enable
+#define NVIC_EN3_INT113         0x00020000  // Interrupt 113 enable
+#define NVIC_EN3_INT114         0x00040000  // Interrupt 114 enable
+#define NVIC_EN3_INT115         0x00080000  // Interrupt 115 enable
+#define NVIC_EN3_INT116         0x00100000  // Interrupt 116 enable
+#define NVIC_EN3_INT117         0x00200000  // Interrupt 117 enable
+#define NVIC_EN3_INT118         0x00400000  // Interrupt 118 enable
+#define NVIC_EN3_INT119         0x00800000  // Interrupt 119 enable
+#define NVIC_EN3_INT120         0x01000000  // Interrupt 120 enable
+#define NVIC_EN3_INT121         0x02000000  // Interrupt 121 enable
+#define NVIC_EN3_INT122         0x04000000  // Interrupt 122 enable
+#define NVIC_EN3_INT123         0x08000000  // Interrupt 123 enable
+#define NVIC_EN3_INT124         0x10000000  // Interrupt 124 enable
+#define NVIC_EN3_INT125         0x20000000  // Interrupt 125 enable
+#define NVIC_EN3_INT126         0x40000000  // Interrupt 126 enable
+#define NVIC_EN3_INT127         0x80000000  // Interrupt 127 enable
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_EN4 register.
+//
+//*****************************************************************************
+#define NVIC_EN4_INT_M          0x0000000F  // Interrupt Enable
+#define NVIC_EN4_INT128         0x00000001  // Interrupt 128 enable
+#define NVIC_EN4_INT129         0x00000002  // Interrupt 129 enable
+#define NVIC_EN4_INT130         0x00000004  // Interrupt 130 enable
+#define NVIC_EN4_INT131         0x00000008  // Interrupt 131 enable
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_DIS0 register.
+//
+//*****************************************************************************
+#define NVIC_DIS0_INT_M         0xFFFFFFFF  // Interrupt Disable
+#define NVIC_DIS0_INT0          0x00000001  // Interrupt 0 disable
+#define NVIC_DIS0_INT1          0x00000002  // Interrupt 1 disable
+#define NVIC_DIS0_INT2          0x00000004  // Interrupt 2 disable
+#define NVIC_DIS0_INT3          0x00000008  // Interrupt 3 disable
+#define NVIC_DIS0_INT4          0x00000010  // Interrupt 4 disable
+#define NVIC_DIS0_INT5          0x00000020  // Interrupt 5 disable
+#define NVIC_DIS0_INT6          0x00000040  // Interrupt 6 disable
+#define NVIC_DIS0_INT7          0x00000080  // Interrupt 7 disable
+#define NVIC_DIS0_INT8          0x00000100  // Interrupt 8 disable
+#define NVIC_DIS0_INT9          0x00000200  // Interrupt 9 disable
+#define NVIC_DIS0_INT10         0x00000400  // Interrupt 10 disable
+#define NVIC_DIS0_INT11         0x00000800  // Interrupt 11 disable
+#define NVIC_DIS0_INT12         0x00001000  // Interrupt 12 disable
+#define NVIC_DIS0_INT13         0x00002000  // Interrupt 13 disable
+#define NVIC_DIS0_INT14         0x00004000  // Interrupt 14 disable
+#define NVIC_DIS0_INT15         0x00008000  // Interrupt 15 disable
+#define NVIC_DIS0_INT16         0x00010000  // Interrupt 16 disable
+#define NVIC_DIS0_INT17         0x00020000  // Interrupt 17 disable
+#define NVIC_DIS0_INT18         0x00040000  // Interrupt 18 disable
+#define NVIC_DIS0_INT19         0x00080000  // Interrupt 19 disable
+#define NVIC_DIS0_INT20         0x00100000  // Interrupt 20 disable
+#define NVIC_DIS0_INT21         0x00200000  // Interrupt 21 disable
+#define NVIC_DIS0_INT22         0x00400000  // Interrupt 22 disable
+#define NVIC_DIS0_INT23         0x00800000  // Interrupt 23 disable
+#define NVIC_DIS0_INT24         0x01000000  // Interrupt 24 disable
+#define NVIC_DIS0_INT25         0x02000000  // Interrupt 25 disable
+#define NVIC_DIS0_INT26         0x04000000  // Interrupt 26 disable
+#define NVIC_DIS0_INT27         0x08000000  // Interrupt 27 disable
+#define NVIC_DIS0_INT28         0x10000000  // Interrupt 28 disable
+#define NVIC_DIS0_INT29         0x20000000  // Interrupt 29 disable
+#define NVIC_DIS0_INT30         0x40000000  // Interrupt 30 disable
+#define NVIC_DIS0_INT31         0x80000000  // Interrupt 31 disable
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_DIS1 register.
+//
+//*****************************************************************************
+#define NVIC_DIS1_INT_M         0xFFFFFFFF  // Interrupt Disable
+#define NVIC_DIS1_INT32         0x00000001  // Interrupt 32 disable
+#define NVIC_DIS1_INT33         0x00000002  // Interrupt 33 disable
+#define NVIC_DIS1_INT34         0x00000004  // Interrupt 34 disable
+#define NVIC_DIS1_INT35         0x00000008  // Interrupt 35 disable
+#define NVIC_DIS1_INT36         0x00000010  // Interrupt 36 disable
+#define NVIC_DIS1_INT37         0x00000020  // Interrupt 37 disable
+#define NVIC_DIS1_INT38         0x00000040  // Interrupt 38 disable
+#define NVIC_DIS1_INT39         0x00000080  // Interrupt 39 disable
+#define NVIC_DIS1_INT40         0x00000100  // Interrupt 40 disable
+#define NVIC_DIS1_INT41         0x00000200  // Interrupt 41 disable
+#define NVIC_DIS1_INT42         0x00000400  // Interrupt 42 disable
+#define NVIC_DIS1_INT43         0x00000800  // Interrupt 43 disable
+#define NVIC_DIS1_INT44         0x00001000  // Interrupt 44 disable
+#define NVIC_DIS1_INT45         0x00002000  // Interrupt 45 disable
+#define NVIC_DIS1_INT46         0x00004000  // Interrupt 46 disable
+#define NVIC_DIS1_INT47         0x00008000  // Interrupt 47 disable
+#define NVIC_DIS1_INT48         0x00010000  // Interrupt 48 disable
+#define NVIC_DIS1_INT49         0x00020000  // Interrupt 49 disable
+#define NVIC_DIS1_INT50         0x00040000  // Interrupt 50 disable
+#define NVIC_DIS1_INT51         0x00080000  // Interrupt 51 disable
+#define NVIC_DIS1_INT52         0x00100000  // Interrupt 52 disable
+#define NVIC_DIS1_INT53         0x00200000  // Interrupt 53 disable
+#define NVIC_DIS1_INT54         0x00400000  // Interrupt 54 disable
+#define NVIC_DIS1_INT55         0x00800000  // Interrupt 55 disable
+#define NVIC_DIS1_INT56         0x01000000  // Interrupt 56 disable
+#define NVIC_DIS1_INT57         0x02000000  // Interrupt 57 disable
+#define NVIC_DIS1_INT58         0x04000000  // Interrupt 58 disable
+#define NVIC_DIS1_INT59         0x08000000  // Interrupt 59 disable
+#define NVIC_DIS1_INT60         0x10000000  // Interrupt 60 disable
+#define NVIC_DIS1_INT61         0x20000000  // Interrupt 61 disable
+#define NVIC_DIS1_INT62         0x40000000  // Interrupt 62 disable
+#define NVIC_DIS1_INT63         0x80000000  // Interrupt 63 disable
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_DIS2 register.
+//
+//*****************************************************************************
+#define NVIC_DIS2_INT_M          0xFFFFFFFF  // Interrupt Disable
+#define NVIC_DIS2_INT64          0x00000001  // Interrupt 64 disable
+#define NVIC_DIS2_INT65          0x00000002  // Interrupt 65 disable
+#define NVIC_DIS2_INT66          0x00000004  // Interrupt 66 disable
+#define NVIC_DIS2_INT67          0x00000008  // Interrupt 67 disable
+#define NVIC_DIS2_INT68          0x00000010  // Interrupt 68 disable
+#define NVIC_DIS2_INT69          0x00000020  // Interrupt 69 disable
+#define NVIC_DIS2_INT70          0x00000040  // Interrupt 70 disable
+#define NVIC_DIS2_INT71          0x00000080  // Interrupt 71 disable
+#define NVIC_DIS2_INT72          0x00000100  // Interrupt 72 disable
+#define NVIC_DIS2_INT73          0x00000200  // Interrupt 73 disable
+#define NVIC_DIS2_INT74          0x00000400  // Interrupt 74 disable
+#define NVIC_DIS2_INT75          0x00000800  // Interrupt 75 disable
+#define NVIC_DIS2_INT76          0x00001000  // Interrupt 76 disable
+#define NVIC_DIS2_INT77          0x00002000  // Interrupt 77 disable
+#define NVIC_DIS2_INT78          0x00004000  // Interrupt 78 disable
+#define NVIC_DIS2_INT79          0x00008000  // Interrupt 79 disable
+#define NVIC_DIS2_INT80          0x00010000  // Interrupt 80 disable
+#define NVIC_DIS2_INT81          0x00020000  // Interrupt 81 disable
+#define NVIC_DIS2_INT82          0x00040000  // Interrupt 82 disable
+#define NVIC_DIS2_INT83          0x00080000  // Interrupt 83 disable
+#define NVIC_DIS2_INT84          0x00100000  // Interrupt 84 disable
+#define NVIC_DIS2_INT85          0x00200000  // Interrupt 85 disable
+#define NVIC_DIS2_INT86          0x00400000  // Interrupt 86 disable
+#define NVIC_DIS2_INT87          0x00800000  // Interrupt 87 disable
+#define NVIC_DIS2_INT88          0x01000000  // Interrupt 88 disable
+#define NVIC_DIS2_INT89          0x02000000  // Interrupt 89 disable
+#define NVIC_DIS2_INT90          0x04000000  // Interrupt 90 disable
+#define NVIC_DIS2_INT91          0x08000000  // Interrupt 91 disable
+#define NVIC_DIS2_INT92          0x10000000  // Interrupt 92 disable
+#define NVIC_DIS2_INT93          0x20000000  // Interrupt 93 disable
+#define NVIC_DIS2_INT94          0x40000000  // Interrupt 94 disable
+#define NVIC_DIS2_INT95          0x80000000  // Interrupt 95 disable
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_DIS3 register.
+//
+//*****************************************************************************
+#define NVIC_DIS3_INT_M          0xFFFFFFFF  // Interrupt Disable
+#define NVIC_DIS3_INT96          0x00000001  // Interrupt 96 disable
+#define NVIC_DIS3_INT97          0x00000002  // Interrupt 97 disable
+#define NVIC_DIS3_INT98          0x00000004  // Interrupt 98 disable
+#define NVIC_DIS3_INT99          0x00000008  // Interrupt 99 disable
+#define NVIC_DIS3_INT100         0x00000010  // Interrupt 100 disable
+#define NVIC_DIS3_INT101         0x00000020  // Interrupt 101 disable
+#define NVIC_DIS3_INT102         0x00000040  // Interrupt 102 disable
+#define NVIC_DIS3_INT103         0x00000080  // Interrupt 103 disable
+#define NVIC_DIS3_INT104         0x00000100  // Interrupt 104 disable
+#define NVIC_DIS3_INT105         0x00000200  // Interrupt 105 disable
+#define NVIC_DIS3_INT106         0x00000400  // Interrupt 106 disable
+#define NVIC_DIS3_INT107         0x00000800  // Interrupt 107 disable
+#define NVIC_DIS3_INT108         0x00001000  // Interrupt 108 disable
+#define NVIC_DIS3_INT109         0x00002000  // Interrupt 109 disable
+#define NVIC_DIS3_INT110         0x00004000  // Interrupt 110 disable
+#define NVIC_DIS3_INT111         0x00008000  // Interrupt 111 disable
+#define NVIC_DIS3_INT112         0x00010000  // Interrupt 112 disable
+#define NVIC_DIS3_INT113         0x00020000  // Interrupt 113 disable
+#define NVIC_DIS3_INT114         0x00040000  // Interrupt 114 disable
+#define NVIC_DIS3_INT115         0x00080000  // Interrupt 115 disable
+#define NVIC_DIS3_INT116         0x00100000  // Interrupt 116 disable
+#define NVIC_DIS3_INT117         0x00200000  // Interrupt 117 disable
+#define NVIC_DIS3_INT118         0x00400000  // Interrupt 118 disable
+#define NVIC_DIS3_INT119         0x00800000  // Interrupt 119 disable
+#define NVIC_DIS3_INT120         0x01000000  // Interrupt 120 disable
+#define NVIC_DIS3_INT121         0x02000000  // Interrupt 121 disable
+#define NVIC_DIS3_INT122         0x04000000  // Interrupt 122 disable
+#define NVIC_DIS3_INT123         0x08000000  // Interrupt 123 disable
+#define NVIC_DIS3_INT124         0x10000000  // Interrupt 124 disable
+#define NVIC_DIS3_INT125         0x20000000  // Interrupt 125 disable
+#define NVIC_DIS3_INT126         0x40000000  // Interrupt 126 disable
+#define NVIC_DIS3_INT127         0x80000000  // Interrupt 127 disable
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_DIS4 register.
+//
+//*****************************************************************************
+#define NVIC_DIS4_INT_M          0x0000000F  // Interrupt Disable
+#define NVIC_DIS4_INT128         0x00000001  // Interrupt 128 disable
+#define NVIC_DIS4_INT129         0x00000002  // Interrupt 129 disable
+#define NVIC_DIS4_INT130         0x00000004  // Interrupt 130 disable
+#define NVIC_DIS4_INT131         0x00000008  // Interrupt 131 disable
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_PEND0 register.
+//
+//*****************************************************************************
+#define NVIC_PEND0_INT_M        0xFFFFFFFF  // Interrupt Set Pending
+#define NVIC_PEND0_INT0         0x00000001  // Interrupt 0 pend
+#define NVIC_PEND0_INT1         0x00000002  // Interrupt 1 pend
+#define NVIC_PEND0_INT2         0x00000004  // Interrupt 2 pend
+#define NVIC_PEND0_INT3         0x00000008  // Interrupt 3 pend
+#define NVIC_PEND0_INT4         0x00000010  // Interrupt 4 pend
+#define NVIC_PEND0_INT5         0x00000020  // Interrupt 5 pend
+#define NVIC_PEND0_INT6         0x00000040  // Interrupt 6 pend
+#define NVIC_PEND0_INT7         0x00000080  // Interrupt 7 pend
+#define NVIC_PEND0_INT8         0x00000100  // Interrupt 8 pend
+#define NVIC_PEND0_INT9         0x00000200  // Interrupt 9 pend
+#define NVIC_PEND0_INT10        0x00000400  // Interrupt 10 pend
+#define NVIC_PEND0_INT11        0x00000800  // Interrupt 11 pend
+#define NVIC_PEND0_INT12        0x00001000  // Interrupt 12 pend
+#define NVIC_PEND0_INT13        0x00002000  // Interrupt 13 pend
+#define NVIC_PEND0_INT14        0x00004000  // Interrupt 14 pend
+#define NVIC_PEND0_INT15        0x00008000  // Interrupt 15 pend
+#define NVIC_PEND0_INT16        0x00010000  // Interrupt 16 pend
+#define NVIC_PEND0_INT17        0x00020000  // Interrupt 17 pend
+#define NVIC_PEND0_INT18        0x00040000  // Interrupt 18 pend
+#define NVIC_PEND0_INT19        0x00080000  // Interrupt 19 pend
+#define NVIC_PEND0_INT20        0x00100000  // Interrupt 20 pend
+#define NVIC_PEND0_INT21        0x00200000  // Interrupt 21 pend
+#define NVIC_PEND0_INT22        0x00400000  // Interrupt 22 pend
+#define NVIC_PEND0_INT23        0x00800000  // Interrupt 23 pend
+#define NVIC_PEND0_INT24        0x01000000  // Interrupt 24 pend
+#define NVIC_PEND0_INT25        0x02000000  // Interrupt 25 pend
+#define NVIC_PEND0_INT26        0x04000000  // Interrupt 26 pend
+#define NVIC_PEND0_INT27        0x08000000  // Interrupt 27 pend
+#define NVIC_PEND0_INT28        0x10000000  // Interrupt 28 pend
+#define NVIC_PEND0_INT29        0x20000000  // Interrupt 29 pend
+#define NVIC_PEND0_INT30        0x40000000  // Interrupt 30 pend
+#define NVIC_PEND0_INT31        0x80000000  // Interrupt 31 pend
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_PEND1 register.
+//
+//*****************************************************************************
+#define NVIC_PEND1_INT_M        0xFFFFFFFF  // Interrupt Set Pending
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_PEND2 register.
+//
+//*****************************************************************************
+#define NVIC_PEND2_INT_M        0xFFFFFFFF  // Interrupt Set Pending
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_PEND3 register.
+//
+//*****************************************************************************
+#define NVIC_PEND3_INT_M        0xFFFFFFFF  // Interrupt Set Pending
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_PEND4 register.
+//
+//*****************************************************************************
+#define NVIC_PEND4_INT_M        0x0000000F  // Interrupt Set Pending
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_UNPEND0 register.
+//
+//*****************************************************************************
+#define NVIC_UNPEND0_INT_M      0xFFFFFFFF  // Interrupt Clear Pending
+#define NVIC_UNPEND0_INT0       0x00000001  // Interrupt 0 unpend
+#define NVIC_UNPEND0_INT1       0x00000002  // Interrupt 1 unpend
+#define NVIC_UNPEND0_INT2       0x00000004  // Interrupt 2 unpend
+#define NVIC_UNPEND0_INT3       0x00000008  // Interrupt 3 unpend
+#define NVIC_UNPEND0_INT4       0x00000010  // Interrupt 4 unpend
+#define NVIC_UNPEND0_INT5       0x00000020  // Interrupt 5 unpend
+#define NVIC_UNPEND0_INT6       0x00000040  // Interrupt 6 unpend
+#define NVIC_UNPEND0_INT7       0x00000080  // Interrupt 7 unpend
+#define NVIC_UNPEND0_INT8       0x00000100  // Interrupt 8 unpend
+#define NVIC_UNPEND0_INT9       0x00000200  // Interrupt 9 unpend
+#define NVIC_UNPEND0_INT10      0x00000400  // Interrupt 10 unpend
+#define NVIC_UNPEND0_INT11      0x00000800  // Interrupt 11 unpend
+#define NVIC_UNPEND0_INT12      0x00001000  // Interrupt 12 unpend
+#define NVIC_UNPEND0_INT13      0x00002000  // Interrupt 13 unpend
+#define NVIC_UNPEND0_INT14      0x00004000  // Interrupt 14 unpend
+#define NVIC_UNPEND0_INT15      0x00008000  // Interrupt 15 unpend
+#define NVIC_UNPEND0_INT16      0x00010000  // Interrupt 16 unpend
+#define NVIC_UNPEND0_INT17      0x00020000  // Interrupt 17 unpend
+#define NVIC_UNPEND0_INT18      0x00040000  // Interrupt 18 unpend
+#define NVIC_UNPEND0_INT19      0x00080000  // Interrupt 19 unpend
+#define NVIC_UNPEND0_INT20      0x00100000  // Interrupt 20 unpend
+#define NVIC_UNPEND0_INT21      0x00200000  // Interrupt 21 unpend
+#define NVIC_UNPEND0_INT22      0x00400000  // Interrupt 22 unpend
+#define NVIC_UNPEND0_INT23      0x00800000  // Interrupt 23 unpend
+#define NVIC_UNPEND0_INT24      0x01000000  // Interrupt 24 unpend
+#define NVIC_UNPEND0_INT25      0x02000000  // Interrupt 25 unpend
+#define NVIC_UNPEND0_INT26      0x04000000  // Interrupt 26 unpend
+#define NVIC_UNPEND0_INT27      0x08000000  // Interrupt 27 unpend
+#define NVIC_UNPEND0_INT28      0x10000000  // Interrupt 28 unpend
+#define NVIC_UNPEND0_INT29      0x20000000  // Interrupt 29 unpend
+#define NVIC_UNPEND0_INT30      0x40000000  // Interrupt 30 unpend
+#define NVIC_UNPEND0_INT31      0x80000000  // Interrupt 31 unpend
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_UNPEND1 register.
+//
+//*****************************************************************************
+#define NVIC_UNPEND1_INT_M      0xFFFFFFFF  // Interrupt Clear Pending
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_UNPEND2 register.
+//
+//*****************************************************************************
+#define NVIC_UNPEND2_INT_M      0xFFFFFFFF  // Interrupt Clear Pending
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_UNPEND3 register.
+//
+//*****************************************************************************
+#define NVIC_UNPEND3_INT_M      0xFFFFFFFF  // Interrupt Clear Pending
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_UNPEND4 register.
+//
+//*****************************************************************************
+#define NVIC_UNPEND4_INT_M      0x0000000F  // Interrupt Clear Pending
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_ACTIVE0 register.
+//
+//*****************************************************************************
+#define NVIC_ACTIVE0_INT_M      0xFFFFFFFF  // Interrupt Active
+#define NVIC_ACTIVE0_INT0       0x00000001  // Interrupt 0 active
+#define NVIC_ACTIVE0_INT1       0x00000002  // Interrupt 1 active
+#define NVIC_ACTIVE0_INT2       0x00000004  // Interrupt 2 active
+#define NVIC_ACTIVE0_INT3       0x00000008  // Interrupt 3 active
+#define NVIC_ACTIVE0_INT4       0x00000010  // Interrupt 4 active
+#define NVIC_ACTIVE0_INT5       0x00000020  // Interrupt 5 active
+#define NVIC_ACTIVE0_INT6       0x00000040  // Interrupt 6 active
+#define NVIC_ACTIVE0_INT7       0x00000080  // Interrupt 7 active
+#define NVIC_ACTIVE0_INT8       0x00000100  // Interrupt 8 active
+#define NVIC_ACTIVE0_INT9       0x00000200  // Interrupt 9 active
+#define NVIC_ACTIVE0_INT10      0x00000400  // Interrupt 10 active
+#define NVIC_ACTIVE0_INT11      0x00000800  // Interrupt 11 active
+#define NVIC_ACTIVE0_INT12      0x00001000  // Interrupt 12 active
+#define NVIC_ACTIVE0_INT13      0x00002000  // Interrupt 13 active
+#define NVIC_ACTIVE0_INT14      0x00004000  // Interrupt 14 active
+#define NVIC_ACTIVE0_INT15      0x00008000  // Interrupt 15 active
+#define NVIC_ACTIVE0_INT16      0x00010000  // Interrupt 16 active
+#define NVIC_ACTIVE0_INT17      0x00020000  // Interrupt 17 active
+#define NVIC_ACTIVE0_INT18      0x00040000  // Interrupt 18 active
+#define NVIC_ACTIVE0_INT19      0x00080000  // Interrupt 19 active
+#define NVIC_ACTIVE0_INT20      0x00100000  // Interrupt 20 active
+#define NVIC_ACTIVE0_INT21      0x00200000  // Interrupt 21 active
+#define NVIC_ACTIVE0_INT22      0x00400000  // Interrupt 22 active
+#define NVIC_ACTIVE0_INT23      0x00800000  // Interrupt 23 active
+#define NVIC_ACTIVE0_INT24      0x01000000  // Interrupt 24 active
+#define NVIC_ACTIVE0_INT25      0x02000000  // Interrupt 25 active
+#define NVIC_ACTIVE0_INT26      0x04000000  // Interrupt 26 active
+#define NVIC_ACTIVE0_INT27      0x08000000  // Interrupt 27 active
+#define NVIC_ACTIVE0_INT28      0x10000000  // Interrupt 28 active
+#define NVIC_ACTIVE0_INT29      0x20000000  // Interrupt 29 active
+#define NVIC_ACTIVE0_INT30      0x40000000  // Interrupt 30 active
+#define NVIC_ACTIVE0_INT31      0x80000000  // Interrupt 31 active
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_ACTIVE1 register.
+//
+//*****************************************************************************
+#define NVIC_ACTIVE1_INT_M      0xFFFFFFFF  // Interrupt Active
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_ACTIVE2 register.
+//
+//*****************************************************************************
+#define NVIC_ACTIVE2_INT_M      0xFFFFFFFF  // Interrupt Active
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_ACTIVE3 register.
+//
+//*****************************************************************************
+#define NVIC_ACTIVE3_INT_M      0xFFFFFFFF  // Interrupt Active
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_ACTIVE4 register.
+//
+//*****************************************************************************
+#define NVIC_ACTIVE4_INT_M      0x0000000F  // Interrupt Active
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_PRI0 register.
+//
+//*****************************************************************************
+#define NVIC_PRI0_INT3_M        0xE0000000  // Interrupt 3 Priority Mask
+#define NVIC_PRI0_INT2_M        0x00E00000  // Interrupt 2 Priority Mask
+#define NVIC_PRI0_INT1_M        0x0000E000  // Interrupt 1 Priority Mask
+#define NVIC_PRI0_INT0_M        0x000000E0  // Interrupt 0 Priority Mask
+#define NVIC_PRI0_INT3_S        29
+#define NVIC_PRI0_INT2_S        21
+#define NVIC_PRI0_INT1_S        13
+#define NVIC_PRI0_INT0_S        5
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_PRI1 register.
+//
+//*****************************************************************************
+#define NVIC_PRI1_INT7_M        0xE0000000  // Interrupt 7 Priority Mask
+#define NVIC_PRI1_INT6_M        0x00E00000  // Interrupt 6 Priority Mask
+#define NVIC_PRI1_INT5_M        0x0000E000  // Interrupt 5 Priority Mask
+#define NVIC_PRI1_INT4_M        0x000000E0  // Interrupt 4 Priority Mask
+#define NVIC_PRI1_INT7_S        29
+#define NVIC_PRI1_INT6_S        21
+#define NVIC_PRI1_INT5_S        13
+#define NVIC_PRI1_INT4_S        5
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_PRI2 register.
+//
+//*****************************************************************************
+#define NVIC_PRI2_INT11_M       0xE0000000  // Interrupt 11 Priority Mask
+#define NVIC_PRI2_INT10_M       0x00E00000  // Interrupt 10 Priority Mask
+#define NVIC_PRI2_INT9_M        0x0000E000  // Interrupt 9 Priority Mask
+#define NVIC_PRI2_INT8_M        0x000000E0  // Interrupt 8 Priority Mask
+#define NVIC_PRI2_INT11_S       29
+#define NVIC_PRI2_INT10_S       21
+#define NVIC_PRI2_INT9_S        13
+#define NVIC_PRI2_INT8_S        5
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_PRI3 register.
+//
+//*****************************************************************************
+#define NVIC_PRI3_INT15_M       0xE0000000  // Interrupt 15 Priority Mask
+#define NVIC_PRI3_INT14_M       0x00E00000  // Interrupt 14 Priority Mask
+#define NVIC_PRI3_INT13_M       0x0000E000  // Interrupt 13 Priority Mask
+#define NVIC_PRI3_INT12_M       0x000000E0  // Interrupt 12 Priority Mask
+#define NVIC_PRI3_INT15_S       29
+#define NVIC_PRI3_INT14_S       21
+#define NVIC_PRI3_INT13_S       13
+#define NVIC_PRI3_INT12_S       5
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_PRI4 register.
+//
+//*****************************************************************************
+#define NVIC_PRI4_INT19_M       0xE0000000  // Interrupt 19 Priority Mask
+#define NVIC_PRI4_INT18_M       0x00E00000  // Interrupt 18 Priority Mask
+#define NVIC_PRI4_INT17_M       0x0000E000  // Interrupt 17 Priority Mask
+#define NVIC_PRI4_INT16_M       0x000000E0  // Interrupt 16 Priority Mask
+#define NVIC_PRI4_INT19_S       29
+#define NVIC_PRI4_INT18_S       21
+#define NVIC_PRI4_INT17_S       13
+#define NVIC_PRI4_INT16_S       5
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_PRI5 register.
+//
+//*****************************************************************************
+#define NVIC_PRI5_INT23_M       0xE0000000  // Interrupt 23 Priority Mask
+#define NVIC_PRI5_INT22_M       0x00E00000  // Interrupt 22 Priority Mask
+#define NVIC_PRI5_INT21_M       0x0000E000  // Interrupt 21 Priority Mask
+#define NVIC_PRI5_INT20_M       0x000000E0  // Interrupt 20 Priority Mask
+#define NVIC_PRI5_INT23_S       29
+#define NVIC_PRI5_INT22_S       21
+#define NVIC_PRI5_INT21_S       13
+#define NVIC_PRI5_INT20_S       5
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_PRI6 register.
+//
+//*****************************************************************************
+#define NVIC_PRI6_INT27_M       0xE0000000  // Interrupt 27 Priority Mask
+#define NVIC_PRI6_INT26_M       0x00E00000  // Interrupt 26 Priority Mask
+#define NVIC_PRI6_INT25_M       0x0000E000  // Interrupt 25 Priority Mask
+#define NVIC_PRI6_INT24_M       0x000000E0  // Interrupt 24 Priority Mask
+#define NVIC_PRI6_INT27_S       29
+#define NVIC_PRI6_INT26_S       21
+#define NVIC_PRI6_INT25_S       13
+#define NVIC_PRI6_INT24_S       5
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_PRI7 register.
+//
+//*****************************************************************************
+#define NVIC_PRI7_INT31_M       0xE0000000  // Interrupt 31 Priority Mask
+#define NVIC_PRI7_INT30_M       0x00E00000  // Interrupt 30 Priority Mask
+#define NVIC_PRI7_INT29_M       0x0000E000  // Interrupt 29 Priority Mask
+#define NVIC_PRI7_INT28_M       0x000000E0  // Interrupt 28 Priority Mask
+#define NVIC_PRI7_INT31_S       29
+#define NVIC_PRI7_INT30_S       21
+#define NVIC_PRI7_INT29_S       13
+#define NVIC_PRI7_INT28_S       5
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_PRI8 register.
+//
+//*****************************************************************************
+#define NVIC_PRI8_INT35_M       0xE0000000  // Interrupt 35 Priority Mask
+#define NVIC_PRI8_INT34_M       0x00E00000  // Interrupt 34 Priority Mask
+#define NVIC_PRI8_INT33_M       0x0000E000  // Interrupt 33 Priority Mask
+#define NVIC_PRI8_INT32_M       0x000000E0  // Interrupt 32 Priority Mask
+#define NVIC_PRI8_INT35_S       29
+#define NVIC_PRI8_INT34_S       21
+#define NVIC_PRI8_INT33_S       13
+#define NVIC_PRI8_INT32_S       5
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_PRI9 register.
+//
+//*****************************************************************************
+#define NVIC_PRI9_INT39_M       0xE0000000  // Interrupt 39 Priority Mask
+#define NVIC_PRI9_INT38_M       0x00E00000  // Interrupt 38 Priority Mask
+#define NVIC_PRI9_INT37_M       0x0000E000  // Interrupt 37 Priority Mask
+#define NVIC_PRI9_INT36_M       0x000000E0  // Interrupt 36 Priority Mask
+#define NVIC_PRI9_INT39_S       29
+#define NVIC_PRI9_INT38_S       21
+#define NVIC_PRI9_INT37_S       13
+#define NVIC_PRI9_INT36_S       5
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_PRI10 register.
+//
+//*****************************************************************************
+#define NVIC_PRI10_INT43_M      0xE0000000  // Interrupt 43 Priority Mask
+#define NVIC_PRI10_INT42_M      0x00E00000  // Interrupt 42 Priority Mask
+#define NVIC_PRI10_INT41_M      0x0000E000  // Interrupt 41 Priority Mask
+#define NVIC_PRI10_INT40_M      0x000000E0  // Interrupt 40 Priority Mask
+#define NVIC_PRI10_INT43_S      29
+#define NVIC_PRI10_INT42_S      21
+#define NVIC_PRI10_INT41_S      13
+#define NVIC_PRI10_INT40_S      5
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_PRI11 register.
+//
+//*****************************************************************************
+#define NVIC_PRI11_INT47_M      0xE0000000  // Interrupt 47 Priority Mask
+#define NVIC_PRI11_INT46_M      0x00E00000  // Interrupt 46 Priority Mask
+#define NVIC_PRI11_INT45_M      0x0000E000  // Interrupt 45 Priority Mask
+#define NVIC_PRI11_INT44_M      0x000000E0  // Interrupt 44 Priority Mask
+#define NVIC_PRI11_INT47_S      29
+#define NVIC_PRI11_INT46_S      21
+#define NVIC_PRI11_INT45_S      13
+#define NVIC_PRI11_INT44_S      5
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_PRI12 register.
+//
+//*****************************************************************************
+#define NVIC_PRI12_INT51_M      0xE0000000  // Interrupt 51 Priority Mask
+#define NVIC_PRI12_INT50_M      0x00E00000  // Interrupt 50 Priority Mask
+#define NVIC_PRI12_INT49_M      0x0000E000  // Interrupt 49 Priority Mask
+#define NVIC_PRI12_INT48_M      0x000000E0  // Interrupt 48 Priority Mask
+#define NVIC_PRI12_INT51_S      29
+#define NVIC_PRI12_INT50_S      21
+#define NVIC_PRI12_INT49_S      13
+#define NVIC_PRI12_INT48_S      5
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_PRI13 register.
+//
+//*****************************************************************************
+#define NVIC_PRI13_INT55_M      0xE0000000  // Interrupt 55 Priority Mask
+#define NVIC_PRI13_INT54_M      0x00E00000  // Interrupt 54 Priority Mask
+#define NVIC_PRI13_INT53_M      0x0000E000  // Interrupt 53 Priority Mask
+#define NVIC_PRI13_INT52_M      0x000000E0  // Interrupt 52 Priority Mask
+#define NVIC_PRI13_INT55_S      29
+#define NVIC_PRI13_INT54_S      21
+#define NVIC_PRI13_INT53_S      13
+#define NVIC_PRI13_INT52_S      5
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_PRI14 register.
+//
+//*****************************************************************************
+#define NVIC_PRI14_INTD_M       0xE0000000  // Interrupt 59 Priority Mask
+#define NVIC_PRI14_INTC_M       0x00E00000  // Interrupt 58 Priority Mask
+#define NVIC_PRI14_INTB_M       0x0000E000  // Interrupt 57 Priority Mask
+#define NVIC_PRI14_INTA_M       0x000000E0  // Interrupt 56 Priority Mask
+#define NVIC_PRI14_INTD_S       29
+#define NVIC_PRI14_INTC_S       21
+#define NVIC_PRI14_INTB_S       13
+#define NVIC_PRI14_INTA_S       5
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_PRI15 register.
+//
+//*****************************************************************************
+#define NVIC_PRI15_INTD_M       0xE0000000  // Interrupt 63 Priority Mask
+#define NVIC_PRI15_INTC_M       0x00E00000  // Interrupt 62 Priority Mask
+#define NVIC_PRI15_INTB_M       0x0000E000  // Interrupt 61 Priority Mask
+#define NVIC_PRI15_INTA_M       0x000000E0  // Interrupt 60 Priority Mask
+#define NVIC_PRI15_INTD_S       29
+#define NVIC_PRI15_INTC_S       21
+#define NVIC_PRI15_INTB_S       13
+#define NVIC_PRI15_INTA_S       5
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_PRI16 register.
+//
+//*****************************************************************************
+#define NVIC_PRI16_INTD_M       0xE0000000  // Interrupt 67 Priority Mask
+#define NVIC_PRI16_INTC_M       0x00E00000  // Interrupt 66 Priority Mask
+#define NVIC_PRI16_INTB_M       0x0000E000  // Interrupt 65 Priority Mask
+#define NVIC_PRI16_INTA_M       0x000000E0  // Interrupt 64 Priority Mask
+#define NVIC_PRI16_INTD_S       29
+#define NVIC_PRI16_INTC_S       21
+#define NVIC_PRI16_INTB_S       13
+#define NVIC_PRI16_INTA_S       5
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_PRI17 register.
+//
+//*****************************************************************************
+#define NVIC_PRI17_INTD_M       0xE0000000  // Interrupt 71 Priority Mask
+#define NVIC_PRI17_INTC_M       0x00E00000  // Interrupt 70 Priority Mask
+#define NVIC_PRI17_INTB_M       0x0000E000  // Interrupt 69 Priority Mask
+#define NVIC_PRI17_INTA_M       0x000000E0  // Interrupt 68 Priority Mask
+#define NVIC_PRI17_INTD_S       29
+#define NVIC_PRI17_INTC_S       21
+#define NVIC_PRI17_INTB_S       13
+#define NVIC_PRI17_INTA_S       5
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_PRI18 register.
+//
+//*****************************************************************************
+#define NVIC_PRI18_INTD_M       0xE0000000  // Interrupt 75 Priority Mask
+#define NVIC_PRI18_INTC_M       0x00E00000  // Interrupt 74 Priority Mask
+#define NVIC_PRI18_INTB_M       0x0000E000  // Interrupt 73 Priority Mask
+#define NVIC_PRI18_INTA_M       0x000000E0  // Interrupt 72 Priority Mask
+#define NVIC_PRI18_INTD_S       29
+#define NVIC_PRI18_INTC_S       21
+#define NVIC_PRI18_INTB_S       13
+#define NVIC_PRI18_INTA_S       5
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_PRI19 register.
+//
+//*****************************************************************************
+#define NVIC_PRI19_INTD_M       0xE0000000  // Interrupt 79 Priority Mask
+#define NVIC_PRI19_INTC_M       0x00E00000  // Interrupt 78 Priority Mask
+#define NVIC_PRI19_INTB_M       0x0000E000  // Interrupt 77 Priority Mask
+#define NVIC_PRI19_INTA_M       0x000000E0  // Interrupt 76 Priority Mask
+#define NVIC_PRI19_INTD_S       29
+#define NVIC_PRI19_INTC_S       21
+#define NVIC_PRI19_INTB_S       13
+#define NVIC_PRI19_INTA_S       5
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_PRI20 register.
+//
+//*****************************************************************************
+#define NVIC_PRI20_INTD_M       0xE0000000  // Interrupt 83 Priority Mask
+#define NVIC_PRI20_INTC_M       0x00E00000  // Interrupt 82 Priority Mask
+#define NVIC_PRI20_INTB_M       0x0000E000  // Interrupt 81 Priority Mask
+#define NVIC_PRI20_INTA_M       0x000000E0  // Interrupt 80 Priority Mask
+#define NVIC_PRI20_INTD_S       29
+#define NVIC_PRI20_INTC_S       21
+#define NVIC_PRI20_INTB_S       13
+#define NVIC_PRI20_INTA_S       5
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_PRI21 register.
+//
+//*****************************************************************************
+#define NVIC_PRI21_INTD_M       0xE0000000  // Interrupt 87 Priority Mask
+#define NVIC_PRI21_INTC_M       0x00E00000  // Interrupt 86 Priority Mask
+#define NVIC_PRI21_INTB_M       0x0000E000  // Interrupt 85 Priority Mask
+#define NVIC_PRI21_INTA_M       0x000000E0  // Interrupt 84 Priority Mask
+#define NVIC_PRI21_INTD_S       29
+#define NVIC_PRI21_INTC_S       21
+#define NVIC_PRI21_INTB_S       13
+#define NVIC_PRI21_INTA_S       5
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_PRI22 register.
+//
+//*****************************************************************************
+#define NVIC_PRI22_INTD_M       0xE0000000  // Interrupt 91 Priority Mask
+#define NVIC_PRI22_INTC_M       0x00E00000  // Interrupt 90 Priority Mask
+#define NVIC_PRI22_INTB_M       0x0000E000  // Interrupt 89 Priority Mask
+#define NVIC_PRI22_INTA_M       0x000000E0  // Interrupt 88 Priority Mask
+#define NVIC_PRI22_INTD_S       29
+#define NVIC_PRI22_INTC_S       21
+#define NVIC_PRI22_INTB_S       13
+#define NVIC_PRI22_INTA_S       5
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_PRI23 register.
+//
+//*****************************************************************************
+#define NVIC_PRI23_INTD_M       0xE0000000  // Interrupt 95 Priority Mask
+#define NVIC_PRI23_INTC_M       0x00E00000  // Interrupt 94 Priority Mask
+#define NVIC_PRI23_INTB_M       0x0000E000  // Interrupt 93 Priority Mask
+#define NVIC_PRI23_INTA_M       0x000000E0  // Interrupt 92 Priority Mask
+#define NVIC_PRI23_INTD_S       29
+#define NVIC_PRI23_INTC_S       21
+#define NVIC_PRI23_INTB_S       13
+#define NVIC_PRI23_INTA_S       5
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_PRI24 register.
+//
+//*****************************************************************************
+#define NVIC_PRI24_INTD_M       0xE0000000  // Interrupt 99 Priority Mask
+#define NVIC_PRI24_INTC_M       0x00E00000  // Interrupt 98 Priority Mask
+#define NVIC_PRI24_INTB_M       0x0000E000  // Interrupt 97 Priority Mask
+#define NVIC_PRI24_INTA_M       0x000000E0  // Interrupt 96 Priority Mask
+#define NVIC_PRI24_INTD_S       29
+#define NVIC_PRI24_INTC_S       21
+#define NVIC_PRI24_INTB_S       13
+#define NVIC_PRI24_INTA_S       5
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_PRI25 register.
+//
+//*****************************************************************************
+#define NVIC_PRI25_INTD_M       0xE0000000  // Interrupt 103 Priority Mask
+#define NVIC_PRI25_INTC_M       0x00E00000  // Interrupt 102 Priority Mask
+#define NVIC_PRI25_INTB_M       0x0000E000  // Interrupt 101 Priority Mask
+#define NVIC_PRI25_INTA_M       0x000000E0  // Interrupt 100 Priority Mask
+#define NVIC_PRI25_INTD_S       29
+#define NVIC_PRI25_INTC_S       21
+#define NVIC_PRI25_INTB_S       13
+#define NVIC_PRI25_INTA_S       5
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_PRI26 register.
+//
+//*****************************************************************************
+#define NVIC_PRI26_INTD_M       0xE0000000  // Interrupt 107 Priority Mask
+#define NVIC_PRI26_INTC_M       0x00E00000  // Interrupt 106 Priority Mask
+#define NVIC_PRI26_INTB_M       0x0000E000  // Interrupt 105 Priority Mask
+#define NVIC_PRI26_INTA_M       0x000000E0  // Interrupt 104 Priority Mask
+#define NVIC_PRI26_INTD_S       29
+#define NVIC_PRI26_INTC_S       21
+#define NVIC_PRI26_INTB_S       13
+#define NVIC_PRI26_INTA_S       5
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_PRI27 register.
+//
+//*****************************************************************************
+#define NVIC_PRI27_INTD_M       0xE0000000  // Interrupt 111 Priority Mask
+#define NVIC_PRI27_INTC_M       0x00E00000  // Interrupt 110 Priority Mask
+#define NVIC_PRI27_INTB_M       0x0000E000  // Interrupt 109 Priority Mask
+#define NVIC_PRI27_INTA_M       0x000000E0  // Interrupt 108 Priority Mask
+#define NVIC_PRI27_INTD_S       29
+#define NVIC_PRI27_INTC_S       21
+#define NVIC_PRI27_INTB_S       13
+#define NVIC_PRI27_INTA_S       5
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_PRI28 register.
+//
+//*****************************************************************************
+#define NVIC_PRI28_INTD_M       0xE0000000  // Interrupt 115 Priority Mask
+#define NVIC_PRI28_INTC_M       0x00E00000  // Interrupt 114 Priority Mask
+#define NVIC_PRI28_INTB_M       0x0000E000  // Interrupt 113 Priority Mask
+#define NVIC_PRI28_INTA_M       0x000000E0  // Interrupt 112 Priority Mask
+#define NVIC_PRI28_INTD_S       29
+#define NVIC_PRI28_INTC_S       21
+#define NVIC_PRI28_INTB_S       13
+#define NVIC_PRI28_INTA_S       5
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_PRI29 register.
+//
+//*****************************************************************************
+#define NVIC_PRI29_INTD_M       0xE0000000  // Interrupt 119 Priority Mask
+#define NVIC_PRI29_INTC_M       0x00E00000  // Interrupt 118 Priority Mask
+#define NVIC_PRI29_INTB_M       0x0000E000  // Interrupt 117 Priority Mask
+#define NVIC_PRI29_INTA_M       0x000000E0  // Interrupt 116 Priority Mask
+#define NVIC_PRI29_INTD_S       29
+#define NVIC_PRI29_INTC_S       21
+#define NVIC_PRI29_INTB_S       13
+#define NVIC_PRI29_INTA_S       5
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_PRI30 register.
+//
+//*****************************************************************************
+#define NVIC_PRI30_INTD_M       0xE0000000  // Interrupt 123 Priority Mask
+#define NVIC_PRI30_INTC_M       0x00E00000  // Interrupt 122 Priority Mask
+#define NVIC_PRI30_INTB_M       0x0000E000  // Interrupt 121 Priority Mask
+#define NVIC_PRI30_INTA_M       0x000000E0  // Interrupt 120 Priority Mask
+#define NVIC_PRI30_INTD_S       29
+#define NVIC_PRI30_INTC_S       21
+#define NVIC_PRI30_INTB_S       13
+#define NVIC_PRI30_INTA_S       5
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_PRI31 register.
+//
+//*****************************************************************************
+#define NVIC_PRI31_INTD_M       0xE0000000  // Interrupt 127 Priority Mask
+#define NVIC_PRI31_INTC_M       0x00E00000  // Interrupt 126 Priority Mask
+#define NVIC_PRI31_INTB_M       0x0000E000  // Interrupt 125 Priority Mask
+#define NVIC_PRI31_INTA_M       0x000000E0  // Interrupt 124 Priority Mask
+#define NVIC_PRI31_INTD_S       29
+#define NVIC_PRI31_INTC_S       21
+#define NVIC_PRI31_INTB_S       13
+#define NVIC_PRI31_INTA_S       5
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_PRI32 register.
+//
+//*****************************************************************************
+#define NVIC_PRI32_INTD_M       0xE0000000  // Interrupt 131 Priority Mask
+#define NVIC_PRI32_INTC_M       0x00E00000  // Interrupt 130 Priority Mask
+#define NVIC_PRI32_INTB_M       0x0000E000  // Interrupt 129 Priority Mask
+#define NVIC_PRI32_INTA_M       0x000000E0  // Interrupt 128 Priority Mask
+#define NVIC_PRI32_INTD_S       29
+#define NVIC_PRI32_INTC_S       21
+#define NVIC_PRI32_INTB_S       13
+#define NVIC_PRI32_INTA_S       5
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_PRI33 register.
+//
+//*****************************************************************************
+#define NVIC_PRI33_INTD_M       0xE0000000  // Interrupt 135 Priority Mask
+#define NVIC_PRI33_INTC_M       0x00E00000  // Interrupt 134 Priority Mask
+#define NVIC_PRI33_INTB_M       0x0000E000  // Interrupt 133 Priority Mask
+#define NVIC_PRI33_INTA_M       0x000000E0  // Interrupt 132 Priority Mask
+#define NVIC_PRI33_INTD_S       29
+#define NVIC_PRI33_INTC_S       21
+#define NVIC_PRI33_INTB_S       13
+#define NVIC_PRI33_INTA_S       5
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_PRI34 register.
+//
+//*****************************************************************************
+#define NVIC_PRI34_INTD_M       0xE0000000  // Interrupt 139 Priority Mask
+#define NVIC_PRI34_INTC_M       0x00E00000  // Interrupt 138 Priority Mask
+#define NVIC_PRI34_INTB_M       0x0000E000  // Interrupt 137 Priority Mask
+#define NVIC_PRI34_INTA_M       0x000000E0  // Interrupt 136 Priority Mask
+#define NVIC_PRI34_INTD_S       29
+#define NVIC_PRI34_INTC_S       21
+#define NVIC_PRI34_INTB_S       13
+#define NVIC_PRI34_INTA_S       5
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_PRI35 register.
+//
+//*****************************************************************************
+#define NVIC_PRI35_INTD_M       0xE0000000  // Interrupt 143 Priority Mask
+#define NVIC_PRI35_INTC_M       0x00E00000  // Interrupt 142 Priority Mask
+#define NVIC_PRI35_INTB_M       0x0000E000  // Interrupt 141 Priority Mask
+#define NVIC_PRI35_INTA_M       0x000000E0  // Interrupt 140 Priority Mask
+#define NVIC_PRI35_INTD_S       29
+#define NVIC_PRI35_INTC_S       21
+#define NVIC_PRI35_INTB_S       13
+#define NVIC_PRI35_INTA_S       5
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_PRI36 register.
+//
+//*****************************************************************************
+#define NVIC_PRI36_INTD_M       0xE0000000  // Interrupt 147 Priority Mask
+#define NVIC_PRI36_INTC_M       0x00E00000  // Interrupt 146 Priority Mask
+#define NVIC_PRI36_INTB_M       0x0000E000  // Interrupt 145 Priority Mask
+#define NVIC_PRI36_INTA_M       0x000000E0  // Interrupt 144 Priority Mask
+#define NVIC_PRI36_INTD_S       29
+#define NVIC_PRI36_INTC_S       21
+#define NVIC_PRI36_INTB_S       13
+#define NVIC_PRI36_INTA_S       5
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_CPUID register.
+//
+//*****************************************************************************
+#define NVIC_CPUID_IMP_M        0xFF000000  // Implementer Code
+#define NVIC_CPUID_IMP_ARM      0x41000000  // ARM
+#define NVIC_CPUID_VAR_M        0x00F00000  // Variant Number
+#define NVIC_CPUID_CON_M        0x000F0000  // Constant
+#define NVIC_CPUID_PARTNO_M     0x0000FFF0  // Part Number
+#define NVIC_CPUID_PARTNO_CM3   0x0000C230  // Cortex-M3 processor
+#define NVIC_CPUID_PARTNO_CM4   0x0000C240  // Cortex-M4 processor
+#define NVIC_CPUID_REV_M        0x0000000F  // Revision Number
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_INT_CTRL register.
+//
+//*****************************************************************************
+#define NVIC_INT_CTRL_NMI_SET   0x80000000  // NMI Set Pending
+#define NVIC_INT_CTRL_PEND_SV   0x10000000  // PendSV Set Pending
+#define NVIC_INT_CTRL_UNPEND_SV 0x08000000  // PendSV Clear Pending
+#define NVIC_INT_CTRL_PENDSTSET 0x04000000  // SysTick Set Pending
+#define NVIC_INT_CTRL_PENDSTCLR 0x02000000  // SysTick Clear Pending
+#define NVIC_INT_CTRL_ISR_PRE   0x00800000  // Debug Interrupt Handling
+#define NVIC_INT_CTRL_ISR_PEND  0x00400000  // Interrupt Pending
+#define NVIC_INT_CTRL_VEC_PEN_M 0x0007F000  // Interrupt Pending Vector Number
+#undef NVIC_INT_CTRL_VEC_PEN_M
+#define NVIC_INT_CTRL_VEC_PEN_M 0x000FF000  // Interrupt Pending Vector Number
+#define NVIC_INT_CTRL_VEC_PEN_NMI \
+                                0x00002000  // NMI
+#define NVIC_INT_CTRL_VEC_PEN_HARD \
+                                0x00003000  // Hard fault
+#define NVIC_INT_CTRL_VEC_PEN_MEM \
+                                0x00004000  // Memory management fault
+#define NVIC_INT_CTRL_VEC_PEN_BUS \
+                                0x00005000  // Bus fault
+#define NVIC_INT_CTRL_VEC_PEN_USG \
+                                0x00006000  // Usage fault
+#define NVIC_INT_CTRL_VEC_PEN_SVC \
+                                0x0000B000  // SVCall
+#define NVIC_INT_CTRL_VEC_PEN_PNDSV \
+                                0x0000E000  // PendSV
+#define NVIC_INT_CTRL_VEC_PEN_TICK \
+                                0x0000F000  // SysTick
+#define NVIC_INT_CTRL_RET_BASE  0x00000800  // Return to Base
+#define NVIC_INT_CTRL_VEC_ACT_M 0x0000007F  // Interrupt Pending Vector Number
+#undef NVIC_INT_CTRL_VEC_ACT_M
+#define NVIC_INT_CTRL_VEC_ACT_M 0x000000FF  // Interrupt Pending Vector Number
+#define NVIC_INT_CTRL_VEC_PEN_S 12
+#define NVIC_INT_CTRL_VEC_ACT_S 0
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_VTABLE register.
+//
+//*****************************************************************************
+#define NVIC_VTABLE_BASE        0x20000000  // Vector Table Base
+#define NVIC_VTABLE_OFFSET_M    0x1FFFFE00  // Vector Table Offset
+#undef NVIC_VTABLE_OFFSET_M
+#define NVIC_VTABLE_OFFSET_M    0x1FFFFC00  // Vector Table Offset
+#define NVIC_VTABLE_OFFSET_S    9
+#undef NVIC_VTABLE_OFFSET_S
+#define NVIC_VTABLE_OFFSET_S    10
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_APINT register.
+//
+//*****************************************************************************
+#define NVIC_APINT_VECTKEY_M    0xFFFF0000  // Register Key
+#define NVIC_APINT_VECTKEY      0x05FA0000  // Vector key
+#define NVIC_APINT_ENDIANESS    0x00008000  // Data Endianess
+#define NVIC_APINT_PRIGROUP_M   0x00000700  // Interrupt Priority Grouping
+#define NVIC_APINT_PRIGROUP_7_1 0x00000000  // Priority group 7.1 split
+#define NVIC_APINT_PRIGROUP_6_2 0x00000100  // Priority group 6.2 split
+#define NVIC_APINT_PRIGROUP_5_3 0x00000200  // Priority group 5.3 split
+#define NVIC_APINT_PRIGROUP_4_4 0x00000300  // Priority group 4.4 split
+#define NVIC_APINT_PRIGROUP_3_5 0x00000400  // Priority group 3.5 split
+#define NVIC_APINT_PRIGROUP_2_6 0x00000500  // Priority group 2.6 split
+#define NVIC_APINT_PRIGROUP_1_7 0x00000600  // Priority group 1.7 split
+#define NVIC_APINT_PRIGROUP_0_8 0x00000700  // Priority group 0.8 split
+#define NVIC_APINT_SYSRESETREQ  0x00000004  // System Reset Request
+#define NVIC_APINT_VECT_CLR_ACT 0x00000002  // Clear Active NMI / Fault
+#define NVIC_APINT_VECT_RESET   0x00000001  // System Reset
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_SYS_CTRL register.
+//
+//*****************************************************************************
+#define NVIC_SYS_CTRL_SEVONPEND 0x00000010  // Wake Up on Pending
+#define NVIC_SYS_CTRL_SLEEPDEEP 0x00000004  // Deep Sleep Enable
+#define NVIC_SYS_CTRL_SLEEPEXIT 0x00000002  // Sleep on ISR Exit
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_CFG_CTRL register.
+//
+//*****************************************************************************
+#define NVIC_CFG_CTRL_STKALIGN  0x00000200  // Stack Alignment on Exception
+                                            // Entry
+#define NVIC_CFG_CTRL_BFHFNMIGN 0x00000100  // Ignore Bus Fault in NMI and
+                                            // Fault
+#define NVIC_CFG_CTRL_DIV0      0x00000010  // Trap on Divide by 0
+#define NVIC_CFG_CTRL_UNALIGNED 0x00000008  // Trap on Unaligned Access
+#define NVIC_CFG_CTRL_MAIN_PEND 0x00000002  // Allow Main Interrupt Trigger
+#define NVIC_CFG_CTRL_BASE_THR  0x00000001  // Thread State Control
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_SYS_PRI1 register.
+//
+//*****************************************************************************
+#define NVIC_SYS_PRI1_USAGE_M   0x00E00000  // Usage Fault Priority
+#define NVIC_SYS_PRI1_BUS_M     0x0000E000  // Bus Fault Priority
+#define NVIC_SYS_PRI1_MEM_M     0x000000E0  // Memory Management Fault Priority
+#define NVIC_SYS_PRI1_USAGE_S   21
+#define NVIC_SYS_PRI1_BUS_S     13
+#define NVIC_SYS_PRI1_MEM_S     5
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_SYS_PRI2 register.
+//
+//*****************************************************************************
+#define NVIC_SYS_PRI2_SVC_M     0xE0000000  // SVCall Priority
+#define NVIC_SYS_PRI2_SVC_S     29
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_SYS_PRI3 register.
+//
+//*****************************************************************************
+#define NVIC_SYS_PRI3_TICK_M    0xE0000000  // SysTick Exception Priority
+#define NVIC_SYS_PRI3_PENDSV_M  0x00E00000  // PendSV Priority
+#define NVIC_SYS_PRI3_DEBUG_M   0x000000E0  // Debug Priority
+#define NVIC_SYS_PRI3_TICK_S    29
+#define NVIC_SYS_PRI3_PENDSV_S  21
+#define NVIC_SYS_PRI3_DEBUG_S   5
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_SYS_HND_CTRL
+// register.
+//
+//*****************************************************************************
+#define NVIC_SYS_HND_CTRL_USAGE 0x00040000  // Usage Fault Enable
+#define NVIC_SYS_HND_CTRL_BUS   0x00020000  // Bus Fault Enable
+#define NVIC_SYS_HND_CTRL_MEM   0x00010000  // Memory Management Fault Enable
+#define NVIC_SYS_HND_CTRL_SVC   0x00008000  // SVC Call Pending
+#define NVIC_SYS_HND_CTRL_BUSP  0x00004000  // Bus Fault Pending
+#define NVIC_SYS_HND_CTRL_MEMP  0x00002000  // Memory Management Fault Pending
+#define NVIC_SYS_HND_CTRL_USAGEP \
+                                0x00001000  // Usage Fault Pending
+#define NVIC_SYS_HND_CTRL_TICK  0x00000800  // SysTick Exception Active
+#define NVIC_SYS_HND_CTRL_PNDSV 0x00000400  // PendSV Exception Active
+#define NVIC_SYS_HND_CTRL_MON   0x00000100  // Debug Monitor Active
+#define NVIC_SYS_HND_CTRL_SVCA  0x00000080  // SVC Call Active
+#define NVIC_SYS_HND_CTRL_USGA  0x00000008  // Usage Fault Active
+#define NVIC_SYS_HND_CTRL_BUSA  0x00000002  // Bus Fault Active
+#define NVIC_SYS_HND_CTRL_MEMA  0x00000001  // Memory Management Fault Active
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_FAULT_STAT
+// register.
+//
+//*****************************************************************************
+#define NVIC_FAULT_STAT_DIV0    0x02000000  // Divide-by-Zero Usage Fault
+#define NVIC_FAULT_STAT_UNALIGN 0x01000000  // Unaligned Access Usage Fault
+#define NVIC_FAULT_STAT_NOCP    0x00080000  // No Coprocessor Usage Fault
+#define NVIC_FAULT_STAT_INVPC   0x00040000  // Invalid PC Load Usage Fault
+#define NVIC_FAULT_STAT_INVSTAT 0x00020000  // Invalid State Usage Fault
+#define NVIC_FAULT_STAT_UNDEF   0x00010000  // Undefined Instruction Usage
+                                            // Fault
+#define NVIC_FAULT_STAT_BFARV   0x00008000  // Bus Fault Address Register Valid
+#define NVIC_FAULT_STAT_BLSPERR 0x00002000  // Bus Fault on Floating-Point Lazy
+                                            // State Preservation
+#define NVIC_FAULT_STAT_BSTKE   0x00001000  // Stack Bus Fault
+#define NVIC_FAULT_STAT_BUSTKE  0x00000800  // Unstack Bus Fault
+#define NVIC_FAULT_STAT_IMPRE   0x00000400  // Imprecise Data Bus Error
+#define NVIC_FAULT_STAT_PRECISE 0x00000200  // Precise Data Bus Error
+#define NVIC_FAULT_STAT_IBUS    0x00000100  // Instruction Bus Error
+#define NVIC_FAULT_STAT_MMARV   0x00000080  // Memory Management Fault Address
+                                            // Register Valid
+#define NVIC_FAULT_STAT_MLSPERR 0x00000020  // Memory Management Fault on
+                                            // Floating-Point Lazy State
+                                            // Preservation
+#define NVIC_FAULT_STAT_MSTKE   0x00000010  // Stack Access Violation
+#define NVIC_FAULT_STAT_MUSTKE  0x00000008  // Unstack Access Violation
+#define NVIC_FAULT_STAT_DERR    0x00000002  // Data Access Violation
+#define NVIC_FAULT_STAT_IERR    0x00000001  // Instruction Access Violation
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_HFAULT_STAT
+// register.
+//
+//*****************************************************************************
+#define NVIC_HFAULT_STAT_DBG    0x80000000  // Debug Event
+#define NVIC_HFAULT_STAT_FORCED 0x40000000  // Forced Hard Fault
+#define NVIC_HFAULT_STAT_VECT   0x00000002  // Vector Table Read Fault
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_DEBUG_STAT
+// register.
+//
+//*****************************************************************************
+#define NVIC_DEBUG_STAT_EXTRNL  0x00000010  // EDBGRQ asserted
+#define NVIC_DEBUG_STAT_VCATCH  0x00000008  // Vector catch
+#define NVIC_DEBUG_STAT_DWTTRAP 0x00000004  // DWT match
+#define NVIC_DEBUG_STAT_BKPT    0x00000002  // Breakpoint instruction
+#define NVIC_DEBUG_STAT_HALTED  0x00000001  // Halt request
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_MM_ADDR register.
+//
+//*****************************************************************************
+#define NVIC_MM_ADDR_M          0xFFFFFFFF  // Fault Address
+#define NVIC_MM_ADDR_S          0
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_FAULT_ADDR
+// register.
+//
+//*****************************************************************************
+#define NVIC_FAULT_ADDR_M       0xFFFFFFFF  // Fault Address
+#define NVIC_FAULT_ADDR_S       0
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_MPU_TYPE register.
+//
+//*****************************************************************************
+#define NVIC_MPU_TYPE_IREGION_M 0x00FF0000  // Number of I Regions
+#define NVIC_MPU_TYPE_DREGION_M 0x0000FF00  // Number of D Regions
+#define NVIC_MPU_TYPE_SEPARATE  0x00000001  // Separate or Unified MPU
+#define NVIC_MPU_TYPE_IREGION_S 16
+#define NVIC_MPU_TYPE_DREGION_S 8
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_MPU_CTRL register.
+//
+//*****************************************************************************
+#define NVIC_MPU_CTRL_PRIVDEFEN 0x00000004  // MPU Default Region
+#define NVIC_MPU_CTRL_HFNMIENA  0x00000002  // MPU Enabled During Faults
+#define NVIC_MPU_CTRL_ENABLE    0x00000001  // MPU Enable
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_MPU_NUMBER
+// register.
+//
+//*****************************************************************************
+#define NVIC_MPU_NUMBER_M       0x00000007  // MPU Region to Access
+#define NVIC_MPU_NUMBER_S       0
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_MPU_BASE register.
+//
+//*****************************************************************************
+#define NVIC_MPU_BASE_ADDR_M    0xFFFFFFE0  // Base Address Mask
+#define NVIC_MPU_BASE_VALID     0x00000010  // Region Number Valid
+#define NVIC_MPU_BASE_REGION_M  0x00000007  // Region Number
+#define NVIC_MPU_BASE_ADDR_S    5
+#define NVIC_MPU_BASE_REGION_S  0
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_MPU_ATTR register.
+//
+//*****************************************************************************
+#define NVIC_MPU_ATTR_M         0xFFFF0000  // Attributes
+#define NVIC_MPU_ATTR_XN        0x10000000  // Instruction Access Disable
+#define NVIC_MPU_ATTR_AP_M      0x07000000  // Access Privilege
+#define NVIC_MPU_ATTR_AP_NO_NO  0x00000000  // prv: no access, usr: no access
+#define NVIC_MPU_ATTR_AP_RW_NO  0x01000000  // prv: rw, usr: none
+#define NVIC_MPU_ATTR_AP_RW_RO  0x02000000  // prv: rw, usr: read-only
+#define NVIC_MPU_ATTR_AP_RW_RW  0x03000000  // prv: rw, usr: rw
+#define NVIC_MPU_ATTR_AP_RO_NO  0x05000000  // prv: ro, usr: none
+#define NVIC_MPU_ATTR_AP_RO_RO  0x06000000  // prv: ro, usr: ro
+#define NVIC_MPU_ATTR_TEX_M     0x00380000  // Type Extension Mask
+#define NVIC_MPU_ATTR_SHAREABLE 0x00040000  // Shareable
+#define NVIC_MPU_ATTR_CACHEABLE 0x00020000  // Cacheable
+#define NVIC_MPU_ATTR_BUFFRABLE 0x00010000  // Bufferable
+#define NVIC_MPU_ATTR_SRD_M     0x0000FF00  // Subregion Disable Bits
+#define NVIC_MPU_ATTR_SRD_0     0x00000100  // Sub-region 0 disable
+#define NVIC_MPU_ATTR_SRD_1     0x00000200  // Sub-region 1 disable
+#define NVIC_MPU_ATTR_SRD_2     0x00000400  // Sub-region 2 disable
+#define NVIC_MPU_ATTR_SRD_3     0x00000800  // Sub-region 3 disable
+#define NVIC_MPU_ATTR_SRD_4     0x00001000  // Sub-region 4 disable
+#define NVIC_MPU_ATTR_SRD_5     0x00002000  // Sub-region 5 disable
+#define NVIC_MPU_ATTR_SRD_6     0x00004000  // Sub-region 6 disable
+#define NVIC_MPU_ATTR_SRD_7     0x00008000  // Sub-region 7 disable
+#define NVIC_MPU_ATTR_SIZE_M    0x0000003E  // Region Size Mask
+#define NVIC_MPU_ATTR_SIZE_32B  0x00000008  // Region size 32 bytes
+#define NVIC_MPU_ATTR_SIZE_64B  0x0000000A  // Region size 64 bytes
+#define NVIC_MPU_ATTR_SIZE_128B 0x0000000C  // Region size 128 bytes
+#define NVIC_MPU_ATTR_SIZE_256B 0x0000000E  // Region size 256 bytes
+#define NVIC_MPU_ATTR_SIZE_512B 0x00000010  // Region size 512 bytes
+#define NVIC_MPU_ATTR_SIZE_1K   0x00000012  // Region size 1 Kbytes
+#define NVIC_MPU_ATTR_SIZE_2K   0x00000014  // Region size 2 Kbytes
+#define NVIC_MPU_ATTR_SIZE_4K   0x00000016  // Region size 4 Kbytes
+#define NVIC_MPU_ATTR_SIZE_8K   0x00000018  // Region size 8 Kbytes
+#define NVIC_MPU_ATTR_SIZE_16K  0x0000001A  // Region size 16 Kbytes
+#define NVIC_MPU_ATTR_SIZE_32K  0x0000001C  // Region size 32 Kbytes
+#define NVIC_MPU_ATTR_SIZE_64K  0x0000001E  // Region size 64 Kbytes
+#define NVIC_MPU_ATTR_SIZE_128K 0x00000020  // Region size 128 Kbytes
+#define NVIC_MPU_ATTR_SIZE_256K 0x00000022  // Region size 256 Kbytes
+#define NVIC_MPU_ATTR_SIZE_512K 0x00000024  // Region size 512 Kbytes
+#define NVIC_MPU_ATTR_SIZE_1M   0x00000026  // Region size 1 Mbytes
+#define NVIC_MPU_ATTR_SIZE_2M   0x00000028  // Region size 2 Mbytes
+#define NVIC_MPU_ATTR_SIZE_4M   0x0000002A  // Region size 4 Mbytes
+#define NVIC_MPU_ATTR_SIZE_8M   0x0000002C  // Region size 8 Mbytes
+#define NVIC_MPU_ATTR_SIZE_16M  0x0000002E  // Region size 16 Mbytes
+#define NVIC_MPU_ATTR_SIZE_32M  0x00000030  // Region size 32 Mbytes
+#define NVIC_MPU_ATTR_SIZE_64M  0x00000032  // Region size 64 Mbytes
+#define NVIC_MPU_ATTR_SIZE_128M 0x00000034  // Region size 128 Mbytes
+#define NVIC_MPU_ATTR_SIZE_256M 0x00000036  // Region size 256 Mbytes
+#define NVIC_MPU_ATTR_SIZE_512M 0x00000038  // Region size 512 Mbytes
+#define NVIC_MPU_ATTR_SIZE_1G   0x0000003A  // Region size 1 Gbytes
+#define NVIC_MPU_ATTR_SIZE_2G   0x0000003C  // Region size 2 Gbytes
+#define NVIC_MPU_ATTR_SIZE_4G   0x0000003E  // Region size 4 Gbytes
+#define NVIC_MPU_ATTR_ENABLE    0x00000001  // Region Enable
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_MPU_BASE1 register.
+//
+//*****************************************************************************
+#define NVIC_MPU_BASE1_ADDR_M   0xFFFFFFE0  // Base Address Mask
+#define NVIC_MPU_BASE1_VALID    0x00000010  // Region Number Valid
+#define NVIC_MPU_BASE1_REGION_M 0x00000007  // Region Number
+#define NVIC_MPU_BASE1_ADDR_S   5
+#define NVIC_MPU_BASE1_REGION_S 0
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_MPU_ATTR1 register.
+//
+//*****************************************************************************
+#define NVIC_MPU_ATTR1_XN       0x10000000  // Instruction Access Disable
+#define NVIC_MPU_ATTR1_AP_M     0x07000000  // Access Privilege
+#define NVIC_MPU_ATTR1_TEX_M    0x00380000  // Type Extension Mask
+#define NVIC_MPU_ATTR1_SHAREABLE \
+                                0x00040000  // Shareable
+#define NVIC_MPU_ATTR1_CACHEABLE \
+                                0x00020000  // Cacheable
+#define NVIC_MPU_ATTR1_BUFFRABLE \
+                                0x00010000  // Bufferable
+#define NVIC_MPU_ATTR1_SRD_M    0x0000FF00  // Subregion Disable Bits
+#define NVIC_MPU_ATTR1_SIZE_M   0x0000003E  // Region Size Mask
+#define NVIC_MPU_ATTR1_ENABLE   0x00000001  // Region Enable
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_MPU_BASE2 register.
+//
+//*****************************************************************************
+#define NVIC_MPU_BASE2_ADDR_M   0xFFFFFFE0  // Base Address Mask
+#define NVIC_MPU_BASE2_VALID    0x00000010  // Region Number Valid
+#define NVIC_MPU_BASE2_REGION_M 0x00000007  // Region Number
+#define NVIC_MPU_BASE2_ADDR_S   5
+#define NVIC_MPU_BASE2_REGION_S 0
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_MPU_ATTR2 register.
+//
+//*****************************************************************************
+#define NVIC_MPU_ATTR2_XN       0x10000000  // Instruction Access Disable
+#define NVIC_MPU_ATTR2_AP_M     0x07000000  // Access Privilege
+#define NVIC_MPU_ATTR2_TEX_M    0x00380000  // Type Extension Mask
+#define NVIC_MPU_ATTR2_SHAREABLE \
+                                0x00040000  // Shareable
+#define NVIC_MPU_ATTR2_CACHEABLE \
+                                0x00020000  // Cacheable
+#define NVIC_MPU_ATTR2_BUFFRABLE \
+                                0x00010000  // Bufferable
+#define NVIC_MPU_ATTR2_SRD_M    0x0000FF00  // Subregion Disable Bits
+#define NVIC_MPU_ATTR2_SIZE_M   0x0000003E  // Region Size Mask
+#define NVIC_MPU_ATTR2_ENABLE   0x00000001  // Region Enable
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_MPU_BASE3 register.
+//
+//*****************************************************************************
+#define NVIC_MPU_BASE3_ADDR_M   0xFFFFFFE0  // Base Address Mask
+#define NVIC_MPU_BASE3_VALID    0x00000010  // Region Number Valid
+#define NVIC_MPU_BASE3_REGION_M 0x00000007  // Region Number
+#define NVIC_MPU_BASE3_ADDR_S   5
+#define NVIC_MPU_BASE3_REGION_S 0
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_MPU_ATTR3 register.
+//
+//*****************************************************************************
+#define NVIC_MPU_ATTR3_XN       0x10000000  // Instruction Access Disable
+#define NVIC_MPU_ATTR3_AP_M     0x07000000  // Access Privilege
+#define NVIC_MPU_ATTR3_TEX_M    0x00380000  // Type Extension Mask
+#define NVIC_MPU_ATTR3_SHAREABLE \
+                                0x00040000  // Shareable
+#define NVIC_MPU_ATTR3_CACHEABLE \
+                                0x00020000  // Cacheable
+#define NVIC_MPU_ATTR3_BUFFRABLE \
+                                0x00010000  // Bufferable
+#define NVIC_MPU_ATTR3_SRD_M    0x0000FF00  // Subregion Disable Bits
+#define NVIC_MPU_ATTR3_SIZE_M   0x0000003E  // Region Size Mask
+#define NVIC_MPU_ATTR3_ENABLE   0x00000001  // Region Enable
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_DBG_CTRL register.
+//
+//*****************************************************************************
+#define NVIC_DBG_CTRL_DBGKEY_M  0xFFFF0000  // Debug key mask
+#define NVIC_DBG_CTRL_DBGKEY    0xA05F0000  // Debug key
+#define NVIC_DBG_CTRL_S_RESET_ST \
+                                0x02000000  // Core has reset since last read
+#define NVIC_DBG_CTRL_S_RETIRE_ST \
+                                0x01000000  // Core has executed insruction
+                                            // since last read
+#define NVIC_DBG_CTRL_S_LOCKUP  0x00080000  // Core is locked up
+#define NVIC_DBG_CTRL_S_SLEEP   0x00040000  // Core is sleeping
+#define NVIC_DBG_CTRL_S_HALT    0x00020000  // Core status on halt
+#define NVIC_DBG_CTRL_S_REGRDY  0x00010000  // Register read/write available
+#define NVIC_DBG_CTRL_C_SNAPSTALL \
+                                0x00000020  // Breaks a stalled load/store
+#define NVIC_DBG_CTRL_C_MASKINT 0x00000008  // Mask interrupts when stepping
+#define NVIC_DBG_CTRL_C_STEP    0x00000004  // Step the core
+#define NVIC_DBG_CTRL_C_HALT    0x00000002  // Halt the core
+#define NVIC_DBG_CTRL_C_DEBUGEN 0x00000001  // Enable debug
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_DBG_XFER register.
+//
+//*****************************************************************************
+#define NVIC_DBG_XFER_REG_WNR   0x00010000  // Write or not read
+#define NVIC_DBG_XFER_REG_SEL_M 0x0000001F  // Register
+#define NVIC_DBG_XFER_REG_R0    0x00000000  // Register R0
+#define NVIC_DBG_XFER_REG_R1    0x00000001  // Register R1
+#define NVIC_DBG_XFER_REG_R2    0x00000002  // Register R2
+#define NVIC_DBG_XFER_REG_R3    0x00000003  // Register R3
+#define NVIC_DBG_XFER_REG_R4    0x00000004  // Register R4
+#define NVIC_DBG_XFER_REG_R5    0x00000005  // Register R5
+#define NVIC_DBG_XFER_REG_R6    0x00000006  // Register R6
+#define NVIC_DBG_XFER_REG_R7    0x00000007  // Register R7
+#define NVIC_DBG_XFER_REG_R8    0x00000008  // Register R8
+#define NVIC_DBG_XFER_REG_R9    0x00000009  // Register R9
+#define NVIC_DBG_XFER_REG_R10   0x0000000A  // Register R10
+#define NVIC_DBG_XFER_REG_R11   0x0000000B  // Register R11
+#define NVIC_DBG_XFER_REG_R12   0x0000000C  // Register R12
+#define NVIC_DBG_XFER_REG_R13   0x0000000D  // Register R13
+#define NVIC_DBG_XFER_REG_R14   0x0000000E  // Register R14
+#define NVIC_DBG_XFER_REG_R15   0x0000000F  // Register R15
+#define NVIC_DBG_XFER_REG_FLAGS 0x00000010  // xPSR/Flags register
+#define NVIC_DBG_XFER_REG_MSP   0x00000011  // Main SP
+#define NVIC_DBG_XFER_REG_PSP   0x00000012  // Process SP
+#define NVIC_DBG_XFER_REG_DSP   0x00000013  // Deep SP
+#define NVIC_DBG_XFER_REG_CFBP  0x00000014  // Control/Fault/BasePri/PriMask
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_DBG_DATA register.
+//
+//*****************************************************************************
+#define NVIC_DBG_DATA_M         0xFFFFFFFF  // Data temporary cache
+#define NVIC_DBG_DATA_S         0
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_DBG_INT register.
+//
+//*****************************************************************************
+#define NVIC_DBG_INT_HARDERR    0x00000400  // Debug trap on hard fault
+#define NVIC_DBG_INT_INTERR     0x00000200  // Debug trap on interrupt errors
+#define NVIC_DBG_INT_BUSERR     0x00000100  // Debug trap on bus error
+#define NVIC_DBG_INT_STATERR    0x00000080  // Debug trap on usage fault state
+#define NVIC_DBG_INT_CHKERR     0x00000040  // Debug trap on usage fault check
+#define NVIC_DBG_INT_NOCPERR    0x00000020  // Debug trap on coprocessor error
+#define NVIC_DBG_INT_MMERR      0x00000010  // Debug trap on mem manage fault
+#define NVIC_DBG_INT_RESET      0x00000008  // Core reset status
+#define NVIC_DBG_INT_RSTPENDCLR 0x00000004  // Clear pending core reset
+#define NVIC_DBG_INT_RSTPENDING 0x00000002  // Core reset is pending
+#define NVIC_DBG_INT_RSTVCATCH  0x00000001  // Reset vector catch
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the NVIC_SW_TRIG register.
+//
+//*****************************************************************************
+#define NVIC_SW_TRIG_INTID_M    0x0000003F  // Interrupt ID
+#undef NVIC_SW_TRIG_INTID_M
+#define NVIC_SW_TRIG_INTID_M    0x000000FF  // Interrupt ID
+#define NVIC_SW_TRIG_INTID_S    0
+
+#endif // __HW_NVIC_H__

--- a/cpu/cc2538/include/vendor/hw_pka.h
+++ b/cpu/cc2538/include/vendor/hw_pka.h
@@ -1,0 +1,792 @@
+/******************************************************************************
+*  Filename:       hw_pka.h
+*  Revised:        $Date: 2013-04-30 17:13:44 +0200 (Tue, 30 Apr 2013) $
+*  Revision:       $Revision: 9943 $
+*
+*  Copyright (C) 2013 Texas Instruments Incorporated - http://www.ti.com/
+*
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*    Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+*
+*    Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+*
+*    Neither the name of Texas Instruments Incorporated nor the names of
+*    its contributors may be used to endorse or promote products derived
+*    from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+*  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+*  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+*  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+*  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+*  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+*  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+*  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+*  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+******************************************************************************/
+
+#ifndef __HW_PKA_H__
+#define __HW_PKA_H__
+
+//*****************************************************************************
+//
+// The following are defines for the PKA register offsets.
+//
+//*****************************************************************************
+#define PKA_APTR                0x44004000  // PKA vector A address During 
+                                            // execution of basic PKCP 
+                                            // operations, this register is 
+                                            // double buffered and can be 
+                                            // written with a new value for the 
+                                            // next operation; when not 
+                                            // written, the value remains 
+                                            // intact. During the execution of 
+                                            // sequencer-controlled complex 
+                                            // operations, this register may 
+                                            // not be written and its value is 
+                                            // undefined at the conclusion of 
+                                            // the operation. The driver 
+                                            // software cannot rely on the 
+                                            // written value to remain intact. 
+#define PKA_BPTR                0x44004004  // PKA vector B address During 
+                                            // execution of basic PKCP 
+                                            // operations, this register is 
+                                            // double buffered and can be 
+                                            // written with a new value for the 
+                                            // next operation; when not 
+                                            // written, the value remains 
+                                            // intact. During the execution of 
+                                            // sequencer-controlled complex 
+                                            // operations, this register may 
+                                            // not be written and its value is 
+                                            // undefined at the conclusion of 
+                                            // the operation. The driver 
+                                            // software cannot rely on the 
+                                            // written value to remain intact. 
+#define PKA_CPTR                0x44004008  // PKA vector C address During 
+                                            // execution of basic PKCP 
+                                            // operations, this register is 
+                                            // double buffered and can be 
+                                            // written with a new value for the 
+                                            // next operation; when not 
+                                            // written, the value remains 
+                                            // intact. During the execution of 
+                                            // sequencer-controlled complex 
+                                            // operations, this register may 
+                                            // not be written and its value is 
+                                            // undefined at the conclusion of 
+                                            // the operation. The driver 
+                                            // software cannot rely on the 
+                                            // written value to remain intact. 
+#define PKA_DPTR                0x4400400C  // PKA vector D address During 
+                                            // execution of basic PKCP 
+                                            // operations, this register is 
+                                            // double buffered and can be 
+                                            // written with a new value for the 
+                                            // next operation; when not 
+                                            // written, the value remains 
+                                            // intact. During the execution of 
+                                            // sequencer-controlled complex 
+                                            // operations, this register may 
+                                            // not be written and its value is 
+                                            // undefined at the conclusion of 
+                                            // the operation. The driver 
+                                            // software cannot rely on the 
+                                            // written value to remain intact. 
+#define PKA_ALENGTH             0x44004010  // PKA vector A length During 
+                                            // execution of basic PKCP 
+                                            // operations, this register is 
+                                            // double buffered and can be 
+                                            // written with a new value for the 
+                                            // next operation; when not 
+                                            // written, the value remains 
+                                            // intact. During the execution of 
+                                            // sequencer-controlled complex 
+                                            // operations, this register may 
+                                            // not be written and its value is 
+                                            // undefined at the conclusion of 
+                                            // the operation. The driver 
+                                            // software cannot rely on the 
+                                            // written value to remain intact. 
+#define PKA_BLENGTH             0x44004014  // PKA vector B length During 
+                                            // execution of basic PKCP 
+                                            // operations, this register is 
+                                            // double buffered and can be 
+                                            // written with a new value for the 
+                                            // next operation; when not 
+                                            // written, the value remains 
+                                            // intact. During the execution of 
+                                            // sequencer-controlled complex 
+                                            // operations, this register may 
+                                            // not be written and its value is 
+                                            // undefined at the conclusion of 
+                                            // the operation. The driver 
+                                            // software cannot rely on the 
+                                            // written value to remain intact. 
+#define PKA_SHIFT               0x44004018  // PKA bit shift value For basic 
+                                            // PKCP operations, modifying the 
+                                            // contents of this register is 
+                                            // made impossible while the 
+                                            // operation is being performed. 
+                                            // For the ExpMod-variable and 
+                                            // ExpMod-CRT operations, this 
+                                            // register is used to indicate the 
+                                            // number of odd powers to use 
+                                            // (directly as a value in the 
+                                            // range 1-16). For the ModInv and 
+                                            // ECC operations, this register is 
+                                            // used to hold a completion code. 
+#define PKA_FUNCTION            0x4400401C  // PKA function This register 
+                                            // contains the control bits to 
+                                            // start basic PKCP as well as 
+                                            // complex sequencer operations. 
+                                            // The run bit can be used to poll 
+                                            // for the completion of the 
+                                            // operation. Modifying bits [11:0] 
+                                            // is made impossible during the 
+                                            // execution of a basic PKCP 
+                                            // operation. During the execution 
+                                            // of sequencer-controlled complex 
+                                            // operations, this register is 
+                                            // modified; the run and stall 
+                                            // result bits are set to zero at 
+                                            // the conclusion, but other bits 
+                                            // are undefined. Attention: 
+                                            // Continuously reading this 
+                                            // register to poll the run bit is 
+                                            // not allowed when executing 
+                                            // complex sequencer operations 
+                                            // (the sequencer cannot access the 
+                                            // PKCP when this is done). Leave 
+                                            // at least one sysclk cycle 
+                                            // between poll operations. 
+#define PKA_COMPARE             0x44004020  // PKA compare result This 
+                                            // register provides the result of 
+                                            // a basic PKCP compare operation. 
+                                            // It is updated when the run bit 
+                                            // in the PKA_FUNCTION register is 
+                                            // reset at the end of that 
+                                            // operation. Status after a 
+                                            // complex sequencer operation is 
+                                            // unknown 
+#define PKA_MSW                 0x44004024  // PKA most-significant-word of 
+                                            // result vector This register 
+                                            // indicates the (word) address in 
+                                            // the PKA RAM where the most 
+                                            // significant nonzero 32-bit word 
+                                            // of the result is stored. Should 
+                                            // be ignored for modulo 
+                                            // operations. For basic PKCP 
+                                            // operations, this register is 
+                                            // updated when the run bit in the 
+                                            // PKA_FUNCTION register is reset 
+                                            // at the end of the operation. For 
+                                            // the complex-sequencer controlled 
+                                            // operations, updating of the 
+                                            // final value matching the actual 
+                                            // result is done near the end of 
+                                            // the operation; note that the 
+                                            // result is only meaningful if no 
+                                            // errors were detected and that 
+                                            // for ECC operations, the PKA_MSW 
+                                            // register will provide 
+                                            // information for the x-coordinate 
+                                            // of the result point only. 
+#define PKA_DIVMSW              0x44004028  // PKA most-significant-word of 
+                                            // divide remainder This register 
+                                            // indicates the (32-bit word) 
+                                            // address in the PKA RAM where the 
+                                            // most significant nonzero 32-bit 
+                                            // word of the remainder result for 
+                                            // the basic divide and modulo 
+                                            // operations is stored. Bits [4:0] 
+                                            // are loaded with the bit number 
+                                            // of the most-significant nonzero 
+                                            // bit in the most-significant 
+                                            // nonzero word when MS one control 
+                                            // bit is set. For divide, modulo, 
+                                            // and MS one reporting, this 
+                                            // register is updated when the RUN 
+                                            // bit in the PKA_FUNCTION register 
+                                            // is reset at the end of the 
+                                            // operation. For the complex 
+                                            // sequencer controlled operations, 
+                                            // updating of bits [4:0] of this 
+                                            // register with the 
+                                            // most-significant bit location of 
+                                            // the actual result is done near 
+                                            // the end of the operation. The 
+                                            // result is meaningful only if no 
+                                            // errors were detected and that 
+                                            // for ECC operations; the 
+                                            // PKA_DIVMSW register provides 
+                                            // information for the x-coordinate 
+                                            // of the result point only. 
+#define PKA_SEQ_CTRL            0x440040C8  // PKA sequencer control and 
+                                            // status register The sequencer is 
+                                            // interfaced with the outside 
+                                            // world through a single control 
+                                            // and status register. With the 
+                                            // exception of bit [31], the 
+                                            // actual use of bits in the 
+                                            // separate sub-fields of this 
+                                            // register is determined by the 
+                                            // sequencer firmware. This 
+                                            // register need only be accessed 
+                                            // when the sequencer program is 
+                                            // stored in RAM. The reset value 
+                                            // of the RESTE bit depends upon 
+                                            // the option chosen for sequencer 
+                                            // program storage. 
+#define PKA_OPTIONS             0x440040F4  // PKA hardware options register 
+                                            // This register provides the host 
+                                            // with a means to determine the 
+                                            // hardware configuration 
+                                            // implemented in this PKA engine, 
+                                            // focused on options that have an 
+                                            // effect on software interacting 
+                                            // with the module. Note: (32 x 
+                                            // (1st LNME nr. of PEs + 1st LNME 
+                                            // FIFO RAM depth - 10)) equals the 
+                                            // maximum modulus vector length 
+                                            // (in bits) that can be handled by 
+                                            // the modular exponentiation and 
+                                            // ECC operations executed on a PKA 
+                                            // engine that includes an LNME. 
+#define PKA_SW_REV              0x440040F8  // PKA firmware revision and 
+                                            // capabilities register This 
+                                            // register allows the host access 
+                                            // to the internal firmware 
+                                            // revision number of the PKA 
+                                            // Engine for software driver 
+                                            // matching and diagnostic 
+                                            // purposes. This register also 
+                                            // contains a field that encodes 
+                                            // the capabilities of the embedded 
+                                            // firmware. The PKA_SW_REV 
+                                            // register is written by the 
+                                            // firmware within a few clock 
+                                            // cycles after starting up that 
+                                            // firmware. The hardware reset 
+                                            // value is zero, indicating that 
+                                            // the information has not been 
+                                            // written yet. 
+#define PKA_REVISION            0x440040FC  // PKA hardware revision register 
+                                            // This register allows the host 
+                                            // access to the hardware revision 
+                                            // number of the PKA engine for 
+                                            // software driver matching and 
+                                            // diagnostic purposes. It is 
+                                            // always located at the highest 
+                                            // address in the access space of 
+                                            // the module and contains an 
+                                            // encoding of the EIP number (with 
+                                            // its complement as signature) for 
+                                            // recognition of the hardware 
+                                            // module. 
+
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the PKA_APTR register.
+//
+//*****************************************************************************
+#define PKA_APTR_APTR_M         0x000007FF  // This register specifies the 
+                                            // location of vector A within the 
+                                            // PKA RAM. Vectors are identified 
+                                            // through the location of their 
+                                            // least-significant 32-bit word. 
+                                            // Note that bit [0] must be zero 
+                                            // to ensure that the vector starts 
+                                            // at an 8-byte boundary. 
+#define PKA_APTR_APTR_S         0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the PKA_BPTR register.
+//
+//*****************************************************************************
+#define PKA_BPTR_BPTR_M         0x000007FF  // This register specifies the 
+                                            // location of vector B within the 
+                                            // PKA RAM. Vectors are identified 
+                                            // through the location of their 
+                                            // least-significant 32-bit word. 
+                                            // Note that bit [0] must be zero 
+                                            // to ensure that the vector starts 
+                                            // at an 8-byte boundary. 
+#define PKA_BPTR_BPTR_S         0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the PKA_CPTR register.
+//
+//*****************************************************************************
+#define PKA_CPTR_CPTR_M         0x000007FF  // This register specifies the 
+                                            // location of vector C within the 
+                                            // PKA RAM. Vectors are identified 
+                                            // through the location of their 
+                                            // least-significant 32-bit word. 
+                                            // Note that bit [0] must be zero 
+                                            // to ensure that the vector starts 
+                                            // at an 8-byte boundary. 
+#define PKA_CPTR_CPTR_S         0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the PKA_DPTR register.
+//
+//*****************************************************************************
+#define PKA_DPTR_DPTR_M         0x000007FF  // This register specifies the 
+                                            // location of vector D within the 
+                                            // PKA RAM. Vectors are identified 
+                                            // through the location of their 
+                                            // least-significant 32-bit word. 
+                                            // Note that bit [0] must be zero 
+                                            // to ensure that the vector starts 
+                                            // at an 8-byte boundary. 
+#define PKA_DPTR_DPTR_S         0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the PKA_ALENGTH register.
+//
+//*****************************************************************************
+#define PKA_ALENGTH_ALENGTH_M   0x000001FF  // This register specifies the 
+                                            // length (in 32-bit words) of 
+                                            // Vector A. 
+#define PKA_ALENGTH_ALENGTH_S   0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the PKA_BLENGTH register.
+//
+//*****************************************************************************
+#define PKA_BLENGTH_BLENGTH_M   0x000001FF  // This register specifies the 
+                                            // length (in 32-bit words) of 
+                                            // Vector B. 
+#define PKA_BLENGTH_BLENGTH_S   0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the PKA_SHIFT register.
+//
+//*****************************************************************************
+#define PKA_SHIFT_NUM_BITS_TO_SHIFT_M \
+                                0x0000001F  // This register specifies the 
+                                            // number of bits to shift the 
+                                            // input vector (in the range 0-31) 
+                                            // during a Rshift or Lshift 
+                                            // operation. 
+
+#define PKA_SHIFT_NUM_BITS_TO_SHIFT_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the PKA_FUNCTION register.
+//
+//*****************************************************************************
+#define PKA_FUNCTION_STALL_RESULT \
+                                0x01000000  // When written with a 1b, 
+                                            // updating of the PKA_COMPARE, 
+                                            // PKA_MSW and PKA_DIVMSW 
+                                            // registers, as well as resetting 
+                                            // the run bit is stalled beyond 
+                                            // the point that a running 
+                                            // operation is actually finished. 
+                                            // Use this to allow software 
+                                            // enough time to read results from 
+                                            // a previous operation when the 
+                                            // newly started operation is known 
+                                            // to take only a short amount of 
+                                            // time. If a result is waiting, 
+                                            // the result registers is updated 
+                                            // and the run bit is reset in the 
+                                            // clock cycle following writing 
+                                            // the stall result bit back to 0b. 
+                                            // The Stall result function may 
+                                            // only be used for basic PKCP 
+                                            // operations. 
+
+#define PKA_FUNCTION_STALL_RESULT_M \
+                                0x01000000
+#define PKA_FUNCTION_STALL_RESULT_S 24
+#define PKA_FUNCTION_RUN        0x00008000  // The host sets this bit to 
+                                            // instruct the PKA module to begin 
+                                            // processing the basic PKCP or 
+                                            // complex sequencer operation. 
+                                            // This bit is reset low 
+                                            // automatically when the operation 
+                                            // is complete. The complement of 
+                                            // this bit is output as 
+                                            // interrupts[1]. After a reset, 
+                                            // the run bit is always set to 1b. 
+                                            // Depending on the option, program 
+                                            // ROM or program RAM, the 
+                                            // following applies: Program ROM - 
+                                            // The first sequencer instruction 
+                                            // sets the bit to 0b. This is done 
+                                            // immediately after the hardware 
+                                            // reset is released. Program RAM - 
+                                            // The sequencer must set the bit 
+                                            // to 0b. As a valid firmware may 
+                                            // not have been loaded, the 
+                                            // sequencer is held in software 
+                                            // reset after the hardware reset 
+                                            // is released (the reset bit in 
+                                            // PKA_SEQ_CRTL is set to 1b). 
+                                            // After the FW image is loaded and 
+                                            // the Reset bit is cleared, the 
+                                            // sequencer starts to execute the 
+                                            // FW. The first instruction clears 
+                                            // the run bit. In both cases a few 
+                                            // clock cycles are needed before 
+                                            // the first instruction is 
+                                            // executed and the run bit state 
+                                            // has been propagated. 
+#define PKA_FUNCTION_RUN_M      0x00008000
+#define PKA_FUNCTION_RUN_S      15
+#define PKA_FUNCTION_SEQUENCER_OPERATIONS_M \
+                                0x00007000  // These bits select the complex 
+                                            // sequencer operation to perform: 
+                                            // 000b: None 001b: ExpMod-CRT 
+                                            // 010b: ExpMod-ACT4 (compatible 
+                                            // with EIP2315) 011b: ECC-ADD (if 
+                                            // available in firmware, otherwise 
+                                            // reserved) 100b: ExpMod-ACT2 
+                                            // (compatible with EIP2316) 101b: 
+                                            // ECC-MUL (if available in 
+                                            // firmware, otherwise reserved) 
+                                            // 110b: ExpMod-variable 111b: 
+                                            // ModInv (if available in 
+                                            // firmware, otherwise reserved) 
+                                            // The encoding of these operations 
+                                            // is determined by sequencer 
+                                            // firmware. 
+
+#define PKA_FUNCTION_SEQUENCER_OPERATIONS_S 12
+#define PKA_FUNCTION_COPY       0x00000800  // Perform copy operation 
+#define PKA_FUNCTION_COPY_M     0x00000800
+#define PKA_FUNCTION_COPY_S     11
+#define PKA_FUNCTION_COMPARE    0x00000400  // Perform compare operation 
+#define PKA_FUNCTION_COMPARE_M  0x00000400
+#define PKA_FUNCTION_COMPARE_S  10
+#define PKA_FUNCTION_MODULO     0x00000200  // Perform modulo operation 
+#define PKA_FUNCTION_MODULO_M   0x00000200
+#define PKA_FUNCTION_MODULO_S   9
+#define PKA_FUNCTION_DIVIDE     0x00000100  // Perform divide operation 
+#define PKA_FUNCTION_DIVIDE_M   0x00000100
+#define PKA_FUNCTION_DIVIDE_S   8
+#define PKA_FUNCTION_LSHIFT     0x00000080  // Perform left shift operation 
+#define PKA_FUNCTION_LSHIFT_M   0x00000080
+#define PKA_FUNCTION_LSHIFT_S   7
+#define PKA_FUNCTION_RSHIFT     0x00000040  // Perform right shift operation 
+#define PKA_FUNCTION_RSHIFT_M   0x00000040
+#define PKA_FUNCTION_RSHIFT_S   6
+#define PKA_FUNCTION_SUBTRACT   0x00000020  // Perform subtract operation 
+#define PKA_FUNCTION_SUBTRACT_M 0x00000020
+#define PKA_FUNCTION_SUBTRACT_S 5
+#define PKA_FUNCTION_ADD        0x00000010  // Perform add operation 
+#define PKA_FUNCTION_ADD_M      0x00000010
+#define PKA_FUNCTION_ADD_S      4
+#define PKA_FUNCTION_MS_ONE     0x00000008  // Loads the location of the Most 
+                                            // Significant one bit within the 
+                                            // result word indicated in the 
+                                            // PKA_MSW register into bits [4:0] 
+                                            // of the PKA_DIVMSW register - can 
+                                            // only be used with basic PKCP 
+                                            // operations, except for Divide, 
+                                            // Modulo and Compare. 
+#define PKA_FUNCTION_MS_ONE_M   0x00000008
+#define PKA_FUNCTION_MS_ONE_S   3
+#define PKA_FUNCTION_ADDSUB     0x00000002  // Perform combined add/subtract 
+                                            // operation 
+#define PKA_FUNCTION_ADDSUB_M   0x00000002
+#define PKA_FUNCTION_ADDSUB_S   1
+#define PKA_FUNCTION_MULTIPLY   0x00000001  // Perform multiply operation 
+#define PKA_FUNCTION_MULTIPLY_M 0x00000001
+#define PKA_FUNCTION_MULTIPLY_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the PKA_COMPARE register.
+//
+//*****************************************************************************
+#define PKA_COMPARE_A_GREATER_THAN_B \
+                                0x00000004  // Vector_A is greater than 
+                                            // Vector_B 
+
+#define PKA_COMPARE_A_GREATER_THAN_B_M \
+                                0x00000004
+#define PKA_COMPARE_A_GREATER_THAN_B_S 2
+#define PKA_COMPARE_A_LESS_THAN_B \
+                                0x00000002  // Vector_A is less than Vector_B 
+
+#define PKA_COMPARE_A_LESS_THAN_B_M \
+                                0x00000002
+#define PKA_COMPARE_A_LESS_THAN_B_S 1
+#define PKA_COMPARE_A_EQUALS_B  0x00000001  // Vector_A is equal to Vector_B 
+#define PKA_COMPARE_A_EQUALS_B_M \
+                                0x00000001
+#define PKA_COMPARE_A_EQUALS_B_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the PKA_MSW register.
+//
+//*****************************************************************************
+#define PKA_MSW_RESULT_IS_ZERO  0x00008000  // The result vector is all 
+                                            // zeroes, ignore the address 
+                                            // returned in bits [10:0] 
+#define PKA_MSW_RESULT_IS_ZERO_M \
+                                0x00008000
+#define PKA_MSW_RESULT_IS_ZERO_S 15
+#define PKA_MSW_MSW_ADDRESS_M   0x000007FF  // Address of the most-significant 
+                                            // nonzero 32-bit word of the 
+                                            // result vector in PKA RAM 
+#define PKA_MSW_MSW_ADDRESS_S   0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the PKA_DIVMSW register.
+//
+//*****************************************************************************
+#define PKA_DIVMSW_RESULT_IS_ZERO \
+                                0x00008000  // The result vector is all 
+                                            // zeroes, ignore the address 
+                                            // returned in bits [10:0] 
+
+#define PKA_DIVMSW_RESULT_IS_ZERO_M \
+                                0x00008000
+#define PKA_DIVMSW_RESULT_IS_ZERO_S 15
+#define PKA_DIVMSW_MSW_ADDRESS_M \
+                                0x000007FF  // Address of the most significant 
+                                            // nonzero 32-bit word of the 
+                                            // remainder result vector in PKA 
+                                            // RAM 
+
+#define PKA_DIVMSW_MSW_ADDRESS_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the PKA_SEQ_CTRL register.
+//
+//*****************************************************************************
+#define PKA_SEQ_CTRL_RESET      0x80000000  // Option program ROM: Reset value 
+                                            // = 0. Read/Write, reset value 0b 
+                                            // (ZERO). Writing 1b resets the 
+                                            // sequencer, write to 0b to 
+                                            // restart operations again. As the 
+                                            // reset value is 0b, the sequencer 
+                                            // will automatically start 
+                                            // operations executing from 
+                                            // program ROM. This bit should 
+                                            // always be written with zero and 
+                                            // ignored when reading this 
+                                            // register. Option Program RAM: 
+                                            // Reset value =1. Read/Write, 
+                                            // reset value 1b (ONE). When 1b, 
+                                            // the sequencer is held in a reset 
+                                            // state and the PKA_PROGRAM area 
+                                            // is accessible for loading the 
+                                            // sequencer program (while the 
+                                            // PKA_DATA_RAM is inaccessible), 
+                                            // write to 0b to (re)start 
+                                            // sequencer operations and disable 
+                                            // PKA_PROGRAM area accessibility 
+                                            // (also enables the PKA_DATA_RAM 
+                                            // accesses). Resetting the 
+                                            // sequencer (in order to load 
+                                            // other firmware) should only be 
+                                            // done when the PKA Engine is not 
+                                            // performing any operations (i.e. 
+                                            // the run bit in the PKA_FUNCTION 
+                                            // register should be zero). 
+#define PKA_SEQ_CTRL_RESET_M    0x80000000
+#define PKA_SEQ_CTRL_RESET_S    31
+#define PKA_SEQ_CTRL_SEQUENCER_STATUS_M \
+                                0x0000FF00  // These read-only bits can be 
+                                            // used by the sequencer to 
+                                            // communicate status to the 
+                                            // outside world. Bit [8] is also 
+                                            // used as sequencer interrupt, 
+                                            // with the complement of this bit 
+                                            // ORed into the run bit in 
+                                            // PKA_FUNCTION. This field should 
+                                            // always be written with zeroes 
+                                            // and ignored when reading this 
+                                            // register. 
+
+#define PKA_SEQ_CTRL_SEQUENCER_STATUS_S 8
+#define PKA_SEQ_CTRL_SW_CONTROL_STATUS_M \
+                                0x000000FF  // These bits can be used by 
+                                            // software to trigger sequencer 
+                                            // operations. External logic can 
+                                            // set these bits by writing 1b, 
+                                            // cannot reset them by writing 0b. 
+                                            // The sequencer can reset these 
+                                            // bits by writing 0b, cannot set 
+                                            // them by writing 1b. Setting the 
+                                            // run bit in PKA_FUNCTION together 
+                                            // with a nonzero sequencer 
+                                            // operations field automatically 
+                                            // sets bit [0] here. This field 
+                                            // should always be written with 
+                                            // zeroes and ignored when reading 
+                                            // this register. 
+
+#define PKA_SEQ_CTRL_SW_CONTROL_STATUS_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the PKA_OPTIONS register.
+//
+//*****************************************************************************
+#define PKA_OPTIONS_FIRST_LNME_FIFO_DEPTH_M \
+                                0xFF000000  // Number of words in the first 
+                                            // LNME's FIFO RAM Should be 
+                                            // ignored if LNME configuration is 
+                                            // 0. The contents of this field 
+                                            // indicate the actual depth as 
+                                            // selected by the LNME FIFO RAM 
+                                            // size strap input, fifo_size_sel. 
+                                            // Note: Reset value is undefined 
+
+#define PKA_OPTIONS_FIRST_LNME_FIFO_DEPTH_S 24
+#define PKA_OPTIONS_FIRST_LNME_NR_OF_PES_M \
+                                0x003F0000  // Number of processing elements 
+                                            // in the pipeline of the first 
+                                            // LNME Should be ignored if LNME 
+                                            // configuration is 0. Note: Reset 
+                                            // value is undefined. 
+
+#define PKA_OPTIONS_FIRST_LNME_NR_OF_PES_S 16
+#define PKA_OPTIONS_MMM3A       0x00001000  // Reserved for a future 
+                                            // functional extension to the LNME 
+                                            // Always 0b 
+#define PKA_OPTIONS_MMM3A_M     0x00001000
+#define PKA_OPTIONS_MMM3A_S     12
+#define PKA_OPTIONS_INT_MASKING 0x00000800  // Value 0b indicates that the 
+                                            // main interrupt output (bit [1] 
+                                            // of the interrupts output bus) is 
+                                            // the direct complement of the run 
+                                            // bit in the PKA_CONTROL register, 
+                                            // value 1b indicates that 
+                                            // interrupt masking logic is 
+                                            // present for this output. Note: 
+                                            // Reset value is undefined 
+#define PKA_OPTIONS_INT_MASKING_M \
+                                0x00000800
+#define PKA_OPTIONS_INT_MASKING_S 11
+#define PKA_OPTIONS_PROTECTION_OPTION_M \
+                                0x00000700  // Value 0 indicates no additional 
+                                            // protection against side channel 
+                                            // attacks, value 1 indicates the 
+                                            // SCAP option, value 3 indicates 
+                                            // the PROT option; other values 
+                                            // are reserved. Note: Reset value 
+                                            // is undefined 
+
+#define PKA_OPTIONS_PROTECTION_OPTION_S 8
+#define PKA_OPTIONS_PROGRAM_RAM 0x00000080  // Value 1b indicates sequencer 
+                                            // program storage in RAM, value 0b 
+                                            // in ROM. Note: Reset value is 
+                                            // undefined 
+#define PKA_OPTIONS_PROGRAM_RAM_M \
+                                0x00000080
+#define PKA_OPTIONS_PROGRAM_RAM_S 7
+#define PKA_OPTIONS_SEQUENCER_CONFIGURATION_M \
+                                0x00000060  // Value 1 indicates a standard 
+                                            // sequencer; other values are 
+                                            // reserved. 
+
+#define PKA_OPTIONS_SEQUENCER_CONFIGURATION_S 5
+#define PKA_OPTIONS_LNME_CONFIGURATION_M \
+                                0x0000001C  // Value 0 indicates NO LNME, 
+                                            // value 1 indicates one standard 
+                                            // LNME (with alpha = 32, beta = 
+                                            // 8); other values reserved. Note: 
+                                            // Reset value is undefined 
+
+#define PKA_OPTIONS_LNME_CONFIGURATION_S 2
+#define PKA_OPTIONS_PKCP_CONFIGURATION_M \
+                                0x00000003  // Value 1 indicates a PKCP with a 
+                                            // 16x16 multiplier, value 2 
+                                            // indicates a PKCP with a 32x32 
+                                            // multiplier, other values 
+                                            // reserved. Note: Reset value is 
+                                            // undefined. 
+
+#define PKA_OPTIONS_PKCP_CONFIGURATION_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the PKA_SW_REV register.
+//
+//*****************************************************************************
+#define PKA_SW_REV_FW_CAPABILITIES_M \
+                                0xF0000000  // 4-bit binary encoding for the 
+                                            // functionality implemented in the 
+                                            // firmware. Value 0 indicates 
+                                            // basic ModExp with/without CRT. 
+                                            // Value 1 adds Modular Inversion, 
+                                            // value 2 adds Modular Inversion 
+                                            // and ECC operations. Values 3-15 
+                                            // are reserved. 
+
+#define PKA_SW_REV_FW_CAPABILITIES_S 28
+#define PKA_SW_REV_MAJOR_FW_REVISION_M \
+                                0x0F000000  // 4-bit binary encoding of the 
+                                            // major firmware revision number 
+
+#define PKA_SW_REV_MAJOR_FW_REVISION_S 24
+#define PKA_SW_REV_MINOR_FW_REVISION_M \
+                                0x00F00000  // 4-bit binary encoding of the 
+                                            // minor firmware revision number 
+
+#define PKA_SW_REV_MINOR_FW_REVISION_S 20
+#define PKA_SW_REV_FW_PATCH_LEVEL_M \
+                                0x000F0000  // 4-bit binary encoding of the 
+                                            // firmware patch level, initial 
+                                            // release will carry value zero 
+                                            // Patches are used to remove bugs 
+                                            // without changing the 
+                                            // functionality or interface of a 
+                                            // module. 
+
+#define PKA_SW_REV_FW_PATCH_LEVEL_S 16
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the PKA_REVISION register.
+//
+//*****************************************************************************
+#define PKA_REVISION_MAJOR_HW_REVISION_M \
+                                0x0F000000  // 4-bit binary encoding of the 
+                                            // major hardware revision number 
+
+#define PKA_REVISION_MAJOR_HW_REVISION_S 24
+#define PKA_REVISION_MINOR_HW_REVISION_M \
+                                0x00F00000  // 4-bit binary encoding of the 
+                                            // minor hardware revision number 
+
+#define PKA_REVISION_MINOR_HW_REVISION_S 20
+#define PKA_REVISION_HW_PATCH_LEVEL_M \
+                                0x000F0000  // 4-bit binary encoding of the 
+                                            // hardware patch level, initial 
+                                            // release will carry value zero 
+                                            // Patches are used to remove bugs 
+                                            // without changing the 
+                                            // functionality or interface of a 
+                                            // module. 
+
+#define PKA_REVISION_HW_PATCH_LEVEL_S 16
+#define PKA_REVISION_COMPLEMENT_OF_BASIC_EIP_NUMBER_M \
+                                0x0000FF00  // Bit-by-bit logic complement of 
+                                            // bits [7:0], EIP-28 gives 0xE3 
+
+#define PKA_REVISION_COMPLEMENT_OF_BASIC_EIP_NUMBER_S 8
+#define PKA_REVISION_BASIC_EIP_NUMBER_M \
+                                0x000000FF  // 8-bit binary encoding of the 
+                                            // EIP number, EIP-28 gives 0x1C 
+
+#define PKA_REVISION_BASIC_EIP_NUMBER_S 0
+
+
+#endif // __HW_PKA_H__
+

--- a/cpu/cc2538/include/vendor/hw_rfcore_ffsm.h
+++ b/cpu/cc2538/include/vendor/hw_rfcore_ffsm.h
@@ -1,0 +1,440 @@
+/******************************************************************************
+*  Filename:       hw_rfcore_ffsm.h
+*  Revised:        $Date: 2013-04-12 15:10:54 +0200 (Fri, 12 Apr 2013) $
+*  Revision:       $Revision: 9735 $
+*
+*  Copyright (C) 2013 Texas Instruments Incorporated - http://www.ti.com/
+*
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*    Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+*
+*    Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+*
+*    Neither the name of Texas Instruments Incorporated nor the names of
+*    its contributors may be used to endorse or promote products derived
+*    from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+*  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+*  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+*  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+*  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+*  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+*  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+*  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+*  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+******************************************************************************/
+
+#ifndef __HW_RFCORE_FFSM_H__
+#define __HW_RFCORE_FFSM_H__
+
+//*****************************************************************************
+//
+// The following are defines for the RFCORE_FFSM register offsets.
+//
+//*****************************************************************************
+#define RFCORE_FFSM_SRCRESMASK0 \
+                                0x40088580  // Source address matching result 
+                                            // This register is stored in RAM; 
+                                            // the reset value is undefined. 
+
+#define RFCORE_FFSM_SRCRESMASK1 \
+                                0x40088584  // Source address matching result 
+                                            // This register is stored in RAM; 
+                                            // the reset value is undefined. 
+
+#define RFCORE_FFSM_SRCRESMASK2 \
+                                0x40088588  // Source address matching result 
+                                            // This register is stored in RAM; 
+                                            // the reset value is undefined. 
+
+#define RFCORE_FFSM_SRCRESINDEX \
+                                0x4008858C  // Source address matching result 
+                                            // This register is stored in RAM; 
+                                            // the reset value is undefined. 
+
+#define RFCORE_FFSM_SRCEXTPENDEN0 \
+                                0x40088590  // Source address matching control 
+                                            // This register is stored in RAM; 
+                                            // the reset value is undefined. 
+
+#define RFCORE_FFSM_SRCEXTPENDEN1 \
+                                0x40088594  // Source address matching control 
+                                            // This register is stored in RAM; 
+                                            // the reset value is undefined. 
+
+#define RFCORE_FFSM_SRCEXTPENDEN2 \
+                                0x40088598  // Source address matching control 
+                                            // This register is stored in RAM; 
+                                            // the reset value is undefined. 
+
+#define RFCORE_FFSM_SRCSHORTPENDEN0 \
+                                0x4008859C  // Source address matching control 
+                                            // This register is stored in RAM; 
+                                            // the reset value is undefined. 
+
+#define RFCORE_FFSM_SRCSHORTPENDEN1 \
+                                0x400885A0  // Source address matching control 
+                                            // This register is stored in RAM; 
+                                            // the reset value is undefined. 
+
+#define RFCORE_FFSM_SRCSHORTPENDEN2 \
+                                0x400885A4  // Source address matching control 
+                                            // This register is stored in RAM; 
+                                            // the reset value is undefined. 
+
+#define RFCORE_FFSM_EXT_ADDR0   0x400885A8  // Local address information This 
+                                            // register is stored in RAM; the 
+                                            // reset value is undefined. 
+#define RFCORE_FFSM_EXT_ADDR1   0x400885AC  // Local address information This 
+                                            // register is stored in RAM; the 
+                                            // reset value is undefined. 
+#define RFCORE_FFSM_EXT_ADDR2   0x400885B0  // Local address information This 
+                                            // register is stored in RAM; the 
+                                            // reset value is undefined. 
+#define RFCORE_FFSM_EXT_ADDR3   0x400885B4  // Local address information This 
+                                            // register is stored in RAM; the 
+                                            // reset value is undefined. 
+#define RFCORE_FFSM_EXT_ADDR4   0x400885B8  // Local address information This 
+                                            // register is stored in RAM; the 
+                                            // reset value is undefined. 
+#define RFCORE_FFSM_EXT_ADDR5   0x400885BC  // Local address information This 
+                                            // register is stored in RAM; the 
+                                            // reset value is undefined. 
+#define RFCORE_FFSM_EXT_ADDR6   0x400885C0  // Local address information This 
+                                            // register is stored in RAM; the 
+                                            // reset value is undefined. 
+#define RFCORE_FFSM_EXT_ADDR7   0x400885C4  // Local address information This 
+                                            // register is stored in RAM; the 
+                                            // reset value is undefined. 
+#define RFCORE_FFSM_PAN_ID0     0x400885C8  // Local address information This 
+                                            // register is stored in RAM; the 
+                                            // reset value is undefined. 
+#define RFCORE_FFSM_PAN_ID1     0x400885CC  // Local address information This 
+                                            // register is stored in RAM; the 
+                                            // reset value is undefined. 
+#define RFCORE_FFSM_SHORT_ADDR0 \
+                                0x400885D0  // Local address information This 
+                                            // register is stored in RAM; the 
+                                            // reset value is undefined. 
+
+#define RFCORE_FFSM_SHORT_ADDR1 \
+                                0x400885D4  // Local address information This 
+                                            // register is stored in RAM; the 
+                                            // reset value is undefined. 
+
+
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_FFSM_SRCRESMASK0 register.
+//
+//*****************************************************************************
+#define RFCORE_FFSM_SRCRESMASK0_SRCRESMASK0_M \
+                                0x000000FF  // Extended address matching When 
+                                            // there is a match on entry ext_n, 
+                                            // bits 2n and 2n + 1 are set in 
+                                            // SRCRESMASK. 
+
+#define RFCORE_FFSM_SRCRESMASK0_SRCRESMASK0_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_FFSM_SRCRESMASK1 register.
+//
+//*****************************************************************************
+#define RFCORE_FFSM_SRCRESMASK1_SRCRESMASK1_M \
+                                0x000000FF  // Short address matching When 
+                                            // there is a match on entry 
+                                            // panid_n + short_n, bit n is set 
+                                            // in SRCRESMASK. 
+
+#define RFCORE_FFSM_SRCRESMASK1_SRCRESMASK1_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_FFSM_SRCRESMASK2 register.
+//
+//*****************************************************************************
+#define RFCORE_FFSM_SRCRESMASK2_SRCRESMASK2_M \
+                                0x000000FF  // 24-bit mask that indicates 
+                                            // source address match for each 
+                                            // individual entry in the source 
+                                            // address table 
+
+#define RFCORE_FFSM_SRCRESMASK2_SRCRESMASK2_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_FFSM_SRCRESINDEX register.
+//
+//*****************************************************************************
+#define RFCORE_FFSM_SRCRESINDEX_SRCRESINDEX_M \
+                                0x000000FF  // The bit index of the 
+                                            // least-significant entry (0-23 
+                                            // for short addresses or 0-11 for 
+                                            // extended addresses) in 
+                                            // SRCRESMASK, or 0x3F when there 
+                                            // is no source match On a match, 
+                                            // bit 5 is 0 when the match is on 
+                                            // a short address and 1 when it is 
+                                            // on an extended address. On a 
+                                            // match, bit 6 is 1 when the 
+                                            // conditions for automatic pending 
+                                            // bit in acknowledgment have been 
+                                            // met (see the description of 
+                                            // SRCMATCH.AUTOPEND). The bit does 
+                                            // not indicate if the 
+                                            // acknowledgment is actually 
+                                            // transmitted, and does not 
+                                            // consider the PENDING_OR register 
+                                            // bit and the SACK/SACKPEND/SNACK 
+                                            // strobes. 
+
+#define RFCORE_FFSM_SRCRESINDEX_SRCRESINDEX_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_FFSM_SRCEXTPENDEN0 register.
+//
+//*****************************************************************************
+#define RFCORE_FFSM_SRCEXTPENDEN0_SRCEXTPENDEN0_M \
+                                0x000000FF  // 8 LSBs of the 24-bit mask that 
+                                            // enables or disables automatic 
+                                            // pending for each of the 12 
+                                            // extended addresses. Entry n is 
+                                            // mapped to SRCEXTPENDEN[2n]. All 
+                                            // SRCEXTPENDEN[2n + 1] bits are 
+                                            // don't care. 
+
+#define RFCORE_FFSM_SRCEXTPENDEN0_SRCEXTPENDEN0_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_FFSM_SRCEXTPENDEN1 register.
+//
+//*****************************************************************************
+#define RFCORE_FFSM_SRCEXTPENDEN1_SRCEXTPENDEN1_M \
+                                0x000000FF  // 8 middle bits of the 24-bit 
+                                            // mask that enables or disables 
+                                            // automatic pending for each of 
+                                            // the 12 extended addresses Entry 
+                                            // n is mapped to SRCEXTPENDEN[2n]. 
+                                            // All SRCEXTPENDEN[2n + 1] bits 
+                                            // are don't care. 
+
+#define RFCORE_FFSM_SRCEXTPENDEN1_SRCEXTPENDEN1_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_FFSM_SRCEXTPENDEN2 register.
+//
+//*****************************************************************************
+#define RFCORE_FFSM_SRCEXTPENDEN2_SRCEXTPENDEN2_M \
+                                0x000000FF  // 8 MSBs of the 24-bit mask that 
+                                            // enables or disables automatic 
+                                            // pending for each of the 12 
+                                            // extended addresses Entry n is 
+                                            // mapped to SRCEXTPENDEN[2n]. All 
+                                            // SRCEXTPENDEN[2n + 1] bits are 
+                                            // don't care. 
+
+#define RFCORE_FFSM_SRCEXTPENDEN2_SRCEXTPENDEN2_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_FFSM_SRCSHORTPENDEN0 register.
+//
+//*****************************************************************************
+#define RFCORE_FFSM_SRCSHORTPENDEN0_SRCSHORTPENDEN0_M \
+                                0x000000FF  // 8 LSBs of the 24-bit mask that 
+                                            // enables or disables automatic 
+                                            // pending for each of the 24 short 
+                                            // addresses 
+
+#define RFCORE_FFSM_SRCSHORTPENDEN0_SRCSHORTPENDEN0_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_FFSM_SRCSHORTPENDEN1 register.
+//
+//*****************************************************************************
+#define RFCORE_FFSM_SRCSHORTPENDEN1_SRCSHORTPENDEN1_M \
+                                0x000000FF  // 8 middle bits of the 24-bit 
+                                            // mask that enables or disables 
+                                            // automatic pending for each of 
+                                            // the 24 short addresses 
+
+#define RFCORE_FFSM_SRCSHORTPENDEN1_SRCSHORTPENDEN1_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_FFSM_SRCSHORTPENDEN2 register.
+//
+//*****************************************************************************
+#define RFCORE_FFSM_SRCSHORTPENDEN2_SRCSHORTPENDEN2_M \
+                                0x000000FF  // 8 MSBs of the 24-bit mask that 
+                                            // enables or disables automatic 
+                                            // pending for each of the 24 short 
+                                            // addresses 
+
+#define RFCORE_FFSM_SRCSHORTPENDEN2_SRCSHORTPENDEN2_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_FFSM_EXT_ADDR0 register.
+//
+//*****************************************************************************
+#define RFCORE_FFSM_EXT_ADDR0_EXT_ADDR0_M \
+                                0x000000FF  // EXT_ADDR[7:0] The IEEE extended 
+                                            // address used during destination 
+                                            // address filtering 
+
+#define RFCORE_FFSM_EXT_ADDR0_EXT_ADDR0_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_FFSM_EXT_ADDR1 register.
+//
+//*****************************************************************************
+#define RFCORE_FFSM_EXT_ADDR1_EXT_ADDR1_M \
+                                0x000000FF  // EXT_ADDR[15:8] The IEEE 
+                                            // extended address used during 
+                                            // destination address filtering 
+
+#define RFCORE_FFSM_EXT_ADDR1_EXT_ADDR1_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_FFSM_EXT_ADDR2 register.
+//
+//*****************************************************************************
+#define RFCORE_FFSM_EXT_ADDR2_EXT_ADDR2_M \
+                                0x000000FF  // EXT_ADDR[23:16] The IEEE 
+                                            // extended address used during 
+                                            // destination address filtering 
+
+#define RFCORE_FFSM_EXT_ADDR2_EXT_ADDR2_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_FFSM_EXT_ADDR3 register.
+//
+//*****************************************************************************
+#define RFCORE_FFSM_EXT_ADDR3_EXT_ADDR3_M \
+                                0x000000FF  // EXT_ADDR[31:24] The IEEE 
+                                            // extended address used during 
+                                            // destination address filtering 
+
+#define RFCORE_FFSM_EXT_ADDR3_EXT_ADDR3_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_FFSM_EXT_ADDR4 register.
+//
+//*****************************************************************************
+#define RFCORE_FFSM_EXT_ADDR4_EXT_ADDR4_M \
+                                0x000000FF  // EXT_ADDR[39:32] The IEEE 
+                                            // extended address used during 
+                                            // destination address filtering 
+
+#define RFCORE_FFSM_EXT_ADDR4_EXT_ADDR4_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_FFSM_EXT_ADDR5 register.
+//
+//*****************************************************************************
+#define RFCORE_FFSM_EXT_ADDR5_EXT_ADDR5_M \
+                                0x000000FF  // EXT_ADDR[47:40] The IEEE 
+                                            // extended address used during 
+                                            // destination address filtering 
+
+#define RFCORE_FFSM_EXT_ADDR5_EXT_ADDR5_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_FFSM_EXT_ADDR6 register.
+//
+//*****************************************************************************
+#define RFCORE_FFSM_EXT_ADDR6_EXT_ADDR6_M \
+                                0x000000FF  // EXT_ADDR[55:48] The IEEE 
+                                            // extended address used during 
+                                            // destination address filtering 
+
+#define RFCORE_FFSM_EXT_ADDR6_EXT_ADDR6_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_FFSM_EXT_ADDR7 register.
+//
+//*****************************************************************************
+#define RFCORE_FFSM_EXT_ADDR7_EXT_ADDR7_M \
+                                0x000000FF  // EXT_ADDR[63:56] The IEEE 
+                                            // extended address used during 
+                                            // destination address filtering 
+
+#define RFCORE_FFSM_EXT_ADDR7_EXT_ADDR7_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_FFSM_PAN_ID0 register.
+//
+//*****************************************************************************
+#define RFCORE_FFSM_PAN_ID0_PAN_ID0_M \
+                                0x000000FF  // PAN_ID[7:0] The PAN ID used 
+                                            // during destination address 
+                                            // filtering 
+
+#define RFCORE_FFSM_PAN_ID0_PAN_ID0_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_FFSM_PAN_ID1 register.
+//
+//*****************************************************************************
+#define RFCORE_FFSM_PAN_ID1_PAN_ID1_M \
+                                0x000000FF  // PAN_ID[15:8] The PAN ID used 
+                                            // during destination address 
+                                            // filtering 
+
+#define RFCORE_FFSM_PAN_ID1_PAN_ID1_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_FFSM_SHORT_ADDR0 register.
+//
+//*****************************************************************************
+#define RFCORE_FFSM_SHORT_ADDR0_SHORT_ADDR0_M \
+                                0x000000FF  // SHORT_ADDR[7:0] The short 
+                                            // address used during destination 
+                                            // address filtering 
+
+#define RFCORE_FFSM_SHORT_ADDR0_SHORT_ADDR0_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_FFSM_SHORT_ADDR1 register.
+//
+//*****************************************************************************
+#define RFCORE_FFSM_SHORT_ADDR1_SHORT_ADDR1_M \
+                                0x000000FF  // SHORT_ADDR[15:8] The short 
+                                            // address used during destination 
+                                            // address filtering 
+
+#define RFCORE_FFSM_SHORT_ADDR1_SHORT_ADDR1_S 0
+
+
+#endif // __HW_RFCORE_FFSM_H__
+

--- a/cpu/cc2538/include/vendor/hw_rfcore_sfr.h
+++ b/cpu/cc2538/include/vendor/hw_rfcore_sfr.h
@@ -1,0 +1,614 @@
+/******************************************************************************
+*  Filename:       hw_rfcore_sfr.h
+*  Revised:        $Date: 2013-04-12 15:10:54 +0200 (Fri, 12 Apr 2013) $
+*  Revision:       $Revision: 9735 $
+*
+*  Copyright (C) 2013 Texas Instruments Incorporated - http://www.ti.com/
+*
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*    Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+*
+*    Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+*
+*    Neither the name of Texas Instruments Incorporated nor the names of
+*    its contributors may be used to endorse or promote products derived
+*    from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+*  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+*  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+*  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+*  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+*  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+*  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+*  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+*  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+******************************************************************************/
+
+#ifndef __HW_RFCORE_SFR_H__
+#define __HW_RFCORE_SFR_H__
+
+//*****************************************************************************
+//
+// The following are defines for the RFCORE_SFR register offsets.
+//
+//*****************************************************************************
+#define RFCORE_SFR_MTCSPCFG     0x40088800  // MAC Timer event configuration 
+#define RFCORE_SFR_MTCTRL       0x40088804  // MAC Timer control register 
+#define RFCORE_SFR_MTIRQM       0x40088808  // MAC Timer interrupt mask 
+#define RFCORE_SFR_MTIRQF       0x4008880C  // MAC Timer interrupt flags 
+#define RFCORE_SFR_MTMSEL       0x40088810  // MAC Timer multiplex select 
+#define RFCORE_SFR_MTM0         0x40088814  // MAC Timer multiplexed register 
+                                            // 0 
+#define RFCORE_SFR_MTM1         0x40088818  // MAC Timer multiplexed register 
+                                            // 1 
+#define RFCORE_SFR_MTMOVF2      0x4008881C  // MAC Timer multiplexed overflow 
+                                            // register 2 
+#define RFCORE_SFR_MTMOVF1      0x40088820  // MAC Timer multiplexed overflow 
+                                            // register 1 
+#define RFCORE_SFR_MTMOVF0      0x40088824  // MAC Timer multiplexed overflow 
+                                            // register 0 
+#define RFCORE_SFR_RFDATA       0x40088828  // The TX FIFO and RX FIFO may be 
+                                            // accessed through this register. 
+                                            // Data is written to the TX FIFO 
+                                            // when writing to the RFD 
+                                            // register. Data is read from the 
+                                            // RX FIFO when the RFD register is 
+                                            // read. The XREG registers 
+                                            // RXFIFOCNT and TXFIFOCNT provide 
+                                            // information on the amount of 
+                                            // data in the FIFOs. The FIFO 
+                                            // contents can be cleared by 
+                                            // issuing SFLUSHRX and SFLUSHTX. 
+#define RFCORE_SFR_RFERRF       0x4008882C  // RF error interrupt flags 
+#define RFCORE_SFR_RFIRQF1      0x40088830  // RF interrupt flags 
+#define RFCORE_SFR_RFIRQF0      0x40088834  // RF interrupt flags 
+#define RFCORE_SFR_RFST         0x40088838  // RF CSMA-CA/strobe processor 
+
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_SFR_MTCSPCFG register.
+//
+//*****************************************************************************
+#define RFCORE_SFR_MTCSPCFG_MACTIMER_EVENMT_CFG_M \
+                                0x00000070  // Selects the event that triggers 
+                                            // an MT_EVENT2 pulse 000: 
+                                            // MT_per_event 001: MT_cmp1_event 
+                                            // 010: MT_cmp2_event 011: 
+                                            // MTovf_per_event 100: 
+                                            // MTovf_cmp1_event 101: 
+                                            // MTovf_cmp2_event 110: Reserved 
+                                            // 111: No event 
+
+#define RFCORE_SFR_MTCSPCFG_MACTIMER_EVENMT_CFG_S 4
+#define RFCORE_SFR_MTCSPCFG_MACTIMER_EVENT1_CFG_M \
+                                0x00000007  // Selects the event that triggers 
+                                            // an MT_EVENT1 pulse 000: 
+                                            // MT_per_event 001: MT_cmp1_event 
+                                            // 010: MT_cmp2_event 011: 
+                                            // MTovf_per_event 100: 
+                                            // MTovf_cmp1_event 101: 
+                                            // MTovf_cmp2_event 110: Reserved 
+                                            // 111: No event 
+
+#define RFCORE_SFR_MTCSPCFG_MACTIMER_EVENT1_CFG_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_SFR_MTCTRL register.
+//
+//*****************************************************************************
+#define RFCORE_SFR_MTCTRL_LATCH_MODE \
+                                0x00000008  // 0: Reading MTM0 with 
+                                            // MTMSEL.MTMSEL = 000 latches the 
+                                            // high byte of the timer, making 
+                                            // it ready to be read from MTM1. 
+                                            // Reading MTMOVF0 with 
+                                            // MTMSEL.MTMOVFSEL = 000 latches 
+                                            // the two most-significant bytes 
+                                            // of the overflow counter, making 
+                                            // it possible to read these from 
+                                            // MTMOVF1 and MTMOVF2. 1: Reading 
+                                            // MTM0 with MTMSEL.MTMSEL = 000 
+                                            // latches the high byte of the 
+                                            // timer and the entire overflow 
+                                            // counter at once, making it 
+                                            // possible to read the values from 
+                                            // MTM1, MTMOVF0, MTMOVF1, and 
+                                            // MTMOVF2. 
+
+#define RFCORE_SFR_MTCTRL_LATCH_MODE_M \
+                                0x00000008
+#define RFCORE_SFR_MTCTRL_LATCH_MODE_S 3
+#define RFCORE_SFR_MTCTRL_STATE 0x00000004  // State of MAC Timer 0: Timer 
+                                            // idle 1: Timer running 
+#define RFCORE_SFR_MTCTRL_STATE_M \
+                                0x00000004
+#define RFCORE_SFR_MTCTRL_STATE_S 2
+#define RFCORE_SFR_MTCTRL_SYNC  0x00000002  // 0: Starting and stopping of 
+                                            // timer is immediate; that is, 
+                                            // synchronous with clk_rf_32m. 1: 
+                                            // Starting and stopping of timer 
+                                            // occurs at the first positive 
+                                            // edge of the 32-kHz clock. For 
+                                            // more details regarding timer 
+                                            // start and stop, see Section 
+                                            // 22.4. 
+#define RFCORE_SFR_MTCTRL_SYNC_M \
+                                0x00000002
+#define RFCORE_SFR_MTCTRL_SYNC_S 1
+#define RFCORE_SFR_MTCTRL_RUN   0x00000001  // Write 1 to start timer, write 0 
+                                            // to stop timer. When read, it 
+                                            // returns the last written value. 
+#define RFCORE_SFR_MTCTRL_RUN_M 0x00000001
+#define RFCORE_SFR_MTCTRL_RUN_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_SFR_MTIRQM register.
+//
+//*****************************************************************************
+#define RFCORE_SFR_MTIRQM_MACTIMER_OVF_COMPARE2M \
+                                0x00000020  // Enables the 
+                                            // MACTIMER_OVF_COMPARE2 interrupt 
+
+#define RFCORE_SFR_MTIRQM_MACTIMER_OVF_COMPARE2M_M \
+                                0x00000020
+#define RFCORE_SFR_MTIRQM_MACTIMER_OVF_COMPARE2M_S 5
+#define RFCORE_SFR_MTIRQM_MACTIMER_OVF_COMPARE1M \
+                                0x00000010  // Enables the 
+                                            // MACTIMER_OVF_COMPARE1 interrupt 
+
+#define RFCORE_SFR_MTIRQM_MACTIMER_OVF_COMPARE1M_M \
+                                0x00000010
+#define RFCORE_SFR_MTIRQM_MACTIMER_OVF_COMPARE1M_S 4
+#define RFCORE_SFR_MTIRQM_MACTIMER_OVF_PERM \
+                                0x00000008  // Enables the MACTIMER_OVF_PER 
+                                            // interrupt 
+
+#define RFCORE_SFR_MTIRQM_MACTIMER_OVF_PERM_M \
+                                0x00000008
+#define RFCORE_SFR_MTIRQM_MACTIMER_OVF_PERM_S 3
+#define RFCORE_SFR_MTIRQM_MACTIMER_COMPARE2M \
+                                0x00000004  // Enables the MACTIMER_COMPARE2 
+                                            // interrupt 
+
+#define RFCORE_SFR_MTIRQM_MACTIMER_COMPARE2M_M \
+                                0x00000004
+#define RFCORE_SFR_MTIRQM_MACTIMER_COMPARE2M_S 2
+#define RFCORE_SFR_MTIRQM_MACTIMER_COMPARE1M \
+                                0x00000002  // Enables the MACTIMER_COMPARE1 
+                                            // interrupt 
+
+#define RFCORE_SFR_MTIRQM_MACTIMER_COMPARE1M_M \
+                                0x00000002
+#define RFCORE_SFR_MTIRQM_MACTIMER_COMPARE1M_S 1
+#define RFCORE_SFR_MTIRQM_MACTIMER_PERM \
+                                0x00000001  // Enables the MACTIMER_PER 
+                                            // interrupt 
+
+#define RFCORE_SFR_MTIRQM_MACTIMER_PERM_M \
+                                0x00000001
+#define RFCORE_SFR_MTIRQM_MACTIMER_PERM_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_SFR_MTIRQF register.
+//
+//*****************************************************************************
+#define RFCORE_SFR_MTIRQF_MACTIMER_OVF_COMPARE2F \
+                                0x00000020  // Set when the MAC Timer overflow 
+                                            // counter counts to the value set 
+                                            // at MTovf_cmp2 
+
+#define RFCORE_SFR_MTIRQF_MACTIMER_OVF_COMPARE2F_M \
+                                0x00000020
+#define RFCORE_SFR_MTIRQF_MACTIMER_OVF_COMPARE2F_S 5
+#define RFCORE_SFR_MTIRQF_MACTIMER_OVF_COMPARE1F \
+                                0x00000010  // Set when the MAC Timer overflow 
+                                            // counter counts to the value set 
+                                            // at Timer 2 MTovf_cmp1 
+
+#define RFCORE_SFR_MTIRQF_MACTIMER_OVF_COMPARE1F_M \
+                                0x00000010
+#define RFCORE_SFR_MTIRQF_MACTIMER_OVF_COMPARE1F_S 4
+#define RFCORE_SFR_MTIRQF_MACTIMER_OVF_PERF \
+                                0x00000008  // Set when the MAC Timer overflow 
+                                            // counter would have counted to a 
+                                            // value equal to MTovf_per, but 
+                                            // instead wraps to 0 
+
+#define RFCORE_SFR_MTIRQF_MACTIMER_OVF_PERF_M \
+                                0x00000008
+#define RFCORE_SFR_MTIRQF_MACTIMER_OVF_PERF_S 3
+#define RFCORE_SFR_MTIRQF_MACTIMER_COMPARE2F \
+                                0x00000004  // Set when the MAC Timer counter 
+                                            // counts to the value set at 
+                                            // MT_cmp2 
+
+#define RFCORE_SFR_MTIRQF_MACTIMER_COMPARE2F_M \
+                                0x00000004
+#define RFCORE_SFR_MTIRQF_MACTIMER_COMPARE2F_S 2
+#define RFCORE_SFR_MTIRQF_MACTIMER_COMPARE1F \
+                                0x00000002  // Set when the MAC Timer counter 
+                                            // counts to the value set at 
+                                            // MT_cmp1 
+
+#define RFCORE_SFR_MTIRQF_MACTIMER_COMPARE1F_M \
+                                0x00000002
+#define RFCORE_SFR_MTIRQF_MACTIMER_COMPARE1F_S 1
+#define RFCORE_SFR_MTIRQF_MACTIMER_PERF \
+                                0x00000001  // Set when the MAC Timer counter 
+                                            // would have counted to a value 
+                                            // equal to MT_per, but instead 
+                                            // wraps to 0 
+
+#define RFCORE_SFR_MTIRQF_MACTIMER_PERF_M \
+                                0x00000001
+#define RFCORE_SFR_MTIRQF_MACTIMER_PERF_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_SFR_MTMSEL register.
+//
+//*****************************************************************************
+#define RFCORE_SFR_MTMSEL_MTMOVFSEL_M \
+                                0x00000070  // The value of this register 
+                                            // selects the internal registers 
+                                            // that are modified or read when 
+                                            // accessing MTMOVF0, MTMOVF1, and 
+                                            // MTMOVF2. 000: MTovf (overflow 
+                                            // counter) 001: MTovf_cap 
+                                            // (overflow capture) 010: 
+                                            // MTovf_per (overflow period) 011: 
+                                            // MTovf_cmp1 (overflow compare 1) 
+                                            // 100: MTovf_cmp2 (overflow 
+                                            // compare 2) 101 to 111: Reserved 
+
+#define RFCORE_SFR_MTMSEL_MTMOVFSEL_S 4
+#define RFCORE_SFR_MTMSEL_MTMSEL_M \
+                                0x00000007  // The value of this register 
+                                            // selects the internal registers 
+                                            // that are modified or read when 
+                                            // accessing MTM0 and MTM1. 000: 
+                                            // MTtim (timer count value) 001: 
+                                            // MT_cap (timer capture) 010: 
+                                            // MT_per (timer period) 011: 
+                                            // MT_cmp1 (timer compare 1) 100: 
+                                            // MT_cmp2 (timer compare 2) 101 to 
+                                            // 111: Reserved MTM0 
+
+#define RFCORE_SFR_MTMSEL_MTMSEL_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_SFR_MTM0 register.
+//
+//*****************************************************************************
+#define RFCORE_SFR_MTM0_MTM0_M  0x000000FF  // Indirectly returns and modifies 
+                                            // bits [7:0] of an internal 
+                                            // register depending on the value 
+                                            // of MTMSEL.MTMSEL. When reading 
+                                            // the MTM0 register with 
+                                            // MTMSEL.MTMSEL set to 000 and 
+                                            // MTCTRL.LATCH_MODE set to 0, the 
+                                            // timer (MTtim) value is latched. 
+                                            // When reading the MTM0 register 
+                                            // with MTMSEL.MTMSEL set to 000 
+                                            // and MTCTRL.LATCH_MODE set to 1, 
+                                            // the timer (MTtim) and overflow 
+                                            // counter (MTovf) values are 
+                                            // latched. 
+#define RFCORE_SFR_MTM0_MTM0_S  0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_SFR_MTM1 register.
+//
+//*****************************************************************************
+#define RFCORE_SFR_MTM1_MTM1_M  0x000000FF  // Indirectly returns and modifies 
+                                            // bits [15:8] of an internal 
+                                            // register, depending on the value 
+                                            // of MTMSEL.MTMSEL. When reading 
+                                            // the MTM0 register with 
+                                            // MTMSEL.MTMSEL set to 000, the 
+                                            // timer (MTtim) value is latched. 
+                                            // Reading this register with 
+                                            // MTMSEL.MTMSEL set to 000 returns 
+                                            // the latched value of 
+                                            // MTtim[15:8]. 
+#define RFCORE_SFR_MTM1_MTM1_S  0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_SFR_MTMOVF2 register.
+//
+//*****************************************************************************
+#define RFCORE_SFR_MTMOVF2_MTMOVF2_M \
+                                0x000000FF  // Indirectly returns and modifies 
+                                            // bits [23:16] of an internal 
+                                            // register, depending on the value 
+                                            // of MTMSEL.MTMOVFSEL. Reading 
+                                            // this register with 
+                                            // MTMSEL.MTMOVFSEL set to 000 
+                                            // returns the latched value of 
+                                            // MTovf[23:16]. 
+
+#define RFCORE_SFR_MTMOVF2_MTMOVF2_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_SFR_MTMOVF1 register.
+//
+//*****************************************************************************
+#define RFCORE_SFR_MTMOVF1_MTMOVF1_M \
+                                0x000000FF  // Indirectly returns and modifies 
+                                            // bits [15:8] of an internal 
+                                            // register, depending on the value 
+                                            // of MTMSEL.MTMSEL. Reading this 
+                                            // register with MTMSEL.MTMOVFSEL 
+                                            // set to 000 returns the latched 
+                                            // value of MTovf[15:8]. 
+
+#define RFCORE_SFR_MTMOVF1_MTMOVF1_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_SFR_MTMOVF0 register.
+//
+//*****************************************************************************
+#define RFCORE_SFR_MTMOVF0_MTMOVF0_M \
+                                0x000000FF  // Indirectly returns and modifies 
+                                            // bits [7:0] of an internal 
+                                            // register, depending on the value 
+                                            // of MTMSEL.MTMOVFSEL. When 
+                                            // reading the MTMOVF0 register 
+                                            // with MTMSEL.MTMOVFSEL set to 000 
+                                            // and MTCTRL.LATCH_MODE set to 0, 
+                                            // the overflow counter value 
+                                            // (MTovf) is latched. When reading 
+                                            // the MTM0 register with 
+                                            // MTMSEL.MTMOVFSEL set to 000 and 
+                                            // MTCTRL.LATCH_MODE set to 1, the 
+                                            // overflow counter value (MTovf) 
+                                            // is latched. 
+
+#define RFCORE_SFR_MTMOVF0_MTMOVF0_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_SFR_RFDATA register.
+//
+//*****************************************************************************
+#define RFCORE_SFR_RFDATA_RFD_M 0x000000FF  // Data written to the register is 
+                                            // written to the TX FIFO. When 
+                                            // reading this register, data from 
+                                            // the RX FIFO is read. 
+#define RFCORE_SFR_RFDATA_RFD_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_SFR_RFERRF register.
+//
+//*****************************************************************************
+#define RFCORE_SFR_RFERRF_STROBEERR \
+                                0x00000040  // A command strobe was issued 
+                                            // when it could not be processed. 
+                                            // Triggered if trying to disable 
+                                            // the radio when it is already 
+                                            // disabled, or when trying to do a 
+                                            // SACK, SACKPEND, or SNACK command 
+                                            // when not in active RX. 0: No 
+                                            // interrupt pending 1: Interrupt 
+                                            // pending 
+
+#define RFCORE_SFR_RFERRF_STROBEERR_M \
+                                0x00000040
+#define RFCORE_SFR_RFERRF_STROBEERR_S 6
+#define RFCORE_SFR_RFERRF_TXUNDERF \
+                                0x00000020  // TX FIFO underflowed. 0: No 
+                                            // interrupt pending 1: Interrupt 
+                                            // pending 
+
+#define RFCORE_SFR_RFERRF_TXUNDERF_M \
+                                0x00000020
+#define RFCORE_SFR_RFERRF_TXUNDERF_S 5
+#define RFCORE_SFR_RFERRF_TXOVERF \
+                                0x00000010  // TX FIFO overflowed. 0: No 
+                                            // interrupt pending 1: Interrupt 
+                                            // pending 
+
+#define RFCORE_SFR_RFERRF_TXOVERF_M \
+                                0x00000010
+#define RFCORE_SFR_RFERRF_TXOVERF_S 4
+#define RFCORE_SFR_RFERRF_RXUNDERF \
+                                0x00000008  // RX FIFO underflowed. 0: No 
+                                            // interrupt pending 1: Interrupt 
+                                            // pending 
+
+#define RFCORE_SFR_RFERRF_RXUNDERF_M \
+                                0x00000008
+#define RFCORE_SFR_RFERRF_RXUNDERF_S 3
+#define RFCORE_SFR_RFERRF_RXOVERF \
+                                0x00000004  // RX FIFO overflowed. 0: No 
+                                            // interrupt pending 1: Interrupt 
+                                            // pending 
+
+#define RFCORE_SFR_RFERRF_RXOVERF_M \
+                                0x00000004
+#define RFCORE_SFR_RFERRF_RXOVERF_S 2
+#define RFCORE_SFR_RFERRF_RXABO 0x00000002  // Reception of a frame was 
+                                            // aborted. 0: No interrupt pending 
+                                            // 1: Interrupt pending 
+#define RFCORE_SFR_RFERRF_RXABO_M \
+                                0x00000002
+#define RFCORE_SFR_RFERRF_RXABO_S 1
+#define RFCORE_SFR_RFERRF_NLOCK 0x00000001  // The frequency synthesizer 
+                                            // failed to achieve lock after 
+                                            // time-out, or lock is lost during 
+                                            // reception. The receiver must be 
+                                            // restarted to clear this error 
+                                            // situation. 0: No interrupt 
+                                            // pending 1: Interrupt pending 
+#define RFCORE_SFR_RFERRF_NLOCK_M \
+                                0x00000001
+#define RFCORE_SFR_RFERRF_NLOCK_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_SFR_RFIRQF1 register.
+//
+//*****************************************************************************
+#define RFCORE_SFR_RFIRQF1_CSP_WAIT \
+                                0x00000020  // Execution continued after a 
+                                            // wait instruction in CSP. 0: No 
+                                            // interrupt pending 1: Interrupt 
+                                            // pending 
+
+#define RFCORE_SFR_RFIRQF1_CSP_WAIT_M \
+                                0x00000020
+#define RFCORE_SFR_RFIRQF1_CSP_WAIT_S 5
+#define RFCORE_SFR_RFIRQF1_CSP_STOP \
+                                0x00000010  // CSP has stopped program 
+                                            // execution. 0: No interrupt 
+                                            // pending 1: Interrupt pending 
+
+#define RFCORE_SFR_RFIRQF1_CSP_STOP_M \
+                                0x00000010
+#define RFCORE_SFR_RFIRQF1_CSP_STOP_S 4
+#define RFCORE_SFR_RFIRQF1_CSP_MANINT \
+                                0x00000008  // Manual interrupt generated from 
+                                            // CSP 0: No interrupt pending 1: 
+                                            // Interrupt pending 
+
+#define RFCORE_SFR_RFIRQF1_CSP_MANINT_M \
+                                0x00000008
+#define RFCORE_SFR_RFIRQF1_CSP_MANINT_S 3
+#define RFCORE_SFR_RFIRQF1_RFIDLE \
+                                0x00000004  // Radio state-machine has entered 
+                                            // the IDLE state. 0: No interrupt 
+                                            // pending 1: Interrupt pending 
+
+#define RFCORE_SFR_RFIRQF1_RFIDLE_M \
+                                0x00000004
+#define RFCORE_SFR_RFIRQF1_RFIDLE_S 2
+#define RFCORE_SFR_RFIRQF1_TXDONE \
+                                0x00000002  // A complete frame has been 
+                                            // transmitted. 0: No interrupt 
+                                            // pending 1: Interrupt pending 
+
+#define RFCORE_SFR_RFIRQF1_TXDONE_M \
+                                0x00000002
+#define RFCORE_SFR_RFIRQF1_TXDONE_S 1
+#define RFCORE_SFR_RFIRQF1_TXACKDONE \
+                                0x00000001  // An acknowledgement frame has 
+                                            // been completely transmitted. 0: 
+                                            // No interrupt pending 1: 
+                                            // Interrupt pending 
+
+#define RFCORE_SFR_RFIRQF1_TXACKDONE_M \
+                                0x00000001
+#define RFCORE_SFR_RFIRQF1_TXACKDONE_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_SFR_RFIRQF0 register.
+//
+//*****************************************************************************
+#define RFCORE_SFR_RFIRQF0_RXMASKZERO \
+                                0x00000080  // The RXENABLE register has gone 
+                                            // from a nonzero state to an 
+                                            // all-zero state. 0: No interrupt 
+                                            // pending 1: Interrupt pending 
+
+#define RFCORE_SFR_RFIRQF0_RXMASKZERO_M \
+                                0x00000080
+#define RFCORE_SFR_RFIRQF0_RXMASKZERO_S 7
+#define RFCORE_SFR_RFIRQF0_RXPKTDONE \
+                                0x00000040  // A complete frame has been 
+                                            // received. 0: No interrupt 
+                                            // pending 1: Interrupt pending 
+
+#define RFCORE_SFR_RFIRQF0_RXPKTDONE_M \
+                                0x00000040
+#define RFCORE_SFR_RFIRQF0_RXPKTDONE_S 6
+#define RFCORE_SFR_RFIRQF0_FRAME_ACCEPTED \
+                                0x00000020  // Frame has passed frame 
+                                            // filtering. 0: No interrupt 
+                                            // pending 1: Interrupt pending 
+
+#define RFCORE_SFR_RFIRQF0_FRAME_ACCEPTED_M \
+                                0x00000020
+#define RFCORE_SFR_RFIRQF0_FRAME_ACCEPTED_S 5
+#define RFCORE_SFR_RFIRQF0_SRC_MATCH_FOUND \
+                                0x00000010  // Source match is found. 0: No 
+                                            // interrupt pending 1: Interrupt 
+                                            // pending 
+
+#define RFCORE_SFR_RFIRQF0_SRC_MATCH_FOUND_M \
+                                0x00000010
+#define RFCORE_SFR_RFIRQF0_SRC_MATCH_FOUND_S 4
+#define RFCORE_SFR_RFIRQF0_SRC_MATCH_DONE \
+                                0x00000008  // Source matching is complete. 0: 
+                                            // No interrupt pending 1: 
+                                            // Interrupt pending 
+
+#define RFCORE_SFR_RFIRQF0_SRC_MATCH_DONE_M \
+                                0x00000008
+#define RFCORE_SFR_RFIRQF0_SRC_MATCH_DONE_S 3
+#define RFCORE_SFR_RFIRQF0_FIFOP \
+                                0x00000004  // The number of bytes in the RX 
+                                            // FIFO is greater than the 
+                                            // threshold. Also raised when a 
+                                            // complete frame is received, and 
+                                            // when a packet is read out 
+                                            // completely and more complete 
+                                            // packets are available. 0: No 
+                                            // interrupt pending 1: Interrupt 
+                                            // pending 
+
+#define RFCORE_SFR_RFIRQF0_FIFOP_M \
+                                0x00000004
+#define RFCORE_SFR_RFIRQF0_FIFOP_S 2
+#define RFCORE_SFR_RFIRQF0_SFD  0x00000002  // SFD has been received or 
+                                            // transmitted. 0: No interrupt 
+                                            // pending 1: Interrupt pending 
+#define RFCORE_SFR_RFIRQF0_SFD_M \
+                                0x00000002
+#define RFCORE_SFR_RFIRQF0_SFD_S 1
+#define RFCORE_SFR_RFIRQF0_ACT_UNUSED \
+                                0x00000001  // Reserved 0: No interrupt 
+                                            // pending 1: Interrupt pending 
+
+#define RFCORE_SFR_RFIRQF0_ACT_UNUSED_M \
+                                0x00000001
+#define RFCORE_SFR_RFIRQF0_ACT_UNUSED_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_SFR_RFST register.
+//
+//*****************************************************************************
+#define RFCORE_SFR_RFST_INSTR_M 0x000000FF  // Data written to this register 
+                                            // is written to the CSP 
+                                            // instruction memory. Reading this 
+                                            // register returns the CSP 
+                                            // instruction currently being 
+                                            // executed. 
+#define RFCORE_SFR_RFST_INSTR_S 0
+
+
+#endif // __HW_RFCORE_SFR_H__
+

--- a/cpu/cc2538/include/vendor/hw_rfcore_xreg.h
+++ b/cpu/cc2538/include/vendor/hw_rfcore_xreg.h
@@ -1,0 +1,2434 @@
+/******************************************************************************
+*  Filename:       hw_rfcore_xreg.h
+*  Revised:        $Date: 2013-04-30 17:13:44 +0200 (Tue, 30 Apr 2013) $
+*  Revision:       $Revision: 9943 $
+*
+*  Copyright (C) 2013 Texas Instruments Incorporated - http://www.ti.com/
+*
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*    Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+*
+*    Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+*
+*    Neither the name of Texas Instruments Incorporated nor the names of
+*    its contributors may be used to endorse or promote products derived
+*    from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+*  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+*  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+*  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+*  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+*  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+*  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+*  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+*  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+******************************************************************************/
+
+#ifndef __HW_RFCORE_XREG_H__
+#define __HW_RFCORE_XREG_H__
+
+//*****************************************************************************
+//
+// The following are defines for the RFCORE_XREG register offsets.
+//
+//*****************************************************************************
+#define RFCORE_XREG_FRMFILT0    0x40088600  // The frame filtering function 
+                                            // rejects unintended frames as 
+                                            // specified by IEEE 802.15.4, 
+                                            // section 7.5.6.2, third filtering 
+                                            // level. In addition, it provides 
+                                            // filtering on: - The eight 
+                                            // different frame types (see the 
+                                            // FRMFILT1 register) - The 
+                                            // reserved bits in the frame 
+                                            // control field (FCF) The function 
+                                            // is controlled by: - The FRMFILT0 
+                                            // and FRMFILT1 registers - The 
+                                            // PAN_ID, SHORT_ADDR, and EXT_ADDR 
+                                            // values in RAM 
+#define RFCORE_XREG_FRMFILT1    0x40088604  // The frame filtering function 
+                                            // rejects unintended frames as 
+                                            // specified by IEEE 802.15.4, 
+                                            // section 7.5.6.2, third filtering 
+                                            // level. In addition, it provides 
+                                            // filtering on: - The eight 
+                                            // different frame types (see the 
+                                            // FRMFILT1 register) - The 
+                                            // reserved bits in the frame 
+                                            // control field (FCF) The function 
+                                            // is controlled by: - The FRMFILT0 
+                                            // and FRMFILT1 registers - The 
+                                            // PAN_ID, SHORT_ADDR, and EXT_ADDR 
+                                            // values in RAM 
+#define RFCORE_XREG_SRCMATCH    0x40088608  // Source address matching and 
+                                            // pending bits 
+#define RFCORE_XREG_SRCSHORTEN0 \
+                                0x4008860C  // Short address matching 
+
+#define RFCORE_XREG_SRCSHORTEN1 \
+                                0x40088610  // Short address matching 
+
+#define RFCORE_XREG_SRCSHORTEN2 \
+                                0x40088614  // Short address matching 
+
+#define RFCORE_XREG_SRCEXTEN0   0x40088618  // Extended address matching 
+#define RFCORE_XREG_SRCEXTEN1   0x4008861C  // Extended address matching 
+#define RFCORE_XREG_SRCEXTEN2   0x40088620  // Extended address matching 
+#define RFCORE_XREG_FRMCTRL0    0x40088624  // Frame handling 
+#define RFCORE_XREG_FRMCTRL1    0x40088628  // Frame handling 
+#define RFCORE_XREG_RXENABLE    0x4008862C  // RX enabling 
+#define RFCORE_XREG_RXMASKSET   0x40088630  // RX enabling 
+#define RFCORE_XREG_RXMASKCLR   0x40088634  // RX disabling 
+#define RFCORE_XREG_FREQTUNE    0x40088638  // Crystal oscillator frequency 
+                                            // tuning 
+#define RFCORE_XREG_FREQCTRL    0x4008863C  // Controls the RF frequency 
+#define RFCORE_XREG_TXPOWER     0x40088640  // Controls the output power 
+#define RFCORE_XREG_TXCTRL      0x40088644  // Controls the TX settings 
+#define RFCORE_XREG_FSMSTAT0    0x40088648  // Radio status register 
+#define RFCORE_XREG_FSMSTAT1    0x4008864C  // Radio status register 
+#define RFCORE_XREG_FIFOPCTRL   0x40088650  // FIFOP threshold 
+#define RFCORE_XREG_FSMCTRL     0x40088654  // FSM options 
+#define RFCORE_XREG_CCACTRL0    0x40088658  // CCA threshold 
+#define RFCORE_XREG_CCACTRL1    0x4008865C  // Other CCA Options 
+#define RFCORE_XREG_RSSI        0x40088660  // RSSI status register 
+#define RFCORE_XREG_RSSISTAT    0x40088664  // RSSI valid status register 
+#define RFCORE_XREG_RXFIRST     0x40088668  // First byte in RX FIFO 
+#define RFCORE_XREG_RXFIFOCNT   0x4008866C  // Number of bytes in RX FIFO 
+#define RFCORE_XREG_TXFIFOCNT   0x40088670  // Number of bytes in TX FIFO 
+#define RFCORE_XREG_RXFIRST_PTR \
+                                0x40088674  // RX FIFO pointer 
+
+#define RFCORE_XREG_RXLAST_PTR \
+                                0x40088678  // RX FIFO pointer 
+
+#define RFCORE_XREG_RXP1_PTR    0x4008867C  // RX FIFO pointer 
+#define RFCORE_XREG_TXFIRST_PTR \
+                                0x40088684  // TX FIFO pointer 
+
+#define RFCORE_XREG_TXLAST_PTR \
+                                0x40088688  // TX FIFO pointer 
+
+#define RFCORE_XREG_RFIRQM0     0x4008868C  // RF interrupt masks 
+#define RFCORE_XREG_RFIRQM1     0x40088690  // RF interrupt masks 
+#define RFCORE_XREG_RFERRM      0x40088694  // RF error interrupt mask 
+#define RFCORE_XREG_RFRND       0x4008869C  // Random data 
+#define RFCORE_XREG_MDMCTRL0    0x400886A0  // Controls modem 
+#define RFCORE_XREG_MDMCTRL1    0x400886A4  // Controls modem 
+#define RFCORE_XREG_FREQEST     0x400886A8  // Estimated RF frequency offset 
+#define RFCORE_XREG_RXCTRL      0x400886AC  // Tune receive section 
+#define RFCORE_XREG_FSCTRL      0x400886B0  // Tune frequency synthesizer 
+#define RFCORE_XREG_FSCAL0      0x400886B4  // Tune frequency calibration 
+#define RFCORE_XREG_FSCAL1      0x400886B8  // Tune frequency calibration 
+#define RFCORE_XREG_FSCAL2      0x400886BC  // Tune frequency calibration 
+#define RFCORE_XREG_FSCAL3      0x400886C0  // Tune frequency calibration 
+#define RFCORE_XREG_AGCCTRL0    0x400886C4  // AGC dynamic range control 
+#define RFCORE_XREG_AGCCTRL1    0x400886C8  // AGC reference level 
+#define RFCORE_XREG_AGCCTRL2    0x400886CC  // AGC gain override 
+#define RFCORE_XREG_AGCCTRL3    0x400886D0  // AGC control 
+#define RFCORE_XREG_ADCTEST0    0x400886D4  // ADC tuning 
+#define RFCORE_XREG_ADCTEST1    0x400886D8  // ADC tuning 
+#define RFCORE_XREG_ADCTEST2    0x400886DC  // ADC tuning 
+#define RFCORE_XREG_MDMTEST0    0x400886E0  // Test register for modem 
+#define RFCORE_XREG_MDMTEST1    0x400886E4  // Test Register for Modem 
+#define RFCORE_XREG_DACTEST0    0x400886E8  // DAC override value 
+#define RFCORE_XREG_DACTEST1    0x400886EC  // DAC override value 
+#define RFCORE_XREG_DACTEST2    0x400886F0  // DAC test setting 
+#define RFCORE_XREG_ATEST       0x400886F4  // Analog test control 
+#define RFCORE_XREG_PTEST0      0x400886F8  // Override power-down register 
+#define RFCORE_XREG_PTEST1      0x400886FC  // Override power-down register 
+#define RFCORE_XREG_CSPPROG0    0x40088700  // CSP program 
+#define RFCORE_XREG_CSPPROG1    0x40088704  // CSP program 
+#define RFCORE_XREG_CSPPROG2    0x40088708  // CSP program 
+#define RFCORE_XREG_CSPPROG3    0x4008870C  // CSP program 
+#define RFCORE_XREG_CSPPROG4    0x40088710  // CSP program 
+#define RFCORE_XREG_CSPPROG5    0x40088714  // CSP program 
+#define RFCORE_XREG_CSPPROG6    0x40088718  // CSP program 
+#define RFCORE_XREG_CSPPROG7    0x4008871C  // CSP program 
+#define RFCORE_XREG_CSPPROG8    0x40088720  // CSP program 
+#define RFCORE_XREG_CSPPROG9    0x40088724  // CSP program 
+#define RFCORE_XREG_CSPPROG10   0x40088728  // CSP program 
+#define RFCORE_XREG_CSPPROG11   0x4008872C  // CSP program 
+#define RFCORE_XREG_CSPPROG12   0x40088730  // CSP program 
+#define RFCORE_XREG_CSPPROG13   0x40088734  // CSP program 
+#define RFCORE_XREG_CSPPROG14   0x40088738  // CSP program 
+#define RFCORE_XREG_CSPPROG15   0x4008873C  // CSP program 
+#define RFCORE_XREG_CSPPROG16   0x40088740  // CSP program 
+#define RFCORE_XREG_CSPPROG17   0x40088744  // CSP program 
+#define RFCORE_XREG_CSPPROG18   0x40088748  // CSP program 
+#define RFCORE_XREG_CSPPROG19   0x4008874C  // CSP program 
+#define RFCORE_XREG_CSPPROG20   0x40088750  // CSP program 
+#define RFCORE_XREG_CSPPROG21   0x40088754  // CSP program 
+#define RFCORE_XREG_CSPPROG22   0x40088758  // CSP program 
+#define RFCORE_XREG_CSPPROG23   0x4008875C  // CSP program 
+#define RFCORE_XREG_CSPCTRL     0x40088780  // CSP control bit 
+#define RFCORE_XREG_CSPSTAT     0x40088784  // CSP status register 
+#define RFCORE_XREG_CSPX        0x40088788  // CSP X data register 
+#define RFCORE_XREG_CSPY        0x4008878C  // CSP Y data register 
+#define RFCORE_XREG_CSPZ        0x40088790  // CSP Z data register 
+#define RFCORE_XREG_CSPT        0x40088794  // CSP T data register 
+#define RFCORE_XREG_RFC_OBS_CTRL0 \
+                                0x400887AC  // RF observation mux control 
+
+#define RFCORE_XREG_RFC_OBS_CTRL1 \
+                                0x400887B0  // RF observation mux control 
+
+#define RFCORE_XREG_RFC_OBS_CTRL2 \
+                                0x400887B4  // RF observation mux control 
+
+#define RFCORE_XREG_TXFILTCFG   0x400887E8  // TX filter configuration 
+
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_FRMFILT0 register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_FRMFILT0_MAX_FRAME_VERSION_M \
+                                0x0000000C  // Used for filtering on the frame 
+                                            // version field of the frame 
+                                            // control field (FCF) If 
+                                            // FCF[13:12] (the frame version 
+                                            // subfield) is higher than 
+                                            // MAX_FRAME_VERSION[1:0] and frame 
+                                            // filtering is enabled, the frame 
+                                            // is rejected. 
+
+#define RFCORE_XREG_FRMFILT0_MAX_FRAME_VERSION_S 2
+#define RFCORE_XREG_FRMFILT0_PAN_COORDINATOR \
+                                0x00000002  // Should be set high when the 
+                                            // device is a PAN coordinator, to 
+                                            // accept frames with no 
+                                            // destination address (as 
+                                            // specified in Section 7.5.6.2 in 
+                                            // IEEE 802.15.4) 0: Device is not 
+                                            // a PAN coordinator 1: Device is a 
+                                            // PAN coordinator 
+
+#define RFCORE_XREG_FRMFILT0_PAN_COORDINATOR_M \
+                                0x00000002
+#define RFCORE_XREG_FRMFILT0_PAN_COORDINATOR_S 1
+#define RFCORE_XREG_FRMFILT0_FRAME_FILTER_EN \
+                                0x00000001  // Enables frame filtering When 
+                                            // this bit is set, the radio 
+                                            // performs frame filtering as 
+                                            // specified in section 7.5.6.2 of 
+                                            // IEEE 802.15.4(b), third 
+                                            // filtering level. FRMFILT0[6:1] 
+                                            // and FRMFILT1[7:1], together with 
+                                            // the local address information, 
+                                            // define the behavior of the 
+                                            // filtering algorithm. 0: Frame 
+                                            // filtering off. (FRMFILT0[6:1], 
+                                            // FRMFILT1[7:1] and SRCMATCH[2:0] 
+                                            // are don't care.) 1: Frame 
+                                            // filtering on. 
+
+#define RFCORE_XREG_FRMFILT0_FRAME_FILTER_EN_M \
+                                0x00000001
+#define RFCORE_XREG_FRMFILT0_FRAME_FILTER_EN_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_FRMFILT1 register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_FRMFILT1_ACCEPT_FT_3_MAC_CMD \
+                                0x00000040  // Defines whether MAC command 
+                                            // frames are accepted or not. MAC 
+                                            // command frames have frame type = 
+                                            // 011. 0: Reject 1: Accept 
+
+#define RFCORE_XREG_FRMFILT1_ACCEPT_FT_3_MAC_CMD_M \
+                                0x00000040
+#define RFCORE_XREG_FRMFILT1_ACCEPT_FT_3_MAC_CMD_S 6
+#define RFCORE_XREG_FRMFILT1_ACCEPT_FT_2_ACK \
+                                0x00000020  // Defines whether acknowledgment 
+                                            // frames are accepted or not. 
+                                            // Acknowledgement frames have 
+                                            // frame type = 010. 0: Reject 1: 
+                                            // Accept 
+
+#define RFCORE_XREG_FRMFILT1_ACCEPT_FT_2_ACK_M \
+                                0x00000020
+#define RFCORE_XREG_FRMFILT1_ACCEPT_FT_2_ACK_S 5
+#define RFCORE_XREG_FRMFILT1_ACCEPT_FT_1_DATA \
+                                0x00000010  // Defines whether data frames are 
+                                            // accepted or not. Data frames 
+                                            // have frame type = 001. 0: Reject 
+                                            // 1: Accept 
+
+#define RFCORE_XREG_FRMFILT1_ACCEPT_FT_1_DATA_M \
+                                0x00000010
+#define RFCORE_XREG_FRMFILT1_ACCEPT_FT_1_DATA_S 4
+#define RFCORE_XREG_FRMFILT1_ACCEPT_FT_0_BEACON \
+                                0x00000008  // Defines whether beacon frames 
+                                            // are accepted or not. Beacon 
+                                            // frames have frame type = 000. 0: 
+                                            // Reject 1: Accept 
+
+#define RFCORE_XREG_FRMFILT1_ACCEPT_FT_0_BEACON_M \
+                                0x00000008
+#define RFCORE_XREG_FRMFILT1_ACCEPT_FT_0_BEACON_S 3
+#define RFCORE_XREG_FRMFILT1_MODIFY_FT_FILTER_M \
+                                0x00000006  // These bits are used to modify 
+                                            // the frame type field of a 
+                                            // received frame before frame type 
+                                            // filtering is performed. The 
+                                            // modification does not influence 
+                                            // the frame that is written to the 
+                                            // RX FIFO. 00: Leave the frame 
+                                            // type as it is. 01: Invert MSB of 
+                                            // the frame type. 10: Set MSB of 
+                                            // the frame type to 0. 11: Set MSB 
+                                            // of the frame type to 1. 
+
+#define RFCORE_XREG_FRMFILT1_MODIFY_FT_FILTER_S 1
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_SRCMATCH register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_SRCMATCH_PEND_DATAREQ_ONLY \
+                                0x00000004  // When this bit is set, the 
+                                            // AUTOPEND function also requires 
+                                            // that the received frame is a 
+                                            // DATA REQUEST MAC command frame. 
+
+#define RFCORE_XREG_SRCMATCH_PEND_DATAREQ_ONLY_M \
+                                0x00000004
+#define RFCORE_XREG_SRCMATCH_PEND_DATAREQ_ONLY_S 2
+#define RFCORE_XREG_SRCMATCH_AUTOPEND \
+                                0x00000002  // Automatic acknowledgment 
+                                            // pending flag enable When a frame 
+                                            // is received, the pending bit in 
+                                            // the (possibly) returned 
+                                            // acknowledgment is set 
+                                            // automatically when the following 
+                                            // conditions are met: - 
+                                            // FRMFILT.FRAME_FILTER_EN is set. 
+                                            // - SRCMATCH.SRC_MATCH_EN is set. 
+                                            // - SRCMATCH.AUTOPEND is set. - 
+                                            // The received frame matches the 
+                                            // current 
+                                            // SRCMATCH.PEND_DATAREQ_ONLY 
+                                            // setting. - The received source 
+                                            // address matches at least one 
+                                            // source match table entry, which 
+                                            // is enabled in SHORT_ADDR_EN and 
+                                            // SHORT_PEND_EN or in EXT_ADDR_EN 
+                                            // and EXT_PEND_EN. 
+
+#define RFCORE_XREG_SRCMATCH_AUTOPEND_M \
+                                0x00000002
+#define RFCORE_XREG_SRCMATCH_AUTOPEND_S 1
+#define RFCORE_XREG_SRCMATCH_SRC_MATCH_EN \
+                                0x00000001  // Source address matching enable 
+                                            // (requires that 
+                                            // FRMFILT.FRAME_FILTER_EN = 1) 
+
+#define RFCORE_XREG_SRCMATCH_SRC_MATCH_EN_M \
+                                0x00000001
+#define RFCORE_XREG_SRCMATCH_SRC_MATCH_EN_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_SRCSHORTEN0 register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_SRCSHORTEN0_SHORT_ADDR_EN_M \
+                                0x000000FF  // 7:0 part of the 24-bit word 
+                                            // SHORT_ADDR_EN that enables or 
+                                            // disables source address matching 
+                                            // for each of the 24 short address 
+                                            // table entries Optional safety 
+                                            // feature: To ensure that an entry 
+                                            // in the source matching table is 
+                                            // not used while it is being 
+                                            // updated, set the corresponding 
+                                            // SHORT_ADDR_EN bit to 0 while 
+                                            // updating. 
+
+#define RFCORE_XREG_SRCSHORTEN0_SHORT_ADDR_EN_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_SRCSHORTEN1 register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_SRCSHORTEN1_SHORT_ADDR_EN_M \
+                                0x000000FF  // 15:8 part of the 24-bit word 
+                                            // SHORT_ADDR_EN See description of 
+                                            // SRCSHORTEN0.SHORT_ADDR_EN. 
+
+#define RFCORE_XREG_SRCSHORTEN1_SHORT_ADDR_EN_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_SRCSHORTEN2 register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_SRCSHORTEN2_SHORT_ADDR_EN_M \
+                                0x000000FF  // 23:16 part of the 24-bit word 
+                                            // SHORT_ADDR_EN See description of 
+                                            // SRCSHORTEN0.SHORT_ADDR_EN. 
+
+#define RFCORE_XREG_SRCSHORTEN2_SHORT_ADDR_EN_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_SRCEXTEN0 register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_SRCEXTEN0_EXT_ADDR_EN_M \
+                                0x000000FF  // 7:0 part of the 24-bit word 
+                                            // EXT_ADDR_EN that enables or 
+                                            // disables source address matching 
+                                            // for each of the 12 extended 
+                                            // address table entries Write 
+                                            // access: Extended address enable 
+                                            // for table entry n (0 to 11) is 
+                                            // mapped to EXT_ADDR_EN[2n]. All 
+                                            // EXT_ADDR_EN[2n + 1] bits are 
+                                            // read only. Read access: Extended 
+                                            // address enable for table entry n 
+                                            // (0 to 11) is mapped to 
+                                            // EXT_ADDR_EN[2n] and 
+                                            // EXT_ADDR_EN[2n + 1]. Optional 
+                                            // safety feature: To ensure that 
+                                            // an entry in the source matching 
+                                            // table is not used while it is 
+                                            // being updated, set the 
+                                            // corresponding EXT_ADDR_EN bit to 
+                                            // 0 while updating. 
+
+#define RFCORE_XREG_SRCEXTEN0_EXT_ADDR_EN_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_SRCEXTEN1 register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_SRCEXTEN1_EXT_ADDR_EN_M \
+                                0x000000FF  // 15:8 part of the 24-bit word 
+                                            // EXT_ADDR_EN See description of 
+                                            // SRCEXTEN0.EXT_ADDR_EN. 
+
+#define RFCORE_XREG_SRCEXTEN1_EXT_ADDR_EN_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_SRCEXTEN2 register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_SRCEXTEN2_EXT_ADDR_EN_M \
+                                0x000000FF  // 23:16 part of the 24-bit word 
+                                            // EXT_ADDR_EN See description of 
+                                            // SRCEXTEN0.EXT_ADDR_EN. 
+
+#define RFCORE_XREG_SRCEXTEN2_EXT_ADDR_EN_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_FRMCTRL0 register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_FRMCTRL0_APPEND_DATA_MODE \
+                                0x00000080  // When AUTOCRC = 0: Don't care 
+                                            // When AUTOCRC = 1: 0: RSSI + The 
+                                            // CRC_OK bit and the 7-bit 
+                                            // correlation value are appended 
+                                            // at the end of each received 
+                                            // frame 1: RSSI + The CRC_OK bit 
+                                            // and the 7-bit SRCRESINDEX are 
+                                            // appended at the end of each 
+                                            // received frame. 
+
+#define RFCORE_XREG_FRMCTRL0_APPEND_DATA_MODE_M \
+                                0x00000080
+#define RFCORE_XREG_FRMCTRL0_APPEND_DATA_MODE_S 7
+#define RFCORE_XREG_FRMCTRL0_AUTOCRC \
+                                0x00000040  // In TX 1: A CRC-16 (ITU-T) is 
+                                            // generated in hardware and 
+                                            // appended to the transmitted 
+                                            // frame. There is no need to write 
+                                            // the last 2 bytes to TXBUF. 0: No 
+                                            // CRC-16 is appended to the frame. 
+                                            // The last 2 bytes of the frame 
+                                            // must be generated manually and 
+                                            // written to TXBUF (if not, 
+                                            // TX_UNDERFLOW occurs). In RX 1: 
+                                            // The CRC-16 is checked in 
+                                            // hardware, and replaced in the 
+                                            // RXFIFO by a 16-bit status word 
+                                            // which contains a CRC OK bit. The 
+                                            // status word is controllable 
+                                            // through APPEND_DATA_MODE. 0: The 
+                                            // last 2 bytes of the frame 
+                                            // (CRC-16 field) are stored in the 
+                                            // RX FIFO. The CRC (if any) must 
+                                            // be done manually. This setting 
+                                            // does not influence 
+                                            // acknowledgment transmission 
+                                            // (including AUTOACK). 
+
+#define RFCORE_XREG_FRMCTRL0_AUTOCRC_M \
+                                0x00000040
+#define RFCORE_XREG_FRMCTRL0_AUTOCRC_S 6
+#define RFCORE_XREG_FRMCTRL0_AUTOACK \
+                                0x00000020  // Defines whether the radio 
+                                            // automatically transmits 
+                                            // acknowledge frames or not. When 
+                                            // autoack is enabled, all frames 
+                                            // that are accepted by address 
+                                            // filtering, have the acknowledge 
+                                            // request flag set, and have a 
+                                            // valid CRC are automatically 
+                                            // acknowledged 12 symbol periods 
+                                            // after being received. 0: Autoack 
+                                            // disabled 1: Autoack enabled 
+
+#define RFCORE_XREG_FRMCTRL0_AUTOACK_M \
+                                0x00000020
+#define RFCORE_XREG_FRMCTRL0_AUTOACK_S 5
+#define RFCORE_XREG_FRMCTRL0_ENERGY_SCAN \
+                                0x00000010  // Defines whether the RSSI 
+                                            // register contains the 
+                                            // most-recent signal strength or 
+                                            // the peak signal strength since 
+                                            // the energy scan was enabled. 0: 
+                                            // Most-recent signal strength 1: 
+                                            // Peak signal strength 
+
+#define RFCORE_XREG_FRMCTRL0_ENERGY_SCAN_M \
+                                0x00000010
+#define RFCORE_XREG_FRMCTRL0_ENERGY_SCAN_S 4
+#define RFCORE_XREG_FRMCTRL0_RX_MODE_M \
+                                0x0000000C  // Set RX modes. 00: Normal 
+                                            // operation, use RX FIFO 01: 
+                                            // Receive serial mode, output 
+                                            // received data on to IOC; 
+                                            // infinite RX 10: RX FIFO looping 
+                                            // ignore overflow in RX FIFO; 
+                                            // infinite reception 11: Same as 
+                                            // normal operation except that 
+                                            // symbol search is disabled. Can 
+                                            // be used for RSSI or CCA 
+                                            // measurements when finding symbol 
+                                            // is not desired. 
+
+#define RFCORE_XREG_FRMCTRL0_RX_MODE_S 2
+#define RFCORE_XREG_FRMCTRL0_TX_MODE_M \
+                                0x00000003  // Set test modes for TX. 00: 
+                                            // Normal operation, transmit TX 
+                                            // FIFO 01: Reserved, should not be 
+                                            // used 10: TX FIFO looping ignore 
+                                            // underflow in TX FIFO and read 
+                                            // cyclic; infinite transmission 
+                                            // 11: Send random data from CRC; 
+                                            // infinite transmission 
+
+#define RFCORE_XREG_FRMCTRL0_TX_MODE_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_FRMCTRL1 register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_FRMCTRL1_PENDING_OR \
+                                0x00000004  // Defines whether the pending 
+                                            // data bit in outgoing 
+                                            // acknowledgment frames is always 
+                                            // set to 1 or controlled by the 
+                                            // main FSM and the address 
+                                            // filtering 0: Pending data bit is 
+                                            // controlled by main FSM and 
+                                            // address filtering. 1: Pending 
+                                            // data bit is always 1. 
+
+#define RFCORE_XREG_FRMCTRL1_PENDING_OR_M \
+                                0x00000004
+#define RFCORE_XREG_FRMCTRL1_PENDING_OR_S 2
+#define RFCORE_XREG_FRMCTRL1_IGNORE_TX_UNDERF \
+                                0x00000002  // Defines whether or not TX 
+                                            // underflow should be ignored 0: 
+                                            // Normal TX operation. TX 
+                                            // underflow is detected and TX is 
+                                            // aborted if underflow occurs. 1: 
+                                            // Ignore TX underflow. Transmit 
+                                            // the number of bytes given by the 
+                                            // frame-length field. 
+
+#define RFCORE_XREG_FRMCTRL1_IGNORE_TX_UNDERF_M \
+                                0x00000002
+#define RFCORE_XREG_FRMCTRL1_IGNORE_TX_UNDERF_S 1
+#define RFCORE_XREG_FRMCTRL1_SET_RXENMASK_ON_TX \
+                                0x00000001  // Defines whether STXON sets bit 
+                                            // 6 in the RXENABLE register or 
+                                            // leaves it unchanged 0: Does not 
+                                            // affect RXENABLE 1: Sets bit 6 in 
+                                            // RXENABLE. Used for backward 
+                                            // compatibility with the CC2420. 
+
+#define RFCORE_XREG_FRMCTRL1_SET_RXENMASK_ON_TX_M \
+                                0x00000001
+#define RFCORE_XREG_FRMCTRL1_SET_RXENMASK_ON_TX_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_RXENABLE register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_RXENABLE_RXENMASK_M \
+                                0x000000FF  // RXENABLE enables the receiver. 
+                                            // A nonzero value in this register 
+                                            // causes FFCTRL to enable the 
+                                            // receiver when in idle, after 
+                                            // transmission and after 
+                                            // acknowledgement transmission. 
+                                            // The following strobes can modify 
+                                            // RXENMASK: SRXON: Set bit 7 in 
+                                            // RXENMASK. STXON: Set bit 6 in 
+                                            // RXENMASK if SET_RXENMASK_ON_TX = 
+                                            // 1. SRFOFF: Clears all bits in 
+                                            // RXENMASK. SRXMASKBITSET: Set bit 
+                                            // 5 in RXENMASK. SRXMASKBITCLR: 
+                                            // Clear bit 5 in RXENMASK. There 
+                                            // could be conflicts between the 
+                                            // CSP and xreg_bus write 
+                                            // operations if both operations 
+                                            // try to modify RXENMASK 
+                                            // simultaneously. To handle the 
+                                            // case of simultaneous access to 
+                                            // RXENMASK the following rules 
+                                            // apply: - If the two sources 
+                                            // agree (they modify different 
+                                            // parts of the register) both of 
+                                            // their requests to modify 
+                                            // RXENMASK are processed. - If 
+                                            // both operations try to modify 
+                                            // the mask simultaneously, bus 
+                                            // write operations to RXMASKSET 
+                                            // and RXMASKCLR have priority over 
+                                            // the CSP. This situation must be 
+                                            // avoided. 
+
+#define RFCORE_XREG_RXENABLE_RXENMASK_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_RXMASKSET register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_RXMASKSET_RXENMASKSET_M \
+                                0x000000FF  // When written, the written data 
+                                            // is ORed with the RXENMASK and 
+                                            // stored in RXENMASK. 
+
+#define RFCORE_XREG_RXMASKSET_RXENMASKSET_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_RXMASKCLR register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_RXMASKCLR_RXENMASKCLR_M \
+                                0x000000FF  // When written, the written data 
+                                            // is inverted and ANDed with the 
+                                            // RXENMASK and stored in RXENMASK. 
+                                            // For example, if 1 is written to 
+                                            // one or more bit positions in 
+                                            // this register, the corresponding 
+                                            // bits are cleared in RXENMASK. 
+
+#define RFCORE_XREG_RXMASKCLR_RXENMASKCLR_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_FREQTUNE register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_FREQTUNE_XOSC32M_TUNE_M \
+                                0x0000000F  // Tune crystal oscillator The 
+                                            // default setting 1111 leaves the 
+                                            // XOSC untuned. Changing the 
+                                            // setting from the default setting 
+                                            // (1111) switches in extra 
+                                            // capacitance to the oscillator, 
+                                            // effectively lowering the XOSC 
+                                            // frequency. Hence, a higher 
+                                            // setting gives a higher 
+                                            // frequency. 
+
+#define RFCORE_XREG_FREQTUNE_XOSC32M_TUNE_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_FREQCTRL register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_FREQCTRL_FREQ_M \
+                                0x0000007F  // Frequency control word The 
+                                            // frequency word in FREQ[6:0] is 
+                                            // an offset value from 2394 (fRF = 
+                                            // FREQ[6 0] + 2394). The 
+                                            // RF-frequency is specified from 
+                                            // 2405 to 2480 MHz in 1-MHz steps; 
+                                            // hence, the only valid settings 
+                                            // for FREQ[6:0] are 11 to 86 (11 + 
+                                            // 2394 = 2405 and 86 + 2394 = 
+                                            // 2480). The device supports the 
+                                            // frequency range from 2394 to 
+                                            // 2507 MHz. Consequently, the 
+                                            // usable settings for FREQ[6:0] 
+                                            // are 0 to 113. Settings outside 
+                                            // of the usable range (114 to 127) 
+                                            // give a frequency of 2507 MHz. 
+                                            // IEEE 802.15.4-2006 specifies a 
+                                            // frequency range from 2405 MHz to 
+                                            // 2480 MHz with 16 channels 5 MHz 
+                                            // apart. The channels are numbered 
+                                            // 11 through 26. For an IEEE 
+                                            // 802.15.4-2006 compliant system, 
+                                            // the only valid settings are thus 
+                                            // FREQ[6:0] = 11 + 5 (channel 
+                                            // number - 11). 
+
+#define RFCORE_XREG_FREQCTRL_FREQ_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_TXPOWER register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_TXPOWER_PA_POWER_M \
+                                0x000000F0  // PA power control 
+
+#define RFCORE_XREG_TXPOWER_PA_POWER_S 4
+#define RFCORE_XREG_TXPOWER_PA_BIAS_M \
+                                0x0000000F  // PA bias control 
+
+#define RFCORE_XREG_TXPOWER_PA_BIAS_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_TXCTRL register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_TXCTRL_DAC_CURR_M \
+                                0x00000070  // Change the current in the DAC. 
+
+#define RFCORE_XREG_TXCTRL_DAC_CURR_S 4
+#define RFCORE_XREG_TXCTRL_DAC_DC_M \
+                                0x0000000C  // Adjusts the DC level to the TX 
+                                            // mixer. 
+
+#define RFCORE_XREG_TXCTRL_DAC_DC_S 2
+#define RFCORE_XREG_TXCTRL_TXMIX_CURRENT_M \
+                                0x00000003  // Transmit mixers core current 
+                                            // Current increases with 
+                                            // increasing setting. 
+
+#define RFCORE_XREG_TXCTRL_TXMIX_CURRENT_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_FSMSTAT0 register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_FSMSTAT0_CAL_DONE \
+                                0x00000080  // Frequency synthesis calibration 
+                                            // has been performed since the 
+                                            // last time the FS was turned on. 
+
+#define RFCORE_XREG_FSMSTAT0_CAL_DONE_M \
+                                0x00000080
+#define RFCORE_XREG_FSMSTAT0_CAL_DONE_S 7
+#define RFCORE_XREG_FSMSTAT0_CAL_RUNNING \
+                                0x00000040  // Frequency synthesis calibration 
+                                            // status 0: Calibration is 
+                                            // complete or not started. 1: 
+                                            // Calibration is in progress. 
+
+#define RFCORE_XREG_FSMSTAT0_CAL_RUNNING_M \
+                                0x00000040
+#define RFCORE_XREG_FSMSTAT0_CAL_RUNNING_S 6
+#define RFCORE_XREG_FSMSTAT0_FSM_FFCTRL_STATE_M \
+                                0x0000003F  // Gives the current state of the 
+                                            // FIFO and frame control (FFCTRL) 
+                                            // finite state-machine. 
+
+#define RFCORE_XREG_FSMSTAT0_FSM_FFCTRL_STATE_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_FSMSTAT1 register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_FSMSTAT1_FIFO \
+                                0x00000080  // FIFO is high when there is data 
+                                            // in the RX FIFO. FIFO is low 
+                                            // during RX FIFO overflow. 
+
+#define RFCORE_XREG_FSMSTAT1_FIFO_M \
+                                0x00000080
+#define RFCORE_XREG_FSMSTAT1_FIFO_S 7
+#define RFCORE_XREG_FSMSTAT1_FIFOP \
+                                0x00000040  // FIFOP is set high when there 
+                                            // are at more than FIFOP_THR bytes 
+                                            // of data in the RX FIFO that has 
+                                            // passed frame filtering. FIFOP is 
+                                            // set high when there is at least 
+                                            // one complete frame in the RX 
+                                            // FIFO. FIFOP is high during RX 
+                                            // FIFO overflow. 
+
+#define RFCORE_XREG_FSMSTAT1_FIFOP_M \
+                                0x00000040
+#define RFCORE_XREG_FSMSTAT1_FIFOP_S 6
+#define RFCORE_XREG_FSMSTAT1_SFD \
+                                0x00000020  // In TX 0: When a complete frame 
+                                            // with SFD was sent or no SFD was 
+                                            // sent 1: SFD was sent. In RX 0: 
+                                            // When a complete frame was 
+                                            // received or no SFD was received 
+                                            // 1: SFD was received. 
+
+#define RFCORE_XREG_FSMSTAT1_SFD_M \
+                                0x00000020
+#define RFCORE_XREG_FSMSTAT1_SFD_S 5
+#define RFCORE_XREG_FSMSTAT1_CCA \
+                                0x00000010  // Clear channel assessment 
+                                            // Dependent on CCA_MODE settings. 
+                                            // See CCACTRL1 for details. 
+
+#define RFCORE_XREG_FSMSTAT1_CCA_M \
+                                0x00000010
+#define RFCORE_XREG_FSMSTAT1_CCA_S 4
+#define RFCORE_XREG_FSMSTAT1_SAMPLED_CCA \
+                                0x00000008  // Contains a sampled value of the 
+                                            // CCA The value is updated when a 
+                                            // SSAMPLECCA or STXONCCA strobe is 
+                                            // issued. 
+
+#define RFCORE_XREG_FSMSTAT1_SAMPLED_CCA_M \
+                                0x00000008
+#define RFCORE_XREG_FSMSTAT1_SAMPLED_CCA_S 3
+#define RFCORE_XREG_FSMSTAT1_LOCK_STATUS \
+                                0x00000004  // 1 when PLL is in lock; 
+                                            // otherwise 0 
+
+#define RFCORE_XREG_FSMSTAT1_LOCK_STATUS_M \
+                                0x00000004
+#define RFCORE_XREG_FSMSTAT1_LOCK_STATUS_S 2
+#define RFCORE_XREG_FSMSTAT1_TX_ACTIVE \
+                                0x00000002  // Status signal Active when FFC 
+                                            // is in one of the transmit states 
+
+#define RFCORE_XREG_FSMSTAT1_TX_ACTIVE_M \
+                                0x00000002
+#define RFCORE_XREG_FSMSTAT1_TX_ACTIVE_S 1
+#define RFCORE_XREG_FSMSTAT1_RX_ACTIVE \
+                                0x00000001  // Status signal Active when FFC 
+                                            // is in one of the receive states 
+
+#define RFCORE_XREG_FSMSTAT1_RX_ACTIVE_M \
+                                0x00000001
+#define RFCORE_XREG_FSMSTAT1_RX_ACTIVE_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_FIFOPCTRL register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_FIFOPCTRL_FIFOP_THR_M \
+                                0x0000007F  // Threshold used when generating 
+                                            // FIFOP signal 
+
+#define RFCORE_XREG_FIFOPCTRL_FIFOP_THR_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_FSMCTRL register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_FSMCTRL_SLOTTED_ACK \
+                                0x00000002  // Controls timing of transmission 
+                                            // of acknowledge frames 0: The 
+                                            // acknowledge frame is sent 12 
+                                            // symbol periods after the end of 
+                                            // the received frame which 
+                                            // requests the aknowledge. 1: The 
+                                            // acknowledge frame is sent at the 
+                                            // first backoff-slot boundary more 
+                                            // than 12 symbol periods after the 
+                                            // end of the received frame which 
+                                            // requests the aknowledge. 
+
+#define RFCORE_XREG_FSMCTRL_SLOTTED_ACK_M \
+                                0x00000002
+#define RFCORE_XREG_FSMCTRL_SLOTTED_ACK_S 1
+#define RFCORE_XREG_FSMCTRL_RX2RX_TIME_OFF \
+                                0x00000001  // Defines whether or not a 
+                                            // 12-symbol time-out should be 
+                                            // used after frame reception has 
+                                            // ended. 0: No time-out 1: 
+                                            // 12-symbol-period time-out 
+
+#define RFCORE_XREG_FSMCTRL_RX2RX_TIME_OFF_M \
+                                0x00000001
+#define RFCORE_XREG_FSMCTRL_RX2RX_TIME_OFF_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_CCACTRL0 register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_CCACTRL0_CCA_THR_M \
+                                0x000000FF  // Clear-channel-assessment 
+                                            // threshold value, signed 
+                                            // 2's-complement number for 
+                                            // comparison with the RSSI. The 
+                                            // unit is 1 dB, offset is 73dB The 
+                                            // CCA signal goes high when the 
+                                            // received signal is below this 
+                                            // value. The CCA signal is 
+                                            // available on the CCA pin and in 
+                                            // the FSMSTAT1 register. The value 
+                                            // must never be set lower than 
+                                            // CCA_HYST - 128 to avoid 
+                                            // erroneous behavior of the CCA 
+                                            // signal. Note: The reset value 
+                                            // translates to an input level of 
+                                            // approximately -32 - 73 = -105 
+                                            // dBm, which is well below the 
+                                            // sensitivity limit. This means 
+                                            // that the CCA signal never 
+                                            // indicates a clear channel. This 
+                                            // register should be updated to 
+                                            // 0xF8, which translates to an 
+                                            // input level of about -8 - 73 = 
+                                            // -81 dBm. 
+
+#define RFCORE_XREG_CCACTRL0_CCA_THR_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_CCACTRL1 register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_CCACTRL1_CCA_MODE_M \
+                                0x00000018  // 00: CCA always set to 1 01: CCA 
+                                            // = 1 when RSSI < CCA_THR - 
+                                            // CCA_HYST; CCA = 0 when RSSI >= 
+                                            // CCA_THR 10: CCA = 1 when not 
+                                            // receiving a frame, else CCA = 0 
+                                            // 11: CCA = 1 when RSSI < CCA_THR 
+                                            // - CCA_HYST and not receiving a 
+                                            // frame; CCA = 0 when RSSI >= 
+                                            // CCA_THR or when receiving a 
+                                            // frame 
+
+#define RFCORE_XREG_CCACTRL1_CCA_MODE_S 3
+#define RFCORE_XREG_CCACTRL1_CCA_HYST_M \
+                                0x00000007  // Sets the level of CCA 
+                                            // hysteresis. Unsigned values 
+                                            // given in dB 
+
+#define RFCORE_XREG_CCACTRL1_CCA_HYST_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_RSSI register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_RSSI_RSSI_VAL_M \
+                                0x000000FF  // RSSI estimate on a logarithmic 
+                                            // scale, signed number on 2's 
+                                            // complement Unit is 1 dB, offset 
+                                            // is 73dB. The RSSI value is 
+                                            // averaged over eight symbol 
+                                            // periods. The RSSI_VALID status 
+                                            // bit should be checked before 
+                                            // reading RSSI_VAL for the first 
+                                            // time. The reset value of -128 
+                                            // also indicates that the RSSI 
+                                            // value is invalid. 
+
+#define RFCORE_XREG_RSSI_RSSI_VAL_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_RSSISTAT register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_RSSISTAT_RSSI_VALID \
+                                0x00000001  // RSSI value is valid. Occurs 
+                                            // eight symbol periods after 
+                                            // entering RX. 
+
+#define RFCORE_XREG_RSSISTAT_RSSI_VALID_M \
+                                0x00000001
+#define RFCORE_XREG_RSSISTAT_RSSI_VALID_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_RXFIRST register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_RXFIRST_DATA_M \
+                                0x000000FF  // First byte of the RX FIFO Note: 
+                                            // Reading this register does not 
+                                            // modify the contents of the FIFO. 
+
+#define RFCORE_XREG_RXFIRST_DATA_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_RXFIFOCNT register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_RXFIFOCNT_RXFIFOCNT_M \
+                                0x000000FF  // Number of bytes in the RX FIFO 
+                                            // (unsigned integer) 
+
+#define RFCORE_XREG_RXFIFOCNT_RXFIFOCNT_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_TXFIFOCNT register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_TXFIFOCNT_TXFIFOCNT_M \
+                                0x000000FF  // Number of bytes in the TX FIFO 
+                                            // (unsigned integer) 
+
+#define RFCORE_XREG_TXFIFOCNT_TXFIFOCNT_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_RXFIRST_PTR register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_RXFIRST_PTR_RXFIRST_PTR_M \
+                                0x000000FF  // RAM address offset of the first 
+                                            // byte in the RX FIFO 
+
+#define RFCORE_XREG_RXFIRST_PTR_RXFIRST_PTR_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_RXLAST_PTR register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_RXLAST_PTR_RXLAST_PTR_M \
+                                0x000000FF  // RAM address offset of the last 
+                                            // byte + 1 byte in the RX FIFO 
+
+#define RFCORE_XREG_RXLAST_PTR_RXLAST_PTR_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_RXP1_PTR register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_RXP1_PTR_RXP1_PTR_M \
+                                0x000000FF  // RAM address offset of the first 
+                                            // byte of the first frame in the 
+                                            // RX FIFO 
+
+#define RFCORE_XREG_RXP1_PTR_RXP1_PTR_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_TXFIRST_PTR register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_TXFIRST_PTR_TXFIRST_PTR_M \
+                                0x000000FF  // RAM address offset of the next 
+                                            // byte to be transmitted from the 
+                                            // TX FIFO 
+
+#define RFCORE_XREG_TXFIRST_PTR_TXFIRST_PTR_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_TXLAST_PTR register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_TXLAST_PTR_TXLAST_PTR_M \
+                                0x000000FF  // RAM address offset of the last 
+                                            // byte + 1 byte of the TX FIFO 
+
+#define RFCORE_XREG_TXLAST_PTR_TXLAST_PTR_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_RFIRQM0 register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_RFIRQM0_RFIRQM_M \
+                                0x000000FF  // Bit mask is masking out 
+                                            // interrupt sources. Bit position: 
+                                            // 7: RXMASKZERO 6: RXPKTDONE 5: 
+                                            // FRAME_ACCEPTED 4: 
+                                            // SRC_MATCH_FOUND 3: 
+                                            // SRC_MATCH_DONE 2: FIFOP 1: SFD 
+                                            // 0: ACT_UNUSED 
+
+#define RFCORE_XREG_RFIRQM0_RFIRQM_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_RFIRQM1 register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_RFIRQM1_RFIRQM_M \
+                                0x0000003F  // Bit mask is masking out 
+                                            // interrupt sources. Bit position: 
+                                            // 5: CSP_WAIT 4: CSP_STOP 3: 
+                                            // CSP_MANINT 2: RF_IDLE 1: TXDONE 
+                                            // 0: TXACKDONE 
+
+#define RFCORE_XREG_RFIRQM1_RFIRQM_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_RFERRM register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_RFERRM_RFERRM_M \
+                                0x0000007F  // Bit mask is masking out 
+                                            // interrupt sources. Bit position: 
+                                            // 6: STROBE_ERR 5: TXUNDERF 4: 
+                                            // TXOVERF 3: RXUNDERF 2: RXOVERF 
+                                            // 1: RXABO 0: NLOCK 
+
+#define RFCORE_XREG_RFERRM_RFERRM_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_RFRND register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_RFRND_QRND  0x00000002  // Random bit from the Q channel 
+                                            // of the receiver 
+#define RFCORE_XREG_RFRND_QRND_M \
+                                0x00000002
+#define RFCORE_XREG_RFRND_QRND_S 1
+#define RFCORE_XREG_RFRND_IRND  0x00000001  // Random bit from the I channel 
+                                            // of the receiver 
+#define RFCORE_XREG_RFRND_IRND_M \
+                                0x00000001
+#define RFCORE_XREG_RFRND_IRND_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_MDMCTRL0 register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_MDMCTRL0_DEM_NUM_ZEROS_M \
+                                0x000000C0  // Sets how many zero symbols must 
+                                            // be detected before the sync word 
+                                            // when searching for sync. Only 
+                                            // one zero symbol is required to 
+                                            // have a correlation value above 
+                                            // the correlation threshold set in 
+                                            // the MDMCTRL1 register. 00: 
+                                            // Reserved 01: 1 zero symbol 10: 2 
+                                            // zero symbols 11: 3 zero symbols 
+
+#define RFCORE_XREG_MDMCTRL0_DEM_NUM_ZEROS_S 6
+#define RFCORE_XREG_MDMCTRL0_DEMOD_AVG_MODE \
+                                0x00000020  // Defines the behavior or the 
+                                            // frequency offset averaging 
+                                            // filter. 0: Lock average level 
+                                            // after preamble match. Restart 
+                                            // frequency offset calibration 
+                                            // when searching for the next 
+                                            // frame. 1: Continuously update 
+                                            // average level. 
+
+#define RFCORE_XREG_MDMCTRL0_DEMOD_AVG_MODE_M \
+                                0x00000020
+#define RFCORE_XREG_MDMCTRL0_DEMOD_AVG_MODE_S 5
+#define RFCORE_XREG_MDMCTRL0_PREAMBLE_LENGTH_M \
+                                0x0000001E  // The number of preamble bytes 
+                                            // (two zero-symbols) to be sent in 
+                                            // TX mode before the SFD, encoded 
+                                            // in steps of 2 symbols (1 byte). 
+                                            // The reset value of 2 is 
+                                            // compliant with IEEE 802.15.4. 
+                                            // 0000: 2 leading-zero bytes 0001: 
+                                            // 3 leading-zero bytes 0010: 4 
+                                            // leading-zero bytes ... 1111: 17 
+                                            // leading-zero bytes 
+
+#define RFCORE_XREG_MDMCTRL0_PREAMBLE_LENGTH_S 1
+#define RFCORE_XREG_MDMCTRL0_TX_FILTER \
+                                0x00000001  // Defines the kind of TX filter 
+                                            // that is used. The normal TX 
+                                            // filter is as defined by the IEEE 
+                                            // 802.15.4 standard. Extra 
+                                            // filtering may be applied to 
+                                            // lower the out-of-band emissions. 
+                                            // 0: Normal TX filtering 1: Enable 
+                                            // extra filtering 
+
+#define RFCORE_XREG_MDMCTRL0_TX_FILTER_M \
+                                0x00000001
+#define RFCORE_XREG_MDMCTRL0_TX_FILTER_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_MDMCTRL1 register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_MDMCTRL1_CORR_THR_SFD \
+                                0x00000020  // Defines requirements for SFD 
+                                            // detection: 0: The correlation 
+                                            // value of one of the zero symbols 
+                                            // of the preamble must be above 
+                                            // the correlation threshold. 1: 
+                                            // The correlation value of one 
+                                            // zero symbol of the preamble and 
+                                            // both symbols in the SFD must be 
+                                            // above the correlation threshold. 
+
+#define RFCORE_XREG_MDMCTRL1_CORR_THR_SFD_M \
+                                0x00000020
+#define RFCORE_XREG_MDMCTRL1_CORR_THR_SFD_S 5
+#define RFCORE_XREG_MDMCTRL1_CORR_THR_M \
+                                0x0000001F  // Demodulator correlator 
+                                            // threshold value, required before 
+                                            // SFD search. Threshold value 
+                                            // adjusts how the receiver 
+                                            // synchronizes to data from the 
+                                            // radio. If the threshold is set 
+                                            // too low, sync can more easily be 
+                                            // found on noise. If set too high, 
+                                            // the sensitivity is reduced, but 
+                                            // sync is not likely to be found 
+                                            // on noise. In combination with 
+                                            // DEM_NUM_ZEROS, the system can be 
+                                            // tuned so sensitivity is high 
+                                            // with less sync found on noise. 
+
+#define RFCORE_XREG_MDMCTRL1_CORR_THR_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_FREQEST register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_FREQEST_FREQEST_M \
+                                0x000000FF  // Signed 2's-complement value. 
+                                            // Contains an estimate of the 
+                                            // frequency offset between carrier 
+                                            // and the receiver LO. The offset 
+                                            // frequency is FREQEST x 7800 Hz. 
+                                            // DEM_AVG_MODE controls when this 
+                                            // estimate is updated. If 
+                                            // DEM_AVG_MODE = 0, it is updated 
+                                            // until sync is found. Then the 
+                                            // frequency offset estimate is 
+                                            // frozen until the end of the 
+                                            // received frame. If DEM_AVG_MODE 
+                                            // = 1, it is updated as long as 
+                                            // the demodulator is enabled. To 
+                                            // calculate the correct value, one 
+                                            // must use an offset 
+                                            // (FREQEST_offset), which can be 
+                                            // found in the device data sheet. 
+                                            // Real FREQEST value = FREQEST - 
+                                            // FREQEST_offset. 
+
+#define RFCORE_XREG_FREQEST_FREQEST_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_RXCTRL register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_RXCTRL_GBIAS_LNA2_REF_M \
+                                0x00000030  // Adjusts front-end LNA2/mixer 
+                                            // PTAT current output (from M = 3 
+                                            // to M = 6), default: M = 5 
+
+#define RFCORE_XREG_RXCTRL_GBIAS_LNA2_REF_S 4
+#define RFCORE_XREG_RXCTRL_GBIAS_LNA_REF_M \
+                                0x0000000C  // Adjusts front-end LNA PTAT 
+                                            // current output (from M = 3 to M 
+                                            // = 6), default: M = 5 
+
+#define RFCORE_XREG_RXCTRL_GBIAS_LNA_REF_S 2
+#define RFCORE_XREG_RXCTRL_MIX_CURRENT_M \
+                                0x00000003  // Control of the output current 
+                                            // from the receiver mixers The 
+                                            // current increases with 
+                                            // increasing setting set. 
+
+#define RFCORE_XREG_RXCTRL_MIX_CURRENT_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_FSCTRL register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_FSCTRL_PRE_CURRENT_M \
+                                0x000000C0  // Prescaler current setting 
+
+#define RFCORE_XREG_FSCTRL_PRE_CURRENT_S 6
+#define RFCORE_XREG_FSCTRL_LODIV_BUF_CURRENT_TX_M \
+                                0x00000030  // Adjusts current in mixer and PA 
+                                            // buffers Used when TX_ACTIVE = 1 
+
+#define RFCORE_XREG_FSCTRL_LODIV_BUF_CURRENT_TX_S 4
+#define RFCORE_XREG_FSCTRL_LODIV_BUF_CURRENT_RX_M \
+                                0x0000000C  // Adjusts current in mixer and PA 
+                                            // buffers Used when TX_ACTIVE = 0 
+
+#define RFCORE_XREG_FSCTRL_LODIV_BUF_CURRENT_RX_S 2
+#define RFCORE_XREG_FSCTRL_LODIV_CURRENT_M \
+                                0x00000003  // Adjusts divider currents, 
+                                            // except mixer and PA buffers 
+
+#define RFCORE_XREG_FSCTRL_LODIV_CURRENT_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_FSCAL0 register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_FSCAL0_VCO_CURR_COMP_EN_OV \
+                                0x00000080  // Force on the current comparator 
+                                            // in the VCO. This signal is ORed 
+                                            // with the signal coming from the 
+                                            // calibration module. 
+
+#define RFCORE_XREG_FSCAL0_VCO_CURR_COMP_EN_OV_M \
+                                0x00000080
+#define RFCORE_XREG_FSCAL0_VCO_CURR_COMP_EN_OV_S 7
+#define RFCORE_XREG_FSCAL0_CHP_DISABLE \
+                                0x00000040  // Set this bit to manually 
+                                            // disable charge pump by masking 
+                                            // the up and down pulses from the 
+                                            // phase detector. 
+
+#define RFCORE_XREG_FSCAL0_CHP_DISABLE_M \
+                                0x00000040
+#define RFCORE_XREG_FSCAL0_CHP_DISABLE_S 6
+#define RFCORE_XREG_FSCAL0_CHP_CURRENT_M \
+                                0x0000003C  // Digital bit vector defining the 
+                                            // charge-pump output current on an 
+                                            // exponential scale If 
+                                            // FFC_BW_BOOST = 0, the read value 
+                                            // is the value stored in 
+                                            // CHP_CURRENT. If FFC_BW_BOOST = 
+                                            // 1, the read value is CHP_CURRENT 
+                                            // + 4. If the addition causes 
+                                            // overflow, the signal is 
+                                            // saturated. 
+
+#define RFCORE_XREG_FSCAL0_CHP_CURRENT_S 2
+#define RFCORE_XREG_FSCAL0_BW_BOOST_MODE_M \
+                                0x00000003  // Control signal Defines the 
+                                            // synthesizer boost mode 00: No 
+                                            // BW_BOOST 01: BW_BOOST is high 
+                                            // during calibration and 
+                                            // approximately 30 us into the 
+                                            // settling. 10: BW_BOOST is always 
+                                            // on (or high). 11: Reserved 
+
+#define RFCORE_XREG_FSCAL0_BW_BOOST_MODE_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_FSCAL1 register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_FSCAL1_VCO_CURR_CAL_OE \
+                                0x00000080  // Override current calibration 
+
+#define RFCORE_XREG_FSCAL1_VCO_CURR_CAL_OE_M \
+                                0x00000080
+#define RFCORE_XREG_FSCAL1_VCO_CURR_CAL_OE_S 7
+#define RFCORE_XREG_FSCAL1_VCO_CURR_CAL_M \
+                                0x0000007C  // Calibration result Override 
+                                            // value if VCO_CURR_CAL_OE = 1 
+
+#define RFCORE_XREG_FSCAL1_VCO_CURR_CAL_S 2
+#define RFCORE_XREG_FSCAL1_VCO_CURR_M \
+                                0x00000003  // Defines current in VCO core 
+                                            // Sets the multiplier between 
+                                            // calibrated current and VCO 
+                                            // current. 
+
+#define RFCORE_XREG_FSCAL1_VCO_CURR_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_FSCAL2 register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_FSCAL2_VCO_CAPARR_OE \
+                                0x00000040  // Override the calibration result 
+                                            // with the value from 
+                                            // VCO_CAPARR[5:0]. 
+
+#define RFCORE_XREG_FSCAL2_VCO_CAPARR_OE_M \
+                                0x00000040
+#define RFCORE_XREG_FSCAL2_VCO_CAPARR_OE_S 6
+#define RFCORE_XREG_FSCAL2_VCO_CAPARR_M \
+                                0x0000003F  // VCO capacitor array setting 
+                                            // Programmed during calibration 
+                                            // Override value when 
+                                            // VCO_CAPARR_OE = 1 
+
+#define RFCORE_XREG_FSCAL2_VCO_CAPARR_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_FSCAL3 register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_FSCAL3_VCO_DAC_EN_OV \
+                                0x00000040  // Enables the VCO DAC when 1 
+
+#define RFCORE_XREG_FSCAL3_VCO_DAC_EN_OV_M \
+                                0x00000040
+#define RFCORE_XREG_FSCAL3_VCO_DAC_EN_OV_S 6
+#define RFCORE_XREG_FSCAL3_VCO_VC_DAC_M \
+                                0x0000003C  // Bit vector for programming 
+                                            // varactor control voltage from VC 
+                                            // DAC 
+
+#define RFCORE_XREG_FSCAL3_VCO_VC_DAC_S 2
+#define RFCORE_XREG_FSCAL3_VCO_CAPARR_CAL_CTRL_M \
+                                0x00000003  // Calibration accuracy setting 
+                                            // for the cap_array calibration 
+                                            // part of the calibration 00: 80 
+                                            // XOSC periods 01: 100 XOSC 
+                                            // periods 10: 125 XOSC periods 11: 
+                                            // 250 XOSC periods 
+
+#define RFCORE_XREG_FSCAL3_VCO_CAPARR_CAL_CTRL_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_AGCCTRL0 register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_AGCCTRL0_AGC_DR_XTND_EN \
+                                0x00000040  // 0: The AGC performs no 
+                                            // adjustment of attenuation in the 
+                                            // AAF. 1: The AGC adjusts the gain 
+                                            // in the AAF to achieve extra 
+                                            // dynamic range for the receiver. 
+
+#define RFCORE_XREG_AGCCTRL0_AGC_DR_XTND_EN_M \
+                                0x00000040
+#define RFCORE_XREG_AGCCTRL0_AGC_DR_XTND_EN_S 6
+#define RFCORE_XREG_AGCCTRL0_AGC_DR_XTND_THR_M \
+                                0x0000003F  // If the measured error between 
+                                            // the AGC reference magnitude and 
+                                            // the actual magnitude in dB is 
+                                            // larger than this threshold, the 
+                                            // extra attenuation is enabled in 
+                                            // the front end. This threshold 
+                                            // must be set higher than 0x0C. 
+                                            // This feature is enabled by 
+                                            // AGC_DR_XTND_EN. 
+
+#define RFCORE_XREG_AGCCTRL0_AGC_DR_XTND_THR_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_AGCCTRL1 register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_AGCCTRL1_AGC_REF_M \
+                                0x0000003F  // Target value for the AGC 
+                                            // control loop, given in 1-dB 
+                                            // steps 
+
+#define RFCORE_XREG_AGCCTRL1_AGC_REF_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_AGCCTRL2 register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_AGCCTRL2_LNA1_CURRENT_M \
+                                0x000000C0  // Overrride value for LNA 1 Used 
+                                            // only when LNA_CURRENT_OE = 1 
+                                            // When read, this register returns 
+                                            // the current applied gain 
+                                            // setting. 00: 0-dB gain 
+                                            // (reference level) 01: 3-dB gain 
+                                            // 10: Reserved 11: 6-dB gain 
+
+#define RFCORE_XREG_AGCCTRL2_LNA1_CURRENT_S 6
+#define RFCORE_XREG_AGCCTRL2_LNA2_CURRENT_M \
+                                0x00000038  // Overrride value for LNA 2 Used 
+                                            // only when LNA_CURRENT_OE = 1 
+                                            // When read, this register returns 
+                                            // the current applied gain 
+                                            // setting. 000: 0-dB gain 
+                                            // (reference level) 001: 3-dB gain 
+                                            // 010: 6-dB gain 011: 9-dB gain 
+                                            // 100: 12-dB gain 101: 15-dB gain 
+                                            // 110: 18-dB gain 111: 21-dB gain 
+
+#define RFCORE_XREG_AGCCTRL2_LNA2_CURRENT_S 3
+#define RFCORE_XREG_AGCCTRL2_LNA3_CURRENT_M \
+                                0x00000006  // Overrride value for LNA 3 Used 
+                                            // only when LNA_CURRENT_OE = 1 
+                                            // When read, this register returns 
+                                            // the current applied gain 
+                                            // setting. 00: 0-dB gain 
+                                            // (reference level) 01: 3-dB gain 
+                                            // 10: 6-dB gain 11: 9-dB gain 
+
+#define RFCORE_XREG_AGCCTRL2_LNA3_CURRENT_S 1
+#define RFCORE_XREG_AGCCTRL2_LNA_CURRENT_OE \
+                                0x00000001  // Write 1 to override the AGC LNA 
+                                            // current setting with the values 
+                                            // above (LNA1_CURRENT, 
+                                            // LNA2_CURRENT, and LNA3_CURRENT). 
+
+#define RFCORE_XREG_AGCCTRL2_LNA_CURRENT_OE_M \
+                                0x00000001
+#define RFCORE_XREG_AGCCTRL2_LNA_CURRENT_OE_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_AGCCTRL3 register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_AGCCTRL3_AGC_SETTLE_WAIT_M \
+                                0x00000060  // Timing for AGC to wait for 
+                                            // analog gain to settle after a 
+                                            // gain change. During this period, 
+                                            // the energy measurement in the 
+                                            // AGC is paused. 00: 15 periods 
+                                            // 01: 20 periods 10: 25 periods 
+                                            // 11: 30 periods 
+
+#define RFCORE_XREG_AGCCTRL3_AGC_SETTLE_WAIT_S 5
+#define RFCORE_XREG_AGCCTRL3_AGC_WIN_SIZE_M \
+                                0x00000018  // Window size for the 
+                                            // accumulate-and-dump function in 
+                                            // the AGC. 00: 16 samples 01: 32 
+                                            // samples 10: 64 samples 11: 128 
+                                            // samples 
+
+#define RFCORE_XREG_AGCCTRL3_AGC_WIN_SIZE_S 3
+#define RFCORE_XREG_AGCCTRL3_AAF_RP_M \
+                                0x00000006  // Overrides the control signals 
+                                            // of the AGC to AAF when AAF_RP_OE 
+                                            // = 1. When read, it returns the 
+                                            // applied signal to the AAF. 00: 
+                                            // 9-dB attenuation in AAF 01: 6-dB 
+                                            // attenuation in AAF 10: 3-dB 
+                                            // attenuation in AAF 11: 0-dB 
+                                            // attenuation in AAF (reference 
+                                            // level) 
+
+#define RFCORE_XREG_AGCCTRL3_AAF_RP_S 1
+#define RFCORE_XREG_AGCCTRL3_AAF_RP_OE \
+                                0x00000001  // Override the AAF control 
+                                            // signals of the AGC with the 
+                                            // values stored in AAF_RP. 
+
+#define RFCORE_XREG_AGCCTRL3_AAF_RP_OE_M \
+                                0x00000001
+#define RFCORE_XREG_AGCCTRL3_AAF_RP_OE_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_ADCTEST0 register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_ADCTEST0_ADC_VREF_ADJ_M \
+                                0x000000C0  // Quantizer threshold control for 
+                                            // test and debug 
+
+#define RFCORE_XREG_ADCTEST0_ADC_VREF_ADJ_S 6
+#define RFCORE_XREG_ADCTEST0_ADC_QUANT_ADJ_M \
+                                0x00000030  // Quantizer threshold control for 
+                                            // test and debug 
+
+#define RFCORE_XREG_ADCTEST0_ADC_QUANT_ADJ_S 4
+#define RFCORE_XREG_ADCTEST0_ADC_GM_ADJ_M \
+                                0x0000000E  // Gm-control for test and debug 
+
+#define RFCORE_XREG_ADCTEST0_ADC_GM_ADJ_S 1
+#define RFCORE_XREG_ADCTEST0_ADC_DAC2_EN \
+                                0x00000001  // Enables DAC2 for enhanced ADC 
+                                            // stability 
+
+#define RFCORE_XREG_ADCTEST0_ADC_DAC2_EN_M \
+                                0x00000001
+#define RFCORE_XREG_ADCTEST0_ADC_DAC2_EN_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_ADCTEST1 register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_ADCTEST1_ADC_TEST_CTRL_M \
+                                0x000000F0  // ADC test mode selector 
+
+#define RFCORE_XREG_ADCTEST1_ADC_TEST_CTRL_S 4
+#define RFCORE_XREG_ADCTEST1_ADC_C2_ADJ_M \
+                                0x0000000C  // Used to adjust capacitor values 
+                                            // in ADC 
+
+#define RFCORE_XREG_ADCTEST1_ADC_C2_ADJ_S 2
+#define RFCORE_XREG_ADCTEST1_ADC_C3_ADJ_M \
+                                0x00000003  // Used to adjust capacitor values 
+                                            // in ADC 
+
+#define RFCORE_XREG_ADCTEST1_ADC_C3_ADJ_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_ADCTEST2 register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_ADCTEST2_ADC_TEST_MODE_M \
+                                0x00000060  // Test mode to enable output of 
+                                            // ADC data from demodulator. When 
+                                            // enabled, raw ADC data is clocked 
+                                            // out on the GPIO pins. 00: Test 
+                                            // mode disabled 01: Data from the 
+                                            // I and Q ADCs are output (data 
+                                            // rate 76 MHz) 10: Data from the I 
+                                            // ADC is output. Two and two ADC 
+                                            // samples grouped (data rate 38 
+                                            // MHz) 11: Data from the Q ADC is 
+                                            // output. Two and two ADC samples 
+                                            // grouped (data rate 38 MHz) 
+
+#define RFCORE_XREG_ADCTEST2_ADC_TEST_MODE_S 5
+#define RFCORE_XREG_ADCTEST2_AAF_RS_M \
+                                0x00000018  // Controls series resistance of 
+                                            // AAF 
+
+#define RFCORE_XREG_ADCTEST2_AAF_RS_S 3
+#define RFCORE_XREG_ADCTEST2_ADC_FF_ADJ_M \
+                                0x00000006  // Adjust feed forward 
+
+#define RFCORE_XREG_ADCTEST2_ADC_FF_ADJ_S 1
+#define RFCORE_XREG_ADCTEST2_ADC_DAC_ROT \
+                                0x00000001  // Control of DAC DWA scheme 0 = 
+                                            // DWA (scrambling) disabled 1 = 
+                                            // DWA enabled 
+
+#define RFCORE_XREG_ADCTEST2_ADC_DAC_ROT_M \
+                                0x00000001
+#define RFCORE_XREG_ADCTEST2_ADC_DAC_ROT_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_MDMTEST0 register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_MDMTEST0_TX_TONE_M \
+                                0x000000F0  // Enables the possibility to 
+                                            // transmit a baseband tone by 
+                                            // picking samples from the sine 
+                                            // tables with a controllable phase 
+                                            // step between the samples. The 
+                                            // step size is controlled by 
+                                            // TX_TONE. If MDMTEST1.MOD_IF is 
+                                            // 0, the tone is superpositioned 
+                                            // on the modulated data, 
+                                            // effectively giving modulation 
+                                            // with an IF. If MDMTEST1.MOD_IF 
+                                            // is 1, only the tone is 
+                                            // transmitted. 0000: -6 MHz 0001: 
+                                            // -4 MHz 0010: -3 MHz 0011: -2 MHz 
+                                            // 0100: -1 MHz 0101: -500 kHz 
+                                            // 0110: -4 kHz 0111: 0 1000: 4 kHz 
+                                            // 1001: 500 kHz 1010: 1 MHz 1011: 
+                                            // 2 MHz 1100: 3 MHz 1101: 4 MHz 
+                                            // 1110: 6 MHz Others: Reserved 
+
+#define RFCORE_XREG_MDMTEST0_TX_TONE_S 4
+#define RFCORE_XREG_MDMTEST0_DC_WIN_SIZE_M \
+                                0x0000000C  // Controls the numbers of samples 
+                                            // to be accumulated between each 
+                                            // dump of the accumulate-and-dump 
+                                            // filter used in DC removal 00: 32 
+                                            // samples 01: 64 samples 10: 128 
+                                            // samples 11: 256 samples 
+
+#define RFCORE_XREG_MDMTEST0_DC_WIN_SIZE_S 2
+#define RFCORE_XREG_MDMTEST0_DC_BLOCK_MODE_M \
+                                0x00000003  // Selects the mode of operation 
+                                            // 00: The input signal to the DC 
+                                            // blocker is passed to the output 
+                                            // without any attempt to remove 
+                                            // DC. 01: Enable DC cancellation. 
+                                            // Normal operation 10: Freeze 
+                                            // estimates of DC when sync is 
+                                            // found. Resume estimating DC when 
+                                            // searching for the next frame. 
+                                            // 11: Reserved 
+
+#define RFCORE_XREG_MDMTEST0_DC_BLOCK_MODE_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_MDMTEST1 register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_MDMTEST1_USEMIRROR_IF \
+                                0x00000020  // 0: Use the normal IF frequency 
+                                            // (MDMTEST0.TX_TONE) for automatic 
+                                            // IF compensation of channel 
+                                            // frequency on TX. 1: Use mirror 
+                                            // IF frequency for automatic 
+                                            // compensation of channel 
+                                            // frequency on TX. 
+
+#define RFCORE_XREG_MDMTEST1_USEMIRROR_IF_M \
+                                0x00000020
+#define RFCORE_XREG_MDMTEST1_USEMIRROR_IF_S 5
+#define RFCORE_XREG_MDMTEST1_MOD_IF \
+                                0x00000010  // 0: Modulation is performed at 
+                                            // an IF set by MDMTEST0.TX_TONE. 
+                                            // The tone set by MDMTEST0.TX_TONE 
+                                            // is superimposed on the data. 1: 
+                                            // Modulate a tone set by 
+                                            // MDMTEST0.TX_TONE. A tone is 
+                                            // transmitted with frequency set 
+                                            // by MDMTEST0.TX_TONE. 
+
+#define RFCORE_XREG_MDMTEST1_MOD_IF_M \
+                                0x00000010
+#define RFCORE_XREG_MDMTEST1_MOD_IF_S 4
+#define RFCORE_XREG_MDMTEST1_RAMP_AMP \
+                                0x00000008  // 1: Enable ramping of DAC output 
+                                            // amplitude during startup and 
+                                            // finish. 0: Disable ramping of 
+                                            // DAC output amplitude. 
+
+#define RFCORE_XREG_MDMTEST1_RAMP_AMP_M \
+                                0x00000008
+#define RFCORE_XREG_MDMTEST1_RAMP_AMP_S 3
+#define RFCORE_XREG_MDMTEST1_RFC_SNIFF_EN \
+                                0x00000004  // 0: Packet sniffer module 
+                                            // disabled 1: Packet sniffer 
+                                            // module enabled. The received and 
+                                            // transmitted data can be observed 
+                                            // on GPIO pins. 
+
+#define RFCORE_XREG_MDMTEST1_RFC_SNIFF_EN_M \
+                                0x00000004
+#define RFCORE_XREG_MDMTEST1_RFC_SNIFF_EN_S 2
+#define RFCORE_XREG_MDMTEST1_LOOPBACK_EN \
+                                0x00000001  // Enables loopback of modulated 
+                                            // data into the receiver chain 0: 
+                                            // An STXCAL instruction calibrates 
+                                            // for TX. Use STXON to continue to 
+                                            // active TX. 1: An STXCAL 
+                                            // instruction enables the loopback 
+                                            // mode. 
+
+#define RFCORE_XREG_MDMTEST1_LOOPBACK_EN_M \
+                                0x00000001
+#define RFCORE_XREG_MDMTEST1_LOOPBACK_EN_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_DACTEST0 register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_DACTEST0_DAC_Q_M \
+                                0x400886FF  // Q-branch DAC override value 
+                                            // when DAC_SRC = 001 If DAC_SRC is 
+                                            // set to be ADC data, CORDIC 
+                                            // magnitude, or channel filtered 
+                                            // data, then DAC_Q_O controls the 
+                                            // part of the word in question 
+                                            // that is actually multiplexed to 
+                                            // the DAC, as described below. 
+                                            // 000111: Bits 7:0 001000: Bits 
+                                            // 8:1 001001: Bits 9:2 ... If an 
+                                            // invalid setting is chosen, the 
+                                            // DAC outputs only zeros (minimum 
+                                            // value). 
+
+#define RFCORE_XREG_DACTEST0_DAC_Q_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_DACTEST1 register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_DACTEST1_DAC_I_M \
+                                0x400886FF  // I-branch DAC override value 
+                                            // when DAC_SRC = 001 If DAC_SRC is 
+                                            // set to be ADC data, CORDIC 
+                                            // magnitude, channel filtered 
+                                            // data, or DC filtered data, then 
+                                            // DAC_I_O controls the part of the 
+                                            // word in question that is 
+                                            // actually multiplexed to the DAC 
+                                            // as described below. 000111: Bits 
+                                            // 7:0 001000: Bits 8:1 001001: 
+                                            // Bits 9:2 ... If an invalid 
+                                            // setting is chosen, then the DAC 
+                                            // outputs only zeros (minimum 
+                                            // value). 
+
+#define RFCORE_XREG_DACTEST1_DAC_I_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_DACTEST2 register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_DACTEST2_DAC_DEM_EN \
+                                0x00000020  // Enable and disable dynamic 
+                                            // element matching Drives 
+                                            // RFR_DAC_DEM_EN 
+
+#define RFCORE_XREG_DACTEST2_DAC_DEM_EN_M \
+                                0x00000020
+#define RFCORE_XREG_DACTEST2_DAC_DEM_EN_S 5
+#define RFCORE_XREG_DACTEST2_DAC_CASC_CTRL_M \
+                                0x00000018  // Adjustment of output stage 
+                                            // Drives RFR_DAC_CASC_CTRL 
+
+#define RFCORE_XREG_DACTEST2_DAC_CASC_CTRL_S 3
+#define RFCORE_XREG_DACTEST2_DAC_SRC_M \
+                                0x00000007  // The TX DACs data source is 
+                                            // selected by DAC_SRC according 
+                                            // to: 000: Normal operation (from 
+                                            // modulator) 001: The DAC_I_O and 
+                                            // DAC_Q_O override values 010: ADC 
+                                            // data after decimation, magnitude 
+                                            // controlled by DAC_I_O and 
+                                            // DAC_Q_O 011: I/Q after 
+                                            // decimation, channel and DC 
+                                            // filtering, magnitude controlled 
+                                            // by DAC_I_O and DAC_Q_O 100: 
+                                            // CORDIC magnitude output and 
+                                            // front-end gain is output, 
+                                            // magnitude controlled by DAC_I_O 
+                                            // and DAC_Q_O 101: RSSI I output 
+                                            // on the I DAC 111: Reserved 
+
+#define RFCORE_XREG_DACTEST2_DAC_SRC_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_ATEST register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_ATEST_ATEST_CTRL_M \
+                                0x0000003F  // Controls the analog test mode: 
+                                            // 00 0000: Disabled 00 0001: 
+                                            // Enables the temperature sensor 
+                                            // (see also the CCTEST_TR0 
+                                            // register description). Other 
+                                            // values reserved. 
+
+#define RFCORE_XREG_ATEST_ATEST_CTRL_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_PTEST0 register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_PTEST0_PRE_PD \
+                                0x00000080  // Prescaler power-down signal 
+                                            // When PD_OVERRIDE = 1 
+
+#define RFCORE_XREG_PTEST0_PRE_PD_M \
+                                0x00000080
+#define RFCORE_XREG_PTEST0_PRE_PD_S 7
+#define RFCORE_XREG_PTEST0_CHP_PD \
+                                0x00000040  // Charge pump power-down signal 
+                                            // When PD_OVERRIDE = 1 
+
+#define RFCORE_XREG_PTEST0_CHP_PD_M \
+                                0x00000040
+#define RFCORE_XREG_PTEST0_CHP_PD_S 6
+#define RFCORE_XREG_PTEST0_ADC_PD \
+                                0x00000020  // ADC power-down signal When 
+                                            // PD_OVERRIDE = 1 
+
+#define RFCORE_XREG_PTEST0_ADC_PD_M \
+                                0x00000020
+#define RFCORE_XREG_PTEST0_ADC_PD_S 5
+#define RFCORE_XREG_PTEST0_DAC_PD \
+                                0x00000010  // DAC power-down signal When 
+                                            // PD_OVERRIDE = 1 
+
+#define RFCORE_XREG_PTEST0_DAC_PD_M \
+                                0x00000010
+#define RFCORE_XREG_PTEST0_DAC_PD_S 4
+#define RFCORE_XREG_PTEST0_LNA_PD_M \
+                                0x0000000C  // Low-noise amplifier power-down 
+                                            // signal Defines LNA/mixer 
+                                            // power-down modes: 00: Power up 
+                                            // 01: LNA off, mixer/regulator on 
+                                            // 10: LNA/mixer off, regulator on 
+                                            // 11: PD When PD_OVERRIDE = 1 
+
+#define RFCORE_XREG_PTEST0_LNA_PD_S 2
+#define RFCORE_XREG_PTEST0_TXMIX_PD \
+                                0x00000002  // Transmit mixer power-down 
+                                            // signal When PD_OVERRIDE = 1 
+
+#define RFCORE_XREG_PTEST0_TXMIX_PD_M \
+                                0x00000002
+#define RFCORE_XREG_PTEST0_TXMIX_PD_S 1
+#define RFCORE_XREG_PTEST0_AAF_PD \
+                                0x00000001  // Antialiasing filter power-down 
+                                            // signal When PD_OVERRIDE = 1 
+
+#define RFCORE_XREG_PTEST0_AAF_PD_M \
+                                0x00000001
+#define RFCORE_XREG_PTEST0_AAF_PD_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_PTEST1 register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_PTEST1_PD_OVERRIDE \
+                                0x00000008  // Override enabling and disabling 
+                                            // of various modules (for debug 
+                                            // and testing only) It is 
+                                            // impossible to override 
+                                            // hard-coded BIAS_PD[1:0] 
+                                            // depenancy. 
+
+#define RFCORE_XREG_PTEST1_PD_OVERRIDE_M \
+                                0x00000008
+#define RFCORE_XREG_PTEST1_PD_OVERRIDE_S 3
+#define RFCORE_XREG_PTEST1_PA_PD \
+                                0x00000004  // Power amplifier power-down 
+                                            // signal When PD_OVERRIDE = 1 
+
+#define RFCORE_XREG_PTEST1_PA_PD_M \
+                                0x00000004
+#define RFCORE_XREG_PTEST1_PA_PD_S 2
+#define RFCORE_XREG_PTEST1_VCO_PD \
+                                0x00000002  // VCO power-down signal When 
+                                            // PD_OVERRIDE = 1 
+
+#define RFCORE_XREG_PTEST1_VCO_PD_M \
+                                0x00000002
+#define RFCORE_XREG_PTEST1_VCO_PD_S 1
+#define RFCORE_XREG_PTEST1_LODIV_PD \
+                                0x00000001  // LO power-down signal When 
+                                            // PD_OVERRIDE = 1 
+
+#define RFCORE_XREG_PTEST1_LODIV_PD_M \
+                                0x00000001
+#define RFCORE_XREG_PTEST1_LODIV_PD_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_CSPPROG0 register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_CSPPROG0_CSP_INSTR_M \
+                                0x000000FF  // Byte N of the CSP program 
+                                            // memory 
+
+#define RFCORE_XREG_CSPPROG0_CSP_INSTR_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_CSPPROG1 register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_CSPPROG1_CSP_INSTR_M \
+                                0x000000FF  // Byte N of the CSP program 
+                                            // memory 
+
+#define RFCORE_XREG_CSPPROG1_CSP_INSTR_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_CSPPROG2 register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_CSPPROG2_CSP_INSTR_M \
+                                0x000000FF  // Byte N of the CSP program 
+                                            // memory 
+
+#define RFCORE_XREG_CSPPROG2_CSP_INSTR_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_CSPPROG3 register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_CSPPROG3_CSP_INSTR_M \
+                                0x000000FF  // Byte N of the CSP program 
+                                            // memory 
+
+#define RFCORE_XREG_CSPPROG3_CSP_INSTR_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_CSPPROG4 register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_CSPPROG4_CSP_INSTR_M \
+                                0x000000FF  // Byte N of the CSP program 
+                                            // memory 
+
+#define RFCORE_XREG_CSPPROG4_CSP_INSTR_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_CSPPROG5 register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_CSPPROG5_CSP_INSTR_M \
+                                0x000000FF  // Byte N of the CSP program 
+                                            // memory 
+
+#define RFCORE_XREG_CSPPROG5_CSP_INSTR_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_CSPPROG6 register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_CSPPROG6_CSP_INSTR_M \
+                                0x000000FF  // Byte N of the CSP program 
+                                            // memory 
+
+#define RFCORE_XREG_CSPPROG6_CSP_INSTR_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_CSPPROG7 register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_CSPPROG7_CSP_INSTR_M \
+                                0x000000FF  // Byte N of the CSP program 
+                                            // memory 
+
+#define RFCORE_XREG_CSPPROG7_CSP_INSTR_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_CSPPROG8 register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_CSPPROG8_CSP_INSTR_M \
+                                0x000000FF  // Byte N of the CSP program 
+                                            // memory 
+
+#define RFCORE_XREG_CSPPROG8_CSP_INSTR_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_CSPPROG9 register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_CSPPROG9_CSP_INSTR_M \
+                                0x000000FF  // Byte N of the CSP program 
+                                            // memory 
+
+#define RFCORE_XREG_CSPPROG9_CSP_INSTR_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_CSPPROG10 register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_CSPPROG10_CSP_INSTR_M \
+                                0x000000FF  // Byte N of the CSP program 
+                                            // memory 
+
+#define RFCORE_XREG_CSPPROG10_CSP_INSTR_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_CSPPROG11 register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_CSPPROG11_CSP_INSTR_M \
+                                0x000000FF  // Byte N of the CSP program 
+                                            // memory 
+
+#define RFCORE_XREG_CSPPROG11_CSP_INSTR_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_CSPPROG12 register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_CSPPROG12_CSP_INSTR_M \
+                                0x000000FF  // Byte N of the CSP program 
+                                            // memory 
+
+#define RFCORE_XREG_CSPPROG12_CSP_INSTR_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_CSPPROG13 register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_CSPPROG13_CSP_INSTR_M \
+                                0x000000FF  // Byte N of the CSP program 
+                                            // memory 
+
+#define RFCORE_XREG_CSPPROG13_CSP_INSTR_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_CSPPROG14 register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_CSPPROG14_CSP_INSTR_M \
+                                0x000000FF  // Byte N of the CSP program 
+                                            // memory 
+
+#define RFCORE_XREG_CSPPROG14_CSP_INSTR_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_CSPPROG15 register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_CSPPROG15_CSP_INSTR_M \
+                                0x000000FF  // Byte N of the CSP program 
+                                            // memory 
+
+#define RFCORE_XREG_CSPPROG15_CSP_INSTR_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_CSPPROG16 register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_CSPPROG16_CSP_INSTR_M \
+                                0x000000FF  // Byte N of the CSP program 
+                                            // memory 
+
+#define RFCORE_XREG_CSPPROG16_CSP_INSTR_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_CSPPROG17 register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_CSPPROG17_CSP_INSTR_M \
+                                0x000000FF  // Byte N of the CSP program 
+                                            // memory 
+
+#define RFCORE_XREG_CSPPROG17_CSP_INSTR_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_CSPPROG18 register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_CSPPROG18_CSP_INSTR_M \
+                                0x000000FF  // Byte N of the CSP program 
+                                            // memory 
+
+#define RFCORE_XREG_CSPPROG18_CSP_INSTR_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_CSPPROG19 register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_CSPPROG19_CSP_INSTR_M \
+                                0x000000FF  // Byte N of the CSP program 
+                                            // memory 
+
+#define RFCORE_XREG_CSPPROG19_CSP_INSTR_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_CSPPROG20 register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_CSPPROG20_CSP_INSTR_M \
+                                0x000000FF  // Byte N of the CSP program 
+                                            // memory 
+
+#define RFCORE_XREG_CSPPROG20_CSP_INSTR_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_CSPPROG21 register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_CSPPROG21_CSP_INSTR_M \
+                                0x000000FF  // Byte N of the CSP program 
+                                            // memory 
+
+#define RFCORE_XREG_CSPPROG21_CSP_INSTR_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_CSPPROG22 register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_CSPPROG22_CSP_INSTR_M \
+                                0x000000FF  // Byte N of the CSP program 
+                                            // memory 
+
+#define RFCORE_XREG_CSPPROG22_CSP_INSTR_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_CSPPROG23 register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_CSPPROG23_CSP_INSTR_M \
+                                0x000000FF  // Byte N of the CSP program 
+                                            // memory 
+
+#define RFCORE_XREG_CSPPROG23_CSP_INSTR_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_CSPCTRL register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_CSPCTRL_MCU_CTRL \
+                                0x00000001  // CSP MCU control input 
+
+#define RFCORE_XREG_CSPCTRL_MCU_CTRL_M \
+                                0x00000001
+#define RFCORE_XREG_CSPCTRL_MCU_CTRL_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_CSPSTAT register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_CSPSTAT_CSP_RUNNING \
+                                0x00000020  // 1: CSP is running. 0: CSP is 
+                                            // idle. 
+
+#define RFCORE_XREG_CSPSTAT_CSP_RUNNING_M \
+                                0x00000020
+#define RFCORE_XREG_CSPSTAT_CSP_RUNNING_S 5
+#define RFCORE_XREG_CSPSTAT_CSP_PC_M \
+                                0x0000001F  // CSP program counter 
+
+#define RFCORE_XREG_CSPSTAT_CSP_PC_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_CSPX register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_CSPX_CSPX_M 0x000000FF  // Used by CSP instructions WAITX, 
+                                            // RANDXY, INCX, DECX, and 
+                                            // conditional instructions. 
+#define RFCORE_XREG_CSPX_CSPX_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_CSPY register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_CSPY_CSPY_M 0x000000FF  // Used by CSP instructions 
+                                            // RANDXY, INCY, DECY, and 
+                                            // conditional instructions. 
+#define RFCORE_XREG_CSPY_CSPY_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_CSPZ register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_CSPZ_CSPZ_M 0x000000FF  // Used by CSP instructions INCZ, 
+                                            // DECZ, and conditional 
+                                            // instructions. 
+#define RFCORE_XREG_CSPZ_CSPZ_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_CSPT register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_CSPT_CSPT_M 0x000000FF  // Content is decremented each 
+                                            // time the MAC Timer overflows 
+                                            // while the CSP program is 
+                                            // running. The SCP program stops 
+                                            // when decremented to 0. Setting 
+                                            // CSPT = 0xFF prevents the 
+                                            // register from being decremented. 
+#define RFCORE_XREG_CSPT_CSPT_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_RFC_OBS_CTRL0 register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_RFC_OBS_CTRL0_RFC_OBS_POL0 \
+                                0x00000040  // The signal chosen by 
+                                            // RFC_OBS_MUX0 is XORed with this 
+                                            // bit. 
+
+#define RFCORE_XREG_RFC_OBS_CTRL0_RFC_OBS_POL0_M \
+                                0x00000040
+#define RFCORE_XREG_RFC_OBS_CTRL0_RFC_OBS_POL0_S 6
+#define RFCORE_XREG_RFC_OBS_CTRL0_RFC_OBS_MUX0_M \
+                                0x0000003F  // Controls which observable 
+                                            // signal from RF Core is to be 
+                                            // muxed out to rfc_obs_sigs[0]. 00 
+                                            // 0000: 0 - Constant value 00 
+                                            // 0001: 1 - Constant value 00 
+                                            // 1000: rfc_sniff_data - Data from 
+                                            // packet sniffer. Sample data on 
+                                            // rising edges of sniff_clk. 00 
+                                            // 1001: rfc_sniff_clk - 250kHz 
+                                            // clock for packet sniffer data. 
+                                            // 00 1100: rssi_valid - Pin is 
+                                            // high when the RSSI value has 
+                                            // been updated at least once since 
+                                            // RX was started. Cleared when 
+                                            // leaving RX. 00 1101: demod_cca - 
+                                            // Clear channel assessment. See 
+                                            // FSMSTAT1 register for details on 
+                                            // how to configure the behavior of 
+                                            // this signal. 00 1110: 
+                                            // sampled_cca - A sampled version 
+                                            // of the CCA bit from demodulator. 
+                                            // The value is updated whenever a 
+                                            // SSAMPLECCA or STXONCCA strobe is 
+                                            // issued. 00 1111: sfd_sync - Pin 
+                                            // is high when a SFD has been 
+                                            // received or transmitted. Cleared 
+                                            // when leaving RX/TX respectively. 
+                                            // Not to be confused with the SFD 
+                                            // exception. 01 0000: tx_active - 
+                                            // Indicates that FFCTRL is in one 
+                                            // of the TX states. Active-high. 
+                                            // Note: This signal might have 
+                                            // glitches, because it has no 
+                                            // output flip-flop and is based on 
+                                            // the current state register of 
+                                            // the FFCTRL FSM. 01 0001: 
+                                            // rx_active - Indicates that 
+                                            // FFCTRL is in one of the RX 
+                                            // states. Active-high. Note: This 
+                                            // signal might have glitches, 
+                                            // because it has no output 
+                                            // flip-flop and is based on the 
+                                            // current state register of the 
+                                            // FFCTRL FSM. 01 0010: ffctrl_fifo 
+                                            // - Pin is high when one or more 
+                                            // bytes are in the RXFIFO. Low 
+                                            // during RXFIFO overflow. 01 0011: 
+                                            // ffctrl_fifop - Pin is high when 
+                                            // the number of bytes in the 
+                                            // RXFIFO exceeds the programmable 
+                                            // threshold or at least one 
+                                            // complete frame is in the RXFIFO. 
+                                            // Also high during RXFIFO 
+                                            // overflow. Not to be confused 
+                                            // with the FIFOP exception. 01 
+                                            // 0100: packet_done - A complete 
+                                            // frame has been received. I.e., 
+                                            // the number of bytes set by the 
+                                            // frame-length field has been 
+                                            // received. 01 0110: 
+                                            // rfc_xor_rand_i_q - XOR between I 
+                                            // and Q random outputs. Updated at 
+                                            // 8 MHz. 01 0111: rfc_rand_q - 
+                                            // Random data output from the Q 
+                                            // channel of the receiver. Updated 
+                                            // at 8 MHz. 01 1000: rfc_rand_i - 
+                                            // Random data output from the I 
+                                            // channel of the receiver. Updated 
+                                            // at 8 MHz 01 1001: lock_status - 
+                                            // 1 when PLL is in lock, otherwise 
+                                            // 0 10 1000: pa_pd - Power 
+                                            // amplifier power-down signal 10 
+                                            // 1010: lna_pd - LNA power-down 
+                                            // signal Others: Reserved 
+
+#define RFCORE_XREG_RFC_OBS_CTRL0_RFC_OBS_MUX0_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_RFC_OBS_CTRL1 register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_RFC_OBS_CTRL1_RFC_OBS_POL1 \
+                                0x00000040  // The signal chosen by 
+                                            // RFC_OBS_MUX1 is XORed with this 
+                                            // bit. 
+
+#define RFCORE_XREG_RFC_OBS_CTRL1_RFC_OBS_POL1_M \
+                                0x00000040
+#define RFCORE_XREG_RFC_OBS_CTRL1_RFC_OBS_POL1_S 6
+#define RFCORE_XREG_RFC_OBS_CTRL1_RFC_OBS_MUX1_M \
+                                0x0000003F  // Controls which observable 
+                                            // signal from RF Core is to be 
+                                            // muxed out to rfc_obs_sigs[1]. 
+                                            // See description of RFC_OBS_CTRL0 
+                                            // for details. 
+
+#define RFCORE_XREG_RFC_OBS_CTRL1_RFC_OBS_MUX1_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_RFC_OBS_CTRL2 register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_RFC_OBS_CTRL2_RFC_OBS_POL2 \
+                                0x00000040  // The signal chosen by 
+                                            // RFC_OBS_MUX2 is XORed with this 
+                                            // bit. 
+
+#define RFCORE_XREG_RFC_OBS_CTRL2_RFC_OBS_POL2_M \
+                                0x00000040
+#define RFCORE_XREG_RFC_OBS_CTRL2_RFC_OBS_POL2_S 6
+#define RFCORE_XREG_RFC_OBS_CTRL2_RFC_OBS_MUX2_M \
+                                0x0000003F  // Controls which observable 
+                                            // signal from RF Core is to be 
+                                            // muxed out to rfc_obs_sigs[2]. 
+                                            // See description of RFC_OBS_CTRL0 
+                                            // for details. 
+
+#define RFCORE_XREG_RFC_OBS_CTRL2_RFC_OBS_MUX2_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// RFCORE_XREG_TXFILTCFG register.
+//
+//*****************************************************************************
+#define RFCORE_XREG_TXFILTCFG_FC_M \
+                                0x0000000F  // Drives signal rfr_txfilt_fc 
+
+#define RFCORE_XREG_TXFILTCFG_FC_S 0
+
+
+#endif // __HW_RFCORE_XREG_H__
+

--- a/cpu/cc2538/include/vendor/hw_smwdthrosc.h
+++ b/cpu/cc2538/include/vendor/hw_smwdthrosc.h
@@ -1,0 +1,264 @@
+/******************************************************************************
+*  Filename:       hw_smwdthrosc.h
+*  Revised:        $Date: 2013-04-30 17:13:44 +0200 (Tue, 30 Apr 2013) $
+*  Revision:       $Revision: 9943 $
+*
+*  Copyright (C) 2013 Texas Instruments Incorporated - http://www.ti.com/
+*
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*    Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+*
+*    Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+*
+*    Neither the name of Texas Instruments Incorporated nor the names of
+*    its contributors may be used to endorse or promote products derived
+*    from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+*  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+*  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+*  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+*  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+*  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+*  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+*  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+*  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+******************************************************************************/
+
+#ifndef __HW_SMWDTHROSC_H__
+#define __HW_SMWDTHROSC_H__
+
+//*****************************************************************************
+//
+// The following are defines for the SMWDTHROSC register offsets.
+//
+//*****************************************************************************
+#define SMWDTHROSC_WDCTL        0x400D5000  // Watchdog Timer Control 
+#define SMWDTHROSC_ST0          0x400D5040  // Sleep Timer 0 count and compare 
+#define SMWDTHROSC_ST1          0x400D5044  // Sleep Timer 1 count and compare 
+#define SMWDTHROSC_ST2          0x400D5048  // Sleep Timer 2 count and compare 
+#define SMWDTHROSC_ST3          0x400D504C  // Sleep Timer 3 count and compare 
+#define SMWDTHROSC_STLOAD       0x400D5050  // Sleep Timer load status 
+#define SMWDTHROSC_STCC         0x400D5054  // Sleep Timer Capture control 
+#define SMWDTHROSC_STCS         0x400D5058  // Sleep Timer Capture status 
+#define SMWDTHROSC_STCV0        0x400D505C  // Sleep Timer Capture value byte 
+                                            // 0 
+#define SMWDTHROSC_STCV1        0x400D5060  // Sleep Timer Capture value byte 
+                                            // 1 
+#define SMWDTHROSC_STCV2        0x400D5064  // Sleep Timer Capture value byte 
+                                            // 2 
+#define SMWDTHROSC_STCV3        0x400D5068  // Sleep Timer Capture value byte 
+                                            // 3 
+
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// SMWDTHROSC_WDCTL register.
+//
+//*****************************************************************************
+#define SMWDTHROSC_WDCTL_CLR_M  0x000000F0  // Clear timer When 0xA followed 
+                                            // by 0x5 is written to these bits, 
+                                            // the timer is loaded with 0x0000. 
+                                            // Note that 0x5 must be written 
+                                            // within one watchdog clock period 
+                                            // Twdt after 0xA was written for 
+                                            // the clearing to take effect 
+                                            // (ensured). If 0x5 is written 
+                                            // between Twdt and 2Twdt after 0xA 
+                                            // was written, the clearing may 
+                                            // take effect, but there is no 
+                                            // guarantee. If 0x5 is written > 
+                                            // 2Twdt after 0xA was written, the 
+                                            // timer will not be cleared. If a 
+                                            // value other than 0x5 is written 
+                                            // after 0xA has been written, the 
+                                            // clear sequence is aborted. If 
+                                            // 0xA is written, this starts a 
+                                            // new clear sequence. Writing to 
+                                            // these bits when EN = 0 has no 
+                                            // effect. 
+#define SMWDTHROSC_WDCTL_CLR_S  4
+#define SMWDTHROSC_WDCTL_EN     0x00000008  // Enable timer When 1 is written 
+                                            // to this bit the timer is enabled 
+                                            // and starts incrementing. The 
+                                            // interval setting specified by 
+                                            // INT[1:0] is used. Writing 0 to 
+                                            // this bit have no effect. 
+#define SMWDTHROSC_WDCTL_EN_M   0x00000008
+#define SMWDTHROSC_WDCTL_EN_S   3
+#define SMWDTHROSC_WDCTL_INT_M  0x00000003  // Timer interval select These 
+                                            // bits select the timer interval 
+                                            // as follows: 00: Twdt x 32768 01: 
+                                            // Twdt x 8192 10: Twdt x 512 11: 
+                                            // Twdt x 64 Writing these bits 
+                                            // when EN = 1 has no effect. 
+#define SMWDTHROSC_WDCTL_INT_S  0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// SMWDTHROSC_ST0 register.
+//
+//*****************************************************************************
+#define SMWDTHROSC_ST0_ST0_M    0x000000FF  // Sleep Timer count and compare 
+                                            // value. When read, this register 
+                                            // returns the low bits [7:0] of 
+                                            // the Sleep Timer count. When 
+                                            // writing this register sets the 
+                                            // low bits [7:0] of the compare 
+                                            // value. 
+#define SMWDTHROSC_ST0_ST0_S    0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// SMWDTHROSC_ST1 register.
+//
+//*****************************************************************************
+#define SMWDTHROSC_ST1_ST1_M    0x000000FF  // Sleep Timer count and compare 
+                                            // value When read, this register 
+                                            // returns the middle bits [15:8] 
+                                            // of the Sleep Timer count. When 
+                                            // writing this register sets the 
+                                            // middle bits [15:8] of the 
+                                            // compare value. The value read is 
+                                            // latched at the time of reading 
+                                            // register ST0. The value written 
+                                            // is latched when ST0 is written. 
+#define SMWDTHROSC_ST1_ST1_S    0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// SMWDTHROSC_ST2 register.
+//
+//*****************************************************************************
+#define SMWDTHROSC_ST2_ST2_M    0x000000FF  // Sleep Timer count and compare 
+                                            // value When read, this register 
+                                            // returns the high bits [23:16] of 
+                                            // the Sleep Timer count. When 
+                                            // writing this register sets the 
+                                            // high bits [23:16] of the compare 
+                                            // value. The value read is latched 
+                                            // at the time of reading register 
+                                            // ST0. The value written is 
+                                            // latched when ST0 is written. 
+#define SMWDTHROSC_ST2_ST2_S    0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// SMWDTHROSC_ST3 register.
+//
+//*****************************************************************************
+#define SMWDTHROSC_ST3_ST3_M    0x000000FF  // Sleep Timer count and compare 
+                                            // value When read, this register 
+                                            // returns the high bits [31:24] of 
+                                            // the Sleep Timer count. When 
+                                            // writing this register sets the 
+                                            // high bits [31:24] of the compare 
+                                            // value. The value read is latched 
+                                            // at the time of reading register 
+                                            // ST0. The value written is 
+                                            // latched when ST0 is written. 
+#define SMWDTHROSC_ST3_ST3_S    0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// SMWDTHROSC_STLOAD register.
+//
+//*****************************************************************************
+#define SMWDTHROSC_STLOAD_STLOAD \
+                                0x00000001  // Status signal for when STx 
+                                            // registers have been uploaded to 
+                                            // 32-kHz counter. 1: Load is 
+                                            // complete 0: Load is busy and STx 
+                                            // regs are blocked for writing 
+
+#define SMWDTHROSC_STLOAD_STLOAD_M \
+                                0x00000001
+#define SMWDTHROSC_STLOAD_STLOAD_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// SMWDTHROSC_STCC register.
+//
+//*****************************************************************************
+#define SMWDTHROSC_STCC_PORT_M  0x00000038  // Port select Valid settings are 
+                                            // 0-3, all others inhibit any 
+                                            // capture from occurring 000: Port 
+                                            // A selected 001: Port B selected 
+                                            // 010: Port C selected 011: Port D 
+                                            // selected 
+#define SMWDTHROSC_STCC_PORT_S  3
+#define SMWDTHROSC_STCC_PIN_M   0x00000007  // Pin select Valid settings are 
+                                            // 1-7 when either port A, B, C, or 
+                                            // D is selected. 
+#define SMWDTHROSC_STCC_PIN_S   0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// SMWDTHROSC_STCS register.
+//
+//*****************************************************************************
+#define SMWDTHROSC_STCS_VALID   0x00000001  // Capture valid flag Set to 1 
+                                            // when capture value in STCV has 
+                                            // been updated Clear explicitly to 
+                                            // allow new capture 
+#define SMWDTHROSC_STCS_VALID_M 0x00000001
+#define SMWDTHROSC_STCS_VALID_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// SMWDTHROSC_STCV0 register.
+//
+//*****************************************************************************
+#define SMWDTHROSC_STCV0_STCV0_M \
+                                0x000000FF  // Bits [7:0] of Sleep Timer 
+                                            // capture value 
+
+#define SMWDTHROSC_STCV0_STCV0_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// SMWDTHROSC_STCV1 register.
+//
+//*****************************************************************************
+#define SMWDTHROSC_STCV1_STCV1_M \
+                                0x000000FF  // Bits [15:8] of Sleep Timer 
+                                            // capture value 
+
+#define SMWDTHROSC_STCV1_STCV1_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// SMWDTHROSC_STCV2 register.
+//
+//*****************************************************************************
+#define SMWDTHROSC_STCV2_STCV2_M \
+                                0x000000FF  // Bits [23:16] of Sleep Timer 
+                                            // capture value 
+
+#define SMWDTHROSC_STCV2_STCV2_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// SMWDTHROSC_STCV3 register.
+//
+//*****************************************************************************
+#define SMWDTHROSC_STCV3_STCV3_M \
+                                0x000000FF  // Bits [32:24] of Sleep Timer 
+                                            // capture value 
+
+#define SMWDTHROSC_STCV3_STCV3_S 0
+
+
+#endif // __HW_SMWDTHROSC_H__
+

--- a/cpu/cc2538/include/vendor/hw_soc_adc.h
+++ b/cpu/cc2538/include/vendor/hw_soc_adc.h
@@ -1,0 +1,267 @@
+/******************************************************************************
+*  Filename:       hw_soc_adc.h
+*  Revised:        $Date: 2013-04-30 17:13:44 +0200 (Tue, 30 Apr 2013) $
+*  Revision:       $Revision: 9943 $
+*
+*  Copyright (C) 2013 Texas Instruments Incorporated - http://www.ti.com/
+*
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*    Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+*
+*    Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+*
+*    Neither the name of Texas Instruments Incorporated nor the names of
+*    its contributors may be used to endorse or promote products derived
+*    from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+*  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+*  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+*  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+*  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+*  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+*  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+*  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+*  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+******************************************************************************/
+
+#ifndef __HW_SOC_ADC_H__
+#define __HW_SOC_ADC_H__
+
+//*****************************************************************************
+//
+// The following are defines for the SOC_ADC register offsets.
+//
+//*****************************************************************************
+#define SOC_ADC_ADCCON1         0x400D7000  // This register controls the ADC. 
+#define SOC_ADC_ADCCON2         0x400D7004  // This register controls the ADC. 
+#define SOC_ADC_ADCCON3         0x400D7008  // This register controls the ADC. 
+#define SOC_ADC_ADCL            0x400D700C  // This register contains the 
+                                            // least-significant part of ADC 
+                                            // conversion result. 
+#define SOC_ADC_ADCH            0x400D7010  // This register contains the 
+                                            // most-significant part of ADC 
+                                            // conversion result. 
+#define SOC_ADC_RNDL            0x400D7014  // This registers contains 
+                                            // random-number-generator data; 
+                                            // low byte. 
+#define SOC_ADC_RNDH            0x400D7018  // This register contains 
+                                            // random-number-generator data; 
+                                            // high byte. 
+#define SOC_ADC_CMPCTL          0x400D7024  // Analog comparator control and 
+                                            // status register. 
+
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// SOC_ADC_ADCCON1 register.
+//
+//*****************************************************************************
+#define SOC_ADC_ADCCON1_EOC     0x00000080  // End of conversion. Cleared when 
+                                            // ADCH has been read. If a new 
+                                            // conversion is completed before 
+                                            // the previous data has been read, 
+                                            // the EOC bit remains high. 0: 
+                                            // Conversion not complete 1: 
+                                            // Conversion completed 
+#define SOC_ADC_ADCCON1_EOC_M   0x00000080
+#define SOC_ADC_ADCCON1_EOC_S   7
+#define SOC_ADC_ADCCON1_ST      0x00000040  // Start conversion Read as 1 
+                                            // until conversion completes 0: No 
+                                            // conversion in progress. 1: Start 
+                                            // a conversion sequence if 
+                                            // ADCCON1.STSEL = 11 and no 
+                                            // sequence is running. 
+#define SOC_ADC_ADCCON1_ST_M    0x00000040
+#define SOC_ADC_ADCCON1_ST_S    6
+#define SOC_ADC_ADCCON1_STSEL_M 0x00000030  // Start select Selects the event 
+                                            // that starts a new conversion 
+                                            // sequence 00: Not implemented 01: 
+                                            // Full speed. Do not wait for 
+                                            // triggers 10: Timer 1 channel 0 
+                                            // compare event 11: ADCCON1.ST = 1 
+#define SOC_ADC_ADCCON1_STSEL_S 4
+#define SOC_ADC_ADCCON1_RCTRL_M 0x0000000C  // Controls the 16-bit 
+                                            // random-number generator (see 
+                                            // User Guide Chapter 16) When 01 
+                                            // is written, the setting 
+                                            // automatically returns to 00 when 
+                                            // the operation completes. 00: 
+                                            // Normal operation (13x unrolling) 
+                                            // 01: Clock the LFSR once (13x 
+                                            // unrolling) 10: Reserved 11: 
+                                            // Stopped. The random-number 
+                                            // generator is turned off. 
+#define SOC_ADC_ADCCON1_RCTRL_S 2
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// SOC_ADC_ADCCON2 register.
+//
+//*****************************************************************************
+#define SOC_ADC_ADCCON2_SREF_M  0x000000C0  // Selects reference voltage used 
+                                            // for the sequence of conversions 
+                                            // 00: Internal reference 01: 
+                                            // External reference on AIN7 pin 
+                                            // 10: AVDD5 pin 11: External 
+                                            // reference on AIN6-AIN7 
+                                            // differential input 
+#define SOC_ADC_ADCCON2_SREF_S  6
+#define SOC_ADC_ADCCON2_SDIV_M  0x00000030  // Sets the decimation rate for 
+                                            // channels included in the 
+                                            // sequence of conversions. The 
+                                            // decimation rate also determines 
+                                            // the resolution and time required 
+                                            // to complete a conversion. 00: 64 
+                                            // decimation rate (7 bits ENOB 
+                                            // setting) 01: 128 decimation rate 
+                                            // (9 bits ENOB setting) 10: 256 
+                                            // decimation rate (10 bits ENOB 
+                                            // setting) 11: 512 decimation rate 
+                                            // (12 bits ENOB setting) 
+#define SOC_ADC_ADCCON2_SDIV_S  4
+#define SOC_ADC_ADCCON2_SCH_M   0x0000000F  // Sequence channel select Selects 
+                                            // the end of the sequence A 
+                                            // sequence can either be from AIN0 
+                                            // to AIN7 (SCH <= 7) or from 
+                                            // differential input AIN0-AIN1 to 
+                                            // AIN6-AIN7 (8 <= SCH <= 11). For 
+                                            // other settings, only one 
+                                            // conversions is performed. When 
+                                            // read, these bits indicate the 
+                                            // channel number on which a 
+                                            // conversion is ongoing: 0000: 
+                                            // AIN0 0001: AIN1 0010: AIN2 0011: 
+                                            // AIN3 0100: AIN4 0101: AIN5 0110: 
+                                            // AIN6 0111: AIN7 1000: AIN0-AIN1 
+                                            // 1001: AIN2-AIN3 1010: AIN4-AIN5 
+                                            // 1011: AIN6-AIN7 1100: GND 1101: 
+                                            // Reserved 1110: Temperature 
+                                            // sensor 1111: VDD/3 
+#define SOC_ADC_ADCCON2_SCH_S   0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// SOC_ADC_ADCCON3 register.
+//
+//*****************************************************************************
+#define SOC_ADC_ADCCON3_EREF_M  0x000000C0  // Selects reference voltage used 
+                                            // for the extra conversion 00: 
+                                            // Internal reference 01: External 
+                                            // reference on AIN7 pin 10: AVDD5 
+                                            // pin 11: External reference on 
+                                            // AIN6-AIN7 differential input 
+#define SOC_ADC_ADCCON3_EREF_S  6
+#define SOC_ADC_ADCCON3_EDIV_M  0x00000030  // Sets the decimation rate used 
+                                            // for the extra conversion The 
+                                            // decimation rate also determines 
+                                            // the resolution and the time 
+                                            // required to complete the 
+                                            // conversion. 00: 64 decimation 
+                                            // rate (7 bits ENOB) 01: 128 
+                                            // decimation rate (9 bits ENOB) 
+                                            // 10: 256 decimation rate (10 bits 
+                                            // ENOB) 11: 512 decimation rate 
+                                            // (12 bits ENOB) 
+#define SOC_ADC_ADCCON3_EDIV_S  4
+#define SOC_ADC_ADCCON3_ECH_M   0x0000000F  // Single channel select. Selects 
+                                            // the channel number of the single 
+                                            // conversion that is triggered by 
+                                            // writing to ADCCON3. 0000: AIN0 
+                                            // 0001: AIN1 0010: AIN2 0011: AIN3 
+                                            // 0100: AIN4 0101: AIN5 0110: AIN6 
+                                            // 0111: AIN7 1000: AIN0-AIN1 1001: 
+                                            // AIN2-AIN3 1010: AIN4-AIN5 1011: 
+                                            // AIN6-AIN7 1100: GND 1101: 
+                                            // Reserved 1110: Temperature 
+                                            // sensor 1111: VDD/3 
+#define SOC_ADC_ADCCON3_ECH_S   0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the SOC_ADC_ADCL register.
+//
+//*****************************************************************************
+#define SOC_ADC_ADCL_ADC_M      0x000000FC  // Least-significant part of ADC 
+                                            // conversion result 
+#define SOC_ADC_ADCL_ADC_S      2
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the SOC_ADC_ADCH register.
+//
+//*****************************************************************************
+#define SOC_ADC_ADCH_ADC_M      0x000000FF  // Most-significant part of ADC 
+                                            // conversion result 
+#define SOC_ADC_ADCH_ADC_S      0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the SOC_ADC_RNDL register.
+//
+//*****************************************************************************
+#define SOC_ADC_RNDL_RNDL_M     0x000000FF  // Random value/seed or CRC 
+                                            // result, low byte When used for 
+                                            // random-number generation, 
+                                            // writing to this register twice 
+                                            // seeds the random-number 
+                                            // generator. Writing to this 
+                                            // register copies the 8 LSBs of 
+                                            // the LFSR to the 8 MSBs and 
+                                            // replaces the 8 LSBs with the 
+                                            // data value written. The value 
+                                            // returned when reading from this 
+                                            // register is the 8 LSBs of the 
+                                            // LFSR. When used for 
+                                            // random-number generation, 
+                                            // reading this register returns 
+                                            // the 8 LSBs of the random number. 
+                                            // When used for CRC calculations, 
+                                            // reading this register returns 
+                                            // the 8 LSBs of the CRC result. 
+#define SOC_ADC_RNDL_RNDL_S     0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the SOC_ADC_RNDH register.
+//
+//*****************************************************************************
+#define SOC_ADC_RNDH_RNDH_M     0x000000FF  // Random value or CRC 
+                                            // result/input data, high byte 
+                                            // When written, a CRC16 
+                                            // calculation is triggered, and 
+                                            // the data value written is 
+                                            // processed starting with the MSB. 
+                                            // The value returned when reading 
+                                            // from this register is the 8 MSBs 
+                                            // of the LFSR. When used for 
+                                            // random-number generation, 
+                                            // reading this register returns 
+                                            // the 8 MSBs of the random number. 
+                                            // When used for CRC calculations, 
+                                            // reading this register returns 
+                                            // the 8 MSBs of the CRC result. 
+#define SOC_ADC_RNDH_RNDH_S     0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// SOC_ADC_CMPCTL register.
+//
+//*****************************************************************************
+#define SOC_ADC_CMPCTL_EN       0x00000002  // Comparator enable 
+#define SOC_ADC_CMPCTL_EN_M     0x00000002
+#define SOC_ADC_CMPCTL_EN_S     1
+#define SOC_ADC_CMPCTL_OUTPUT   0x00000001  // Comparator output 
+#define SOC_ADC_CMPCTL_OUTPUT_M 0x00000001
+#define SOC_ADC_CMPCTL_OUTPUT_S 0
+
+
+#endif // __HW_SOC_ADC_H__
+

--- a/cpu/cc2538/include/vendor/hw_ssi.h
+++ b/cpu/cc2538/include/vendor/hw_ssi.h
@@ -1,0 +1,491 @@
+/******************************************************************************
+*  Filename:       hw_ssi.h
+*  Revised:        $Date: 2013-04-30 17:13:44 +0200 (Tue, 30 Apr 2013) $
+*  Revision:       $Revision: 9943 $
+*
+*  Copyright (C) 2013 Texas Instruments Incorporated - http://www.ti.com/
+*
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*    Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+*
+*    Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+*
+*    Neither the name of Texas Instruments Incorporated nor the names of
+*    its contributors may be used to endorse or promote products derived
+*    from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+*  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+*  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+*  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+*  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+*  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+*  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+*  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+*  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+******************************************************************************/
+
+#ifndef __HW_SSI_H__
+#define __HW_SSI_H__
+
+//*****************************************************************************
+//
+// The following are defines for the SSI register offsets.
+//
+//*****************************************************************************
+#define SSI_O_CR0               0x00000000  // The CR0 register contains bit 
+                                            // fields that control various 
+                                            // functions within the SSI module. 
+                                            // Functionality such as protocol 
+                                            // mode, clock rate, and data size 
+                                            // are configured in this register. 
+#define SSI_O_CR1               0x00000004  // The CR1 register contains bit 
+                                            // fields that control various 
+                                            // functions within the SSI module. 
+                                            // Master and slave mode 
+                                            // functionality is controlled by 
+                                            // this register. 
+#define SSI_O_DR                0x00000008  // The DR register is 16 bits 
+                                            // wide. When the SSIDR register is 
+                                            // read, the entry in the receive 
+                                            // FIFO that is pointed to by the 
+                                            // current FIFO read pointer is 
+                                            // accessed. When a data value is 
+                                            // removed by the SSI receive logic 
+                                            // from the incoming data frame, it 
+                                            // is placed into the entry in the 
+                                            // receive FIFO pointed to by the 
+                                            // current FIFO write pointer. When 
+                                            // the DR register is written to, 
+                                            // the entry in the transmit FIFO 
+                                            // that is pointed to by the write 
+                                            // pointer is written to. Data 
+                                            // values are removed from the 
+                                            // transmit FIFO one value at a 
+                                            // time by the transmit logic. Each 
+                                            // data value is loaded into the 
+                                            // transmit serial shifter, then 
+                                            // serially shifted out onto the 
+                                            // SSITx pin at the programmed bit 
+                                            // rate. When a data size of less 
+                                            // than 16 bits is selected, the 
+                                            // user must right-justify data 
+                                            // written to the transmit FIFO. 
+                                            // The transmit logic ignores the 
+                                            // unused bits. Received data less 
+                                            // than 16 bits is automatically 
+                                            // right-justified in the receive 
+                                            // buffer. When the SSI is 
+                                            // programmed for MICROWIRE frame 
+                                            // format, the default size for 
+                                            // transmit data is eight bits (the 
+                                            // most significant byte is 
+                                            // ignored). The receive data size 
+                                            // is controlled by the programmer. 
+                                            // The transmit FIFO and the 
+                                            // receive FIFO are not cleared 
+                                            // even when the SSE bit in the 
+                                            // SSICR1 register is cleared, 
+                                            // allowing the software to fill 
+                                            // the transmit FIFO before 
+                                            // enabling the SSI. 
+#define SSI_O_SR                0x0000000C  // The SR register contains bits 
+                                            // that indicate the FIFO fill 
+                                            // status and the SSI busy status. 
+#define SSI_O_CPSR              0x00000010  // The CPSR register specifies the 
+                                            // division factor which is used to 
+                                            // derive the SSIClk from the 
+                                            // system clock. The clock is 
+                                            // further divided by a value from 
+                                            // 1 to 256, which is 1 + SCR. SCR 
+                                            // is programmed in the SSICR0 
+                                            // register. The frequency of the 
+                                            // SSIClk is defined by: SSIClk = 
+                                            // SysClk / (CPSDVSR x (1 + SCR)) 
+                                            // The value programmed into this 
+                                            // register must be an even number 
+                                            // between 2 and 254. The 
+                                            // least-significant bit of the 
+                                            // programmed number is hard-coded 
+                                            // to zero. If an odd number is 
+                                            // written to this register, data 
+                                            // read back from this register has 
+                                            // the least-significant bit as 
+                                            // zero. 
+#define SSI_O_IM                0x00000014  // The IM register is the 
+                                            // interrupt mask set or clear 
+                                            // register. It is a read/write 
+                                            // register and all bits are 
+                                            // cleared on reset. On a read, 
+                                            // this register gives the current 
+                                            // value of the mask on the 
+                                            // corresponding interrupt. Setting 
+                                            // a bit sets the mask, preventing 
+                                            // the interrupt from being 
+                                            // signaled to the interrupt 
+                                            // controller. Clearing a bit 
+                                            // clears the corresponding mask, 
+                                            // enabling the interrupt to be 
+                                            // sent to the interrupt 
+                                            // controller. 
+#define SSI_O_RIS               0x00000018  // The RIS register is the raw 
+                                            // interrupt status register. On a 
+                                            // read, this register gives the 
+                                            // current raw status value of the 
+                                            // corresponding interrupt before 
+                                            // masking. A write has no effect. 
+#define SSI_O_MIS               0x0000001C  // The MIS register is the masked 
+                                            // interrupt status register. On a 
+                                            // read, this register gives the 
+                                            // current masked status value of 
+                                            // the corresponding interrupt. A 
+                                            // write has no effect. 
+#define SSI_O_ICR               0x00000020  // The ICR register is the 
+                                            // interrupt clear register. On a 
+                                            // write of 1, the corresponding 
+                                            // interrupt is cleared. A write of 
+                                            // 0 has no effect. 
+#define SSI_O_DMACTL            0x00000024  // The DMACTL register is the uDMA 
+                                            // control register. 
+#define SSI_O_CC                0x00000FC8  // SSI clock configuration The CC 
+                                            // register controls the baud clock 
+                                            // and system clocks sources for 
+                                            // the SSI module. Note: If the 
+                                            // PIOSC is used for the SSI baud 
+                                            // clock, the system clock 
+                                            // frequency must be at least 16 
+                                            // MHz in run mode. 
+
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the SSI_O_CR0 register.
+//
+//*****************************************************************************
+#define SSI_CR0_SCR_M           0x0000FF00  // SSI serial clock rate (R/W) 
+                                            // Reset value: 0x0 The value SCR 
+                                            // is used to generate the transmit 
+                                            // and receive bit rate of the SSI. 
+                                            // Where the bit rate is: BR = 
+                                            // FSSICLK/(CPSDVR * (1 + SCR)) 
+                                            // where CPSDVR is an even value 
+                                            // from 2-254, programmed in the 
+                                            // SSICPSR register and SCR is a 
+                                            // value from 0-255. 
+#define SSI_CR0_SCR_S           8
+#define SSI_CR0_SPH             0x00000080  // SSI serial clock phase (R/W) 
+                                            // Reset value: 0x0 This bit is 
+                                            // only applicable to the Motorola 
+                                            // SPI Format. 
+#define SSI_CR0_SPH_M           0x00000080
+#define SSI_CR0_SPH_S           7
+#define SSI_CR0_SPO             0x00000040  // SSI serial clock phase (R/W) 
+                                            // Reset value: 0x0 This bit is 
+                                            // only applicable to the Motorola 
+                                            // SPI Format. 
+#define SSI_CR0_SPO_M           0x00000040
+#define SSI_CR0_SPO_S           6
+#define SSI_CR0_FRF_M           0x00000030  // SSI frame format select (R/W) 
+                                            // Reset value: 0x0 00: Motorola 
+                                            // SPI frame format 01: TI 
+                                            // synchronous serial frame format 
+                                            // 10: National Microwire frame 
+                                            // format 11: Reserved 
+#define SSI_CR0_FRF_S           4
+#define SSI_CR0_DSS_M           0x0000000F  // SSI data size select (R/W) 
+                                            // Reset value: 0x0 0000-0010: 
+                                            // Reserved 0011: 4-bit data 0100: 
+                                            // 5-bit data 0101: 6-bit data 
+                                            // 0110: 7-bit data 0111: 8-bit 
+                                            // data 1000: 9-bit data 1001: 
+                                            // 10-bit data 1010: 11-bit data 
+                                            // 1011: 12-bit data 1100: 13-bit 
+                                            // data 1101: 14-bit data 1110: 
+                                            // 15-bit data 1111: 16-bit data 
+#define SSI_CR0_DSS_S           0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the SSI_O_CR1 register.
+//
+//*****************************************************************************
+#define SSI_CR1_SOD             0x00000008  // SSI slave mode output disable 
+                                            // (R/W) Reset value: 0x0 This bit 
+                                            // is relevant only in the slave 
+                                            // mode (MS = 1). In multiple-slave 
+                                            // systems, it is possible for the 
+                                            // SSI master to broadcast a 
+                                            // message to all slaves in the 
+                                            // system while ensuring that only 
+                                            // one slave drives data onto the 
+                                            // serial output line. In such 
+                                            // systems, the RXD lines from 
+                                            // multiple slaves could be tied 
+                                            // together. To operate in such a 
+                                            // system, the SOD bit can be set 
+                                            // if the SSI slave is not suppose 
+                                            // to drive the SSITXD line. 0: SSI 
+                                            // can drive SSITXD in slave output 
+                                            // mode 1: SSI must not drive the 
+                                            // SSITXD output in slave mode 
+#define SSI_CR1_SOD_M           0x00000008
+#define SSI_CR1_SOD_S           3
+#define SSI_CR1_MS              0x00000004  // SSI master and slave select 
+                                            // (R/W) Reset value: 0x0 This bit 
+                                            // can be modified only when the 
+                                            // SSI is disabled (SSE = 0). 0: 
+                                            // Device configured as a master 
+                                            // (default) 1: Device configured 
+                                            // as a slave 
+#define SSI_CR1_MS_M            0x00000004
+#define SSI_CR1_MS_S            2
+#define SSI_CR1_SSE             0x00000002  // SSI synchronous serial port 
+                                            // enable (R/W) Reset value: 0x0 0: 
+                                            // SSI operation is disabled. 1: 
+                                            // SSI operation is enabled. 
+#define SSI_CR1_SSE_M           0x00000002
+#define SSI_CR1_SSE_S           1
+#define SSI_CR1_LBM             0x00000001  // SSI loop-back mode (R/W) Reset 
+                                            // value: 0x0 0: Normal serial port 
+                                            // operation is enabled. 1: The 
+                                            // output of the transmit serial 
+                                            // shifter is connected to the 
+                                            // input of the receive serial 
+                                            // shift register internally. 
+#define SSI_CR1_LBM_M           0x00000001
+#define SSI_CR1_LBM_S           0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the SSI_O_DR register.
+//
+//*****************************************************************************
+#define SSI_DR_DATA_M           0x0000FFFF  // SSI receive/transmit data 
+                                            // register (R/W) Reset value: 
+                                            // 0xXXXX A read operation reads 
+                                            // the receive FIFO. A write 
+                                            // operation writes the transmit 
+                                            // FIFO. Software must 
+                                            // right-justify data when the SSI 
+                                            // is programmed for a data size 
+                                            // that is less than 16 bits. 
+                                            // Unused bits at the top are 
+                                            // ignored by the transmit logic. 
+                                            // The receive logic automatically 
+                                            // right-justified the data. 
+#define SSI_DR_DATA_S           0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the SSI_O_SR register.
+//
+//*****************************************************************************
+#define SSI_SR_BSY              0x00000010  // SSI busy bit (RO) Reset value: 
+                                            // 0x0 0: SSI is idle. 1: SSI is 
+                                            // currently transmitting and/or 
+                                            // receiving a frame or the 
+                                            // transmit FIFO is not empty. 
+#define SSI_SR_BSY_M            0x00000010
+#define SSI_SR_BSY_S            4
+#define SSI_SR_RFF              0x00000008  // SSI receive FIFO full (RO) 
+                                            // Reset value: 0x0 0: Receive FIFO 
+                                            // is not full. 1: Receive FIFO is 
+                                            // full. 
+#define SSI_SR_RFF_M            0x00000008
+#define SSI_SR_RFF_S            3
+#define SSI_SR_RNE              0x00000004  // SSI receive FIFO not empty (RO) 
+                                            // Reset value: 0x0 0: Receive FIFO 
+                                            // is empty. 1: Receive FIFO is not 
+                                            // empty. 
+#define SSI_SR_RNE_M            0x00000004
+#define SSI_SR_RNE_S            2
+#define SSI_SR_TNF              0x00000002  // SSI transmit FIFO not full (RO) 
+                                            // Reset value: 0x1 0: Transmit 
+                                            // FIFO is full. 1: Transmit FIFO 
+                                            // is not full. 
+#define SSI_SR_TNF_M            0x00000002
+#define SSI_SR_TNF_S            1
+#define SSI_SR_TFE              0x00000001  // SSI transmit FIFO empty (RO) 
+                                            // Reset value: 0x1 0: Transmit 
+                                            // FIFO is not empty. 1: Transmit 
+                                            // FIFO is empty. 
+#define SSI_SR_TFE_M            0x00000001
+#define SSI_SR_TFE_S            0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the SSI_O_CPSR register.
+//
+//*****************************************************************************
+#define SSI_CPSR_CPSDVSR_M      0x000000FF  // SSI clock prescale divisor 
+                                            // (R/W) Reset value: 0x0 This 
+                                            // value must be an even number 
+                                            // from 2 to 254, depending on the 
+                                            // frequency of SSICLK. The LSB 
+                                            // always returns zero on reads. 
+#define SSI_CPSR_CPSDVSR_S      0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the SSI_O_IM register.
+//
+//*****************************************************************************
+#define SSI_IM_TXIM             0x00000008  // SSI transmit FIFO interrupt 
+                                            // mask (R/W) Reset value: 0x0 0: 
+                                            // TX FIFO half empty or condition 
+                                            // interrupt is masked. 1: TX FIFO 
+                                            // half empty or less condition 
+                                            // interrupt is not masked. 
+#define SSI_IM_TXIM_M           0x00000008
+#define SSI_IM_TXIM_S           3
+#define SSI_IM_RXIM             0x00000004  // SSI receive FIFO interrupt mask 
+                                            // (R/W) Reset value: 0x0 0: RX 
+                                            // FIFO half empty or condition 
+                                            // interrupt is masked. 1: RX FIFO 
+                                            // half empty or less condition 
+                                            // interrupt is not masked. 
+#define SSI_IM_RXIM_M           0x00000004
+#define SSI_IM_RXIM_S           2
+#define SSI_IM_RTIM             0x00000002  // SSI receive time-out interrupt 
+                                            // mask (R/W) Reset value: 0x0 0: 
+                                            // RX FIFO time-out interrupt is 
+                                            // masked. 1: RX FIFO time-out 
+                                            // interrupt is not masked 
+#define SSI_IM_RTIM_M           0x00000002
+#define SSI_IM_RTIM_S           1
+#define SSI_IM_RORIM            0x00000001  // SSI receive overrun interrupt 
+                                            // mask (R/W) Reset value: 0x0 0: 
+                                            // RX FIFO Overrun interrupt is 
+                                            // masked. 1: RX FIFO Overrun 
+                                            // interrupt is not masked 
+#define SSI_IM_RORIM_M          0x00000001
+#define SSI_IM_RORIM_S          0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the SSI_O_RIS register.
+//
+//*****************************************************************************
+#define SSI_RIS_TXRIS           0x00000008  // SSI SSITXINTR raw state (RO) 
+                                            // Reset value: 0x1 Gives the raw 
+                                            // interrupt state (before masking) 
+                                            // of SSITXINTR 
+#define SSI_RIS_TXRIS_M         0x00000008
+#define SSI_RIS_TXRIS_S         3
+#define SSI_RIS_RXRIS           0x00000004  // SSI SSIRXINTR raw state (RO) 
+                                            // Reset value: 0x0 Gives the raw 
+                                            // interrupt state (before masking) 
+                                            // of SSIRXINTR 
+#define SSI_RIS_RXRIS_M         0x00000004
+#define SSI_RIS_RXRIS_S         2
+#define SSI_RIS_RTRIS           0x00000002  // SSI SSIRTINTR raw state (RO) 
+                                            // Reset value: 0x0 Gives the raw 
+                                            // interrupt state (before masking) 
+                                            // of SSIRTINTR 
+#define SSI_RIS_RTRIS_M         0x00000002
+#define SSI_RIS_RTRIS_S         1
+#define SSI_RIS_RORRIS          0x00000001  // SSI SSIRORINTR raw state (RO) 
+                                            // Reset value: 0x0 Gives the raw 
+                                            // interrupt state (before masking) 
+                                            // of SSIRORINTR 
+#define SSI_RIS_RORRIS_M        0x00000001
+#define SSI_RIS_RORRIS_S        0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the SSI_O_MIS register.
+//
+//*****************************************************************************
+#define SSI_MIS_TXMIS           0x00000008  // SSI SSITXINTR masked state (RO) 
+                                            // Reset value: 0x0 Gives the 
+                                            // interrupt state (after masking) 
+                                            // of SSITXINTR 
+#define SSI_MIS_TXMIS_M         0x00000008
+#define SSI_MIS_TXMIS_S         3
+#define SSI_MIS_RXMIS           0x00000004  // SSI SSIRXINTR masked state (RO) 
+                                            // Reset value: 0x0 Gives the 
+                                            // interrupt state (after masking) 
+                                            // of SSIRXINTR 
+#define SSI_MIS_RXMIS_M         0x00000004
+#define SSI_MIS_RXMIS_S         2
+#define SSI_MIS_RTMIS           0x00000002  // SSI SSIRTINTR masked state (RO) 
+                                            // Reset value: 0x0 Gives the 
+                                            // interrupt state (after masking) 
+                                            // of SSIRTINTR 
+#define SSI_MIS_RTMIS_M         0x00000002
+#define SSI_MIS_RTMIS_S         1
+#define SSI_MIS_RORMIS          0x00000001  // SSI SSIRORINTR masked state 
+                                            // (RO) Reset value: 0x0 Gives the 
+                                            // interrupt state (after masking) 
+                                            // of SSIRORINTR 
+#define SSI_MIS_RORMIS_M        0x00000001
+#define SSI_MIS_RORMIS_S        0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the SSI_O_ICR register.
+//
+//*****************************************************************************
+#define SSI_ICR_RTIC            0x00000002  // SSI receive time-out interrupt 
+                                            // clear (W1C) Reset value: 0x0 0: 
+                                            // No effect on interrupt 1: Clears 
+                                            // interrupt 
+#define SSI_ICR_RTIC_M          0x00000002
+#define SSI_ICR_RTIC_S          1
+#define SSI_ICR_RORIC           0x00000001  // SSI receive overrun interrupt 
+                                            // clear (W1C) Reset value: 0x0 0: 
+                                            // No effect on interrupt 1: Clears 
+                                            // interrupt 
+#define SSI_ICR_RORIC_M         0x00000001
+#define SSI_ICR_RORIC_S         0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the SSI_O_DMACTL register.
+//
+//*****************************************************************************
+#define SSI_DMACTL_TXDMAE       0x00000002  // Transmit DMA enable 0: uDMA for 
+                                            // the transmit FIFO is disabled. 
+                                            // 1: uDMA for the transmit FIFO is 
+                                            // enabled. 
+#define SSI_DMACTL_TXDMAE_M     0x00000002
+#define SSI_DMACTL_TXDMAE_S     1
+#define SSI_DMACTL_RXDMAE       0x00000001  // Receive DMA enable 0: uDMA for 
+                                            // the receive FIFO is disabled. 1: 
+                                            // uDMA for the receive FIFO is 
+                                            // enabled. 
+#define SSI_DMACTL_RXDMAE_M     0x00000001
+#define SSI_DMACTL_RXDMAE_S     0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the SSI_O_CC register.
+//
+//*****************************************************************************
+#define SSI_CC_CS_M             0x00000007  // SSI baud and system clock 
+                                            // source The following bits 
+                                            // determine the clock source that 
+                                            // generates the baud and system 
+                                            // clocks for the SSI. bit0 
+                                            // (PIOSC): 1: The SSI baud clock 
+                                            // is determined by the IO DIV 
+                                            // setting in the system 
+                                            // controller. 0: The SSI baud 
+                                            // clock is determined by the SYS 
+                                            // DIV setting in the system 
+                                            // controller. bit1: Unused bit2: 
+                                            // (DSEN) Only meaningful when the 
+                                            // system is in deep sleep mode. 
+                                            // This bit is a don't care when 
+                                            // not in sleep mode. 1: The SSI 
+                                            // system clock is running on the 
+                                            // same clock as the baud clock, as 
+                                            // per PIOSC setting above. 0: The 
+                                            // SSI system clock is determined 
+                                            // by the SYS DIV setting in the 
+                                            // system controller. 
+#define SSI_CC_CS_S             0
+
+
+#endif // __HW_SSI_H__
+

--- a/cpu/cc2538/include/vendor/hw_sys_ctrl.h
+++ b/cpu/cc2538/include/vendor/hw_sys_ctrl.h
@@ -1,0 +1,961 @@
+/******************************************************************************
+*  Filename:       hw_sys_ctrl.h
+*  Revised:        $Date: 2013-04-12 15:10:54 +0200 (Fri, 12 Apr 2013) $
+*  Revision:       $Revision: 9735 $
+*
+*  Copyright (C) 2013 Texas Instruments Incorporated - http://www.ti.com/
+*
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*    Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+*
+*    Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+*
+*    Neither the name of Texas Instruments Incorporated nor the names of
+*    its contributors may be used to endorse or promote products derived
+*    from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+*  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+*  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+*  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+*  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+*  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+*  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+*  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+*  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+******************************************************************************/
+
+#ifndef __HW_SYS_CTRL_H__
+#define __HW_SYS_CTRL_H__
+
+//*****************************************************************************
+//
+// The following are defines for the SYS_CTRL register offsets.
+//
+//*****************************************************************************
+#define SYS_CTRL_CLOCK_CTRL     0x400D2000  // The clock control register 
+                                            // handels clock settings in the 
+                                            // CC2538. The settings in 
+                                            // CLOCK_CTRL do not always reflect 
+                                            // the current chip status which is 
+                                            // found in CLOCK_STA register. 
+#define SYS_CTRL_CLOCK_STA      0x400D2004  // Clock status register This 
+                                            // register reflects the current 
+                                            // chip status. 
+#define SYS_CTRL_RCGCGPT        0x400D2008  // This register defines the 
+                                            // module clocks for GPT[3:0] when 
+                                            // the CPU is in active (run) mode. 
+                                            // This register setting is don't 
+                                            // care for PM1-3, because the 
+                                            // system clock is powered down in 
+                                            // these modes. 
+#define SYS_CTRL_SCGCGPT        0x400D200C  // This register defines the 
+                                            // module clocks for GPT[3:0] when 
+                                            // the CPU is in sleep mode. This 
+                                            // register setting is don't care 
+                                            // for PM1-3, because the system 
+                                            // clock is powered down in these 
+                                            // modes. 
+#define SYS_CTRL_DCGCGPT        0x400D2010  // This register defines the 
+                                            // module clocks for GPT[3:0] when 
+                                            // the CPU is in PM0. This register 
+                                            // setting is don't care for PM1-3, 
+                                            // because the system clock is 
+                                            // powered down in these modes. 
+#define SYS_CTRL_SRGPT          0x400D2014  // This register controls the 
+                                            // reset for GPT[3:0]. 
+#define SYS_CTRL_RCGCSSI        0x400D2018  // This register defines the 
+                                            // module clocks for SSI[1:0] when 
+                                            // the CPU is in active (run) mode. 
+                                            // This register setting is don't 
+                                            // care for PM1-3, because the 
+                                            // system clock is powered down in 
+                                            // these modes. 
+#define SYS_CTRL_SCGCSSI        0x400D201C  // This register defines the 
+                                            // module clocks for SSI[1:0] when 
+                                            // the CPU is insSleep mode. This 
+                                            // register setting is don't care 
+                                            // for PM1-3, because the system 
+                                            // clock is powered down in these 
+                                            // modes. 
+#define SYS_CTRL_DCGCSSI        0x400D2020  // This register defines the 
+                                            // module clocks for SSI[1:0] when 
+                                            // the CPU is in PM0. This register 
+                                            // setting is don't care for PM1-3, 
+                                            // because the system clock is 
+                                            // powered down in these modes. 
+#define SYS_CTRL_SRSSI          0x400D2024  // This register controls the 
+                                            // reset for SSI[1:0]. 
+#define SYS_CTRL_RCGCUART       0x400D2028  // This register defines the 
+                                            // module clocks for UART[1:0] when 
+                                            // the CPU is in active (run) mode. 
+                                            // This register setting is don't 
+                                            // care for PM1-3, because the 
+                                            // system clock is powered down in 
+                                            // these modes. 
+#define SYS_CTRL_SCGCUART       0x400D202C  // This register defines the 
+                                            // module clocks for UART[1:0] when 
+                                            // the CPU is in sleep mode. This 
+                                            // register setting is don't care 
+                                            // for PM1-3, because the system 
+                                            // clock is powered down in these 
+                                            // modes. 
+#define SYS_CTRL_DCGCUART       0x400D2030  // This register defines the 
+                                            // module clocks for UART[1:0] when 
+                                            // the CPU is in PM0. This register 
+                                            // setting is don't care for PM1-3, 
+                                            // because the system clock is 
+                                            // powered down in these modes. 
+#define SYS_CTRL_SRUART         0x400D2034  // This register controls the 
+                                            // reset for UART[1:0]. 
+#define SYS_CTRL_RCGCI2C        0x400D2038  // This register defines the 
+                                            // module clocks for I2C when the 
+                                            // CPU is in active (run) mode. 
+                                            // This register setting is don't 
+                                            // care for PM1-3, because the 
+                                            // system clock is powered down in 
+                                            // these modes. 
+#define SYS_CTRL_SCGCI2C        0x400D203C  // This register defines the 
+                                            // module clocks for I2C when the 
+                                            // CPU is in sleep mode. This 
+                                            // register setting is don't care 
+                                            // for PM1-3, because the system 
+                                            // clock is powered down in these 
+                                            // modes. 
+#define SYS_CTRL_DCGCI2C        0x400D2040  // This register defines the 
+                                            // module clocks for I2C when the 
+                                            // CPU is in PM0. This register 
+                                            // setting is don't care for PM1-3, 
+                                            // because the system clock is 
+                                            // powered down in these modes. 
+#define SYS_CTRL_SRI2C          0x400D2044  // This register controls the 
+                                            // reset for I2C. 
+#define SYS_CTRL_RCGCSEC        0x400D2048  // This register defines the 
+                                            // module clocks for the security 
+                                            // module when the CPU is in active 
+                                            // (run) mode. This register 
+                                            // setting is don't care for PM1-3, 
+                                            // because the system clock is 
+                                            // powered down in these modes. 
+#define SYS_CTRL_SCGCSEC        0x400D204C  // This register defines the 
+                                            // module clocks for the security 
+                                            // module when the CPU is in sleep 
+                                            // mode. This register setting is 
+                                            // don't care for PM1-3, because 
+                                            // the system clock is powered down 
+                                            // in these modes. 
+#define SYS_CTRL_DCGCSEC        0x400D2050  // This register defines the 
+                                            // module clocks for the security 
+                                            // module when the CPU is in PM0. 
+                                            // This register setting is don't 
+                                            // care for PM1-3, because the 
+                                            // system clock is powered down in 
+                                            // these modes. 
+#define SYS_CTRL_SRSEC          0x400D2054  // This register controls the 
+                                            // reset for the security module. 
+#define SYS_CTRL_PMCTL          0x400D2058  // This register controls the 
+                                            // power mode. Note: The 
+                                            // Corresponding PM is not entered 
+                                            // before the WFI instruction is 
+                                            // asserted. To enter PM1-3 the 
+                                            // DEEPSLEEP bit in SYSCTRL must be 
+                                            // 1. 
+#define SYS_CTRL_SRCRC          0x400D205C  // This register controls CRC on 
+                                            // state retention. 
+#define SYS_CTRL_PWRDBG         0x400D2074  // Power debug register 
+#define SYS_CTRL_CLD            0x400D2080  // This register controls the 
+                                            // clock loss detection feature. 
+#define SYS_CTRL_IWE            0x400D2094  // This register controls 
+                                            // interrupt wake-up. 
+#define SYS_CTRL_I_MAP          0x400D2098  // This register selects which 
+                                            // interrupt map to be used. 
+#define SYS_CTRL_RCGCRFC        0x400D20A8  // This register defines the 
+                                            // module clocks for RF CORE when 
+                                            // the CPU is in active (run) mode. 
+                                            // This register setting is don't 
+                                            // care for PM1-3, because the 
+                                            // system clock is powered down in 
+                                            // these modes. 
+#define SYS_CTRL_SCGCRFC        0x400D20AC  // This register defines the 
+                                            // module clocks for RF CORE when 
+                                            // the CPU is in sleep mode. This 
+                                            // register setting is don't care 
+                                            // for PM1-3, because the system 
+                                            // clock is powered down in these 
+                                            // modes. 
+#define SYS_CTRL_DCGCRFC        0x400D20B0  // This register defines the 
+                                            // module clocks for RF CORE when 
+                                            // the CPU is in PM0. This register 
+                                            // setting is don't care for PM1-3, 
+                                            // because the system clock is 
+                                            // powered down in these modes. 
+#define SYS_CTRL_EMUOVR         0x400D20B4  // This register defines the 
+                                            // emulator override controls for 
+                                            // power mode and peripheral clock 
+                                            // gate. 
+
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// SYS_CTRL_CLOCK_CTRL register.
+//
+//*****************************************************************************
+#define SYS_CTRL_CLOCK_CTRL_OSC32K_CALDIS \
+                                0x02000000  // Disable calibration 32-kHz RC 
+                                            // oscillator. 0: Enable 
+                                            // calibration 1: Disable 
+                                            // calibration 
+
+#define SYS_CTRL_CLOCK_CTRL_OSC32K_CALDIS_M \
+                                0x02000000
+#define SYS_CTRL_CLOCK_CTRL_OSC32K_CALDIS_S 25
+#define SYS_CTRL_CLOCK_CTRL_OSC32K \
+                                0x01000000  // 32-kHz clock oscillator 
+                                            // selection 0: 32-kHz crystal 
+                                            // oscillator 1: 32-kHz RC 
+                                            // oscillator 
+
+#define SYS_CTRL_CLOCK_CTRL_OSC32K_M \
+                                0x01000000
+#define SYS_CTRL_CLOCK_CTRL_OSC32K_S 24
+#define SYS_CTRL_CLOCK_CTRL_AMP_DET \
+                                0x00200000  // Amplitude detector of XOSC 
+                                            // during power up 0: No action 1: 
+                                            // Delay qualification of XOSC 
+                                            // until amplitude is greater than 
+                                            // the threshold. 
+
+#define SYS_CTRL_CLOCK_CTRL_AMP_DET_M \
+                                0x00200000
+#define SYS_CTRL_CLOCK_CTRL_AMP_DET_S 21
+#define SYS_CTRL_CLOCK_CTRL_OSC_PD \
+                                0x00020000  // 0: Power up both oscillators 1: 
+                                            // Power down oscillator not 
+                                            // selected by OSC bit 
+                                            // (hardware-controlled when 
+                                            // selected). 
+
+#define SYS_CTRL_CLOCK_CTRL_OSC_PD_M \
+                                0x00020000
+#define SYS_CTRL_CLOCK_CTRL_OSC_PD_S 17
+#define SYS_CTRL_CLOCK_CTRL_OSC 0x00010000  // System clock oscillator 
+                                            // selection 0: 32-MHz crystal 
+                                            // oscillator 1: 16-MHz HF-RC 
+                                            // oscillator 
+#define SYS_CTRL_CLOCK_CTRL_OSC_M \
+                                0x00010000
+#define SYS_CTRL_CLOCK_CTRL_OSC_S 16
+#define SYS_CTRL_CLOCK_CTRL_IO_DIV_M \
+                                0x00000700  // I/O clock rate setting Cannot 
+                                            // be higher than OSC setting 000: 
+                                            // 32 MHz 001: 16 MHz 010: 8 MHz 
+                                            // 011: 4 MHz 100: 2 MHz 101: 1 MHz 
+                                            // 110: 0.5 MHz 111: 0.25 MHz 
+
+#define SYS_CTRL_CLOCK_CTRL_IO_DIV_S 8
+#define SYS_CTRL_CLOCK_CTRL_SYS_DIV_M \
+                                0x00000007  // System clock rate setting 
+                                            // Cannot be higher than OSC 
+                                            // setting 000: 32 MHz 001: 16 MHz 
+                                            // 010: 8 MHz 011: 4 MHz 100: 2 MHz 
+                                            // 101: 1 MHz 110: 0.5 MHz 111: 
+                                            // 0.25 MHz 
+
+#define SYS_CTRL_CLOCK_CTRL_SYS_DIV_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// SYS_CTRL_CLOCK_STA register.
+//
+//*****************************************************************************
+#define SYS_CTRL_CLOCK_STA_SYNC_32K \
+                                0x04000000  // 32-kHz clock source synced to 
+                                            // undivided system clock (16 or 32 
+                                            // MHz). 
+
+#define SYS_CTRL_CLOCK_STA_SYNC_32K_M \
+                                0x04000000
+#define SYS_CTRL_CLOCK_STA_SYNC_32K_S 26
+#define SYS_CTRL_CLOCK_STA_OSC32K_CALDIS \
+                                0x02000000  // Disable calibration 32-kHz RC 
+                                            // oscillator. 0: Calibration 
+                                            // enabled 1: Calibration disabled 
+
+#define SYS_CTRL_CLOCK_STA_OSC32K_CALDIS_M \
+                                0x02000000
+#define SYS_CTRL_CLOCK_STA_OSC32K_CALDIS_S 25
+#define SYS_CTRL_CLOCK_STA_OSC32K \
+                                0x01000000  // Current 32-kHz clock oscillator 
+                                            // selected. 0: 32-kHz crystal 
+                                            // oscillator 1: 32-kHz RC 
+                                            // oscillator 
+
+#define SYS_CTRL_CLOCK_STA_OSC32K_M \
+                                0x01000000
+#define SYS_CTRL_CLOCK_STA_OSC32K_S 24
+#define SYS_CTRL_CLOCK_STA_RST_M \
+                                0x00C00000  // Returns last source of reset 
+                                            // 00: POR 01: External reset 10: 
+                                            // WDT 11: CLD or software reset 
+
+#define SYS_CTRL_CLOCK_STA_RST_S 22
+#define SYS_CTRL_CLOCK_STA_SOURCE_CHANGE \
+                                0x00100000  // 0: System clock is not 
+                                            // requested to change. 1: A change 
+                                            // of system clock source has been 
+                                            // initiated and is not finished. 
+                                            // Same as when OSC bit in 
+                                            // CLOCK_STA and CLOCK_CTRL 
+                                            // register are not equal 
+
+#define SYS_CTRL_CLOCK_STA_SOURCE_CHANGE_M \
+                                0x00100000
+#define SYS_CTRL_CLOCK_STA_SOURCE_CHANGE_S 20
+#define SYS_CTRL_CLOCK_STA_XOSC_STB \
+                                0x00080000  // XOSC stable status 0: XOSC is 
+                                            // not powered up or not yet 
+                                            // stable. 1: XOSC is powered up 
+                                            // and stable. 
+
+#define SYS_CTRL_CLOCK_STA_XOSC_STB_M \
+                                0x00080000
+#define SYS_CTRL_CLOCK_STA_XOSC_STB_S 19
+#define SYS_CTRL_CLOCK_STA_HSOSC_STB \
+                                0x00040000  // HSOSC stable status 0: HSOSC is 
+                                            // not powered up or not yet 
+                                            // stable. 1: HSOSC is powered up 
+                                            // and stable. 
+
+#define SYS_CTRL_CLOCK_STA_HSOSC_STB_M \
+                                0x00040000
+#define SYS_CTRL_CLOCK_STA_HSOSC_STB_S 18
+#define SYS_CTRL_CLOCK_STA_OSC_PD \
+                                0x00020000  // 0: Both oscillators powered up 
+                                            // and stable and OSC_PD_CMD = 0. 
+                                            // 1: Oscillator not selected by 
+                                            // CLOCK_CTRL.OSC bit is powered 
+                                            // down. 
+
+#define SYS_CTRL_CLOCK_STA_OSC_PD_M \
+                                0x00020000
+#define SYS_CTRL_CLOCK_STA_OSC_PD_S 17
+#define SYS_CTRL_CLOCK_STA_OSC  0x00010000  // Current clock source selected 
+                                            // 0: 32-MHz crystal oscillator 1: 
+                                            // 16-MHz HF-RC oscillator 
+#define SYS_CTRL_CLOCK_STA_OSC_M \
+                                0x00010000
+#define SYS_CTRL_CLOCK_STA_OSC_S 16
+#define SYS_CTRL_CLOCK_STA_IO_DIV_M \
+                                0x00000700  // Returns current functional 
+                                            // frequency for IO_CLK (may differ 
+                                            // from setting in the CLOCK_CTRL 
+                                            // register) 000: 32 MHz 001: 16 
+                                            // MHz 010: 8 MHz 011: 4 MHz 100: 2 
+                                            // MHz 101: 1 MHz 110: 0.5 MHz 111: 
+                                            // 0.25 MHz 
+
+#define SYS_CTRL_CLOCK_STA_IO_DIV_S 8
+#define SYS_CTRL_CLOCK_STA_RTCLK_FREQ_M \
+                                0x00000018  // Returns current functional 
+                                            // frequency for real-time clock. 
+                                            // (may differ from setting in the 
+                                            // CLOCK_CTRL register) 1x : 8 MHz 
+                                            // 01: 2 MHz 00: 62.5 kHz 
+
+#define SYS_CTRL_CLOCK_STA_RTCLK_FREQ_S 3
+#define SYS_CTRL_CLOCK_STA_SYS_DIV_M \
+                                0x00000007  // Returns current functional 
+                                            // frequency for system clock (may 
+                                            // differ from setting in the 
+                                            // CLOCK_CTRL register) 000: 32 MHz 
+                                            // 001: 16 MHz 010: 8 MHz 011: 4 
+                                            // MHz 100: 2 MHz 101: 1 MHz 110: 
+                                            // 0.5 MHz 111: 0.25 MHz 
+
+#define SYS_CTRL_CLOCK_STA_SYS_DIV_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// SYS_CTRL_RCGCGPT register.
+//
+//*****************************************************************************
+#define SYS_CTRL_RCGCGPT_GPT3   0x00000008  // 0: Clock for GPT3 is gated. 1: 
+                                            // Clock for GPT3 is enabled. 
+#define SYS_CTRL_RCGCGPT_GPT3_M 0x00000008
+#define SYS_CTRL_RCGCGPT_GPT3_S 3
+#define SYS_CTRL_RCGCGPT_GPT2   0x00000004  // 0: Clock for GPT2 is gated. 1: 
+                                            // Clock for GPT2 is enabled. 
+#define SYS_CTRL_RCGCGPT_GPT2_M 0x00000004
+#define SYS_CTRL_RCGCGPT_GPT2_S 2
+#define SYS_CTRL_RCGCGPT_GPT1   0x00000002  // 0: Clock for GPT1 is gated. 1: 
+                                            // Clock for GPT1 is enabled. 
+#define SYS_CTRL_RCGCGPT_GPT1_M 0x00000002
+#define SYS_CTRL_RCGCGPT_GPT1_S 1
+#define SYS_CTRL_RCGCGPT_GPT0   0x00000001  // 0: Clock for GPT0 is gated. 1: 
+                                            // Clock for GPT0 is enabled. 
+#define SYS_CTRL_RCGCGPT_GPT0_M 0x00000001
+#define SYS_CTRL_RCGCGPT_GPT0_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// SYS_CTRL_SCGCGPT register.
+//
+//*****************************************************************************
+#define SYS_CTRL_SCGCGPT_GPT3   0x00000008  // 0: Clock for GPT3 is gated. 1: 
+                                            // Clock for GPT3 is enabled. 
+#define SYS_CTRL_SCGCGPT_GPT3_M 0x00000008
+#define SYS_CTRL_SCGCGPT_GPT3_S 3
+#define SYS_CTRL_SCGCGPT_GPT2   0x00000004  // 0: Clock for GPT2 is gated. 1: 
+                                            // Clock for GPT2 is enabled. 
+#define SYS_CTRL_SCGCGPT_GPT2_M 0x00000004
+#define SYS_CTRL_SCGCGPT_GPT2_S 2
+#define SYS_CTRL_SCGCGPT_GPT1   0x00000002  // 0: Clock for GPT1 is gated. 1: 
+                                            // Clock for GPT1 is enabled. 
+#define SYS_CTRL_SCGCGPT_GPT1_M 0x00000002
+#define SYS_CTRL_SCGCGPT_GPT1_S 1
+#define SYS_CTRL_SCGCGPT_GPT0   0x00000001  // 0: Clock for GPT0 is gated. 1: 
+                                            // Clock for GPT0 is enabled. 
+#define SYS_CTRL_SCGCGPT_GPT0_M 0x00000001
+#define SYS_CTRL_SCGCGPT_GPT0_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// SYS_CTRL_DCGCGPT register.
+//
+//*****************************************************************************
+#define SYS_CTRL_DCGCGPT_GPT3   0x00000008  // 0: Clock for GPT3 is gated. 1: 
+                                            // Clock for GPT3 is enabled. 
+#define SYS_CTRL_DCGCGPT_GPT3_M 0x00000008
+#define SYS_CTRL_DCGCGPT_GPT3_S 3
+#define SYS_CTRL_DCGCGPT_GPT2   0x00000004  // 0: Clock for GPT2 is gated. 1: 
+                                            // Clock for GPT2 is enabled. 
+#define SYS_CTRL_DCGCGPT_GPT2_M 0x00000004
+#define SYS_CTRL_DCGCGPT_GPT2_S 2
+#define SYS_CTRL_DCGCGPT_GPT1   0x00000002  // 0: Clock for GPT1 is gated. 1: 
+                                            // Clock for GPT1 is enabled. 
+#define SYS_CTRL_DCGCGPT_GPT1_M 0x00000002
+#define SYS_CTRL_DCGCGPT_GPT1_S 1
+#define SYS_CTRL_DCGCGPT_GPT0   0x00000001  // 0: Clock for GPT0 is gated. 1: 
+                                            // Clock for GPT0 is enabled. 
+#define SYS_CTRL_DCGCGPT_GPT0_M 0x00000001
+#define SYS_CTRL_DCGCGPT_GPT0_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// SYS_CTRL_SRGPT register.
+//
+//*****************************************************************************
+#define SYS_CTRL_SRGPT_GPT3     0x00000008  // 0: GPT3 module is not reset 1: 
+                                            // GPT3 module is reset 
+#define SYS_CTRL_SRGPT_GPT3_M   0x00000008
+#define SYS_CTRL_SRGPT_GPT3_S   3
+#define SYS_CTRL_SRGPT_GPT2     0x00000004  // 0: GPT2 module is not reset 1: 
+                                            // GPT2 module is reset 
+#define SYS_CTRL_SRGPT_GPT2_M   0x00000004
+#define SYS_CTRL_SRGPT_GPT2_S   2
+#define SYS_CTRL_SRGPT_GPT1     0x00000002  // 0: GPT1 module is not reset 1: 
+                                            // GPT1 module is reset 
+#define SYS_CTRL_SRGPT_GPT1_M   0x00000002
+#define SYS_CTRL_SRGPT_GPT1_S   1
+#define SYS_CTRL_SRGPT_GPT0     0x00000001  // 0: GPT0 module is not reset 1: 
+                                            // GPT0 module is reset 
+#define SYS_CTRL_SRGPT_GPT0_M   0x00000001
+#define SYS_CTRL_SRGPT_GPT0_S   0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// SYS_CTRL_RCGCSSI register.
+//
+//*****************************************************************************
+#define SYS_CTRL_RCGCSSI_SSI1   0x00000002  // 0: Clock for SSI1 is gated. 1: 
+                                            // Clock for SSI1 is enabled. 
+#define SYS_CTRL_RCGCSSI_SSI1_M 0x00000002
+#define SYS_CTRL_RCGCSSI_SSI1_S 1
+#define SYS_CTRL_RCGCSSI_SSI0   0x00000001  // 0: Clock for SSI0 is gated. 1: 
+                                            // Clock for SSI0 is enabled. 
+#define SYS_CTRL_RCGCSSI_SSI0_M 0x00000001
+#define SYS_CTRL_RCGCSSI_SSI0_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// SYS_CTRL_SCGCSSI register.
+//
+//*****************************************************************************
+#define SYS_CTRL_SCGCSSI_SSI1   0x00000002  // 0: Clock for SSI1 is gated. 1: 
+                                            // Clock for SSI1 is enabled. 
+#define SYS_CTRL_SCGCSSI_SSI1_M 0x00000002
+#define SYS_CTRL_SCGCSSI_SSI1_S 1
+#define SYS_CTRL_SCGCSSI_SSI0   0x00000001  // 0: Clock for SSI0 is gated. 1: 
+                                            // Clock for SSI0 is enabled. 
+#define SYS_CTRL_SCGCSSI_SSI0_M 0x00000001
+#define SYS_CTRL_SCGCSSI_SSI0_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// SYS_CTRL_DCGCSSI register.
+//
+//*****************************************************************************
+#define SYS_CTRL_DCGCSSI_SSI1   0x00000002  // 0: Clock for SSI1 is gated. 1: 
+                                            // Clock for SSI1 is enabled. 
+#define SYS_CTRL_DCGCSSI_SSI1_M 0x00000002
+#define SYS_CTRL_DCGCSSI_SSI1_S 1
+#define SYS_CTRL_DCGCSSI_SSI0   0x00000001  // 0: Clock for SSI0 is gated. 1: 
+                                            // Clock for SSI0 is enabled. 
+#define SYS_CTRL_DCGCSSI_SSI0_M 0x00000001
+#define SYS_CTRL_DCGCSSI_SSI0_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// SYS_CTRL_SRSSI register.
+//
+//*****************************************************************************
+#define SYS_CTRL_SRSSI_SSI1     0x00000002  // 0: SSI1 module is not reset 1: 
+                                            // SSI1 module is reset 
+#define SYS_CTRL_SRSSI_SSI1_M   0x00000002
+#define SYS_CTRL_SRSSI_SSI1_S   1
+#define SYS_CTRL_SRSSI_SSI0     0x00000001  // 0: SSI0 module is not reset 1: 
+                                            // SSI0 module is reset 
+#define SYS_CTRL_SRSSI_SSI0_M   0x00000001
+#define SYS_CTRL_SRSSI_SSI0_S   0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// SYS_CTRL_RCGCUART register.
+//
+//*****************************************************************************
+#define SYS_CTRL_RCGCUART_UART1 0x00000002  // 0: Clock for UART1 is gated. 1: 
+                                            // Clock for UART1 is enabled. 
+#define SYS_CTRL_RCGCUART_UART1_M \
+                                0x00000002
+#define SYS_CTRL_RCGCUART_UART1_S 1
+#define SYS_CTRL_RCGCUART_UART0 0x00000001  // 0: Clock for UART0 is gated. 1: 
+                                            // Clock for UART0 is enabled. 
+#define SYS_CTRL_RCGCUART_UART0_M \
+                                0x00000001
+#define SYS_CTRL_RCGCUART_UART0_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// SYS_CTRL_SCGCUART register.
+//
+//*****************************************************************************
+#define SYS_CTRL_SCGCUART_UART1 0x00000002  // 0: Clock for UART1 is gated. 1: 
+                                            // Clock for UART1 is enabled. 
+#define SYS_CTRL_SCGCUART_UART1_M \
+                                0x00000002
+#define SYS_CTRL_SCGCUART_UART1_S 1
+#define SYS_CTRL_SCGCUART_UART0 0x00000001  // 0: Clock for UART0 is gated. 1: 
+                                            // Clock for UART0 is enabled. 
+#define SYS_CTRL_SCGCUART_UART0_M \
+                                0x00000001
+#define SYS_CTRL_SCGCUART_UART0_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// SYS_CTRL_DCGCUART register.
+//
+//*****************************************************************************
+#define SYS_CTRL_DCGCUART_UART1 0x00000002  // 0: Clock for UART1 is gated. 1: 
+                                            // Clock for UART1 is enabled. 
+#define SYS_CTRL_DCGCUART_UART1_M \
+                                0x00000002
+#define SYS_CTRL_DCGCUART_UART1_S 1
+#define SYS_CTRL_DCGCUART_UART0 0x00000001  // 0: Clock for UART0 is gated. 1: 
+                                            // Clock for UART0 is enabled. 
+#define SYS_CTRL_DCGCUART_UART0_M \
+                                0x00000001
+#define SYS_CTRL_DCGCUART_UART0_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// SYS_CTRL_SRUART register.
+//
+//*****************************************************************************
+#define SYS_CTRL_SRUART_UART1   0x00000002  // 0: UART1 module is not reset 1: 
+                                            // UART1 module is reset 
+#define SYS_CTRL_SRUART_UART1_M 0x00000002
+#define SYS_CTRL_SRUART_UART1_S 1
+#define SYS_CTRL_SRUART_UART0   0x00000001  // 0: UART0 module is not reset 1: 
+                                            // UART0 module is reset 
+#define SYS_CTRL_SRUART_UART0_M 0x00000001
+#define SYS_CTRL_SRUART_UART0_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// SYS_CTRL_RCGCI2C register.
+//
+//*****************************************************************************
+#define SYS_CTRL_RCGCI2C_I2C0   0x00000001  // 0: Clock for I2C0 is gated. 1: 
+                                            // Clock for I2C0 is enabled. 
+#define SYS_CTRL_RCGCI2C_I2C0_M 0x00000001
+#define SYS_CTRL_RCGCI2C_I2C0_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// SYS_CTRL_SCGCI2C register.
+//
+//*****************************************************************************
+#define SYS_CTRL_SCGCI2C_I2C0   0x00000001  // 0: Clock for I2C0 is gated. 1: 
+                                            // Clock for I2C0 is enabled. 
+#define SYS_CTRL_SCGCI2C_I2C0_M 0x00000001
+#define SYS_CTRL_SCGCI2C_I2C0_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// SYS_CTRL_DCGCI2C register.
+//
+//*****************************************************************************
+#define SYS_CTRL_DCGCI2C_I2C0   0x00000001  // 0: Clock for I2C0 is gated. 1: 
+                                            // Clock for I2C0 is enabled. 
+#define SYS_CTRL_DCGCI2C_I2C0_M 0x00000001
+#define SYS_CTRL_DCGCI2C_I2C0_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// SYS_CTRL_SRI2C register.
+//
+//*****************************************************************************
+#define SYS_CTRL_SRI2C_I2C0     0x00000001  // 0: I2C0 module is not reset 1: 
+                                            // I2C0 module is reset 
+#define SYS_CTRL_SRI2C_I2C0_M   0x00000001
+#define SYS_CTRL_SRI2C_I2C0_S   0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// SYS_CTRL_RCGCSEC register.
+//
+//*****************************************************************************
+#define SYS_CTRL_RCGCSEC_AES    0x00000002  // 0: Clock for AES is gated. 1: 
+                                            // Clock for AES is enabled. 
+#define SYS_CTRL_RCGCSEC_AES_M  0x00000002
+#define SYS_CTRL_RCGCSEC_AES_S  1
+#define SYS_CTRL_RCGCSEC_PKA    0x00000001  // 0: Clock for PKA is gated. 1: 
+                                            // Clock for PKA is enabled. 
+#define SYS_CTRL_RCGCSEC_PKA_M  0x00000001
+#define SYS_CTRL_RCGCSEC_PKA_S  0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// SYS_CTRL_SCGCSEC register.
+//
+//*****************************************************************************
+#define SYS_CTRL_SCGCSEC_AES    0x00000002  // 0: Clock for AES is gated. 1: 
+                                            // Clock for AES is enabled. 
+#define SYS_CTRL_SCGCSEC_AES_M  0x00000002
+#define SYS_CTRL_SCGCSEC_AES_S  1
+#define SYS_CTRL_SCGCSEC_PKA    0x00000001  // 0: Clock for PKA is gated. 1: 
+                                            // Clock for PKA is enabled. 
+#define SYS_CTRL_SCGCSEC_PKA_M  0x00000001
+#define SYS_CTRL_SCGCSEC_PKA_S  0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// SYS_CTRL_DCGCSEC register.
+//
+//*****************************************************************************
+#define SYS_CTRL_DCGCSEC_AES    0x00000002  // 0: Clock for AES is gated. 1: 
+                                            // Clock for AES is enabled. 
+#define SYS_CTRL_DCGCSEC_AES_M  0x00000002
+#define SYS_CTRL_DCGCSEC_AES_S  1
+#define SYS_CTRL_DCGCSEC_PKA    0x00000001  // 0: Clock for PKA is gated. 1: 
+                                            // Clock for PKA is enabled. 
+#define SYS_CTRL_DCGCSEC_PKA_M  0x00000001
+#define SYS_CTRL_DCGCSEC_PKA_S  0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// SYS_CTRL_SRSEC register.
+//
+//*****************************************************************************
+#define SYS_CTRL_SRSEC_AES      0x00000002  // 0: AES module is not reset 1: 
+                                            // AES module is reset 
+#define SYS_CTRL_SRSEC_AES_M    0x00000002
+#define SYS_CTRL_SRSEC_AES_S    1
+#define SYS_CTRL_SRSEC_PKA      0x00000001  // 0: PKA module is not reset 1: 
+                                            // PKA module is reset 
+#define SYS_CTRL_SRSEC_PKA_M    0x00000001
+#define SYS_CTRL_SRSEC_PKA_S    0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// SYS_CTRL_PMCTL register.
+//
+//*****************************************************************************
+#define SYS_CTRL_PMCTL_PM_M     0x00000003  // 00: No action 01: PM1 10: PM2 
+                                            // 11: PM3 
+#define SYS_CTRL_PMCTL_PM_S     0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// SYS_CTRL_SRCRC register.
+//
+//*****************************************************************************
+#define SYS_CTRL_SRCRC_CRC_REN_USB \
+                                0x00000100  // 1: Enable reset of chip if CRC 
+                                            // fails. 0: Disable reset feature 
+                                            // of chip due to CRC. 
+
+#define SYS_CTRL_SRCRC_CRC_REN_USB_M \
+                                0x00000100
+#define SYS_CTRL_SRCRC_CRC_REN_USB_S 8
+#define SYS_CTRL_SRCRC_CRC_REN_RF \
+                                0x00000001  // 1: Enable reset of chip if CRC 
+                                            // fails. 0: Disable reset feature 
+                                            // of chip due to CRC. 
+
+#define SYS_CTRL_SRCRC_CRC_REN_RF_M \
+                                0x00000001
+#define SYS_CTRL_SRCRC_CRC_REN_RF_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// SYS_CTRL_PWRDBG register.
+//
+//*****************************************************************************
+#define SYS_CTRL_PWRDBG_FORCE_WARM_RESET \
+                                0x00000008  // 0: No action 1: When written 
+                                            // high, the chip is reset in the 
+                                            // same manner as a CLD event and 
+                                            // is readable from the RST field 
+                                            // in the CLOCK_STA register. 
+
+#define SYS_CTRL_PWRDBG_FORCE_WARM_RESET_M \
+                                0x00000008
+#define SYS_CTRL_PWRDBG_FORCE_WARM_RESET_S 3
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the SYS_CTRL_CLD register.
+//
+//*****************************************************************************
+#define SYS_CTRL_CLD_VALID      0x00000100  // 0: CLD status in always-on 
+                                            // domain is not equal to status in 
+                                            // the EN register. 1: CLD status 
+                                            // in always-on domain and EN 
+                                            // register are equal. 
+#define SYS_CTRL_CLD_VALID_M    0x00000100
+#define SYS_CTRL_CLD_VALID_S    8
+#define SYS_CTRL_CLD_EN         0x00000001  // 0: CLD is disabled. 1: CLD is 
+                                            // enabled. Writing to this 
+                                            // register shall be ignored if 
+                                            // VALID = 0 
+#define SYS_CTRL_CLD_EN_M       0x00000001
+#define SYS_CTRL_CLD_EN_S       0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the SYS_CTRL_IWE register.
+//
+//*****************************************************************************
+#define SYS_CTRL_IWE_SM_TIMER_IWE \
+                                0x00000020  // 1: Enable SM Timer wake-up 
+                                            // interrupt. 0: Disable SM Timer 
+                                            // wake-up interrupt. 
+
+#define SYS_CTRL_IWE_SM_TIMER_IWE_M \
+                                0x00000020
+#define SYS_CTRL_IWE_SM_TIMER_IWE_S 5
+#define SYS_CTRL_IWE_USB_IWE    0x00000010  // 1: Enable USB wake-up 
+                                            // interrupt. 0: Disable USB 
+                                            // wake-up interrupt. 
+#define SYS_CTRL_IWE_USB_IWE_M  0x00000010
+#define SYS_CTRL_IWE_USB_IWE_S  4
+#define SYS_CTRL_IWE_PORT_D_IWE 0x00000008  // 1: Enable port D wake-up 
+                                            // interrupt. 0: Disable port D 
+                                            // wake-up interrupt. 
+#define SYS_CTRL_IWE_PORT_D_IWE_M \
+                                0x00000008
+#define SYS_CTRL_IWE_PORT_D_IWE_S 3
+#define SYS_CTRL_IWE_PORT_C_IWE 0x00000004  // 1: Enable port C wake-up 
+                                            // interrupt. 0: Disable port C 
+                                            // wake-up interrupt. 
+#define SYS_CTRL_IWE_PORT_C_IWE_M \
+                                0x00000004
+#define SYS_CTRL_IWE_PORT_C_IWE_S 2
+#define SYS_CTRL_IWE_PORT_B_IWE 0x00000002  // 1: Enable port B wake-up 
+                                            // interrupt. 0: Disable port B 
+                                            // wake-up interrupt. 
+#define SYS_CTRL_IWE_PORT_B_IWE_M \
+                                0x00000002
+#define SYS_CTRL_IWE_PORT_B_IWE_S 1
+#define SYS_CTRL_IWE_PORT_A_IWE 0x00000001  // 1: Enable port A wake-up 
+                                            // interrupt. 0: Disable port A 
+                                            // wake-up interrupt. 
+#define SYS_CTRL_IWE_PORT_A_IWE_M \
+                                0x00000001
+#define SYS_CTRL_IWE_PORT_A_IWE_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// SYS_CTRL_I_MAP register.
+//
+//*****************************************************************************
+#define SYS_CTRL_I_MAP_ALTMAP   0x00000001  // 1: Select alternate interrupt 
+                                            // map. 0: Select regular interrupt 
+                                            // map. (See the ASD document for 
+                                            // details.) 
+#define SYS_CTRL_I_MAP_ALTMAP_M 0x00000001
+#define SYS_CTRL_I_MAP_ALTMAP_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// SYS_CTRL_RCGCRFC register.
+//
+//*****************************************************************************
+#define SYS_CTRL_RCGCRFC_RFC0   0x00000001  // 0: Clock for RF CORE is gated. 
+                                            // 1: Clock for RF CORE is enabled. 
+#define SYS_CTRL_RCGCRFC_RFC0_M 0x00000001
+#define SYS_CTRL_RCGCRFC_RFC0_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// SYS_CTRL_SCGCRFC register.
+//
+//*****************************************************************************
+#define SYS_CTRL_SCGCRFC_RFC0   0x00000001  // 0: Clock for RF CORE is gated. 
+                                            // 1: Clock for RF CORE is enabled. 
+#define SYS_CTRL_SCGCRFC_RFC0_M 0x00000001
+#define SYS_CTRL_SCGCRFC_RFC0_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// SYS_CTRL_DCGCRFC register.
+//
+//*****************************************************************************
+#define SYS_CTRL_DCGCRFC_RFC0   0x00000001  // 0: Clock for RF CORE is gated. 
+                                            // 1: Clock for RF CORE is enabled. 
+#define SYS_CTRL_DCGCRFC_RFC0_M 0x00000001
+#define SYS_CTRL_DCGCRFC_RFC0_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// SYS_CTRL_EMUOVR register.
+//
+//*****************************************************************************
+#define SYS_CTRL_EMUOVR_ICEPICK_FORCE_CLOCK_CG \
+                                0x00000080  // ICEPick 'Force Active' clock 
+                                            // gate override bit. 'Force 
+                                            // Active' is an ICEPick command. 1 
+                                            // --> In non-sleep power mode, 
+                                            // peripherals clocks are forced to 
+                                            // follow RCG* register settings. 
+                                            // It forces CM3 clocks on. 0 --> 
+                                            // Does not affect the peripheral 
+                                            // clock settings. 
+
+#define SYS_CTRL_EMUOVR_ICEPICK_FORCE_CLOCK_CG_M \
+                                0x00000080
+#define SYS_CTRL_EMUOVR_ICEPICK_FORCE_CLOCK_CG_S 7
+#define SYS_CTRL_EMUOVR_ICEPICK_FORCE_POWER_CG \
+                                0x00000040  // ICEPick 'Force Power' clock 
+                                            // gate override bit. 'Force Power' 
+                                            // is an ICEPick command. 1 --> In 
+                                            // non-sleep power mode, 
+                                            // peripherals clocks are forced to 
+                                            // follow RCG* register settings. 
+                                            // It forces CM3 clocks on. 0 --> 
+                                            // Does not affect the peripheral 
+                                            // clock settings. 
+
+#define SYS_CTRL_EMUOVR_ICEPICK_FORCE_POWER_CG_M \
+                                0x00000040
+#define SYS_CTRL_EMUOVR_ICEPICK_FORCE_POWER_CG_S 6
+#define SYS_CTRL_EMUOVR_ICEPICK_INHIBIT_SLEEP_CG \
+                                0x00000020  // ICEPick 'Inhibit Sleep' clock 
+                                            // gate override bit. 'Inhibit 
+                                            // Sleep' is an ICEPick command. 1 
+                                            // --> In non-sleep power mode, 
+                                            // peripherals clocks are forced to 
+                                            // follow RCG* register settings. 
+                                            // It forces CM3 clocks on. 0 --> 
+                                            // Does not affect the peripheral 
+                                            // clock settings. 
+
+#define SYS_CTRL_EMUOVR_ICEPICK_INHIBIT_SLEEP_CG_M \
+                                0x00000020
+#define SYS_CTRL_EMUOVR_ICEPICK_INHIBIT_SLEEP_CG_S 5
+#define SYS_CTRL_EMUOVR_ICEMELTER_WKUP_CG \
+                                0x00000010  // ICEMelter 'WAKEUPEMU' clock 
+                                            // gate override bit. 1 --> In 
+                                            // non-sleep power mode, 
+                                            // peripherals clocks are forced to 
+                                            // follow RCG* register settings. 
+                                            // It forces CM3 clocks on. 0 --> 
+                                            // Does not affect the peripheral 
+                                            // clock settings 
+
+#define SYS_CTRL_EMUOVR_ICEMELTER_WKUP_CG_M \
+                                0x00000010
+#define SYS_CTRL_EMUOVR_ICEMELTER_WKUP_CG_S 4
+#define SYS_CTRL_EMUOVR_ICEPICK_FORCE_CLOCK_PM \
+                                0x00000008  // ICEPick 'Force Active' power 
+                                            // mode override bit. 'Force 
+                                            // Active' is an ICEPick command. 1 
+                                            // --> Prohibit the system to go 
+                                            // into any power down modes. Keeps 
+                                            // the emulator attached. 0 --> 
+                                            // Does not override any power mode 
+                                            // settings from SYSREGS and does 
+                                            // not prohibit system to go into 
+                                            // any power down modes. 
+
+#define SYS_CTRL_EMUOVR_ICEPICK_FORCE_CLOCK_PM_M \
+                                0x00000008
+#define SYS_CTRL_EMUOVR_ICEPICK_FORCE_CLOCK_PM_S 3
+#define SYS_CTRL_EMUOVR_ICEPICK_FORCE_POWER_PM \
+                                0x00000004  // ICEPick 'Force Power' power 
+                                            // mode override bit. 'Force Power' 
+                                            // is an ICEPick command. 1 --> 
+                                            // Prohibit the system to go into 
+                                            // any power down modes. Keeps the 
+                                            // emulator attached. 0 --> Does 
+                                            // not override any power mode 
+                                            // settings from SYSREGS and does 
+                                            // not prohibit system to go into 
+                                            // any power down modes. 
+
+#define SYS_CTRL_EMUOVR_ICEPICK_FORCE_POWER_PM_M \
+                                0x00000004
+#define SYS_CTRL_EMUOVR_ICEPICK_FORCE_POWER_PM_S 2
+#define SYS_CTRL_EMUOVR_ICEPICK_INHIBIT_SLEEP_PM \
+                                0x00000002  // ICEPick 'Inhibit Sleep' power 
+                                            // mode override bit. 'Inhibit 
+                                            // Sleep' is an ICEPick command. 1 
+                                            // --> Prohibit the system to go 
+                                            // into any power down modes. Keeps 
+                                            // the emulator attached. 0 --> 
+                                            // Does not override any power mode 
+                                            // settings from SYSREGS and does 
+                                            // not prohibit system to go into 
+                                            // any power down modes. 
+
+#define SYS_CTRL_EMUOVR_ICEPICK_INHIBIT_SLEEP_PM_M \
+                                0x00000002
+#define SYS_CTRL_EMUOVR_ICEPICK_INHIBIT_SLEEP_PM_S 1
+#define SYS_CTRL_EMUOVR_ICEMELTER_WKUP_PM \
+                                0x00000001  // ICEMelter 'WAKEUPEMU' power 
+                                            // mode override bit. 1 --> 
+                                            // Prohibit the system to go into 
+                                            // any power down modes. Keeps the 
+                                            // emulator attached. 0 --> Does 
+                                            // not override any power mode 
+                                            // settings from SYSREGS and does 
+                                            // not prohibit system to go into 
+                                            // any power down modes. 
+
+#define SYS_CTRL_EMUOVR_ICEMELTER_WKUP_PM_M \
+                                0x00000001
+#define SYS_CTRL_EMUOVR_ICEMELTER_WKUP_PM_S 0
+
+
+#endif // __HW_SYS_CTRL_H__
+

--- a/cpu/cc2538/include/vendor/hw_types.h
+++ b/cpu/cc2538/include/vendor/hw_types.h
@@ -1,0 +1,84 @@
+/******************************************************************************
+*  Filename:       hw_types.h
+*  Revised:        $Date: 2013-04-29 09:49:55 +0200 (Mon, 29 Apr 2013) $
+*  Revision:       $Revision: 9923 $
+*
+*  Description:    Common types and macros.
+*
+*  Copyright (C) 2013 Texas Instruments Incorporated - http://www.ti.com/
+*
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*    Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+*
+*    Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+*
+*    Neither the name of Texas Instruments Incorporated nor the names of
+*    its contributors may be used to endorse or promote products derived
+*    from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+*  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+*  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+*  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+*  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+*  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+*  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+*  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+*  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+******************************************************************************/
+
+
+#ifndef __HW_TYPES_H__
+#define __HW_TYPES_H__
+
+#include <stdint.h>
+#include <stdbool.h>
+
+//*****************************************************************************
+//
+// Define a boolean type, and values for true and false.
+//
+//*****************************************************************************
+typedef unsigned char tBoolean;
+
+#ifndef true
+#define true 1
+#endif
+
+#ifndef false
+#define false 0
+#endif
+
+//*****************************************************************************
+//
+// Macros for hardware access, both direct and via the bit-band region.
+//
+//*****************************************************************************
+#define HWREG(x)                                                              \
+        (*((volatile uint32_t *)(x)))
+#define HWREGH(x)                                                             \
+        (*((volatile uint16_t *)(x)))
+#define HWREGB(x)                                                             \
+        (*((volatile unsigned char *)(x)))
+#define HWREGBITW(x, b)                                                       \
+        HWREG(((uint32_t)(x) & 0xF0000000) | 0x02000000 |                     \
+              (((uint32_t)(x) & 0x000FFFFF) << 5) | ((b) << 2))
+#define HWREGBITH(x, b)                                                       \
+        HWREGH(((uint32_t)(x) & 0xF0000000) | 0x02000000 |                    \
+               (((uint32_t)(x) & 0x000FFFFF) << 5) | ((b) << 2))
+#define HWREGBITB(x, b)                                                       \
+        HWREGB(((uint32_t)(x) & 0xF0000000) | 0x02000000 |                    \
+               (((uint32_t)(x) & 0x000FFFFF) << 5) | ((b) << 2))
+
+
+#endif // __HW_TYPES_H__

--- a/cpu/cc2538/include/vendor/hw_uart.h
+++ b/cpu/cc2538/include/vendor/hw_uart.h
@@ -1,0 +1,1361 @@
+/******************************************************************************
+*  Filename:       hw_uart.h
+*  Revised:        $Date: 2013-04-30 17:13:44 +0200 (Tue, 30 Apr 2013) $
+*  Revision:       $Revision: 9943 $
+*
+*  Copyright (C) 2013 Texas Instruments Incorporated - http://www.ti.com/
+*
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*    Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+*
+*    Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+*
+*    Neither the name of Texas Instruments Incorporated nor the names of
+*    its contributors may be used to endorse or promote products derived
+*    from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+*  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+*  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+*  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+*  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+*  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+*  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+*  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+*  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+******************************************************************************/
+
+#ifndef __HW_UART_H__
+#define __HW_UART_H__
+
+//*****************************************************************************
+//
+// The following are defines for the UART register offsets.
+//
+//*****************************************************************************
+#define UART_O_DR               0x00000000  // UART data Important: This 
+                                            // register is read-sensitive. See 
+                                            // the register description for 
+                                            // details. This register is the 
+                                            // data register (the interface to 
+                                            // the FIFOs). For transmitted 
+                                            // data, if the FIFO is enabled, 
+                                            // data written to this location is 
+                                            // pushed onto the transmit FIFO. 
+                                            // If the FIFO is disabled, data is 
+                                            // stored in the transmitter 
+                                            // holding register (the bottom 
+                                            // word of the transmit FIFO). A 
+                                            // write to this register initiates 
+                                            // a transmission from the UART. 
+                                            // For received data, if the FIFO 
+                                            // is enabled, the data byte and 
+                                            // the 4-bit status (break, frame, 
+                                            // parity, and overrun) is pushed 
+                                            // onto the 12-bit wide receive 
+                                            // FIFO. If the FIFO is disabled, 
+                                            // the data byte and status are 
+                                            // stored in the receiving holding 
+                                            // register (the bottom word of the 
+                                            // receive FIFO). The received data 
+                                            // can be retrieved by reading this 
+                                            // register. 
+#define UART_O_RSR              0x00000004  // UART receive status and error 
+                                            // clear The RSR/ECR register is 
+                                            // the receive status register and 
+                                            // error clear register. In 
+                                            // addition to the DR register, 
+                                            // receive status can also be read 
+                                            // from the RSR register. If the 
+                                            // status is read from this 
+                                            // register, then the status 
+                                            // information corresponds to the 
+                                            // entry read from DR before 
+                                            // reading RSR. The status 
+                                            // information for overrun is set 
+                                            // immediately when an overrun 
+                                            // condition occurs. The RSR 
+                                            // register cannot be written. 
+                                            // Read-only status register 
+#define UART_O_ECR              0x00000004  // UART receive status and error 
+                                            // clear The RSR/ECR register is 
+                                            // the receive status 
+                                            // register/error clear register. A 
+                                            // write of any value to the ECR 
+                                            // register clears the framing, 
+                                            // parity, break, and overrun 
+                                            // errors. All the bits are cleared 
+                                            // on reset. Write-only error clear 
+                                            // register 
+#define UART_O_FR               0x00000018  // UART flag The FR register is 
+                                            // the flag register. After reset, 
+                                            // the TXFF, RXFF, and BUSY bits 
+                                            // are 0, and TXFE and RXFE bits 
+                                            // are 1. The CTS bit indicate the 
+                                            // modem flow control. Note that 
+                                            // the modem bits are only 
+                                            // implemented on UART1 and are 
+                                            // tied inactive on UART0. Due to 
+                                            // this difference, the reset state 
+                                            // of the UART0 FR register is 
+                                            // 0x90, while UART1 FR register 
+                                            // reset state 0x197 . 
+#define UART_O_ILPR             0x00000020  // UART IrDA low-power register 
+                                            // The ILPR register stores the 
+                                            // 8-bit low-power counter divisor 
+                                            // value used to derive the 
+                                            // low-power SIR pulse width clock 
+                                            // by dividing down the system 
+                                            // clock (SysClk). All the bits are 
+                                            // cleared when reset. The internal 
+                                            // IrLPBaud16 clock is generated by 
+                                            // dividing down SysClk according 
+                                            // to the low-power divisor value 
+                                            // written to ILPR. The duration of 
+                                            // SIR pulses generated when 
+                                            // low-power mode is enabled is 
+                                            // three times the period of the 
+                                            // IrLPBaud16 clock. The low-power 
+                                            // divisor value is calculated as 
+                                            // follows: ILPDVSR = SysClk / 
+                                            // FIrLPBaud16 where FIrLPBaud16 is 
+                                            // nominally 1.8432 MHz The divisor 
+                                            // must be programmed such that 
+                                            // FIrLPBaud16 is in the range 1.42 
+                                            // MHz to 2.12 MHz, resulting in a 
+                                            // low-power pulse duration of 
+                                            // 1.41-2.11 us (three times the 
+                                            // period of IrLPBaud16). The 
+                                            // minimum frequency of IrLPBaud16 
+                                            // ensures that pulses less than 
+                                            // one period of IrLPBaud16 are 
+                                            // rejected, but pulses greater 
+                                            // than 1.4 us are accepted as 
+                                            // valid pulses. Note: Zero is an 
+                                            // illegal value. Programming a 
+                                            // zero value results in no 
+                                            // IrLPBaud16 pulses being 
+                                            // generated. 
+#define UART_O_IBRD             0x00000024  // UART integer baud-rate divisor 
+                                            // The IBRD register is the integer 
+                                            // part of the baud-rate divisor 
+                                            // value. All the bits are cleared 
+                                            // on reset. The minimum possible 
+                                            // divide ratio is 1 (when IBRD = 
+                                            // 0), in which case the FBRD 
+                                            // register is ignored. When 
+                                            // changing the IBRD register, the 
+                                            // new value does not take effect 
+                                            // until transmission or reception 
+                                            // of the current character is 
+                                            // complete. Any changes to the 
+                                            // baud-rate divisor must be 
+                                            // followed by a write to the LCRH 
+                                            // register. 
+#define UART_O_FBRD             0x00000028  // UART fractional baud-rate 
+                                            // divisor The FBRD register is the 
+                                            // fractional part of the baud-rate 
+                                            // divisor value. All the bits are 
+                                            // cleared on reset. When changing 
+                                            // the FBRD register, the new value 
+                                            // does not take effect until 
+                                            // transmission or reception of the 
+                                            // current character is complete. 
+                                            // Any changes to the baud-rate 
+                                            // divisor must be followed by a 
+                                            // write to the LCRH register. 
+#define UART_O_LCRH             0x0000002C  // UART line control The LCRH 
+                                            // register is the line control 
+                                            // register. Serial parameters such 
+                                            // as data length, parity, and stop 
+                                            // bit selection are implemented in 
+                                            // this register. When updating the 
+                                            // baud-rate divisor (IBRD and/or 
+                                            // IFRD), the LCRH register must 
+                                            // also be written. The write 
+                                            // strobe for the baud-rate divisor 
+                                            // registers is tied to the LCRH 
+                                            // register. 
+#define UART_O_CTL              0x00000030  // UART control The CTL register 
+                                            // is the control register. All the 
+                                            // bits are cleared on reset except 
+                                            // for the transmit enable (TXE) 
+                                            // and receive enable (RXE) bits, 
+                                            // which are set. To enable the 
+                                            // UART module, the UARTEN bit must 
+                                            // be set. If software requires a 
+                                            // configuration change in the 
+                                            // module, the UARTEN bit must be 
+                                            // cleared before the configuration 
+                                            // changes are written. If the UART 
+                                            // is disabled during a transmit or 
+                                            // receive operation, the current 
+                                            // transaction is completed before 
+                                            // the UART stopping. Note: The 
+                                            // UARTCTL register should not be 
+                                            // changed while the UART is 
+                                            // enabled or else the results are 
+                                            // unpredictable. The following 
+                                            // sequence is recommended for 
+                                            // making changes to the UARTCTL 
+                                            // register: 1. Disable the UART. 
+                                            // 2. Wait for the end of 
+                                            // transmission or reception of the 
+                                            // current character. 3. Flush the 
+                                            // transmit FIFO by clearing bit 4 
+                                            // (FEN) in the line control 
+                                            // register (UARTLCRH). 4. 
+                                            // Reprogram the control register. 
+                                            // 5. Enable the UART. 
+#define UART_O_IFLS             0x00000034  // UART interrupt FIFO level 
+                                            // select The IFLS register is the 
+                                            // interrupt FIFO level select 
+                                            // register. This register can be 
+                                            // used to define the FIFO level at 
+                                            // which the TXRIS and RXRIS bits 
+                                            // in the RIS register are 
+                                            // triggered. The interrupts are 
+                                            // generated based on a transition 
+                                            // through a level rather than 
+                                            // being based on the level. That 
+                                            // is, the interrupts are generated 
+                                            // when the fill level progresses 
+                                            // through the trigger level. For 
+                                            // example, if the receive trigger 
+                                            // level is set to the half-way 
+                                            // mark, the interrupt is triggered 
+                                            // as the module is receiving the 
+                                            // 9th character. Out of reset, the 
+                                            // TXIFLSEL and RXIFLSEL bits are 
+                                            // configured so that the FIFOs 
+                                            // trigger an interrupt at the 
+                                            // half-way mark. 
+#define UART_O_IM               0x00000038  // UART interrupt mask The IM 
+                                            // register is the interrupt mask 
+                                            // set/clear register. On a read, 
+                                            // this register gives the current 
+                                            // value of the mask on the 
+                                            // relevant interrupt. Setting a 
+                                            // bit allows the corresponding raw 
+                                            // interrupt signal to be routed to 
+                                            // the interrupt controller. 
+                                            // Clearing a bit prevents the raw 
+                                            // interrupt signal from being sent 
+                                            // to the interrupt controller. 
+#define UART_O_RIS              0x0000003C  // UART raw interrupt status The 
+                                            // RIS register is the raw 
+                                            // interrupt status register. On a 
+                                            // read, this register gives the 
+                                            // current raw status value of the 
+                                            // corresponding interrupt. A write 
+                                            // has no effect. Note that the HW 
+                                            // modem flow control bits are only 
+                                            // implemented on UART1 and are 
+                                            // tied inactive on UART0. 
+#define UART_O_MIS              0x00000040  // UART masked interrupt status 
+                                            // The MIS register is the masked 
+                                            // interrupt status register. On a 
+                                            // read, this register gives the 
+                                            // current masked status value of 
+                                            // the corresponding interrupt. A 
+                                            // write has no effect. 
+#define UART_O_ICR              0x00000044  // UART interrupt clear The ICR 
+                                            // register is the interrupt clear 
+                                            // register. On a write of 1, the 
+                                            // corresponding interrupt (both 
+                                            // raw interrupt and masked 
+                                            // interrupt, if enabled) is 
+                                            // cleared. A write of 0 has no 
+                                            // effect. 
+#define UART_O_DMACTL           0x00000048  // UART DMA control The DMACTL 
+                                            // register is the DMA control 
+                                            // register. 
+#define UART_O_LCTL             0x00000090  // UART LIN control The LCTL 
+                                            // register is the configures the 
+                                            // operation of the UART when in 
+                                            // LIN mode. 
+#define UART_O_LSS              0x00000094  // LIN snap shot The LSS register 
+                                            // captures the free-running timer 
+                                            // value when either the sync edge 
+                                            // 1 or the sync edge 5 is detected 
+                                            // in LIN mode. 
+#define UART_O_LTIM             0x00000098  // UART LIN timer The LTIM 
+                                            // register contains the current 
+                                            // timer value for the free-running 
+                                            // timer that is used to calculate 
+                                            // the baud rate when in LIN slave 
+                                            // mode. The value in this register 
+                                            // is used along with the value in 
+                                            // the UART LIN snap shot (LSS) 
+                                            // register to adjust the baud rate 
+                                            // to match that of the master. 
+#define UART_O_NINEBITADDR      0x000000A4  // UART 9-bit self address The 
+                                            // NINEBITADDR register is used to 
+                                            // write the specific address that 
+                                            // should be matched with the 
+                                            // receiving byte when the 9-bit 
+                                            // address mask (NINEBITAMASK) is 
+                                            // set to 0xFF. This register is 
+                                            // used in conjunction with 
+                                            // NINEBITAMASK to form a match for 
+                                            // address-byte received. 
+#define UART_O_NINEBITAMASK     0x000000A8  // UART 9-bit self address mask 
+                                            // The NINEBITAMASK register is 
+                                            // used to enable the address mask 
+                                            // for 9-bit mode. The lower 
+                                            // address bits are masked to 
+                                            // create a range of address to be 
+                                            // matched with the received 
+                                            // address byte. 
+#define UART_O_PP               0x00000FC0  // UART peripheral properties The 
+                                            // PP register provides information 
+                                            // regarding the properties of the 
+                                            // UART module. 
+#define UART_O_CC               0x00000FC8  // UART clock configuration The CC 
+                                            // register controls the baud and 
+                                            // system clocks sources for the 
+                                            // UART module. For more 
+                                            // information, see the section 
+                                            // called "Baud-Rate Generation". 
+                                            // Note: If the PIOSC is used for 
+                                            // the UART baud clock, the system 
+                                            // clock frequency must be at least 
+                                            // 9 MHz in run mode. 
+
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the UART_O_DR register.
+//
+//*****************************************************************************
+#define UART_DR_OE              0x00000800  // UART overrun error 1: New data 
+                                            // was received when the FIFO was 
+                                            // full, resulting in data loss. 0: 
+                                            // No data has been lost due to a 
+                                            // FIFO overrun. 
+#define UART_DR_OE_M            0x00000800
+#define UART_DR_OE_S            11
+#define UART_DR_BE              0x00000400  // UART break error 1: A break 
+                                            // condition has been detected, 
+                                            // indicating that the receive data 
+                                            // input was held low for longer 
+                                            // than a full-word transmission 
+                                            // time (defined as start, data, 
+                                            // parity, and stop bits). 0: No 
+                                            // break condition has occurred. In 
+                                            // FIFO mode, this error is 
+                                            // associated with the character at 
+                                            // the top of the FIFO. When a 
+                                            // break occurs, only the one 0 
+                                            // character is loaded into the 
+                                            // FIFO. The next character is only 
+                                            // enabled after the received data 
+                                            // input goes to a 1 (marking 
+                                            // state), and the next valid start 
+                                            // bit is received. 
+#define UART_DR_BE_M            0x00000400
+#define UART_DR_BE_S            10
+#define UART_DR_PE              0x00000200  // UART parity error 1: The parity 
+                                            // of the received data character 
+                                            // does not match the parity 
+                                            // defined by bits 2 and 7 of the 
+                                            // UARTLCRH register 0: No parity 
+                                            // error has occurred. In FIFO 
+                                            // mode, this error is associated 
+                                            // with the character at the top of 
+                                            // the FIFO. 
+#define UART_DR_PE_M            0x00000200
+#define UART_DR_PE_S            9
+#define UART_DR_FE              0x00000100  // UART framing error 1: The 
+                                            // received character does not have 
+                                            // a valid stop bit (a valid stop 
+                                            // bit is 1). 0: No framing error 
+                                            // has occurred. 
+#define UART_DR_FE_M            0x00000100
+#define UART_DR_FE_S            8
+#define UART_DR_DATA_M          0x000000FF  // Data transmitted or received 
+                                            // Data that is to be transmitted 
+                                            // via the UART is written to this 
+                                            // field. When read, this field 
+                                            // contains the data that was 
+                                            // received by the UART. 
+#define UART_DR_DATA_S          0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the UART_O_RSR register.
+//
+//*****************************************************************************
+#define UART_RSR_OE             0x00000008  // UART overrun error 1: New data 
+                                            // was received when the FIFO was 
+                                            // full, resulting in data loss. 0: 
+                                            // No data has been lost due to a 
+                                            // FIFO overrun. This bit is 
+                                            // cleared by a write to UARTECR. 
+                                            // The FIFO contents remain valid 
+                                            // because no further data is 
+                                            // written when the FIFO is full, 
+                                            // only the contents of the shift 
+                                            // register are overwritten. The 
+                                            // CPU must read the data in order 
+                                            // to empty the FIFO. 
+#define UART_RSR_OE_M           0x00000008
+#define UART_RSR_OE_S           3
+#define UART_RSR_BE             0x00000004  // UART break error 1: A break 
+                                            // condition has been detected, 
+                                            // indicating that the receive data 
+                                            // input was held low for longer 
+                                            // than a full-word transmission 
+                                            // time (defined as start, data, 
+                                            // parity, and stop bits). 0: No 
+                                            // break condition has occurred. 
+                                            // This bit is cleared to 0 by a 
+                                            // write to UARTECR. In FIFO mode, 
+                                            // this error is associated with 
+                                            // the character at the top of the 
+                                            // FIFO. When a break occurs, only 
+                                            // one 0 character is loaded into 
+                                            // the FIFO. The next character is 
+                                            // only enabled after the receive 
+                                            // data input goes to a 1 (marking 
+                                            // state) and the next valid start 
+                                            // bit is received. 
+#define UART_RSR_BE_M           0x00000004
+#define UART_RSR_BE_S           2
+#define UART_RSR_PE             0x00000002  // UART parity error 1: The parity 
+                                            // of the received data character 
+                                            // does not match the parity 
+                                            // defined by bits 2 and 7 of the 
+                                            // UARTLCRH register. 0: No parity 
+                                            // error has occurred. This bit is 
+                                            // cleared to 0 by a write to 
+                                            // UARTECR. 
+#define UART_RSR_PE_M           0x00000002
+#define UART_RSR_PE_S           1
+#define UART_RSR_FE             0x00000001  // UART framing error 1: The 
+                                            // received character does not have 
+                                            // a valid stop bit (a valid stop 
+                                            // bit is 1). 0: No framing error 
+                                            // has occurred. This bit is 
+                                            // cleared to 0 by a write to 
+                                            // UARTECR. In FIFO mode, this 
+                                            // error is associated with the 
+                                            // character at the top of the 
+                                            // FIFO. 
+#define UART_RSR_FE_M           0x00000001
+#define UART_RSR_FE_S           0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the UART_O_ECR register.
+//
+//*****************************************************************************
+#define UART_ECR_DATA_M         0x000000FF  // Error clear A write to this 
+                                            // register of any data clears the 
+                                            // framing, parity, break, and 
+                                            // overrun flags. 
+#define UART_ECR_DATA_S         0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the UART_O_FR register.
+//
+//*****************************************************************************
+#define UART_FR_TXFE            0x00000080  // UART transmit FIFO empty The 
+                                            // meaning of this bit depends on 
+                                            // the state of the FEN bit in the 
+                                            // UARTLCRH register. 1: If the 
+                                            // FIFO is disabled (FEN is 0), the 
+                                            // transmit holding register is 
+                                            // empty. If the FIFO is enabled 
+                                            // (FEN is 1), the transmit FIFO is 
+                                            // empty. 0: The transmitter has 
+                                            // data to transmit. 
+#define UART_FR_TXFE_M          0x00000080
+#define UART_FR_TXFE_S          7
+#define UART_FR_RXFF            0x00000040  // UART receive FIFO full The 
+                                            // meaning of this bit depends on 
+                                            // the state of the FEN bit in the 
+                                            // UARTLCRH register. 1: If the 
+                                            // FIFO is disabled (FEN is 0), the 
+                                            // receive holding register is 
+                                            // full. If the FIFO is enabled 
+                                            // (FEN is 1), the receive FIFO is 
+                                            // full. 0: The receiver can 
+                                            // receive data. 
+#define UART_FR_RXFF_M          0x00000040
+#define UART_FR_RXFF_S          6
+#define UART_FR_TXFF            0x00000020  // UART transmit FIFO full The 
+                                            // meaning of this bit depends on 
+                                            // the state of the FEN bit in the 
+                                            // UARTLCRH register. 1: If the 
+                                            // FIFO is disabled (FEN is 0), the 
+                                            // transmit holding register is 
+                                            // full. If the FIFO is enabled 
+                                            // (FEN is 1), the transmit FIFO is 
+                                            // full. 0: The transmitter is not 
+                                            // full. 
+#define UART_FR_TXFF_M          0x00000020
+#define UART_FR_TXFF_S          5
+#define UART_FR_RXFE            0x00000010  // UART receive FIFO empty The 
+                                            // meaning of this bit depends on 
+                                            // the state of the FEN bit in the 
+                                            // UARTLCRH register. 1: If the 
+                                            // FIFO is disabled (FEN is 0), the 
+                                            // receive holding register is 
+                                            // empty. If the FIFO is enabled 
+                                            // (FEN is 1), the receive FIFO is 
+                                            // empty. 0: The receiver is not 
+                                            // empty. 
+#define UART_FR_RXFE_M          0x00000010
+#define UART_FR_RXFE_S          4
+#define UART_FR_BUSY            0x00000008  // UART busy 1: The UART is busy 
+                                            // transmitting data. This bit 
+                                            // remains set until the complete 
+                                            // byte, including all stop bits, 
+                                            // has been sent from the shift 
+                                            // register. 0: The UART is not 
+                                            // busy. This bit is set as soon as 
+                                            // the transmit FIFO becomes 
+                                            // non-empty (regardless of whether 
+                                            // UART is enabled). 
+#define UART_FR_BUSY_M          0x00000008
+#define UART_FR_BUSY_S          3
+#define UART_FR_CTS             0x00000001  // Clear to send (UART1 only, 
+                                            // reserved for UART0). 1: The 
+                                            // U1CTS signal is asserted. 0: The 
+                                            // U1CTS signal is not asserted. 
+#define UART_FR_CTS_M           0x00000001
+#define UART_FR_CTS_S           0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the UART_O_ILPR register.
+//
+//*****************************************************************************
+#define UART_ILPR_ILPDVSR_M     0x000000FF  // IrDA low-power divisor This 
+                                            // field contains the 8-bit 
+                                            // low-power divisor value. 
+#define UART_ILPR_ILPDVSR_S     0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the UART_O_IBRD register.
+//
+//*****************************************************************************
+#define UART_IBRD_DIVINT_M      0x0000FFFF  // Integer baud-rate divisor 
+#define UART_IBRD_DIVINT_S      0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the UART_O_FBRD register.
+//
+//*****************************************************************************
+#define UART_FBRD_DIVFRAC_M     0x0000003F  // Fractional baud-rate divisor 
+#define UART_FBRD_DIVFRAC_S     0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the UART_O_LCRH register.
+//
+//*****************************************************************************
+#define UART_LCRH_SPS           0x00000080  // UART stick parity select When 
+                                            // bits 1, 2, and 7 of UARTLCRH are 
+                                            // set, the parity bit is 
+                                            // transmitted and checked as a 0. 
+                                            // When bits 1 and 7 are set and 2 
+                                            // is cleared, the parity bit is 
+                                            // transmitted and checked as a 1. 
+                                            // When this bit is cleared, stick 
+                                            // parity is disabled. 
+#define UART_LCRH_SPS_M         0x00000080
+#define UART_LCRH_SPS_S         7
+#define UART_LCRH_WLEN_M        0x00000060  // UART word length The bits 
+                                            // indicate the number of data bits 
+                                            // transmitted or received in a 
+                                            // frame as follows: 0x0: 5 bits 
+                                            // (default) 0x1: 6 bits 0x2: 7 
+                                            // bits 0x3: 8 bits 
+#define UART_LCRH_WLEN_S        5
+#define UART_LCRH_FEN           0x00000010  // UART enable FIFOs 1: The 
+                                            // transmit and receive FIFObuffers 
+                                            // are enabled (FIFOmode). 0: The 
+                                            // FIFOs are disabled (Character 
+                                            // mode). The FIFOs become 
+                                            // 1-byte-deep holding registers. 
+#define UART_LCRH_FEN_M         0x00000010
+#define UART_LCRH_FEN_S         4
+#define UART_LCRH_STP2          0x00000008  // UART two stop bits select 1: 
+                                            // Two stop bits are transmitted at 
+                                            // the end of a frame. The receive 
+                                            // logic does not check for two 
+                                            // stop bits being received. 0: One 
+                                            // stop bit is transmitted at the 
+                                            // end of a frame. 
+#define UART_LCRH_STP2_M        0x00000008
+#define UART_LCRH_STP2_S        3
+#define UART_LCRH_EPS           0x00000004  // UART even parity select 1: Even 
+                                            // parity generation and checking 
+                                            // is performed during transmission 
+                                            // and reception, which checks for 
+                                            // an even number of 1s in data and 
+                                            // parity bits. 0: Odd parity is 
+                                            // performed, which checks for an 
+                                            // odd number of 1s. This bit has 
+                                            // no effect when parity is 
+                                            // disabled by the PEN bit. 
+#define UART_LCRH_EPS_M         0x00000004
+#define UART_LCRH_EPS_S         2
+#define UART_LCRH_PEN           0x00000002  // UART parity enable 1: Parity 
+                                            // checking and generation is 
+                                            // enabled. 0: Parity is disabled 
+                                            // and no parity bit is added to 
+                                            // the data frame. 
+#define UART_LCRH_PEN_M         0x00000002
+#define UART_LCRH_PEN_S         1
+#define UART_LCRH_BRK           0x00000001  // UART send break 1: A low level 
+                                            // is continually output on the 
+                                            // UnTx signal, after completing 
+                                            // transmission of the current 
+                                            // character. For the proper 
+                                            // execution of the break command, 
+                                            // software must set this bit for 
+                                            // at least two frames (character 
+                                            // periods). 0: Normal use 
+#define UART_LCRH_BRK_M         0x00000001
+#define UART_LCRH_BRK_S         0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the UART_O_CTL register.
+//
+//*****************************************************************************
+#define UART_CTL_CTSEN          0x00008000  // U1CTS Hardware Flow control 
+                                            // enable 1: When U1CTS input is 
+                                            // asserted, UART1 can transmit 
+                                            // data. 0: U1CTS does not control 
+                                            // UART1 data transmission. Note: 
+                                            // Only used for UART1. This bit is 
+                                            // reserved RO for UART0. 
+#define UART_CTL_CTSEN_M        0x00008000
+#define UART_CTL_CTSEN_S        15
+#define UART_CTL_RTSEN          0x00004000  // U1RTS Hardware Flow control 
+                                            // enable 1: U1RTS indicates the 
+                                            // state of UART1 receive FIFO. 
+                                            // U1RTS remains asserted until the 
+                                            // preprogrammed watermark level is 
+                                            // reached, indicating that the 
+                                            // UART1 RXFIFO has no space to 
+                                            // store additional characters. 0: 
+                                            // U1RTS does not indicate state of 
+                                            // UART1 RX FIFO. Note: Only used 
+                                            // for UART1. This bit is reserved 
+                                            // RO for UART0. 
+#define UART_CTL_RTSEN_M        0x00004000
+#define UART_CTL_RTSEN_S        14
+#define UART_CTL_RXE            0x00000200  // UART receive enable 1: The 
+                                            // receive section of the UART is 
+                                            // enabled. 0: The receive section 
+                                            // of the UART is disabled. If the 
+                                            // UART is disabled in the middle 
+                                            // of a receive, it completes the 
+                                            // current character before 
+                                            // stopping. Note: To enable 
+                                            // reception, the UARTEN bit must 
+                                            // also be set. 
+#define UART_CTL_RXE_M          0x00000200
+#define UART_CTL_RXE_S          9
+#define UART_CTL_TXE            0x00000100  // UART transmit enable 1: The 
+                                            // transmit section of the UART is 
+                                            // enabled. 0: The transmit section 
+                                            // of the UART is disabled. If the 
+                                            // UART is disabled in the middle 
+                                            // of a transmission, it completes 
+                                            // the current character before 
+                                            // stopping. Note: To enable 
+                                            // transmission, the UARTEN bit 
+                                            // must also be set. 
+#define UART_CTL_TXE_M          0x00000100
+#define UART_CTL_TXE_S          8
+#define UART_CTL_LBE            0x00000080  // UART loop back enable 1: The 
+                                            // UnTx path is fed through the 
+                                            // UnRx path. 0: Normal operation 
+#define UART_CTL_LBE_M          0x00000080
+#define UART_CTL_LBE_S          7
+#define UART_CTL_LIN            0x00000040  // LIN mode enable 1: The UART 
+                                            // operates in LIN mode. 0: Normal 
+                                            // operation 
+#define UART_CTL_LIN_M          0x00000040
+#define UART_CTL_LIN_S          6
+#define UART_CTL_HSE            0x00000020  // High-speed enable 0: The UART 
+                                            // is clocked using the system 
+                                            // clock divided by 16. 1: The UART 
+                                            // is clocked using the system 
+                                            // clock divided by 8. Note: System 
+                                            // clock used is also dependent on 
+                                            // the baud-rate divisor 
+                                            // configuration (See Universal 
+                                            // Asynchronous 
+                                            // Receivers/Transmitters - 
+                                            // Baud-Rate Generation). 
+#define UART_CTL_HSE_M          0x00000020
+#define UART_CTL_HSE_S          5
+#define UART_CTL_EOT            0x00000010  // End of transmission This bit 
+                                            // determines the behavior of the 
+                                            // TXRIS bit in the UARTRIS 
+                                            // register. 1: The TXRIS bit is 
+                                            // set only after all transmitted 
+                                            // data, including stop bits, have 
+                                            // cleared the serializer. 0: The 
+                                            // TXRIS bit is set when the 
+                                            // transmit FIFO condition 
+                                            // specified in UARTIFLS is met. 
+#define UART_CTL_EOT_M          0x00000010
+#define UART_CTL_EOT_S          4
+#define UART_CTL_SIRLP          0x00000004  // UART SIR low-power mode This 
+                                            // bit selects the IrDA encoding 
+                                            // mode. 1: The UART operates in 
+                                            // SIR Low-Power mode. Low-level 
+                                            // bits are transmitted with a 
+                                            // pulse width which is 3 times the 
+                                            // period of the IrLPBaud16 input 
+                                            // signal, regardless of the 
+                                            // selected bit rate. 0: Low-level 
+                                            // bits are transmitted as an 
+                                            // active high pulse with a width 
+                                            // of 3/16th of the bit period. 
+                                            // Setting this bit uses less 
+                                            // power, but might reduce 
+                                            // transmission distances. 
+#define UART_CTL_SIRLP_M        0x00000004
+#define UART_CTL_SIRLP_S        2
+#define UART_CTL_SIREN          0x00000002  // UART SIR enable 1: The IrDA SIR 
+                                            // block is enabled, and the UART 
+                                            // transmits and receives data 
+                                            // using SIR protocol. 0: Normal 
+                                            // operation. 
+#define UART_CTL_SIREN_M        0x00000002
+#define UART_CTL_SIREN_S        1
+#define UART_CTL_UARTEN         0x00000001  // UART enable 1: The UART is 
+                                            // enabled. 0: The UART is 
+                                            // disabled. If the UART is 
+                                            // disabled in the middle of 
+                                            // transmission or reception, it 
+                                            // completes the current character 
+                                            // before stopping. 
+#define UART_CTL_UARTEN_M       0x00000001
+#define UART_CTL_UARTEN_S       0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the UART_O_IFLS register.
+//
+//*****************************************************************************
+#define UART_IFLS_RXIFLSEL_M    0x00000038  // UART receive interrupt FIFO 
+                                            // level select The trigger points 
+                                            // for the receive interrupt are as 
+                                            // follows: 0x0: RX FIFO >= 1/8 
+                                            // full 0x1: RX FIFO >= 1/4 full 
+                                            // 0x2: RX FIFO >= 1/2 full 
+                                            // (default) 0x3: RX FIFO >= 3/4 
+                                            // full 0x4: RX FIFO >= 7/8 full 
+                                            // 0x5-0x7: Reserved 
+#define UART_IFLS_RXIFLSEL_S    3
+#define UART_IFLS_TXIFLSEL_M    0x00000007  // UART Transmit Interrupt FIFO 
+                                            // Level Select The trigger points 
+                                            // for the transmit interrupt are 
+                                            // as follows: 0x0: TX FIFO <= 7/8 
+                                            // empty 0x1: TX FIFO <= 3/4 empty 
+                                            // 0x2: TX FIFO <= 1/2 empty 
+                                            // (default) 0x3: TX FIFO <= 1/4 
+                                            // empty 0x4: TX FIFO <= 1/8 empty 
+                                            // 0x5-0x7: Reserved Note: If the 
+                                            // EOT bit in UARTCTL is set, the 
+                                            // transmit interrupt is generated 
+                                            // once the FIFO is completely 
+                                            // empty and all data including 
+                                            // stop bits have left the transmit 
+                                            // serializer. In this case, the 
+                                            // setting of TXIFLSEL is ignored. 
+#define UART_IFLS_TXIFLSEL_S    0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the UART_O_IM register.
+//
+//*****************************************************************************
+#define UART_IM_LME5IM          0x00008000  // LIN mode edge 5 interrupt mask 
+                                            // 1: An interrupt is sent to the 
+                                            // interrupt controller when the 
+                                            // LME5RIS bit in the UARTRIS 
+                                            // register is set. 0: The LME5RIS 
+                                            // interrupt is suppressed and not 
+                                            // sent to the interrupt 
+                                            // controller. 
+#define UART_IM_LME5IM_M        0x00008000
+#define UART_IM_LME5IM_S        15
+#define UART_IM_LME1IM          0x00004000  // LIN mode edge 1 interrupt mask 
+                                            // 1: An interrupt is sent to the 
+                                            // interrupt controller when the 
+                                            // LME1RIS bit in the UARTRIS 
+                                            // register is set. 0: The LME1RIS 
+                                            // interrupt is suppressed and not 
+                                            // sent to the interrupt 
+                                            // controller. 
+#define UART_IM_LME1IM_M        0x00004000
+#define UART_IM_LME1IM_S        14
+#define UART_IM_LMSBIM          0x00002000  // LIN mode sync break interrupt 
+                                            // mask 1: An interrupt is sent to 
+                                            // the interrupt controller when 
+                                            // the LMSBRIS bit in the UARTRIS 
+                                            // register is set. 0: The LMSBRIS 
+                                            // interrupt is suppressed and not 
+                                            // sent to the interrupt 
+                                            // controller. 
+#define UART_IM_LMSBIM_M        0x00002000
+#define UART_IM_LMSBIM_S        13
+#define UART_IM_NINEBITIM       0x00001000  // 9-bit mode interrupt mask 1: An 
+                                            // interrupt is sent to the 
+                                            // interrupt controller when the 
+                                            // 9BITRIS bit in the UARTRIS 
+                                            // register is set. 0: The 9BITRIS 
+                                            // interrupt is suppressed and not 
+                                            // sent to the interrupt 
+                                            // controller. 
+#define UART_IM_NINEBITIM_M     0x00001000
+#define UART_IM_NINEBITIM_S     12
+#define UART_IM_OEIM            0x00000400  // UART overrun error interrupt 
+                                            // mask 1: An interrupt is sent to 
+                                            // the interrupt controller when 
+                                            // the OERIS bit in the UARTRIS 
+                                            // register is set. 0: The OERIS 
+                                            // interrupt is suppressed and not 
+                                            // sent to the interrupt 
+                                            // controller. 
+#define UART_IM_OEIM_M          0x00000400
+#define UART_IM_OEIM_S          10
+#define UART_IM_BEIM            0x00000200  // UART break error interrupt mask 
+                                            // 1: An interrupt is sent to the 
+                                            // interrupt controller when the 
+                                            // BERIS bit in the UARTRIS 
+                                            // register is set. 0: The BERIS 
+                                            // interrupt is suppressed and not 
+                                            // sent to the interrupt 
+                                            // controller. 
+#define UART_IM_BEIM_M          0x00000200
+#define UART_IM_BEIM_S          9
+#define UART_IM_PEIM            0x00000100  // UART parity error interrupt 
+                                            // mask 1: An interrupt is sent to 
+                                            // the interrupt controller when 
+                                            // the PERIS bit in the UARTRIS 
+                                            // register is set. 0: The PERIS 
+                                            // interrupt is suppressed and not 
+                                            // sent to the interrupt 
+                                            // controller. 
+#define UART_IM_PEIM_M          0x00000100
+#define UART_IM_PEIM_S          8
+#define UART_IM_FEIM            0x00000080  // UART framing error interrupt 
+                                            // mask 1: An interrupt is sent to 
+                                            // the interrupt controller when 
+                                            // the FERIS bit in the UARTRIS 
+                                            // register is set. 0: The FERIS 
+                                            // interrupt is suppressed and not 
+                                            // sent to the interrupt 
+                                            // controller. 
+#define UART_IM_FEIM_M          0x00000080
+#define UART_IM_FEIM_S          7
+#define UART_IM_RTIM            0x00000040  // UART receive time-out interrupt 
+                                            // mask 1: An interrupt is sent to 
+                                            // the interrupt controller when 
+                                            // the RTRIS bit in the UARTRIS 
+                                            // register is set. 0: The RTRIS 
+                                            // interrupt is suppressed and not 
+                                            // sent to the interrupt 
+                                            // controller. 
+#define UART_IM_RTIM_M          0x00000040
+#define UART_IM_RTIM_S          6
+#define UART_IM_TXIM            0x00000020  // UART transmit interrupt mask 1: 
+                                            // An interrupt is sent to the 
+                                            // interrupt controller when the 
+                                            // TXRIS bit in the UARTRIS 
+                                            // register is set. 0: The TXRIS 
+                                            // interrupt is suppressed and not 
+                                            // sent to the interrupt 
+                                            // controller. 
+#define UART_IM_TXIM_M          0x00000020
+#define UART_IM_TXIM_S          5
+#define UART_IM_RXIM            0x00000010  // UART receive interrupt mask 1: 
+                                            // An interrupt is sent to the 
+                                            // interrupt controller when the 
+                                            // RXRIS bit in the UARTRIS 
+                                            // register is set. 0: The RXRIS 
+                                            // interrupt is suppressed and not 
+                                            // sent to the interrupt 
+                                            // controller. 
+#define UART_IM_RXIM_M          0x00000010
+#define UART_IM_RXIM_S          4
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the UART_O_RIS register.
+//
+//*****************************************************************************
+#define UART_RIS_LME5RIS        0x00008000  // LIN mode edge 5 raw interrupt 
+                                            // status 1: The timer value at the 
+                                            // 5th falling edge of the LIN sync 
+                                            // field has been captured. 0: No 
+                                            // interrupt This bit is cleared by 
+                                            // writing 1 to the LME5IC bit in 
+                                            // the UARTICR register. 
+#define UART_RIS_LME5RIS_M      0x00008000
+#define UART_RIS_LME5RIS_S      15
+#define UART_RIS_LME1RIS        0x00004000  // LIN mode edge 1 raw interrupt 
+                                            // status 1: The timer value at the 
+                                            // 1st falling edge of the LIN Sync 
+                                            // Field has been captured. 0: No 
+                                            // interrupt This bit is cleared by 
+                                            // writing 1 to the LME1IC bit in 
+                                            // the UARTICR register. 
+#define UART_RIS_LME1RIS_M      0x00004000
+#define UART_RIS_LME1RIS_S      14
+#define UART_RIS_LMSBRIS        0x00002000  // LIN mode sync break raw 
+                                            // interrupt status 1: A LIN sync 
+                                            // break has been detected. 0: No 
+                                            // interrupt This bit is cleared by 
+                                            // writing 1 to the LMSBIC bit in 
+                                            // the UARTICR register. 
+#define UART_RIS_LMSBRIS_M      0x00002000
+#define UART_RIS_LMSBRIS_S      13
+#define UART_RIS_NINEBITRIS     0x00001000  // 9-mit mode raw interrupt status 
+                                            // 1: A receive address match has 
+                                            // occurred. 0: No interrupt This 
+                                            // bit is cleared by writing 1 to 
+                                            // the 9BITIC bit in the UARTICR 
+                                            // register. 
+#define UART_RIS_NINEBITRIS_M   0x00001000
+#define UART_RIS_NINEBITRIS_S   12
+#define UART_RIS_OERIS          0x00000400  // UART overrun error raw 
+                                            // interrupt status 1: An overrun 
+                                            // error has occurred. 0: No 
+                                            // interrupt This bit is cleared by 
+                                            // writing 1 to the OEIC bit in the 
+                                            // UARTICR register. 
+#define UART_RIS_OERIS_M        0x00000400
+#define UART_RIS_OERIS_S        10
+#define UART_RIS_BERIS          0x00000200  // UART break error raw interrupt 
+                                            // status 1: A break error has 
+                                            // occurred. 0: No interrupt This 
+                                            // bit is cleared by writing 1 to 
+                                            // the BEIC bit in the UARTICR 
+                                            // register. 
+#define UART_RIS_BERIS_M        0x00000200
+#define UART_RIS_BERIS_S        9
+#define UART_RIS_PERIS          0x00000100  // UART parity error raw interrupt 
+                                            // status 1: A parity error has 
+                                            // occurred. 0: No interrupt This 
+                                            // bit is cleared by writing 1 to 
+                                            // the PEIC bit in the UARTICR 
+                                            // register. 
+#define UART_RIS_PERIS_M        0x00000100
+#define UART_RIS_PERIS_S        8
+#define UART_RIS_FERIS          0x00000080  // UART framing error raw 
+                                            // interrupt status 1: A framing 
+                                            // error has occurred. 0: No 
+                                            // interrupt This bit is cleared by 
+                                            // writing 1 to the FEIC bit in the 
+                                            // UARTICR register. 
+#define UART_RIS_FERIS_M        0x00000080
+#define UART_RIS_FERIS_S        7
+#define UART_RIS_RTRIS          0x00000040  // UART receive time-out raw 
+                                            // interrupt status 1: A receive 
+                                            // time out has occurred. 0: No 
+                                            // interrupt This bit is cleared by 
+                                            // writing 1 to the RTIC bit in the 
+                                            // UARTICR register. 
+#define UART_RIS_RTRIS_M        0x00000040
+#define UART_RIS_RTRIS_S        6
+#define UART_RIS_TXRIS          0x00000020  // UART transmit raw interrupt 
+                                            // status 1: If the EOT bit in the 
+                                            // UARTCTL register is clear, the 
+                                            // transmit FIFO level has passed 
+                                            // through the condition defined in 
+                                            // the UARTIFLS register. If the 
+                                            // EOT bit is set, the last bit of 
+                                            // all transmitted data and flags 
+                                            // has left the serializer. 0: No 
+                                            // interrupt This bit is cleared by 
+                                            // writing 1 to the TXIC bit in the 
+                                            // UARTICR register. 
+#define UART_RIS_TXRIS_M        0x00000020
+#define UART_RIS_TXRIS_S        5
+#define UART_RIS_RXRIS          0x00000010  // UART receive raw interrupt 
+                                            // status 1: The receive FIFO level 
+                                            // has passed through the condition 
+                                            // defined in the UARTIFLS 
+                                            // register. 0: No interrupt This 
+                                            // bit is cleared by writing 1 to 
+                                            // the RXIC bit in the UARTICR 
+                                            // register. 
+#define UART_RIS_RXRIS_M        0x00000010
+#define UART_RIS_RXRIS_S        4
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the UART_O_MIS register.
+//
+//*****************************************************************************
+#define UART_MIS_LME5MIS        0x00008000  // LIN mode edge 5 masked 
+                                            // interrupt status 1: An unmasked 
+                                            // interrupt was signaled due to 
+                                            // the 5th falling edge of the LIN 
+                                            // sync field. 0: An interrupt has 
+                                            // not occurred or is masked. This 
+                                            // bit is cleared by writing 1 to 
+                                            // the LME5IC bit in the UARTICR 
+                                            // register. 
+#define UART_MIS_LME5MIS_M      0x00008000
+#define UART_MIS_LME5MIS_S      15
+#define UART_MIS_LME1MIS        0x00004000  // LIN mode edge 1 masked 
+                                            // interrupt status 1: An unmasked 
+                                            // interrupt was signaled due to 
+                                            // the 1st falling edge of the LIN 
+                                            // sync field. 0: An interrupt has 
+                                            // not occurred or is masked. This 
+                                            // bit is cleared by writing 1 to 
+                                            // the LME1IC bit in the UARTICR 
+                                            // register. 
+#define UART_MIS_LME1MIS_M      0x00004000
+#define UART_MIS_LME1MIS_S      14
+#define UART_MIS_LMSBMIS        0x00002000  // LIN mode sync break masked 
+                                            // interrupt status 1: An unmasked 
+                                            // interrupt was signaled due to 
+                                            // the receipt of a LIN sync break. 
+                                            // 0: An interrupt has not occurred 
+                                            // or is masked. This bit is 
+                                            // cleared by writing 1 to the 
+                                            // LMSBIC bit in the UARTICR 
+                                            // register. 
+#define UART_MIS_LMSBMIS_M      0x00002000
+#define UART_MIS_LMSBMIS_S      13
+#define UART_MIS_NINEBITMIS     0x00001000  // 9-bit mode masked interrupt 
+                                            // status 1: An unmasked interrupt 
+                                            // was signaled due to a receive 
+                                            // address match. 0: An interrupt 
+                                            // has not occurred or is masked. 
+                                            // This bit is cleared by writing 1 
+                                            // to the 9BITIC bit in the UARTICR 
+                                            // register. 
+#define UART_MIS_NINEBITMIS_M   0x00001000
+#define UART_MIS_NINEBITMIS_S   12
+#define UART_MIS_OEMIS          0x00000400  // UART overrun error masked 
+                                            // interrupt status 1: An unmasked 
+                                            // interrupt was signaled due to an 
+                                            // overrun error. 0: An interrupt 
+                                            // has not occurred or is masked. 
+                                            // This bit is cleared by writing 1 
+                                            // to the OEIC bit in the UARTICR 
+                                            // register. 
+#define UART_MIS_OEMIS_M        0x00000400
+#define UART_MIS_OEMIS_S        10
+#define UART_MIS_BEMIS          0x00000200  // UART break error masked 
+                                            // interrupt status 1: An unmasked 
+                                            // interrupt was signaled due to a 
+                                            // break error. 0: An interrupt has 
+                                            // not occurred or is masked. This 
+                                            // bit is cleared by writing 1 to 
+                                            // the BEIC bit in the UARTICR 
+                                            // register. 
+#define UART_MIS_BEMIS_M        0x00000200
+#define UART_MIS_BEMIS_S        9
+#define UART_MIS_PEMIS          0x00000100  // UART parity error masked 
+                                            // interrupt status 1: An unmasked 
+                                            // interrupt was signaled due to a 
+                                            // parity error. 0: An interrupt 
+                                            // has not occurred or is masked. 
+                                            // This bit is cleared by writing 1 
+                                            // to the PEIC bit in the UARTICR 
+                                            // register. 
+#define UART_MIS_PEMIS_M        0x00000100
+#define UART_MIS_PEMIS_S        8
+#define UART_MIS_FEMIS          0x00000080  // UART framing error masked 
+                                            // interrupt status 1: An unmasked 
+                                            // interrupt was signaled due to a 
+                                            // framing error. 0: An interrupt 
+                                            // has not occurred or is masked. 
+                                            // This bit is cleared by writing 1 
+                                            // to the FEIC bit in the UARTICR 
+                                            // register. 
+#define UART_MIS_FEMIS_M        0x00000080
+#define UART_MIS_FEMIS_S        7
+#define UART_MIS_RTMIS          0x00000040  // UART receive time-out masked 
+                                            // interrupt status 1: An unmasked 
+                                            // interrupt was signaled due to a 
+                                            // receive time out. 0: An 
+                                            // interrupt has not occurred or is 
+                                            // masked. This bit is cleared by 
+                                            // writing 1 to the RTIC bit in the 
+                                            // UARTICR register. 
+#define UART_MIS_RTMIS_M        0x00000040
+#define UART_MIS_RTMIS_S        6
+#define UART_MIS_TXMIS          0x00000020  // UART transmit masked interrupt 
+                                            // status 1: An unmasked interrupt 
+                                            // was signaled due to passing 
+                                            // through the specified transmit 
+                                            // FIFO level (if the EOT bit is 
+                                            // clear) or due to the 
+                                            // transmission of the last data 
+                                            // bit (if the EOT bit is set). 0: 
+                                            // An interrupt has not occurred or 
+                                            // is masked. This bit is cleared 
+                                            // by writing 1 to the TXIC bit in 
+                                            // the UARTICR register. 
+#define UART_MIS_TXMIS_M        0x00000020
+#define UART_MIS_TXMIS_S        5
+#define UART_MIS_RXMIS          0x00000010  // UART receive masked interrupt 
+                                            // status 1: An unmasked interrupt 
+                                            // was signaled due to passing 
+                                            // through the specified receive 
+                                            // FIFO level. 0: An interrupt has 
+                                            // not occurred or is masked. This 
+                                            // bit is cleared by writing 1 to 
+                                            // the RXIC bit in the UARTICR 
+                                            // register. 
+#define UART_MIS_RXMIS_M        0x00000010
+#define UART_MIS_RXMIS_S        4
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the UART_O_ICR register.
+//
+//*****************************************************************************
+#define UART_ICR_LME5IC         0x00008000  // LIN mode edge 5 interrupt clear 
+                                            // Writing 1 to this bit clears the 
+                                            // LME5RIS bit in the UARTRIS 
+                                            // register and the LME5MIS bit in 
+                                            // the UARTMIS register. 
+#define UART_ICR_LME5IC_M       0x00008000
+#define UART_ICR_LME5IC_S       15
+#define UART_ICR_LME1IC         0x00004000  // LIN mode edge 1 interrupt clear 
+                                            // Writing 1 to this bit clears the 
+                                            // LME1RIS bit in the UARTRIS 
+                                            // register and the LME1MIS bit in 
+                                            // the UARTMIS register. 
+#define UART_ICR_LME1IC_M       0x00004000
+#define UART_ICR_LME1IC_S       14
+#define UART_ICR_LMSBIC         0x00002000  // LIN mode sync break interrupt 
+                                            // clear Writing 1 to this bit 
+                                            // clears the LMSBRIS bit in the 
+                                            // UARTRIS register and the LMSBMIS 
+                                            // bit in the UARTMIS register. 
+#define UART_ICR_LMSBIC_M       0x00002000
+#define UART_ICR_LMSBIC_S       13
+#define UART_ICR_NINEBITIC      0x00001000  // 9-bit mode interrupt clear 
+                                            // Writing 1 to this bit clears the 
+                                            // 9BITRIS bit in the UARTRIS 
+                                            // register and the 9BITMIS bit in 
+                                            // the UARTMIS register. 
+#define UART_ICR_NINEBITIC_M    0x00001000
+#define UART_ICR_NINEBITIC_S    12
+#define UART_ICR_OEIC           0x00000400  // Overrun error interrupt clear 
+                                            // Writing 1 to this bit clears the 
+                                            // OERIS bit in the UARTRIS 
+                                            // register and the OEMIS bit in 
+                                            // the UARTMIS register. 
+#define UART_ICR_OEIC_M         0x00000400
+#define UART_ICR_OEIC_S         10
+#define UART_ICR_BEIC           0x00000200  // Break error interrupt clear 
+                                            // Writing 1 to this bit clears the 
+                                            // BERIS bit in the UARTRIS 
+                                            // register and the BEMIS bit in 
+                                            // the UARTMIS register. 
+#define UART_ICR_BEIC_M         0x00000200
+#define UART_ICR_BEIC_S         9
+#define UART_ICR_PEIC           0x00000100  // Parity error interrupt clear 
+                                            // Writing 1 to this bit clears the 
+                                            // PERIS bit in the UARTRIS 
+                                            // register and the PEMIS bit in 
+                                            // the UARTMIS register. 
+#define UART_ICR_PEIC_M         0x00000100
+#define UART_ICR_PEIC_S         8
+#define UART_ICR_FEIC           0x00000080  // Framing error interrupt clear 
+                                            // Writing 1 to this bit clears the 
+                                            // FERIS bit in the UARTRIS 
+                                            // register and the FEMIS bit in 
+                                            // the UARTMIS register. 
+#define UART_ICR_FEIC_M         0x00000080
+#define UART_ICR_FEIC_S         7
+#define UART_ICR_RTIC           0x00000040  // Receive time-out interrupt 
+                                            // clear Writing 1 to this bit 
+                                            // clears the RTRIS bit in the 
+                                            // UARTRIS register and the RTMIS 
+                                            // bit in the UARTMIS register. 
+#define UART_ICR_RTIC_M         0x00000040
+#define UART_ICR_RTIC_S         6
+#define UART_ICR_TXIC           0x00000020  // Transmit interrupt clear 
+                                            // Writing 1 to this bit clears the 
+                                            // TXRIS bit in the UARTRIS 
+                                            // register and the TXMIS bit in 
+                                            // the UARTMIS register. 
+#define UART_ICR_TXIC_M         0x00000020
+#define UART_ICR_TXIC_S         5
+#define UART_ICR_RXIC           0x00000010  // Receive interrupt clear Writing 
+                                            // 1 to this bit clears the RXRIS 
+                                            // bit in the UARTRIS register and 
+                                            // the RXMIS bit in the UARTMIS 
+                                            // register. 
+#define UART_ICR_RXIC_M         0x00000010
+#define UART_ICR_RXIC_S         4
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the UART_O_DMACTL register.
+//
+//*****************************************************************************
+#define UART_DMACTL_DMAERR      0x00000004  // DMA on error 1: uDMA receive 
+                                            // requests are automatically 
+                                            // disabled when a receive error 
+                                            // occurs. 0: uDMA receive requests 
+                                            // are unaffected when a receive 
+                                            // error occurs. 
+#define UART_DMACTL_DMAERR_M    0x00000004
+#define UART_DMACTL_DMAERR_S    2
+#define UART_DMACTL_TXDMAE      0x00000002  // Transmit DMA enable 1: uDMA for 
+                                            // the transmit FIFO is enabled. 0: 
+                                            // uDMA for the transmit FIFO is 
+                                            // disabled. 
+#define UART_DMACTL_TXDMAE_M    0x00000002
+#define UART_DMACTL_TXDMAE_S    1
+#define UART_DMACTL_RXDMAE      0x00000001  // Receive DMA enable 1: uDMA for 
+                                            // the receive FIFO is enabled. 0: 
+                                            // uDMA for the receive FIFO is 
+                                            // disabled. 
+#define UART_DMACTL_RXDMAE_M    0x00000001
+#define UART_DMACTL_RXDMAE_S    0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the UART_O_LCTL register.
+//
+//*****************************************************************************
+#define UART_LCTL_BLEN_M        0x00000030  // Sync break length 0x3: Sync 
+                                            // break length is 16T bits 0x2: 
+                                            // Sync break length is 15T bits 
+                                            // 0x1: Sync break length is 14T 
+                                            // bits 0x0: Sync break length is 
+                                            // 13T bits (default) 
+#define UART_LCTL_BLEN_S        4
+#define UART_LCTL_MASTER        0x00000001  // LIN master enable 1: The UART 
+                                            // operates as a LIN master. 0: The 
+                                            // UART operates as a LIN slave. 
+#define UART_LCTL_MASTER_M      0x00000001
+#define UART_LCTL_MASTER_S      0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the UART_O_LSS register.
+//
+//*****************************************************************************
+#define UART_LSS_TSS_M          0x0000FFFF  // Timer snap shot This field 
+                                            // contains the value of the 
+                                            // free-running timer when either 
+                                            // the sync edge 5 or the sync edge 
+                                            // 1 was detected. 
+#define UART_LSS_TSS_S          0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the UART_O_LTIM register.
+//
+//*****************************************************************************
+#define UART_LTIM_TIMER_M       0x0000FFFF  // Timer value This field contains 
+                                            // the value of the free-running 
+                                            // timer. 
+#define UART_LTIM_TIMER_S       0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// UART_O_NINEBITADDR register.
+//
+//*****************************************************************************
+#define UART_NINEBITADDR_NINEBITEN \
+                                0x00008000  // Enable 9-bit mode 1: 9-bit mode 
+                                            // is enabled. 0: 9-bit mode is 
+                                            // disabled. 
+
+#define UART_NINEBITADDR_NINEBITEN_M \
+                                0x00008000
+#define UART_NINEBITADDR_NINEBITEN_S 15
+#define UART_NINEBITADDR_ADDR_M 0x000000FF  // Self address for 9-bit mode 
+                                            // This field contains the address 
+                                            // that should be matched when 
+                                            // UART9BITAMASK is 0xFF. 
+#define UART_NINEBITADDR_ADDR_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// UART_O_NINEBITAMASK register.
+//
+//*****************************************************************************
+#define UART_NINEBITAMASK_RANGE_M \
+                                0x0000FF00  // Self address range for 9-bit 
+                                            // mode Writing to the RANGE field 
+                                            // does not have any effect; 
+                                            // reading it reflects the ANDed 
+                                            // output of the ADDR field in the 
+                                            // UART9BITADDR register and the 
+                                            // MASK field. 
+
+#define UART_NINEBITAMASK_RANGE_S 8
+#define UART_NINEBITAMASK_MASK_M \
+                                0x000000FF  // Self Address Mask for 9-Bit 
+                                            // Mode This field contains the 
+                                            // address mask that creates a 
+                                            // range of addresses that should 
+                                            // be matched. 
+
+#define UART_NINEBITAMASK_MASK_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the UART_O_PP register.
+//
+//*****************************************************************************
+#define UART_PP_NB              0x00000002  // 9-bit support 1: The UART 
+                                            // module provides support for the 
+                                            // transmission of 9-bit data for 
+                                            // RS-485 support. 0: The UART 
+                                            // module does not provide support 
+                                            // for the transmission of 9-bit 
+                                            // data for RS-485 support. 
+#define UART_PP_NB_M            0x00000002
+#define UART_PP_NB_S            1
+#define UART_PP_SC              0x00000001  // Smart card support 1: The UART 
+                                            // module provides smart card 
+                                            // support. 0: The UART module does 
+                                            // not provide smart card support. 
+#define UART_PP_SC_M            0x00000001
+#define UART_PP_SC_S            0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the UART_O_CC register.
+//
+//*****************************************************************************
+#define UART_CC_CS_M            0x00000007  // UART baud and system clock 
+                                            // source The following bits 
+                                            // determine the clock source that 
+                                            // generates the baud and system 
+                                            // clocks for the UART. bit0 
+                                            // (PIOSC): 1: The UART baud clock 
+                                            // is determined by the IO DIV 
+                                            // setting in the system 
+                                            // controller. 0: The UART baud 
+                                            // clock is determined by the SYS 
+                                            // DIV setting in the system 
+                                            // controller. bit1: Unused bit2: 
+                                            // (DSEN) Only meaningful when the 
+                                            // system is in deep sleep mode. 
+                                            // This bit is a don't care when 
+                                            // not in sleep mode. 1: The UART 
+                                            // system clock is running on the 
+                                            // same clock as the baud clock, as 
+                                            // per PIOSC setting above. 0: The 
+                                            // UART system clock is determined 
+                                            // by the SYS DIV setting in the 
+                                            // system controller. 
+#define UART_CC_CS_S            0
+
+
+#endif // __HW_UART_H__
+

--- a/cpu/cc2538/include/vendor/hw_udma.h
+++ b/cpu/cc2538/include/vendor/hw_udma.h
@@ -1,0 +1,744 @@
+/******************************************************************************
+*  Filename:       hw_udma.h
+*  Revised:        $Date: 2013-04-30 17:13:44 +0200 (Tue, 30 Apr 2013) $
+*  Revision:       $Revision: 9943 $
+*
+*  Copyright (C) 2013 Texas Instruments Incorporated - http://www.ti.com/
+*
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*    Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+*
+*    Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+*
+*    Neither the name of Texas Instruments Incorporated nor the names of
+*    its contributors may be used to endorse or promote products derived
+*    from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+*  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+*  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+*  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+*  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+*  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+*  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+*  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+*  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+******************************************************************************/
+
+#ifndef __HW_UDMA_H__
+#define __HW_UDMA_H__
+
+//*****************************************************************************
+//
+// The following are defines for the UDMA register offsets.
+//
+//*****************************************************************************
+#define UDMA_STAT               0x400FF000  // DMA status The STAT register 
+                                            // returns the status of the uDMA 
+                                            // controller. This register cannot 
+                                            // be read when the uDMA controller 
+                                            // is in the reset state. 
+#define UDMA_CFG                0x400FF004  // DMA configuration The CFG 
+                                            // register controls the 
+                                            // configuration of the uDMA 
+                                            // controller. 
+#define UDMA_CTLBASE            0x400FF008  // DMA channel control base 
+                                            // pointer The CTLBASE register 
+                                            // must be configured so that the 
+                                            // base pointer points to a 
+                                            // location in system memory. The 
+                                            // amount of system memory that 
+                                            // must be assigned to the uDMA 
+                                            // controller depends on the number 
+                                            // of uDMA channels used and 
+                                            // whether the alternate channel 
+                                            // control data structure is used. 
+                                            // See Section 10.2.5 for details 
+                                            // about the Channel Control Table. 
+                                            // The base address must be aligned 
+                                            // on a 1024-byte boundary. This 
+                                            // register cannot be read when the 
+                                            // uDMA controller is in the reset 
+                                            // state. 
+#define UDMA_ALTBASE            0x400FF00C  // DMA alternate channel control 
+                                            // base pointer The ALTBASE 
+                                            // register returns the base 
+                                            // address of the alternate channel 
+                                            // control data. This register 
+                                            // removes the necessity for 
+                                            // application software to 
+                                            // calculate the base address of 
+                                            // the alternate channel control 
+                                            // structures. This register cannot 
+                                            // be read when the uDMA controller 
+                                            // is in the reset state. 
+#define UDMA_WAITSTAT           0x400FF010  // DMA channel wait-on-request 
+                                            // status This read-only register 
+                                            // indicates that the uDMA channel 
+                                            // is waiting on a request. A 
+                                            // peripheral can hold off the uDMA 
+                                            // from performing a single request 
+                                            // until the peripheral is ready 
+                                            // for a burst request to enhance 
+                                            // the uDMA performance. The use of 
+                                            // this feature is dependent on the 
+                                            // design of the peripheral and is 
+                                            // not controllable by software in 
+                                            // any way. This register cannot be 
+                                            // read when the uDMA controller is 
+                                            // in the reset state. 
+#define UDMA_SWREQ              0x400FF014  // DMA channel software request 
+                                            // Each bit of the SWREQ register 
+                                            // represents the corresponding 
+                                            // uDMA channel. Setting a bit 
+                                            // generates a request for the 
+                                            // specified uDMA channel. 
+#define UDMA_USEBURSTSET        0x400FF018  // DMA channel useburst set Each 
+                                            // bit of the USEBURSTSET register 
+                                            // represents the corresponding 
+                                            // uDMA channel. Setting a bit 
+                                            // disables the channel single 
+                                            // request input from generating 
+                                            // requests, configuring the 
+                                            // channel to only accept burst 
+                                            // requests. Reading the register 
+                                            // returns the status of USEBURST. 
+                                            // If the amount of data to 
+                                            // transfer is a multiple of the 
+                                            // arbitration (burst) size, the 
+                                            // corresponding SET[n] bit is 
+                                            // cleared after completing the 
+                                            // final transfer. If there are 
+                                            // fewer items remaining to 
+                                            // transfer than the arbitration 
+                                            // (burst) size, the uDMA 
+                                            // controller automatically clears 
+                                            // the corresponding SET[n] bit, 
+                                            // allowing the remaining items to 
+                                            // transfer using single requests. 
+                                            // To resume transfers using burst 
+                                            // requests, the corresponding bit 
+                                            // must be set again. A bit must 
+                                            // not be set if the corresponding 
+                                            // peripheral does not support the 
+                                            // burst request model. 
+#define UDMA_USEBURSTCLR        0x400FF01C  // DMA channel useburst clear Each 
+                                            // bit of the USEBURSTCLR register 
+                                            // represents the corresponding 
+                                            // uDMA channel. Setting a bit 
+                                            // clears the corresponding SET[n] 
+                                            // bit in the USEBURSTSET register. 
+#define UDMA_REQMASKSET         0x400FF020  // DMA channel request mask set 
+                                            // Each bit of the REQMASKSET 
+                                            // register represents the 
+                                            // corresponding uDMA channel. 
+                                            // Setting a bit disables uDMA 
+                                            // requests for the channel. 
+                                            // Reading the register returns the 
+                                            // request mask status. When a uDMA 
+                                            // channel request is masked, that 
+                                            // means the peripheral can no 
+                                            // longer request uDMA transfers. 
+                                            // The channel can then be used for 
+                                            // software-initiated transfers. 
+#define UDMA_REQMASKCLR         0x400FF024  // DMA channel request mask clear 
+                                            // Each bit of the REQMASKCLR 
+                                            // register represents the 
+                                            // corresponding uDMA channel. 
+                                            // Setting a bit clears the 
+                                            // corresponding SET[n] bit in the 
+                                            // REQMASKSET register. 
+#define UDMA_ENASET             0x400FF028  // DMA channel enable set Each bit 
+                                            // of the ENASET register 
+                                            // represents the corresponding 
+                                            // uDMA channel. Setting a bit 
+                                            // enables the corresponding uDMA 
+                                            // channel. Reading the register 
+                                            // returns the enable status of the 
+                                            // channels. If a channel is 
+                                            // enabled but the request mask is 
+                                            // set (REQMASKSET), then the 
+                                            // channel can be used for 
+                                            // software-initiated transfers. 
+#define UDMA_ENACLR             0x400FF02C  // DMA channel enable clear Each 
+                                            // bit of the ENACLR register 
+                                            // represents the corresponding 
+                                            // uDMA channel. Setting a bit 
+                                            // clears the corresponding SET[n] 
+                                            // bit in the ENASET register. 
+#define UDMA_ALTSET             0x400FF030  // DMA channel primary alternate 
+                                            // set Each bit of the ALTSET 
+                                            // register represents the 
+                                            // corresponding uDMA channel. 
+                                            // Setting a bit configures the 
+                                            // uDMA channel to use the 
+                                            // alternate control data 
+                                            // structure. Reading the register 
+                                            // returns the status of which 
+                                            // control data structure is in use 
+                                            // for the corresponding uDMA 
+                                            // channel. 
+#define UDMA_ALTCLR             0x400FF034  // DMA channel primary alternate 
+                                            // clear Each bit of the ALTCLR 
+                                            // register represents the 
+                                            // corresponding uDMA channel. 
+                                            // Setting a bit clears the 
+                                            // corresponding SET[n] bit in the 
+                                            // ALTSET register. 
+#define UDMA_PRIOSET            0x400FF038  // DMA channel priority set Each 
+                                            // bit of the PRIOSET register 
+                                            // represents the corresponding 
+                                            // uDMA channel. Setting a bit 
+                                            // configures the uDMA channel to 
+                                            // have a high priority level. 
+                                            // Reading the register returns the 
+                                            // status of the channel priority 
+                                            // mask. 
+#define UDMA_PRIOCLR            0x400FF03C  // DMA channel priority clear Each 
+                                            // bit of the DMAPRIOCLR register 
+                                            // represents the corresponding 
+                                            // uDMA channel. Setting a bit 
+                                            // clears the corresponding SET[n] 
+                                            // bit in the PRIOSET register. 
+#define UDMA_ERRCLR             0x400FF04C  // DMA bus error clear The ERRCLR 
+                                            // register is used to read and 
+                                            // clear the uDMA bus error status. 
+                                            // The error status is set if the 
+                                            // uDMA controller encountered a 
+                                            // bus error while performing a 
+                                            // transfer. If a bus error occurs 
+                                            // on a channel, that channel is 
+                                            // automatically disabled by the 
+                                            // uDMA controller. The other 
+                                            // channels are unaffected. 
+#define UDMA_CHASGN             0x400FF500  // DMA channel assignment Each bit 
+                                            // of the CHASGN register 
+                                            // represents the corresponding 
+                                            // uDMA channel. Setting a bit 
+                                            // selects the secondary channel 
+                                            // assignment as specified in the 
+                                            // section "Channel Assignments" 
+#define UDMA_CHIS               0x400FF504  // DMA channel interrupt status 
+                                            // Each bit of the CHIS register 
+                                            // represents the corresponding 
+                                            // uDMA channel. A bit is set when 
+                                            // that uDMA channel causes a 
+                                            // completion interrupt. The bits 
+                                            // are cleared by writing 1. 
+#define UDMA_CHMAP0             0x400FF510  // DMA channel map select 0 Each 
+                                            // 4-bit field of the CHMAP0 
+                                            // register configures the uDMA 
+                                            // channel assignment as specified 
+                                            // in the uDMA channel assignment 
+                                            // table in the "Channel 
+                                            // Assignments" section. 
+#define UDMA_CHMAP1             0x400FF514  // DMA channel map select 1 Each 
+                                            // 4-bit field of the CHMAP1 
+                                            // register configures the uDMA 
+                                            // channel assignment as specified 
+                                            // in the uDMA channel assignment 
+                                            // table in the "Channel 
+                                            // Assignments" section. 
+#define UDMA_CHMAP2             0x400FF518  // DMA channel map select 2 Each 
+                                            // 4-bit field of the CHMAP2 
+                                            // register configures the uDMA 
+                                            // channel assignment as specified 
+                                            // in the uDMA channel assignment 
+                                            // table in the "Channel 
+                                            // Assignments" section. 
+#define UDMA_CHMAP3             0x400FF51C  // DMA channel map select 3 Each 
+                                            // 4-bit field of the CHMAP3 
+                                            // register configures the uDMA 
+                                            // channel assignment as specified 
+                                            // in the uDMA channel assignment 
+                                            // table in the "Channel 
+                                            // Assignments" section. 
+
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the UDMA_STAT register.
+//
+//*****************************************************************************
+#define UDMA_STAT_DMACHANS_M    0x001F0000  // Available uDMA channels minus 1 
+                                            // This field contains a value 
+                                            // equal to the number of uDMA 
+                                            // channels the uDMA controller is 
+                                            // configured to use, minus one. 
+                                            // The value of 0x1F corresponds to 
+                                            // 32 uDMA channels. 
+#define UDMA_STAT_DMACHANS_S    16
+#define UDMA_STAT_STATE_M       0x000000F0  // Control state machine status 
+                                            // This field shows the current 
+                                            // status of the control 
+                                            // state-machine. Status can be one 
+                                            // of the following: 0x0: Idle 0x1: 
+                                            // Reading channel controller data 
+                                            // 0x2: Reading source end pointer 
+                                            // 0x3: Reading destination end 
+                                            // pointer 0x4: Reading source data 
+                                            // 0x5: Writing destination data 
+                                            // 0x6: Waiting for uDMA request to 
+                                            // clear 0x7: Writing channel 
+                                            // controller data 0x8: Stalled 
+                                            // 0x9: Done 0xA-0xF: Undefined 
+#define UDMA_STAT_STATE_S       4
+#define UDMA_STAT_MASTEN        0x00000001  // Master enable status 0: The 
+                                            // uDMA controller is disabled. 1: 
+                                            // The uDMA controller is enabled. 
+#define UDMA_STAT_MASTEN_M      0x00000001
+#define UDMA_STAT_MASTEN_S      0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the UDMA_CFG register.
+//
+//*****************************************************************************
+#define UDMA_CFG_MASTEN         0x00000001  // Controller master enable 0: 
+                                            // Disables the uDMA controller. 1: 
+                                            // Enables the uDMA controller. 
+#define UDMA_CFG_MASTEN_M       0x00000001
+#define UDMA_CFG_MASTEN_S       0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the UDMA_CTLBASE register.
+//
+//*****************************************************************************
+#define UDMA_CTLBASE_ADDR_M     0xFFFFFC00  // Channel control base address 
+                                            // This field contains the pointer 
+                                            // to the base address of the 
+                                            // channel control table. The base 
+                                            // address must be 1024-byte 
+                                            // alligned. 
+#define UDMA_CTLBASE_ADDR_S     10
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the UDMA_ALTBASE register.
+//
+//*****************************************************************************
+#define UDMA_ALTBASE_ADDR_M     0xFFFFFFFF  // Alternate channel address 
+                                            // pointer This field provides the 
+                                            // base address of the alternate 
+                                            // channel control structures. 
+#define UDMA_ALTBASE_ADDR_S     0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// UDMA_WAITSTAT register.
+//
+//*****************************************************************************
+#define UDMA_WAITSTAT_WAITREQ_M 0xFFFFFFFF  // Channel [n] wait status These 
+                                            // bits provide the tchannel 
+                                            // wait-on-request status. Bit 0 
+                                            // corresponds to channel 0. 1: The 
+                                            // corresponding channel is waiting 
+                                            // on a request. 0: The 
+                                            // corresponding channel is not 
+                                            // waiting on a request. 
+#define UDMA_WAITSTAT_WAITREQ_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the UDMA_SWREQ register.
+//
+//*****************************************************************************
+#define UDMA_SWREQ_SWREQ_M      0xFFFFFFFF  // Channel [n] software request 
+                                            // These bits generate software 
+                                            // requests. Bit 0 corresponds to 
+                                            // channel 0. 1: Generate a 
+                                            // software request for the 
+                                            // corresponding channel 0: No 
+                                            // request generated These bits are 
+                                            // automatically cleared when the 
+                                            // software request has been 
+                                            // completed. 
+#define UDMA_SWREQ_SWREQ_S      0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// UDMA_USEBURSTSET register.
+//
+//*****************************************************************************
+#define UDMA_USEBURSTSET_SET_M  0xFFFFFFFF  // Channel [n] useburst set 0: 
+                                            // uDMA channel [n] responds to 
+                                            // single or burst requests. 1: 
+                                            // uDMA channel [n] responds only 
+                                            // to burst requests. Bit 0 
+                                            // corresponds to channel 0. This 
+                                            // bit is automatically cleared as 
+                                            // described above. A bit can also 
+                                            // be manually cleared by setting 
+                                            // the corresponding CLR[n] bit in 
+                                            // the DMAUSEBURSTCLR register. 
+#define UDMA_USEBURSTSET_SET_S  0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// UDMA_USEBURSTCLR register.
+//
+//*****************************************************************************
+#define UDMA_USEBURSTCLR_CLR_M  0xFFFFFFFF  // Channel [n] useburst clear 0: 
+                                            // No effect 1: Setting a bit 
+                                            // clears the corresponding SET[n] 
+                                            // bit in the DMAUSEBURSTSET 
+                                            // register meaning that uDMA 
+                                            // channel [n] responds to single 
+                                            // and burst requests. 
+#define UDMA_USEBURSTCLR_CLR_S  0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// UDMA_REQMASKSET register.
+//
+//*****************************************************************************
+#define UDMA_REQMASKSET_SET_M   0xFFFFFFFF  // Channel [n] request mask set 0: 
+                                            // The peripheral associated with 
+                                            // channel [n] is enabled to 
+                                            // request uDMA transfers 1: The 
+                                            // peripheral associated with 
+                                            // channel [n] is not able to 
+                                            // request uDMA transfers. Channel 
+                                            // [n] may be used for 
+                                            // software-initiated transfers. 
+                                            // Bit 0 corresponds to channel 0. 
+                                            // A bit can only be cleared by 
+                                            // setting the corresponding CLR[n] 
+                                            // bit in the DMAREQMASKCLR 
+                                            // register. 
+#define UDMA_REQMASKSET_SET_S   0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// UDMA_REQMASKCLR register.
+//
+//*****************************************************************************
+#define UDMA_REQMASKCLR_CLR_M   0xFFFFFFFF  // Channel [n] request mask clear 
+                                            // 0: No effect 1: Setting a bit 
+                                            // clears the corresponding SET[n] 
+                                            // bit in the DMAREQMASKSET 
+                                            // register meaning that the 
+                                            // peripheral associated with 
+                                            // channel [n] is enabled to 
+                                            // request uDMA transfers. 
+#define UDMA_REQMASKCLR_CLR_S   0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the UDMA_ENASET register.
+//
+//*****************************************************************************
+#define UDMA_ENASET_SET_M       0xFFFFFFFF  // Channel [n] enable set 0: uDMA 
+                                            // channel [n] is disabled 1: uDMA 
+                                            // channel [n] is enabled Bit 0 
+                                            // corresponds to channel 0. A bit 
+                                            // can only be cleared by setting 
+                                            // the corresponding CLR[n] bit in 
+                                            // the DMAENACLR register. 
+#define UDMA_ENASET_SET_S       0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the UDMA_ENACLR register.
+//
+//*****************************************************************************
+#define UDMA_ENACLR_CLR_M       0xFFFFFFFF  // Channel [n] enable clear 0: No 
+                                            // effect 1: Setting a bit clears 
+                                            // the corresponding SET[n] bit in 
+                                            // the DMAENASET register meaning 
+                                            // that channel [n] is disabled for 
+                                            // uDMA transfers. Note: The 
+                                            // controller disables a channel 
+                                            // when it completes the uDMA 
+                                            // cycle. 
+#define UDMA_ENACLR_CLR_S       0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the UDMA_ALTSET register.
+//
+//*****************************************************************************
+#define UDMA_ALTSET_SET_M       0xFFFFFFFF  // Channel [n] alternate set 0: 
+                                            // uDMA channel [n] is using the 
+                                            // primary control structure 1: 
+                                            // uDMA channel [n] is using the 
+                                            // alternate control structure Bit 
+                                            // 0 corresponds to channel 0. A 
+                                            // bit can only be cleared by 
+                                            // setting the corresponding CLR[n] 
+                                            // bit in the DMAALTCLR register. 
+                                            // Note: For Ping-Pong and 
+                                            // Scatter-Gather cycle types, the 
+                                            // uDMA controller automatically 
+                                            // sets these bits to select the 
+                                            // alternate channel control data 
+                                            // structure. 
+#define UDMA_ALTSET_SET_S       0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the UDMA_ALTCLR register.
+//
+//*****************************************************************************
+#define UDMA_ALTCLR_CLR_M       0xFFFFFFFF  // Channel [n] alternate clear 0: 
+                                            // No effect 1: Setting a bit 
+                                            // clears the corresponding SET[n] 
+                                            // bit in the DMAALTSET register 
+                                            // meaning that channel [n] is 
+                                            // using the primary control 
+                                            // structure. Note: For Ping-Pong 
+                                            // and Scatter-Gather cycle types, 
+                                            // the uDMA controller 
+                                            // automatically sets these bits to 
+                                            // select the alternate channel 
+                                            // control data structure. 
+#define UDMA_ALTCLR_CLR_S       0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the UDMA_PRIOSET register.
+//
+//*****************************************************************************
+#define UDMA_PRIOSET_SET_M      0xFFFFFFFF  // Channel [n] priority set 0: 
+                                            // uDMA channel [n] is using the 
+                                            // default priority level 1: uDMA 
+                                            // channel [n] is using a high 
+                                            // priority level Bit 0 corresponds 
+                                            // to channel 0. A bit can only be 
+                                            // cleared by setting the 
+                                            // corresponding CLR[n] bit in the 
+                                            // DMAPRIOCLR register. 
+#define UDMA_PRIOSET_SET_S      0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the UDMA_PRIOCLR register.
+//
+//*****************************************************************************
+#define UDMA_PRIOCLR_CLR_M      0xFFFFFFFF  // Channel [n] priority clear 0: 
+                                            // No effect 1: Setting a bit 
+                                            // clears the corresponding SET[n] 
+                                            // bit in the DMAPRIOSET register 
+                                            // meaning that channel [n] is 
+                                            // using the default priority 
+                                            // level. 
+#define UDMA_PRIOCLR_CLR_S      0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the UDMA_ERRCLR register.
+//
+//*****************************************************************************
+#define UDMA_ERRCLR_ERRCLR      0x00000001  // uDMA bus error status 0: No bus 
+                                            // error is pending 1: A bus error 
+                                            // is pending This bit is cleared 
+                                            // by writing 1 to it. 
+#define UDMA_ERRCLR_ERRCLR_M    0x00000001
+#define UDMA_ERRCLR_ERRCLR_S    0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the UDMA_CHASGN register.
+//
+//*****************************************************************************
+#define UDMA_CHASGN_CHASGN_M    0xFFFFFFFF  // Channel [n] assignment select 
+                                            // 0: Use the primary channel 
+                                            // assignment 1: Use the secondary 
+                                            // channel assignment 
+#define UDMA_CHASGN_CHASGN_S    0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the UDMA_CHIS register.
+//
+//*****************************************************************************
+#define UDMA_CHIS_CHIS_M        0xFFFFFFFF  // Channel [n] interrupt status 0: 
+                                            // The corresponding uDMA channel 
+                                            // has not caused an interrupt. 1: 
+                                            // The corresponding uDMA channel 
+                                            // has caused an interrupt. This 
+                                            // bit is cleared by writing 1 to 
+                                            // it. 
+#define UDMA_CHIS_CHIS_S        0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the UDMA_CHMAP0 register.
+//
+//*****************************************************************************
+#define UDMA_CHMAP0_CH7SEL_M    0xF0000000  // uDMA channel 7 source select 
+                                            // See section titled "Channel 
+                                            // Assignments" in Micro Direct 
+                                            // Memory Access chapter. 
+#define UDMA_CHMAP0_CH7SEL_S    28
+#define UDMA_CHMAP0_CH6SEL_M    0x0F000000  // uDMA channel 6 source select 
+                                            // See section titled "Channel 
+                                            // Assignments" in Micro Direct 
+                                            // Memory Access chapter. 
+#define UDMA_CHMAP0_CH6SEL_S    24
+#define UDMA_CHMAP0_CH5SEL_M    0x00F00000  // uDMA channel 5 source select 
+                                            // See section titled "Channel 
+                                            // Assignments" in Micro Direct 
+                                            // Memory Access chapter. 
+#define UDMA_CHMAP0_CH5SEL_S    20
+#define UDMA_CHMAP0_CH4SEL_M    0x000F0000  // uDMA channel 4 source select 
+                                            // See section titled "Channel 
+                                            // Assignments" in Micro Direct 
+                                            // Memory Access chapter. 
+#define UDMA_CHMAP0_CH4SEL_S    16
+#define UDMA_CHMAP0_CH3SEL_M    0x0000F000  // uDMA channel 3 source select 
+                                            // See section titled "Channel 
+                                            // Assignments" in Micro Direct 
+                                            // Memory Access chapter. 
+#define UDMA_CHMAP0_CH3SEL_S    12
+#define UDMA_CHMAP0_CH2SEL_M    0x00000F00  // uDMA channel 2 source select 
+                                            // See section titled "Channel 
+                                            // Assignments" in Micro Direct 
+                                            // Memory Access chapter. 
+#define UDMA_CHMAP0_CH2SEL_S    8
+#define UDMA_CHMAP0_CH1SEL_M    0x000000F0  // uDMA channel 1 source select 
+                                            // See section titled "Channel 
+                                            // Assignments" in Micro Direct 
+                                            // Memory Access chapter. 
+#define UDMA_CHMAP0_CH1SEL_S    4
+#define UDMA_CHMAP0_CH0SEL_M    0x0000000F  // uDMA channel 0 source select 
+                                            // See section titled "Channel 
+                                            // Assignments" in Micro Direct 
+                                            // Memory Access chapter. 
+#define UDMA_CHMAP0_CH0SEL_S    0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the UDMA_CHMAP1 register.
+//
+//*****************************************************************************
+#define UDMA_CHMAP1_CH15SEL_M   0xF0000000  // uDMA channel 15 source select 
+                                            // See section titled "Channel 
+                                            // Assignments" in Micro Direct 
+                                            // Memory Access chapter. 
+#define UDMA_CHMAP1_CH15SEL_S   28
+#define UDMA_CHMAP1_CH14SEL_M   0x0F000000  // uDMA channel 14 source select 
+                                            // See section titled "Channel 
+                                            // Assignments" in Micro Direct 
+                                            // Memory Access chapter. 
+#define UDMA_CHMAP1_CH14SEL_S   24
+#define UDMA_CHMAP1_CH13SEL_M   0x00F00000  // uDMA channel 13 source select 
+                                            // See section titled "Channel 
+                                            // Assignments" in Micro Direct 
+                                            // Memory Access chapter. 
+#define UDMA_CHMAP1_CH13SEL_S   20
+#define UDMA_CHMAP1_CH12SEL_M   0x000F0000  // uDMA channel 12 source select 
+                                            // See section titled "Channel 
+                                            // Assignments" in Micro Direct 
+                                            // Memory Access chapter. 
+#define UDMA_CHMAP1_CH12SEL_S   16
+#define UDMA_CHMAP1_CH11SEL_M   0x0000F000  // uDMA channel 11 source select 
+                                            // See section titled "Channel 
+                                            // Assignments" in Micro Direct 
+                                            // Memory Access chapter. 
+#define UDMA_CHMAP1_CH11SEL_S   12
+#define UDMA_CHMAP1_CH10SEL_M   0x00000F00  // uDMA channel 10 source select 
+                                            // See section titled "Channel 
+                                            // Assignments" in Micro Direct 
+                                            // Memory Access chapter. 
+#define UDMA_CHMAP1_CH10SEL_S   8
+#define UDMA_CHMAP1_CH9SEL_M    0x000000F0  // uDMA channel 9 source select 
+                                            // See section titled "Channel 
+                                            // Assignments" in Micro Direct 
+                                            // Memory Access chapter. 
+#define UDMA_CHMAP1_CH9SEL_S    4
+#define UDMA_CHMAP1_CH8SEL_M    0x0000000F  // uDMA channel 8 source select 
+                                            // See section titled "Channel 
+                                            // Assignments" in Micro Direct 
+                                            // Memory Access chapter. 
+#define UDMA_CHMAP1_CH8SEL_S    0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the UDMA_CHMAP2 register.
+//
+//*****************************************************************************
+#define UDMA_CHMAP2_CH23SEL_M   0xF0000000  // uDMA channel 23 source select 
+                                            // See section titled "Channel 
+                                            // Assignments" in Micro Direct 
+                                            // Memory Access chapter. 
+#define UDMA_CHMAP2_CH23SEL_S   28
+#define UDMA_CHMAP2_CH22SEL_M   0x0F000000  // uDMA channel 22 source select 
+                                            // See section titled "Channel 
+                                            // Assignments" in Micro Direct 
+                                            // Memory Access chapter. 
+#define UDMA_CHMAP2_CH22SEL_S   24
+#define UDMA_CHMAP2_CH21SEL_M   0x00F00000  // uDMA channel 21 source select 
+                                            // See section titled "Channel 
+                                            // Assignments" in Micro Direct 
+                                            // Memory Access chapter. 
+#define UDMA_CHMAP2_CH21SEL_S   20
+#define UDMA_CHMAP2_CH20SEL_M   0x000F0000  // uDMA channel 20 source select 
+                                            // See section titled "Channel 
+                                            // Assignments" in Micro Direct 
+                                            // Memory Access chapter. 
+#define UDMA_CHMAP2_CH20SEL_S   16
+#define UDMA_CHMAP2_CH19SEL_M   0x0000F000  // uDMA channel 19 source select 
+                                            // See section titled "Channel 
+                                            // Assignments" in Micro Direct 
+                                            // Memory Access chapter. 
+#define UDMA_CHMAP2_CH19SEL_S   12
+#define UDMA_CHMAP2_CH18SEL_M   0x00000F00  // uDMA channel 18 source select 
+                                            // See section titled "Channel 
+                                            // Assignments" in Micro Direct 
+                                            // Memory Access chapter. 
+#define UDMA_CHMAP2_CH18SEL_S   8
+#define UDMA_CHMAP2_CH17SEL_M   0x000000F0  // uDMA channel 17 source select 
+                                            // See section titled "Channel 
+                                            // Assignments" in Micro Direct 
+                                            // Memory Access chapter. 
+#define UDMA_CHMAP2_CH17SEL_S   4
+#define UDMA_CHMAP2_CH16SEL_M   0x0000000F  // uDMA channel 16 source select 
+                                            // See section titled "Channel 
+                                            // Assignments" in Micro Direct 
+                                            // Memory Access chapter. 
+#define UDMA_CHMAP2_CH16SEL_S   0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the UDMA_CHMAP3 register.
+//
+//*****************************************************************************
+#define UDMA_CHMAP3_CH31SEL_M   0xF0000000  // uDMA channel 31 source select 
+                                            // See section titled "Channel 
+                                            // Assignments" in Micro Direct 
+                                            // Memory Access chapter. 
+#define UDMA_CHMAP3_CH31SEL_S   28
+#define UDMA_CHMAP3_CH30SEL_M   0x0F000000  // uDMA channel 30 source select 
+                                            // See section titled "Channel 
+                                            // Assignments" in Micro Direct 
+                                            // Memory Access chapter. 
+#define UDMA_CHMAP3_CH30SEL_S   24
+#define UDMA_CHMAP3_CH29SEL_M   0x00F00000  // uDMA channel 29 source select 
+                                            // See section titled "Channel 
+                                            // Assignments" in Micro Direct 
+                                            // Memory Access chapter. 
+#define UDMA_CHMAP3_CH29SEL_S   20
+#define UDMA_CHMAP3_CH28SEL_M   0x000F0000  // uDMA channel 28 source select 
+                                            // See section titled "Channel 
+                                            // Assignments" in Micro Direct 
+                                            // Memory Access chapter. 
+#define UDMA_CHMAP3_CH28SEL_S   16
+#define UDMA_CHMAP3_CH27SEL_M   0x0000F000  // uDMA channel 27 source select 
+                                            // See section titled "Channel 
+                                            // Assignments" in Micro Direct 
+                                            // Memory Access chapter. 
+#define UDMA_CHMAP3_CH27SEL_S   12
+#define UDMA_CHMAP3_CH26SEL_M   0x00000F00  // uDMA channel 26 source select 
+                                            // See section titled "Channel 
+                                            // Assignments" in Micro Direct 
+                                            // Memory Access chapter. 
+#define UDMA_CHMAP3_CH26SEL_S   8
+#define UDMA_CHMAP3_CH25SEL_M   0x000000F0  // uDMA channel 25 source select 
+                                            // See section titled "Channel 
+                                            // Assignments" in Micro Direct 
+                                            // Memory Access chapter. 
+#define UDMA_CHMAP3_CH25SEL_S   4
+#define UDMA_CHMAP3_CH24SEL_M   0x0000000F  // uDMA channel 24 source select 
+                                            // See section titled "Channel 
+                                            // Assignments" in Micro Direct 
+                                            // Memory Access chapter. 
+#define UDMA_CHMAP3_CH24SEL_S   0
+
+
+#endif // __HW_UDMA_H__
+

--- a/cpu/cc2538/include/vendor/hw_udmachctl.h
+++ b/cpu/cc2538/include/vendor/hw_udmachctl.h
@@ -1,0 +1,243 @@
+/******************************************************************************
+*  Filename:       hw_udmachctl.h
+*  Revised:        $Date: 2013-04-12 15:10:54 +0200 (Fri, 12 Apr 2013) $
+*  Revision:       $Revision: 9735 $
+*
+*  Copyright (C) 2013 Texas Instruments Incorporated - http://www.ti.com/
+*
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*    Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+*
+*    Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+*
+*    Neither the name of Texas Instruments Incorporated nor the names of
+*    its contributors may be used to endorse or promote products derived
+*    from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+*  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+*  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+*  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+*  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+*  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+*  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+*  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+*  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+******************************************************************************/
+
+#ifndef __HW_UDMACHCTL_H__
+#define __HW_UDMACHCTL_H__
+
+//*****************************************************************************
+//
+// The following are defines for the UDMACHCTL register offsets.
+//
+//*****************************************************************************
+#define UDMACHCTL_O_SRCENDP     0x00000000  
+#define UDMACHCTL_O_DSTENDP     0x00000004  
+#define UDMACHCTL_O_CHCTL       0x00000008  
+
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// UDMACHCTL_O_SRCENDP register.
+//
+//*****************************************************************************
+#define UDMACHCTL_SRCENDP_ADDR_M \
+                                0xFFFFFFFF  // Source address end pointer This 
+                                            // field points to the last address 
+                                            // of the uDMA transfer source 
+                                            // (inclusive). If the source 
+                                            // address is not incrementing (the 
+                                            // SRCINC field in the DMACHCTL 
+                                            // register is 0x3), then this 
+                                            // field points at the source 
+                                            // location itself (such as a 
+                                            // peripheral control register). 
+
+#define UDMACHCTL_SRCENDP_ADDR_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// UDMACHCTL_O_DSTENDP register.
+//
+//*****************************************************************************
+#define UDMACHCTL_DSTENDP_ADDR_M \
+                                0xFFFFFFFF  // Destination address end pointer 
+                                            // This field points to the last 
+                                            // address of the uDMA transfer 
+                                            // destination (inclusive). If the 
+                                            // destination address is not 
+                                            // incrementing (the DSTINC field 
+                                            // in the DMACHCTL register is 
+                                            // 0x3), then this field points at 
+                                            // the destination location itself 
+                                            // (such as a peripheral control 
+                                            // register). 
+
+#define UDMACHCTL_DSTENDP_ADDR_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// UDMACHCTL_O_CHCTL register.
+//
+//*****************************************************************************
+#define UDMACHCTL_CHCTL_DSTINC_M \
+                                0xC0000000  // Destination address increment 
+                                            // This field configures the 
+                                            // destination address increment. 
+                                            // The address increment value must 
+                                            // be equal or greater than the 
+                                            // value of the destination size 
+                                            // (DSTSIZE). 0x0: Byte - Increment 
+                                            // by 8-bit locations 0x1: 
+                                            // Half-word - Increment by 16-bit 
+                                            // locations 0x2: Word - Increment 
+                                            // by 32-bit locations 0x3: No 
+                                            // increment - Address remains set 
+                                            // to the value of the Destination 
+                                            // address end pointer (DMADSTENDP) 
+                                            // for the channel. 
+
+#define UDMACHCTL_CHCTL_DSTINC_S 30
+#define UDMACHCTL_CHCTL_DSTSIZE_M \
+                                0x30000000  // Destination data size This 
+                                            // field configures the destination 
+                                            // item data size. Note: DSTSIZE 
+                                            // must be the same as SRCSIZE. 
+                                            // 0x0: Byte - 8-bit data size 0x1: 
+                                            // Half-word - 16-bit data size 
+                                            // 0x2: Word - 32-bit data size 
+                                            // 0x3: Reserved 
+
+#define UDMACHCTL_CHCTL_DSTSIZE_S 28
+#define UDMACHCTL_CHCTL_SRCINC_M \
+                                0x0C000000  // Source address increment This 
+                                            // field configures the source 
+                                            // address increment. The address 
+                                            // increment value must be equal or 
+                                            // greater than the value of the 
+                                            // source size (SRCSIZE). 0x0: Byte 
+                                            // - Increment by 8-bit locations 
+                                            // 0x1: Half-word - Increment by 
+                                            // 16-bit locations 0x2: Word - 
+                                            // Increment by 32-bit locations 
+                                            // 0x3: No increment - Address 
+                                            // remains set to the value of the 
+                                            // Source address end pointer 
+                                            // (DMASRCENDP) for the channel. 
+
+#define UDMACHCTL_CHCTL_SRCINC_S 26
+#define UDMACHCTL_CHCTL_SRCSIZE_M \
+                                0x03000000  // Source data size This field 
+                                            // configures the source item data 
+                                            // size. Note: SRCSIZE must be the 
+                                            // same as DSTSIZE. 0x0: Byte - 
+                                            // 8-bit data size 0x1: Half-word - 
+                                            // 16-bit data size 0x2: Word - 
+                                            // 32-bit data size 0x3: Reserved 
+
+#define UDMACHCTL_CHCTL_SRCSIZE_S 24
+#define UDMACHCTL_CHCTL_ARBSIZE_M \
+                                0x0003C000  // Arbitration size This field 
+                                            // configures the number of 
+                                            // transfers that can occur before 
+                                            // the uDMA controller 
+                                            // re-arbitrates. The possible 
+                                            // arbitration rate configurations 
+                                            // represent powers of 2 and are 
+                                            // shown below. 0x0: 1 Transfer - 
+                                            // Arbitrates after each uDMA 
+                                            // transfer 0x1: 2 Transfers 0x2: 4 
+                                            // Transfers 0x3: 8 Transfers 0x4: 
+                                            // 16 Transfers 0x5: 32 Transfers 
+                                            // 0x6: 64 Transfers 0x7: 128 
+                                            // Transfers 0x8: 256 Transfers 
+                                            // 0x9: 512 Transfers 0xA-0xF: 1024 
+                                            // Transfers - In this 
+                                            // configuration, no arbitration 
+                                            // occurs during the uDMA transfer 
+                                            // because the maximum transfer 
+                                            // size is 1024. 
+
+#define UDMACHCTL_CHCTL_ARBSIZE_S 14
+#define UDMACHCTL_CHCTL_XFERSIZE_M \
+                                0x00003FF0  // Transfer size (minus 1) This 
+                                            // field configures the total 
+                                            // number of items to transfer. The 
+                                            // value of this field is 1 less 
+                                            // than the number to transfer 
+                                            // (value 0 means transfer 1 item). 
+                                            // The maximum value for this 
+                                            // 10-bit field is 1023which 
+                                            // represents a transfer size of 
+                                            // 1024 items. The transfer size is 
+                                            // the number of items, not the 
+                                            // number of bytes, If the data 
+                                            // size is 32 bits, then this value 
+                                            // is the number of 32-bit words to 
+                                            // transfer. The uDMA controller 
+                                            // updates this field immediately 
+                                            // before entering the arbitration 
+                                            // process, so it contrains the 
+                                            // number of outstanding items that 
+                                            // is necessary to complete the 
+                                            // uDMA cycle. 
+
+#define UDMACHCTL_CHCTL_XFERSIZE_S 4
+#define UDMACHCTL_CHCTL_NXTUSEBURST \
+                                0x00000008  // Next useburst This field 
+                                            // controls whether the Useburst 
+                                            // SET[n] bit is automatically set 
+                                            // for the last transfer of a 
+                                            // peripheral scatter-gather 
+                                            // operation. Normally, for the 
+                                            // last transfer, if the number of 
+                                            // remaining items to transfer is 
+                                            // less than the arbitration size, 
+                                            // the uDMA controller uses single 
+                                            // transfers to complete the 
+                                            // transaction. If this bit is set, 
+                                            // then the controller uses a burst 
+                                            // transfer to complete the last 
+                                            // transfer. 
+
+#define UDMACHCTL_CHCTL_NXTUSEBURST_M \
+                                0x00000008
+#define UDMACHCTL_CHCTL_NXTUSEBURST_S 3
+#define UDMACHCTL_CHCTL_XFERMODE_M \
+                                0x00000007  // uDMA transfer mode This field 
+                                            // configures the operating mode of 
+                                            // the uDMA cycle. Refer to "Micro 
+                                            // Direct Memory Access - Transfer 
+                                            // Modes" for a detailed 
+                                            // explanation of transfer modes. 
+                                            // Because this register is in 
+                                            // system RAM, it has no reset 
+                                            // value. Therefore, this field 
+                                            // should be initialized to 0 
+                                            // before the channel is enabled. 
+                                            // 0x0: Stop 0x1: Basic 0x2: 
+                                            // Auto-request 0x3: Ping-pong 0x4: 
+                                            // Memory scatter-gather 0x5: 
+                                            // Alternate memory scatter-gather 
+                                            // 0x6: Peripheral scatter-gather 
+                                            // 0x7: Alternate peripheral 
+                                            // scatter-gather 
+
+#define UDMACHCTL_CHCTL_XFERMODE_S 0
+
+
+#endif // __HW_UDMACHCTL_H__
+

--- a/cpu/cc2538/include/vendor/hw_usb.h
+++ b/cpu/cc2538/include/vendor/hw_usb.h
@@ -1,0 +1,802 @@
+/******************************************************************************
+*  Filename:       hw_usb.h
+*  Revised:        $Date: 2013-04-30 17:13:44 +0200 (Tue, 30 Apr 2013) $
+*  Revision:       $Revision: 9943 $
+*
+*  Copyright (C) 2013 Texas Instruments Incorporated - http://www.ti.com/
+*
+*
+*  Redistribution and use in source and binary forms, with or without
+*  modification, are permitted provided that the following conditions
+*  are met:
+*
+*    Redistributions of source code must retain the above copyright
+*    notice, this list of conditions and the following disclaimer.
+*
+*    Redistributions in binary form must reproduce the above copyright
+*    notice, this list of conditions and the following disclaimer in the
+*    documentation and/or other materials provided with the distribution.
+*
+*    Neither the name of Texas Instruments Incorporated nor the names of
+*    its contributors may be used to endorse or promote products derived
+*    from this software without specific prior written permission.
+*
+*  THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS
+*  "AS IS" AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT
+*  LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR
+*  A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT
+*  OWNER OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT, INCIDENTAL,
+*  SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+*  LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE,
+*  DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
+*  THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
+*  (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+*  OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
+*
+******************************************************************************/
+
+#ifndef __HW_USB_H__
+#define __HW_USB_H__
+
+//*****************************************************************************
+//
+// The following are defines for the USB register offsets.
+//
+//*****************************************************************************
+#define USB_ADDR                0x40089000  // Function address 
+#define USB_POW                 0x40089004  // Power management and control 
+                                            // register 
+#define USB_IIF                 0x40089008  // Interrupt flags for endpoint 0 
+                                            // and IN endpoints 1-5 
+#define USB_OIF                 0x40089010  // Interrupt flags for OUT 
+                                            // endpoints 1-5 
+#define USB_CIF                 0x40089018  // Common USB interrupt flags 
+#define USB_IIE                 0x4008901C  // Interrupt enable mask for IN 
+                                            // endpoints 1-5 and endpoint 0 
+#define USB_OIE                 0x40089024  // Interrupt enable mask for OUT 
+                                            // endpoints 1-5 
+#define USB_CIE                 0x4008902C  // Common USB interrupt enable 
+                                            // mask 
+#define USB_FRML                0x40089030  // Frame number (low byte) 
+#define USB_FRMH                0x40089034  // Frame number (high byte) 
+#define USB_INDEX               0x40089038  // Index register for selecting 
+                                            // the endpoint status and control 
+                                            // registers 
+#define USB_CTRL                0x4008903C  // USB peripheral control register 
+#define USB_MAXI                0x40089040  // Indexed register: For USB_INDEX 
+                                            // = 1-5: Maximum packet size for 
+                                            // IN endpoint {1-5} 
+#define USB_CS0_CSIL            0x40089044  // Indexed register: For USB_INDEX 
+                                            // = 0: Endpoint 0 control and 
+                                            // status For USB_INDEX = 1-5: IN 
+                                            // endpoint {1-5} control and 
+                                            // status (low byte) 
+#define USB_CSIH                0x40089048  // Indexed register: For USB_INDEX 
+                                            // = 1-5: IN endpoint {1-5} control 
+                                            // and status (high byte) 
+#define USB_MAXO                0x4008904C  // Indexed register: For USB_INDEX 
+                                            // = 1-5: Maximum packet size for 
+                                            // OUT endpoint {1-5} 
+#define USB_CSOL                0x40089050  // Indexed register: For USB_INDEX 
+                                            // = 1-5: OUT endpoint {1-5} 
+                                            // control and status (low byte) 
+#define USB_CSOH                0x40089054  // Indexed register: For USB_INDEX 
+                                            // = 1-5: OUT endpoint {1-5} 
+                                            // control and status (high byte) 
+#define USB_CNT0_CNTL           0x40089058  // Indexed register: For USB_INDEX 
+                                            // = 0: Number of received bytes in 
+                                            // the endpoint 0 FIFO For 
+                                            // USB_INDEX = 1-5: Number of 
+                                            // received bytes in the OUT 
+                                            // endpoint {1-5} FIFO (low byte) 
+#define USB_CNTH                0x4008905C  // Indexed register: For USB_INDEX 
+                                            // = 1-5: Number of received in the 
+                                            // OUT endpoint {1-5} FIFO (high 
+                                            // byte) 
+#define USB_F0                  0x40089080  // Endpoint 0 FIFO 
+#define USB_F1                  0x40089088  // IN/OUT endpoint 1 FIFO 
+#define USB_F2                  0x40089090  // IN/OUT endpoint 2 FIFO 
+#define USB_F3                  0x40089098  // IN/OUT endpoint 3 FIFO 
+#define USB_F4                  0x400890A0  // IN/OUT endpoint 4 FIFO 
+#define USB_F5                  0x400890A8  // IN/OUT endpoint 5 FIFO 
+
+
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the USB_ADDR register.
+//
+//*****************************************************************************
+#define USB_ADDR_UPDATE         0x00000080  // This bit is set by hardware 
+                                            // when writing to this register, 
+                                            // and is cleared by hardware when 
+                                            // the new address becomes 
+                                            // effective. 
+#define USB_ADDR_UPDATE_M       0x00000080
+#define USB_ADDR_UPDATE_S       7
+#define USB_ADDR_USBADDR_M      0x0000007F  // Device address. The address 
+                                            // shall be updated upon successful 
+                                            // completion of the status stage 
+                                            // of the SET_ADDRESS request. 
+#define USB_ADDR_USBADDR_S      0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the USB_POW register.
+//
+//*****************************************************************************
+#define USB_POW_ISOWAITSOF      0x00000080  // For isochronous mode IN 
+                                            // endpoints: When set, the USB 
+                                            // controller will wait for an SOF 
+                                            // token from the time 
+                                            // USB_CSIL.INPKTRDY is set before 
+                                            // sending the packet. If an IN 
+                                            // token is received before an SOF 
+                                            // token, then a zero length data 
+                                            // packet will be sent. 
+#define USB_POW_ISOWAITSOF_M    0x00000080
+#define USB_POW_ISOWAITSOF_S    7
+#define USB_POW_RST             0x00000008  // Indicates that reset signaling 
+                                            // is present on the bus 
+#define USB_POW_RST_M           0x00000008
+#define USB_POW_RST_S           3
+#define USB_POW_RESUME          0x00000004  // Drives resume signaling for 
+                                            // remote wakeup According to the 
+                                            // USB Specification, the resume 
+                                            // signal must be held active for 
+                                            // at least 1 ms and no more than 
+                                            // 15 ms. It is recommended to keep 
+                                            // this bit set for approximately 
+                                            // 10 ms. 
+#define USB_POW_RESUME_M        0x00000004
+#define USB_POW_RESUME_S        2
+#define USB_POW_SUSPEND         0x00000002  // Indicates entry into suspend 
+                                            // mode Suspend mode must be 
+                                            // enabled by setting 
+                                            // USB_POW.SUSPENDEN Software 
+                                            // clears this bit by reading the 
+                                            // USB_CIF register or by asserting 
+                                            // USB_POW.RESUME 
+#define USB_POW_SUSPEND_M       0x00000002
+#define USB_POW_SUSPEND_S       1
+#define USB_POW_SUSPENDEN       0x00000001  // Enables detection of and entry 
+                                            // into suspend mode. 
+#define USB_POW_SUSPENDEN_M     0x00000001
+#define USB_POW_SUSPENDEN_S     0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the USB_IIF register.
+//
+//*****************************************************************************
+#define USB_IIF_INEP5IF         0x00000020  // Interrupt flag for IN endpoint 
+                                            // 5 Cleared by hardware when read 
+#define USB_IIF_INEP5IF_M       0x00000020
+#define USB_IIF_INEP5IF_S       5
+#define USB_IIF_INEP4IF         0x00000010  // Interrupt flag for IN endpoint 
+                                            // 4 Cleared by hardware when read 
+#define USB_IIF_INEP4IF_M       0x00000010
+#define USB_IIF_INEP4IF_S       4
+#define USB_IIF_INEP3IF         0x00000008  // Interrupt flag for IN endpoint 
+                                            // 3 Cleared by hardware when read 
+#define USB_IIF_INEP3IF_M       0x00000008
+#define USB_IIF_INEP3IF_S       3
+#define USB_IIF_INEP2IF         0x00000004  // Interrupt flag for IN endpoint 
+                                            // 2 Cleared by hardware when read 
+#define USB_IIF_INEP2IF_M       0x00000004
+#define USB_IIF_INEP2IF_S       2
+#define USB_IIF_INEP1IF         0x00000002  // Interrupt flag for IN endpoint 
+                                            // 1 Cleared by hardware when read 
+#define USB_IIF_INEP1IF_M       0x00000002
+#define USB_IIF_INEP1IF_S       1
+#define USB_IIF_EP0IF           0x00000001  // Interrupt flag for endpoint 0 
+                                            // Cleared by hardware when read 
+#define USB_IIF_EP0IF_M         0x00000001
+#define USB_IIF_EP0IF_S         0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the USB_OIF register.
+//
+//*****************************************************************************
+#define USB_OIF_OUTEP5IF        0x00000020  // Interrupt flag for OUT endpoint 
+                                            // 5 Cleared by hardware when read 
+#define USB_OIF_OUTEP5IF_M      0x00000020
+#define USB_OIF_OUTEP5IF_S      5
+#define USB_OIF_OUTEP4IF        0x00000010  // Interrupt flag for OUT endpoint 
+                                            // 4 Cleared by hardware when read 
+#define USB_OIF_OUTEP4IF_M      0x00000010
+#define USB_OIF_OUTEP4IF_S      4
+#define USB_OIF_OUTEP3IF        0x00000008  // Interrupt flag for OUT endpoint 
+                                            // 3 Cleared by hardware when read 
+#define USB_OIF_OUTEP3IF_M      0x00000008
+#define USB_OIF_OUTEP3IF_S      3
+#define USB_OIF_OUTEP2IF        0x00000004  // Interrupt flag for OUT endpoint 
+                                            // 2 Cleared by hardware when read 
+#define USB_OIF_OUTEP2IF_M      0x00000004
+#define USB_OIF_OUTEP2IF_S      2
+#define USB_OIF_OUTEP1IF        0x00000002  // Interrupt flag for OUT endpoint 
+                                            // 1 Cleared by hardware when read 
+#define USB_OIF_OUTEP1IF_M      0x00000002
+#define USB_OIF_OUTEP1IF_S      1
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the USB_CIF register.
+//
+//*****************************************************************************
+#define USB_CIF_SOFIF           0x00000008  // Start-of-frame interrupt flag 
+                                            // Cleared by hardware when read 
+#define USB_CIF_SOFIF_M         0x00000008
+#define USB_CIF_SOFIF_S         3
+#define USB_CIF_RSTIF           0x00000004  // Reset interrupt flag Cleared by 
+                                            // hardware when read 
+#define USB_CIF_RSTIF_M         0x00000004
+#define USB_CIF_RSTIF_S         2
+#define USB_CIF_RESUMEIF        0x00000002  // Resume interrupt flag Cleared 
+                                            // by hardware when read 
+#define USB_CIF_RESUMEIF_M      0x00000002
+#define USB_CIF_RESUMEIF_S      1
+#define USB_CIF_SUSPENDIF       0x00000001  // Suspend interrupt flag Cleared 
+                                            // by hardware when read 
+#define USB_CIF_SUSPENDIF_M     0x00000001
+#define USB_CIF_SUSPENDIF_S     0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the USB_IIE register.
+//
+//*****************************************************************************
+#define USB_IIE_INEP5IE         0x00000020  // Interrupt enable for IN 
+                                            // endpoint 5 0: Interrupt disabled 
+                                            // 1: Interrupt enabled 
+#define USB_IIE_INEP5IE_M       0x00000020
+#define USB_IIE_INEP5IE_S       5
+#define USB_IIE_INEP4IE         0x00000010  // Interrupt enable for IN 
+                                            // endpoint 4 0: Interrupt disabled 
+                                            // 1: Interrupt enabled 
+#define USB_IIE_INEP4IE_M       0x00000010
+#define USB_IIE_INEP4IE_S       4
+#define USB_IIE_INEP3IE         0x00000008  // Interrupt enable for IN 
+                                            // endpoint 3 0: Interrupt disabled 
+                                            // 1: Interrupt enabled 
+#define USB_IIE_INEP3IE_M       0x00000008
+#define USB_IIE_INEP3IE_S       3
+#define USB_IIE_INEP2IE         0x00000004  // Interrupt enable for IN 
+                                            // endpoint 2 0: Interrupt disabled 
+                                            // 1: Interrupt enabled 
+#define USB_IIE_INEP2IE_M       0x00000004
+#define USB_IIE_INEP2IE_S       2
+#define USB_IIE_INEP1IE         0x00000002  // Interrupt enable for IN 
+                                            // endpoint 1 0: Interrupt disabled 
+                                            // 1: Interrupt enabled 
+#define USB_IIE_INEP1IE_M       0x00000002
+#define USB_IIE_INEP1IE_S       1
+#define USB_IIE_EP0IE           0x00000001  // Interrupt enable for endpoint 0 
+                                            // 0: Interrupt disabled 1: 
+                                            // Interrupt enabled 
+#define USB_IIE_EP0IE_M         0x00000001
+#define USB_IIE_EP0IE_S         0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the USB_OIE register.
+//
+//*****************************************************************************
+#define USB_OIE_reserved8_M     0x000000C0  // Reserved 
+#define USB_OIE_reserved8_S     6
+#define USB_OIE_OUTEP5IE        0x00000020  // Interrupt enable for OUT 
+                                            // endpoint 5 0: Interrupt disabled 
+                                            // 1: Interrupt enabled 
+#define USB_OIE_OUTEP5IE_M      0x00000020
+#define USB_OIE_OUTEP5IE_S      5
+#define USB_OIE_OUTEP4IE        0x00000010  // Interrupt enable for OUT 
+                                            // endpoint 4 0: Interrupt disabled 
+                                            // 1: Interrupt enabled 
+#define USB_OIE_OUTEP4IE_M      0x00000010
+#define USB_OIE_OUTEP4IE_S      4
+#define USB_OIE_OUTEP3IE        0x00000008  // Interrupt enable for OUT 
+                                            // endpoint 3 0: Interrupt disabled 
+                                            // 1: Interrupt enabled 
+#define USB_OIE_OUTEP3IE_M      0x00000008
+#define USB_OIE_OUTEP3IE_S      3
+#define USB_OIE_OUTEP2IE        0x00000004  // Interrupt enable for OUT 
+                                            // endpoint 2 0: Interrupt disabled 
+                                            // 1: Interrupt enabled 
+#define USB_OIE_OUTEP2IE_M      0x00000004
+#define USB_OIE_OUTEP2IE_S      2
+#define USB_OIE_OUTEP1IE        0x00000002  // Interrupt enable for OUT 
+                                            // endpoint 1 0: Interrupt disabled 
+                                            // 1: Interrupt enabled 
+#define USB_OIE_OUTEP1IE_M      0x00000002
+#define USB_OIE_OUTEP1IE_S      1
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the USB_CIE register.
+//
+//*****************************************************************************
+#define USB_CIE_SOFIE           0x00000008  // Start-of-frame interrupt enable 
+                                            // 0: Interrupt disabled 1: 
+                                            // Interrupt enabled 
+#define USB_CIE_SOFIE_M         0x00000008
+#define USB_CIE_SOFIE_S         3
+#define USB_CIE_RSTIE           0x00000004  // Reset interrupt enable 0: 
+                                            // Interrupt disabled 1: Interrupt 
+                                            // enabled 
+#define USB_CIE_RSTIE_M         0x00000004
+#define USB_CIE_RSTIE_S         2
+#define USB_CIE_RESUMEIE        0x00000002  // Resume interrupt enable 0: 
+                                            // Interrupt disabled 1: Interrupt 
+                                            // enabled 
+#define USB_CIE_RESUMEIE_M      0x00000002
+#define USB_CIE_RESUMEIE_S      1
+#define USB_CIE_SUSPENDIE       0x00000001  // Suspend interrupt enable 0: 
+                                            // Interrupt disabled 1: Interrupt 
+                                            // enabled 
+#define USB_CIE_SUSPENDIE_M     0x00000001
+#define USB_CIE_SUSPENDIE_S     0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the USB_FRML register.
+//
+//*****************************************************************************
+#define USB_FRML_FRAMEL_M       0x000000FF  // Bits 7:0 of the 11-bit frame 
+                                            // number The frame number is only 
+                                            // updated upon successful 
+                                            // reception of SOF tokens 
+#define USB_FRML_FRAMEL_S       0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the USB_FRMH register.
+//
+//*****************************************************************************
+#define USB_FRMH_FRAMEH_M       0x00000007  // Bits 10:8 of the 11-bit frame 
+                                            // number The frame number is only 
+                                            // updated upon successful 
+                                            // reception of SOF tokens 
+#define USB_FRMH_FRAMEH_S       0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the USB_INDEX register.
+//
+//*****************************************************************************
+#define USB_INDEX_USBINDEX_M    0x0000000F  // Index of the currently selected 
+                                            // endpoint The index is set to 0 
+                                            // to enable access to endpoint 0 
+                                            // control and status registers The 
+                                            // index is set to 1, 2, 3, 4 or 5 
+                                            // to enable access to IN/OUT 
+                                            // endpoint 1, 2, 3, 4 or 5 control 
+                                            // and status registers, 
+                                            // respectively 
+#define USB_INDEX_USBINDEX_S    0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the USB_CTRL register.
+//
+//*****************************************************************************
+#define USB_CTRL_PLLLOCKED      0x00000080  // PLL lock status. The PLL is 
+                                            // locked when USB_CTRL.PLLLOCKED 
+                                            // is 1. 
+#define USB_CTRL_PLLLOCKED_M    0x00000080
+#define USB_CTRL_PLLLOCKED_S    7
+#define USB_CTRL_PLLEN          0x00000002  // 48 MHz USB PLL enable When this 
+                                            // bit is set, the 48 MHz PLL is 
+                                            // started. Software must avoid 
+                                            // access to other USB registers 
+                                            // before the PLL has locked; that 
+                                            // is, USB_CTRL.PLLLOCKED is 1. 
+                                            // This bit can be set only when 
+                                            // USB_CTRL.USBEN is 1. The PLL 
+                                            // must be disabled before entering 
+                                            // PM1 when suspended, and must be 
+                                            // re-enabled when resuming 
+                                            // operation. 
+#define USB_CTRL_PLLEN_M        0x00000002
+#define USB_CTRL_PLLEN_S        1
+#define USB_CTRL_USBEN          0x00000001  // USB enable The USB controller 
+                                            // is reset when this bit is 
+                                            // cleared 
+#define USB_CTRL_USBEN_M        0x00000001
+#define USB_CTRL_USBEN_S        0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the USB_MAXI register.
+//
+//*****************************************************************************
+#define USB_MAXI_USBMAXI_M      0x000000FF  // Maximum packet size, in units 
+                                            // of 8 bytes, for the selected IN 
+                                            // endpoint The value of this 
+                                            // register should match the 
+                                            // wMaxPacketSize field in the 
+                                            // standard endpoint descriptor for 
+                                            // the endpoint. The value must not 
+                                            // exceed the available memory. 
+#define USB_MAXI_USBMAXI_S      0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the USB_CS0_CSIL register.
+//
+//*****************************************************************************
+#define USB_CS0_CSIL_CLROUTPKTRDY_or_CLRDATATOG \
+                                0x00000040  // USB_CS0.CLROUTPKTRDY [RW]: 
+                                            // Software sets this bit to clear 
+                                            // the USB_CS0.OUTPKTRDY bit. It is 
+                                            // cleared automatically. 
+                                            // USB_CSIL.CLRDATATOG [RW]: 
+                                            // Software sets this bit to reset 
+                                            // the IN endpoint data toggle to 
+                                            // 0. 
+
+#define USB_CS0_CSIL_CLROUTPKTRDY_or_CLRDATATOG_M \
+                                0x00000040
+#define USB_CS0_CSIL_CLROUTPKTRDY_or_CLRDATATOG_S 6
+#define USB_CS0_CSIL_SENDSTALL_or_SENTSTALL \
+                                0x00000020  // USB_CS0.SENDSTALL [RW]: 
+                                            // Software sets this bit to 
+                                            // terminate the current 
+                                            // transaction with a STALL 
+                                            // handshake. The bit is cleared 
+                                            // automatically when the STALL 
+                                            // handshake has been transmitted. 
+                                            // USB_CSIL.SENTSTALL [RW]: For 
+                                            // bulk/interrupt mode IN 
+                                            // endpoints: This bit is set when 
+                                            // a STALL handshake is 
+                                            // transmitted. The FIFO is flushed 
+                                            // and the USB_CSIL.INPKTRDY bit 
+                                            // cleared. Software should clear 
+                                            // this bit. 
+
+#define USB_CS0_CSIL_SENDSTALL_or_SENTSTALL_M \
+                                0x00000020
+#define USB_CS0_CSIL_SENDSTALL_or_SENTSTALL_S 5
+#define USB_CS0_CSIL_SETUPEND_or_SENDSTALL \
+                                0x00000010  // USB_CS0.SETUPEND [RO]: This bit 
+                                            // is set when a control 
+                                            // transaction ends before the 
+                                            // USB_CS0.DATAEND bit has been 
+                                            // set. An interrupt is generated 
+                                            // and the FIFO flushed at this 
+                                            // time. Software clears this bit 
+                                            // by setting USB_CS0.CLRSETUPEND. 
+                                            // CSIL.SENDSTALL [RW]: For 
+                                            // bulk/interrupt mode IN 
+                                            // endpoints: Software sets this 
+                                            // bit to issue a STALL handshake. 
+                                            // Software clears this bit to 
+                                            // terminate the stall condition. 
+
+#define USB_CS0_CSIL_SETUPEND_or_SENDSTALL_M \
+                                0x00000010
+#define USB_CS0_CSIL_SETUPEND_or_SENDSTALL_S 4
+#define USB_CS0_CSIL_DATAEND_or_FLUSHPACKET \
+                                0x00000008  // USB_CS0.DATAEND [RW]: This bit 
+                                            // is used to signal the end of the 
+                                            // data stage, and must be set: 1. 
+                                            // When the last data packet is 
+                                            // loaded and USB_CS0.INPKTRDY is 
+                                            // set. 2. When the last data 
+                                            // packet is unloaded and 
+                                            // USB_CS0.CLROUTPKTRDY is set. 3. 
+                                            // When USB_CS0.INPKTRDY is set to 
+                                            // send a zero-length packet. The 
+                                            // USB controller clears this bit 
+                                            // automatically. 
+                                            // USB_CSIL.FLUSHPACKET [RW]: 
+                                            // Software sets this bit to flush 
+                                            // the next packet to be 
+                                            // transmitted from the IN endpoint 
+                                            // FIFO. The FIFO pointer is reset 
+                                            // and the USB_CSIL.INPKTRDY bit is 
+                                            // cleared. Note: If the FIFO 
+                                            // contains two packets, 
+                                            // USB_CSIL.FLUSHPACKET will need 
+                                            // to be set twice to completely 
+                                            // clear the FIFO. 
+
+#define USB_CS0_CSIL_DATAEND_or_FLUSHPACKET_M \
+                                0x00000008
+#define USB_CS0_CSIL_DATAEND_or_FLUSHPACKET_S 3
+#define USB_CS0_CSIL_SENTSTALL_or_UNDERRUN \
+                                0x00000004  // USB_CS0.SENTSTALL [RW]: This 
+                                            // bit is set when a STALL 
+                                            // handshake is sent. An interrupt 
+                                            // is generated is generated when 
+                                            // this bit is set. Software must 
+                                            // clear this bit. 
+                                            // USB_CSIL.UNDERRUN [RW]: In 
+                                            // isochronous mode, this bit is 
+                                            // set when a zero length data 
+                                            // packet is sent after receiving 
+                                            // an IN token with 
+                                            // USB_CSIL.INPKTRDY not set. In 
+                                            // bulk/interrupt mode, this bit is 
+                                            // set when a NAK is returned in 
+                                            // response to an IN token. 
+                                            // Software should clear this bit. 
+
+#define USB_CS0_CSIL_SENTSTALL_or_UNDERRUN_M \
+                                0x00000004
+#define USB_CS0_CSIL_SENTSTALL_or_UNDERRUN_S 2
+#define USB_CS0_CSIL_INPKTRDY_or_PKTPRESENT \
+                                0x00000002  // USB_CS0. INPKTRDY [RW]: 
+                                            // Software sets this bit after 
+                                            // loading a data packet into the 
+                                            // endpoint 0 FIFO. It is cleared 
+                                            // automatically when the data 
+                                            // packet has been transmitted. An 
+                                            // interrupt is generated when the 
+                                            // bit is cleared. 
+                                            // USB_CSIL.PKTPRESENT [RO]: This 
+                                            // bit is set when there is at 
+                                            // least one packet in the IN 
+                                            // endpoint FIFO. 
+
+#define USB_CS0_CSIL_INPKTRDY_or_PKTPRESENT_M \
+                                0x00000002
+#define USB_CS0_CSIL_INPKTRDY_or_PKTPRESENT_S 1
+#define USB_CS0_CSIL_OUTPKTRDY_or_INPKTRDY \
+                                0x00000001  // USB_CS0.OUTPKTRDY [RO]: 
+                                            // Endpoint 0 data packet received 
+                                            // An interrupt request (EP0) is 
+                                            // generated if the interrupt is 
+                                            // enabled. Software must read the 
+                                            // endpoint 0 FIFO empty, and clear 
+                                            // this bit by setting 
+                                            // USB_CS0.CLROUTPKTRDY 
+                                            // USB_CSIL.INPKTRDY [RW]: IN 
+                                            // endpoint {1-5} packet transfer 
+                                            // pending Software sets this bit 
+                                            // after loading a data packet into 
+                                            // the FIFO. It is cleared 
+                                            // automatically when a data packet 
+                                            // has been transmitted. An 
+                                            // interrupt is generated (if 
+                                            // enabled) when the bit is 
+                                            // cleared. When using 
+                                            // double-buffering, the bit is 
+                                            // cleared immediately if the other 
+                                            // FIFO is empty. 
+
+#define USB_CS0_CSIL_OUTPKTRDY_or_INPKTRDY_M \
+                                0x00000001
+#define USB_CS0_CSIL_OUTPKTRDY_or_INPKTRDY_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the USB_CSIH register.
+//
+//*****************************************************************************
+#define USB_CSIH_AUTISET        0x00000080  // If set by software, the 
+                                            // USB_CSIL.INPKTRDY bit is 
+                                            // automatically set when a data 
+                                            // packet of maximum size 
+                                            // (specified by USBMAXI) is loaded 
+                                            // into the IN endpoint FIFO. If a 
+                                            // packet of less than the maximum 
+                                            // packet size is loaded, then 
+                                            // USB_CSIL.INPKTRDY will have to 
+                                            // be set manually. 
+#define USB_CSIH_AUTISET_M      0x00000080
+#define USB_CSIH_AUTISET_S      7
+#define USB_CSIH_ISO            0x00000040  // Selects IN endpoint type: 0: 
+                                            // Bulk/interrupt 1: Isochronous 
+#define USB_CSIH_ISO_M          0x00000040
+#define USB_CSIH_ISO_S          6
+#define USB_CSIH_FORCEDATATOG   0x00000008  // Software sets this bit to force 
+                                            // the IN endpoint's data toggle to 
+                                            // switch after each data packet is 
+                                            // sent regardless of whether an 
+                                            // ACK was received. This can be 
+                                            // used by interrupt IN endpoints 
+                                            // which are used to communicate 
+                                            // rate feedback for isochronous 
+                                            // endpoints. 
+#define USB_CSIH_FORCEDATATOG_M 0x00000008
+#define USB_CSIH_FORCEDATATOG_S 3
+#define USB_CSIH_INDBLBUF       0x00000001  // IN endpoint FIFO 
+                                            // double-buffering enable: 0: 
+                                            // Double buffering disabled 1: 
+                                            // Double buffering enabled 
+#define USB_CSIH_INDBLBUF_M     0x00000001
+#define USB_CSIH_INDBLBUF_S     0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the USB_MAXO register.
+//
+//*****************************************************************************
+#define USB_MAXO_USBMAXO_M      0x000000FF  // Maximum packet size, in units 
+                                            // of 8 bytes, for the selected OUT 
+                                            // endpoint The value of this 
+                                            // register should match the 
+                                            // wMaxPacketSize field in the 
+                                            // standard endpoint descriptor for 
+                                            // the endpoint. The value must not 
+                                            // exceed the available memory. 
+#define USB_MAXO_USBMAXO_S      0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the USB_CSOL register.
+//
+//*****************************************************************************
+#define USB_CSOL_CLRDATATOG     0x00000080  // Software sets this bit to reset 
+                                            // the endpoint data toggle to 0. 
+#define USB_CSOL_CLRDATATOG_M   0x00000080
+#define USB_CSOL_CLRDATATOG_S   7
+#define USB_CSOL_SENTSTALL      0x00000040  // This bit is set when a STALL 
+                                            // handshake is transmitted. An 
+                                            // interrupt is generated when this 
+                                            // bit is set. Software should 
+                                            // clear this bit. 
+#define USB_CSOL_SENTSTALL_M    0x00000040
+#define USB_CSOL_SENTSTALL_S    6
+#define USB_CSOL_SENDSTALL      0x00000020  // For bulk/interrupt mode OUT 
+                                            // endpoints: Software sets this 
+                                            // bit to issue a STALL handshake. 
+                                            // Software clears this bit to 
+                                            // terminate the stall condition. 
+#define USB_CSOL_SENDSTALL_M    0x00000020
+#define USB_CSOL_SENDSTALL_S    5
+#define USB_CSOL_FLUSHPACKET    0x00000010  // Software sets this bit to flush 
+                                            // the next packet to be read from 
+                                            // the endpoint OUT FIFO. Note: If 
+                                            // the FIFO contains two packets, 
+                                            // USB_CSOL.FLUSHPACKET will need 
+                                            // to be set twice to completely 
+                                            // clear the FIFO. 
+#define USB_CSOL_FLUSHPACKET_M  0x00000010
+#define USB_CSOL_FLUSHPACKET_S  4
+#define USB_CSOL_DATAERROR      0x00000008  // For isochronous mode OUT 
+                                            // endpoints: This bit is set when 
+                                            // USB_CSOL.OUTPKTRDY is set if the 
+                                            // data packet has a CRC or 
+                                            // bit-stuff error. It is cleared 
+                                            // automatically when 
+                                            // USB_CSOL.OUTPKTRDY is cleared. 
+#define USB_CSOL_DATAERROR_M    0x00000008
+#define USB_CSOL_DATAERROR_S    3
+#define USB_CSOL_OVERRUN        0x00000004  // For isochronous mode OUT 
+                                            // endpoints: This bit is set when 
+                                            // an OUT packet cannot be loaded 
+                                            // into the OUT endpoint FIFO. 
+                                            // Firmware should clear this bit. 
+#define USB_CSOL_OVERRUN_M      0x00000004
+#define USB_CSOL_OVERRUN_S      2
+#define USB_CSOL_FIFOFULL       0x00000002  // This bit is set when no more 
+                                            // packets can be loaded into the 
+                                            // OUT endpoint FIFO. 
+#define USB_CSOL_FIFOFULL_M     0x00000002
+#define USB_CSOL_FIFOFULL_S     1
+#define USB_CSOL_OUTPKTRDY      0x00000001  // This bit is set when a data 
+                                            // packet has been received. 
+                                            // Software should clear this bit 
+                                            // when the packet has been 
+                                            // unloaded from the OUT endpoint 
+                                            // FIFO. An interrupt is generated 
+                                            // when the bit is set. 
+#define USB_CSOL_OUTPKTRDY_M    0x00000001
+#define USB_CSOL_OUTPKTRDY_S    0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the USB_CSOH register.
+//
+//*****************************************************************************
+#define USB_CSOH_AUTOCLEAR      0x00000080  // If software sets this bit, the 
+                                            // USB_CSOL.OUTPKTRDY bit will be 
+                                            // automatically cleared when a 
+                                            // packet of maximum size 
+                                            // (specified by USB_MAXO) has been 
+                                            // unloaded from the OUT FIFO. When 
+                                            // packets of less than the maximum 
+                                            // packet size are unloaded, 
+                                            // USB_CSOL.OUTPKTRDY will have to 
+                                            // be cleared manually. 
+#define USB_CSOH_AUTOCLEAR_M    0x00000080
+#define USB_CSOH_AUTOCLEAR_S    7
+#define USB_CSOH_ISO            0x00000040  // Selects OUT endpoint type: 0: 
+                                            // Bulk/interrupt 1: Isochronous 
+#define USB_CSOH_ISO_M          0x00000040
+#define USB_CSOH_ISO_S          6
+#define USB_CSOH_OUTDBLBUF      0x00000001  // OUT endpoint FIFO 
+                                            // double-buffering enable: 0: 
+                                            // Double buffering disabled 1: 
+                                            // Double buffering enabled 
+#define USB_CSOH_OUTDBLBUF_M    0x00000001
+#define USB_CSOH_OUTDBLBUF_S    0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the 
+// USB_CNT0_CNTL register.
+//
+//*****************************************************************************
+#define USB_CNT0_CNTL_FIFOCNT_or_FIFOCNTL_M \
+                                0x000000FF  // USB_CS0.FIFOCNT (USBINDEX = 0) 
+                                            // [RO]: Number of bytes received 
+                                            // in the packet in the endpoint 0 
+                                            // FIFO Valid only when 
+                                            // USB_CS0.OUTPKTRDY is set 
+                                            // USB_CSIL.FIFOCNTL (USBINDEX = 1 
+                                            // to 5) [RW]: Bits 7:0 of the of 
+                                            // the number of bytes received in 
+                                            // the packet in the OUT endpoint 
+                                            // {1-5} FIFO Valid only when 
+                                            // USB_CSOL.OUTPKTRDY is set 
+
+#define USB_CNT0_CNTL_FIFOCNT_or_FIFOCNTL_S 0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the USB_CNTH register.
+//
+//*****************************************************************************
+#define USB_CNTH_FIFOCNTH_M     0x00000007  // Bits 10:8 of the of the number 
+                                            // of bytes received in the packet 
+                                            // in the OUT endpoint {1-5} FIFO 
+                                            // Valid only when 
+                                            // USB_CSOL.OUTPKTRDY is set 
+#define USB_CNTH_FIFOCNTH_S     0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the USB_F0 register.
+//
+//*****************************************************************************
+#define USB_F0_USBF0_M          0x000000FF  // Endpoint 0 FIFO Reading this 
+                                            // register unloads one byte from 
+                                            // the endpoint 0 FIFO. Writing to 
+                                            // this register loads one byte 
+                                            // into the endpoint 0 FIFO. The 
+                                            // FIFO memory for EP0 is used for 
+                                            // incoming and outgoing data 
+                                            // packets. 
+#define USB_F0_USBF0_S          0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the USB_F1 register.
+//
+//*****************************************************************************
+#define USB_F1_USBF1_M          0x000000FF  // Endpoint 1 FIFO register 
+                                            // Reading this register unloads 
+                                            // one byte from the EP1 OUT FIFO. 
+                                            // Writing to this register loads 
+                                            // one byte into the EP1 IN FIFO. 
+#define USB_F1_USBF1_S          0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the USB_F2 register.
+//
+//*****************************************************************************
+#define USB_F2_USBF2_M          0x000000FF  // Endpoint 2 FIFO register 
+                                            // Reading this register unloads 
+                                            // one byte from the EP2 OUT FIFO. 
+                                            // Writing to this register loads 
+                                            // one byte into the EP2 IN FIFO. 
+#define USB_F2_USBF2_S          0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the USB_F3 register.
+//
+//*****************************************************************************
+#define USB_F3_USBF3_M          0x000000FF  // Endpoint 3 FIFO register 
+                                            // Reading this register unloads 
+                                            // one byte from the EP3 OUT FIFO. 
+                                            // Writing to this register loads 
+                                            // one byte into the EP3 IN FIFO. 
+#define USB_F3_USBF3_S          0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the USB_F4 register.
+//
+//*****************************************************************************
+#define USB_F4_USBF4_M          0x000000FF  // Endpoint 4 FIFO register 
+                                            // Reading this register unloads 
+                                            // one byte from the EP4 OUT FIFO. 
+                                            // Writing to this register loads 
+                                            // one byte into the EP4 IN FIFO. 
+#define USB_F4_USBF4_S          0
+//*****************************************************************************
+//
+// The following are defines for the bit fields in the USB_F5 register.
+//
+//*****************************************************************************
+#define USB_F5_USBF5_M          0x000000FF  // Endpoint 5 FIFO register 
+                                            // Reading this register unloads 
+                                            // one byte from the EP5 OUT FIFO. 
+                                            // Writing to this register loads 
+                                            // one byte into the EP5 IN FIFO. 
+#define USB_F5_USBF5_S          0
+
+
+#endif // __HW_USB_H__
+


### PR DESCRIPTION
    Currently the cc2538 is based on from-scratch adaption which is
    not feature complete and thus lacks defines etc. Introducing the
    official vendor header will ease future extension and adaptions
    of the CPU and its features.

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR adds official TI vendor headers for the CC2538. In follow-up PRs I'll adapt existing
implementation to use vendor header defines where ever useful. Hence, this only a first step only adding files not touching existing code.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->