### PR TITLE
cc2538: cleanup and optimisation of periph timer

### DIFF
--- a/cpu/cc2538/include/cc2538_gptimer.h
+++ b/cpu/cc2538/include/cc2538_gptimer.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2014 Loci Controls Inc.
+ *               2018 HAW Hamburg
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -15,6 +16,7 @@
  * @brief           CC2538 General Purpose Timer (GPTIMER) driver
  *
  * @author          Ian Martin <ian@locicontrols.com>
+ * @author          Sebastian Meiling <s@mlng.net>
  */
 
 #ifndef CC2538_GPTIMER_H
@@ -28,15 +30,18 @@
 extern "C" {
 #endif
 
-#define GPTIMER_NUMOF            4          /**< The CC2538 has four general-purpose timer units. */
-#define NUM_CHANNELS_PER_GPTIMER 2          /**< Each G.P. timer unit has two channels: A and B. */
-
+/**
+ * @brief Timer modes
+ */
 enum {
     GPTIMER_ONE_SHOT_MODE = 1,              /**< GPTIMER one-shot mode */
     GPTIMER_PERIODIC_MODE = 2,              /**< GPTIMER periodic mode */
     GPTIMER_CAPTURE_MODE  = 3,              /**< GPTIMER capture mode */
 };
 
+/**
+ * @brief Timer width configuration
+ */
 enum {
     GPTMCFG_32_BIT_TIMER           = 0,     /**< 32-bit timer configuration */
     GPTMCFG_32_BIT_REAL_TIME_CLOCK = 1,     /**< 32-bit real-time clock */
@@ -48,95 +53,12 @@ enum {
  */
 typedef struct {
     cc2538_reg_t CFG;                       /**< GPTIMER Configuration */
-
-    /**
-     * @brief Timer A
-     */
-    union {
-        cc2538_reg_t TAMR;                  /**< GPTIMER Timer A mode */
-        struct {
-            cc2538_reg_t TAMR2     :  2;    /**< GPTM Timer A mode */
-            cc2538_reg_t TACMR     :  1;    /**< GPTM Timer A capture mode */
-            cc2538_reg_t TAAMS     :  1;    /**< GPTM Timer A alternate mode */
-            cc2538_reg_t TACDIR    :  1;    /**< GPTM Timer A count direction */
-            cc2538_reg_t TAMIE     :  1;    /**< GPTM Timer A match interrupt enable */
-            cc2538_reg_t TAWOT     :  1;    /**< GPTM Timer A wait-on-trigger */
-            cc2538_reg_t TASNAPS   :  1;    /**< GPTM Timer A snap shot mode */
-            cc2538_reg_t TAILD     :  1;    /**< GPTM Timer A interval load write */
-            cc2538_reg_t TAPWMIE   :  1;    /**< GPTM Timer A PWM interrupt enable */
-            cc2538_reg_t TAMRSU    :  1;    /**< Timer A match register update mode */
-            cc2538_reg_t TAPLO     :  1;    /**< Legacy PWM operation */
-            cc2538_reg_t RESERVED5 : 20;    /**< Reserved bits */
-        } TAMRbits;
-    } cc2538_gptimer_tamr;
-
-    /**
-     * @brief Timer B
-     */
-    union {
-        cc2538_reg_t TBMR;                  /**< GPTIMER Timer B mode */
-        struct {
-            cc2538_reg_t TBMR2     :  2;    /**< GPTM Timer B mode */
-            cc2538_reg_t TBCMR     :  1;    /**< GPTM Timer B capture mode */
-            cc2538_reg_t TBAMS     :  1;    /**< GPTM Timer B alternate mode */
-            cc2538_reg_t TBCDIR    :  1;    /**< GPTM Timer B count direction */
-            cc2538_reg_t TBMIE     :  1;    /**< GPTM Timer B match interrupt enable */
-            cc2538_reg_t TBWOT     :  1;    /**< GPTM Timer B wait-on-trigger */
-            cc2538_reg_t TBSNAPS   :  1;    /**< GPTM Timer B snap shot mode */
-            cc2538_reg_t TBILD     :  1;    /**< GPTM Timer B interval load write */
-            cc2538_reg_t TBPWMIE   :  1;    /**< GPTM Timer B PWM interrupt enable */
-            cc2538_reg_t TBMRSU    :  1;    /**< Timer B match register update mode */
-            cc2538_reg_t TBPLO     :  1;    /**< Legacy PWM operation */
-            cc2538_reg_t RESERVED6 : 20;    /**< Reserved bits */
-        } TBMRbits;
-    } cc2538_gptimer_tbmr;
-
-    /**
-     * @brief Timer Control
-     */
-    union {
-        cc2538_reg_t CTL;                   /**< GPTIMER Control */
-        struct {
-            cc2538_reg_t TAEN      :  1;    /**< GPTM Timer A enable */
-            cc2538_reg_t TASTALL   :  1;    /**< GPTM Timer A stall enable */
-            cc2538_reg_t TAEVENT   :  1;    /**< GPTM Timer A event mode */
-            cc2538_reg_t RESERVED1 :  1;    /**< Reserved bits */
-            cc2538_reg_t TAOTE     :  1;    /**< GPTM Timer A PWM output trigger enable */
-            cc2538_reg_t TAPWML    :  1;    /**< GPTM Timer A PWM output level */
-            cc2538_reg_t RESERVED2 :  1;    /**< Reserved bits */
-            cc2538_reg_t TBEN      :  1;    /**< GPTM Timer B enable */
-            cc2538_reg_t TBSTALL   :  1;    /**< GPTM Timer B stall enable */
-            cc2538_reg_t TBEVENT   :  1;    /**< GPTM Timer B event mode */
-            cc2538_reg_t RESERVED3 :  1;    /**< Reserved bits */
-            cc2538_reg_t TBOTE     :  1;    /**< GPTM Timer B PWM output trigger enable */
-            cc2538_reg_t TBPWML    :  1;    /**< GPTM Timer B PWM output level */
-            cc2538_reg_t RESERVED4 : 17;    /**< Reserved bits */
-        } CTLbits;
-    } cc2538_gptimer_ctl;
-
+    cc2538_reg_t TAMR;                      /**< GPTIMER Timer A mode */
+    cc2538_reg_t TBMR;                      /**< GPTIMER Timer B mode */
+    cc2538_reg_t CTL;                       /**< GPTIMER Control */
     cc2538_reg_t SYNC;                      /**< GPTIMER Synchronize */
     cc2538_reg_t RESERVED2;                 /**< Reserved word */
-
-    /**
-     * @brief Interrupt mask control
-     */
-    union {
-        cc2538_reg_t IMR;                   /**< GPTIMER Interrupt Mask */
-        struct {
-            cc2538_reg_t TATOIM    :  1;    /**< GPTM Timer A time-out interrupt mask */
-            cc2538_reg_t CAMIM     :  1;    /**< GPTM Timer A capture match interrupt mask */
-            cc2538_reg_t CAEIM     :  1;    /**< GPTM Timer A capture event interrupt mask */
-            cc2538_reg_t RESERVED1 :  1;    /**< Reserved bits */
-            cc2538_reg_t TAMIM     :  1;    /**< GPTM Timer A match interrupt mask */
-            cc2538_reg_t RESERVED2 :  3;    /**< Reserved bits */
-            cc2538_reg_t TBTOIM    :  1;    /**< GPTM Timer B time-out interrupt mask */
-            cc2538_reg_t CBMIM     :  1;    /**< GPTM Timer B capture match interrupt mask */
-            cc2538_reg_t CBEIM     :  1;    /**< GPTM Timer B capture event interrupt mask */
-            cc2538_reg_t TBMIM     :  1;    /**< GPTM Timer B match interrupt mask */
-            cc2538_reg_t RESERVED3 : 20;    /**< Reserved bits */
-        } IMRbits;
-    } cc2538_gptimer_imr;
-
+    cc2538_reg_t IMR;                       /**< GPTIMER Interrupt Mask */
     cc2538_reg_t RIS;                       /**< GPTIMER Raw Interrupt Status */
     cc2538_reg_t MIS;                       /**< GPTIMER Masked Interrupt Status */
     cc2538_reg_t ICR;                       /**< GPTIMER Interrupt Clear */
@@ -161,25 +83,6 @@ typedef struct {
     cc2538_reg_t PP;                        /**< GPTIMER Peripheral Properties */
     cc2538_reg_t RESERVED4[15];             /**< Reserved */
 } cc2538_gptimer_t;
-
-/**
- * @brief   Base address of general-purpose timers (GPT)
- */
-#define GPTIMER_BASE    (0x40030000)
-
-#define GPTIMER0 ( (cc2538_gptimer_t*)0x40030000 )       /**< GPTIMER0 Instance */
-#define GPTIMER1 ( (cc2538_gptimer_t*)0x40031000 )       /**< GPTIMER1 Instance */
-#define GPTIMER2 ( (cc2538_gptimer_t*)0x40032000 )       /**< GPTIMER2 Instance */
-#define GPTIMER3 ( (cc2538_gptimer_t*)0x40033000 )       /**< GPTIMER3 Instance */
-
-void isr_timer0_chan0(void);                /**< RIOT Timer 0 Channel 0 Interrupt Service Routine */
-void isr_timer0_chan1(void);                /**< RIOT Timer 0 Channel 1 Interrupt Service Routine */
-void isr_timer1_chan0(void);                /**< RIOT Timer 1 Channel 0 Interrupt Service Routine */
-void isr_timer1_chan1(void);                /**< RIOT Timer 1 Channel 1 Interrupt Service Routine */
-void isr_timer2_chan0(void);                /**< RIOT Timer 2 Channel 0 Interrupt Service Routine */
-void isr_timer2_chan1(void);                /**< RIOT Timer 2 Channel 1 Interrupt Service Routine */
-void isr_timer3_chan0(void);                /**< RIOT Timer 3 Channel 0 Interrupt Service Routine */
-void isr_timer3_chan1(void);                /**< RIOT Timer 3 Channel 1 Interrupt Service Routine */
 
 #ifdef __cplusplus
 } /* end extern "C" */

--- a/cpu/cc2538/periph/timer.c
+++ b/cpu/cc2538/periph/timer.c
@@ -107,7 +107,7 @@ int timer_init(tim_t tim, unsigned long freq, timer_cb_t cb, void *arg)
     SYS_CTRL->RCGCGPT |= (1 << tim);
 
     /* Disable this timer before configuring it: */
-    dev(tim)->cc2538_gptimer_ctl.CTL = 0;
+    dev(tim)->CTL = 0;
 
     uint32_t prescaler = 0;
     uint32_t chan_mode = TNMIE | GPTIMER_PERIODIC_MODE;
@@ -142,15 +142,15 @@ int timer_init(tim_t tim, unsigned long freq, timer_cb_t cb, void *arg)
     }
 
     dev(tim)->CFG = timer_config[tim].cfg;
-    dev(tim)->cc2538_gptimer_ctl.CTL = TAEN;
-    dev(tim)->cc2538_gptimer_tamr.TAMR = chan_mode;
+    dev(tim)->CTL = TAEN;
+    dev(tim)->TAMR = chan_mode;
 
     if (timer_config[tim].chn > 1) {
-        dev(tim)->cc2538_gptimer_tbmr.TBMR = chan_mode;
+        dev(tim)->TBMR = chan_mode;
         dev(tim)->TBPR = prescaler;
         dev(tim)->TBILR = LOAD_VALUE;
         /* Enable the timer: */
-        dev(tim)->cc2538_gptimer_ctl.CTL = TBEN | TAEN;
+        dev(tim)->CTL = TBEN | TAEN;
     }
 
     /* Enable interrupts for given timer: */
@@ -175,7 +175,7 @@ int timer_set_absolute(tim_t tim, int channel, unsigned int value)
     else {
         dev(tim)->TBMATCHR = (LOAD_VALUE - value);
     }
-    dev(tim)->cc2538_gptimer_imr.IMR |= chn_isr_cfg[channel].flag;
+    dev(tim)->IMR |= chn_isr_cfg[channel].flag;
 
     return 1;
 }
@@ -188,7 +188,7 @@ int timer_clear(tim_t tim, int channel)
         return -1;
     }
     /* clear interupt flags */
-    dev(tim)->cc2538_gptimer_imr.IMR &= ~(chn_isr_cfg[channel].flag);
+    dev(tim)->IMR &= ~(chn_isr_cfg[channel].flag);
 
     return 1;
 }
@@ -221,7 +221,7 @@ void timer_stop(tim_t tim)
     DEBUG("%s(%u)\n", __FUNCTION__, tim);
 
     if (tim < TIMER_NUMOF) {
-        dev(tim)->cc2538_gptimer_ctl.CTL = 0;
+        dev(tim)->CTL = 0;
     }
 }
 
@@ -231,10 +231,10 @@ void timer_start(tim_t tim)
 
     if (tim < TIMER_NUMOF) {
         if (timer_config[tim].chn == 1) {
-            dev(tim)->cc2538_gptimer_ctl.CTL = TAEN;
+            dev(tim)->CTL = TAEN;
         }
         else if (timer_config[tim].chn == 2) {
-            dev(tim)->cc2538_gptimer_ctl.CTL = TBEN | TAEN;
+            dev(tim)->CTL = TBEN | TAEN;
         }
     }
 }
@@ -259,7 +259,7 @@ static void irq_handler(tim_t tim, int channel)
 
   if (mis & chn_isr_cfg[channel].flag) {
       /* Disable further match interrupts for this timer/channel */
-      dev(tim)->cc2538_gptimer_imr.IMR &= ~chn_isr_cfg[channel].flag;
+      dev(tim)->IMR &= ~chn_isr_cfg[channel].flag;
       /* Invoke the callback function */
       isr_ctx[tim].cb(isr_ctx[tim].arg, channel);
   }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR adapts the periph/timer implementation of the CC2538 CPU to use vendor header
defines where possible. It also removes obsolete or unused defines and refines the timer
struct. Also it (re)introduces the possibility to config timers out-of-order by explicitly setting
the under-lying timer device.

Overall goody: this save 56B binary size on `tests/periph_timer` for `remote-revb`

Test output:

```
2018-08-03 09:49:49,164 - INFO # main(): This is RIOT! (Version: 2018.10-devel-330-gf1678-mobi25.inet.haw-hamburg.de-cpu/cc2538/vendor_header)
2018-08-03 09:49:49,170 - INFO # 
2018-08-03 09:49:49,170 - INFO # Test for peripheral TIMERs
2018-08-03 09:49:49,170 - INFO # 
2018-08-03 09:49:49,171 - INFO # This test will test all configured peripheral timers of the
2018-08-03 09:49:49,172 - INFO # targeted platform. For each timer, it will set each channel with
2018-08-03 09:49:49,173 - INFO # an incrementing timeout. CH0 set to 5ms, CH1 to 10ms, CH2 to 15ms
2018-08-03 09:49:49,173 - INFO # and so on.
2018-08-03 09:49:49,174 - INFO # In the output you should see that every channel fired, after an
2018-08-03 09:49:49,175 - INFO # evenly distributed amount of time -> the shown diff values should
2018-08-03 09:49:49,175 - INFO # be pretty much equal (to some jitter...)
2018-08-03 09:49:49,176 - INFO # This test does however NOT show, if the timeouts were correct in
2018-08-03 09:49:49,177 - INFO # relation to the expected real-time ~ use e.g. tests/xtimer_msg for
2018-08-03 09:49:49,177 - INFO # this.
2018-08-03 09:49:49,177 - INFO # 
2018-08-03 09:49:49,177 - INFO # 
2018-08-03 09:49:49,177 - INFO # Available timers: 4
2018-08-03 09:49:49,177 - INFO # 
2018-08-03 09:49:49,178 - INFO # Testing TIMER_0:
2018-08-03 09:49:49,178 - INFO # TIMER_0: initialization successful
2018-08-03 09:49:49,178 - INFO # TIMER_0: stopped
2018-08-03 09:49:49,179 - INFO # TIMER_0: set channel 0 to 5000
2018-08-03 09:49:49,179 - INFO # TIMER_0: set channel 1 to 10000
2018-08-03 09:49:49,179 - INFO # TIMER_0: starting
2018-08-03 09:49:49,202 - INFO # TIMER_0: channel 0 fired at SW count     6154 - init:     6154
2018-08-03 09:49:49,203 - INFO # TIMER_0: channel 1 fired at SW count    12304 - diff:     6150
2018-08-03 09:49:49,203 - INFO # 
2018-08-03 09:49:49,203 - INFO # Testing TIMER_1:
2018-08-03 09:49:49,204 - INFO # TIMER_1: ERROR on initialization - skipping
2018-08-03 09:49:49,204 - INFO # 
2018-08-03 09:49:49,204 - INFO # 
2018-08-03 09:49:49,204 - INFO # Testing TIMER_2:
2018-08-03 09:49:49,204 - INFO # TIMER_2: initialization successful
2018-08-03 09:49:49,205 - INFO # TIMER_2: stopped
2018-08-03 09:49:49,205 - INFO # TIMER_2: set channel 0 to 5000
2018-08-03 09:49:49,206 - INFO # TIMER_2: set channel 1 to 10000
2018-08-03 09:49:49,206 - INFO # TIMER_2: starting
2018-08-03 09:49:49,229 - INFO # TIMER_2: channel 0 fired at SW count     6155 - init:     6155
2018-08-03 09:49:49,229 - INFO # TIMER_2: channel 1 fired at SW count    12305 - diff:     6150
2018-08-03 09:49:49,230 - INFO # 
2018-08-03 09:49:49,230 - INFO # Testing TIMER_3:
2018-08-03 09:49:49,230 - INFO # TIMER_3: ERROR on initialization - skipping
2018-08-03 09:49:49,231 - INFO # 
2018-08-03 09:49:49,231 - INFO # 
2018-08-03 09:49:49,231 - INFO # TEST FAILED
2018-08-03 09:49:53,991 - INFO # Exiting Pyterm
```

Timer 1 and 3 fail because in 32Bit mode there is no pre-scaler and the timer has to run with system clock speed, but the test app tries to set 1MHz which fails - so failure is expected here but timer 0 and 2 work as expected.

Also `tests/xtimer_hang` succeeds:

```
2018-08-03 09:42:48,339 - INFO # main(): This is RIOT! (Version: 2018.10-devel-329-gfae94-mobi25.inet.haw-hamburg.de-cpu/cc2538/vendor_header)
2018-08-03 09:42:48,339 - INFO # [START]
2018-08-03 09:42:48,438 - INFO # Testing (  0%)
2018-08-03 09:42:48,538 - INFO # Testing (  1%)
2018-08-03 09:42:48,638 - INFO # Testing (  2%)
2018-08-03 09:42:48,739 - INFO # Testing (  3%)
2018-08-03 09:42:48,839 - INFO # Testing (  4%)
2018-08-03 09:42:48,939 - INFO # Testing (  5%)
2018-08-03 09:42:49,040 - INFO # Testing (  6%)
2018-08-03 09:42:49,140 - INFO # Testing (  7%)
2018-08-03 09:42:49,240 - INFO # Testing (  8%)
2018-08-03 09:42:49,341 - INFO # Testing (  9%)
2018-08-03 09:42:49,441 - INFO # Testing ( 10%)
2018-08-03 09:42:49,541 - INFO # Testing ( 11%)
2018-08-03 09:42:49,642 - INFO # Testing ( 12%)
2018-08-03 09:42:49,742 - INFO # Testing ( 13%)
2018-08-03 09:42:49,842 - INFO # Testing ( 14%)
2018-08-03 09:42:49,942 - INFO # Testing ( 15%)
2018-08-03 09:42:50,043 - INFO # Testing ( 16%)
2018-08-03 09:42:50,143 - INFO # Testing ( 17%)
2018-08-03 09:42:50,243 - INFO # Testing ( 18%)
2018-08-03 09:42:50,344 - INFO # Testing ( 19%)
2018-08-03 09:42:50,444 - INFO # Testing ( 20%)
2018-08-03 09:42:50,544 - INFO # Testing ( 21%)
2018-08-03 09:42:50,645 - INFO # Testing ( 22%)
2018-08-03 09:42:50,745 - INFO # Testing ( 23%)
2018-08-03 09:42:50,845 - INFO # Testing ( 24%)
2018-08-03 09:42:50,946 - INFO # Testing ( 25%)
2018-08-03 09:42:51,046 - INFO # Testing ( 26%)
2018-08-03 09:42:51,146 - INFO # Testing ( 27%)
2018-08-03 09:42:51,247 - INFO # Testing ( 28%)
2018-08-03 09:42:51,347 - INFO # Testing ( 29%)
2018-08-03 09:42:51,447 - INFO # Testing ( 30%)
2018-08-03 09:42:51,548 - INFO # Testing ( 31%)
2018-08-03 09:42:51,648 - INFO # Testing ( 32%)
2018-08-03 09:42:51,748 - INFO # Testing ( 33%)
2018-08-03 09:42:51,849 - INFO # Testing ( 34%)
2018-08-03 09:42:51,949 - INFO # Testing ( 35%)
2018-08-03 09:42:52,049 - INFO # Testing ( 36%)
2018-08-03 09:42:52,149 - INFO # Testing ( 37%)
2018-08-03 09:42:52,250 - INFO # Testing ( 38%)
2018-08-03 09:42:52,350 - INFO # Testing ( 39%)
2018-08-03 09:42:52,450 - INFO # Testing ( 40%)
2018-08-03 09:42:52,551 - INFO # Testing ( 41%)
2018-08-03 09:42:52,651 - INFO # Testing ( 42%)
2018-08-03 09:42:52,751 - INFO # Testing ( 43%)
2018-08-03 09:42:52,852 - INFO # Testing ( 44%)
2018-08-03 09:42:52,952 - INFO # Testing ( 45%)
2018-08-03 09:42:53,052 - INFO # Testing ( 46%)
2018-08-03 09:42:53,153 - INFO # Testing ( 47%)
2018-08-03 09:42:53,253 - INFO # Testing ( 48%)
2018-08-03 09:42:53,354 - INFO # Testing ( 49%)
2018-08-03 09:42:53,454 - INFO # Testing ( 50%)
2018-08-03 09:42:53,554 - INFO # Testing ( 51%)
2018-08-03 09:42:53,655 - INFO # Testing ( 52%)
2018-08-03 09:42:53,755 - INFO # Testing ( 53%)
2018-08-03 09:42:53,855 - INFO # Testing ( 54%)
2018-08-03 09:42:53,955 - INFO # Testing ( 55%)
2018-08-03 09:42:54,056 - INFO # Testing ( 56%)
2018-08-03 09:42:54,156 - INFO # Testing ( 57%)
2018-08-03 09:42:54,256 - INFO # Testing ( 58%)
2018-08-03 09:42:54,357 - INFO # Testing ( 59%)
2018-08-03 09:42:54,457 - INFO # Testing ( 60%)
2018-08-03 09:42:54,557 - INFO # Testing ( 61%)
2018-08-03 09:42:54,658 - INFO # Testing ( 62%)
2018-08-03 09:42:54,758 - INFO # Testing ( 63%)
2018-08-03 09:42:54,858 - INFO # Testing ( 64%)
2018-08-03 09:42:54,959 - INFO # Testing ( 65%)
2018-08-03 09:42:55,059 - INFO # Testing ( 66%)
2018-08-03 09:42:55,159 - INFO # Testing ( 67%)
2018-08-03 09:42:55,260 - INFO # Testing ( 68%)
2018-08-03 09:42:55,360 - INFO # Testing ( 69%)
2018-08-03 09:42:55,460 - INFO # Testing ( 70%)
2018-08-03 09:42:55,561 - INFO # Testing ( 71%)
2018-08-03 09:42:55,661 - INFO # Testing ( 72%)
2018-08-03 09:42:55,761 - INFO # Testing ( 73%)
2018-08-03 09:42:55,861 - INFO # Testing ( 74%)
2018-08-03 09:42:55,962 - INFO # Testing ( 75%)
2018-08-03 09:42:56,062 - INFO # Testing ( 76%)
2018-08-03 09:42:56,162 - INFO # Testing ( 77%)
2018-08-03 09:42:56,263 - INFO # Testing ( 78%)
2018-08-03 09:42:56,363 - INFO # Testing ( 79%)
2018-08-03 09:42:56,463 - INFO # Testing ( 80%)
2018-08-03 09:42:56,564 - INFO # Testing ( 81%)
2018-08-03 09:42:56,664 - INFO # Testing ( 82%)
2018-08-03 09:42:56,764 - INFO # Testing ( 83%)
2018-08-03 09:42:56,865 - INFO # Testing ( 84%)
2018-08-03 09:42:56,965 - INFO # Testing ( 85%)
2018-08-03 09:42:57,065 - INFO # Testing ( 86%)
2018-08-03 09:42:57,166 - INFO # Testing ( 87%)
2018-08-03 09:42:57,266 - INFO # Testing ( 88%)
2018-08-03 09:42:57,366 - INFO # Testing ( 89%)
2018-08-03 09:42:57,467 - INFO # Testing ( 90%)
2018-08-03 09:42:57,567 - INFO # Testing ( 91%)
2018-08-03 09:42:57,667 - INFO # Testing ( 92%)
2018-08-03 09:42:57,768 - INFO # Testing ( 93%)
2018-08-03 09:42:57,868 - INFO # Testing ( 94%)
2018-08-03 09:42:57,968 - INFO # Testing ( 95%)
2018-08-03 09:42:58,069 - INFO # Testing ( 96%)
2018-08-03 09:42:58,169 - INFO # Testing ( 97%)
2018-08-03 09:42:58,269 - INFO # Testing ( 98%)
2018-08-03 09:42:58,372 - INFO # Testing ( 99%)
2018-08-03 09:42:58,372 - INFO # Testing (100%)
2018-08-03 09:42:58,372 - INFO # [SUCCESS]
```
### Issues/PRs references

based on #9691