### PR TITLE
nrf5x_common: gpio: remove unused pin_num() function

### DIFF
--- a/cpu/nrf5x_common/periph/gpio.c
+++ b/cpu/nrf5x_common/periph/gpio.c
@@ -55,18 +55,6 @@ static inline NRF_GPIO_Type* port(gpio_t pin)
 #endif
 }
 
-/**
- * @brief   Get a pin's offset
- */
-static inline int pin_num(gpio_t pin)
-{
-#ifdef CPU_MODEL_NRF52840XXAA
-    return (pin & PIN_MASK);
-#else
-    return (int)pin;
-#endif
-}
-
 int gpio_init(gpio_t pin, gpio_mode_t mode)
 {
     switch (mode) {


### PR DESCRIPTION
### Contribution description
This came up when compiling an application for an NRF5x-based board
with LLVM/clang. The function does not seem to be used throughout the
file so I just removed it.

### Issues/PRs references
None (but discovered during local testing for #9398)