### PR TITLE
Fmt: add fmt hex byte

### DIFF
--- a/sys/fmt/fmt.c
+++ b/sys/fmt/fmt.c
@@ -142,7 +142,6 @@ size_t fmt_hex_bytes(uint8_t *out, const char *hex)
     size_t len = fmt_strlen(hex);
 
     if (len & 1) {
-        out = NULL;
         return 0;
     }
 

--- a/sys/fmt/fmt.c
+++ b/sys/fmt/fmt.c
@@ -132,6 +132,11 @@ static uint8_t _hex_nib(uint8_t nib)
     return _byte_mod25((nib & 0x1f) + 9);
 }
 
+uint8_t fmt_hex_byte(const char *hex)
+{
+    return (_hex_nib(hex[0]) << 4) | _hex_nib(hex[1]);
+}
+
 size_t fmt_hex_bytes(uint8_t *out, const char *hex)
 {
     size_t len = fmt_strlen(hex);
@@ -143,7 +148,7 @@ size_t fmt_hex_bytes(uint8_t *out, const char *hex)
 
     size_t final_len = len >> 1;
     for (size_t i = 0, j = 0; j < final_len; i += 2, j++) {
-        out[j] = (_hex_nib(hex[i]) << 4) | _hex_nib(hex[i+1]);
+        out[j] = fmt_hex_byte(hex + i);
     }
 
     return final_len;

--- a/sys/include/fmt.h
+++ b/sys/include/fmt.h
@@ -92,6 +92,17 @@ size_t fmt_bytes_hex(char *out, const uint8_t *ptr, size_t n);
 size_t fmt_bytes_hex_reverse(char *out, const uint8_t *ptr, size_t n);
 
 /**
+ * @brief Converts a sequence of two hex characters to a byte
+ *
+ * The hex characters sequence must contain valid hexadecimal characters
+ * otherwise the result is undefined.
+ *
+ * @param[in]  hex  Pointer to input buffer
+ * @returns    byte based on hex string
+ */
+uint8_t fmt_hex_byte(const char *hex);
+
+/**
  * @brief Converts a sequence of hex bytes to an array of bytes
  *
  * The sequence of hex characters must have an even length:

--- a/tests/unittests/tests-fmt/tests-fmt.c
+++ b/tests/unittests/tests-fmt/tests-fmt.c
@@ -118,6 +118,31 @@ static void test_fmt_bytes_hex_reverse(void)
     TEST_ASSERT_EQUAL_STRING("zz", &out[9]);
 }
 
+static void test_fmt_hex_byte(void)
+{
+    char hex[3] = "00";
+    uint8_t byte;
+
+    byte = fmt_hex_byte(hex);
+    TEST_ASSERT_EQUAL_INT(0x00, byte);
+
+    memcpy(hex, "12", 2);
+    byte = fmt_hex_byte(hex);
+    TEST_ASSERT_EQUAL_INT(0x12, byte);
+
+    memcpy(hex, "AB", 2);
+    byte = fmt_hex_byte(hex);
+    TEST_ASSERT_EQUAL_INT(0xAB, byte);
+
+    memcpy(hex, "CD", 2);
+    byte = fmt_hex_byte(hex);
+    TEST_ASSERT_EQUAL_INT(0xCD, byte);
+
+    memcpy(hex, "EF", 2);
+    byte = fmt_hex_byte(hex);
+    TEST_ASSERT_EQUAL_INT(0xEF, byte);
+}
+
 static void test_fmt_hex_bytes(void)
 {
     uint8_t val = 0;
@@ -772,6 +797,7 @@ Test *tests_fmt_tests(void)
         new_TestFixture(test_fmt_byte_hex),
         new_TestFixture(test_fmt_bytes_hex),
         new_TestFixture(test_fmt_bytes_hex_reverse),
+        new_TestFixture(test_fmt_hex_byte),
         new_TestFixture(test_fmt_hex_bytes),
         new_TestFixture(test_fmt_u32_hex),
         new_TestFixture(test_fmt_u64_hex),


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->
Create fmt function for converting a single hex string byte (two characters, eg. 5E) to an actual byte.
This diverges a bit from the other functions of fmt in that it does not return a size_t, but to me this seems justified based on the use case of this API function. 
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->