### PR TITLE
pkg: deal with format string non-literals

### DIFF
--- a/pkg/libcoap/Makefile
+++ b/pkg/libcoap/Makefile
@@ -12,3 +12,7 @@ all: git-download
 	"$(MAKE)" -C $(PKG_BUILDDIR)
 
 include $(RIOTBASE)/pkg/pkg.mk
+
+ifeq (llvm,$(TOOLCHAIN))
+  CFLAGS += -Wno-format-nonliteral
+endif

--- a/pkg/openthread/contrib/platform_logging.c
+++ b/pkg/openthread/contrib/platform_logging.c
@@ -28,6 +28,7 @@
 
 /* adapted from OpenThread posix example:
  * See: https://github.com/openthread/openthread/blob/master/examples/platforms/posix/logging.c */
+__attribute__((__format__ (__printf__, 3, 4)))
 void otPlatLog(otLogLevel aLogLevel, otLogRegion aLogRegion, const char *aFormat, ...)
 {
     va_list args;

--- a/pkg/tinydtls/Makefile
+++ b/pkg/tinydtls/Makefile
@@ -17,3 +17,7 @@ all: git-download
 	"$(MAKE)" -C $(PKG_BUILDDIR)
 
 include $(RIOTBASE)/pkg/pkg.mk
+
+ifeq (llvm,$(TOOLCHAIN))
+  CFLAGS += -Wno-format-nonliteral
+endif


### PR DESCRIPTION
### Contribution description
Some packages use format string non-literals for their debugging/logging functions. This takes care of it so they can build (at least with that regard) for LLVM.

### Issues/PRs references
Detected in #9398 