### PR TITLE
boards: slstk3402a: add i2c

### DIFF
--- a/boards/slstk3402a/Makefile.dep
+++ b/boards/slstk3402a/Makefile.dep
@@ -1,5 +1,6 @@
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
+  USEMODULE += si7021
 endif
 
 # include board common dependencies

--- a/boards/slstk3402a/Makefile.features
+++ b/boards/slstk3402a/Makefile.features
@@ -1,6 +1,7 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_gpio
+FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi

--- a/boards/slstk3402a/include/periph_conf.h
+++ b/boards/slstk3402a/include/periph_conf.h
@@ -89,7 +89,16 @@ static const adc_chan_conf_t adc_channel_config[] = {
  * @{
  */
 static const i2c_conf_t i2c_config[] = {
-
+    {
+        .dev = I2C0,
+        .sda_pin = GPIO_PIN(PC, 10),
+        .scl_pin = GPIO_PIN(PC, 11),
+        .loc = I2C_ROUTELOC0_SDALOC_LOC15 |
+               I2C_ROUTELOC0_SCLLOC_LOC15,
+        .cmu = cmuClock_I2C0,
+        .irq = I2C0_IRQn,
+        .speed = I2C_SPEED_NORMAL
+    }
 };
 
 #define I2C_NUMOF           PERIPH_NUMOF(i2c_config)


### PR DESCRIPTION
### Contribution description

I2C for the SLSTK3402a was disabled/removed when it got merged during the I2C embargo. This PR re-adds it now that the embargo has ended

### Issues/PRs references

#8802