### PR TITLE
pkg: gecko_sdk: update for llvm support

### DIFF
--- a/pkg/gecko_sdk/Makefile
+++ b/pkg/gecko_sdk/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME=gecko_sdk
 PKG_URL=https://github.com/basilfx/RIOT-gecko-sdk
-PKG_VERSION=a5e7be18ef3d7947ab6f04f9cd74f8808da7aece
+PKG_VERSION=6f076bc0557e6f9a44a9d08e0a734f0d24d7c97c
 PKG_LICENSE=Zlib
 
 ifneq ($(CPU),efm32)

--- a/pkg/gecko_sdk/Makefile
+++ b/pkg/gecko_sdk/Makefile
@@ -7,7 +7,9 @@ ifneq ($(CPU),efm32)
   $(error This package can only be used with EFM32 CPUs)
 endif
 
-CFLAGS += -Wno-int-in-bool-context
+ifneq (llvm,$(TOOLCHAIN))
+  CFLAGS += -Wno-int-in-bool-context
+endif
 
 .PHONY: all
 


### PR DESCRIPTION
### Contribution description

This PR updates Gecko-SDK (for EFM32 support) to add support for LLVM.

The upstream change in Gecko-SDK can be found [here](https://github.com/basilfx/RIOT-gecko-sdk/commit/297de636a77e84d12c71af525d3d998b071f8d30).

### Issues/PRs references

Fixes #9696