### PR TITLE
boards/b-l475e-iot01a: configure second I2C and on-board sensors (lis3mdl, lsm6dsl and hts221)

### DIFF
--- a/boards/b-l475e-iot01a/Makefile.dep
+++ b/boards/b-l475e-iot01a/Makefile.dep
@@ -1,3 +1,6 @@
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
+  USEMODULE += hts221
+  USEMODULE += lis3mdl
+  USEMODULE += lsm6dsl
 endif

--- a/boards/b-l475e-iot01a/include/board.h
+++ b/boards/b-l475e-iot01a/include/board.h
@@ -54,6 +54,28 @@ extern "C" {
 #define BTN_B1_PIN          GPIO_PIN(PORT_C, 13)
 
 /**
+ * @name    HTS221 temperature/humidity sensor configuration
+ * @{
+ */
+#define HTS221_PARAM_I2C    I2C_DEV(1)
+/** @} */
+
+/**
+ * @name    LIS3MDL 3-axis magnetometer configuration
+ * @{
+ */
+#define LIS3MDL_PARAM_I2C   I2C_DEV(1)
+/** @} */
+
+/**
+ * @name    LSM6DSL accelerometer sensor configuration
+ * @{
+ */
+#define LSM6DSL_PARAM_I2C   I2C_DEV(1)
+#define LSM6DSL_PARAM_ADDR  (0x6A)
+/** @} */
+
+/**
  * @brief   Initialize board specific hardware, including clock, LEDs and std-IO
  */
 void board_init(void);

--- a/boards/b-l475e-iot01a/include/periph_conf.h
+++ b/boards/b-l475e-iot01a/include/periph_conf.h
@@ -204,10 +204,22 @@ static const i2c_conf_t i2c_config[] = {
         .bus            = APB1,
         .rcc_mask       = RCC_APB1ENR1_I2C1EN,
         .irqn           = I2C1_ER_IRQn,
-    }
+    },
+    {
+        .dev            = I2C2,
+        .speed          = I2C_SPEED_NORMAL,
+        .scl_pin        = GPIO_PIN(PORT_B, 10),
+        .sda_pin        = GPIO_PIN(PORT_B, 11),
+        .scl_af         = GPIO_AF4,
+        .sda_af         = GPIO_AF4,
+        .bus            = APB1,
+        .rcc_mask       = RCC_APB1ENR1_I2C2EN,
+        .irqn           = I2C2_ER_IRQn,
+    },
 };
 
 #define I2C_0_ISR           isr_i2c1_er
+#define I2C_1_ISR           isr_i2c2_er
 
 #define I2C_NUMOF           (sizeof(i2c_config) / sizeof(i2c_config[0]))
 /** @} */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Now that the I2C refactoring is in and since it provides I2C support for STM32 L4, this PR configures a second I2C peripheral and defines default parameters for the on-board HTS221, LIS3MDL and LSM6DSL sensors of the ST B-L475E-IOT01A board.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

### Issues/PRs references

#7585

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->