### PR TITLE
examples/gcoap: fix post/put without port number

### DIFF
--- a/examples/gcoap/gcoap_cli.c
+++ b/examples/gcoap/gcoap_cli.c
@@ -233,7 +233,13 @@ int gcoap_cli_cmd(int argc, char **argv)
         apos++;
     }
 
-    if (argc == apos + 3 || argc == apos + 4) {
+    /*
+     * "get" (code_pos 0) must have exactly apos + 3 arguments
+     * while "post" (code_pos 1) and "put" (code_pos 2) and must have exactly
+     * apos + 4 arguments
+     */
+    if (((argc == apos + 3) && (code_pos == 0)) ||
+        ((argc == apos + 4) && (code_pos != 0))) {
         gcoap_req_init(&pdu, &buf[0], GCOAP_PDU_BUF_SIZE, code_pos+1, argv[apos+2]);
         if (argc == apos + 4) {
             memcpy(pdu.payload, argv[apos+3], strlen(argv[apos+3]));


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

Made a mistake during rebasing and somehow Github manage to close the PR. So here's a new PR. Sorry for the inconvenience @kb2ma @smlng 
Link to old PR: #9688 

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

Fix failed assertion when using coap post/put without specifying the port number.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
Fixes #9686 