### PR TITLE
core: rmutex: include stdint.h [backport 2018.07]

### DIFF
--- a/core/include/rmutex.h
+++ b/core/include/rmutex.h
@@ -21,6 +21,7 @@
 #ifndef RMUTEX_H
 #define RMUTEX_H
 
+#include <stdint.h>
 #include <stdatomic.h>
 
 #include "mutex.h"


### PR DESCRIPTION
# Backport of #9705

### Contribution description
For some reason the LLVM/clang version of `stdatomic.h` does not include
`stdint.h`, though it uses types from it.

### Issues/PRs references
Detected in #9398 