### PR TITLE
pkg/ccn-lite/relic: check for minimal cmake version

### DIFF
--- a/dist/tools/has_minimal_version/has_minimal_version.sh
+++ b/dist/tools/has_minimal_version/has_minimal_version.sh
@@ -1,0 +1,33 @@
+#! /bin/bash
+#
+# usage: has_minimal_version.sh <version> <minimal_version> [toolname]
+#   Checks that version >= minimal_version
+#   Version format MAJOR.MINOR.PATCH ex 3.1.4
+
+# Adapted from https://stackoverflow.com/a/24067243 to have >=
+# Checking versions with '-rcX' does not work properly due to the usage of
+# `sort -V`.
+
+if [ $# -lt 2 ]; then
+    echo "usage: ${0} <version> <minimal_version> [toolname]" >&2
+    echo "  Checks that version >= minimal_version" >&2
+    echo "  Version format MAJOR.MINOR.PATCH ex 3.1.4" >&2
+    exit 1
+fi
+
+readonly TOOLVERSION="${1}"
+readonly MINVERSION="${2}"
+readonly TOOLNAME="${3}"
+
+if [ "${TOOLNAME}" != "" ]; then
+  readonly TOOLSTR="${TOOLNAME} "
+else
+  readonly TOOLSTR=""
+fi
+
+
+HIGHEST=$(printf "%s\n%s\n" "${TOOLVERSION}" "${MINVERSION}" | sort -rV | head -n 1)
+test "${HIGHEST}" = "${TOOLVERSION}" && exit 0
+
+printf "\nInvalid version, found %s%s, minimal required is %s\n\n" "${TOOLSTR}" "${TOOLVERSION}" "${MINVERSION}" >&2
+exit 1

--- a/pkg/ccn-lite/Makefile
+++ b/pkg/ccn-lite/Makefile
@@ -3,7 +3,10 @@ PKG_URL=https://github.com/cn-uofbasel/ccn-lite/
 PKG_VERSION=f85a2a055db92b5978f2d4f92b830b5b6b9acb42
 PKG_LICENSE=ISC
 
-.PHONY: all
+.PHONY: all ..cmake_version_supported
+
+CMAKE_MINIMAL_VERSION = 3.6.0
+
 
 RIOT_CFLAGS = $(INCLUDES)
 
@@ -17,9 +20,17 @@ $(PKG_BUILDDIR)/src/Makefile: $(TOOLCHAIN_FILE)
 	cd $(PKG_BUILDDIR)/src && \
 	cmake -DCMAKE_TOOLCHAIN_FILE=$(TOOLCHAIN_FILE) \
 		  -DCCNL_RIOT=1 -DRIOT_CFLAGS="$(RIOT_CFLAGS)" -DBUILD_TESTING=OFF .
-
 $(TOOLCHAIN_FILE): git-download
 	$(RIOTTOOLS)/cmake/generate-xcompile-toolchain.sh > $(TOOLCHAIN_FILE)
+
+git-download: | ..cmake_version_supported
+
+..cmake_version_supported:
+	@ # Remove '-rcX' from version as they are not well handled
+	$(Q)\
+	CMAKE_VERSION=$$(cmake --version | sed -n '1 {s/cmake version //;s/-rc.*//;p;}'); \
+	$(RIOTTOOLS)/has_minimal_version/has_minimal_version.sh "$${CMAKE_VERSION}" "$(CMAKE_MINIMAL_VERSION)" cmake
+
 
 include $(RIOTBASE)/pkg/pkg.mk
 ifneq (,$(filter -Wformat-nonliteral -Wformat=2, $(CFLAGS)))

--- a/pkg/relic/Makefile
+++ b/pkg/relic/Makefile
@@ -3,7 +3,10 @@ PKG_URL=https://github.com/relic-toolkit/relic.git
 PKG_VERSION=0b0442a8218df8d309266923f2dd5b9ae3b318ce
 PKG_LICENSE=LGPL-2.1
 
-.PHONY: all
+.PHONY: all ..cmake_version_supported
+
+CMAKE_MINIMAL_VERSION = 3.6.0
+
 
 CFLAGS += -Wno-gnu-zero-variadic-macro-arguments -Wno-unused-function -Wno-newline-eof
 
@@ -21,6 +24,14 @@ $(PKG_BUILDDIR)/Makefile: $(TOOLCHAIN_FILE)
 
 $(TOOLCHAIN_FILE): git-download
 	$(RIOTTOOLS)/cmake/generate-xcompile-toolchain.sh > $(TOOLCHAIN_FILE)
+
+git-download: | ..cmake_version_supported
+
+..cmake_version_supported:
+	@ # Remove '-rcX' from version as they are not well handled
+	$(Q)\
+	CMAKE_VERSION=$$(cmake --version | sed -n '1 {s/cmake version //;s/-rc.*//;p;}'); \
+	$(RIOTTOOLS)/has_minimal_version/has_minimal_version.sh "$${CMAKE_VERSION}" "$(CMAKE_MINIMAL_VERSION)" cmake
 
 clean::
 	@rm -rf $(BINDIR)/$(PKG_NAME).a


### PR DESCRIPTION
### Contribution description

ccn-lite/relic do not build with cmake < 3.6.0. This checks for a minimal version
instead of failing to compile.

    cmake version 3.5.2 is not >= to minimal required 3.6.0

    Makefile:25: recipe for target '..cmake_version_supported' failed

Tested with versions 3.5.2, 3.6.0-rc1, 3.6.0, 3.6.3, 3.7.0-rc1, 3.7.0.

Note: the check used does not consider '-rcX' as 'sort -V' does not handle them
properly.


### Testing

You can test this by compiling `examples/ccn-lite-relay` with different cmake versions:

Last 3.5 release

```
PATH=/tmp/cmake/cmake-3.5.2-Linux-x86_64/bin/:${PATH} make clean all BOARD=samr21-xpro

cmake version 3.5.2 is not >= to minimal required 3.6.0

Makefile:28: recipe for target '..cmake_version_supported' failed
make[1]: *** [..cmake_version_supported] Error 1
```

First 3.6 stable release

```
PATH=/tmp/cmake/cmake-3.6.0-Linux-x86_64/bin/:${PATH} make clean all BOARD=samr21-xpro
...
Build successfully
```


You can download cmake old versions here:

https://cmake.org/files/

### Issues/PRs references

Fixes #9064 by making the problem clear

Found during release testing.