### PR TITLE
gnrc_udp: assert ports not zero

### DIFF
--- a/sys/include/net/gnrc/udp.h
+++ b/sys/include/net/gnrc/udp.h
@@ -76,6 +76,8 @@ int gnrc_udp_calc_csum(gnrc_pktsnip_t *hdr, gnrc_pktsnip_t *pseudo_hdr);
  * @return  pointer to the newly created (and allocated) header
  * @return  NULL on `src == NULL`, `dst == NULL`, `src_len != 2`, `dst_len != 2`
  *          or on allocation error
+ *
+ * @pre     `src > 0` and `dst > 0`
  */
 gnrc_pktsnip_t *gnrc_udp_hdr_build(gnrc_pktsnip_t *payload, uint16_t src,
                                    uint16_t dst);

--- a/sys/net/gnrc/transport_layer/udp/gnrc_udp.c
+++ b/sys/net/gnrc/transport_layer/udp/gnrc_udp.c
@@ -280,6 +280,8 @@ int gnrc_udp_calc_csum(gnrc_pktsnip_t *hdr, gnrc_pktsnip_t *pseudo_hdr)
 gnrc_pktsnip_t *gnrc_udp_hdr_build(gnrc_pktsnip_t *payload, uint16_t src,
                                    uint16_t dst)
 {
+    assert((src > 0) && (dst > 0));
+
     gnrc_pktsnip_t *res;
     udp_hdr_t *hdr;
 


### PR DESCRIPTION
    UDP port 0 is reserved for system usage, e.g., to tell the OS to
    set a random source port. Hence, neither source nor destination
    port should be 0 when transmitting. This PR adds proper asserts.

### Contribution description

Minor enhancement to ensure UDP ports are non-zero on transmission. I fiddled around
with the gnrc_networking example and found that there is no check to verify this and hence
I was able to send a packet with source port 0. 

We could make this a proper runtime check, but I decided against it because of the overhead and
just a added an equivalent `assert` to verify this while testing.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->