### PR TITLE
cpu/cc2538: enhance periph ADC

### DIFF
--- a/boards/cc2538dk/include/periph_conf.h
+++ b/boards/cc2538dk/include/periph_conf.h
@@ -118,7 +118,7 @@ static const spi_conf_t spi_config[] = {
  * @name ADC configuration
  * @{
  */
-#define SOC_ADC_ADCCON_REF  SOC_ADC_ADCCON_REF_AVDD5
+#define SOC_ADC_ADCCON3_EREF  SOC_ADC_ADCCON3_EREF_AVDD5
 
 static const adc_conf_t adc_config[] = {
     GPIO_PIN(0, 6), /**< GPIO_PA6 = ADC_ALS_PIN */

--- a/boards/openmote-b/include/periph_conf.h
+++ b/boards/openmote-b/include/periph_conf.h
@@ -71,7 +71,7 @@ static const timer_conf_t timer_config[] = {
  * @name ADC configuration
  * @{
  */
-#define SOC_ADC_ADCCON_REF  SOC_ADC_ADCCON_REF_AVDD5
+#define SOC_ADC_ADCCON3_EREF  SOC_ADC_ADCCON3_EREF_AVDD5
 
 static const adc_conf_t adc_config[] = {
     GPIO_PIN(1, 0), /**< GPIO_PB0 = GPIO0_PIN */

--- a/boards/openmote-cc2538/include/periph_conf.h
+++ b/boards/openmote-cc2538/include/periph_conf.h
@@ -69,7 +69,7 @@ static const timer_conf_t timer_config[] = {
  * @name ADC configuration
  * @{
  */
-#define SOC_ADC_ADCCON_REF  SOC_ADC_ADCCON_REF_AVDD5
+#define SOC_ADC_ADCCON3_EREF  SOC_ADC_ADCCON3_EREF_AVDD5
 
 static const adc_conf_t adc_config[] = {
     GPIO_PIN(0, 2), /**< GPIO_PA2 = AD4_PIN */

--- a/boards/remote-pa/include/periph_conf.h
+++ b/boards/remote-pa/include/periph_conf.h
@@ -73,7 +73,7 @@ static const spi_conf_t spi_config[] = {
  * @name ADC configuration
  * @{
  */
-#define SOC_ADC_ADCCON_REF  SOC_ADC_ADCCON_REF_AVDD5
+#define SOC_ADC_ADCCON3_EREF  SOC_ADC_ADCCON3_EREF_AVDD5
 
 static const adc_conf_t adc_config[] = {
     GPIO_PIN(0, 6), /**< GPIO_PA6 = ADC2_PIN */

--- a/boards/remote-reva/include/periph_conf.h
+++ b/boards/remote-reva/include/periph_conf.h
@@ -73,7 +73,7 @@ static const spi_conf_t spi_config[] = {
  * @name ADC configuration
  * @{
  */
-#define SOC_ADC_ADCCON_REF  SOC_ADC_ADCCON_REF_AVDD5
+#define SOC_ADC_ADCCON3_EREF  SOC_ADC_ADCCON3_EREF_AVDD5
 
 static const adc_conf_t adc_config[] = {
     GPIO_PIN(0, 5), /**< GPIO_PA5 = ADC1_PIN */

--- a/boards/remote-revb/include/periph_conf.h
+++ b/boards/remote-revb/include/periph_conf.h
@@ -75,7 +75,7 @@ static const spi_conf_t spi_config[] = {
  * @name ADC configuration
  * @{
  */
-#define SOC_ADC_ADCCON_REF  SOC_ADC_ADCCON_REF_AVDD5
+#define SOC_ADC_ADCCON3_EREF  SOC_ADC_ADCCON3_EREF_AVDD5
 
 static const adc_conf_t adc_config[] = {
     GPIO_PIN(0, 5), /**< GPIO_PA5 = ADC1_PIN */

--- a/cpu/cc2538/include/cc2538.h
+++ b/cpu/cc2538/include/cc2538.h
@@ -675,14 +675,6 @@ typedef volatile uint32_t cc2538_reg_t; /**< Least-significant 32 bits of the IE
 #define SMWDTHROSC_STCV2            ( *(cc2538_reg_t*)0x400d5064 ) /**< Sleep Timer Capture value byte 2 */
 #define SMWDTHROSC_STCV3            ( *(cc2538_reg_t*)0x400d5068 ) /**< Sleep Timer Capture value byte 3 */
 #define ANA_REGS_IVCTRL             ( *(cc2538_reg_t*)0x400d6004 ) /**< Analog control register */
-#define SOC_ADC_ADCCON1             ( *(cc2538_reg_t*)0x400d7000 ) /**< ADC Control Register 1 */
-#define SOC_ADC_ADCCON2             ( *(cc2538_reg_t*)0x400d7004 ) /**< ADC Control Register 2 */
-#define SOC_ADC_ADCCON3             ( *(cc2538_reg_t*)0x400d7008 ) /**< ADC Control Register 3 */
-#define SOC_ADC_ADCL                ( *(cc2538_reg_t*)0x400d700c ) /**< Least-significant part of ADC conversion result. */
-#define SOC_ADC_ADCH                ( *(cc2538_reg_t*)0x400d7010 ) /**< Most-significant part of ADC conversion result. */
-#define SOC_ADC_RNDL                ( *(cc2538_reg_t*)0x400d7014 ) /**< Random-number-generator data; low byte. */
-#define SOC_ADC_RNDH                ( *(cc2538_reg_t*)0x400d7018 ) /**< Random-number-generator data; high byte. */
-#define SOC_ADC_CMPCTL              ( *(cc2538_reg_t*)0x400d7024 ) /**< Analog comparator control and status register. */
 #define GPIO_A_DATA                 ( *(cc2538_reg_t*)0x400d9000 ) /**< GPIO_A Data Register */
 #define GPIO_A_DIR                  ( *(cc2538_reg_t*)0x400d9400 ) /**< GPIO_A data direction register */
 #define GPIO_A_IS                   ( *(cc2538_reg_t*)0x400d9404 ) /**< GPIO_A Interrupt Sense register */

--- a/cpu/cc2538/include/cc2538_soc_adc.h
+++ b/cpu/cc2538/include/cc2538_soc_adc.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2014 Loci Controls Inc.
+ *               2018 HAW Hamburg
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -15,6 +16,7 @@
  * @brief           CC2538 SOC ADC interface
  *
  * @author          Ian Martin <ian@locicontrols.com>
+ * @author          Sebastian Meiling <s@mlng.net>
  */
 
 #ifndef CC2538_SOC_ADC_H
@@ -30,33 +32,16 @@ extern "C" {
  * @brief SOC ADC component registers
  */
 typedef struct {
-
-    /**
-     * @brief ADC control register
-     */
-    union {
-        cc2538_reg_t ADCCON1;            /**< ADC Control Register 1 */
-        struct {
-            cc2538_reg_t RESERVED2 :  2; /**< Reserved bits */
-            cc2538_reg_t RCTRL     :  2; /**< Random number generator control */
-            cc2538_reg_t STSEL     :  2; /**< Start select */
-            cc2538_reg_t ST        :  1; /**< Start conversion */
-            cc2538_reg_t EOC       :  1; /**< End of conversion */
-            cc2538_reg_t RESERVED1 : 24; /**< Reserved bits */
-        } ADCCON1bits;
-    } cc2538_adc_adccon1;
-
-    cc2538_reg_t ADCCON2;                /**< ADC Control Register 2 */
-    cc2538_reg_t ADCCON3;                /**< ADC Control Register 3 */
-    cc2538_reg_t ADCL;                   /**< Least-significant part of ADC conversion result. */
-    cc2538_reg_t ADCH;                   /**< Most-significant part of ADC conversion result. */
-    cc2538_reg_t RNDL;                   /**< Random-number-generator data; low byte. */
-    cc2538_reg_t RNDH;                   /**< Random-number-generator data; high byte. */
-    cc2538_reg_t RESERVED[2];            /**< Reserved bytes */
-    cc2538_reg_t CMPCTL;                 /**< Analog comparator control and status register. */
+    cc2538_reg_t ADCCON1;       /**< ADC Control Register 1 */
+    cc2538_reg_t ADCCON2;       /**< ADC Control Register 2 */
+    cc2538_reg_t ADCCON3;       /**< ADC Control Register 3 */
+    cc2538_reg_t ADCL;          /**< Least-significant part of ADC conversion result. */
+    cc2538_reg_t ADCH;          /**< Most-significant part of ADC conversion result. */
+    cc2538_reg_t RNDL;          /**< Random-number-generator data; low byte. */
+    cc2538_reg_t RNDH;          /**< Random-number-generator data; high byte. */
+    cc2538_reg_t RESERVED[2];   /**< Reserved bytes */
+    cc2538_reg_t CMPCTL;        /**< Analog comparator control and status register. */
 } cc2538_soc_adc_t;
-
-#define SOC_ADC ( (cc2538_soc_adc_t*)0x400d7000 ) /**< One and only instance of the SOC ADC component */
 
 #ifdef __cplusplus
 } /* end extern "C" */

--- a/cpu/cc2538/include/periph_cpu.h
+++ b/cpu/cc2538/include/periph_cpu.h
@@ -24,6 +24,8 @@
 #include <stdint.h>
 #include <stdio.h>
 
+#include "vendor/hw_soc_adc.h"
+
 #include "cpu.h"
 #include "vendor/hw_ssi.h"
 
@@ -264,36 +266,13 @@ typedef enum {
 typedef gpio_t adc_conf_t;
 
 /**
- * @name SOC_ADC_ADCCON3 register bit masks
+ * @name SOC_ADC_ADCCON3_EREF registers field values
  * @{
  */
-#define SOC_ADC_ADCCON3_EREF    (0x000000C0) /**< Reference voltage for extra */
-#define SOC_ADC_ADCCON3_EDIV    (0x00000030) /**< Decimation rate for extra */
-#define SOC_ADC_ADCCON3_ECH     (0x0000000F) /**< Single channel select */
-/** @} */
-
-/**
- * @name SOC_ADC_ADCCONx registers field values
- * @{
- */
-#define SOC_ADC_ADCCON_REF_INT      (0 << 6)    /**< Internal reference */
-#define SOC_ADC_ADCCON_REF_EXT      (1 << 6)    /**< External reference on AIN7 pin */
-#define SOC_ADC_ADCCON_REF_AVDD5    (2 << 6)    /**< AVDD5 pin */
-#define SOC_ADC_ADCCON_REF_DIFF     (3 << 6)    /**< External reference on AIN6-AIN7 differential input */
-#define SOC_ADC_ADCCON_CH_GND       (0xC)       /**< GND */
-/** @} */
-
-/**
- * @brief Mask to check end-of-conversion (EOC) bit
- */
-#define SOC_ADC_ADCCON1_EOC_MASK    (0x80)
-
-/**
- * @name Masks for ADC raw data
- * @{
- */
-#define SOC_ADC_ADCL_MASK       (0x000000FC)
-#define SOC_ADC_ADCH_MASK       (0x000000FF)
+#define SOC_ADC_ADCCON3_EREF_INT      (0 << SOC_ADC_ADCCON3_EREF_S)    /**< Internal reference */
+#define SOC_ADC_ADCCON3_EREF_EXT      (1 << SOC_ADC_ADCCON3_EREF_S)    /**< External reference on AIN7 pin */
+#define SOC_ADC_ADCCON3_EREF_AVDD5    (2 << SOC_ADC_ADCCON3_EREF_S)    /**< AVDD5 pin */
+#define SOC_ADC_ADCCON3_EREF_DIFF     (3 << SOC_ADC_ADCCON3_EREF_S)    /**< External reference on AIN6-AIN7 differential input */
 /** @} */
 
 /**

--- a/cpu/cc2538/periph/hwrng.c
+++ b/cpu/cc2538/periph/hwrng.c
@@ -21,8 +21,16 @@
  * @}
  */
 
+#include "vendor/hw_memmap.h"
+#include "vendor/hw_soc_adc.h"
+
 #include "cpu.h"
 #include "periph/hwrng.h"
+
+#define ENABLE_DEBUG (0)
+#include "debug.h"
+
+static cc2538_soc_adc_t *soc_adc = (cc2538_soc_adc_t *)SOC_ADC_BASE;
 
 void hwrng_init(void)
 {
@@ -30,13 +38,14 @@ void hwrng_init(void)
     int i;
 
     /* Make sure the RNG is on */
-    SOC_ADC->cc2538_adc_adccon1.ADCCON1bits.RCTRL = 0;
+    uint32_t reg32 = soc_adc->ADCCON1 & ~(SOC_ADC_ADCCON1_RCTRL_M);
+    soc_adc->ADCCON1 = reg32;
 
     /* Enable clock for the RF Core */
     SYS_CTRL_RCGCRFC = 1;
 
     /* Wait for the clock ungating to take effect */
-    while (SYS_CTRL_RCGCRFC != 1);
+    while (SYS_CTRL_RCGCRFC != 1) {}
 
     /* Infinite RX - FRMCTRL0[3:2] = 10. This will mess with radio operation */
     RFCORE_XREG_FRMCTRL0 = 0x00000008;
@@ -63,8 +72,8 @@ void hwrng_init(void)
     }
 
     /* Seed the high byte first: */
-    SOC_ADC_RNDL = (seed >> 8) & 0xff;
-    SOC_ADC_RNDL = seed & 0xff;
+    soc_adc->RNDH = (seed >> 8) & 0xff;
+    soc_adc->RNDL = seed & 0xff;
 
     /* Turn RF off: */
     RFCORE_SFR_RFST = ISRFOFF;
@@ -72,16 +81,16 @@ void hwrng_init(void)
 
 void hwrng_read(void *buf, unsigned int num)
 {
-    unsigned count;
     uint8_t *b = (uint8_t *)buf;
 
-    for (count = 0; count < num; ) {
+    for (unsigned count = 0; count < num; count++) {
         /* Clock the RNG LSFR once: */
-        SOC_ADC->cc2538_adc_adccon1.ADCCON1bits.RCTRL = 1;
-
+        soc_adc->ADCCON1 = soc_adc->ADCCON1 | (1UL << SOC_ADC_ADCCON1_RCTRL_S);
         /* Read up to 2 bytes of hwrng data: */
-        b[count++] = SOC_ADC_RNDL;
-        if (count >= num) break;
-        b[count++] = SOC_ADC_RNDH;
+        b[count] = soc_adc->RNDL;
+        count++;
+        if (count < num) {
+            b[count] = soc_adc->RNDH;
+        }
     }
 }


### PR DESCRIPTION
    Adapt the periph ADC implementation to use vendor defines where
    ever possible. Remove duplicate or obsolete defines and adapt
    board configuration as required.

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

follow up on #9691

compare #9698 and #9693 