### PR TITLE
cpu/cc2538: generalise SPI clock configuration

### DIFF
--- a/boards/cc2538dk/include/periph_conf.h
+++ b/boards/cc2538dk/include/periph_conf.h
@@ -98,21 +98,6 @@ static const i2c_conf_t i2c_config[] = {
 /** @} */
 
 /**
- * @brief   Pre-calculated clock divider values based on a CLOCK_CORECLOCK (32MHz)
- *
- * Calculated with (CPSR * (SCR + 1)) = (CLOCK_CORECLOCK / bus_freq), where
- * 1 < CPSR < 255 and
- * 0 < SCR  < 256
- */
-static const spi_clk_conf_t spi_clk_config[] = {
-    { .cpsr = 10, .scr = 31 },  /* 100khz */
-    { .cpsr =  2, .scr = 39 },  /* 400khz */
-    { .cpsr =  2, .scr = 15 },  /* 1MHz */
-    { .cpsr =  2, .scr =  2 },  /* ~4.5MHz */
-    { .cpsr =  2, .scr =  1 }   /* ~10.7MHz */
-};
-
-/**
  * @name SPI configuration
  * @{
  */

--- a/boards/openmote-b/include/periph_conf.h
+++ b/boards/openmote-b/include/periph_conf.h
@@ -125,20 +125,6 @@ static const i2c_conf_t i2c_config[] = {
 /** @} */
 
 /**
- * @brief   Pre-calculated clock divider values based on a CLOCK_CORECLOCK (32MHz)
- *
- * Calculated with (CPSR * (SCR + 1)) = (CLOCK_CORECLOCK / bus_freq),
- * where 1 < CPSR < 255 and 0 < SCR  < 256
- */
-static const spi_clk_conf_t spi_clk_config[] = {
-    { .cpsr = 10, .scr = 31 },  /* 100khz */
-    { .cpsr =  2, .scr = 39 },  /* 400khz */
-    { .cpsr =  2, .scr = 15 },  /* 1MHz */
-    { .cpsr =  2, .scr =  2 },  /* ~4.5MHz */
-    { .cpsr =  2, .scr =  1 }   /* ~10.7MHz */
-};
-
-/**
  * @name    SPI configuration
  * @{
  */

--- a/boards/openmote-cc2538/include/periph_conf.h
+++ b/boards/openmote-cc2538/include/periph_conf.h
@@ -121,21 +121,6 @@ static const i2c_conf_t i2c_config[] = {
 /** @} */
 
 /**
- * @brief   Pre-calculated clock divider values based on a CLOCK_CORECLOCK (32MHz)
- *
- * Calculated with (CPSR * (SCR + 1)) = (CLOCK_CORECLOCK / bus_freq), where
- * 1 < CPSR < 255 and
- * 0 < SCR  < 256
- */
-static const spi_clk_conf_t spi_clk_config[] = {
-    { .cpsr = 10, .scr = 31 },  /* 100khz */
-    { .cpsr =  2, .scr = 39 },  /* 400khz */
-    { .cpsr =  2, .scr = 15 },  /* 1MHz */
-    { .cpsr =  2, .scr =  2 },  /* ~4.5MHz */
-    { .cpsr =  2, .scr =  1 }   /* ~10.7MHz */
-};
-
-/**
  * @name    SPI configuration
  * @{
  */

--- a/boards/remote-pa/include/periph_conf.h
+++ b/boards/remote-pa/include/periph_conf.h
@@ -46,21 +46,6 @@ static const i2c_conf_t i2c_config[] = {
 /** @} */
 
 /**
- * @brief   Pre-calculated clock divider values based on a CLOCK_CORECLOCK (32MHz)
- *
- * Calculated with (CPSR * (SCR + 1)) = (CLOCK_CORECLOCK / bus_freq), where
- * 1 < CPSR < 255 and
- * 0 < SCR  < 256
- */
-static const spi_clk_conf_t spi_clk_config[] = {
-    { .cpsr = 10, .scr = 31 },  /* 100khz */
-    { .cpsr =  2, .scr = 39 },  /* 400khz */
-    { .cpsr =  2, .scr = 15 },  /* 1MHz */
-    { .cpsr =  2, .scr =  2 },  /* ~4.5MHz */
-    { .cpsr =  2, .scr =  1 }   /* ~10.7MHz */
-};
-
-/**
  * @name    SPI configuration
  * @{
  */

--- a/boards/remote-reva/include/periph_conf.h
+++ b/boards/remote-reva/include/periph_conf.h
@@ -49,21 +49,6 @@ static const i2c_conf_t i2c_config[] = {
  * @name SPI configuration
  * @{
  */
-/**
- * @brief   Pre-calculated clock divider values based on a CLOCK_CORECLOCK (32MHz)
- *
- * Calculated with (CPSR * (SCR + 1)) = (CLOCK_CORECLOCK / bus_freq), where
- * 1 < CPSR < 255 and
- * 0 < SCR  < 256
- */
-static const spi_clk_conf_t spi_clk_config[] = {
-    { .cpsr = 10, .scr = 31 },  /* 100khz */
-    { .cpsr =  2, .scr = 39 },  /* 400khz */
-    { .cpsr =  2, .scr = 15 },  /* 1MHz */
-    { .cpsr =  2, .scr =  2 },  /* ~4.5MHz */
-    { .cpsr =  2, .scr =  1 }   /* ~10.7MHz */
-};
-
 static const spi_conf_t spi_config[] = {
     {
         .dev      = SSI0,

--- a/boards/remote-revb/include/periph_conf.h
+++ b/boards/remote-revb/include/periph_conf.h
@@ -52,21 +52,6 @@ static const i2c_conf_t i2c_config[] = {
  * @name SPI configuration
  * @{
  */
-/**
- * @brief   Pre-calculated clock divider values based on a CLOCK_CORECLOCK (32MHz)
- *
- * Calculated with (CPSR * (SCR + 1)) = (CLOCK_CORECLOCK / bus_freq), where
- * 1 < CPSR < 255 and
- * 0 < SCR  < 256
- */
-static const spi_clk_conf_t spi_clk_config[] = {
-    { .cpsr = 10, .scr = 31 },  /* 100khz */
-    { .cpsr =  2, .scr = 39 },  /* 400khz */
-    { .cpsr =  2, .scr = 15 },  /* 1MHz */
-    { .cpsr =  2, .scr =  2 },  /* ~4.5MHz */
-    { .cpsr =  2, .scr =  1 }   /* ~10.7MHz */
-};
-
 static const spi_conf_t spi_config[] = {
     {
         .dev      = SSI0,

--- a/cpu/cc2538/include/periph_cpu.h
+++ b/cpu/cc2538/include/periph_cpu.h
@@ -195,6 +195,23 @@ typedef struct {
     uint8_t scr;            /**< SCR clock divider */
 } spi_clk_conf_t;
 
+#ifndef BOARD_HAS_SPI_CLK_CONF
+/**
+ * @brief   Pre-calculated clock divider values based on a CLOCK_CORECLOCK (32MHz)
+ *
+ * SPI bus frequency =  CLOCK_CORECLOCK / (CPSR * (SCR + 1)), with
+ * CPSR = 2..254 and even,
+ *  SCR = 0..255
+ */
+static const spi_clk_conf_t spi_clk_config[] = {
+    { .cpsr = 64, .scr =  4 },  /* 100khz */
+    { .cpsr = 16, .scr =  4 },  /* 400khz */
+    { .cpsr = 32, .scr =  0 },  /* 1.0MHz */
+    { .cpsr =  2, .scr =  2 },  /* 5.3MHz */
+    { .cpsr =  2, .scr =  1 }   /* 8.0MHz */
+};
+#endif /* BOARD_HAS_SPI_CLK_CONF */
+
 /**
  * @name    SPI configuration data structure
  * @{


### PR DESCRIPTION
    The SPI bus frequency/clock is calculated relative to the MCUs
    core clock. Currently all boards use the default 32MHz, hence
    prescaler settings for SPI are all the same. This PR moves the
    default config for 32MHz to the CPU and allows to be overriden
    by board config if needed.

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->