### PR TITLE
boards/sensebox: Add support for SenseBox board

### DIFF
--- a/boards/sensebox_samd21/Makefile
+++ b/boards/sensebox_samd21/Makefile
@@ -1,0 +1,3 @@
+MODULE = board
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/sensebox_samd21/Makefile.dep
+++ b/boards/sensebox_samd21/Makefile.dep
@@ -1,0 +1,3 @@
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += saul_gpio
+endif

--- a/boards/sensebox_samd21/Makefile.features
+++ b/boards/sensebox_samd21/Makefile.features
@@ -1,0 +1,12 @@
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_gpio
+FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_rtc
+FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart
+
+# The board MPU family (used for grouping by the CI system)
+FEATURES_MCU_GROUP = cortex_m0_2
+
+-include $(RIOTCPU)/samd21/Makefile.features

--- a/boards/sensebox_samd21/Makefile.include
+++ b/boards/sensebox_samd21/Makefile.include
@@ -1,0 +1,26 @@
+# define the cpu used by SenseBox board
+export CPU = samd21
+export CPU_MODEL = samd21g18a
+
+#export needed for flash rule
+export PORT_LINUX ?= /dev/ttyACM0
+export PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
+
+# setup serial terminal
+include $(RIOTMAKE)/tools/serial.inc.mk
+
+# setup the flash tool used
+ifeq ($(PROGRAMMER),jlink)
+  # in case J-Link is attached to SWD pins, use a plain CPU memory model
+  export JLINK_DEVICE := atsamd21
+  include $(RIOTMAKE)/tools/jlink.inc.mk
+else
+  # by default, we use BOSSA to flash this board to take into account the
+  # pre-flashed Arduino bootloader. ROM_OFFSET skips the space taken by
+  # such bootloader.
+  ROM_OFFSET ?= 0x2000
+  include $(RIOTMAKE)/tools/bossa.inc.mk
+endif
+
+# setup the boards dependencies
+include $(RIOTBOARD)/$(BOARD)/Makefile.dep

--- a/boards/sensebox_samd21/board.c
+++ b/boards/sensebox_samd21/board.c
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2018 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_sensebox_samd21
+ * @{
+ *
+ * @file
+ * @brief       Board specific implementations for the SenseBox MCU with SAMD21
+ * board.
+ *
+ * @author      Leandro Lanzieri <leandro.lanzieri@haw-hamburg.de>
+ * @}
+ */
+
+#include "cpu.h"
+#include "board.h"
+#include "periph/gpio.h"
+
+void board_init(void)
+{
+    /* initialize the CPU */
+    cpu_init();
+
+    /* initialize the on-board red LED on pin PA27 */
+    gpio_init(LED0_PIN, GPIO_OUT);
+
+    /* initialize the on-board green LED on pin PA28 */
+    gpio_init(LED1_PIN, GPIO_OUT);
+
+    /* initialize the on-board button on pin PA20 */
+    gpio_init(BTN0_PIN, BTN0_MODE);
+
+    /* initialize XBEE1 bus enable pin */
+    gpio_init(XBEE1_EN_PIN, XBEE1_EN_MODE);
+
+    /* enable XBEE1 bus */
+    XBEE1_ENABLE;
+
+    /* initialize XBEE2 bus enable pin */
+    gpio_init(XBEE2_EN_PIN, XBEE2_EN_MODE);
+
+    /* enable XBEE2 bus */
+    XBEE2_ENABLE;
+
+    /* initialize I2C bus enable pin */
+    gpio_init(I2C_EN_PIN, I2C_EN_MODE);
+
+    /* enable I2C bus */
+    I2C_ENABLE;
+
+    /* delay for SPI reset. Read README.md for more information. */
+    for (unsigned i = 0; i < WAIT_FOR_SPI_RESET; i++) {
+        __asm__("nop");
+    }
+}

--- a/boards/sensebox_samd21/doc.txt
+++ b/boards/sensebox_samd21/doc.txt
@@ -1,0 +1,56 @@
+/**
+ * @defgroup    boards_sensebox_samd21 SenseBox MCU with SAMD21
+ * @ingroup     boards
+ * @brief       Support for the SenseBox MCU with SAMD21 board.
+
+### General information
+
+[SenseBox](https://www.sensebox.de/) is a do-it-yourself kit for stationary
+and mobile sensor stations.
+
+SenseBox board is based on the Atmel SAMD21G18A microcontroller. See
+@ref cpu_samd21.
+
+
+### Flash the board
+
+1. Put the board in bootloader mode by double tapping the reset button.<br/>
+    When the board is in bootloader mode, the user led (red) oscillates smoothly.
+
+
+2. Use `BOARD=sensebox` with the `make` command.<br/>
+    Example with `hello-world` application:
+```
+    make BOARD=sensebox_samd21 -C examples/hello-world flash
+```
+
+### Accessing STDIO via UART
+
+To access the STDIO of RIOT, a FTDI to USB converted needs to be plugged to
+the UART/Serial 1 pins on the board.
+
+### On I2C port
+I2C port is enabled by default. To disable it use ```I2C_DISABLE```. To
+re-enable use ```I2C_ENABLE```.
+
+### On XBEE ports
+XBEE1 and XBEE2 ports are enabled by default. To disable any of them use
+```XBEEn_DISABLE```. To re-enable use ```XBEEn_ENABLE```.
+
+On the board there is a reset circuit for this ports that delays the reset
+signal from the enable signal for about 300ms. Because of that a delay has
+been introduced in the ```board_init``` function, so that any SPI device
+connected to the ports is reset before use.
+
+#### SX127X radio
+The pin configuration for the SX127X radio on the
+*boards/sensebox/include/board.h** file assumes that it will be connected to
+the XBEE1 port. If a different configuraion is needed please modify this
+file.
+
+#### SD card
+The pin configuration for the mSD-Bee module radio on the
+*boards/sensebox/include/sdcard_spi_params.h** file assumes that it will be
+connected to the XBEE2 port. If a different configuraion is needed please
+modify this file.
+ */

--- a/boards/sensebox_samd21/include/board.h
+++ b/boards/sensebox_samd21/include/board.h
@@ -1,0 +1,171 @@
+/*
+ * Copyright (C) 2018 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_sensebox_samd21
+ * @brief       Support for the SenseBox MCU with SAMD21 board.
+ *
+ * @{
+ *
+ * @file
+ * @brief       Board specific configuration for the SenseBox MCU with SAMD21
+ * board.
+ *
+ * @author      Leandro Lanzieri <leandro.lanzieri@haw-hamburg.de>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include "cpu.h"
+#include "periph_conf.h"
+#include "periph_cpu.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name   LED pin definitions and handlers
+ * @{
+ */
+#define LED0_PIN            GPIO_PIN(PA, 27)
+
+#define LED_PORT            PORT->Group[PA]
+#define LED0_MASK           (1 << 27)
+
+#define LED0_ON             (LED_PORT.OUTSET.reg = LED0_MASK)
+#define LED0_OFF            (LED_PORT.OUTCLR.reg = LED0_MASK)
+#define LED0_TOGGLE         (LED_PORT.OUTTGL.reg = LED0_MASK)
+
+#define LED1_PIN            GPIO_PIN(PA, 28)
+#define LED1_MASK           (1 << 28)
+
+#define LED1_ON             (LED_PORT.OUTSET.reg = LED1_MASK)
+#define LED1_OFF            (LED_PORT.OUTCLR.reg = LED1_MASK)
+#define LED1_TOGGLE         (LED_PORT.OUTTGL.reg = LED1_MASK)
+/** @} */
+
+/**
+ * @name    SW0 (Button) pin definitions
+ * @{
+ */
+#define BTN0_PORT           PORT->Group[PA]
+#define BTN0_PIN            GPIO_PIN(PA, 20)
+#define BTN0_MODE           GPIO_IN_PU
+/** @} */
+
+/**
+ * @name    XBEE1 bus
+ * @brief   XBEE1 is enabled by default. The enable pin is
+ * 'XBEE1_EN_PIN'. To disable this bus call 'XBEE1_DISABLE', to re-enable it
+ * call 'XBEE1_ENABLE'.
+ * @{
+ */
+#define XBEE1_EN_PORT           PORT->Group[PB]
+#define XBEE1_EN_MASK           (1 << 3)
+#define XBEE1_EN_MODE           GPIO_OUT
+#define XBEE1_EN_PIN            GPIO_PIN(PB, 3)
+
+#define XBEE1_ENABLE            (XBEE1_EN_PORT.OUTCLR.reg = XBEE1_EN_MASK)
+#define XBEE1_DISABLE           (XBEE1_EN_PORT.OUTSET.reg = XBEE1_EN_MASK)
+
+#define XBEE1_CS_PIN            GPIO_PIN(PA, 18)
+
+#define XBEE1_INT_PIN           GPIO_PIN(PA, 21)
+/** @} */
+
+/**
+ * @name    XBEE2 bus
+ * @brief   XBEE2 is enabled by default. The enable pin is
+ * 'XBEE2_EN_PIN'. To disable this bus call 'XBEE2_DISABLE', to re-enable it
+ * call 'XBEE2_ENABLE'.
+ * @{
+ */
+#define XBEE2_EN_PORT           PORT->Group[PB]
+#define XBEE2_EN_MASK           (1 << 10)
+#define XBEE2_EN_PIN            GPIO_PIN(PB, 10)
+#define XBEE2_EN_MODE           GPIO_OUT
+
+#define XBEE2_ENABLE            (XBEE2_EN_PORT.OUTCLR.reg = XBEE2_EN_MASK)
+#define XBEE2_DISABLE           (XBEE2_EN_PORT.OUTSET.reg = XBEE2_EN_MASK)
+
+#define XBEE2_CS_PIN            GPIO_PIN(PA, 14)
+
+#define XBEE2_INT_PIN           GPIO_PIN(PA, 15)
+/** @} */
+
+/**
+ * @name    I2C bus
+ * @brief   I2C is enabled by default. The enable pin is
+ * 'I2C_EN_PIN'. To disable this bus call 'I2C_DISABLE', to re-enable it call
+ * 'I2C_ENABLE'.
+ * @{
+ */
+#define I2C_EN_PORT           PORT->Group[PB]
+#define I2C_EN_MASK           (1 << 11)
+#define I2C_EN_PIN            GPIO_PIN(PB, 11)
+#define I2C_EN_MODE           GPIO_OUT
+
+#define I2C_ENABLE            (I2C_EN_PORT.OUTSET.reg = I2C_EN_MASK)
+#define I2C_DISABLE           (I2C_EN_PORT.OUTCLR.reg = I2C_EN_MASK)
+/** @} */
+
+/**
+ * @name        SX127X
+ *
+ * SX127X configuration (on XBEE1 port). This particular board has
+ * merged DIO0 and DIO1 interupt pins into one (defined as DIOMULTI).
+ * @{
+ */
+#define SX127X_PARAM_SPI                    (SPI_DEV(0))
+
+#define SX127X_PARAM_SPI_NSS                XBEE1_CS_PIN        /* D23 */
+
+#define SX127X_PARAM_RESET                  GPIO_UNDEF
+
+#define SX127X_PARAM_DIOMULTI               XBEE1_INT_PIN       /* D24 */
+
+#define SX127X_PARAM_PASELECT               (SX127X_PA_RFO)
+
+#define SX127X_PARAMS                     { .spi       = SX127X_PARAM_SPI,     \
+                                            .nss_pin   = SX127X_PARAM_SPI_NSS, \
+                                            .reset_pin = SX127X_PARAM_RESET,   \
+                                            .dio0_pin  = SX127X_PARAM_DIOMULTI,\
+                                            .dio1_pin  = SX127X_PARAM_DIO1,    \
+                                            .dio2_pin  = SX127X_PARAM_DIO2,    \
+                                            .dio3_pin  = SX127X_PARAM_DIO3,    \
+                                            .paselect  = SX127X_PARAM_PASELECT }
+/** @} */
+
+/**
+ * @brief   Delay to wait for SPI reset
+ */
+#define WAIT_FOR_SPI_RESET (3000000UL)
+
+/**
+ * @brief    HDC1000 Temperature & Humidity sensor
+ */
+#define HDC1000_PARAM_ADDR           (0x40)
+
+/**
+ * @brief    TSL2561 Visible light sensor
+ */
+#define TSL2561_PARAM_ADDR           TSL2561_ADDR_LOW
+
+/**
+ * @brief   Initialize board specific hardware, including clock, LEDs and std-IO
+ */
+void board_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/sensebox_samd21/include/gpio_params.h
+++ b/boards/sensebox_samd21/include/gpio_params.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2018 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_sensebox_samd21
+ * @{
+ *
+ * @file
+ * @brief       Board specific configuration of direct mapped GPIOs
+ *
+ * @author      Leandro Lanzieri <leandro.lanzieri@haw-hamburg.de>
+ */
+
+#ifndef GPIO_PARAMS_H
+#define GPIO_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    GPIO pin configuration
+ */
+static const  saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name = "LED(Red)",
+        .pin = LED0_PIN,
+        .mode = GPIO_OUT
+    },
+    {
+        .name = "LED(Green)",
+        .pin = LED1_PIN,
+        .mode = GPIO_OUT
+    },
+    {
+        .name = "BTN",
+        .pin = BTN0_PIN,
+        .mode = BTN0_MODE
+    }
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_PARAMS_H */
+/** @} */

--- a/boards/sensebox_samd21/include/periph_conf.h
+++ b/boards/sensebox_samd21/include/periph_conf.h
@@ -1,0 +1,194 @@
+/*
+ * Copyright (C) 2018 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_sensebox_samd21
+ * @{
+ *
+ * @file
+ * @brief       Configuration of CPU peripherals for SenseBox MCU with SAMD21
+ *
+ * @author      Jose Alamos <jose.alamos@haw-hamburg.de>
+ * @author      Leandro Lanzieri <leandro.lanzieri@haw-hamburg.de>
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+#include <stdint.h>
+
+#include "cpu.h"
+#include "periph_cpu.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    External oscillator and clock configuration
+ *
+ * For selection of the used CORECLOCK, we have implemented two choices:
+ *
+ * - usage of the PLL fed by the internal 8MHz oscillator divided by 8
+ * - usage of the internal 8MHz oscillator directly, divided by N if needed
+ *
+ *
+ * The PLL option allows for the usage of a wider frequency range and a more
+ * stable clock with less jitter. This is why we use this option as default.
+ *
+ * The target frequency is computed from the PLL multiplier and the PLL divisor.
+ * Use the following formula to compute your values:
+ *
+ * CORECLOCK = ((PLL_MUL + 1) * 1MHz) / PLL_DIV
+ *
+ * NOTE: The PLL circuit does not run with less than 32MHz while the maximum PLL
+ *       frequency is 96MHz. So PLL_MULL must be between 31 and 95!
+ *
+ *
+ * The internal Oscillator used directly can lead to a slightly better power
+ * efficiency to the cost of a less stable clock. Use this option when you know
+ * what you are doing! The actual core frequency is adjusted as follows:
+ *
+ * CORECLOCK = 8MHz / DIV
+ *
+ * NOTE: A core clock frequency below 1MHz is not recommended
+ *
+ * @{
+ */
+#define CLOCK_USE_PLL       (1)
+
+#if CLOCK_USE_PLL
+/* edit these values to adjust the PLL output frequency */
+#define CLOCK_PLL_MUL       (47U)               /* must be >= 31 & <= 95 */
+#define CLOCK_PLL_DIV       (1U)                /* adjust to your needs */
+#define CLOCK_CORECLOCK     (((CLOCK_PLL_MUL + 1) * 1000000U) / CLOCK_PLL_DIV)
+#else
+/* edit this value to your needs */
+#define CLOCK_DIV           (1U)
+/* generate the actual core clock frequency */
+#define CLOCK_CORECLOCK     (8000000 / CLOCK_DIV)
+#endif
+/** @} */
+
+/**
+ * @name    Timer peripheral configuration
+ * @{
+ */
+#define TIMER_NUMOF         (2U)
+#define TIMER_0_EN          1
+#define TIMER_1_EN          1
+
+/* Timer 0 configuration */
+#define TIMER_0_DEV         TC3->COUNT16
+#define TIMER_0_CHANNELS    2
+#define TIMER_0_MAX_VALUE   (0xffff)
+#define TIMER_0_ISR         isr_tc3
+
+/* Timer 1 configuration */
+#define TIMER_1_DEV         TC4->COUNT32
+#define TIMER_1_CHANNELS    2
+#define TIMER_1_MAX_VALUE   (0xffffffff)
+#define TIMER_1_ISR         isr_tc4
+/** @} */
+
+/**
+ * @name    UART configuration
+ * @{
+ */
+static const uart_conf_t uart_config[] = {
+    {
+        .dev    = &SERCOM3->USART,
+        .rx_pin = GPIO_PIN(PA, 23),
+        .tx_pin = GPIO_PIN(PA, 22),
+        .mux    = GPIO_MUX_C,
+        .rx_pad = UART_PAD_RX_1,
+        .tx_pad = UART_PAD_TX_0,
+        .flags  = UART_FLAG_NONE,
+        .gclk_src = GCLK_CLKCTRL_GEN_GCLK0,
+    },
+    {
+        .dev    = &SERCOM4->USART,
+        .rx_pin = GPIO_PIN(PB, 9),
+        .tx_pin = GPIO_PIN(PB, 8),
+        .mux    = GPIO_MUX_D,
+        .rx_pad = UART_PAD_RX_1,
+        .tx_pad = UART_PAD_TX_0,
+        .flags  = UART_FLAG_NONE,
+        .gclk_src = GCLK_CLKCTRL_GEN_GCLK0,
+    }
+};
+
+/* interrupt function name mapping */
+#define UART_0_ISR          isr_sercom3
+#define UART_1_ISR          isr_sercom4
+
+#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+/** @} */
+
+/**
+ * @name    SPI configuration
+ * @{
+ */
+static const spi_conf_t spi_config[] = {
+    {
+        .dev      = &SERCOM1->SPI,
+        .miso_pin = GPIO_PIN(PA, 19),
+        .mosi_pin = GPIO_PIN(PA, 16),
+        .clk_pin  = GPIO_PIN(PA, 17),
+        .miso_mux = GPIO_MUX_C,
+        .mosi_mux = GPIO_MUX_C,
+        .clk_mux  = GPIO_MUX_C,
+        .miso_pad = SPI_PAD_MISO_3,
+        .mosi_pad = SPI_PAD_MOSI_0_SCK_1
+    }
+};
+
+#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+
+/**
+ * @name    I2C configuration
+ * @{
+ */
+static const i2c_conf_t i2c_config[] = {
+    {
+        .dev      = &(SERCOM0->I2CM),
+        .speed    = I2C_SPEED_NORMAL,
+        .scl_pin  = GPIO_PIN(PA, 8),
+        .sda_pin  = GPIO_PIN(PA, 9),
+        .mux      = GPIO_MUX_C,
+        .gclk_src = GCLK_CLKCTRL_GEN_GCLK0,
+        .flags    = I2C_FLAG_NONE
+    },
+    {
+        .dev      = &(SERCOM2->I2CM),
+        .speed    = I2C_SPEED_NORMAL,
+        .scl_pin  = GPIO_PIN(PA, 12),
+        .sda_pin  = GPIO_PIN(PA, 13),
+        .mux      = GPIO_MUX_C,
+        .gclk_src = GCLK_CLKCTRL_GEN_GCLK0,
+        .flags    = I2C_FLAG_NONE
+    }
+};
+
+#define I2C_NUMOF          (sizeof(i2c_config) / sizeof(i2c_config[0]))
+
+/**
+ * @name    RTC configuration
+ * @{
+ */
+#define RTC_NUMOF           (1U)
+#define RTC_DEV             RTC->MODE2
+
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_CONF_H */
+/** @} */

--- a/boards/sensebox_samd21/include/sdcard_spi_params.h
+++ b/boards/sensebox_samd21/include/sdcard_spi_params.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2018 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_sensebox_samd21
+ * @{
+ *
+ * @file
+ * @brief       SD card configuration for SenseBox MCU with SAMD21 board. This
+ * configuration
+ *              considers that SD is connected to the XBEE2 port.
+ *
+ * @author      Leandro Lanzieri <leandro.lanzieri@haw-hamburg.de>
+ */
+
+#ifndef SDCARD_SPI_PARAMS_H
+#define SDCARD_SPI_PARAMS_H
+
+#include "board.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Card detect pin
+ */
+ #define CARD_DETECT_PIN              (XBEE2_INT_PIN)
+
+/**
+ * @brief   sdcard_spi configuration
+ */
+static const  sdcard_spi_params_t sdcard_spi_params[] = {
+    {
+        .spi_dev        = SPI_DEV(0),
+        .cs             = XBEE2_CS_PIN,
+        .clk            = GPIO_PIN(PA, 17),
+        .mosi           = GPIO_PIN(PA, 16),
+        .miso           = GPIO_PIN(PA, 19),
+        .power          = GPIO_UNDEF,
+        .power_act_high = true
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SDCARD_SPI_PARAMS_H */
+/** @} */

--- a/examples/lua_REPL/Makefile
+++ b/examples/lua_REPL/Makefile
@@ -18,12 +18,12 @@ BOARD_INSUFFICIENT_MEMORY := bluepill calliope-mini cc2650-launchpad \
                              b-l072z-lrwan1  cc2538dk ek-lm4f120xl  feather-m0 \
                              ikea-tradfri limifrog-v1 mbed_lpc1768  nrf6310 \
                              nucleo-f091rc  nucleo-l073rz  nz32-sc151 \
-                             openmote-cc2538 openmote-b  pba-d-01-kw2x \
+                             openmote-cc2538 openmote-b pba-d-01-kw2x \
                              remote-pa remote-reva remote-revb samd21-xpro \
                              saml21-xpro samr21-xpro seeeduino_arch-pro \
-                             slstk3401a sltb001a slwstk6220a sodaq-autonomo \
-                             sodaq-explorer sodaq-one stk3600  stm32f3discovery \
-                             yunjia-nrf51822
+                             sensebox_samd21 slstk3401a sltb001a slwstk6220a \
+                             sodaq-autonomo sodaq-explorer sodaq-one stk3600 \
+                             stm32f3discovery yunjia-nrf51822
 
 BOARD_BLACKLIST := arduino-duemilanove arduino-mega2560 arduino-uno \
                    chronos hifive1 jiminy-mega256rfr2 mega-xplained mips-malta \

--- a/tests/unittests/Makefile
+++ b/tests/unittests/Makefile
@@ -58,6 +58,7 @@ BOARD_INSUFFICIENT_MEMORY := airfy-beacon \
                              samd21-xpro \
                              samr21-xpro \
                              seeeduino_arch-pro \
+                             sensebox_samd21 \
                              slstk3401a \
                              sltb001a \
                              slwstk6220a \


### PR DESCRIPTION
### Contribution description
Support for [SenseBox board](https://www.sensebox.de/). This board is based on the Atmel SAMD21G18A microcontroller.
![sensebox-top](https://user-images.githubusercontent.com/5381296/43781342-f75eca62-9a5c-11e8-9fe7-79d8dcb2f780.png)

#### Implemented and tested on the board:
* LEDs
* Digital Pins
* UART1 and UART2
* I2C interface
* XBEE1 and XBEE2 ports (SPI)

#### Note:
The kit comes with several XBEE shields. For this porting the SX127X shield is supposed to be connected on the XBEE1 port, and the mSD-Bee shield on the XBEE2 port.

For more information about XBEE ports please read **boards/sensebox/doc.txt** file.
