### PR TITLE
make: provide support for listing supported and blacklisting toolchains

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -245,6 +245,9 @@ include $(RIOTBOARD)/$(BOARD)/Makefile.include
 INCLUDES += -I$(RIOTCPU)/$(CPU)/include
 include $(RIOTCPU)/$(CPU)/Makefile.include
 
+# Assume GCC/GNU as supported toolchain if CPU's Makefile.include doesn't
+# provide this macro
+TOOLCHAINS_SUPPORTED ?= gnu
 # Import all toolchain settings
 include $(RIOTMAKE)/toolchain/$(TOOLCHAIN).inc.mk
 
@@ -588,6 +591,20 @@ ifneq (, $(filter all, $(if $(MAKECMDGOALS), $(MAKECMDGOALS), all)))
   ifneq (, $(BOARD_BLACKLIST))
     ifneq (, $(filter $(BOARD_BLACKLIST), $(BOARD)))
       $(shell $(COLOR_ECHO) "$(COLOR_RED)The selected BOARD=$(BOARD) is blacklisted:$(COLOR_RESET) $(BOARD_BLACKLIST)" 1>&2)
+      EXPECT_ERRORS := 1
+    endif
+  endif
+
+  #  test if toolchain is supported.
+  ifeq (,$(filter $(TOOLCHAIN),$(TOOLCHAINS_SUPPORTED)))
+    $(shell $(COLOR_ECHO) "$(COLOR_RED)The selected TOOLCHAIN=$(TOOLCHAIN) is not supported.$(COLOR_RESET)\nSupported toolchains: $(TOOLCHAINS_SUPPORTED)" 1>&2)
+    EXPECT_ERRORS := 1
+  endif
+
+  # If there is a blacklist, then test if the board is blacklisted.
+  ifneq (,$(TOOLCHAINS_BLACKLIST))
+    ifneq (,$(filter $(TOOLCHAIN),$(TOOLCHAINS_BLACKLIST)))
+      $(shell $(COLOR_ECHO) "$(COLOR_RED)The selected TOOLCHAIN=$(TOOLCHAIN) is blacklisted:$(COLOR_RESET) $(TOOLCHAINS_BLACKLIST)" 1>&2)
       EXPECT_ERRORS := 1
     endif
   endif

--- a/cpu/cortexm_common/Makefile.include
+++ b/cpu/cortexm_common/Makefile.include
@@ -15,6 +15,7 @@ ifneq (,$(ROM_START_ADDR)$(RAM_START_ADDR)$(ROM_LEN)$(RAM_LEN))
   LINKFLAGS += $(LINKFLAGPREFIX)--defsym=_ram_length=$(RAM_LEN)
 endif
 
+TOOLCHAINS_SUPPORTED = gnu llvm
 
 # Only define the linker symbol if the variable is set
 # The variable can be set using target specific variable thanks to lazy evaluation

--- a/cpu/native/Makefile.include
+++ b/cpu/native/Makefile.include
@@ -10,3 +10,5 @@ USEMODULE += periph_uart
 
 # include common peripheral initialization
 USEMODULE += periph_common
+
+TOOLCHAINS_SUPPORTED = gnu llvm

--- a/makefiles/buildtests.inc.mk
+++ b/makefiles/buildtests.inc.mk
@@ -9,17 +9,19 @@ buildtest:
 	@ \
 	RESULT=true ; \
 	for board in $(BOARDS); do \
-		$(COLOR_ECHO) -n "Building for $$board ... " ; \
-		BOARD=$${board} RIOT_CI_BUILD=1 RIOT_VERSION_OVERRIDE=buildtest \
-			$(MAKE) clean all -j $(NPROC) $(BUILDTEST_MAKE_REDIRECT); \
-		RES=$$? ; \
-		if [ $$RES -eq 0 ]; then \
-			$(COLOR_ECHO) "$(COLOR_GREEN)success.$(COLOR_RESET)" ; \
-		else \
-			$(COLOR_ECHO) "$(COLOR_RED)failed!$(COLOR_RESET)" ; \
-			RESULT=false ; \
-		fi ; \
-		$(MAKE) clean-intermediates >/dev/null 2>&1 || true; \
+		if BOARD=$${board} $(MAKE) check-toolchain-supported > /dev/null 2>&1; then \
+			$(COLOR_ECHO) -n "Building for $$board ... " ; \
+			BOARD=$${board} RIOT_CI_BUILD=1 RIOT_VERSION_OVERRIDE=buildtest \
+				$(MAKE) clean all -j $(NPROC) $(BUILDTEST_MAKE_REDIRECT); \
+			RES=$$? ; \
+			if [ $$RES -eq 0 ]; then \
+				$(COLOR_ECHO) "$(COLOR_GREEN)success.$(COLOR_RESET)" ; \
+			else \
+				$(COLOR_ECHO) "$(COLOR_RED)failed!$(COLOR_RESET)" ; \
+				RESULT=false ; \
+			fi ; \
+			$(MAKE) clean-intermediates >/dev/null 2>&1 || true; \
+		fi; \
 	done ; \
 	$${RESULT}
 endif # BUILD_IN_DOCKER

--- a/makefiles/info.inc.mk
+++ b/makefiles/info.inc.mk
@@ -1,7 +1,8 @@
 .PHONY: info-objsize info-buildsizes info-build info-boards-supported \
         info-features-missing info-modules info-cpu \
         info-features-provided info-features-required \
-        info-debug-variable-%
+        info-debug-variable-% info-toolchains-supported \
+        check-toolchain-supported
 
 info-objsize:
 	@case "$(SORTROW)" in \
@@ -130,3 +131,9 @@ info-features-missing:
 
 info-debug-variable-%:
 	@echo $($*)
+
+info-toolchains-supported:
+	@echo $(filter-out $(TOOLCHAINS_BLACKLIST),$(TOOLCHAINS_SUPPORTED))
+
+check-toolchain-supported:
+	@exit $(if $(filter $(TOOLCHAIN),$(filter-out $(TOOLCHAINS_BLACKLIST),$(TOOLCHAINS_SUPPORTED))),0,1)

--- a/makefiles/vars.inc.mk
+++ b/makefiles/vars.inc.mk
@@ -36,6 +36,8 @@ export PYTHONPATH            # Python default search path for module filesi, wit
 export FEATURES_REQUIRED     # List of required features by the application
 export FEATURES_PROVIDED     # List of provided features by the board
 export FEATURES_OPTIONAL     # List of nice to have features
+# TOOLCHAINS_SUPPORTED       # List of supported toolchains by an MCU (gnu/llvm/...).
+# TOOLCHAINS_BLACKLISTED     # List of unspported toolchains for a module or an application.
 
 export TARGET_ARCH           # The target platform name, in GCC triple notation, e.g. "arm-none-eabi", "i686-elf", "avr"
 export PREFIX                # The prefix of the toolchain commands, usually "$(TARGET_ARCH)-", e.g. "arm-none-eabi-" or "msp430-".


### PR DESCRIPTION
### Contribution description
This PR introduces two things:

- The ability of a board/cpu-family to define the toolchains they support via the `TOOLCHAINS_SUPPORTED` macro
- The ability to blacklist certain toolchains for modules, applications, or `pkg` that does not support that particular toolchain via the `TOOLCHAINS_BLACKLIST` (similar to `BOARD_BLACKLIST`)

As a consequence of those to introductions this PR also contains:

- A make target to list all supported toolchains (excluding blacklisted ones) for a specific (board, application)-tuple
- ~~Blacklisting of `llvm` for `pkg`s we encountered hard to fix problems with in combination with LLVM/clang in #9398~~ (moved to #9734)

Things that might be worth an inclusion into this:
- A global make target that lists all boards that support a given toolchain (e.g. `info-%-supporting` or something)

### Issues/PRs references
Errors for packages that caused blacklisting were detected in #9398.

#9734 applies the concept of blacklisting toolchains for several packets that have problems with LLVM/clang.