### PR TITLE
makefiles: refactor use of serial number with multiple targets

### DIFF
--- a/makefiles/boards/sam0.inc.mk
+++ b/makefiles/boards/sam0.inc.mk
@@ -2,16 +2,11 @@
 PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 
-ifneq (,$(SERIAL))
-  # The SERIAL setting is only available for backwards compatibility with older
-  # settings.
-  # Use DEBUG_ADAPTER_ID to specify the programmer serial number to use:
-  # export DEBUG_ADAPTER_ID=<serial number>
-  export DEBUG_ADAPTER_ID ?= $(SERIAL)
-endif
-
 # setup serial terminal
 include $(RIOTMAKE)/tools/serial.inc.mk
+
+# Include SERIAL variable compatibility code here
+include $(RIOTMAKE)/tools/serial_compat.inc.mk
 
 # Default for these boards is to use a CMSIS-DAP programmer
 export DEBUG_ADAPTER ?= dap

--- a/makefiles/boards/sam0.inc.mk
+++ b/makefiles/boards/sam0.inc.mk
@@ -1,18 +1,12 @@
 # set default port depending on operating system
 PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
-# Use DEBUG_ADAPTER_ID to specify the programmer serial number to use:
-# export DEBUG_ADAPTER_ID="ATML..."
 
-# The SERIAL setting is only available for backwards compatibility with older
-# settings.
 ifneq (,$(SERIAL))
-  EDBG_ARGS += --serial $(SERIAL)
-  SERIAL_TTY = $(firstword $(shell $(RIOTTOOLS)/usb-serial/find-tty.sh $(SERIAL)))
-  ifeq (,$(SERIAL_TTY))
-    $(error Did not find a device with serial $(SERIAL))
-  endif
-  PORT_LINUX := $(SERIAL_TTY)
+  # The SERIAL setting is only available for backwards compatibility with older
+  # settings.
+  # Use DEBUG_ADAPTER_ID to specify the programmer serial number to use:
+  # export DEBUG_ADAPTER_ID=<serial number>
   export DEBUG_ADAPTER_ID ?= $(SERIAL)
 endif
 

--- a/makefiles/boards/sam0.inc.mk
+++ b/makefiles/boards/sam0.inc.mk
@@ -5,9 +5,6 @@ PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 # setup serial terminal
 include $(RIOTMAKE)/tools/serial.inc.mk
 
-# Include SERIAL variable compatibility code here
-include $(RIOTMAKE)/tools/serial_compat.inc.mk
-
 # Default for these boards is to use a CMSIS-DAP programmer
 export DEBUG_ADAPTER ?= dap
 

--- a/makefiles/tools/edbg.inc.mk
+++ b/makefiles/tools/edbg.inc.mk
@@ -3,6 +3,9 @@ EDBG ?= $(RIOT_EDBG)
 FLASHER ?= $(EDBG)
 HEXFILE = $(BINFILE)
 
+# Include SERIAL variable compatibility code here
+include $(RIOTMAKE)/tools/serial_compat.inc.mk
+
 # Use USB serial number to select device when more than one is connected
 # Use /dist/tools/usb-serial/list-ttys.sh to find out serial number.
 #   Usage:

--- a/makefiles/tools/edbg.inc.mk
+++ b/makefiles/tools/edbg.inc.mk
@@ -2,6 +2,7 @@ RIOT_EDBG = $(RIOTTOOLS)/edbg/edbg
 EDBG ?= $(RIOT_EDBG)
 FLASHER ?= $(EDBG)
 HEXFILE = $(BINFILE)
+
 # Use USB serial number to select device when more than one is connected
 # Use /dist/tools/usb-serial/list-ttys.sh to find out serial number.
 #   Usage:

--- a/makefiles/tools/openocd.inc.mk
+++ b/makefiles/tools/openocd.inc.mk
@@ -8,6 +8,9 @@ export DEBUGGER_FLAGS ?= debug
 export DEBUGSERVER_FLAGS ?= debug-server
 export RESET_FLAGS ?= reset
 
+# Include SERIAL variable compatibility code here
+include $(RIOTMAKE)/tools/serial_compat.inc.mk
+
 ifneq (,$(DEBUG_ADAPTER))
   include $(RIOTMAKE)/tools/openocd-adapters/$(DEBUG_ADAPTER).inc.mk
 endif

--- a/makefiles/tools/serial.inc.mk
+++ b/makefiles/tools/serial.inc.mk
@@ -20,3 +20,13 @@ else ifeq ($(RIOT_TERMINAL),picocom)
     export TERMPROG  ?= picocom
     export TERMFLAGS ?= --nolock --imap lfcrlf --echo --baud "$(BAUD)" "$(PORT)"
 endif
+
+# The SERIAL setting is only available for backwards compatibility with older
+# settings.
+ifneq (,$(SERIAL))
+  SERIAL_TTY = $(firstword $(shell $(RIOTTOOLS)/usb-serial/find-tty.sh $(SERIAL)))
+  ifeq (,$(SERIAL_TTY))
+    $(error Did not find a device with serial $(SERIAL))
+  endif
+  PORT_LINUX := $(SERIAL_TTY)
+endif

--- a/makefiles/tools/serial_compat.inc.mk
+++ b/makefiles/tools/serial_compat.inc.mk
@@ -1,0 +1,7 @@
+ifneq (,$(SERIAL))
+  # The SERIAL setting is only available for backwards compatibility with older
+  # settings.
+  # Use DEBUG_ADAPTER_ID to specify the programmer serial number to use:
+  # export DEBUG_ADAPTER_ID=<serial number>
+  export DEBUG_ADAPTER_ID ?= $(SERIAL)
+endif


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR fixes an annoying problem when working with multiple nucleo boards (or stlink based boards) plugged on a single computer.

Using the `list_tty.sh` script it's possible to list boards by their serial number and serial port. But the build system doesn't work when using the `SERIAL` variable and I find `DEBUG_ADAPTER_ID` not intuitive at all (to say the least).

It tested the changes with 2 different nucleos and 2 different sam0 based boards (samr21 and arduino-zero) and it works like a charm now.

Example with 3 boards plugged on a computer (1 samr21 and 2 different nucleos):
```
$ ./dist/tools/usb-serial/list-ttys.sh 
/sys/bus/usb/devices/2-3.4: Atmel Corp. EDBG CMSIS-DAP serial: 'ATML2127031800004957', tty(s): ttyACM0
/sys/bus/usb/devices/2-3.2: STMicroelectronics STM32 STLink serial: '066BFF485550755187074222', tty(s): ttyACM2
/sys/bus/usb/devices/2-2: STMicroelectronics STM32 STLink serial: '0670FF574857847167121746', tty(s): ttyACM1
$ make SERIAL=ATML2127031800004957 BOARD=samr21-xpro -C examples/hello-world flash term
[...]
2018-08-07 17:05:34,482 - INFO # Connect to serial port /dev/ttyACM0
Welcome to pyterm!
Type '/exit' to exit.
2018-08-07 17:05:42,480 - INFO # main(): This is RIOT! (Version: 2018.10-devel-388-gbf6ef-trek-saclay-pr/tools/make_serial)
2018-08-07 17:05:42,481 - INFO # Hello World!
2018-08-07 17:05:42,485 - INFO # You are running RIOT on a(n) samr21-xpro board.
2018-08-07 17:05:42,488 - INFO # This board features a(n) samd21 MCU.

$ make SERIAL=0670FF574857847167121746 BOARD=nucleo-l053r8 -C examples/hello-world/ flash term
[...]
Welcome to pyterm!
Type '/exit' to exit.
2018-08-07 17:06:33,839 - INFO # main(): This is RIOT! (Version: 2018.10-devel-388-gbf6ef-trek-saclay-pr/tools/make_serial)
2018-08-07 17:06:33,840 - INFO # Hello World!
2018-08-07 17:06:33,845 - INFO # You are running RIOT on a(n) nucleo-l053r8 board.
2018-08-07 17:06:33,848 - INFO # This board features a(n) stm32l0 MCU.

$ make SERIAL=066BFF485550755187074222 BOARD=nucleo-l152re -C examples/hello-world/ flash term
Welcome to pyterm!
Type '/exit' to exit.
2018-08-07 17:07:16,905 - INFO # main(): This is RIOT! (Version: 2018.10-devel-388-gbf6ef-trek-saclay-pr/tools/make_serial)
2018-08-07 17:07:16,905 - INFO # Hello World!
2018-08-07 17:07:16,911 - INFO # You are running RIOT on a(n) nucleo-l152re board.
2018-08-07 17:07:16,912 - INFO # This board features a(n) stm32l1 MCU.
```

@adjih will probably appreciate this PR ;)

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->