### PR TITLE
pkg: blacklist selected `pkg`s for LLVM/clang

### DIFF
--- a/pkg/jerryscript/Makefile.include
+++ b/pkg/jerryscript/Makefile.include
@@ -1,2 +1,9 @@
 INCLUDES += -I$(PKGDIRBASE)/jerryscript/jerry-core/include
 INCLUDES += -I$(PKGDIRBASE)/jerryscript/jerry-ext/include
+
+ifneq (,$(filter cortex-m%,$(CPU_ARCH)))
+  # jerryscript package package is not using system includes right now, so
+  # many newlib hearders (not even stdio.h) is found
+  # Fixed in #9821 (so remove when merged)
+  TOOLCHAINS_BLACKLIST += llvm
+endif

--- a/pkg/micro-ecc/Makefile.include
+++ b/pkg/micro-ecc/Makefile.include
@@ -1,1 +1,7 @@
 INCLUDES += -I$(PKGDIRBASE)/micro-ecc
+
+ifneq (,$(filter cortex-m0%,$(CPU_ARCH)))
+  # LLVM/clang can't handle the inline assembler instructions on M0 in this
+  # package
+  TOOLCHAINS_BLACKLIST += llvm
+endif

--- a/pkg/nordic_softdevice_ble/Makefile.include
+++ b/pkg/nordic_softdevice_ble/Makefile.include
@@ -31,3 +31,6 @@ DIRS += \
 		$(NORDIC_SRCS)/components/softdevice/common/softdevice_handler \
 		$(NORDIC_SRCS)/components/ble/common \
 		$(NORDIC_SRCS)/components/iot/ble_ipsp
+
+# LLVM ARM assembler has massive problems digesting this
+TOOLCHAINS_BLACKLIST += llvm

--- a/pkg/openthread/Makefile.include
+++ b/pkg/openthread/Makefile.include
@@ -8,3 +8,9 @@ ifneq (,$(filter openthread_contrib,$(USEMODULE)))
   DIRS += $(OPENTHREAD_DIR)/contrib
   DIRS += $(OPENTHREAD_DIR)/contrib/netdev
 endif
+
+ifneq (,$(filter cortex-m0% cortex-m3%,$(CPU_ARCH)))
+  # There are problem with unused `-mcpu...` arguments in clang and with
+  # ranlib + LLVM/clang in this package with Cortex-M0 and M3
+  TOOLCHAINS_BLACKLIST += llvm
+endif

--- a/pkg/qDSA/Makefile.include
+++ b/pkg/qDSA/Makefile.include
@@ -11,3 +11,9 @@ endif
 export QDSA_IMPL
 
 INCLUDES += -I$(PKGDIRBASE)/qDSA/$(QDSA_IMPL)
+
+ifeq (cortex-m0plus,$(CPU_ARCH))
+  # There are problems with the LLVM assembler and the Cortex-M0+ instruction
+  # set with this package
+  TOOLCHAINS_BLACKLIST += llvm
+endif


### PR DESCRIPTION
### Contribution description
Some `pkg`s have problems when compiled with LLVM/clang. This fixes that by blacklisting LLVM for them.

This is still WIP:

* for some boards it works. Since most of the issues we encounter are assembly related, this might be fixable by filtering by CPU(-family)/instruction set and make the addition to the blacklist dependent on that [similar as we did with qDSA already](https://github.com/RIOT-OS/RIOT/blob/a7241384bee6aca4385ada86ce529e9f2fc9d38c/pkg/qDSA/Makefile.include#L1-L9).

### Issues/PRs references
Depends on ~~#9730~~ (merged).