### PR TITLE
drivers/at: fix invalid function pointer cast.

### DIFF
--- a/drivers/at/at.c
+++ b/drivers/at/at.c
@@ -22,11 +22,16 @@
 #define AT_PRINT_INCOMING (0)
 #endif
 
+static void _isrpipe_write_one_wrapper(void *_isrpipe, uint8_t data)
+{
+    isrpipe_write_one(_isrpipe, (char)data);
+}
+
 int at_dev_init(at_dev_t *dev, uart_t uart, uint32_t baudrate, char *buf, size_t bufsize)
 {
     dev->uart = uart;
     isrpipe_init(&dev->isrpipe, buf, bufsize);
-    uart_init(uart, baudrate, (uart_rx_cb_t) isrpipe_write_one,
+    uart_init(uart, baudrate, _isrpipe_write_one_wrapper,
               &dev->isrpipe);
 
     return 0;


### PR DESCRIPTION
### Contribution description

Fix an invalid cast of a function pointer. ARM GCC 8.2.0 (on Arch linux) was (rightly) complaining about this.

As a note, I'd regard any explicit cast of function pointers suspicious. That's something that simply should not be done.
