### PR TITLE
sys: rtt_stdio: use uart_stdio_read/write for vfs

### DIFF
--- a/sys/rtt_stdio/rtt_stdio.c
+++ b/sys/rtt_stdio/rtt_stdio.c
@@ -305,7 +305,7 @@ static ssize_t rtt_stdio_vfs_read(vfs_file_t *filp, void *dest, size_t nbytes)
     if (fd != STDIN_FILENO) {
         return -EBADF;
     }
-    return rtt_read(dest, nbytes);
+    return uart_stdio_read(dest, nbytes);
 }
 
 static ssize_t rtt_stdio_vfs_write(vfs_file_t *filp, const void *src, size_t nbytes)
@@ -314,7 +314,7 @@ static ssize_t rtt_stdio_vfs_write(vfs_file_t *filp, const void *src, size_t nby
     if (fd == STDIN_FILENO) {
         return -EBADF;
     }
-    return rtt_write(src, nbytes);
+    return uart_stdio_write(src, nbytes);
 }
 
 #endif


### PR DESCRIPTION
### Contribution description

Comparing `uart_stdio` and `rtt_stdio` reveals differences when VFS is used. This caused #9743. This PR fixes this, because `uart_stdio_read/write` does a lot more for `rtt_stdio`.

Tested this using SLSTK3402a with SEGGER JLink, by modifying `examples/filesystem` to add `rtt_stdio`.

### Issues/PRs references

#9743