### PR TITLE
drivers/sdcard_spi: fix uint64_t cast location

### DIFF
--- a/drivers/sdcard_spi/sdcard_spi.c
+++ b/drivers/sdcard_spi/sdcard_spi.c
@@ -1009,7 +1009,7 @@ uint64_t sdcard_spi_get_capacity(sdcard_spi_t *card)
         return blocknr * block_len;
     }
     else if (card->csd_structure == SD_CSD_V2) {
-        return (card->csd.v2.C_SIZE + 1) * (uint64_t)(SD_HC_BLOCK_SIZE << 10);
+        return (card->csd.v2.C_SIZE + 1) * (((uint64_t)SD_HC_BLOCK_SIZE) << 10);
     }
     return 0;
 }


### PR DESCRIPTION
### Contribution description

When compiling `tests/drivers_sdcard_spi` with `avr-gcc: avr-gcc (GCC) 6.4.0`
it detected this error

    RIOT/drivers/sdcard_spi/sdcard_spi.c:1012:72:
    error: result of '512 << 10' requires 21 bits to represent, but 'int' only has 16 bits [-Werror=shift-overflow=]
    return (card->csd.v2.C_SIZE + 1) * (uint64_t)(SD_HC_BLOCK_SIZE << 10);

### Issues/PRs references

https://github.com/RIOT-OS/Release-Specs/issues/69#issuecomment-411640662