### PR TITLE
tests/gnrc_netif: add test for ULA source selection

### DIFF
--- a/tests/gnrc_netif/common.h
+++ b/tests/gnrc_netif/common.h
@@ -56,6 +56,15 @@ extern "C" {
 #define LA7 (0xfdU)
 #define LA8 (0x0aU)
 
+#define ULA1 (0xfdU)
+#define ULA2 (0x01U)
+#define ULA3 (0x0dU)
+#define ULA4 (0xb8U)
+#define ULA5 (0x00U)
+#define ULA6 (0x00U)
+#define ULA7 (0x5aU)
+#define ULA8 (0x1aU)
+
 #define TEST_IEEE802154_MAX_FRAG_SIZE   (102)
 
 #define ETHERNET_SRC        { LA1, LA2, LA3, LA6, LA7, LA8 }
@@ -71,6 +80,8 @@ extern "C" {
                               LA1 ^ 0x2, LA2, LA3, LA4, LA5, LA6, LA7, LA8 }
 #define NETIF0_SRC          { LA1, LA2 + 1, LA3, LA4, LA5, LA6, LA7, LA8 }
 #define NETIF0_IPV6_LL      { LP1, LP2, LP3, LP4, LP5, LP6, LP7, LP8, \
+                              LA1 ^ 0x2, LA2 + 1, LA3, LA4, LA5, LA6, LA7, LA8 }
+#define NETIF0_IPV6_ULA     { ULA1, ULA2, ULA3, ULA4, ULA5, ULA6, ULA7, ULA8, \
                               LA1 ^ 0x2, LA2 + 1, LA3, LA4, LA5, LA6, LA7, LA8 }
 #define NETIF0_IPV6_G       { GP1, GP2, GP3, GP4, GP5, GP6, GP7, GP8, \
                               LA1 ^ 0x2, LA2 + 1, LA3, LA4, LA5, LA6, LA7, LA8 }

--- a/tests/gnrc_netif/main.c
+++ b/tests/gnrc_netif/main.c
@@ -450,6 +450,28 @@ static void test_ipv6_addr_best_src__other_subnet(void)
     TEST_ASSERT(!ipv6_addr_is_unspecified(out));
 }
 
+static void test_ipv6_addr_best_src__ula_src_dst(void)
+{
+    static const ipv6_addr_t ula_src = { .u8 = NETIF0_IPV6_ULA };
+    static const ipv6_addr_t ula_dst = { .u8 = { ULA1, ULA2, ULA3, ULA4,
+                                                 ULA5, ULA6, ULA7, ULA8,
+                                                 0, 0, 0, 0, 0, 0, 0, 1 } };
+    ipv6_addr_t *out = NULL;
+    int idx;
+
+    test_ipv6_addr_add__success();
+    TEST_ASSERT(0 <= (idx = gnrc_netif_ipv6_addr_add_internal(netifs[0], &ula_src, 64U,
+                                                     GNRC_NETIF_IPV6_ADDRS_FLAGS_STATE_VALID)));
+    TEST_ASSERT_EQUAL_INT(GNRC_NETIF_IPV6_ADDRS_FLAGS_STATE_VALID,
+                          netifs[0]->ipv6.addrs_flags[idx]);
+    TEST_ASSERT(ipv6_addr_equal(&ula_src, &netifs[0]->ipv6.addrs[idx]));
+
+    TEST_ASSERT_NOT_NULL((out = gnrc_netif_ipv6_addr_best_src(netifs[0],
+                                                              &ula_dst,
+                                                              false)));
+    TEST_ASSERT(ipv6_addr_equal(&ula_src, out));
+}
+
 static void test_get_by_ipv6_addr__empty(void)
 {
     static const ipv6_addr_t addr = { .u8 = NETIF0_IPV6_LL };
@@ -1469,6 +1491,7 @@ static Test *embunit_tests_gnrc_netif(void)
         new_TestFixture(test_ipv6_addr_best_src__multicast_input),
         new_TestFixture(test_ipv6_addr_best_src__unspecified_addr),
         new_TestFixture(test_ipv6_addr_best_src__other_subnet),
+        new_TestFixture(test_ipv6_addr_best_src__ula_src_dst),
         new_TestFixture(test_get_by_ipv6_addr__empty),
         new_TestFixture(test_get_by_ipv6_addr__unspecified_addr),
         new_TestFixture(test_get_by_ipv6_addr__success),


### PR DESCRIPTION
### Contribution description
Adds a test case for ULA source selection. For me it passes, but this test is an edge-case, as link-local addresses (`fe80::/64`) and ULAs (`fd00::/8`) are very close to matching so if something is messed up in the implementation this might fail.

### Issues/PRs references
Discussed in https://github.com/RIOT-OS/RIOT/pull/9522#issuecomment-411688679