### PR TITLE
tests: remove echo=False [backport 2018.07]

### DIFF
--- a/tests/cbor/tests/01-run.py
+++ b/tests/cbor/tests/01-run.py
@@ -52,4 +52,4 @@ def testfunc(child):
 if __name__ == "__main__":
     sys.path.append(os.path.join(os.environ['RIOTTOOLS'], 'testrunner'))
     from testrunner import run
-    sys.exit(run(testfunc, echo=False))
+    sys.exit(run(testfunc))

--- a/tests/evtimer_msg/tests/01-run.py
+++ b/tests/evtimer_msg/tests/01-run.py
@@ -32,4 +32,4 @@ def testfunc(child):
 if __name__ == "__main__":
     sys.path.append(os.path.join(os.environ['RIOTTOOLS'], 'testrunner'))
     from testrunner import run
-    sys.exit(run(testfunc, echo=False))
+    sys.exit(run(testfunc))

--- a/tests/evtimer_underflow/tests/01-run.py
+++ b/tests/evtimer_underflow/tests/01-run.py
@@ -26,4 +26,4 @@ def testfunc(child):
 if __name__ == "__main__":
     sys.path.append(os.path.join(os.environ['RIOTTOOLS'], 'testrunner'))
     from testrunner import run
-    sys.exit(run(testfunc, echo=False))
+    sys.exit(run(testfunc))

--- a/tests/isr_yield_higher/tests/test.py
+++ b/tests/isr_yield_higher/tests/test.py
@@ -20,4 +20,4 @@ def testfunc(child):
 if __name__ == "__main__":
     sys.path.append(os.path.join(os.environ['RIOTTOOLS'], 'testrunner'))
     from testrunner import run
-    sys.exit(run(testfunc, echo=False))
+    sys.exit(run(testfunc))

--- a/tests/od/tests/01-run.py
+++ b/tests/od/tests/01-run.py
@@ -42,4 +42,4 @@ def testfunc(child):
 if __name__ == "__main__":
     sys.path.append(os.path.join(os.environ['RIOTTOOLS'], 'testrunner'))
     from testrunner import run
-    sys.exit(run(testfunc, timeout=1, echo=False))
+    sys.exit(run(testfunc, timeout=1))

--- a/tests/od/tests/02-run.py
+++ b/tests/od/tests/02-run.py
@@ -42,4 +42,4 @@ def testfunc(child):
 if __name__ == "__main__":
     sys.path.append(os.path.join(os.environ['RIOTTOOLS'], 'testrunner'))
     from testrunner import run
-    sys.exit(run(testfunc, timeout=1, echo=False))
+    sys.exit(run(testfunc, timeout=1))


### PR DESCRIPTION
# Backport of #9744

### Contribution description

All tests should be run with an output by default.

### Issues/PRs references

No output for successful tests when building tests in native in release tests.

https://github.com/RIOT-OS/Release-Specs/issues/69#issuecomment-411638607