### PR TITLE
make: add APPDIR to info-build target

### DIFF
--- a/makefiles/info.inc.mk
+++ b/makefiles/info.inc.mk
@@ -23,6 +23,7 @@ info-buildsize:
 
 info-build:
 	@echo 'APPLICATION: $(APPLICATION)'
+	@echo 'APPDIR:      $(APPDIR)'
 	@echo ''
 	@echo 'supported boards:'
 	@echo $$($(MAKE) info-boards-supported)


### PR DESCRIPTION
    While info-build already provides lots of useful information
    it does not print the application source dir. However this
    might be useful for debugging and logging, hence its added
    to the output.

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->