### PR TITLE
crc validity variable in netdev_radio_rx_info and gnrc_netif_hdr_t and read it for at86rf2xx and cc2420

### DIFF
--- a/drivers/cc2420/cc2420.c
+++ b/drivers/cc2420/cc2420.c
@@ -200,6 +200,7 @@ int cc2420_rx(cc2420_t *dev, uint8_t *buf, size_t max_len, void *info)
             netdev_ieee802154_rx_info_t *radio_info = info;
             radio_info->rssi = CC2420_RSSI_OFFSET + rssi;
             radio_info->lqi = crc_corr & CC2420_CRCCOR_COR_MASK;
+            radio_info->crc_ok = (uint16_t) ((crc_corr & ~CC2420_CRCCOR_COR_MASK)>>7);
         }
 
         /* finally flush the FIFO */

--- a/drivers/include/net/netdev.h
+++ b/drivers/include/net/netdev.h
@@ -249,7 +249,8 @@ typedef enum {
 struct netdev_radio_rx_info {
     int16_t rssi;       /**< RSSI of a received packet in dBm */
     uint8_t lqi;        /**< LQI of a received packet */
-    uint16_t crc_ok;        /**< CRC Ok of received packet */
+    uint16_t crc_ok;    /**< CRC Ok of received packet */
+	uint16_t fcs;       /**< FCS of received packet */
 };
 
 /**

--- a/drivers/include/net/netdev.h
+++ b/drivers/include/net/netdev.h
@@ -249,6 +249,7 @@ typedef enum {
 struct netdev_radio_rx_info {
     int16_t rssi;       /**< RSSI of a received packet in dBm */
     uint8_t lqi;        /**< LQI of a received packet */
+    uint16_t crc_ok;        /**< CRC Ok of received packet */
 };
 
 /**

--- a/sys/include/net/gnrc/netif/hdr.h
+++ b/sys/include/net/gnrc/netif/hdr.h
@@ -87,7 +87,8 @@ typedef struct {
     uint8_t flags;              /**< flags as defined above */
     uint8_t lqi;                /**< lqi of received packet (optional) */
     int16_t rssi;               /**< rssi of received packet in dBm (optional) */
-    uint8_t crc_ok;          /**< crc valid indicator (optional) */
+    uint8_t crc_ok;             /**< crc valid indicator (optional) */
+	uint16_t fcs;               /**< FCS of received packet */
 } gnrc_netif_hdr_t;
 
 /**

--- a/sys/include/net/gnrc/netif/hdr.h
+++ b/sys/include/net/gnrc/netif/hdr.h
@@ -87,6 +87,7 @@ typedef struct {
     uint8_t flags;              /**< flags as defined above */
     uint8_t lqi;                /**< lqi of received packet (optional) */
     int16_t rssi;               /**< rssi of received packet in dBm (optional) */
+    uint8_t crc_ok;          /**< crc valid indicator (optional) */
 } gnrc_netif_hdr_t;
 
 /**

--- a/sys/net/gnrc/link_layer/lwmac/lwmac.c
+++ b/sys/net/gnrc/link_layer/lwmac/lwmac.c
@@ -173,6 +173,7 @@ static gnrc_pktsnip_t *_recv(gnrc_netif_t *netif)
 
             hdr->lqi = rx_info.lqi;
             hdr->rssi = rx_info.rssi;
+            hdr->crc_ok = rx_info.crc_ok;
             hdr->if_pid = thread_getpid();
             pkt->type = state->proto;
 #if ENABLE_DEBUG

--- a/sys/net/gnrc/link_layer/lwmac/lwmac.c
+++ b/sys/net/gnrc/link_layer/lwmac/lwmac.c
@@ -174,6 +174,7 @@ static gnrc_pktsnip_t *_recv(gnrc_netif_t *netif)
             hdr->lqi = rx_info.lqi;
             hdr->rssi = rx_info.rssi;
             hdr->crc_ok = rx_info.crc_ok;
+            hdr->fcs = rx_info.fcs;
             hdr->if_pid = thread_getpid();
             pkt->type = state->proto;
 #if ENABLE_DEBUG

--- a/sys/net/gnrc/netif/gnrc_netif_ieee802154.c
+++ b/sys/net/gnrc/netif/gnrc_netif_ieee802154.c
@@ -140,6 +140,7 @@ static gnrc_pktsnip_t *_recv(gnrc_netif_t *netif)
             hdr->lqi = rx_info.lqi;
             hdr->rssi = rx_info.rssi;
             hdr->crc_ok = rx_info.crc_ok;
+            hdr->fcs = rx_info.fcs;
             hdr->if_pid = thread_getpid();
             pkt->type = state->proto;
 #if ENABLE_DEBUG

--- a/sys/net/gnrc/netif/gnrc_netif_ieee802154.c
+++ b/sys/net/gnrc/netif/gnrc_netif_ieee802154.c
@@ -139,6 +139,7 @@ static gnrc_pktsnip_t *_recv(gnrc_netif_t *netif)
 
             hdr->lqi = rx_info.lqi;
             hdr->rssi = rx_info.rssi;
+            hdr->crc_ok = rx_info.crc_ok;
             hdr->if_pid = thread_getpid();
             pkt->type = state->proto;
 #if ENABLE_DEBUG

--- a/sys/net/gnrc/netif/hdr/gnrc_netif_hdr_print.c
+++ b/sys/net/gnrc/netif/hdr/gnrc_netif_hdr_print.c
@@ -25,7 +25,8 @@ void gnrc_netif_hdr_print(gnrc_netif_hdr_t *hdr)
     printf("if_pid: %u  ", (unsigned) hdr->if_pid);
     printf("rssi: %d  ", (signed) hdr->rssi);
     printf("lqi: %u  ", (unsigned) hdr->lqi);
-    printf("crc_ok: %u\n", (unsigned) hdr->crc_ok);
+    printf("crc_ok: %u  ", (unsigned) hdr->crc_ok);
+    printf("fcs: %04x\n", (unsigned) hdr->fcs);
     printf("flags: ");
 
     if (hdr->flags) {

--- a/sys/net/gnrc/netif/hdr/gnrc_netif_hdr_print.c
+++ b/sys/net/gnrc/netif/hdr/gnrc_netif_hdr_print.c
@@ -24,7 +24,8 @@ void gnrc_netif_hdr_print(gnrc_netif_hdr_t *hdr)
 
     printf("if_pid: %u  ", (unsigned) hdr->if_pid);
     printf("rssi: %d  ", (signed) hdr->rssi);
-    printf("lqi: %u\n", (unsigned) hdr->lqi);
+    printf("lqi: %u  ", (unsigned) hdr->lqi);
+    printf("crc_ok: %u\n", (unsigned) hdr->crc_ok);
     printf("flags: ");
 
     if (hdr->flags) {


### PR DESCRIPTION
 ### Contribution description
 
  - adds "crc_ok" and "fcs" to netdev_radio_rx_info and gnrc_netif_hdr_t
 - in all cases the crc_ok is set according to the state of the packet
 - fcs is read on at86rf2xx in all cases
 
Problem:
 - fcs is not readable on cc2420 if AUTOCRC is enabled



