### PR TITLE
pkg: update ccn-lite and adapt shell commands

### DIFF
--- a/pkg/ccn-lite/Makefile
+++ b/pkg/ccn-lite/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME=ccn-lite
 PKG_URL=https://github.com/cn-uofbasel/ccn-lite/
-PKG_VERSION=48b17ebee7600b2e79b3acf0728217473d7a4ee8
+PKG_VERSION=f85a2a055db92b5978f2d4f92b830b5b6b9acb42
 PKG_LICENSE=ISC
 
 .PHONY: all

--- a/sys/shell/commands/sc_ccnl.c
+++ b/sys/shell/commands/sc_ccnl.c
@@ -110,7 +110,7 @@ int _ccnl_content(int argc, char **argv)
 
     arg_len = strlen(buf);
 
-    struct ccnl_prefix_s *prefix = ccnl_URItoPrefix(argv[1], CCNL_SUITE_NDNTLV, NULL, NULL);
+    struct ccnl_prefix_s *prefix = ccnl_URItoPrefix(argv[1], CCNL_SUITE_NDNTLV, NULL);
     int offs = CCNL_MAX_PACKET_SIZE;
     arg_len = ccnl_ndntlv_prependContent(prefix, (unsigned char*) buf, arg_len, NULL, NULL, &offs, _out);
 
@@ -167,7 +167,7 @@ static struct ccnl_face_s *_intern_face_get(char *addr_str)
 static int _intern_fib_add(char *pfx, char *addr_str)
 {
     int suite = CCNL_SUITE_NDNTLV;
-    struct ccnl_prefix_s *prefix = ccnl_URItoPrefix(pfx, suite, NULL, 0);
+    struct ccnl_prefix_s *prefix = ccnl_URItoPrefix(pfx, suite, NULL);
     if (!prefix) {
         puts("Error: prefix could not be created!");
         return -1;
@@ -210,7 +210,7 @@ int _ccnl_interest(int argc, char **argv)
 
     memset(_int_buf, '\0', BUF_SIZE);
 
-    struct ccnl_prefix_s *prefix = ccnl_URItoPrefix(argv[1], CCNL_SUITE_NDNTLV, NULL, 0);
+    struct ccnl_prefix_s *prefix = ccnl_URItoPrefix(argv[1], CCNL_SUITE_NDNTLV, NULL);
     int res = ccnl_send_interest(prefix, _int_buf, BUF_SIZE, NULL);
     ccnl_prefix_free(prefix);
 
@@ -239,7 +239,7 @@ int _ccnl_fib(int argc, char **argv)
     else if ((argc == 3) && (strncmp(argv[1], "del", 3) == 0)) {
         int suite = CCNL_SUITE_NDNTLV;
         if (strchr(argv[2], '/')) {
-            struct ccnl_prefix_s *prefix = ccnl_URItoPrefix(argv[2], suite, NULL, 0);
+            struct ccnl_prefix_s *prefix = ccnl_URItoPrefix(argv[2], suite, NULL);
             if (!prefix) {
                 puts("Error: prefix could not be created!");
                 return -1;


### PR DESCRIPTION
    This updates the ccn-lite package version which brings in the
    latest upstream fixes for some compiler issues found on macOS
    with clang and newer GCC versions.

    A minor adaption of the RIOT shell commands is also included.

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references

https://github.com/cn-uofbasel/ccn-lite/pull/298