### PR TITLE
make: introduce common Python lib path

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -70,6 +70,9 @@ BUILDRELPATH ?= $(CURDIR:$(RIOTPROJECT)/%=%)/
 # get host operating system
 OS := $(shell uname)
 
+# set python path, e.g. for tests
+PYTHONPATH := $(RIOTBASE)/dist/pythonlibs/:$(PYTHONPATH)
+
 # Include Docker settings near the top because we need to build the environment
 # command line before some of the variable origins are overwritten below when
 # using abspath, strip etc.

--- a/dist/pythonlibs/README.md
+++ b/dist/pythonlibs/README.md
@@ -1,0 +1,2 @@
+This directory is exported through PYTHONPATH environment variable in the build system.
+Put any RIOT specific Python packages here.

--- a/makefiles/vars.inc.mk
+++ b/makefiles/vars.inc.mk
@@ -31,6 +31,8 @@ export BINDIR                # This is the folder where the application should b
 export APPDIR                # The base folder containing the application
 export PKGDIRBASE            # The base folder for building packages
 
+export PYTHONPATH            # Python default search path for module filesi, with RIOT specific packages
+
 export FEATURES_REQUIRED     # List of required features by the application
 export FEATURES_PROVIDED     # List of provided features by the board
 export FEATURES_OPTIONAL     # List of nice to have features


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Introduce dist/pythonlibs directory to store RIOT python packages.
This directory is exported via PYTHONPATH by the build system to
make it commonly available.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->