### PR TITLE
boards/stm32f103c8: fix openocd config

### DIFF
--- a/boards/common/stm32f103c8/Makefile.include
+++ b/boards/common/stm32f103c8/Makefile.include
@@ -30,5 +30,9 @@ else
   export DEBUG_ADAPTER ?= stlink
   export STLINK_VERSION ?= 2
 
+  # call a 'reset halt' command before starting the debugger
+  # it is required as `connect_assert_srst` is set
+  export OPENOCD_DBG_START_CMD = -c 'reset halt'
+
   include $(RIOTMAKE)/tools/openocd.inc.mk
 endif

--- a/boards/common/stm32f103c8/dist/openocd.cfg
+++ b/boards/common/stm32f103c8/dist/openocd.cfg
@@ -1,4 +1,25 @@
+source [find interface/stlink.cfg]
+
+set WORKAREASIZE 0x5000
+
+transport select "hla_swd"
+
+set CHIPNAME STM32F103C8Tx
+
+# Enable debug when in low power modes
+set ENABLE_LOW_POWER 1
+
+# Stop Watchdog counters when halt
+set STOP_WATCHDOG 1
+
+# STlink Debug clock frequency
+set CLOCK_FREQ 4000
+
+# use hardware reset, connect under reset
+# connect_assert_srst needed if low power mode application running (WFI...)
+reset_config srst_only srst_nogate connect_assert_srst
+set CONNECT_UNDER_RESET 1
+
 source [find target/stm32f1x.cfg]
-reset_config none separate
 
 $_TARGETNAME configure -rtos auto


### PR DESCRIPTION
### Contribution description

Update the common/stm32f103c8 openocd configuration file to fix occasional flash problems that was noticed when running multiple tests with [compile_and_test_for_board.py](https://github.com/RIOT-OS/Release-Specs/pull/68).

I used the default configuration from ST for the board and reran all the tests.  I did not receive any flashing errors after that.  I added modifications for RIOT and to allow debug.

### Issues/PRs references
[Release-Specs/pull/68](https://github.com/RIOT-OS/Release-Specs/pull/68).
