### PR TITLE
 Makefile.include: Include VERSION file for release

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -287,6 +287,9 @@ endif
 # Feature test default CFLAGS and LINKFLAGS for the set compiled.
 include $(RIOTMAKE)/cflags.inc.mk
 
+# Include VERSION for releases
+-include $(RIOTBASE)/VERSION
+
 # make the RIOT version available to the program
 ifeq ($(origin RIOT_VERSION), undefined)
   GIT_STRING := $(shell git --git-dir="$(RIOTBASE)/.git" describe --always --abbrev=4 --dirty=-`hostname` 2> /dev/null)


### PR DESCRIPTION
### Contribution description

When downloading the release archive and building an example, the RIOT_VERSION string is not set to "Version: 2018.04" but to
    
    Version: UNKNOWN (builddir: /home/me/Downloads/RIOT-2018.04)

This allows sourcing a global VERSION file to manually set it before releases.

### Testing

In the basic repository run

    make -C examples/hello-world all term

You have the git calculated version

Create a VERSION file with

    RIOT_VERSION = "2042.13"

And run

    make -C examples/hello-world all term

You should see the set version.

### Issues/PRs references

Release