### PR TITLE
frdm-k64f: Update ADC configuration 

### DIFF
--- a/boards/frdm-k64f/include/periph_conf.h
+++ b/boards/frdm-k64f/include/periph_conf.h
@@ -120,12 +120,12 @@ static const uart_conf_t uart_config[] = {
  * @{
  */
 static const adc_conf_t adc_config[] = {
-    { .dev = ADC0, .pin = GPIO_PIN(PORT_B, 10), .chan = 14 },
-    { .dev = ADC0, .pin = GPIO_PIN(PORT_B, 11), .chan = 15 },
-    { .dev = ADC0, .pin = GPIO_PIN(PORT_C, 11), .chan =  7 },
-    { .dev = ADC0, .pin = GPIO_PIN(PORT_C, 10), .chan =  6 },
-    { .dev = ADC0, .pin = GPIO_PIN(PORT_C,  8), .chan =  4 },
-    { .dev = ADC0, .pin = GPIO_PIN(PORT_C,  9), .chan =  5 }
+    [ 0] = { .dev = ADC1, .pin = GPIO_PIN(PORT_B, 10), .chan = 14 }, /* PTB10 */
+    [ 1] = { .dev = ADC1, .pin = GPIO_PIN(PORT_B, 11), .chan = 15 }, /* PTB11 */
+    [ 2] = { .dev = ADC1, .pin = GPIO_PIN(PORT_C, 11), .chan =  7 }, /* PTC11 */
+    [ 3] = { .dev = ADC1, .pin = GPIO_PIN(PORT_C, 10), .chan =  6 }, /* PTC10 */
+    [ 4] = { .dev = ADC1, .pin = GPIO_PIN(PORT_C,  8), .chan =  4 }, /* PTC8 */
+    [ 5] = { .dev = ADC1, .pin = GPIO_PIN(PORT_C,  9), .chan =  5 }, /* PTC9 */
 };
 
 #define ADC_NUMOF           (sizeof(adc_config) / sizeof(adc_config[0]))

--- a/boards/frdm-k64f/include/periph_conf.h
+++ b/boards/frdm-k64f/include/periph_conf.h
@@ -126,6 +126,26 @@ static const adc_conf_t adc_config[] = {
     [ 3] = { .dev = ADC1, .pin = GPIO_PIN(PORT_B, 11), .chan = 15 }, /* PTB11 (Arduino A3) */
     [ 4] = { .dev = ADC1, .pin = GPIO_PIN(PORT_C, 11), .chan =  7 }, /* PTC11 (Arduino A4) */
     [ 5] = { .dev = ADC1, .pin = GPIO_PIN(PORT_C, 10), .chan =  6 }, /* PTC10 (Arduino A5) */
+    [ 6] = { .dev = ADC0, .pin = GPIO_UNDEF          , .chan =  0 }, /* ADC0_DP0 */
+    [ 7] = { .dev = ADC0, .pin = GPIO_UNDEF          , .chan = 19 }, /* ADC0_DM0 */
+    [ 8] = { .dev = ADC0, .pin = GPIO_UNDEF          , .chan = (0 | ADC_SC1_DIFF_MASK) }, /* ADC0_DP0 - ADC0_DM0 */
+    [ 9] = { .dev = ADC1, .pin = GPIO_UNDEF          , .chan =  0 }, /* ADC1_DP0 */
+    [10] = { .dev = ADC1, .pin = GPIO_UNDEF          , .chan = 19 }, /* ADC1_DM0 */
+    [11] = { .dev = ADC1, .pin = GPIO_UNDEF          , .chan = (0 | ADC_SC1_DIFF_MASK) }, /* ADC1_DP0 - ADC1_DM0 */
+    [12] = { .dev = ADC0, .pin = GPIO_UNDEF          , .chan =  1 }, /* ADC0_DP1 */
+    [13] = { .dev = ADC0, .pin = GPIO_UNDEF          , .chan = 20 }, /* ADC0_DM1 */
+    [14] = { .dev = ADC0, .pin = GPIO_UNDEF          , .chan = (1 | ADC_SC1_DIFF_MASK) }, /* ADC0_DP1 - ADC0_DM1 */
+    [15] = { .dev = ADC1, .pin = GPIO_UNDEF          , .chan =  1 }, /* ADC1_DP1 */
+    [16] = { .dev = ADC1, .pin = GPIO_UNDEF          , .chan = 20 }, /* ADC1_DM1 */
+    [17] = { .dev = ADC1, .pin = GPIO_UNDEF          , .chan = (1 | ADC_SC1_DIFF_MASK) }, /* ADC1_DP1 - ADC1_DM1 */
+    /* internal: temperature sensor */
+    /* The temperature sensor has a very high output impedance, it must not be
+     * sampled using hardware averaging, or the sampled values will be garbage */
+    [18] = { .dev = ADC0, .pin = GPIO_UNDEF, .chan = 26 },
+    /* internal: band gap */
+    /* Note: the band gap buffer uses a bit of current and is turned off by default,
+     * Set PMC->REGSC |= PMC_REGSC_BGBE_MASK before reading or the input will be floating */
+    [19] = { .dev = ADC0, .pin = GPIO_UNDEF, .chan = 27 },
 };
 
 #define ADC_NUMOF           (sizeof(adc_config) / sizeof(adc_config[0]))

--- a/boards/frdm-k64f/include/periph_conf.h
+++ b/boards/frdm-k64f/include/periph_conf.h
@@ -120,12 +120,12 @@ static const uart_conf_t uart_config[] = {
  * @{
  */
 static const adc_conf_t adc_config[] = {
-    [ 0] = { .dev = ADC1, .pin = GPIO_PIN(PORT_B, 10), .chan = 14 }, /* PTB10 */
-    [ 1] = { .dev = ADC1, .pin = GPIO_PIN(PORT_B, 11), .chan = 15 }, /* PTB11 */
-    [ 2] = { .dev = ADC1, .pin = GPIO_PIN(PORT_C, 11), .chan =  7 }, /* PTC11 */
-    [ 3] = { .dev = ADC1, .pin = GPIO_PIN(PORT_C, 10), .chan =  6 }, /* PTC10 */
-    [ 4] = { .dev = ADC1, .pin = GPIO_PIN(PORT_C,  8), .chan =  4 }, /* PTC8 */
-    [ 5] = { .dev = ADC1, .pin = GPIO_PIN(PORT_C,  9), .chan =  5 }, /* PTC9 */
+    [ 0] = { .dev = ADC0, .pin = GPIO_PIN(PORT_B,  2), .chan = 12 }, /* PTB2 (Arduino A0) */
+    [ 1] = { .dev = ADC0, .pin = GPIO_PIN(PORT_B,  3), .chan = 13 }, /* PTB3 (Arduino A1) */
+    [ 2] = { .dev = ADC1, .pin = GPIO_PIN(PORT_B, 10), .chan = 14 }, /* PTB10 (Arduino A2) */
+    [ 3] = { .dev = ADC1, .pin = GPIO_PIN(PORT_B, 11), .chan = 15 }, /* PTB11 (Arduino A3) */
+    [ 4] = { .dev = ADC1, .pin = GPIO_PIN(PORT_C, 11), .chan =  7 }, /* PTC11 (Arduino A4) */
+    [ 5] = { .dev = ADC1, .pin = GPIO_PIN(PORT_C, 10), .chan =  6 }, /* PTC10 (Arduino A5) */
 };
 
 #define ADC_NUMOF           (sizeof(adc_config) / sizeof(adc_config[0]))


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->
The ADC configuration for the frdm-k64f board was incorrect with respect to the pins used. This PR changes the existing configuration to match the [Arduino R3 pinout] (https://os.mbed.com/media/uploads/Ting_Wang/frdm-kw41z_arduino-header-pinout.jpg) used in mbed OS. Additionally, some dedicated analog pins that exist in the expansion header on the board are mapped in this configuration to make it easier to use them from applications. The dedicated pins are not connected to the pin mux so they are always connected to the ADC and thus can only be used as analog inputs. The increased ROM usage for a few more entries in the configuration table is only a few bytes. 

### Issues/PRs references

None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->