### PR TITLE
tests/gnrc_netif: Fix -Wformat-overflow

### DIFF
--- a/tests/gnrc_netif/main.c
+++ b/tests/gnrc_netif/main.c
@@ -1043,7 +1043,7 @@ static void test_netif_iter(void)
 
 static void test_netif_get_name(void)
 {
-    char exp_name[NETIF_NAMELENMAX];
+    char exp_name[NETIF_NAMELENMAX + 1];
     char name[NETIF_NAMELENMAX];
     int res;
     netif_t netif = netif_iter(NETIF_INVALID);


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Fixes the following error with GCC 7

```
main.c: In function 'test_netif_get_name':
main.c:1054:23: error: 'sprintf' may write a terminating nul past the end of the destination [-Werror=format-overflow=]
     sprintf(exp_name, "if%d", (int)netif);
                       ^~~~~~
main.c:1054:5: note: 'sprintf' output between 4 and 9 bytes into a destination of size 8
     sprintf(exp_name, "if%d", (int)netif);
     ^~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
```


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->