### PR TITLE
kinetis: timer: #ifdef unused functions

### DIFF
--- a/cpu/kinetis/periph/timer.c
+++ b/cpu/kinetis/periph/timer.c
@@ -114,12 +114,14 @@ static inline unsigned int _lptmr_index(tim_t dev) {
     return ((unsigned int)dev) - TIMER_DEV(0) - PIT_NUMOF;
 }
 
+#if defined(LPTMR_ISR_0) || defined(LPTMR_ISR_1)
 /**
  * @brief  Get TIMER_x enum value from LPTMR device index
  */
 static inline tim_t _lptmr_tim_t(uint8_t dev) {
     return (tim_t)(((unsigned int)TIMER_DEV(0)) + PIT_NUMOF + dev);
 }
+#endif /* defined(LPTMR_ISR_0) || defined(LPTMR_ISR_1) */
 
 /* ****** PIT module functions ****** */
 
@@ -294,7 +296,9 @@ static inline int lptmr_clear(uint8_t dev);
 static inline uint16_t lptmr_read(uint8_t dev);
 static inline void lptmr_start(uint8_t dev);
 static inline void lptmr_stop(uint8_t dev);
+#if defined(LPTMR_ISR_0) || defined(LPTMR_ISR_1)
 static inline void lptmr_irq_handler(tim_t tim);
+#endif
 
 static inline void _lptmr_set_cb_config(uint8_t dev, timer_cb_t cb, void *arg)
 {
@@ -558,6 +562,7 @@ static inline void lptmr_stop(uint8_t dev)
     irq_restore(mask);
 }
 
+#if defined(LPTMR_ISR_0) || defined(LPTMR_ISR_1)
 static inline void lptmr_irq_handler(tim_t tim)
 {
     uint8_t dev = _lptmr_index(tim);
@@ -575,6 +580,7 @@ static inline void lptmr_irq_handler(tim_t tim)
 
     cortexm_isr_end();
 }
+#endif /* defined(LPTMR_ISR_0) || defined(LPTMR_ISR_1) */
 
 /* ****** Common timer API functions ****** */
 


### PR DESCRIPTION
### Contribution description
Another issue revealed by compiling several apps with LLVM/clang for
the `teensy31` board.

### Issues/PRs references
This board causes [a lot of fails because of this](https://ci.riot-os.org/RIOT-OS/RIOT/9398/15010cd63ff22ebe3965687647e5fd849eefd3c4/output.html) in #9398 when activated.