### PR TITLE
drivers/periph/gpio_util: add gpio_util_shiftin()

### DIFF
--- a/drivers/include/periph/gpio_util.h
+++ b/drivers/include/periph/gpio_util.h
@@ -1,0 +1,43 @@
+/*
+ * Copyright (C) 2019 Philipp-Alexander Blum <philipp-blum@jakiku.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup   gpio_util GPIO I/O Utils
+ * @ingroup    drivers_periph_gpio
+ * @brief      GPIO I/O utility functions
+ *
+ * @{
+ *
+ * @file
+ * @brief      GPIO I/O utility function implementations
+ *
+ * @author     Philipp-Alexander Blum <philipp-blum@jakiku.de>
+ */
+
+#include "gpio.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Shift in a byte from data_pin, create clock pulses on clock_pin
+ *
+ * This funtion has the same functionality as the Arduino shiftIn() in Advanced
+ * I/O.
+ *
+ * @param[in]   data_pin    Pin to read data from
+ * @param       clock_pin   Pin to create clock pulses on
+ * @return      the resulting uint8_t of the shift (MSB first)
+ */
+uint8_t gpio_util_shiftin(gpio_t data_pin, gpio_t clock_pin);
+
+#ifdef __cplusplus
+}
+#endif
+/** @} */

--- a/drivers/periph_common/gpio_util.c
+++ b/drivers/periph_common/gpio_util.c
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2019 Philipp-Alexander Blum <philipp-blum@jakiku.de>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+#include "periph/gpio.h"
+#include <stdint.h>
+
+#ifdef MODULE_PERIPH_GPIO
+
+uint8_t gpio_util_shiftin(gpio_t data_pin, gpio_t clock_pin)
+{
+    uint8_t byte = 0x00;
+
+    for (unsigned int i = 8; i > 0; i--) {
+        gpio_set(clock_pin);
+        if (gpio_read(data_pin) > 0) {
+            byte |= (1 << (i - 1));
+        }
+        gpio_clear(clock_pin);
+    }
+
+    return byte;
+}
+
+#endif /* MODULE_PERIPH_GPIO */


### PR DESCRIPTION
### Contribution description
gpio_util with gpio_util_shiftin. Needed for the HX711 driver in #11416.
### Issues/PRs references
See also #9712 