### PR TITLE
sht1x: Fix Wimplicit-fallthrough warning

### DIFF
--- a/drivers/sht1x/sht1x_saul.c
+++ b/drivers/sht1x/sht1x_saul.c
@@ -41,6 +41,7 @@ static int read(const sht1x_dev_t *dev, int16_t *temp, int16_t *hum)
                 continue;
             case -ECANCELED:
                 puts("[sht1x] Measurement times out");
+                /* falls through */
             default:
                 /* Other failure, cannot recover so giving up */
                 return -1;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Trivial fix

### Issues/PRs references

Picked from #9362 