### PR TITLE
nimble: deactivate -Wunused-function with LLVM/clang

### DIFF
--- a/pkg/nimble/Makefile
+++ b/pkg/nimble/Makefile
@@ -9,6 +9,12 @@ PDIR = $(PKG_BUILDDIR)
 # As of now, NimBLE does not build without warnings for -Wextra, so we disable
 # that flag for this package. Will hopefully be fixed some time in the future.
 CFLAGS += -Wno-extra
+# the static function `ble_ll_adv_active_chanset_is_sec()` in
+# `nimble/controller/src/ble_ll_adv.c` isn't used in our compilation path, so
+# tell LLVM/clang not to be so pedantic with this.
+ifeq (llvm,$(TOOLCHAIN))
+  CFLAGS += -Wno-unused-function
+endif
 
 .PHONY: all
 


### PR DESCRIPTION
### Contribution description
When building `nimble` with LLVM/clang the function `ble_ll_adv_active_chanset_is_sec()` in [ble_ll_adv.c] is reported to be unused, it is used within an assertions and `ifdef`s within that file though. So this just disables that warning.

### Issues/PRs references
[Detected](https://ci.riot-os.org/RIOT-OS/RIOT/9398/8a92c3f60b000d54fb0120e498aa1288e78e534b/output/compile/examples/nimble_gatt/nrf52dk:llvm.txt) in #9398 

[ble_ll_adv.c]: https://github.com/apache/mynewt-nimble/blob/master/nimble/controller/src/ble_ll_adv.c