### PR TITLE
stm32_common/eeprom: fix DEBUG formatting

### DIFF
--- a/cpu/stm32_common/periph/eeprom.c
+++ b/cpu/stm32_common/periph/eeprom.c
@@ -39,7 +39,7 @@ uint8_t eeprom_read_byte(uint32_t pos)
 {
     assert(pos < EEPROM_SIZE);
 
-    DEBUG("Reading data from EEPROM at pos %lu\n", pos);
+    DEBUG("Reading data from EEPROM at pos %" PRIu32 "\n", pos);
     return *(uint8_t *)(EEPROM_START_ADDR + pos);
 }
 
@@ -47,7 +47,7 @@ void eeprom_write_byte(uint32_t pos, uint8_t data)
 {
     assert(pos < EEPROM_SIZE);
 
-    DEBUG("Writing data '%c' to EEPROM at pos %lu\n", data, pos);
+    DEBUG("Writing data '%c' to EEPROM at pos %" PRIu32 "\n", data, pos);
     _unlock();
     *(uint8_t *)(EEPROM_START_ADDR + pos) = data;
     _lock();


### PR DESCRIPTION
### Contribution description
This fixes compilation for `periph_eeprom` with LLVM/clang and also is
more in accordance with our [coding conventions].

### Issues/PRs references
[Detected](https://ci.riot-os.org/RIOT-OS/RIOT/9398/8a92c3f60b000d54fb0120e498aa1288e78e534b/output/compile/tests/periph_eeprom/nucleo-l031k6:llvm.txt) in #9398.

[coding conventions]: https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions#-wformat