### PR TITLE
style-check/vera++: add style validator and scripts

### DIFF
--- a/dist/tools/ci/build_and_test.sh
+++ b/dist/tools/ci/build_and_test.sh
@@ -89,6 +89,7 @@ then
         run ./dist/tools/doccheck/check.sh
         run ./dist/tools/externc/check.sh
         run ./dist/tools/cppcheck/check.sh
+        run ./dist/tools/vera++/check.sh
         run ./dist/tools/pr_check/pr_check.sh ${CI_BASE_BRANCH}
         run ./dist/tools/coccinelle/check.sh
         run ./dist/tools/flake8/check.sh

--- a/dist/tools/vera++/README.md
+++ b/dist/tools/vera++/README.md
@@ -1,0 +1,30 @@
+## Overview
+
+Vera++ is a programmable tool for verification, analysis and transformation of
+C++ source code. Vera++ is mainly an engine that parses C++ source files and
+presents the result of this parsing to scripts in the form of various
+collections - the scripts are actually performing the requested tasks.
+
+## Rules
+
+Rules can be added in the `rules` folder. The default rules from Vera++ were
+added. However, it's possible to implement new rules in TCL. See
+https://bitbucket.org/verateam/vera/wiki/Rules for information about the
+available rules.
+
+# Profiles
+
+A `riot_force` profile was made for describing the set of applied rules as well as
+special parameters. A `riot` profile includes all rules that should be treated as
+warnings. In case new rules are added, they can be updated for both profiles under
+`profiles` folder.
+
+## Example usage
+Check style for all changed files changed in current branch:
+    check.sh
+
+Check all changed files and don't display the results (only exit code):
+    QUIET=1 check.sh
+
+Don't display the warnings
+    WARNING=0 check.sh

--- a/dist/tools/vera++/check.sh
+++ b/dist/tools/vera++/check.sh
@@ -1,0 +1,36 @@
+#!/bin/bash
+
+# Copyright 2018 Jose Ignacio Alamos <jose.alamos@haw-hamburg.de>
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+RIOTBASE=$(git rev-parse --show-toplevel)
+CURDIR=$(cd "$(dirname "$0")" && pwd)
+: "${QUIET:=0}"
+: "${WARNING:=1}"
+
+. "$RIOTBASE"/dist/tools/ci/changed_files.sh
+FILEREGEX='\.([CcHh]|[ch]pp)$'
+EXCLUDE='^(.+/vendor/)'
+FILES=$(FILEREGEX=${FILEREGEX} EXCLUDE=${EXCLUDE} changed_files)
+
+if [ -z "${FILES}" ]; then
+    exit 0
+fi
+
+PARAMS=""
+if [ $QUIET -eq 1 ]; then
+    _QUIET="--quiet"
+fi
+
+VERA_CMD="vera++ --root $CURDIR --exclusions $CURDIR/exclude $_QUIET"
+
+if [ $WARNING -ne 0 ]; then
+    echo "$FILES" | $VERA_CMD --profile riot \
+        --parameters $CURDIR/profiles/riot_params.txt | sed 's/^/warning: /g'
+fi
+
+echo "$FILES" | $VERA_CMD --profile riot_force \
+    --parameters $CURDIR/profiles/riot_force_params.txt --error

--- a/dist/tools/vera++/profiles/riot
+++ b/dist/tools/vera++/profiles/riot
@@ -1,0 +1,7 @@
+#!/usr/bin/tclsh
+
+# L004: Line cannot be too long
+
+set rules {
+  L004
+}

--- a/dist/tools/vera++/profiles/riot_force
+++ b/dist/tools/vera++/profiles/riot_force
@@ -1,0 +1,47 @@
+#!/usr/bin/tclsh
+
+# F001: Source files should not use the '\r' (CR) character
+# L001: No trailing whitespace
+# L002: Don't use tab characters
+# L003: No leading and no trailing empty lines
+# L004: Line cannot be too long
+# L005: There should not be too many consecutive empty lines
+# L006: Source file should not be too long
+# T001: One-line comments should not have forced continuation
+# T003: Some keywords should be followed by a single space
+# T004: Some keywords should be immediately followed by a colon
+# T005: Keywords break and continue should be immediately followed by a semicolon
+# T006: Keywords return and throw should be immediately followed by a semicolon or a single space
+# T007: Semicolons should not be isolated by spaces or comments from the rest of the code
+# T008: Keywords catch, for, if and while should be followed by a single space
+# T009: Comma should not be preceded by whitespace, but should be followed by one
+# T010: Identifiers should not be composed of 'l' and 'O' characters only
+# T013: Source files should contain the copyright notice
+# T015: HTML links in comments and string literals should be correct
+# T017: Unnamed namespaces are not allowed in header files
+# T018: using namespace are not allowed in header files
+# T019: control structures should have complete curly-braced block of code
+
+set rules {
+  F001
+  L001
+  L002
+  L003
+  L004
+  L005
+  L006
+  T001
+  T003
+  T004
+  T005
+  T006
+  T007
+  T008
+  T009
+  T010
+  T013
+  T015
+  T017
+  T018
+  T019
+}

--- a/dist/tools/vera++/profiles/riot_force_params.txt
+++ b/dist/tools/vera++/profiles/riot_force_params.txt
@@ -1,0 +1,2 @@
+max-line-length=100
+max-consecutive-empty-lines=1

--- a/dist/tools/vera++/profiles/riot_params.txt
+++ b/dist/tools/vera++/profiles/riot_params.txt
@@ -1,0 +1,1 @@
+max-line-length=80

--- a/dist/tools/vera++/scripts/CMakeLists.txt
+++ b/dist/tools/vera++/scripts/CMakeLists.txt
@@ -1,0 +1,2 @@
+add_subdirectory(rules)
+add_subdirectory(transformations)

--- a/dist/tools/vera++/scripts/rules/CMakeLists.txt
+++ b/dist/tools/vera++/scripts/rules/CMakeLists.txt
@@ -1,0 +1,3 @@
+file(GLOB_RECURSE srcs RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *)
+list(REMOVE_ITEM srcs CMakeLists.txt)
+install(FILES ${srcs} DESTINATION lib/vera++/scripts/rules)

--- a/dist/tools/vera++/scripts/rules/DUMP.tcl
+++ b/dist/tools/vera++/scripts/rules/DUMP.tcl
@@ -1,0 +1,13 @@
+#!/usr/bin/tclsh
+foreach f [getSourceFileNames] {
+    puts "Tokens in file ${f}:"
+    foreach t [getTokens $f 1 0 -1 -1 {}] {
+        set value [lindex $t 0]
+        set line [lindex $t 1]
+        set column [lindex $t 2]
+        set name [lindex $t 3]
+
+        puts "${line}/${column}\t${name}\t${value}"
+    }
+    puts ""
+}

--- a/dist/tools/vera++/scripts/rules/F001.tcl
+++ b/dist/tools/vera++/scripts/rules/F001.tcl
@@ -1,0 +1,22 @@
+#!/usr/bin/tclsh
+# Source files should not use the '\r' (CR) character
+
+foreach fileName [getSourceFileNames] {
+    if { $fileName == "-" } {
+      # can't check the content from stdin
+      continue
+    }
+    set file [open $fileName "r"]
+    fconfigure $file -translation lf
+    set line [gets $file]
+    set lineCounter 1
+    while {![eof $file]} {
+        set pos [string first "\r" $line]
+        if {$pos != -1 && $pos != [expr [string length $line] - 1]} {
+            report $fileName $lineCounter "\\r (CR) detected in isolation at position ${pos}"
+        }
+        set line [gets $file]
+        incr lineCounter
+    }
+    close $file
+}

--- a/dist/tools/vera++/scripts/rules/F002.tcl
+++ b/dist/tools/vera++/scripts/rules/F002.tcl
@@ -1,0 +1,56 @@
+#!/usr/bin/tclsh
+# File names should be well-formed
+
+set maxDirectoryDepth [getParameter "max-directory-depth" 8]
+set maxDirnameLength [getParameter "max-dirname-length" 31]
+set maxFilenameLength [getParameter "max-filename-length" 31]
+set maxPathLength [getParameter "max-path-length" 100]
+
+foreach fileName [getSourceFileNames] {
+    if {[string length $fileName] > $maxPathLength} {
+        report $fileName 1 "path name too long"
+    }
+
+    set dirDepth 0
+    foreach dir [file split [file dirname $fileName]] {
+        if {$dir == "/" || $dir == "." || $dir == ".."} {
+            continue
+        }
+
+        incr dirDepth
+
+        if {[string length $dir] > $maxDirnameLength} {
+            report $fileName 1 "directory name component too long"
+            break
+        }
+
+        set first [string index $dir 0]
+        if {[string is alpha $first] == 0 && $first != "_"} {
+            report $fileName 1 "directory name should start with alphabetic character or underscore"
+            break
+        }
+
+        if {[string first "." $dir] != -1} {
+            report $fileName 1 "directory name should not contain the dot"
+            break
+        }
+    }
+
+    if {$dirDepth >= $maxDirectoryDepth} {
+        report $fileName 1 "directory structure too deep"
+    }
+
+    set leafName [file tail $fileName]
+    if {[string length $leafName] > $maxFilenameLength} {
+        report $fileName 1 "file name too long"
+    }
+
+    set first [string index $leafName 0]
+    if {[string is alpha $first] == 0 && $first != "_"} {
+        report $fileName 1 "file name should start with alphabetic character or underscore"
+    }
+
+    if {[llength [split $leafName .]] > 2} {
+        report $fileName 1 "file name should not contain more than one dot"
+    }
+}

--- a/dist/tools/vera++/scripts/rules/L001.tcl
+++ b/dist/tools/vera++/scripts/rules/L001.tcl
@@ -1,0 +1,20 @@
+#!/usr/bin/tclsh
+# No trailing whitespace
+
+set strictMode [getParameter "strict-trailing-space" 0]
+
+foreach f [getSourceFileNames] {
+    set lineNumber 1
+    set previousIndent ""
+    foreach line [getAllLines $f] {
+
+        if [regexp {^.*[[:space:]]+$} $line] {
+            if {$strictMode || [string trim $line] != "" || $line != $previousIndent} {
+                report $f $lineNumber "trailing whitespace"
+            }
+        }
+
+        regexp {^([[:space:]]*).*$} $line dummy previousIndent
+        incr lineNumber
+    }
+}

--- a/dist/tools/vera++/scripts/rules/L002.tcl
+++ b/dist/tools/vera++/scripts/rules/L002.tcl
@@ -1,0 +1,14 @@
+#!/usr/bin/tclsh
+# Don't use tab characters
+
+foreach f [getSourceFileNames] {
+    set lineNumber 1
+    foreach line [getAllLines $f] {
+
+        if [regexp {\t} $line] {
+            report $f $lineNumber "horizontal tab used"
+        }
+
+        incr lineNumber
+    }
+}

--- a/dist/tools/vera++/scripts/rules/L003.tcl
+++ b/dist/tools/vera++/scripts/rules/L003.tcl
@@ -1,0 +1,17 @@
+#!/usr/bin/tclsh
+# No leading and no trailing empty lines
+
+foreach f [getSourceFileNames] {
+    set lineCount [getLineCount $f]
+    if {$lineCount > 0} {
+        set firstLine [getLine $f 1]
+        if {[string trim $firstLine] == ""} {
+            report $f 1 "leading empty line(s)"
+        }
+
+        set lastLine [getLine $f $lineCount]
+        if {[string trim $lastLine] == ""} {
+            report $f $lineCount "trailing empty line(s)"
+        }
+    }
+}

--- a/dist/tools/vera++/scripts/rules/L004.tcl
+++ b/dist/tools/vera++/scripts/rules/L004.tcl
@@ -1,0 +1,14 @@
+#!/usr/bin/tclsh
+# Line cannot be too long
+
+set maxLength [getParameter "max-line-length" 100]
+
+foreach f [getSourceFileNames] {
+    set lineNumber 1
+    foreach line [getAllLines $f] {
+        if {[string length $line] > $maxLength} {
+            report $f $lineNumber "line is longer than ${maxLength} characters"
+        }
+        incr lineNumber
+    }
+}

--- a/dist/tools/vera++/scripts/rules/L005.tcl
+++ b/dist/tools/vera++/scripts/rules/L005.tcl
@@ -1,0 +1,23 @@
+#!/usr/bin/tclsh
+# There should not be too many consecutive empty lines
+
+set maxEmptyLines [getParameter "max-consecutive-empty-lines" 2]
+
+foreach f [getSourceFileNames] {
+    set lineNumber 1
+    set emptyCount 0
+    set reported false
+    foreach line [getAllLines $f] {
+        if {[string trim $line] == ""} {
+            incr emptyCount
+            if {$emptyCount > $maxEmptyLines && $reported == "false"} {
+                report $f $lineNumber "too many consecutive empty lines"
+                set reported true
+            }
+        } else {
+            set emptyCount 0
+            set reported false
+        }
+        incr lineNumber
+    }
+}

--- a/dist/tools/vera++/scripts/rules/L006.tcl
+++ b/dist/tools/vera++/scripts/rules/L006.tcl
@@ -1,0 +1,11 @@
+#!/usr/bin/tclsh
+# Source file should not be too long
+
+set maxLines [getParameter "max-file-length" 2000]
+
+foreach f [getSourceFileNames] {
+    set length [getLineCount $f]
+    if {$length > $maxLines} {
+        report $f $length "source file is too long"
+    }
+}

--- a/dist/tools/vera++/scripts/rules/T001.tcl
+++ b/dist/tools/vera++/scripts/rules/T001.tcl
@@ -1,0 +1,13 @@
+#!/usr/bin/tclsh
+# One-line comments should not have forced continuation
+
+foreach f [getSourceFileNames] {
+    foreach t [getTokens $f 1 0 -1 -1 {cppcomment}] {
+        set lineNumber [lindex $t 1]
+        set wholeLine [getLine $f $lineNumber]
+
+        if {[string index $wholeLine end] == "\\"} {
+            report $f $lineNumber "line-continuation in one-line comment"
+        }
+    }
+}

--- a/dist/tools/vera++/scripts/rules/T002.tcl
+++ b/dist/tools/vera++/scripts/rules/T002.tcl
@@ -1,0 +1,99 @@
+#!/usr/bin/tclsh
+# Reserved names should not be used for preprocessor macros
+
+set keywords {
+    asm
+    auto
+    bool
+    break
+    case
+    catch
+    char
+    class
+    const
+    const_cast
+    continue
+    default
+    delete
+    goto
+    do
+    double
+    dynamic_cast
+    else
+    enum
+    explicit
+    export
+    extern
+    false
+    float
+    for
+    friend
+    if
+    inline
+    int
+    long
+    mutable
+    namespace
+    new
+    operator
+    private
+    protected
+    public
+    register
+    reinterpret_cast
+    return
+    short
+    signed
+    sizeof
+    static
+    static_cast
+    struct
+    switch
+    template
+    this
+    throw
+    true
+    try
+    typedef
+    typeid
+    typename
+    union
+    unsigned
+    using
+    virtual
+    void
+    volatile
+    wchar_t
+    while
+
+    and
+    and_eq
+    bitand
+    bitor
+    compl
+    not
+    not_eq
+    or
+    or_eq
+    xor
+    xor_eq
+}
+
+foreach f [getSourceFileNames] {
+    foreach t [getTokens $f 1 0 -1 -1 {pp_define}] {
+        set lineNumber [lindex $t 1]
+
+        set line [getLine $f $lineNumber]
+        set rest [string trimleft [string range $line \
+                                       [expr [lindex $t 2] + [string length [lindex $t 0]]] end]]
+        set macroName [string range $rest 0 [expr [string wordend $rest 0] - 1]]
+
+        if {([regexp {^_} $macroName] && [string is upper -strict [string index $macroName 1]]) ||
+            [string first "__" $macroName] != -1} {
+            report $f $lineNumber "reserved name used for macro (incorrect use of underscore)"
+        }
+        if {[lsearch $keywords $macroName] != -1} {
+            report $f $lineNumber "reserved name used for macro (keyword or alternative token redefined)"
+        }
+    }
+}

--- a/dist/tools/vera++/scripts/rules/T003.tcl
+++ b/dist/tools/vera++/scripts/rules/T003.tcl
@@ -1,0 +1,48 @@
+#!/usr/bin/tclsh
+# Some keywords should be followed by a single space
+
+set keywords {
+    case
+    class
+    delete
+    enum
+    explicit
+    extern
+    goto
+    new
+    struct
+    union
+    using
+}
+
+proc isKeyword {s} {
+    global keywords
+    return [expr [lsearch $keywords $s] != -1]
+}
+
+set state "other"
+foreach f [getSourceFileNames] {
+    foreach t [getTokens $f 1 0 -1 -1 {}] {
+        set tokenValue [lindex $t 0]
+        set tokenName [lindex $t 3]
+        if {$state == "keyword"} {
+            if {$tokenName == "space" && $tokenValue == " "} {
+                set state "space"
+            } else {
+                report $f $lineNumber "keyword \'${keywordValue}\' not followed by a single space"
+                set state "other"
+            }
+        } elseif {$state == "space"} {
+            if {$tokenName == "newline"} {
+                report $f $lineNumber "keyword \'${keywordValue}\' not followed by a single space"
+            }
+            set state "other"
+        } else {
+            if [isKeyword $tokenName] {
+                set state "keyword"
+                set lineNumber [lindex $t 1]
+                set keywordValue [lindex $t 0]
+            }
+        }
+    }
+}

--- a/dist/tools/vera++/scripts/rules/T004.tcl
+++ b/dist/tools/vera++/scripts/rules/T004.tcl
@@ -1,0 +1,51 @@
+#!/usr/bin/tclsh
+# Some keywords should be immediately followed by a colon
+
+set keywords {
+    default
+    private
+    protected
+    public
+}
+
+proc isKeyword {s} {
+    global keywords
+    return [expr [lsearch $keywords $s] != -1]
+}
+
+foreach f [getSourceFileNames] {
+    set lastKeywordLine 0
+    set lastKeywordColumn 0
+    set lastKeywordValue ""
+    set last ""
+    foreach t [getTokens $f 1 0 -1 -1 [concat $keywords colon]] {
+        set tokenValue [lindex $t 0]
+        set tokenName [lindex $t 3]
+        if {$tokenName == "colon"} {
+            if {$last == "keyword" && $lastKeywordLine != 0} {
+                set line [lindex $t 1]
+                set column [lindex $t 2]
+                if {$line != $lastKeywordLine ||
+                    $column != [expr $lastKeywordColumn + [string length $lastKeywordValue]]} {
+                    set nonWhiteFound "false"
+                    foreach tb [getTokens $f $lastKeywordLine [expr $lastKeywordColumn + 1] $line $column {}] {
+                        set tbName [lindex $tb 3]
+                        if {[lsearch {space newline ccomment cppcomment} $tbName] == -1} {
+                            set nonWhiteFound "true"
+                            break
+                        }
+                    }
+                    if {$nonWhiteFound == "false"} {
+                        report $f $line "colon not immediately after the \'$lastKeywordValue\' keyword"
+                    }
+                }
+            }
+            set last "colon"
+        } else {
+            set lastKeywordLine [lindex $t 1]
+            set lastKeywordColumn [lindex $t 2]
+            set lastKeywordValue $tokenValue
+            set last "keyword"
+        }
+    }
+}

--- a/dist/tools/vera++/scripts/rules/T005.tcl
+++ b/dist/tools/vera++/scripts/rules/T005.tcl
@@ -1,0 +1,19 @@
+#!/usr/bin/tclsh
+# Keywords break and continue should be immediately followed by a semicolon
+
+foreach f [getSourceFileNames] {
+    foreach t [getTokens $f 1 0 -1 -1 {break continue}] {
+        set keyword [lindex $t 0]
+        set line [lindex $t 1]
+        set column [lindex $t 2]
+        set semicolons [getTokens $f $line [expr $column + [string length $keyword]] [expr $line + 1] 0 {semicolon}]
+        if {$semicolons == {}} {
+            report $f $line "keyword '${keyword}' not immediately followed by a semicolon"
+        } else {
+            set semColumn [lindex [lindex $semicolons 0] 2]
+            if {$semColumn != $column + [string length $keyword]} {
+                report $f $line "keyword '${keyword}' not immediately followed by a semicolon"
+            }
+        }
+    }
+}

--- a/dist/tools/vera++/scripts/rules/T006.tcl
+++ b/dist/tools/vera++/scripts/rules/T006.tcl
@@ -1,0 +1,21 @@
+#!/usr/bin/tclsh
+# Keywords return and throw should be immediately followed by a semicolon or a single space
+
+foreach f [getSourceFileNames] {
+    foreach t [getTokens $f 1 0 -1 -1 {return throw}] {
+        set keyword [lindex $t 0]
+        set line [lindex $t 1]
+        set column [lindex $t 2]
+        set followingTokens [getTokens $f $line [expr $column + [string length $keyword]] [expr $line + 1] 0 {}]
+        if {$followingTokens == {}} {
+            report $f $line "keyword '${keyword}' not immediately followed by a semicolon or a single space"
+        } else {
+            set first [lindex [lindex $followingTokens 0] 0]
+            if {$first != ";" && $first != " "} {
+                if {!([llength $followingTokens] >= 2 && $keyword == "throw" && $first == "(" && [lindex [lindex $followingTokens 1] 0] == ")")} {
+                    report $f $line "keyword '${keyword}' not immediately followed by a semicolon or a single space"
+                }
+            }
+        }
+    }
+}

--- a/dist/tools/vera++/scripts/rules/T007.tcl
+++ b/dist/tools/vera++/scripts/rules/T007.tcl
@@ -1,0 +1,22 @@
+#!/usr/bin/tclsh
+# Semicolons should not be isolated by spaces or comments from the rest of the code
+
+foreach f [getSourceFileNames] {
+    foreach t [getTokens $f 1 0 -1 -1 {semicolon}] {
+        set line [lindex $t 1]
+        set column [lindex $t 2]
+        set previousTokens [getTokens $f $line 0 $line $column {}]
+        if {$previousTokens == {}} {
+            report $f $line "semicolon is isolated from other tokens"
+        } else {
+            set lastToken [lindex $previousTokens end]
+            set lastName [lindex $lastToken 3]
+            if {[lsearch {space ccomment} $lastName] != -1} {
+                set forTokens [getTokens $f $line 0 $line $column {for leftparen}]
+                if {[list [lindex [lindex $forTokens 0] 3] [lindex [lindex $forTokens 1] 3]] != {for leftparen}} {
+                    report $f $line "semicolon is isolated from other tokens"
+                }
+            }
+        }
+    }
+}

--- a/dist/tools/vera++/scripts/rules/T008.tcl
+++ b/dist/tools/vera++/scripts/rules/T008.tcl
@@ -1,0 +1,18 @@
+#!/usr/bin/tclsh
+# Keywords catch, for, if and while should be followed by a single space
+
+foreach f [getSourceFileNames] {
+    foreach t [getTokens $f 1 0 -1 -1 {catch for if switch while}] {
+        set keyword [lindex $t 0]
+        set line [lindex $t 1]
+        set column [lindex $t 2]
+        set followingTokens [getTokens $f $line [expr $column + [string length $keyword]] [expr $line + 1] -1 {}]
+        if {[llength $followingTokens] < 2} {
+            report $f $line "keyword '${keyword}' not followed by a single space"
+        } else {
+            if {[list [lindex [lindex $followingTokens 0] 0] [lindex [lindex $followingTokens 1] 0]] != [list " " "("]} {
+                report $f $line "keyword '${keyword}' not followed by a single space"
+            }
+        }
+    }
+}

--- a/dist/tools/vera++/scripts/rules/T009.tcl
+++ b/dist/tools/vera++/scripts/rules/T009.tcl
@@ -1,0 +1,26 @@
+#!/usr/bin/tclsh
+# Comma should not be preceded by whitespace, but should be followed by one
+
+foreach f [getSourceFileNames] {
+    foreach t [getTokens $f 1 0 -1 -1 {comma}] {
+        set line [lindex $t 1]
+        set column [lindex $t 2]
+        set preceding [getTokens $f $line 0 $line $column {}]
+        if {$preceding == {}} {
+            report $f $line "comma should not be preceded by whitespace"
+        } else {
+            set lastPreceding [lindex [lindex $preceding end] 3]
+            if {$lastPreceding == "space"} {
+                report $f $line "comma should not be preceded by whitespace"
+            }
+        }
+        set following [getTokens $f $line [expr $column + 1] [expr $line + 1] -1 {}]
+        if {$following != {}} {
+            set firstFollowing [lindex [lindex $following 0] 3]
+            if {$firstFollowing != "space" && $firstFollowing != "newline" &&
+                !($lastPreceding == "operator" && $firstFollowing == "leftparen")} {
+                report $f $line "comma should be followed by whitespace"
+            }
+        }
+    }
+}

--- a/dist/tools/vera++/scripts/rules/T010.tcl
+++ b/dist/tools/vera++/scripts/rules/T010.tcl
@@ -1,0 +1,11 @@
+#!/usr/bin/tclsh
+# Identifiers should not be composed of 'l' and 'O' characters only
+
+foreach file [getSourceFileNames] {
+    foreach t [getTokens $file 1 0 -1 -1 {identifier}] {
+        set value [lindex $t 0]
+        if [regexp {^(l|O)+$} $value] {
+            report $file [lindex $t 1] "identifier should not be composed of only 'l' and 'O'"
+        }
+    }
+}

--- a/dist/tools/vera++/scripts/rules/T011.tcl
+++ b/dist/tools/vera++/scripts/rules/T011.tcl
@@ -1,0 +1,51 @@
+#!/usr/bin/tclsh
+# Curly brackets from the same pair should be either in the same line or in the same column
+
+proc acceptPairs {} {
+    global file parens index end
+
+    while {$index != $end} {
+        set nextToken [lindex $parens $index]
+        set tokenValue [lindex $nextToken 0]
+
+        if {$tokenValue == "\{"} {
+            incr index
+            set leftParenLine [lindex $nextToken 1]
+            set leftParenColumn [lindex $nextToken 2]
+
+            acceptPairs
+
+            if {$index == $end} {
+                report $file $leftParenLine "opening curly bracket is not closed"
+                return
+            }
+
+            set nextToken [lindex $parens $index]
+            incr index
+            set tokenValue [lindex $nextToken 0]
+            set rightParenLine [lindex $nextToken 1]
+            set rightParenColumn [lindex $nextToken 2]
+
+            if {($leftParenLine != $rightParenLine) && ($leftParenColumn != $rightParenColumn)} {
+                # make an exception for line continuation
+                set leftLine [getLine $file $leftParenLine]
+                set rightLine [getLine $file $rightParenLine]
+                if {[string index $leftLine end] != "\\" && [string index $rightLine end] != "\\"} {
+                    report $file $rightParenLine "closing curly bracket not in the same line or column"
+                }
+            }
+        } else {
+            return
+        }
+    }
+}
+
+foreach file [getSourceFileNames] {
+    set parens [getTokens $file 1 0 -1 -1 {leftbrace rightbrace}]
+    set index 0
+    set end [llength $parens]
+    acceptPairs
+    if {$index != $end} {
+        report $file [lindex [lindex $parens $index] 1] "excessive closing bracket?"
+    }
+}

--- a/dist/tools/vera++/scripts/rules/T012.tcl
+++ b/dist/tools/vera++/scripts/rules/T012.tcl
@@ -1,0 +1,12 @@
+#!/usr/bin/tclsh
+# Negation operator should not be used in its short form
+
+foreach file [getSourceFileNames] {
+    foreach negation [getTokens $file 1 0 -1 -1 {not}] {
+        set value [lindex $negation 0]
+        if {$value == "!"} {
+            set lineNumber [lindex $negation 1]
+            report $file $lineNumber "negation operator used in its short form"
+        }
+    }
+}

--- a/dist/tools/vera++/scripts/rules/T013.tcl
+++ b/dist/tools/vera++/scripts/rules/T013.tcl
@@ -1,0 +1,16 @@
+#!/usr/bin/tclsh
+# Source files should contain the copyright notice
+
+foreach file [getSourceFileNames] {
+    set found false
+    foreach comment [getTokens $file 1 0 -1 -1 {ccomment cppcomment}] {
+        set value [lindex $comment 0]
+        if {[string first "copyright" [string tolower $value]] != -1} {
+            set found true
+            break
+        }
+    }
+    if {$found == false} {
+        report $file 1 "no copyright notice found"
+    }
+}

--- a/dist/tools/vera++/scripts/rules/T014.tcl
+++ b/dist/tools/vera++/scripts/rules/T014.tcl
@@ -1,0 +1,16 @@
+#!/usr/bin/tclsh
+# Source files should refer the Boost Software License
+
+foreach file [getSourceFileNames] {
+    set found false
+    foreach comment [getTokens $file 1 0 -1 -1 {ccomment cppcomment}] {
+        set value [lindex $comment 0]
+        if {[string first "Boost Software License" $value] != -1} {
+            set found true
+            break
+        }
+    }
+    if {$found == false} {
+        report $file 1 "no reference to the Boost Software License found"
+    }
+}

--- a/dist/tools/vera++/scripts/rules/T015.tcl
+++ b/dist/tools/vera++/scripts/rules/T015.tcl
@@ -1,0 +1,49 @@
+#!/usr/bin/tclsh
+# HTML links in comments and string literals should be correct
+
+set urlRe {<[[:space:]]*[^>]*[[:space:]]+(?:HREF|SRC)[[:space:]]*=[[:space:]]*\"([^\"]*)\"}
+
+foreach file [getSourceFileNames] {
+    foreach token [getTokens $file 1 0 -1 -1 {ccomment cppcomment stringlit}] {
+        set tokenValue [lindex $token 0]
+        if {[regexp -nocase $urlRe $tokenValue dummy link] == 1} {
+
+            if {[string index $link 0] == "\#" ||
+                [string first "mailto:" $link] == 0 ||
+                [string first "http:" $link] == 0 ||
+                [string first "https:" $link] == 0 ||
+                [string first "ftp:" $link] == 0 ||
+                [string first "news:" $link] == 0 ||
+                [string first "javascript:" $link] == 0} {
+                continue
+            }
+
+            set lineNumber [lindex $token 1]
+
+            if {[string first "file:" $link] == 0} {
+                report $file $lineNumber "URL links to files are not allowed"
+                continue
+            }
+
+            if {[regexp {[ \<\>\'\{\}\|\\\^\[\]]} $link] == 1} {
+                report $file $lineNumber "URL link contains illegal character(s)"
+                continue
+            }
+
+            set plainLink $link
+            set pos [string first "\#" $link]
+            if {$pos != -1} {
+                set plainLink [string range $link 0 [expr $pos - 1]]
+            }
+
+            if {[string first "\#" $link [expr $pos + 1]] != -1} {
+                report $file $lineNumber "URL link contains invalid bookmark"
+            }
+
+            set completeLink [file join [file dirname $file] $plainLink]
+            if {[file isfile $completeLink] == 0} {
+                report $file $lineNumber "URL points to non-existing file"
+            }
+        }
+    }
+}

--- a/dist/tools/vera++/scripts/rules/T016.tcl
+++ b/dist/tools/vera++/scripts/rules/T016.tcl
@@ -1,0 +1,17 @@
+#!/usr/bin/tclsh
+# Calls to min/max should be protected against accidental macro substitution
+
+foreach file [getSourceFileNames] {
+    foreach identifier [getTokens $file 1 0 -1 -1 {identifier}] {
+        set value [lindex $identifier 0]
+        if {$value == "min" || $value == "max"} {
+            set lineNumber [lindex $identifier 1]
+            set columnNumber [expr [lindex $identifier 2] + [string length $value]]
+            set restOfLine [string range [getLine $file $lineNumber] $columnNumber end]
+
+            if {[regexp {^[[:space:]]*\(} $restOfLine] == 1} {
+                report $file $lineNumber "min/max potential macro substitution problem"
+            }
+        }
+    }
+}

--- a/dist/tools/vera++/scripts/rules/T017.tcl
+++ b/dist/tools/vera++/scripts/rules/T017.tcl
@@ -1,0 +1,23 @@
+#!/usr/bin/tclsh
+# Unnamed namespaces are not allowed in header files
+
+foreach fileName [getSourceFileNames] {
+    set extension [file extension $fileName]
+    if {[lsearch {.h .hh .hpp .hxx .ipp} $extension] != -1} {
+
+        set state "start"
+        foreach token [getTokens $fileName 1 0 -1 -1 {namespace identifier leftbrace}] {
+            set type [lindex $token 3]
+
+            if {$state == "namespace" && $type == "leftbrace"} {
+                report $fileName $namespaceLine "unnamed namespace not allowed in header file"
+            }
+
+            if {$type == "namespace"} {
+                set namespaceLine [lindex $token 1]
+            }
+
+            set state $type
+        }
+    }
+}

--- a/dist/tools/vera++/scripts/rules/T018.tcl
+++ b/dist/tools/vera++/scripts/rules/T018.tcl
@@ -1,0 +1,23 @@
+#!/usr/bin/tclsh
+# using namespace are not allowed in header files
+
+foreach fileName [getSourceFileNames] {
+    set extension [file extension $fileName]
+    if {[lsearch {.h .hh .hpp .hxx .ipp} $extension] != -1} {
+
+        set state "start"
+        foreach token [getTokens $fileName 1 0 -1 -1 {using namespace identifier}] {
+            set type [lindex $token 3]
+
+            if {$state == "using" && $type == "namespace"} {
+                report $fileName $usingLine "using namespace not allowed in header file"
+            }
+
+            if {$type == "using"} {
+                set usingLine [lindex $token 1]
+            }
+
+            set state $type
+        }
+    }
+}

--- a/dist/tools/vera++/scripts/rules/T019.tcl
+++ b/dist/tools/vera++/scripts/rules/T019.tcl
@@ -1,0 +1,39 @@
+#!/usr/bin/tclsh
+# control structures should have complete curly-braced block of code
+
+foreach fileName [getSourceFileNames] {
+
+    set state "start"
+    set prev ""
+    foreach token [getTokens $fileName 1 0 -1 -1 {for if while do leftparen rightparen leftbrace rightbrace semicolon}] {
+        set type [lindex $token 3]
+
+        if {$state == "control"} {
+            if {$type == "leftparen"} {
+                incr parenCount
+            } elseif {$type == "rightparen"} {
+                incr parenCount -1
+                if {$parenCount == 0} {
+                    set state "expectedblock"
+                }
+            }
+        } elseif {$state == "expectedblock"} {
+            if {$type != "leftbrace"} {
+                set line [lindex $token 1]
+                report $fileName $line "full block {} expected in the control structure"
+            }
+            set state "block"
+        }
+
+        if {$type == "for" || $type == "if"} {
+            set parenCount 0
+            set state "control"
+        } elseif {$type == "do"} {
+            set state "expectedblock"
+        } elseif {$type == "while" && $prev != "rightbrace"} {
+            set parenCount 0
+            set state "control"
+        }
+        set prev $type
+    }
+}

--- a/dist/tools/vera++/scripts/transformations/CMakeLists.txt
+++ b/dist/tools/vera++/scripts/transformations/CMakeLists.txt
@@ -1,0 +1,3 @@
+file(GLOB_RECURSE srcs RELATIVE ${CMAKE_CURRENT_SOURCE_DIR} *)
+list(REMOVE_ITEM srcs CMakeLists.txt)
+install(FILES ${srcs} DESTINATION lib/vera++/scripts/transformations)

--- a/dist/tools/vera++/scripts/transformations/move_includes.tcl
+++ b/dist/tools/vera++/scripts/transformations/move_includes.tcl
@@ -1,0 +1,24 @@
+#!/usr/bin/tclsh
+# change prefix of #include paths
+
+set oldPrefix "\"boost/"
+set newPrefix "\"boom/"
+
+set oldPrefixLength [string length $oldPrefix]
+
+foreach fileName [getSourceFileNames] {
+    set tokens [getTokens $fileName 1 0 -1 -1 {}]
+    set newFile [open $fileName "w"]
+    foreach token $tokens {
+        set tokenValue [lindex $token 0]
+        set tokenType [lindex $token 3]
+        if {$tokenType == "pp_qheader"} {
+            set index [string first $oldPrefix $tokenValue]
+            if {$index != -1} {
+                set tokenValue [string replace $tokenValue $index [expr $index + $oldPrefixLength - 1] $newPrefix]
+            }
+        }
+        puts -nonewline $newFile $tokenValue
+    }
+    close $newFile
+}

--- a/dist/tools/vera++/scripts/transformations/move_macros.tcl
+++ b/dist/tools/vera++/scripts/transformations/move_macros.tcl
@@ -1,0 +1,22 @@
+#!/usr/bin/tclsh
+# change the prefix in all macros
+
+set oldPrefix "BOOST"
+set newPrefix "BOOM"
+
+set oldPrefixLength [string length $oldPrefix]
+
+foreach fileName [getSourceFileNames] {
+    set tokens [getTokens $fileName 1 0 -1 -1 {}]
+    set newFile [open $fileName "w"]
+    foreach token $tokens {
+        set tokenValue [lindex $token 0]
+        set tokenType [lindex $token 3]
+        if {$tokenType == "identifier" && \
+                [string compare -length $oldPrefixLength $oldPrefix $tokenValue] == 0} {
+            set tokenValue [string replace $tokenValue 0 [expr $oldPrefixLength - 1] $newPrefix]
+        }
+        puts -nonewline $newFile $tokenValue
+    }
+    close $newFile
+}

--- a/dist/tools/vera++/scripts/transformations/move_namespace.tcl
+++ b/dist/tools/vera++/scripts/transformations/move_namespace.tcl
@@ -1,0 +1,19 @@
+#!/usr/bin/tclsh
+# change the namespace of all source files
+
+set oldNamespace "boost"
+set newNamespace "boom"
+
+foreach fileName [getSourceFileNames] {
+    set tokens [getTokens $fileName 1 0 -1 -1 {}]
+    set newFile [open $fileName "w"]
+    foreach token $tokens {
+        set tokenValue [lindex $token 0]
+        set tokenType [lindex $token 3]
+        if {$tokenType == "identifier" && $tokenValue == $oldNamespace} {
+            set tokenValue $newNamespace
+        }
+        puts -nonewline $newFile $tokenValue
+    }
+    close $newFile
+}

--- a/dist/tools/vera++/scripts/transformations/to_lower.tcl
+++ b/dist/tools/vera++/scripts/transformations/to_lower.tcl
@@ -1,0 +1,54 @@
+#!/usr/bin/tclsh
+# transform indentifier names from CamelCase to standard_lower_case
+
+# this list contains exceptional mappings as pairs ?original new?
+
+set exceptions {SOMESpecialName some_special_name SOMEOTHER some_other}
+
+proc transformIdentifier {old} {
+    global exceptions
+
+    if [string is lower $old] {
+        set new $old
+    } else {
+        set e [lsearch $exceptions $old]
+        if {$e != -1} {
+            set new [lindex $exceptions [expr $e + 1]]
+        } else {
+            set state "upper"
+            set new ""
+            for {set i 0} {$i != [string length $old]} {incr i} {
+                set c [string index $old $i]
+                if [string is upper $c] {
+                    if {$state == "upper"} {
+                        set new ${new}[string tolower $c]
+                    } else {
+                        set new ${new}_[string tolower $c]
+                        set state "upper"
+                    }
+                } else {
+                    set new ${new}${c}
+                    set state "lower"
+                }
+            }
+        }
+    }
+
+    return $new
+}
+
+foreach fileName [getSourceFileNames] {
+    set tokens [getTokens $fileName 1 0 -1 -1 {}]
+    set newFile [open $fileName "w"]
+    foreach t $tokens {
+        set tokenValue [lindex $t 0]
+        set tokenType [lindex $t 3]
+        if {$tokenType == "identifier"} {
+            set newToken [transformIdentifier $tokenValue]
+        } else {
+            set newToken $tokenValue
+        }
+        puts -nonewline $newFile $newToken
+    }
+    close $newFile
+}

--- a/dist/tools/vera++/scripts/transformations/to_xml.tcl
+++ b/dist/tools/vera++/scripts/transformations/to_xml.tcl
@@ -1,0 +1,26 @@
+#!/usr/bin/tclsh
+# transform the source file into XML file
+
+foreach f [getSourceFileNames] {
+    set outFileName "${f}.xml"
+    set outFile [open $outFileName "w"]
+    puts $outFile "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>"
+    puts $outFile "<cpp-source file-name=\"${f}\">"
+    foreach t [getTokens $f 1 0 -1 -1 {}] {
+        set value [lindex $t 0]
+        set line [lindex $t 1]
+        set column [lindex $t 2]
+        set name [lindex $t 3]
+
+        if {$value == "\n"} {
+            set value "!\[CDATA\[\n\]]"
+        } else {
+            set value [regsub -all "&" $value {\&amp;}]
+            set value [regsub -all "<" $value {\&lt;}]
+            set value [regsub -all ">" $value {\&gt;}]
+        }
+        puts $outFile "    <token name=\"${name}\" line=\"${line}\" column=\"${column}\">${value}</token>"
+    }
+    puts $outFile "</cpp-source>"
+    close $outFile
+}

--- a/dist/tools/vera++/scripts/transformations/to_xml2.tcl
+++ b/dist/tools/vera++/scripts/transformations/to_xml2.tcl
@@ -1,0 +1,26 @@
+#!/usr/bin/tclsh
+# transform the source file into XML file (another variant)
+
+foreach f [getSourceFileNames] {
+    set outFileName "${f}.xml"
+    set outFile [open $outFileName "w"]
+    puts $outFile "<?xml version=\"1.0\" encoding=\"ISO-8859-1\"?>"
+    puts $outFile "<cpp-source file-name=\"${f}\">"
+    foreach t [getTokens $f 1 0 -1 -1 {}] {
+        set value [lindex $t 0]
+        set line [lindex $t 1]
+        set column [lindex $t 2]
+        set name [lindex $t 3]
+
+        if {$value == "\n"} {
+            set value "!\[CDATA\[\n\]]"
+        } else {
+            set value [regsub -all "&" $value {\&amp;}]
+            set value [regsub -all "<" $value {\&lt;}]
+            set value [regsub -all ">" $value {\&gt;}]
+        }
+        puts $outFile "    <${name} line=\"${line}\" column=\"${column}\">${value}</${name}>"
+    }
+    puts $outFile "</cpp-source>"
+    close $outFile
+}

--- a/dist/tools/vera++/scripts/transformations/trim_right.tcl
+++ b/dist/tools/vera++/scripts/transformations/trim_right.tcl
@@ -1,0 +1,12 @@
+#!/usr/bin/tclsh
+# trim each line by removing trailing whitespace
+
+foreach fileName [getSourceFileNames] {
+    set lines [getAllLines $fileName]
+    set newFile [open $fileName "w"]
+    foreach line $lines {
+        set newLine [string trimright $line]
+        puts $newFile $newLine
+    }
+    close $newFile
+}


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR adds configuration files and a check script for using [Vera++](https://bitbucket.org/verateam/vera/overview) in RIOT. This tool does C/C++ style checks with a given set of rules. The difference to other tools (like Uncrustify) is the fact this is not a code beautifier but a code validator.

New rules can be added in TCL, Python or LUA. The tool defines a "profile" which consists in a set of rules to be applied and some rule-specific parameters. A default `riot` profile was added.

This PR also adds a `exclude` file for excluding source files based on regular expressions (see `--exclusions` command [here](https://bitbucket.org/verateam/vera/wiki/Running))

The `riot` profile enables all rules except:
- F002 File names should be well-formed
- T002 Reserved names should not be used for preprocessor macros
- T011 Curly brackets from the same pair should be either in the same line or in the same column
- T012 Negation operator should not be used in its short form
- T014 Source files should refer the Boost Software License
- T016 Calls to min/max should be protected against accidental macro substitution

And also defines some parameters for certain rules:
- L004: parameter=max-line-length=80
- L005: parameter=max-consecutive-empty-lines=1

I also enabled "T008 Keywords catch, for, if, switch and while should be followed by a single space" but not sure if it's intended. 

All feedback is more than welcome!

Check README.md file for more details.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

### Test procedure
Run `dist/tools/vera++/check.sh`

### Issues/PRs references
#8519 (which could be dropped if this one gets merged)
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->