### PR TITLE
boards: Harmonized UART config of Nucleo-64 boards

### DIFF
--- a/boards/nucleo-f334r8/include/periph_conf.h
+++ b/boards/nucleo-f334r8/include/periph_conf.h
@@ -90,10 +90,32 @@ static const uart_conf_t uart_config[] = {
         .tx_af    = GPIO_AF7,
         .bus      = APB1,
         .irqn     = USART2_IRQn
+    },
+    {
+        .dev        = USART1,
+        .rcc_mask   = RCC_APB2ENR_USART1EN,
+        .rx_pin     = GPIO_PIN(PORT_A, 10),
+        .tx_pin     = GPIO_PIN(PORT_A,  9),
+        .rx_af      = GPIO_AF7,
+        .tx_af      = GPIO_AF7,
+        .bus        = APB2,
+        .irqn       = USART1_IRQn
+    },
+    {
+        .dev        = USART3,
+        .rcc_mask   = RCC_APB1ENR_USART3EN,
+        .rx_pin     = GPIO_PIN(PORT_B, 11),
+        .tx_pin     = GPIO_PIN(PORT_B, 10),
+        .rx_af      = GPIO_AF7,
+        .tx_af      = GPIO_AF7,
+        .bus        = APB1,
+        .irqn       = USART3_IRQn
     }
 };
 
 #define UART_0_ISR          (isr_usart2)
+#define UART_1_ISR          (isr_usart1)
+#define UART_2_ISR          (isr_usart3)
 
 #define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
 /** @} */

--- a/boards/nucleo-f401re/include/periph_conf.h
+++ b/boards/nucleo-f401re/include/periph_conf.h
@@ -97,20 +97,6 @@ static const uart_conf_t uart_config[] = {
 #endif
     },
     {
-        .dev        = USART6,
-        .rcc_mask   = RCC_APB2ENR_USART6EN,
-        .rx_pin     = GPIO_PIN(PORT_A, 12),
-        .tx_pin     = GPIO_PIN(PORT_A, 11),
-        .rx_af      = GPIO_AF8,
-        .tx_af      = GPIO_AF8,
-        .bus        = APB2,
-        .irqn       = USART6_IRQn,
-#ifdef UART_USE_DMA
-        .dma_stream = 6,
-        .dma_chan   = 4
-#endif
-    },
-    {
         .dev        = USART1,
         .rcc_mask   = RCC_APB2ENR_USART1EN,
         .rx_pin     = GPIO_PIN(PORT_A, 10),
@@ -123,14 +109,28 @@ static const uart_conf_t uart_config[] = {
         .dma_stream = 6,
         .dma_chan   = 4
 #endif
+    },
+    {
+        .dev        = USART6,
+        .rcc_mask   = RCC_APB2ENR_USART6EN,
+        .rx_pin     = GPIO_PIN(PORT_A, 12),
+        .tx_pin     = GPIO_PIN(PORT_A, 11),
+        .rx_af      = GPIO_AF8,
+        .tx_af      = GPIO_AF8,
+        .bus        = APB2,
+        .irqn       = USART6_IRQn,
+#ifdef UART_USE_DMA
+        .dma_stream = 6,
+        .dma_chan   = 4
+#endif
     }
 };
 
 #define UART_0_ISR          (isr_usart2)
 #define UART_0_DMA_ISR      (isr_dma1_stream6)
-#define UART_1_ISR          (isr_usart6)
+#define UART_1_ISR          (isr_usart1)
 #define UART_1_DMA_ISR      (isr_dma1_stream6)
-#define UART_2_ISR          (isr_usart1)
+#define UART_2_ISR          (isr_usart6)
 #define UART_2_DMA_ISR      (isr_dma1_stream6)
 
 #define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))

--- a/boards/nucleo-f410rb/include/periph_conf.h
+++ b/boards/nucleo-f410rb/include/periph_conf.h
@@ -106,8 +106,22 @@ static const uart_conf_t uart_config[] = {
         .bus        = APB2,
         .irqn       = USART1_IRQn,
 #ifdef UART_USE_DMA
-        .dma_stream = 5,
+        .dma_stream = 7,
         .dma_chan   = 4
+#endif
+    },
+    {
+        .dev        = USART6,
+        .rcc_mask   = RCC_APB2ENR_USART6EN,
+        .rx_pin     = GPIO_PIN(PORT_A, 12),
+        .tx_pin     = GPIO_PIN(PORT_A, 11),
+        .rx_af      = GPIO_AF8,
+        .tx_af      = GPIO_AF8,
+        .bus        = APB2,
+        .irqn       = USART6_IRQn,
+#ifdef UART_USE_DMA
+        .dma_stream = 7,
+        .dma_chan   = 5
 #endif
     }
 };
@@ -116,7 +130,9 @@ static const uart_conf_t uart_config[] = {
 #define UART_0_ISR          (isr_usart2)
 #define UART_0_DMA_ISR      (isr_dma1_stream6)
 #define UART_1_ISR          (isr_usart1)
-#define UART_1_DMA_ISR      (isr_dma1_stream5)
+#define UART_1_DMA_ISR      (isr_dma2_stream7)
+#define UART_2_ISR          (isr_usart6)
+#define UART_2_DMA_ISR      (isr_dma2_stream7)
 
 /* deduct number of defined UART interfaces */
 #define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))

--- a/boards/nucleo-f446re/include/periph_conf.h
+++ b/boards/nucleo-f446re/include/periph_conf.h
@@ -68,20 +68,6 @@ static const uart_conf_t uart_config[] = {
 #endif
     },
     {
-        .dev        = USART3,
-        .rcc_mask   = RCC_APB1ENR_USART3EN,
-        .rx_pin     = GPIO_PIN(PORT_C, 11),
-        .tx_pin     = GPIO_PIN(PORT_C, 10),
-        .rx_af      = GPIO_AF7,
-        .tx_af      = GPIO_AF7,
-        .bus        = APB1,
-        .irqn       = USART3_IRQn,
-#ifdef UART_USE_DMA
-        .dma_stream = 5,
-        .dma_chan   = 4
-#endif
-    },
-    {
         .dev        = USART1,
         .rcc_mask   = RCC_APB2ENR_USART1EN,
         .rx_pin     = GPIO_PIN(PORT_A, 10),
@@ -95,14 +81,28 @@ static const uart_conf_t uart_config[] = {
         .dma_chan   = 4
 #endif
     },
+    {
+        .dev        = USART3,
+        .rcc_mask   = RCC_APB1ENR_USART3EN,
+        .rx_pin     = GPIO_PIN(PORT_C, 11),
+        .tx_pin     = GPIO_PIN(PORT_C, 10),
+        .rx_af      = GPIO_AF7,
+        .tx_af      = GPIO_AF7,
+        .bus        = APB1,
+        .irqn       = USART3_IRQn,
+#ifdef UART_USE_DMA
+        .dma_stream = 5,
+        .dma_chan   = 4
+#endif
+    },
 };
 
 #define UART_0_ISR          (isr_usart2)
 #define UART_0_DMA_ISR      (isr_dma1_stream6)
-#define UART_1_ISR          (isr_usart3)
-#define UART_1_DMA_ISR      (isr_dma1_stream5)
-#define UART_2_ISR          (isr_usart1)
-#define UART_2_DMA_ISR      (isr_dma1_stream4)
+#define UART_1_ISR          (isr_usart1)
+#define UART_1_DMA_ISR      (isr_dma1_stream4)
+#define UART_2_ISR          (isr_usart3)
+#define UART_2_DMA_ISR      (isr_dma1_stream5)
 
 #define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
 /** @} */

--- a/boards/nucleo-l152re/include/periph_conf.h
+++ b/boards/nucleo-l152re/include/periph_conf.h
@@ -104,16 +104,6 @@ static const uart_conf_t uart_config[] = {
         .irqn     = USART2_IRQn
     },
     {
-        .dev      = USART3,
-        .rcc_mask = RCC_APB1ENR_USART3EN,
-        .rx_pin   = GPIO_PIN(PORT_C, 11),
-        .tx_pin   = GPIO_PIN(PORT_C, 10),
-        .rx_af    = GPIO_AF7,
-        .tx_af    = GPIO_AF7,
-        .bus      = APB1,
-        .irqn     = USART3_IRQn
-    },
-    {
         .dev      = USART1,
         .rcc_mask = RCC_APB2ENR_USART1EN,
         .rx_pin   = GPIO_PIN(PORT_A, 9),
@@ -123,11 +113,21 @@ static const uart_conf_t uart_config[] = {
         .bus      = APB2,
         .irqn     = USART1_IRQn
     },
+    {
+        .dev      = USART3,
+        .rcc_mask = RCC_APB1ENR_USART3EN,
+        .rx_pin   = GPIO_PIN(PORT_C, 11),
+        .tx_pin   = GPIO_PIN(PORT_C, 10),
+        .rx_af    = GPIO_AF7,
+        .tx_af    = GPIO_AF7,
+        .bus      = APB1,
+        .irqn     = USART3_IRQn
+    },
 };
 
 #define UART_0_ISR          (isr_usart2)
-#define UART_1_ISR          (isr_usart3)
-#define UART_2_ISR          (isr_usart1)
+#define UART_1_ISR          (isr_usart1)
+#define UART_2_ISR          (isr_usart3)
 
 #define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
 /** @} */


### PR DESCRIPTION
# Motivation
The Nucleo-64 boards are a convenient platform to evaluate the different STM32 MCUs, as they are pretty identical. However, the configuration in RIOT creates differences between the boards, e.g. the UARTs are added in different order. This PR changes the order so that USARTs are added in ascending order with the exception of USART2, which is always the first. (USART2 is the one connected to the integrated ST-LINKv2, for this special role it was chosen as the first.) In fact, most Nucleo-64 boards did already comply with this order.

# Changes in Detail

- nucleo-f334r8:
  - Added USART1 and USART3 config
- nucleo-f401re:
  - Changed order of UARTs to match the other boards
- nucleo-f410rb:
  - Added USART6 configuration
  - Fixed incorrect DMA settings (according to reference manual of the MCU)
- nucleo-f446re:
  - Changed order of UARTs to match the other boards
- nucleo-l152re:
  - Changed order of UARTs to match the other boards

