### PR TITLE
boards/stm32f103c8: update flash flags for DFU

### DIFF
--- a/boards/common/doc.txt
+++ b/boards/common/doc.txt
@@ -5,4 +5,29 @@
 
 Several boards share many definitions and implementations, these are
 collectively stored into a common module per board group.
+
+## Utilise DFU-Util with bootloader to flash RIOT binaries
+
+### Flash the bootloader
+
+1. Download the bootloader binary matching you boards from
+   https://github.com/rogerclarkmelbourne/STM32duino-bootloader
+   e.g., for the STM32 bluepill use `generic_boot20_pc13.bin`.
+
+2. Flash the bootloader using ST-Link, for instructions see:
+   - https://github.com/rogerclarkmelbourne/Arduino_STM32/wiki/Flashing-Bootloader-for-BluePill-Boards
+   - https://github.com/rogerclarkmelbourne/Arduino_STM32/wiki/Programming-an-STM32F103XXX-with-a-generic-%22ST-Link-V2%22-programmer-from-Linux
+
+### Flash RIOT binaries
+
+The following steps are tested with the STM32 bluepill board:
+
+1. Set Boot1 pin to 1 and reset device via button, this will ensure that the
+   bootloader stops and will not load any binary already present on the device.
+2. Connect bluepill via USB to your PC, the LED should blink continuously.
+3. Run `dfu-util -l` to list available, it should list (at least) 3 device with
+   USB device ID `1eaf:0003`. If not check Boot1 pin setting
+4. Flash RIOT binary by running `PROGRAMMER=dfu-util BOARD=bluepill make flash`
+5. Reset Boot1 pin to 0 and reset device via button, this should boot the RIOT
+   binary.
  */

--- a/boards/common/stm32f103c8/Makefile.include
+++ b/boards/common/stm32f103c8/Makefile.include
@@ -23,7 +23,9 @@ ifeq ($(PROGRAMMER),dfu-util)
   export RESET = # dfu-util has no support for resetting the device
 
   HEXFILE = $(BINFILE)
-  export FFLAGS = -d 1d50:6017 -s 0x08002000:leave -D "$(HEXFILE)"
+  export FFLAGS = -d 1eaf:0003 -a 2 -D "$(HEXFILE)"
+  # for older bootloader versions use this:
+  #export FFLAGS = -d 1d50:6017 -s 0x08002000:leave -D "$(HEXFILE)"
 else
 
   # this board uses openocd by default


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR updates the flash flags for the alternative DFU programmer, this is necessary as the boot loader was updated with new USB device ID. This also adds a short documentation on how to flash the boot loader and use DFU to flash RIOT binaries.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->