### PR TITLE
[RFC] drivers/cc110x: Extended cc110x_params_t

### DIFF
--- a/boards/msbiot/include/board.h
+++ b/boards/msbiot/include/board.h
@@ -30,11 +30,12 @@ extern "C" {
  * @name    Configure connected CC1101 (radio) device
  * @{
  */
-#define CC110X_PARAM_SPI    SPI_DEV(0)
-#define CC110X_PARAM_CS     GPIO_PIN(PORT_B, 12)
-#define CC110X_PARAM_GDO0   GPIO_PIN(PORT_C, 4)
-#define CC110X_PARAM_GDO1   GPIO_PIN(PORT_A, 6)
-#define CC110X_PARAM_GDO2   GPIO_PIN(PORT_C, 5)
+#define CC110X_PARAM_SPI      SPI_DEV(0)
+#define CC110X_PARAM_CS       GPIO_PIN(PORT_B, 12)
+#define CC110X_PARAM_GDO0     GPIO_PIN(PORT_C, 4)
+#define CC110X_PARAM_GDO1     GPIO_PIN(PORT_A, 6)
+#define CC110X_PARAM_GDO2     GPIO_PIN(PORT_C, 5)
+#define CC110X_PARAM_SPI_CLK  SPI_CLK_1MHZ
 /** @} */
 
 /**

--- a/drivers/cc110x/cc110x-defaultsettings.c
+++ b/drivers/cc110x/cc110x-defaultsettings.c
@@ -40,7 +40,14 @@ const char cc110x_default_pa_table[8] = {
     0xC3    /*< +10 dBm */
 };
 
-const char cc110x_default_base_freq[3] = { 0x21, 0x71, 0x7F };
+const char cc110x_base_freqs[3][3] = {
+    /* 0x10a81f * 26MHz / 65536 = 433.0748 MHz (Channel 1 LPD433) */
+    { 0x10, 0xA8, 0x1F, },
+    /* 0x21717a * 26MHz / 65536 = 869.5250 MHz base frequency */
+    { 0x21, 0x71, 0x7A, },
+    /* 0x22bbdd * 26MHz / 65536 = 903.0799 MHz (LoRa 900 Channel 0) */
+    { 0x22, 0xBB, 0xDD, },
+};
 
 /**
  * @brief cc110x default settings
@@ -65,12 +72,16 @@ const char cc110x_default_conf[] = {
     0x00, /* CHANNR */
     0x0F, /* FSCTRL1 */
     0x00, /* FSCTRL0 */
+    /* 0x21717a * 26MHz / 65536 = 869.5250 MHz base frequency */
     0x21, /* FREQ2 */
     0x71, /* FREQ1 */
     0x7A, /* FREQ0 */
+    /* 58.04kHz channel filter bandwidth, 149.96 kBaud symbol rate */
     0x7C, /* MDMCFG4 */
     0x7A, /* MDMCFG3 */
+    /* DC blocking filter on, 2-FSK modulation, no manchester code, use 16 bit sync word */
     0x06, /* MDMCFG2 */
+    /* FEC enabled, 8 preamble bytes, 49.99 kHz channel width */
     0xC0, /* MDMCFG1 */
     0xF8, /* MDMCFG0 */
     0x44, /* DEVIATN */

--- a/drivers/cc110x/cc110x-defaultsettings.c
+++ b/drivers/cc110x/cc110x-defaultsettings.c
@@ -70,20 +70,21 @@ const char cc110x_default_conf[] = {
     0x45, /* PKTCTRL0 (variable packet length) */
     0xFF, /* ADDR */
     0x00, /* CHANNR */
+    /* Intermediate frequency: 0x0f * 26MHz / 1024 = 380.9kHz */
     0x0F, /* FSCTRL1 */
     0x00, /* FSCTRL0 */
     /* 0x21717a * 26MHz / 65536 = 869.5250 MHz base frequency */
     0x21, /* FREQ2 */
     0x71, /* FREQ1 */
     0x7A, /* FREQ0 */
-    /* 58.04kHz channel filter bandwidth, 149.96 kBaud symbol rate */
-    0x7C, /* MDMCFG4 */
+    /* 203.13kHz channel filter bandwidth, 149.96 kBaud symbol rate */
+    0x8C, /* MDMCFG4 */
     0x7A, /* MDMCFG3 */
-    /* DC blocking filter on, 2-FSK modulation, no manchester code, use 16 bit sync word */
+    /* DC blocking filter on, 2-FSK modulation, no manchester code, use 16 bit sync word + carrier sense */
     0x06, /* MDMCFG2 */
-    /* FEC enabled, 8 preamble bytes, 49.99 kHz channel width */
+    /* FEC enabled, 8 preamble bytes, 25.39 kHz channel width */
     0xC0, /* MDMCFG1 */
-    0xF8, /* MDMCFG0 */
+    0x00, /* MDMCFG0 */
     0x44, /* DEVIATN */
     0x07, /* MCSM2 */
     0x03, /* MCSM1 */

--- a/drivers/cc110x/cc110x-defaultsettings.c
+++ b/drivers/cc110x/cc110x-defaultsettings.c
@@ -70,7 +70,7 @@ const char cc110x_default_conf[] = {
     0x45, /* PKTCTRL0 (variable packet length) */
     0xFF, /* ADDR */
     0x00, /* CHANNR */
-    /* Intermediate frequency: 0x0f * 26MHz / 1024 = 380.9kHz */
+    /* Intermediate frequency: 0x0F * 26MHz / 1024 = 380.9kHz */
     0x0F, /* FSCTRL1 */
     0x00, /* FSCTRL0 */
     /* 0x21717a * 26MHz / 65536 = 869.5250 MHz base frequency */
@@ -85,6 +85,7 @@ const char cc110x_default_conf[] = {
     /* FEC enabled, 8 preamble bytes, 25.39 kHz channel width */
     0xC0, /* MDMCFG1 */
     0x00, /* MDMCFG0 */
+    /* Deviation: +- 38.09kHz in 2-FSK/4-FSK/GFSK */
     0x44, /* DEVIATN */
     0x07, /* MCSM2 */
     0x03, /* MCSM1 */

--- a/drivers/cc110x/cc110x-spi.c
+++ b/drivers/cc110x/cc110x-spi.c
@@ -35,7 +35,6 @@
 #include "xtimer.h"
 #include "irq.h"
 
-#define SPI_CLK         SPI_CLK_5MHZ
 #define SPI_MODE        SPI_MODE_0
 
 /**********************************************************************
@@ -44,7 +43,7 @@
 
 static inline void lock(cc110x_t *dev)
 {
-    spi_acquire(dev->params.spi, dev->params.cs, SPI_MODE, SPI_CLK);
+    spi_acquire(dev->params.spi, dev->params.cs, SPI_MODE, dev->params.spi_clk);
 }
 
 void cc110x_cs(cc110x_t *dev)

--- a/drivers/cc110x/cc110x.c
+++ b/drivers/cc110x/cc110x.c
@@ -38,6 +38,8 @@
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
 
+static const char *cc110x_band_name[] = { "433", "868", "900" };
+
 /* Internal function prototypes */
 #ifndef CC110X_DONT_RESET
 static void _reset(cc110x_t *dev);
@@ -75,7 +77,7 @@ int cc110x_setup(cc110x_t *dev, const cc110x_params_t *params)
     cc110x_writeburst_reg(dev, CC110X_PATABLE, CC110X_DEFAULT_PATABLE, 8);
 
     /* set base frequency */
-    cc110x_set_base_freq_raw(dev, CC110X_DEFAULT_FREQ);
+    cc110x_set_band(dev, dev->params.band);
 
     /* Set default channel number */
     cc110x_set_channel(dev, CC110X_DEFAULT_CHANNEL);
@@ -85,9 +87,10 @@ int cc110x_setup(cc110x_t *dev, const cc110x_params_t *params)
     luid_get(&addr, 1);
     cc110x_set_address(dev, addr);
 
-    LOG_INFO("cc110x: initialized with address=%u and channel=%i\n",
+    LOG_INFO("cc110x: initialized with address=%u and channel=%i @ %sMHz\n",
             (unsigned)dev->radio_address,
-            dev->radio_channel);
+            dev->radio_channel,
+            cc110x_band_name[dev->params.band]);
 
     return 0;
 }
@@ -107,16 +110,13 @@ uint8_t cc110x_set_address(cc110x_t *dev, uint8_t address)
     return 0;
 }
 
-void cc110x_set_base_freq_raw(cc110x_t *dev, const char* freq_array)
+void cc110x_set_band(cc110x_t *dev, cc110x_band_t band)
 {
 #if ENABLE_DEBUG == 1
-    uint8_t _tmp[] = { freq_array[2], freq_array[1], freq_array[0], 0x00};
-    uint32_t *FREQ = (uint32_t*) _tmp;
 
-    DEBUG("cc110x_set_base_freq_raw(): setting base frequency to %uHz\n",
-            (26000000>>16) * (unsigned)(*FREQ));
+    DEBUG("cc110x_set_band(): Setting band to %sMHz\n", cc110x_band_name[band]);
 #endif
-    cc110x_writeburst_reg(dev, CC110X_FREQ2, freq_array, 3);
+    cc110x_writeburst_reg(dev, CC110X_FREQ2, cc110x_base_freqs[band], 3);
 }
 
 void cc110x_set_monitor(cc110x_t *dev, uint8_t mode)

--- a/drivers/cc110x/cc110x.c
+++ b/drivers/cc110x/cc110x.c
@@ -38,7 +38,9 @@
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
 
+#if ENABLE_DEBUG == 1
 static const char *cc110x_band_name[] = { "433", "868", "900" };
+#endif
 
 /* Internal function prototypes */
 #ifndef CC110X_DONT_RESET
@@ -113,7 +115,6 @@ uint8_t cc110x_set_address(cc110x_t *dev, uint8_t address)
 void cc110x_set_band(cc110x_t *dev, cc110x_band_t band)
 {
 #if ENABLE_DEBUG == 1
-
     DEBUG("cc110x_set_band(): Setting band to %sMHz\n", cc110x_band_name[band]);
 #endif
     cc110x_writeburst_reg(dev, CC110X_FREQ2, cc110x_base_freqs[band], 3);

--- a/drivers/cc110x/cc110x.c
+++ b/drivers/cc110x/cc110x.c
@@ -89,10 +89,9 @@ int cc110x_setup(cc110x_t *dev, const cc110x_params_t *params)
     luid_get(&addr, 1);
     cc110x_set_address(dev, addr);
 
-    LOG_INFO("cc110x: initialized with address=%u and channel=%i @ %sMHz\n",
+    LOG_INFO("cc110x: initialized with address=%u and channel=%i\n",
             (unsigned)dev->radio_address,
-            dev->radio_channel,
-            cc110x_band_name[dev->params.band]);
+            dev->radio_channel);
 
     return 0;
 }

--- a/drivers/cc110x/include/cc110x-defaultsettings.h
+++ b/drivers/cc110x/include/cc110x-defaultsettings.h
@@ -34,7 +34,6 @@ extern const char cc110x_default_pa_table[8];
 #endif
 
 extern const char cc110x_base_freqs[3][3];
-extern const char cc110x_channel_widths[3][2];
 
 #ifdef __cplusplus
 }

--- a/drivers/cc110x/include/cc110x-defaultsettings.h
+++ b/drivers/cc110x/include/cc110x-defaultsettings.h
@@ -33,10 +33,8 @@ extern "C" {
 extern const char cc110x_default_pa_table[8];
 #endif
 
-#ifndef CC110X_DEFAULT_FREQ
-#define CC110X_DEFAULT_FREQ cc110x_default_base_freq
-extern const char cc110x_default_base_freq[3];
-#endif
+extern const char cc110x_base_freqs[3][3];
+extern const char cc110x_channel_widths[3][2];
 
 #ifdef __cplusplus
 }

--- a/drivers/cc110x/include/cc110x-interface.h
+++ b/drivers/cc110x/include/cc110x-interface.h
@@ -39,7 +39,7 @@ const char *cc110x_state_to_text(uint8_t state);
 int cc110x_rd_set_mode(cc110x_t *dev, int mode);
 uint8_t cc110x_get_buffer_pos(cc110x_t *dev);
 void cc110x_isr_handler(cc110x_t *dev, void(*callback)(void*), void*arg);
-void cc110x_set_base_freq_raw(cc110x_t *dev, const char* freq_array);
+void cc110x_set_band(cc110x_t *dev, cc110x_band_t band);
 void cc110x_setup_rx_mode(cc110x_t *dev);
 void cc110x_switch_to_pwd(cc110x_t *dev);
 void cc110x_switch_to_rx(cc110x_t *dev);

--- a/drivers/cc110x/include/cc110x_params.h
+++ b/drivers/cc110x/include/cc110x_params.h
@@ -51,13 +51,23 @@ extern "C" {
 #define CC110X_PARAM_GDO2           GPIO_PIN(0, 28)
 #endif
 
+#ifndef CC110X_PARAM_SPI_CLK
+#define CC110X_PARAM_SPI_CLK        SPI_CLK_5MHZ
+#endif
+
+#ifndef CC110X_PARAM_BAND
+#define CC110X_PARAM_BAND           CC110X_BAND_868MHZ
+#endif
+
 #ifndef CC110X_PARAMS
 #define CC110X_PARAMS               { \
-                                        .spi  = CC110X_PARAM_SPI,  \
-                                        .cs   = CC110X_PARAM_CS,   \
-                                        .gdo0 = CC110X_PARAM_GDO0, \
-                                        .gdo1 = CC110X_PARAM_GDO1, \
-                                        .gdo2 = CC110X_PARAM_GDO2, \
+                                        .spi     = CC110X_PARAM_SPI,  \
+                                        .cs      = CC110X_PARAM_CS,   \
+                                        .gdo0    = CC110X_PARAM_GDO0, \
+                                        .gdo1    = CC110X_PARAM_GDO1, \
+                                        .gdo2    = CC110X_PARAM_GDO2, \
+                                        .spi_clk = CC110X_PARAM_SPI_CLK, \
+                                        .band    = CC110X_PARAM_BAND, \
                                     }
 
 #endif

--- a/drivers/include/cc110x.h
+++ b/drivers/include/cc110x.h
@@ -30,6 +30,15 @@ extern "C" {
 #include "net/gnrc/nettype.h"
 
 /**
+ * @brief   Enum over supported frequency bands
+ */
+typedef enum {
+    CC110X_BAND_433MHZ = 0, /**< 433MHz frequency band */
+    CC110X_BAND_868MHZ = 1, /**< 868MHz frequency band */
+    CC110X_BAND_900MHZ = 2, /**< 900MHz frequency band */
+} cc110x_band_t;
+
+/**
  * @brief   Struct for holding cc110x IO parameters
  */
 typedef struct cc110x_params {
@@ -38,6 +47,8 @@ typedef struct cc110x_params {
     gpio_t gdo0;        /**< GPIO connected to the GDO0 pin of the CC110x */
     gpio_t gdo1;        /**< GPIO connected to the GDO1 pin of the CC110x */
     gpio_t gdo2;        /**< GPIO connected to the GDO2 pin of the CC110x */
+    spi_clk_t spi_clk;  /**< SPI clock frequency to use */
+    cc110x_band_t band; /**< Frequency band to operate in */
 } cc110x_params_t;
 
 /**


### PR DESCRIPTION
# Motivation
Currently the cc110x driver allows to change the base frequency manually by `#define`-ing the configuration register values. Arbitrary frequencies could be set in software, but based on the circuit/antenna design only a narrow bandwidth will actually work. In practice, only 433MHz, 868MHz and 900MHz are relevant. Even though the actual frequency also depends on the oscillator used, only a 26 MHz quartz (as used in the reference design) is used in practice.

Channel configuration in those ISM band is quite harmonized (and sometimes even enforced by legislation). As a result, three possible base frequencies should be sufficient (~433MHz, ~868MHz, ~900MHz). This PR allows choosing the base frequency in `cc110x_params_t` using an enum of the three possible base frequencies.

# Changes in detail
- Added two entries to cc110x_params_t:
    - Allows choosing base frequency (433 MHz, 868 MHz, 900 MHz)
    - Allows choosing SPI frequency
- Reduced SPI clock frequency on the MSB-IoT
    - RTT (ping6) increases from ~16.7ms to ~17.3ms
    - packet loss rate decreases from ~90% to ~0%

# To be discussed
What are the "best" configuration for the three base frequencies? How about the bandwidth of each channel? Currently 49.99kHz channel width is configured, which matches the input filter of width of 58.04kHz quite nicely. However, 25kHz channel width matches e.g. LPD433 channel spacing.

Before this commit two different base frequency configurations were used: 869.5250 MHz in  `const char cc110x_default_conf[]` and 869.5269 MHz in `const char cc110x_default_base_freq[3]`. While the former is just in the middle of an 25kHz wide 868 MHz channel, the latter is just between two 25kHz channels.

Choosing a frequency just between of two 25kHz channels seems to make sense when using 50kHz channels, so that those two channels are actually "combined". But is this legal? If not, I suggest to stick with the 25kHz channels spacing and use a base frequency in the lowest 25kHz channel and reduce the channel bandwidth two 25kHz. (However, the input filter cannot be smaller than 58.04 kHz.)

(Currently this commit uses the center of 25kHz channels as base frequency with 50 kHz channel width. This would interfere with 3 channels and is the worst possible configuration. So this PR should not be accepted as it is.)

# Testing
- [x] Test with an 868 MHz circuit (done on MSB-IoT and MSB-A2)
- [x] Test with an 433 MHz circuit (done with an CC1101 breakout board on nucleo-f303re boards)
- [ ] Test with an 900 MHz circuit (not legal in E.U. as far as I know, so I'm unable to test. Also, I do not have any CC1101 with appropriate antenna design)