### PR TITLE
openocd.sh: allow flashing binary files without configuration

### DIFF
--- a/dist/tools/openocd/openocd.sh
+++ b/dist/tools/openocd/openocd.sh
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 #
 # Unified OpenOCD script for RIOT
 #

--- a/dist/tools/openocd/openocd.sh
+++ b/dist/tools/openocd/openocd.sh
@@ -159,6 +159,29 @@ _is_binfile() {
         [[ -z "${firmware_type}" ]] && _has_bin_extension "${firmware}"; }
 }
 
+# Outputs bank info on different lines without the '{}'
+_flash_list() {
+    # Openocd output for 'flash list' is
+    # ....
+    # {name nrf51 base 0 size 0 bus_width 1 chip_width 1} {name nrf51 base 268439552 size 0 bus_width 1 chip_width 1}
+    # ....
+    sh -c "${OPENOCD} \
+            ${OPENOCD_ADAPTER_INIT} \
+            -f '${OPENOCD_CONFIG}' \
+            -c 'flash list' \
+            -c 'shutdown'" 2>&1 | sed -n '/^{.*}$/ {s/\} /\}\n/g;s/[{}]//g;p}'
+}
+
+# Print flash address for 'bank_num' num defaults to 1
+# _flash_address  [bank_num:1]
+_flash_address() {
+    bank_num=${1:-1}
+
+    # extract 'base' value and print as hexadecimal
+    # name nrf51 base 268439552 size 0 bus_width 1 chip_width 1
+    _flash_list | awk "NR==${bank_num}"'{printf "0x%08x\n", $4}'
+}
+
 #
 # now comes the actual actions
 #

--- a/dist/tools/openocd/openocd.sh
+++ b/dist/tools/openocd/openocd.sh
@@ -197,6 +197,16 @@ do_flash() {
         fi
     fi
 
+    # In case of binary file, IMAGE_OFFSET should include the flash base address
+    # This allows flashing normal binary files without env configuration
+    if _is_binfile "${IMAGE_FILE}" "${IMAGE_TYPE}"; then
+        # hardwritten to use the first bank
+        FLASH_ADDR=$(_flash_address 1)
+        echo "Binfile detected, adding ROM base address: ${FLASH_ADDR}"
+        IMAGE_TYPE=bin
+        IMAGE_OFFSET=$(printf "0x%08x\n" "$((${IMAGE_OFFSET} + ${FLASH_ADDR}))")
+    fi
+
     if [ "${IMAGE_OFFSET}" != "0" ]; then
         echo "Flashing with IMAGE_OFFSET: ${IMAGE_OFFSET}"
     fi

--- a/dist/tools/openocd/openocd.sh
+++ b/dist/tools/openocd/openocd.sh
@@ -178,7 +178,7 @@ do_flash() {
             ${OPENOCD_PRE_FLASH_CMDS} \
             -c 'flash write_image erase \"${IMAGE_FILE}\" ${IMAGE_OFFSET} ${IMAGE_TYPE}' \
             ${OPENOCD_PRE_VERIFY_CMDS} \
-            -c 'verify_image \"${IMAGE_FILE}\"' \
+            -c 'verify_image \"${IMAGE_FILE}\" ${IMAGE_OFFSET}' \
             -c 'reset run' \
             -c 'shutdown'" &&
     echo 'Done flashing'

--- a/dist/tools/openocd/openocd.sh
+++ b/dist/tools/openocd/openocd.sh
@@ -159,6 +159,11 @@ do_flash() {
             exit $RETVAL
         fi
     fi
+
+    if [ "${IMAGE_OFFSET}" != "0" ]; then
+        echo "Flashing with IMAGE_OFFSET: ${IMAGE_OFFSET}"
+    fi
+
     # flash device
     sh -c "${OPENOCD} \
             ${OPENOCD_ADAPTER_INIT} \

--- a/dist/tools/openocd/openocd.sh
+++ b/dist/tools/openocd/openocd.sh
@@ -145,6 +145,20 @@ test_imagefile() {
     fi
 }
 
+_has_bin_extension() {
+    # The regex need to be without quotes
+    local firmware=$1
+    [[ "${firmware}" =~ ^.*\.bin$ ]]
+}
+
+# Return 0 if given file should be considered a binary
+_is_binfile() {
+    local firmware="$1"
+    local firmware_type="$2"
+    [[ "${firmware_type}" = "bin" ]] || { \
+        [[ -z "${firmware_type}" ]] && _has_bin_extension "${firmware}"; }
+}
+
 #
 # now comes the actual actions
 #


### PR DESCRIPTION
### Contribution description

This adds support for flashing binary files using openocd and not configuring anything.

When flashing binaries, openocd needs the absolute address for flashing.
There was already `IMAGE_OFFSET` but it required configuration for flashing by default for boards that do not start at 0x0, like `iotlab-m3`.

The rom base address is now queried from `openocd` and `IMAGE_OFFSET` is added to that.

* API change to `IMAGE_OFFSET` with binary files as it should now be an offset to the base address
    * This makes it more compatible with `edbg` behavior too, which as an `--offset` variable that takes into account the base address.
* FIX verify image that is not using `IMAGE_OFFSET` when it should
* Use openocd `flash list` to extract the first bank address
    * I did not make this bank number configurable for now. It could be addressed later if necessary.

### API change

This is an API change but would still consider it minor as it only affects openocd when flashing binary files and was also not working as `IMAGE_OFFSET` was not set for verify_image. So changing an API of something that did not work.

### Testing

I tested with `iotlab-m3` but using any board using `openocd` should do. Even better if the board start address is not zero, and if it has with multiple rom banks.

For easier eye debugging, openocd can be run with `sh -xc` instead of `sh -c` here:

https://github.com/RIOT-OS/RIOT/blob/31aba49a3115ada8d52629019d9837d9007219f6/dist/tools/openocd/openocd.sh#L163

Flash an elf with offset

    make -C examples/hello-world BOARD=iotlab-m3 flash IMAGE_OFFSET=0x1000
    # With debug output there is the correct address
    -c 'flash write_image erase "/RIOT/examples/hello-world/bin/iotlab-m3/hello-world.elf" 0x1000 '

    # In master it generated
    # Error: checksum mismatch - attempting binary compare
    # diff 0 address 0x08000000. Was 0x7f instead of 0x00
    # diff 1 address 0x08000001. Was 0x45 instead of 0x02
    # diff 2 address 0x08000002. Was 0x4c instead of 0x00

Flash a simple binary without configuration

    make -C examples/hello-world BOARD=iotlab-m3 IMAGE_FILE=bin/iotlab-m3/hello-world.bin binfile flash-only
    # In master it generated
    # Warn : no flash bank found for address 0            
    # wrote 0 bytes from file bin/iotlab-m3/hello-world.bin in 0.001894s (0.000 KiB/s)

Flash a binary with offset

    make -C examples/hello-world BOARD=iotlab-m3 IMAGE_FILE=bin/iotlab-m3/hello-world.bin binfile flash-only IMAGE_OFFSET=0x100
    # With debug output there is the correct address
    -c 'flash write_image erase "bin/iotlab-m3/hello-world.bin" 0x8000100 '


### Issues/PRs references

This is part of the OTA implementation required features in https://github.com/RIOT-OS/RIOT/issues/9342