### PR TITLE
edbg.inc.mk: allow flashing with an offset in rom without erasing all ROM

### DIFF
--- a/makefiles/tools/edbg.inc.mk
+++ b/makefiles/tools/edbg.inc.mk
@@ -10,6 +10,10 @@ HEXFILE = $(BINFILE)
 ifneq (,$(DEBUG_ADAPTER_ID))
   EDBG_ARGS += --serial $(DEBUG_ADAPTER_ID)
 endif
+
+# Set offset according to IMAGE_OFFSET if it's defined
+EDBG_ARGS += $(addprefix --offset,$(IMAGE_OFFFSET))
+
 FFLAGS ?= $(EDBG_ARGS) -t $(EDBG_DEVICE_TYPE) -b -v -p -f $(HEXFILE)
 
 ifeq ($(RIOT_EDBG),$(FLASHER))

--- a/makefiles/tools/edbg.inc.mk
+++ b/makefiles/tools/edbg.inc.mk
@@ -10,7 +10,7 @@ HEXFILE = $(BINFILE)
 ifneq (,$(DEBUG_ADAPTER_ID))
   EDBG_ARGS += --serial $(DEBUG_ADAPTER_ID)
 endif
-FFLAGS ?= $(EDBG_ARGS) -t $(EDBG_DEVICE_TYPE) -b -e -v -p -f $(HEXFILE)
+FFLAGS ?= $(EDBG_ARGS) -t $(EDBG_DEVICE_TYPE) -b -v -p -f $(HEXFILE)
 
 ifeq ($(RIOT_EDBG),$(FLASHER))
   FLASHDEPS += $(RIOT_EDBG)


### PR DESCRIPTION
### Contribution description

This makes `edbg.inc.mk` more similar to `openocd.sh` behavior that can flash with an offset and only erasing the needed parts of the ROM. (at least after bug fixes https://github.com/RIOT-OS/RIOT/pull/9787)

* Disable erase of the whole ROM when flashing.
  * I could make this configurable if needed
* Handle `IMAGE_OFFFSET` for configuring rom offset


Openocd is already not erasing the memory so not sure how "major" this is to change this default.

### Testing

I do not currently have a dedicated test for this, but I will enable murdock to show it is not breaking the current tests.

* [ ] Write a test for this

### Issues/PRs references

This is part of the OTA implementation required features in #9342