### PR TITLE
vfs/stdio: cleanup STDIO mapping for vfs

### DIFF
--- a/sys/include/vfs.h
+++ b/sys/include/vfs.h
@@ -562,6 +562,15 @@ struct vfs_file_system_ops {
 };
 
 /**
+ * @brief   Allocate and bind file descriptors for  STDIN, STDERR, and STDOUT
+ *
+ * This function is meant to be called once during system initialization time.
+ * It is typically called from the initialization of the selected STDIO
+ * implementation.
+ */
+void vfs_bind_stdio(void);
+
+/**
  * @brief Close an open file
  *
  * @param[in]  fd    fd number to close

--- a/sys/stdio_rtt/stdio_rtt.c
+++ b/sys/stdio_rtt/stdio_rtt.c
@@ -75,12 +75,6 @@
  * @}
  */
 
-#include <stdio.h>
-#if MODULE_VFS
-#include <unistd.h>
-#include <errno.h>
-#include <fcntl.h>
-#endif
 #include <string.h>
 
 #include "stdio_rtt.h"
@@ -284,39 +278,6 @@ int rtt_write(const char* buf_ptr, unsigned num_bytes) {
     return num_bytes_written;
 }
 
-#if MODULE_VFS
-
-static ssize_t rtt_stdio_vfs_read(vfs_file_t *filp, void *dest, size_t nbytes);
-static ssize_t rtt_stdio_vfs_write(vfs_file_t *filp, const void *src, size_t nbytes);
-
-/**
- * @brief VFS file operation table for stdin/stdout/stderr
- */
-static vfs_file_ops_t rtt_stdio_vfs_ops = {
-    .read = rtt_stdio_vfs_read,
-    .write = rtt_stdio_vfs_write,
-};
-
-static ssize_t rtt_stdio_vfs_read(vfs_file_t *filp, void *dest, size_t nbytes)
-{
-    int fd = filp->private_data.value;
-    if (fd != STDIN_FILENO) {
-        return -EBADF;
-    }
-    return rtt_read(dest, nbytes);
-}
-
-static ssize_t rtt_stdio_vfs_write(vfs_file_t *filp, const void *src, size_t nbytes)
-{
-    int fd = filp->private_data.value;
-    if (fd == STDIN_FILENO) {
-        return -EBADF;
-    }
-    return rtt_write(src, nbytes);
-}
-
-#endif
-
 void stdio_init(void) {
     #ifndef STDIO_RTT_DISABLE_STDIN
     stdin_enabled = 1;
@@ -327,19 +288,7 @@ void stdio_init(void) {
     #endif
 
 #if MODULE_VFS
-    int fd;
-    fd = vfs_bind(STDIN_FILENO, O_RDONLY, &rtt_stdio_vfs_ops, (void *)STDIN_FILENO);
-    if (fd < 0) {
-        /* How to handle errors on init? */
-    }
-    fd = vfs_bind(STDOUT_FILENO, O_WRONLY, &rtt_stdio_vfs_ops, (void *)STDOUT_FILENO);
-    if (fd < 0) {
-        /* How to handle errors on init? */
-    }
-    fd = vfs_bind(STDERR_FILENO, O_WRONLY, &rtt_stdio_vfs_ops, (void *)STDERR_FILENO);
-    if (fd < 0) {
-        /* How to handle errors on init? */
-    }
+    vfs_bind_stdio();
 #endif
 
     /* the mutex should start locked */

--- a/sys/vfs/vfs_stdio.c
+++ b/sys/vfs/vfs_stdio.c
@@ -1,0 +1,71 @@
+/*
+ * Copyright (C) 2016 Eistec AB
+ *               2018 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     sys
+ * @{
+ *
+ * @file
+ * @brief       STDIO binding for the VFS module
+ *
+ * @author      Joakim Nohlgård <joakim.nohlgard@eistec.se>
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include <unistd.h>
+#include <errno.h>
+#include <fcntl.h>
+
+#include "assert.h"
+#include "stdio_base.h"
+#include "vfs.h"
+
+static ssize_t _stdio_read(vfs_file_t *filp, void *dest, size_t nbytes)
+{
+    int fd = filp->private_data.value;
+    if (fd != STDIN_FILENO) {
+        return -EBADF;
+    }
+    return stdio_read(dest, nbytes);
+}
+
+static ssize_t _stdio_write(vfs_file_t *filp, const void *src, size_t nbytes)
+{
+    int fd = filp->private_data.value;
+    if (fd == STDIN_FILENO) {
+        return -EBADF;
+    }
+    return stdio_write(src, nbytes);
+}
+
+/**
+ * @brief   VFS file operation table for stdin/stdout/stderr
+ */
+static vfs_file_ops_t _stdio_ops = {
+    .read = _stdio_read,
+    .write = _stdio_write,
+};
+
+void vfs_bind_stdio(void)
+{
+    int fd;
+    fd = vfs_bind(STDIN_FILENO, O_RDONLY, &_stdio_ops, (void *)STDIN_FILENO);
+    /* Is there a better way to handle errors on init? */
+    assert(fd >= 0);
+    fd = vfs_bind(STDOUT_FILENO, O_WRONLY, &_stdio_ops, (void *)STDOUT_FILENO);
+    assert(fd >= 0);
+    fd = vfs_bind(STDERR_FILENO, O_WRONLY, &_stdio_ops, (void *)STDERR_FILENO);
+    assert(fd >= 0);
+    /* we are not interested in the return value in case assert is not
+     * compiled in */
+    (void)fd;
+}


### PR DESCRIPTION
### Contribution description
The STDIO code for the `vfs` module was basically duplicated for `stdio_uart` and `stdio_rtt`. This PR unifies this shared code into the `vfs` module and hooks it into the STDIO intialization for rtt and uart.

IMHO this is not the perfect solution w.r.t. to the duplicated 3 line 'ifdefs' in the stdio implementations, but it improves the situation a bit. So I think this is a good intermediate step, until we find a more elegant structure for some of the STDIO code in general (e.g. separate `ethos` and `stdio_uart` even more, integrate slip, etc).

### Issues/PRs references
~~based on #9503~~