### PR TITLE
Makefile.include: configure '--output-sync=target'

### DIFF
--- a/.murdock
+++ b/.murdock
@@ -155,7 +155,7 @@ compile() {
 
     # compile
     CCACHE_BASEDIR="$(pwd)" BOARD=$board TOOLCHAIN=$toolchain RIOT_CI_BUILD=1 \
-        make -C${appdir} clean all -j${JOBS:-4}
+        make --output-sync=target -C${appdir} clean all -j${JOBS:-4}
     RES=$?
 
     # run tests

--- a/pkg/openthread/Makefile
+++ b/pkg/openthread/Makefile
@@ -32,7 +32,7 @@ all: git-download
 		-specs=nosys.specs -Wl,--gc-sections -Wl,-Map=map.map " \
 		./configure --disable-docs --host=$(TARGET_ARCH) --target=$(TARGET_ARCH) \
 		--prefix=/ --enable-default-logging $(OPENTHREAD_ARGS)
-	cd $(PKG_BUILDDIR) &&  DESTDIR=$(PKG_BUILDDIR)/output PREFIX=/ make -j4 --no-print-directory install
+	cd $(PKG_BUILDDIR) &&  DESTDIR=$(PKG_BUILDDIR)/output PREFIX=/ make --output-sync=none -j4 --no-print-directory install
 
 	cp $(PKG_BUILDDIR)/output/lib/libmbedcrypto.a ${BINDIR}/mbedcrypto.a
 ifneq (,$(filter openthread-cli-ftd,$(USEMODULE)))


### PR DESCRIPTION
### Contribution description

This should allow better output with parallel build.

### Issues/PRs references

For example the `cortexm_common_ldscript` test and also it looks like it led to misunderstanding of issues in https://github.com/RIOT-OS/RIOT/pull/9398