### PR TITLE
net stats: move layer 2 netstats from netdev driver to gnrc_netif

### DIFF
--- a/cpu/cc2538/radio/cc2538_rf_netdev.c
+++ b/cpu/cc2538/radio/cc2538_rf_netdev.c
@@ -283,10 +283,6 @@ static int _send(netdev_t *netdev, const iolist_t *iolist)
         rfcore_write_fifo(iol->iol_base, iol->iol_len);
     }
 
-#ifdef MODULE_NETSTATS_L2
-    netdev->stats.tx_bytes += pkt_len;
-#endif
-
     /* Set first byte of TX FIFO to the packet length */
     rfcore_poke_tx_fifo(0, pkt_len + CC2538_AUTOCRC_LEN);
 
@@ -333,10 +329,6 @@ static int _recv(netdev_t *netdev, void *buf, size_t len, void *info)
         pkt_len = len;
     }
 
-#ifdef MODULE_NETSTATS_L2
-    netdev->stats.rx_count++;
-    netdev->stats.rx_bytes += pkt_len;
-#endif
     rfcore_read_fifo(buf, pkt_len);
 
     if (info != NULL && RFCORE->XREG_RSSISTATbits.RSSI_VALID) {
@@ -396,10 +388,6 @@ static int _init(netdev_t *netdev)
                           &addr_long, sizeof(addr_long));
 
     cc2538_set_state(dev, NETOPT_STATE_IDLE);
-
-#ifdef MODULE_NETSTATS_L2
-    memset(&netdev->stats, 0, sizeof(netstats_t));
-#endif
 
     return 0;
 }

--- a/cpu/esp32/esp-eth/esp_eth_netdev.c
+++ b/cpu/esp32/esp-eth/esp_eth_netdev.c
@@ -169,10 +169,6 @@ static int _esp_eth_init(netdev_t *netdev)
         LOG_TAG_ERROR("esp_eth", "enable failed");
     }
 
-    #ifdef MODULE_NETSTATS_L2
-    memset(&netdev->stats, 0, sizeof(netstats_t));
-    #endif
-
     mutex_unlock(&dev->dev_lock);
 
     return (ret == ESP_OK) ? 0 : -1;
@@ -215,16 +211,9 @@ static int _esp_eth_send(netdev_t *netdev, const iolist_t *iolist)
 
     /* send the the packet to the peer(s) mac address */
     if (esp_eth_tx(dev->tx_buf, dev->tx_len) == ESP_OK) {
-        #ifdef MODULE_NETSTATS_L2
-        netdev->stats.tx_success++;
-        netdev->stats.tx_bytes += dev->tx_len;
-        #endif
         netdev->event_callback(netdev, NETDEV_EVENT_TX_COMPLETE);
     }
     else {
-        #ifdef MODULE_NETSTATS_L2
-        netdev->stats.tx_failed++;
-        #endif
         ret = -EIO;
     }
 
@@ -270,11 +259,6 @@ static int _esp_eth_recv(netdev_t *netdev, void *buf, size_t len, void *info)
     /* copy received date and reset the receive length */
     memcpy(buf, dev->rx_buf, dev->rx_len);
     dev->rx_len = 0;
-
-    #ifdef MODULE_NETSTATS_L2
-    netdev->stats.rx_count++;
-    netdev->stats.rx_bytes += size;
-    #endif
 
     mutex_unlock(&dev->dev_lock);
     return size;

--- a/cpu/esp32/esp-wifi/esp_wifi_netdev.c
+++ b/cpu/esp32/esp-wifi/esp_wifi_netdev.c
@@ -271,10 +271,6 @@ static int _esp_wifi_init(netdev_t *netdev)
 {
     DEBUG("%s: %p\n", __func__, netdev);
 
-    #ifdef MODULE_NETSTATS_L2
-    memset(&netdev->stats, 0x00, sizeof(netstats_t));
-    #endif
-
     return 0;
 }
 
@@ -315,17 +311,10 @@ static int _esp_wifi_send(netdev_t *netdev, const iolist_t *iolist)
 
     /* send the the packet to the peer(s) mac address */
     if (esp_wifi_internal_tx(ESP_IF_WIFI_STA, dev->tx_buf, dev->tx_len) == ESP_OK) {
-        #ifdef MODULE_NETSTATS_L2
-        netdev->stats.tx_success++;
-        netdev->stats.tx_bytes += dev->tx_len;
-        #endif
         netdev->event_callback(netdev, NETDEV_EVENT_TX_COMPLETE);
     }
     else {
         DEBUG("%s: sending WiFi packet failed\n", __func__);
-        #ifdef MODULE_NETSTATS_L2
-        netdev->stats.tx_failed++;
-        #endif
         ret = -EIO;
     }
 
@@ -373,11 +362,6 @@ static int _esp_wifi_recv(netdev_t *netdev, void *buf, size_t len, void *info)
         /* copy received date and reset the receive length */
         memcpy(buf, dev->rx_buf, dev->rx_len);
         dev->rx_len = 0;
-
-        #ifdef MODULE_NETSTATS_L2
-        netdev->stats.rx_count++;
-        netdev->stats.rx_bytes += size;
-        #endif
 
         mutex_unlock(&dev->dev_lock);
         return size;

--- a/cpu/native/netdev_tap/netdev_tap.c
+++ b/cpu/native/netdev_tap/netdev_tap.c
@@ -254,10 +254,6 @@ static int _recv(netdev_t *netdev, void *buf, size_t len, void *info)
 
         _continue_reading(dev);
 
-#ifdef MODULE_NETSTATS_L2
-        netdev->stats.rx_count++;
-        netdev->stats.rx_bytes += nread;
-#endif
         return nread;
     }
     else if (nread == -1) {
@@ -284,14 +280,10 @@ static int _send(netdev_t *netdev, const iolist_t *iolist)
     struct iovec iov[iolist_count(iolist)];
 
     unsigned n;
-    size_t bytes = iolist_to_iovec(iolist, iov, &n);
+    iolist_to_iovec(iolist, iov, &n);
 
     int res = _native_writev(dev->tap_fd, iov, n);
-#ifdef MODULE_NETSTATS_L2
-    netdev->stats.tx_bytes += bytes;
-#else
-    (void)bytes;
-#endif
+
     if (netdev->event_callback) {
         netdev->event_callback(netdev, NETDEV_EVENT_TX_COMPLETE);
     }
@@ -392,9 +384,6 @@ static int _init(netdev_t *netdev)
     native_async_read_setup();
     native_async_read_add_handler(dev->tap_fd, netdev, _tap_isr);
 
-#ifdef MODULE_NETSTATS_L2
-    memset(&netdev->stats, 0, sizeof(netstats_t));
-#endif
     DEBUG("gnrc_tapnet: initialized.\n");
     return 0;
 }

--- a/cpu/nrf5x_common/radio/nrfble/nrfble.c
+++ b/cpu/nrf5x_common/radio/nrfble/nrfble.c
@@ -230,9 +230,6 @@ netdev_t *nrfble_setup(void)
     _nrfble_dev.driver = &netdev_driver;
     _nrfble_dev.event_callback = NULL;
     _nrfble_dev.context = NULL;
-#ifdef MODULE_NETSTATS_L2
-    memset(&_nrfble_dev.stats, 0, sizeof(netstats_t));;
-#endif
     return &_nrfble_dev;
 }
 

--- a/cpu/nrf5x_common/radio/nrfmin/nrfmin.c
+++ b/cpu/nrf5x_common/radio/nrfmin/nrfmin.c
@@ -178,9 +178,6 @@ void nrfmin_setup(void)
     nrfmin_dev.driver = &nrfmin_netdev;
     nrfmin_dev.event_callback = NULL;
     nrfmin_dev.context = NULL;
-#ifdef MODULE_NETSTATS_L2
-    memset(&nrfmin_dev.stats, 0, sizeof(netstats_t));;
-#endif
 }
 
 uint16_t nrfmin_get_addr(void)

--- a/drivers/at86rf2xx/at86rf2xx_netdev.c
+++ b/drivers/at86rf2xx/at86rf2xx_netdev.c
@@ -88,10 +88,6 @@ static int _init(netdev_t *netdev)
         return -1;
     }
 
-#ifdef MODULE_NETSTATS_L2
-    memset(&netdev->stats, 0, sizeof(netstats_t));
-#endif
-
     return 0;
 }
 
@@ -110,9 +106,6 @@ static int _send(netdev_t *netdev, const iolist_t *iolist)
                   (unsigned)len + 2);
             return -EOVERFLOW;
         }
-#ifdef MODULE_NETSTATS_L2
-        netdev->stats.tx_bytes += len;
-#endif
         len = at86rf2xx_tx_load(dev, iol->iol_base, iol->iol_len, len);
     }
 
@@ -167,10 +160,6 @@ static int _recv(netdev_t *netdev, void *buf, size_t len, void *info)
         at86rf2xx_set_state(dev, dev->idle_state);
         return -ENOBUFS;
     }
-#ifdef MODULE_NETSTATS_L2
-    netdev->stats.rx_count++;
-    netdev->stats.rx_bytes += pkt_len;
-#endif
     /* copy payload */
     at86rf2xx_fb_read(dev, (uint8_t *)buf, pkt_len);
 

--- a/drivers/cc1xxx_common/gnrc_netif_cc1xxx.c
+++ b/drivers/cc1xxx_common/gnrc_netif_cc1xxx.c
@@ -139,14 +139,6 @@ static int cc1xxx_adpt_send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
         .iol_len = sizeof(l2hdr),
     };
 
-#ifdef MODULE_NETSTATS_L2
-    if (netif_hdr->flags & BCAST) {
-        netif->dev->stats.tx_mcast_count++;
-    }
-    else {
-        netif->dev->stats.tx_unicast_count++;
-    }
-#endif
     DEBUG("[cc1xxx-gnrc] send: triggering the drivers send function\n");
     res = netif->dev->driver->send(netif->dev, &iolist);
 

--- a/drivers/cc2420/cc2420_netdev.c
+++ b/drivers/cc2420/cc2420_netdev.c
@@ -137,10 +137,6 @@ static int _init(netdev_t *netdev)
         return -1;
     }
 
-#ifdef MODULE_NETSTATS_L2
-    memset(&netdev->stats, 0, sizeof(netstats_t));
-#endif
-
     return cc2420_init((cc2420_t *)dev);
 }
 

--- a/drivers/enc28j60/enc28j60.c
+++ b/drivers/enc28j60/enc28j60.c
@@ -299,10 +299,6 @@ static int nd_send(netdev_t *netdev, const iolist_t *iolist)
     /* set last transmission time for timeout handling */
     dev->tx_time = xtimer_now_usec();
 
-#ifdef MODULE_NETSTATS_L2
-    netdev->stats.tx_bytes += c;
-#endif
-
     mutex_unlock(&dev->lock);
     return c;
 }
@@ -340,10 +336,6 @@ static int nd_recv(netdev_t *netdev, void *buf, size_t max_len, void *info)
           (int)size, (int)next, buf, max_len);
 
     if (buf != NULL) {
-#ifdef MODULE_NETSTATS_L2
-        netdev->stats.rx_count++;
-        netdev->stats.rx_bytes += size;
-#endif
         /* read packet content into the supplied buffer */
         if (size <= max_len) {
             cmd_rbm(dev, (uint8_t *)buf, size);
@@ -454,9 +446,6 @@ static int nd_init(netdev_t *netdev)
     /* allow receiving bytes from now on */
     cmd_bfs(dev, REG_ECON1, -1, ECON1_RXEN);
 
-#ifdef MODULE_NETSTATS_L2
-    memset(&netdev->stats, 0, sizeof(netstats_t));
-#endif
     mutex_unlock(&dev->lock);
     return 0;
 }

--- a/drivers/encx24j600/encx24j600.c
+++ b/drivers/encx24j600/encx24j600.c
@@ -33,11 +33,6 @@
 #include "net/eui64.h"
 #include "net/ethernet.h"
 
-#ifdef MODULE_NETSTATS_L2
-#include <string.h>
-#include "net/netstats.h"
-#endif
-
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
@@ -285,9 +280,6 @@ static int _init(netdev_t *encdev)
 
     unlock(dev);
 
-#ifdef MODULE_NETSTATS_L2
-    memset(&encdev->stats, 0, sizeof(netstats_t));
-#endif
     return 0;
 }
 
@@ -316,10 +308,6 @@ static int _send(netdev_t *netdev, const iolist_t *iolist) {
     /* wait for sending to complete */
     /* (not sure if it is needed, keeping the line uncommented) */
     /*while ((reg_get(dev, ENC_ECON1) & ENC_TXRTS)) {}*/
-
-#ifdef MODULE_NETSTATS_L2
-    netdev->stats.tx_bytes += len;
-#endif
 
     unlock(dev);
 
@@ -367,10 +355,6 @@ static int _recv(netdev_t *netdev, void *buf, size_t len, void *info)
             unlock(dev);
             return -ENOBUFS;
         }
-#ifdef MODULE_NETSTATS_L2
-        netdev->stats.rx_count++;
-        netdev->stats.rx_bytes += payload_len;
-#endif
         /* read packet (without 4 bytes checksum) */
         sram_op(dev, ENC_RRXDATA, 0xFFFF, buf, payload_len);
 

--- a/drivers/include/net/netdev.h
+++ b/drivers/include/net/netdev.h
@@ -200,9 +200,6 @@ extern "C" {
 #include "iolist.h"
 #include "net/netopt.h"
 
-#ifdef MODULE_NETSTATS_L2
-#include "net/netstats.h"
-#endif
 #ifdef MODULE_L2FILTER
 #include "net/l2filter.h"
 #endif
@@ -280,9 +277,6 @@ struct netdev {
     void* context;                          /**< ptr to network stack context */
 #ifdef MODULE_NETDEV_LAYER
     netdev_t *lower;                        /**< ptr to the lower netdev layer */
-#endif
-#ifdef MODULE_NETSTATS_L2
-    netstats_t stats;                       /**< transceiver's statistics */
 #endif
 #ifdef MODULE_L2FILTER
     l2filter_t filter[L2FILTER_LISTSIZE];   /**< link layer address filters */

--- a/drivers/include/xbee.h
+++ b/drivers/include/xbee.h
@@ -131,9 +131,6 @@ typedef struct {
     const struct netdev_driver *driver;     /**< ptr to that driver's interface. */
     netdev_event_cb_t event_callback;       /**< callback for device events */
     void* context;                          /**< ptr to network stack context */
-#ifdef MODULE_NETSTATS_L2
-    netstats_t stats;                       /**< transceiver's statistics */
-#endif
     /* device driver specific fields */
     xbee_params_t p;                    /**< configuration parameters */
     uint8_t options;                    /**< options field */

--- a/drivers/kw2xrf/kw2xrf_netdev.c
+++ b/drivers/kw2xrf/kw2xrf_netdev.c
@@ -81,10 +81,6 @@ static int _init(netdev_t *netdev)
         return -1;
     }
 
-#ifdef MODULE_NETSTATS_L2
-    memset(&netdev->stats, 0, sizeof(netstats_t));
-#endif
-
     /* reset device to default values and put it into RX state */
     kw2xrf_reset_phy(dev);
 
@@ -169,9 +165,6 @@ static int _send(netdev_t *netdev, const iolist_t *iolist)
     _send_last_fcf = dev->buf[1];
 
     kw2xrf_write_fifo(dev, dev->buf, dev->buf[0]);
-#ifdef MODULE_NETSTATS_L2
-    netdev->stats.tx_bytes += len;
-#endif
 
     /* send data out directly if pre-loading id disabled */
     if (!(dev->netdev.flags & KW2XRF_OPT_PRELOADING)) {
@@ -193,11 +186,6 @@ static int _recv(netdev_t *netdev, void *buf, size_t len, void *info)
     if (buf == NULL) {
         return pkt_len + 1;
     }
-
-#ifdef MODULE_NETSTATS_L2
-    netdev->stats.rx_count++;
-    netdev->stats.rx_bytes += pkt_len;
-#endif
 
     if (pkt_len > len) {
         /* not enough space in buf */

--- a/drivers/mrf24j40/mrf24j40_netdev.c
+++ b/drivers/mrf24j40/mrf24j40_netdev.c
@@ -57,9 +57,6 @@ static int _init(netdev_t *netdev)
     gpio_set(dev->params.reset_pin);
     gpio_init_int(dev->params.int_pin, GPIO_IN, GPIO_RISING, _irq_handler, dev);
 
-#ifdef MODULE_NETSTATS_L2
-    memset(&netdev->stats, 0, sizeof(netstats_t));
-#endif
     /* reset device to default values and put it into RX state */
     mrf24j40_reset(dev);
     return 0;
@@ -80,10 +77,6 @@ static int _send(netdev_t *netdev, const iolist_t *iolist)
                   (unsigned)len + 2);
             return -EOVERFLOW;
         }
-
-#ifdef MODULE_NETSTATS_L2
-        netdev->stats.tx_bytes += len;
-#endif
         len = mrf24j40_tx_load(dev, iol->iol_base, iol->iol_len, len);
         /* only on first iteration: */
         if (iol == iolist) {
@@ -136,10 +129,6 @@ static int _recv(netdev_t *netdev, void *buf, size_t len, void *info)
             mrf24j40_rx_fifo_read(dev, phr + 2, &(rssi_scalar), 1);
             radio_info->rssi = mrf24j40_dbm_from_reg(rssi_scalar);
         }
-#ifdef MODULE_NETSTATS_L2
-        netdev->stats.rx_count++;
-        netdev->stats.rx_bytes += pkt_len;
-#endif
         res = pkt_len;
     }
     /* Turn on reception of packets off the air */

--- a/drivers/netdev_eth/netdev_eth.c
+++ b/drivers/netdev_eth/netdev_eth.c
@@ -80,15 +80,6 @@ int netdev_eth_get(netdev_t *dev, netopt_t opt, void *value, size_t max_len)
             {
                 return _get_iid(dev, value, max_len);
             }
-#ifdef MODULE_NETSTATS_L2
-        case NETOPT_STATS:
-            {
-                assert(max_len >= sizeof(uintptr_t));
-                *((netstats_t**)value) = &dev->stats;
-                res = sizeof(uintptr_t);
-                break;
-            }
-#endif
 #ifdef MODULE_L2FILTER
         case NETOPT_L2FILTER:
             {

--- a/drivers/netdev_ieee802154/netdev_ieee802154.c
+++ b/drivers/netdev_ieee802154/netdev_ieee802154.c
@@ -143,13 +143,6 @@ int netdev_ieee802154_get(netdev_ieee802154_t *dev, netopt_t opt, void *value,
         case NETOPT_IPV6_IID:
             res = _get_iid(dev, value, max_len);
             break;
-#ifdef MODULE_NETSTATS_L2
-        case NETOPT_STATS:
-            assert(max_len == sizeof(uintptr_t));
-            *((netstats_t **)value) = &dev->netdev.stats;
-            res = sizeof(uintptr_t);
-            break;
-#endif
 #ifdef MODULE_L2FILTER
         case NETOPT_L2FILTER:
             assert(max_len >= sizeof(l2filter_t **));

--- a/drivers/xbee/gnrc_xbee.c
+++ b/drivers/xbee/gnrc_xbee.c
@@ -153,10 +153,10 @@ static int xbee_adpt_send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
 
 #ifdef MODULE_NETSTATS_L2
     if (hdr->flags & BCAST) {
-        netif->dev->stats.tx_mcast_count++;
+        netif->stats.tx_mcast_count++;
     }
     else {
-        netif->dev->stats.tx_unicast_count++;
+        netif->stats.tx_unicast_count++;
     }
 #endif
     DEBUG("[xbee-gnrc] send: triggering the drivers send function\n");

--- a/drivers/xbee/gnrc_xbee.c
+++ b/drivers/xbee/gnrc_xbee.c
@@ -151,14 +151,6 @@ static int xbee_adpt_send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
         .iol_len = res
     };
 
-#ifdef MODULE_NETSTATS_L2
-    if (hdr->flags & BCAST) {
-        netif->stats.tx_mcast_count++;
-    }
-    else {
-        netif->stats.tx_unicast_count++;
-    }
-#endif
     DEBUG("[xbee-gnrc] send: triggering the drivers send function\n");
     res = netif->dev->driver->send(netif->dev, &iolist);
 

--- a/sys/include/net/gnrc/netif.h
+++ b/sys/include/net/gnrc/netif.h
@@ -47,6 +47,9 @@
 #include "net/ndp.h"
 #include "net/netdev.h"
 #include "net/netopt.h"
+#ifdef MODULE_NETSTATS_L2
+#include "net/netstats.h"
+#endif
 #include "rmutex.h"
 
 #ifdef __cplusplus
@@ -65,6 +68,9 @@ typedef struct {
     const gnrc_netif_ops_t *ops;            /**< Operations of the network interface */
     netdev_t *dev;                          /**< Network device of the network interface */
     rmutex_t mutex;                         /**< Mutex of the interface */
+#ifdef MODULE_NETSTATS_L2
+    netstats_t stats;                       /**< transceiver's statistics */
+#endif
 #if defined(MODULE_GNRC_IPV6) || DOXYGEN
     gnrc_netif_ipv6_t ipv6;                 /**< IPv6 component */
 #endif

--- a/sys/net/gnrc/link_layer/gomach/gomach_internal.c
+++ b/sys/net/gnrc/link_layer/gomach/gomach_internal.c
@@ -103,10 +103,10 @@ int _gnrc_gomach_transmit(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
 #ifdef MODULE_NETSTATS_L2
     if (netif_hdr->flags &
             (GNRC_NETIF_HDR_FLAGS_BROADCAST | GNRC_NETIF_HDR_FLAGS_MULTICAST)) {
-        netif->dev->stats.tx_mcast_count++;
+        netif->stats.tx_mcast_count++;
     }
     else {
-        netif->dev->stats.tx_unicast_count++;
+        netif->stats.tx_unicast_count++;
     }
 #endif
 #ifdef MODULE_GNRC_MAC

--- a/sys/net/gnrc/link_layer/gomach/gomach_internal.c
+++ b/sys/net/gnrc/link_layer/gomach/gomach_internal.c
@@ -343,8 +343,8 @@ int gnrc_gomach_send_preamble_ack(gnrc_netif_t *netif, gnrc_gomach_packet_info_t
     assert(netif != NULL);
     assert(info != NULL);
 
+    gnrc_pktsnip_t *pkt;
     gnrc_pktsnip_t *gomach_pkt = NULL;
-    gnrc_pktsnip_t *pkt = NULL;
     gnrc_netif_hdr_t *nethdr_preamble_ack = NULL;
 
     /* Start assemble the preamble-ACK packet according to preamble packet info. */

--- a/sys/net/gnrc/link_layer/lwmac/lwmac_internal.c
+++ b/sys/net/gnrc/link_layer/lwmac/lwmac_internal.c
@@ -90,10 +90,10 @@ int _gnrc_lwmac_transmit(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
 #ifdef MODULE_NETSTATS_L2
     if (netif_hdr->flags &
             (GNRC_NETIF_HDR_FLAGS_BROADCAST | GNRC_NETIF_HDR_FLAGS_MULTICAST)) {
-        netif->dev->stats.tx_mcast_count++;
+        netif->stats.tx_mcast_count++;
     }
     else {
-        netif->dev->stats.tx_unicast_count++;
+        netif->stats.tx_unicast_count++;
     }
 #endif
 #ifdef MODULE_GNRC_MAC

--- a/sys/net/gnrc/netif/ethernet/gnrc_netif_ethernet.c
+++ b/sys/net/gnrc/netif/ethernet/gnrc_netif_ethernet.c
@@ -145,10 +145,10 @@ static int _send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
 #ifdef MODULE_NETSTATS_L2
     if ((netif_hdr->flags & GNRC_NETIF_HDR_FLAGS_BROADCAST) ||
         (netif_hdr->flags & GNRC_NETIF_HDR_FLAGS_MULTICAST)) {
-        dev->stats.tx_mcast_count++;
+        netif->stats.tx_mcast_count++;
     }
     else {
-        dev->stats.tx_unicast_count++;
+        netif->stats.tx_unicast_count++;
     }
 #endif
     res = dev->driver->send(dev, &iolist);
@@ -183,6 +183,10 @@ static gnrc_pktsnip_t *_recv(gnrc_netif_t *netif)
             DEBUG("gnrc_netif_ethernet: read error.\n");
             goto safe_out;
         }
+#ifdef MODULE_NETSTATS_L2
+        netif->stats.rx_count++;
+        netif->stats.rx_bytes += nread;
+#endif
 
         if (nread < bytes_expected) {
             /* we've got less than the expected packet size,

--- a/sys/net/gnrc/netif/gnrc_netif_raw.c
+++ b/sys/net/gnrc/netif/gnrc_netif_raw.c
@@ -70,6 +70,11 @@ static gnrc_pktsnip_t *_recv(gnrc_netif_t *netif)
             gnrc_pktbuf_release(pkt);
             return NULL;
         }
+#ifdef MODULE_NETSTATS_L2
+        netif->stats.rx_count++;
+        netif->stats.rx_bytes += nread;
+#endif
+
         if (nread < bytes_expected) {
             /* we've got less then the expected packet size,
              * so free the unused space.*/
@@ -102,7 +107,7 @@ static int _send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
     netdev_t *dev = netif->dev;
 
 #ifdef MODULE_NETSTATS_L2
-    dev->stats.tx_unicast_count++;
+    netif->stats.tx_unicast_count++;
 #endif
 
     res = dev->driver->send(dev, (iolist_t *)pkt);

--- a/sys/net/gnrc/netif/ieee802154/gnrc_netif_ieee802154.c
+++ b/sys/net/gnrc/netif/ieee802154/gnrc_netif_ieee802154.c
@@ -95,6 +95,11 @@ static gnrc_pktsnip_t *_recv(gnrc_netif_t *netif)
             gnrc_pktbuf_release(pkt);
             return NULL;
         }
+#ifdef MODULE_NETSTATS_L2
+        netif->stats.rx_count++;
+        netif->stats.rx_bytes += nread;
+#endif
+
         if (netif->flags & GNRC_NETIF_FLAGS_RAWMODE) {
             /* Raw mode, skip packet processing, but provide rx_info via
              * GNRC_NETTYPE_NETIF */
@@ -241,10 +246,10 @@ static int _send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
 #ifdef MODULE_NETSTATS_L2
     if (netif_hdr->flags &
             (GNRC_NETIF_HDR_FLAGS_BROADCAST | GNRC_NETIF_HDR_FLAGS_MULTICAST)) {
-        netif->dev->stats.tx_mcast_count++;
+        netif->stats.tx_mcast_count++;
     }
     else {
-        netif->dev->stats.tx_unicast_count++;
+        netif->stats.tx_unicast_count++;
     }
 #endif
 #ifdef MODULE_GNRC_MAC


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Currently handling and collection of layer 2 netstats is rather distributed, i.e. some is handled in the low level netdev drivers other parts are in GNRC. This PR move handling of layer 2 netstats to gnrc_netif. This is done step by step so each commit should be one after another.

### Testing

use `tests/gnrc_netif` or `examples/gnrc_networking` and transmit something, then lookup `ifconfig`.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->