### PR TITLE
tests/driver_isl29125: fix of compilation error

### DIFF
--- a/tests/driver_isl29125/main.c
+++ b/tests/driver_isl29125/main.c
@@ -76,7 +76,7 @@ int main(void)
         "ISL29125_MODE_R", "ISL29125_MODE_G", "ISL29125_MODE_B",
         "ISL29125_MODE_RG", "ISL29125_MODE_GB"};
 
-    for (size_t i = 0; i < sizeof(modes); i++) {
+    for (size_t i = 0; i < sizeof(modes) / sizeof(modes[0]); i++) {
         printf("Setting mode %s\n", mode_names[i]);
         isl29125_set_mode(&dev, modes[i]);
         xtimer_usleep(SLEEP);


### PR DESCRIPTION
Compilation of ```tests/driver_isl29125``` aborts with following error message:
```
.../tests/driver_isl29125/main.c:80:15: error: iteration 8u invokes undefined behavior [-Werror=aggressive-loop-optimizations]
         printf("Setting mode %s\n", mode_names[i]);
               ^
/home/gs/src/RIOT-Xtensa-ESP.working/tests/driver_isl29125/main.c:79:5: note: containing loop
     for (size_t i = 0; i < sizeof(modes); i++) {
```
Platform is Xtensa GCC version 4.8.5. The PR fixes this problem by changing
```
for (size_t i = 0; i < sizeof(modes); i++)
```
to
```
for (size_t i = 0; i < sizeof(modes)/sizeof(isl29125_mode_t); i++)
```