### PR TITLE
frdm-kw41z: Clean up ADC configuration

### DIFF
--- a/boards/frdm-kw41z/include/adc_params.h
+++ b/boards/frdm-kw41z/include/adc_params.h
@@ -32,43 +32,38 @@ extern "C" {
 static const  saul_adc_params_t saul_adc_params[] =
 {
     {
-        .name = "coretemp",
+        .name = "ADC0_DP-DM",
         .line = ADC_LINE(0),
         .res  = ADC_RES_16BIT,
     },
     {
-        .name = "corebandgap",
+        .name = "ADC0_DP",
         .line = ADC_LINE(1),
         .res  = ADC_RES_16BIT,
     },
     {
-        .name = "corevrefh",
+        .name = "PTB2",
         .line = ADC_LINE(2),
         .res  = ADC_RES_16BIT,
     },
     {
-        .name = "corevrefl",
+        .name = "PTB3",
         .line = ADC_LINE(3),
         .res  = ADC_RES_16BIT,
     },
     {
-        .name = "dcdcvbat",
+        .name = "coretemp",
         .line = ADC_LINE(4),
         .res  = ADC_RES_16BIT,
     },
     {
-        .name = "ADC0_DP-DM",
+        .name = "corebandgap",
         .line = ADC_LINE(5),
         .res  = ADC_RES_16BIT,
     },
     {
-        .name = "ADC0_SE2",
+        .name = "dcdcvbat",
         .line = ADC_LINE(6),
-        .res  = ADC_RES_16BIT,
-    },
-    {
-        .name = "ADC0_SE3",
-        .line = ADC_LINE(7),
         .res  = ADC_RES_16BIT,
     },
 };

--- a/boards/frdm-kw41z/include/periph_conf.h
+++ b/boards/frdm-kw41z/include/periph_conf.h
@@ -128,16 +128,22 @@ static const uart_conf_t uart_config[] = {
  */
 static const adc_conf_t adc_config[] = {
     /* dev, pin, channel */
-    [ 0] = { ADC0, GPIO_UNDEF, 26 },       /* internal: temperature sensor */
+    /* ADC0_DP-ADC0_DM differential reading (Arduino A5 - A0) */
+    [ 0] = { .dev = ADC0, .pin = GPIO_UNDEF, .chan =  0 | ADC_SC1_DIFF_MASK },
+    /* ADC0_DP single ended reading (Arduino A5) */
+    [ 1] = { .dev = ADC0, .pin = GPIO_UNDEF, .chan =  0 },
+    /* PTB2 (Arduino A2) */
+    [ 2] = { .dev = ADC0, .pin = GPIO_PIN(PORT_B,  2), .chan =  3 },
+    /* PTB3 (Arduino A3) */
+    [ 3] = { .dev = ADC0, .pin = GPIO_PIN(PORT_B,  3), .chan =  2 },
+    /* internal: temperature sensor */
+    [ 4] = { .dev = ADC0, .pin = GPIO_UNDEF, .chan = 26 },
     /* Note: the band gap buffer uses a bit of current and is turned off by default,
      * Set PMC->REGSC |= PMC_REGSC_BGBE_MASK before reading or the input will be floating */
-    [ 1] = { ADC0, GPIO_UNDEF, 27 },       /* internal: band gap */
-    [ 2] = { ADC0, GPIO_UNDEF, 29 },       /* internal: V_REFH */
-    [ 3] = { ADC0, GPIO_UNDEF, 30 },       /* internal: V_REFL */
-    [ 4] = { ADC0, GPIO_UNDEF, 23 },       /* internal: DCDC divided battery level */
-    [ 5] = { ADC0, GPIO_UNDEF,  0 | ADC_SC1_DIFF_MASK }, /* ADC0_DP-ADC0_DM differential reading */
-    [ 6] = { ADC0, GPIO_PIN(PORT_B,  3),  2 }, /* ADC0_SE2 */
-    [ 7] = { ADC0, GPIO_PIN(PORT_B,  2),  3 }, /* ADC0_SE3 */
+    /* internal: band gap */
+    [ 5] = { .dev = ADC0, .pin = GPIO_UNDEF, .chan = 27 },
+    /* internal: DCDC divided battery level */
+    [ 6] = { .dev = ADC0, .pin = GPIO_UNDEF, .chan = 23 },
 };
 #define ADC_NUMOF           (sizeof(adc_config) / sizeof(adc_config[0]))
 /*


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

- Reorder ADC lines to put the external connections first in the list.
- Remove VREFH, VREFL signals. 
- Add single ended reading of ADC0_DP

The NMI and I2C0 functions collide with the analog function on the other pins in the Arduino analog input part of the pinout: pins PTB1, PTB18. This configuration ignores these pins to avoid potential problems.

### Issues/PRs references

Similar to #9763 