### PR TITLE
stm32_common/i2c: fix wrong speed parameters for stm32l4 and stm32f7

### DIFF
--- a/boards/b-l475e-iot01a/include/periph_conf.h
+++ b/boards/b-l475e-iot01a/include/periph_conf.h
@@ -203,6 +203,7 @@ static const i2c_conf_t i2c_config[] = {
         .sda_af         = GPIO_AF4,
         .bus            = APB1,
         .rcc_mask       = RCC_APB1ENR1_I2C1EN,
+        .rcc_sw_mask    = RCC_CCIPR_I2C1SEL_1, /* HSI (16 MHz) */
         .irqn           = I2C1_ER_IRQn,
     },
     {
@@ -214,6 +215,7 @@ static const i2c_conf_t i2c_config[] = {
         .sda_af         = GPIO_AF4,
         .bus            = APB1,
         .rcc_mask       = RCC_APB1ENR1_I2C2EN,
+        .rcc_sw_mask    = RCC_CCIPR_I2C2SEL_1, /* HSI (16 MHz) */
         .irqn           = I2C2_ER_IRQn,
     },
 };

--- a/boards/nucleo-f722ze/include/periph_conf.h
+++ b/boards/nucleo-f722ze/include/periph_conf.h
@@ -150,6 +150,7 @@ static const i2c_conf_t i2c_config[] = {
         .sda_af         = GPIO_AF4,
         .bus            = APB1,
         .rcc_mask       = RCC_APB1ENR_I2C1EN,
+        .rcc_sw_mask    = RCC_DCKCFGR2_I2C1SEL_1, /* HSI (16 MHz) */
         .irqn           = I2C1_ER_IRQn,
     }
 };

--- a/cpu/stm32_common/include/cpu_conf_stm32_common.h
+++ b/cpu/stm32_common/include/cpu_conf_stm32_common.h
@@ -31,6 +31,14 @@ extern "C" {
     defined(CPU_FAM_STM32F7) || defined(CPU_FAM_STM32L0) || \
     defined(CPU_FAM_STM32L4)
 
+#if defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32F3)
+#define I2C_CLOCK_SRC_REG (RCC->CFGR3)
+#elif defined(CPU_FAM_STM32L4)
+#define I2C_CLOCK_SRC_REG (RCC->CCIPR)
+#elif defined(CPU_FAM_STM32F7)
+#define I2C_CLOCK_SRC_REG (RCC->DCKCFGR2)
+#endif
+
 /**
  * @brief   Timing register settings
  *

--- a/cpu/stm32_common/include/cpu_conf_stm32_common.h
+++ b/cpu/stm32_common/include/cpu_conf_stm32_common.h
@@ -31,14 +31,6 @@ extern "C" {
     defined(CPU_FAM_STM32F7) || defined(CPU_FAM_STM32L0) || \
     defined(CPU_FAM_STM32L4)
 
-#if defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32F3)
-#define I2C_CLOCK_SRC_REG (RCC->CFGR3)
-#elif defined(CPU_FAM_STM32L4)
-#define I2C_CLOCK_SRC_REG (RCC->CCIPR)
-#elif defined(CPU_FAM_STM32F7)
-#define I2C_CLOCK_SRC_REG (RCC->DCKCFGR2)
-#endif
-
 /**
  * @brief   Timing register settings
  *

--- a/cpu/stm32_common/include/cpu_conf_stm32_common.h
+++ b/cpu/stm32_common/include/cpu_conf_stm32_common.h
@@ -45,8 +45,7 @@ extern "C" {
  * @ref i2c_timing_param_t
  */
 static const i2c_timing_param_t timing_params[] = {
-#if defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32L4) || \
-    defined(CPU_FAM_STM32F7)
+#if defined(CPU_FAM_STM32F0)
     [ I2C_SPEED_NORMAL ]    = {
         .presc  = 0xB,
         .scll   = 0x13,     /* t_SCLL   = 5.0us  */
@@ -67,6 +66,28 @@ static const i2c_timing_param_t timing_params[] = {
         .sclh =   0x1,      /* t_SCLH   = 250ns */
         .sdadel = 0x0,      /* t_SDADEL = 0ns   */
         .scldel = 0x1,      /* t_SCLDEL = 250ns */
+    }
+#elif defined(CPU_FAM_STM32L4) || defined(CPU_FAM_STM32F7)
+    [ I2C_SPEED_NORMAL ]    = {
+        .presc  = 3,
+        .scll   = 0x13,     /* t_SCLL   = 5.0us  */
+        .sclh   = 0xF,      /* t_SCLH   = 4.0us  */
+        .sdadel = 0x2,      /* t_SDADEL = 500ns  */
+        .scldel = 0x4,      /* t_SCLDEL = 1250ns */
+    },
+    [ I2C_SPEED_FAST ]      = {
+        .presc  = 1,
+        .scll   = 0x9,      /* t_SCLL   = 1250ns */
+        .sclh   = 0x3,      /* t_SCLH   = 500ns  */
+        .sdadel = 0x2,      /* t_SDADEL = 250ns  */
+        .scldel = 0x3,      /* t_SCLDEL = 500ns  */
+    },
+    [ I2C_SPEED_FAST_PLUS ] = {
+        .presc =  0,
+        .scll =   0x4,      /* t_SCLL   = 312.5ns */
+        .sclh =   0x2,      /* t_SCLH   = 187.5ns */
+        .sdadel = 0x0,      /* t_SDADEL = 0ns     */
+        .scldel = 0x2,      /* t_SCLDEL = 187.5ns */
     }
 #elif defined(CPU_FAM_STM32F3)
     [ I2C_SPEED_NORMAL ]    = {

--- a/cpu/stm32_common/include/periph_cpu_common.h
+++ b/cpu/stm32_common/include/periph_cpu_common.h
@@ -416,7 +416,8 @@ typedef struct {
 #endif
     uint8_t bus;            /**< APB bus */
     uint32_t rcc_mask;      /**< bit in clock enable register */
-#if defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32F3)
+#if defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32F3) || \
+    defined(CPU_FAM_STM32L4) || defined(CPU_FAM_STM32F7)
     uint32_t rcc_sw_mask;   /**< bit to switch I2C clock */
 #endif
 #if defined(CPU_FAM_STM32F1) || defined(CPU_FAM_STM32F2) || \

--- a/cpu/stm32_common/periph/i2c_1.c
+++ b/cpu/stm32_common/periph/i2c_1.c
@@ -54,6 +54,14 @@
 #define CLEAR_FLAG              (I2C_ICR_NACKCF | I2C_ICR_ARLOCF | I2C_ICR_BERRCF)
 #define ERROR_FLAG              (I2C_ISR_NACKF | I2C_ISR_ARLO | I2C_ISR_BERR)
 
+#if defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32F3)
+#define I2C_CLOCK_SRC_REG       (RCC->CFGR3)
+#elif defined(CPU_FAM_STM32L4)
+#define I2C_CLOCK_SRC_REG       (RCC->CCIPR)
+#elif defined(CPU_FAM_STM32F7)
+#define I2C_CLOCK_SRC_REG       (RCC->DCKCFGR2)
+#endif
+
 /* static function definitions */
 static inline void _i2c_init(I2C_TypeDef *i2c, uint32_t timing);
 static inline int _start(I2C_TypeDef *dev, uint16_t address, size_t length,

--- a/cpu/stm32_common/periph/i2c_1.c
+++ b/cpu/stm32_common/periph/i2c_1.c
@@ -82,9 +82,10 @@ void i2c_init(i2c_t dev)
     NVIC_SetPriority(i2c_config[dev].irqn, I2C_IRQ_PRIO);
     NVIC_EnableIRQ(i2c_config[dev].irqn);
 
-#if defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32F3)
-    /* Set I2CSW bits to enable I2C clock source */
-    RCC->CFGR3 |= i2c_config[dev].rcc_sw_mask;
+#if defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32F3) || \
+    defined(CPU_FAM_STM32L4) || defined(CPU_FAM_STM32F7)
+    /* select I2C clock source */
+    I2C_CLOCK_SRC_REG |= i2c_config[dev].rcc_sw_mask;
 #endif
 
     DEBUG("[i2c] init: configuring pins\n");

--- a/cpu/stm32_common/periph/i2c_1.c
+++ b/cpu/stm32_common/periph/i2c_1.c
@@ -34,6 +34,7 @@
 #include <errno.h>
 
 #include "cpu.h"
+#include "stmclk.h"
 #include "mutex.h"
 
 #include "cpu_conf_stm32_common.h"
@@ -89,6 +90,10 @@ void i2c_init(i2c_t dev)
 
     NVIC_SetPriority(i2c_config[dev].irqn, I2C_IRQ_PRIO);
     NVIC_EnableIRQ(i2c_config[dev].irqn);
+
+#if defined(CPU_FAM_STM32L4) || defined(CPU_FAM_STM32F7)
+    stmclk_enable_hsi();
+#endif
 
 #if defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32F3) || \
     defined(CPU_FAM_STM32L4) || defined(CPU_FAM_STM32F7)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

The common i2c driver shares speed configuration data (scll / sclh, etc.) among multiple MCUs. The correct values for these parameters depend on the i2c clock that can be configured to various sources. For the L4 and F7 the configuration was based on the examples for 48 Mhz clock but that isn't correct. The clock source is changed as follows (# means old config * means new):
```
stm32-f722ze
HSI     16 MHz *
SYSCLK 216 MHz
PCLK    54 Mhz #

stm32-l475vg
HSI     16 MHz *
SYSCLK  80 MHz
PCLK    20 Mhz #
```

I used the HSI because that doesn't depend on other configurations on these MCUs, and this way the configuration for L4 and F7 can still be shared.

I haven't checked yet if the other MCUs (F3 / L0) are also affected.

### Issues/PRs references
none
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->