### PR TITLE
 murdock: add selected cortex-m boards to LLVM build

### DIFF
--- a/.murdock
+++ b/.murdock
@@ -1,7 +1,7 @@
 #!/bin/sh
 
 : ${TEST_BOARDS_AVAILABLE:="samr21-xpro"}
-: ${TEST_BOARDS_LLVM_COMPILE:="native"}
+: ${TEST_BOARDS_LLVM_COMPILE:="iotlab-m3 native nrf52dk mulle nucleo-f401re samr21-xpro slstk3402a"}
 
 export RIOT_CI_BUILD=1
 export STATIC_TESTS=${STATIC_TESTS:-1}

--- a/.murdock
+++ b/.murdock
@@ -166,7 +166,7 @@ compile() {
                     BOARD=$board make -C${appdir} test
                     RES=$?
                 elif is_in_list "$board" "$TEST_BOARDS_AVAILABLE"; then
-                    BOARD=$board make -C${appdir} test-murdock
+                    BOARD=$board TOOLCHAIN=$toolchain make -C${appdir} test-murdock
                     RES=$?
                 fi
             fi


### PR DESCRIPTION
### Contribution description
This allows Murdock also to build selected Cortex-M boards with LLVM.

There might be some discussion needed on the selection of boards. I tried to have one board present for each:

* CPU architecture (Cortex-M0(+), Cortex-M3, Cortex-M4, ...)
* Vendor (?) (STM32, EFM32, Kintetis, NRF, ...)

But up until now the selection is pretty arbitrary.

### Issues/PRs references
This list was originally selected in #9398.

Depends on ~~#9734~~ (merged), ~~#9821, #9824~~ (postponed), and ~~#9808~~ (merged).

Dependencies due to testing: ~~#10014~~ (merged), ~~#10024~~ (merged).