### PR TITLE
saul_adc: Add scaling option 

### DIFF
--- a/boards/frdm-k64f/Makefile.dep
+++ b/boards/frdm-k64f/Makefile.dep
@@ -1,5 +1,6 @@
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_adc
+  USEMODULE += analog_util
 endif
 
 include $(RIOTCPU)/kinetis/Makefile.dep

--- a/boards/frdm-k64f/include/adc_params.h
+++ b/boards/frdm-k64f/include/adc_params.h
@@ -49,7 +49,18 @@ static const  saul_adc_params_t saul_adc_params[] =
     { .name = "ADC1_DP1", .line = ADC_LINE(15), .res  = ADC_RES_16BIT, },
     { .name = "ADC1_DM1", .line = ADC_LINE(16), .res  = ADC_RES_16BIT, },
     { .name = "ADC1_DP1-ADC1_DM1", .line = ADC_LINE(17), .res  = ADC_RES_16BIT, },
-    { .name = "coretemp", .line = ADC_LINE(18), .res  = ADC_RES_16BIT, },
+    {
+        .name = "coretemp", .line = ADC_LINE(18), .res  = ADC_RES_16BIT,
+        .unit = UNIT_TEMP_C, .scale = -1,
+        /* Scaling the temperature sensor voltage to units of 0.1 Celsius, this
+         * depends on several numbers found in the data sheet as well as the
+         * analog reference voltage (VREFH), which is 3.3 V on FRDM-K64F.
+         * These numbers yield a full range of -1570..466 Cel, which is
+         * unrealistic, but because of the physical limits, the sensor will ever
+         * only use a small range of that interval. */
+        .val_min = (int32_t)(250 - ((   0 - 716) / 1.62) * 10),
+        .val_max = (int32_t)(250 - ((3300 - 716) / 1.62) * 10),
+    },
     { .name = "corebandgap", .line = ADC_LINE(19), .res  = ADC_RES_16BIT, },
 };
 

--- a/boards/mulle/Makefile.dep
+++ b/boards/mulle/Makefile.dep
@@ -18,6 +18,7 @@ USEMODULE += periph_rtt
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
   USEMODULE += saul_adc
+  USEMODULE += analog_util
 endif
 
 include $(RIOTCPU)/kinetis/Makefile.dep

--- a/boards/mulle/include/adc_params.h
+++ b/boards/mulle/include/adc_params.h
@@ -32,9 +32,16 @@ extern "C" {
 static const  saul_adc_params_t saul_adc_params[] =
 {
     {
-        .name = "k60temp",
-        .line = ADC_LINE(0),
-        .res  = ADC_RES_16BIT,
+        .name = "coretemp", .line = ADC_LINE(0), .res  = ADC_RES_16BIT,
+        .unit = UNIT_TEMP_C, .scale = -1,
+        /* Scaling the temperature sensor voltage to units of 0.1 Celsius, this
+         * depends on several numbers found in the data sheet as well as the
+         * analog reference voltage (VREFH), which is 3.3 V on FRDM-K64F.
+         * These numbers yield a full range of -1570..466 Cel, which is
+         * unrealistic, but because of the physical limits, the sensor will ever
+         * only use a small range of that interval. */
+        .val_min = (int32_t)(250 - ((   0 - 716) / 1.62) * 10),
+        .val_max = (int32_t)(250 - ((3300 - 716) / 1.62) * 10),
     },
     {
         .name = "k60vrefsh",
@@ -65,11 +72,17 @@ static const  saul_adc_params_t saul_adc_params[] =
         .name = "Vbat",
         .line = MULLE_VBAT_ADC_LINE,
         .res  = ADC_RES_16BIT,
+        .unit = UNIT_V, .scale = -3,
+        .val_min = 0,
+        .val_max = (3300 * 2), /* Compensate for the ADC input connected to Vbat/2 */
     },
     {
         .name = "Vchr",
         .line = MULLE_VCHR_ADC_LINE,
         .res  = ADC_RES_16BIT,
+        .unit = UNIT_V, .scale = -3,
+        .val_min = 0,
+        .val_max = (3300 * 2), /* Compensate for the ADC input connected to Vchr/2 */
     },
     {
         .name = "PGA0_DP",

--- a/drivers/include/saul/periph.h
+++ b/drivers/include/saul/periph.h
@@ -60,6 +60,10 @@ typedef struct {
     const char *name;       /**< name of the device connected to this pin */
     adc_t line;             /**< ADC line to initialize and expose */
     adc_res_t res;          /**< ADC resolution */
+    int32_t val_min;        /**< value corresponding to an ADC raw value of 0 */
+    int32_t val_max;        /**< value corresponding to the maximum ADC reading */
+    uint8_t unit;           /**< phydat unit */
+    int8_t  scale;          /**< phydat scale */
 } saul_adc_params_t;
 #endif /* MODULE_SAUL_ADC */
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Allows the saul_adc driver to produce physical measurements instead of raw ADC counts.
Only enabled when the analog_util module is used. Requires some additional configuration in adc_params.h.
The configuration is static for now, so certain use cases will need to hard code the analog reference voltage into the scaling parameters in adc_params.h (see Kinetis temperature sensor configuration for frdm-k64f).

Potential follow up PRs:
 - add option to convert to real voltage before scaling.
 - add option for non-linear scaling functions.

### Issues/PRs references

Configuration for this approach is much less complicated than what #8581 proposes. 