### PR TITLE
posix/pthread_rwlock: fix unsigned variable comparison

### DIFF
--- a/sys/posix/pthread/pthread_rwlock.c
+++ b/sys/posix/pthread/pthread_rwlock.c
@@ -191,7 +191,7 @@ static int pthread_rwlock_timedlock(pthread_rwlock_t *rwlock,
     uint64_t then = ((uint64_t)abstime->tv_sec * US_PER_SEC) +
                     (abstime->tv_nsec / NS_PER_US);
 
-    if ((then - now) <= 0) {
+    if (now >= then) {
         return ETIMEDOUT;
     }
     else {


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR fixes an unsigned int comparison in pthread_rwlock file ([as pointed out by Codacy](https://app.codacy.com/app/RIOT-OS/RIOT/file/21292631253/issues/source?bid=8454032&fileBranchId=8454032#l194)).
The line:
```
if ((then - now) <= 0) {
```
will only succeed when `then == now` but not when `then <= now` since `then` and `now` are unsigned int.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Issues/PRs references
none
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->