### PR TITLE
drivers/sx127x: Add initial support for multi interrupt pins

### DIFF
--- a/boards/sensebox_samd21/Makefile.include
+++ b/boards/sensebox_samd21/Makefile.include
@@ -22,5 +22,7 @@ else
   include $(RIOTMAKE)/tools/bossa.inc.mk
 endif
 
+CFLAGS += -DSX127X_USE_DIO_MULTI
+
 # setup the boards dependencies
 include $(RIOTBOARD)/$(BOARD)/Makefile.dep

--- a/boards/sensebox_samd21/include/board.h
+++ b/boards/sensebox_samd21/include/board.h
@@ -129,18 +129,17 @@ extern "C" {
 
 #define SX127X_PARAM_RESET                  GPIO_UNDEF
 
-#define SX127X_PARAM_DIOMULTI               XBEE1_INT_PIN       /* D24 */
+#define SX127X_PARAM_DIO0                   GPIO_UNDEF
+
+#define SX127X_PARAM_DIO1                   GPIO_UNDEF
+
+#define SX127X_PARAM_DIO2                   GPIO_UNDEF
+
+#define SX127X_PARAM_DIO3                   GPIO_UNDEF
+
+#define SX127X_PARAM_DIO_MULTI              XBEE1_INT_PIN       /* D24 */
 
 #define SX127X_PARAM_PASELECT               (SX127X_PA_BOOST)
-
-#define SX127X_PARAMS                     { .spi       = SX127X_PARAM_SPI,     \
-                                            .nss_pin   = SX127X_PARAM_SPI_NSS, \
-                                            .reset_pin = SX127X_PARAM_RESET,   \
-                                            .dio0_pin  = SX127X_PARAM_DIOMULTI,\
-                                            .dio1_pin  = SX127X_PARAM_DIO1,    \
-                                            .dio2_pin  = SX127X_PARAM_DIO2,    \
-                                            .dio3_pin  = SX127X_PARAM_DIO3,    \
-                                            .paselect  = SX127X_PARAM_PASELECT }
 /** @} */
 
 /**

--- a/drivers/include/sx127x.h
+++ b/drivers/include/sx127x.h
@@ -92,6 +92,9 @@ extern "C" {
 #define SX127X_IRQ_DIO3                  (1<<3)  /**< DIO3 IRQ */
 #define SX127X_IRQ_DIO4                  (1<<4)  /**< DIO4 IRQ */
 #define SX127X_IRQ_DIO5                  (1<<5)  /**< DIO5 IRQ */
+#ifdef SX127X_USE_DIO_MULTI
+#define SX127X_IRQ_DIO_MULTI             (1<<6)  /**< DIO MULTI IRQ */
+#endif
 /** @} */
 
 /**
@@ -208,6 +211,9 @@ typedef struct {
     gpio_t dio3_pin;                   /**< Interrupt line DIO3 (CAD done) */
     gpio_t dio4_pin;                   /**< Interrupt line DIO4 (not used) */
     gpio_t dio5_pin;                   /**< Interrupt line DIO5 (not used) */
+#ifdef SX127X_USE_DIO_MULTI
+    gpio_t dio_multi_pin;              /**< Interrupt line for multiple IRQs */
+#endif
     uint8_t paselect;                  /**< Power amplifier mode (RFO or PABOOST) */
 } sx127x_params_t;
 
@@ -246,7 +252,7 @@ void sx127x_setup(sx127x_t *dev, const sx127x_params_t *params);
  *
  * @param[in] dev                      The sx127x device descriptor
  */
-void sx127x_reset(const sx127x_t *dev);
+int sx127x_reset(const sx127x_t *dev);
 
 /**
  * @brief   Initializes the transceiver.

--- a/drivers/sx127x/include/sx127x_params.h
+++ b/drivers/sx127x/include/sx127x_params.h
@@ -60,19 +60,35 @@ extern "C" {
 #define SX127X_PARAM_DIO3                   GPIO_PIN(1, 4)       /* D5 */
 #endif
 
+#ifndef SX127X_PARAM_DIO_MULTI
+#define SX127X_PARAM_DIO_MULTI              GPIO_UNDEF
+#endif
+
 #ifndef SX127X_PARAM_PASELECT
 #define SX127X_PARAM_PASELECT               (SX127X_PA_RFO)
 #endif
 
 #ifndef SX127X_PARAMS
-#define SX127X_PARAMS                       { .spi       = SX127X_PARAM_SPI,     \
-                                              .nss_pin   = SX127X_PARAM_SPI_NSS, \
-                                              .reset_pin = SX127X_PARAM_RESET,   \
-                                              .dio0_pin  = SX127X_PARAM_DIO0,    \
-                                              .dio1_pin  = SX127X_PARAM_DIO1,    \
-                                              .dio2_pin  = SX127X_PARAM_DIO2,    \
-                                              .dio3_pin  = SX127X_PARAM_DIO3,    \
-                                              .paselect  = SX127X_PARAM_PASELECT }
+#ifdef SX127X_USE_DIO_MULTI
+#define SX127X_PARAMS             { .spi       = SX127X_PARAM_SPI,          \
+                                    .nss_pin   = SX127X_PARAM_SPI_NSS,      \
+                                    .reset_pin = SX127X_PARAM_RESET,        \
+                                    .dio0_pin  = SX127X_PARAM_DIO0,         \
+                                    .dio1_pin  = SX127X_PARAM_DIO1,         \
+                                    .dio2_pin  = SX127X_PARAM_DIO2,         \
+                                    .dio3_pin  = SX127X_PARAM_DIO3,         \
+                                    .dio_multi_pin = SX127X_PARAM_DIO_MULTI,\
+                                    .paselect  = SX127X_PARAM_PASELECT }
+#else
+#define SX127X_PARAMS             { .spi       = SX127X_PARAM_SPI,          \
+                                    .nss_pin   = SX127X_PARAM_SPI_NSS,      \
+                                    .reset_pin = SX127X_PARAM_RESET,        \
+                                    .dio0_pin  = SX127X_PARAM_DIO0,         \
+                                    .dio1_pin  = SX127X_PARAM_DIO1,         \
+                                    .dio2_pin  = SX127X_PARAM_DIO2,         \
+                                    .dio3_pin  = SX127X_PARAM_DIO3,         \
+                                    .paselect  = SX127X_PARAM_PASELECT }
+#endif
 #endif
 /**@}*/
 

--- a/drivers/sx127x/sx127x_netdev.c
+++ b/drivers/sx127x/sx127x_netdev.c
@@ -240,6 +240,37 @@ static void _isr(netdev_t *netdev)
     sx127x_t *dev = (sx127x_t *) netdev;
 
     uint8_t irq = dev->irq;
+
+#ifdef SX127X_USE_DIO_MULTI
+    /* if the IRQ is from an OR'd pin check the actual IRQ on the registers */
+    if (irq == SX127X_IRQ_DIO_MULTI) {
+        uint8_t interruptReg = sx127x_reg_read(dev, SX127X_REG_LR_IRQFLAGS);
+
+        switch (interruptReg) {
+            case SX127X_RF_LORA_IRQFLAGS_TXDONE:
+            case SX127X_RF_LORA_IRQFLAGS_RXDONE:
+                irq = SX127X_IRQ_DIO0;
+                break;
+
+            case SX127X_RF_LORA_IRQFLAGS_RXTIMEOUT:
+                irq = SX127X_IRQ_DIO1;
+                break;
+
+            case SX127X_RF_LORA_IRQFLAGS_FHSSCHANGEDCHANNEL:
+                irq = SX127X_IRQ_DIO2;
+                break;
+
+            case SX127X_RF_LORA_IRQFLAGS_CADDETECTED:
+            case SX127X_RF_LORA_IRQFLAGS_CADDONE:
+                irq = SX127X_IRQ_DIO3;
+                break;
+
+            default:
+                break;
+        }
+    }
+#endif
+
     dev->irq = 0;
 
     switch (irq) {


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
[Some boards](https://learn.watterott.com/bee-modules/lora/) that breakout the sx127x radios unify the interrupt pins into a single one. This is an initial support for those cases. When the *multi dio* pin triggers an interrupt the registers on the sx127x are checked to identify the interrupt cause, and the appropriate isr is executed. 

Currently this fix is needed by the 'SenseBox with SAMD21' board.

### Usage
To enable the "multi dio" pin the macro `SX127X_USE_DIO_MULTI` must be defined. This can be done by adding `CFLAGS += -DSX127X_USE_DIO_MULTI` to the makefile of the board.