### PR TITLE
boards/lobaro-lorabox: Add support for Lobaro LoraBox board

### DIFF
--- a/boards/lobaro-lorabox/Makefile
+++ b/boards/lobaro-lorabox/Makefile
@@ -1,0 +1,3 @@
+MODULE = board
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/lobaro-lorabox/Makefile.dep
+++ b/boards/lobaro-lorabox/Makefile.dep
@@ -1,0 +1,3 @@
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += saul_gpio
+endif

--- a/boards/lobaro-lorabox/Makefile.features
+++ b/boards/lobaro-lorabox/Makefile.features
@@ -1,0 +1,9 @@
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_gpio
+FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_rtc
+FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart
+
+-include $(RIOTCPU)/stm32l1/Makefile.features

--- a/boards/lobaro-lorabox/Makefile.include
+++ b/boards/lobaro-lorabox/Makefile.include
@@ -1,0 +1,26 @@
+## the cpu to build for
+export CPU = stm32l1
+export CPU_MODEL = stm32l151cb
+
+# add the common header files to the include path
+INCLUDES  += -I$(RIOTBOARD)/lobaro-lorabox/include
+
+# configure the serial terminal
+PORT_LINUX ?= /dev/ttyUSB0
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
+
+# setup serial terminal
+include $(RIOTMAKE)/tools/serial.inc.mk
+
+FLASHER = $(RIOTTOOLS)/stm32loader/stm32loader.py
+
+# needed for now so the build system generates the .bin file
+HEXFILE = $(BINFILE)
+
+# -e: erase
+# -u: use sector by sector erase
+# -S: swap RTS and DTR
+# -l 0x1ff: amount of sectors to erase
+FFLAGS += -e -u -S -l 0x1ff -w $(BINFILE)
+
+TERMFLAGS +=  --set-rts 0

--- a/boards/lobaro-lorabox/board.c
+++ b/boards/lobaro-lorabox/board.c
@@ -1,0 +1,29 @@
+/*
+ * Copyright (C) 2018 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_lobaro_lorabox
+ * @{
+ *
+ * @file
+ * @brief       Board initialization code for Lobaro LoraBox
+ *
+ * @author      Leandro Lanzieri <leandro.lanzieri@haw-hamburg.de>
+ * @}
+ */
+
+#include "board.h"
+#include "periph/gpio.h"
+
+void board_init(void)
+{
+    /* initialize the CPU */
+    cpu_init();
+    gpio_init(LED0_PIN, GPIO_OUT);
+    gpio_init(EN3V3_PIN, GPIO_OUT);
+}

--- a/boards/lobaro-lorabox/doc.txt
+++ b/boards/lobaro-lorabox/doc.txt
@@ -1,0 +1,91 @@
+/**
+@defgroup    boards_lobaro_lorabox Lobaro Lorabox
+@ingroup     boards
+@brief       Support for the Lobaro LoraBox with stm32l151cb-a
+
+## Hardware
+
+![LoraBox](https://www.lobaro.com/wp/wp-content/uploads/2017/03/Lobaro_wMBUS_LoRaWAN_Bridge.jpg)
+
+
+### MCU
+| MCU        | stm32l151cb-a |
+|:------------- |:--------------------- |
+| Family | ARM Cortex-M3     |
+| Vendor | ST Microelectronics   |
+| RAM        | 16Kb  |
+| Flash      | 128Kb             |
+| Frequency  | 32MHz (no external oscilator connected) |
+| FPU        | no                |
+| Timers | 10 (8x 16-bit, 2x watchdog timers)   |
+| ADCs       | 1x 24-channel 12-bit          |
+| UARTs      | 3                 |
+| SPIs       | 2                 |
+| I2Cs       | 2                 |
+| Vcc        | 1.65V - 3.6V          |
+| Datasheet  | [Datasheet](https://www.st.com/resource/en/datasheet/stm32l151cb-a.pdf) |
+| Reference Manual | [Reference Manual](https://www.st.com/content/ccc/resource/technical/document/reference_manual/cc/f9/93/b2/f0/82/42/57/CD00240193.pdf/files/CD00240193.pdf/jcr:content/translations/en.CD00240193.pdf) |
+| Programming Manual | [Programming Manual](https://www.st.com/content/ccc/resource/technical/document/programming_manual/5b/ca/8d/83/56/7f/40/08/CD00228163.pdf/files/CD00228163.pdf/jcr:content/translations/en.CD00228163.pdf) |
+| Board Manual   | [Board Manual](https://www.lobaro.com/download/7250/)|
+
+### User Interface
+
+1 LEDs:
+
+| NAME   | LED0   |
+| -----  | ----- |
+| Color  | green |
+| Pin    | P1   |
+
+
+## Flashing
+### Connections
+To flash using the STM32 ROM bootloader on the board, use the provided UART-USB
+bridge and connect it to the *Config* port. The *Config* port pinout is the
+following:
+
+```
+---------------     ---------------
+| 1 2 3 4 5 6 |     | x x x x x x |
+---------------     ---------------
+    Config               Addon
+
+1: RST
+2: VCC
+3: RX1
+4: TX1
+5: Boot0
+6: GND
+```
+
+### STM32 Loader
+To flash RIOT on the board, after connection the UART-USB bridge, just run:
+```
+BOARD=lobaro-lorabox make flash
+```
+This uses the stm32loader script to erase the memory and flash it interfacing
+with the STM32 ROM bootloader.
+
+### Lobaro Tool
+Another way of interfacing with the STM32 ROM bootloader is using the **Lobaro Maintenance Tool** provided
+[online](https://www.lobaro.com/lobaro-maintenance-tool/) for free for Linux,
+Mac & Windows. It allows flashing and accessing the UART.
+
+![LobaroTool](https://www.lobaro.com/wp/wp-content/uploads/2018/03/Lobaro_Tool_FirmwareUpdateFeature.png)
+
+## Connecting via Serial
+The default UART port is the USART1, the same that is used for flashing, so it
+is available on the *Config* port. The default port is /dev/ttyUSB0. To access
+the port run:
+```
+BOARD=lobaro-lorabox make term
+```
+**Note:** If you want to access the port with a different application please
+keep in mind that RTS must be set to '0' and DTR to '1' as the provided UART-USB
+bridge seems to invert this lines.
+ */
+
+## SX1272 radio
+Please note that the board has a Semtech SX1272 radio. This means that when the
+semtech-loramac package or the sx127x driver are used the correct driver version
+(sx1272) must be selected.

--- a/boards/lobaro-lorabox/include/board.h
+++ b/boards/lobaro-lorabox/include/board.h
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2018 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_lobaro_lorabox
+ * @brief       Support for Lobaro LoraBox
+ * @{
+ *
+ * @file
+ * @brief       Common pin definitions and board configuration options
+ *
+ * @author      Leandro Lanzieri <leandro.lanzieri@haw-hamburg.de>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    LED pin definitions and handlers
+ * @{
+ */
+#define AUTO_INIT_LED0
+#define LED0_PORT           GPIOA
+#define LED0_PIN            GPIO_PIN(PORT_A, 1)
+#define LED0_MASK           (1 << 1)
+
+#define LED0_ON             (LED0_PORT->BSRR = (LED0_MASK << 16))
+#define LED0_OFF            (LED0_PORT->BSRR = LED0_MASK)
+#define LED0_TOGGLE         (LED0_PORT->ODR  ^= LED0_MASK)
+
+#define EN3V3_PORT          GPIOA
+#define EN3V3_PIN           GPIO_PIN(PORT_A, 11)
+#define EN3V3_MASK          (1 << 11)
+
+#define EN3V3_ON            (EN3V3_PORT->BSRR = EN3V3_MASK)
+#define EN3V3_OFF           (EN3V3_PORT->BSRR = (EN3V3_MASK << 16))
+#define EN3V3_TOGGLE        (EN3V3_PORT->ODR  ^= EN3V3_MASK)
+/** @} */
+
+/**
+ * @name        SX127X
+ *
+ * SX127X configuration.
+ * @{
+ */
+#define SX127X_PARAM_SPI                (SPI_DEV(0))
+
+#define SX127X_PARAM_SPI_NSS            GPIO_PIN(PORT_B, 0)
+
+#define SX127X_PARAM_RESET              GPIO_PIN(PORT_A, 4)
+
+#define SX127X_PARAM_DIO0               GPIO_PIN(PORT_B, 1)
+
+#define SX127X_PARAM_DIO1               GPIO_PIN(PORT_B, 10)
+
+#define SX127X_PARAM_DIO2               GPIO_PIN(PORT_B, 11)
+
+#define SX127X_PARAM_DIO3               GPIO_PIN(PORT_B, 7)
+
+#define SX127X_PARAM_PASELECT           (SX127X_PA_RFO)
+
+#define SX127X_PARAMS                   {   .spi       = SX127X_PARAM_SPI,     \
+                                            .nss_pin   = SX127X_PARAM_SPI_NSS, \
+                                            .reset_pin = SX127X_PARAM_RESET,   \
+                                            .dio0_pin  = SX127X_PARAM_DIO0,    \
+                                            .dio1_pin  = SX127X_PARAM_DIO1,    \
+                                            .dio2_pin  = SX127X_PARAM_DIO2,    \
+                                            .dio3_pin  = SX127X_PARAM_DIO3,    \
+                                            .paselect  = SX127X_PARAM_PASELECT \
+                                        }
+/** @} */
+
+/**
+ * @brief Initialize board specific hardware, including clock, LEDs and std-IO
+ */
+void board_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/lobaro-lorabox/include/gpio_params.h
+++ b/boards/lobaro-lorabox/include/gpio_params.h
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2018 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_lobaro_lorabox
+ * @{
+ *
+ * @file
+ * @brief       Board specific configuration of direct mapped GPIOs
+ *
+ * @author      Leandro Lanzieri <leandro.lanzieri@haw-hamburg.de>
+ */
+
+#ifndef GPIO_PARAMS_H
+#define GPIO_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    GPIO pin configuration
+ */
+static const  saul_gpio_params_t saul_gpio_params[] =
+{
+#ifdef AUTO_INIT_LED0
+    {
+        .name = "LED(green)",
+        .pin = LED0_PIN,
+        .mode = GPIO_OUT
+    },
+#endif
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_PARAMS_H */
+/** @} */

--- a/boards/lobaro-lorabox/include/periph_conf.h
+++ b/boards/lobaro-lorabox/include/periph_conf.h
@@ -1,0 +1,232 @@
+/*
+ * Copyright (C) 2014-2016 Freie Universität Berlin
+ *               2018 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_lobaro_lorabox
+ * @brief       Support for the Lobaro lorabox with stm32l151cb
+ * @{
+ *
+ * @file
+ * @brief       Peripheral MCU configuration for the Lobaro lorabox board
+ *
+ * @author      Thomas Eichinger <thomas.eichinger@fu-berlin.de>
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author      Kevin Weiss <kevin.weiss@haw-hamburg.de>
+ * @author      Leandro Lanzieri <leandro.lanzieri@haw-hamburg.de>
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+#include "periph_cpu.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+
+/**
+ * @name    xtimer configuration
+ * @{
+ */
+#define XTIMER_WIDTH        (16)
+#define XTIMER_BACKOFF      (50)
+#define XTIMER_ISR_BACKOFF  (40)
+/** @} */
+
+/**
+ * @name Clock system configuration
+ * @{
+ **/
+#define CLOCK_HSI           (16000000U)             /* frequency of internal oscillator */
+#define CLOCK_CORECLOCK     (32000000U)             /* targeted core clock frequency */
+/*
+ * 0: no external low speed crystal available,
+ * 1: external crystal available (always 32.768kHz)
+ */
+#ifndef CLOCK_LSE
+#define CLOCK_LSE           (1)
+#endif
+/* configuration of PLL prescaler and multiply values */
+/* CORECLOCK := HSI / CLOCK_PLL_DIV * CLOCK_PLL_MUL */
+#define CLOCK_PLL_DIV       RCC_CFGR_PLLDIV2
+#define CLOCK_PLL_MUL       RCC_CFGR_PLLMUL4
+/* configuration of peripheral bus clock prescalers */
+#define CLOCK_AHB_DIV       RCC_CFGR_HPRE_DIV1      /* AHB clock -> 32MHz */
+#define CLOCK_APB2_DIV      RCC_CFGR_PPRE2_DIV1     /* APB2 clock -> 32MHz */
+#define CLOCK_APB1_DIV      RCC_CFGR_PPRE1_DIV1     /* APB1 clock -> 32MHz */
+/* configuration of flash access cycles */
+#define CLOCK_FLASH_LATENCY FLASH_ACR_LATENCY
+
+/* bus clocks for simplified peripheral initialization, UPDATE MANUALLY! */
+#define CLOCK_AHB           (CLOCK_CORECLOCK / 1)
+#define CLOCK_APB2          (CLOCK_CORECLOCK / 1)
+#define CLOCK_APB1          (CLOCK_CORECLOCK / 1)
+/** @} */
+
+/**
+ * @name   Timer configuration
+ * @{
+ */
+static const timer_conf_t timer_config[] = {
+    {
+        .dev      = TIM2,
+        .max      = 0x0000ffff,
+        .rcc_mask = RCC_APB1ENR_TIM2EN,
+        .bus      = APB1,
+        .irqn     = TIM2_IRQn
+    }
+};
+
+#define TIMER_0_ISR         (isr_tim2)
+
+#define TIMER_NUMOF         (sizeof(timer_config) / sizeof(timer_config[0]))
+/** @} */
+
+/**
+ * @name Real time counter configuration
+ * @{
+ */
+#define RTC_NUMOF           (1U)
+/** @} */
+
+/**
+ * @name   UART configuration
+ * @{
+ */
+static const uart_conf_t uart_config[] = {
+    {
+        .dev      = USART1,
+        .rcc_mask = RCC_APB2ENR_USART1EN,
+        .rx_pin   = GPIO_PIN(PORT_A, 10),
+        .tx_pin   = GPIO_PIN(PORT_A, 9),
+        .rx_af    = GPIO_AF7,
+        .tx_af    = GPIO_AF7,
+        .bus      = APB2,
+        .irqn     = USART1_IRQn
+    },
+    {
+        .dev      = USART2,
+        .rcc_mask = RCC_APB1ENR_USART2EN,
+        .rx_pin   = GPIO_PIN(PORT_A, 3),
+        .tx_pin   = GPIO_PIN(PORT_A, 2),
+        .rx_af    = GPIO_AF7,
+        .tx_af    = GPIO_AF7,
+        .bus      = APB1,
+        .irqn     = USART2_IRQn
+    }
+};
+
+#define UART_0_ISR          (isr_usart1)
+#define UART_1_ISR          (isr_usart2)
+
+#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+/** @} */
+
+/**
+ * @name   PWM configuration
+ * @{
+ */
+#define PWM_NUMOF           0
+/** @} */
+
+/**
+ * @name   SPI configuration
+ *
+ * @note    The spi_divtable is auto-generated from
+ *          `cpu/stm32_common/dist/spi_divtable/spi_divtable.c`
+ * @{
+ */
+static const uint8_t spi_divtable[2][5] = {
+    {       /* for APB1 @ 32000000Hz */
+        7,  /* -> 125000Hz */
+        5,  /* -> 500000Hz */
+        4,  /* -> 1000000Hz */
+        2,  /* -> 4000000Hz */
+        1   /* -> 8000000Hz */
+    },
+    {       /* for APB2 @ 32000000Hz */
+        7,  /* -> 125000Hz */
+        5,  /* -> 500000Hz */
+        4,  /* -> 1000000Hz */
+        2,  /* -> 4000000Hz */
+        1   /* -> 8000000Hz */
+    }
+};
+
+static const spi_conf_t spi_config[] = {
+    {
+        .dev      = SPI1,
+        .mosi_pin = GPIO_PIN(PORT_A, 7),
+        .miso_pin = GPIO_PIN(PORT_A, 6),
+        .sclk_pin = GPIO_PIN(PORT_A, 5),
+        .cs_pin   = GPIO_PIN(PORT_B, 0),
+        .af       = GPIO_AF5,
+        .rccmask  = RCC_APB2ENR_SPI1EN,
+        .apbbus   = APB2
+    },
+    {
+        .dev      = SPI2,
+        .mosi_pin = GPIO_PIN(PORT_B, 14),
+        .miso_pin = GPIO_PIN(PORT_B, 15),
+        .sclk_pin = GPIO_PIN(PORT_B, 13),
+        .cs_pin   = GPIO_PIN(PORT_B, 12),
+        .af       = GPIO_AF5,
+        .rccmask  = RCC_APB1ENR_SPI2EN,
+        .apbbus   = APB1
+    }
+};
+
+#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+/** @} */
+
+/**
+ * @name I2C configuration
+  * @{
+ */
+static const i2c_conf_t i2c_config[] = {
+    {
+        .dev            = I2C1,
+        .speed          = I2C_SPEED_NORMAL,
+        .scl_pin        = GPIO_PIN(PORT_B, 8),
+        .sda_pin        = GPIO_PIN(PORT_B, 9),
+        .scl_af         = GPIO_AF4,
+        .sda_af         = GPIO_AF4,
+        .bus            = APB1,
+        .rcc_mask       = RCC_APB1ENR_I2C1EN,
+        .clk            = CLOCK_APB1,
+        .irqn           = I2C1_EV_IRQn
+    }
+};
+
+#define I2C_0_ISR           isr_i2c1_ev
+
+#define I2C_NUMOF           (sizeof(i2c_config) / sizeof(i2c_config[0]))
+/** @} */
+
+/**
+ * @name   ADC configuration
+ * @{
+ */
+#define ADC_NUMOF           (0U)
+/** @} */
+
+/**
+ * @name   DAC configuration
+ * @{
+ */
+#define DAC_NUMOF           0
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_CONF_H */
+/** @} */

--- a/cpu/stm32l1/include/cpu_conf.h
+++ b/cpu/stm32l1/include/cpu_conf.h
@@ -46,7 +46,7 @@
  * * STM32L1XX_XL: Ultra Low Power XL-density devices: STM32L151xExx,
  *   STM32L152xExx and STM32L162xExx
  */
-#if defined(CPU_MODEL_STM32L151RBA)
+#if defined(CPU_MODEL_STM32L151RBA) || defined(CPU_MODEL_STM32L151CB)
 #define STM32L1XX_MD (1U)
 #elif defined(CPU_MODEL_STM32L151RC)
 #define STM32L1XX_MDP (1U)
@@ -64,7 +64,7 @@ extern "C" {
  * @{
  */
 #define CPU_DEFAULT_IRQ_PRIO            (1U)
-#if defined(CPU_MODEL_STM32L151RBA)
+#if defined(CPU_MODEL_STM32L151RBA) || defined(CPU_MODEL_STM32L151CB)
 #define CPU_IRQ_NUMOF                   (45U)
 #else
 #define CPU_IRQ_NUMOF                   (57U)
@@ -76,13 +76,16 @@ extern "C" {
  * @name   Flash page configuration
  * @{
  */
-#if defined(CPU_MODEL_STM32L152RE) || defined(CPU_MODEL_STM32L151RC)
+#if defined(CPU_MODEL_STM32L152RE) || defined(CPU_MODEL_STM32L151RC) || defined(CPU_MODEL_STM32L151CB)
 #define FLASHPAGE_SIZE             (256U)
 #if defined(CPU_MODEL_STM32L152RE)
 #define FLASHPAGE_NUMOF            (2048U)    /* 512KB */
 #endif
 #if defined(CPU_MODEL_STM32L151RC)
 #define FLASHPAGE_NUMOF            (1024U)    /* 256KB */
+#endif
+#if defined(CPU_MODEL_STM32L151CB)
+#define FLASHPAGE_NUMOF            (512U)     /* 128KB */
 #endif
 #endif
 /* The minimum block size which can be written is 4B. However, the erase

--- a/cpu/stm32l1/include/periph_cpu.h
+++ b/cpu/stm32l1/include/periph_cpu.h
@@ -30,7 +30,7 @@ extern "C" {
 /**
  * @name    Starting address of the CPU ID
  */
-#ifdef CPU_MODEL_STM32L151RBA
+#if defined(CPU_MODEL_STM32L151RBA) || defined(CPU_MODEL_STM32L151CB)
 #define CPUID_ADDR          (0x1ff80050)
 #else
 #define CPUID_ADDR          (0x1ff800d0)
@@ -82,6 +82,8 @@ typedef enum {
 #define EEPROM_SIZE                (16384UL)  /* 16kB */
 #elif defined(CPU_MODEL_STM32L151RC)
 #define EEPROM_SIZE                (8192U)    /* 8kB */
+#elif defined(CPU_MODEL_STM32L151CB)
+#define EEPROM_SIZE                (4096U)    /* 4kB */
 #endif
 /** @} */
 

--- a/dist/tools/flake8/check.sh
+++ b/dist/tools/flake8/check.sh
@@ -23,7 +23,7 @@ cd $RIOTBASE
 : "${RIOTTOOLS:=${RIOTBASE}/dist/tools}"
 . "${RIOTTOOLS}"/ci/changed_files.sh
 
-EXCLUDE='^(.+/vendor/|dist/tools/cc2538-bsl|dist/tools/mcuboot|dist/tools/uhcpd)'
+EXCLUDE='^(.+/vendor/|dist/tools/cc2538-bsl|dist/tools/mcuboot|dist/tools/uhcpd|dist/tools/stm32loader)'
 FILEREGEX='(\.py$|pyterm$)'
 FILES=$(FILEREGEX=${FILEREGEX} EXCLUDE=${EXCLUDE} changed_files)
 

--- a/dist/tools/stm32loader/stm32loader.py
+++ b/dist/tools/stm32loader/stm32loader.py
@@ -1,0 +1,668 @@
+#!/usr/bin/env python3
+
+# -*- coding: utf-8 -*-
+# vim: sw=4:ts=4:si:et:enc=utf-8
+
+# Author: Ivan A-R <ivan@tuxotronic.org>
+# With hacky error recovery by Gordon Williams <gw@pur3.co.uk>
+# Project page: http://tuxotronic.org/wiki/projects/stm32loader
+#
+# This file is part of stm32loader.
+#
+# stm32loader is free software; you can redistribute it and/or modify it under
+# the terms of the GNU General Public License as published by the Free
+# Software Foundation; either version 3, or (at your option) any later
+# version.
+#
+# stm32loader is distributed in the hope that it will be useful, but WITHOUT ANY
+# WARRANTY; without even the implied warranty of MERCHANTABILITY or
+# FITNESS FOR A PARTICULAR PURPOSE.  See the GNU General Public License
+# for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with stm32loader; see the file COPYING3.  If not see
+# <http://www.gnu.org/licenses/>.
+
+from __future__ import print_function
+
+import sys
+import getopt
+import serial
+import time
+import glob
+import tempfile
+import os
+import subprocess
+
+try:
+    from progressbar import *
+    usepbar = 1
+except:
+    usepbar = 0
+
+# Verbose level
+QUIET = 0
+
+def mdebug(level, message):
+    if QUIET >= level:
+        print(message, file=sys.stderr)
+
+# Takes chip IDs (obtained via Get ID command) to human-readable names
+CHIP_ID_STRS = {0x410: 'STM32F1, performance, medium-density',
+                0x411: 'STM32F2',
+                0x412: 'STM32F1, performance, low-density',
+                0x413: 'STM32F4',
+                0x414: 'STM32F1, performance, high-density',
+                0x416: 'STM32L1, performance, medium-density',
+                0x418: 'STM32F1, connectivity',
+                0x420: 'STM32F1, value, medium-density',
+                0x428: 'STM32F1, value, high-density',
+                0x429: 'STM32L1',
+                0x430: 'STM32F1, performance, XL-density'}
+
+class CmdException(Exception):
+    pass
+
+class CommandInterface(object):
+    def open(self, aport='/dev/tty.usbserial-FTD3TMCH', abaudrate=115200) :
+        self.sp = serial.Serial(
+            port=aport,
+            baudrate=abaudrate,     # baudrate
+            bytesize=8,             # number of databits
+            parity=serial.PARITY_EVEN,
+            stopbits=1,
+            xonxoff=0,              # enable software flow control
+            rtscts=0,               # disable RTS/CTS flow control
+            timeout=0.5             # set a timeout value, None for waiting forever
+        )
+
+
+    def _wait_for_ack(self, info="", timeout=0):
+        stop = time.time() + timeout
+        got = None
+        while not got:
+            got = self.sp.read(1)
+            if time.time() > stop:
+                break
+
+        if not got:
+            raise CmdException("No response to %s" % info)
+
+        # wait for ask
+        ask = ord(got)
+
+        if ask == 0x79:
+            # ACK
+            return 1
+        elif ask == 0x1F:
+            # NACK
+            raise CmdException("Chip replied with a NACK during %s" % info)
+
+        # Unknown response
+        raise CmdException("Unrecognised response 0x%x to %s" % (ask, info))
+
+    def reset(self, swapRtsDtr=False):
+        if swapRtsDtr:
+            self.sp.setRTS(1)
+            time.sleep(0.1)
+            self.sp.setRTS(0)
+            time.sleep(0.5)
+        else:
+            self.sp.setDTR(1)
+            time.sleep(0.1)
+            self.sp.setDTR(0)
+            time.sleep(0.5)
+
+    def initChip(self, swapRtsDtr=False):
+        # Set boot
+        if swapRtsDtr:
+            self.sp.setDTR(0)
+        else:
+            self.sp.setRTS(0)
+
+        self.reset(swapRtsDtr)
+
+        # Be a bit more persistent when trying to initialise the chip
+        stop = time.time() + 5.0
+
+        while time.time() <= stop:
+            self.sp.write(bytes([0x7f]))
+
+            got = self.sp.read()
+
+            # The chip will ACK a sync the very first time and
+            # NACK it every time afterwards
+            if got and got in bytes([0x79,0x1f]):
+                # Synced up
+                return
+
+        raise CmdException('No response while trying to sync')
+
+    def releaseChip(self, swapRtsDtr=False):
+        if swapRtsDtr:
+            self.sp.setDTR(1)
+        else:
+            self.sp.setRTS(1)
+
+        self.reset()
+
+    def cmdGeneric(self, cmd):
+        cmdByte = bytes([cmd])
+        ctrlByte = bytes([cmd ^ 0xFF])
+        self.sp.write(cmdByte)
+        self.sp.write(ctrlByte) # Control byte
+        return self._wait_for_ack(hex(cmd))
+
+    def cmdGet(self):
+        if self.cmdGeneric(0x00):
+            mdebug(10, "*** Get command");
+            len = ord(self.sp.read())
+            version = ord(self.sp.read())
+            mdebug(10, "    Bootloader version: "+hex(version))
+            dat = map(lambda c: hex(ord(c)), self.sp.read(len))
+            mdebug(10, "    Available commands: "+str(dat))
+            self._wait_for_ack("0x00 end")
+            return version
+        else:
+            raise CmdException("Get (0x00) failed")
+
+    def cmdGetVersion(self):
+        if self.cmdGeneric(0x01):
+            mdebug(10, "*** GetVersion command")
+            version = ord(self.sp.read())
+            self.sp.read(2)
+            self._wait_for_ack("0x01 end")
+            mdebug(10, "    Bootloader version: "+hex(version))
+            return version
+        else:
+            raise CmdException("GetVersion (0x01) failed")
+
+    def cmdGetID(self):
+        if self.cmdGeneric(0x02):
+            mdebug(10, "*** GetID command")
+            len = ord(self.sp.read())
+            id = self.sp.read(len+1)
+            self._wait_for_ack("0x02 end")
+            return id
+        else:
+            raise CmdException("GetID (0x02) failed")
+
+
+    def _encode_addr(self, addr):
+        byte3 = (addr >> 0) & 0xFF
+        byte2 = (addr >> 8) & 0xFF
+        byte1 = (addr >> 16) & 0xFF
+        byte0 = (addr >> 24) & 0xFF
+        crc = byte0 ^ byte1 ^ byte2 ^ byte3
+        return [byte0, byte1, byte2, byte3, crc]
+
+
+    def cmdReadMemory(self, addr, lng):
+        assert(lng <= 256)
+        if self.cmdGeneric(0x11):
+            mdebug(10, "*** ReadMemory command")
+            self.sp.write(self._encode_addr(addr))
+            self._wait_for_ack("0x11 address failed")
+            N = (lng - 1) & 0xFF
+            crc = N ^ 0xFF
+            self.sp.write(bytes([N, crc]))
+            self._wait_for_ack("0x11 length failed")
+            return self.sp.read(lng)
+        else:
+            raise CmdException("ReadMemory (0x11) failed")
+
+
+    def cmdGo(self, addr):
+        if self.cmdGeneric(0x21):
+            mdebug(10, "*** Go command")
+            self.sp.write(self._encode_addr(addr))
+            self._wait_for_ack("0x21 go failed")
+        else:
+            raise CmdException("Go (0x21) failed")
+
+
+    def cmdWriteMemory(self, addr, data):
+        assert(len(data) <= 256)
+        if self.cmdGeneric(0x31):
+            mdebug(10, "*** Write memory command")
+            self.sp.write(bytes(self._encode_addr(addr)))
+            self._wait_for_ack("0x31 address failed")
+            #map(lambda c: hex(ord(c)), data)
+            lng = (len(data)-1) & 0xFF
+            mdebug(10, "    %s bytes to write" % [lng+1]);
+            self.sp.write(bytes([lng])) # len really
+            crc = 0xFF
+            try:
+              dataBytes = []
+              for c in data:
+                  crc = crc ^ c
+                  dataBytes.append(c)
+              dataBytes.append(crc)
+              self.sp.write(bytes(dataBytes))
+              self._wait_for_ack("0x31 programming failed")
+              mdebug(10, "    Write memory done")
+            except:
+              mdebug(5, "    WRITE FAIL - try and recover")
+              for c in data:
+                self.sp.write(bytes([255]))
+              mdebug(5, "    WRITE FAIL - wait")
+              stop = time.time() + 1
+              while time.time() < stop:
+                if self.sp.inWaiting()>0: self.sp.read(self.sp.inWaiting())
+              mdebug(5, "    WRITE FAIL - retry")
+              self.cmdWriteMemory(addr, data)
+        else:
+            raise CmdException("Write memory (0x31) failed")
+
+
+    def cmdEraseMemory(self, sectors = None):
+        if self.cmdGeneric(0x43):
+            mdebug(10, "*** Erase memory command")
+            if sectors is None:
+                # Global erase
+                self.sp.write(chr(0xFF))
+                self.sp.write(chr(0x00))
+            else:
+                # Sectors erase
+                self.sp.write(chr((len(sectors)-1) & 0xFF))
+                crc = 0xFF
+                for c in sectors:
+                    crc = crc ^ c
+                    self.sp.write(chr(c))
+                self.sp.write(chr(crc))
+            self._wait_for_ack("0x43 erasing failed")
+            mdebug(10, "    Erase memory done")
+        else:
+            raise CmdException("Erase memory (0x43) failed")
+
+
+    GLOBAL_ERASE_TIMEOUT_SECONDS = 20   # This takes a while
+    def cmdExtendedEraseMemory(self, useSectorErase = False, amountOfSectors = 0x1ff):
+        if self.cmdGeneric(0x44):
+            if not useSectorErase:
+                mdebug(10, "*** Extended erase memory command")
+                # Global mass erase
+                mdebug(5, "Global mass erase; this may take a while")
+                self.sp.write(chr(0xFF))
+                self.sp.write(chr(0xFF))
+                # Checksum
+                self.sp.write(chr(0x00))
+                self._wait_for_ack("0x44 extended erase failed",
+                                timeout=self.GLOBAL_ERASE_TIMEOUT_SECONDS)
+                mdebug(10, "    Extended erase memory done")
+            else:
+                mdebug(10, "    Performing non global erase")
+
+                # Data to be sent
+                data = []
+
+                crc = 0
+                msb = (amountOfSectors >> 8) & 0xff
+                lsb = amountOfSectors & 0xff
+
+                crc ^= msb
+                crc ^= lsb
+
+                data.append(msb)
+                data.append(lsb)
+
+                for sector in range(0, amountOfSectors+1):
+                    msb = sector >> 8 & 0xff
+                    lsb = sector & 0xff
+                    crc ^= msb
+                    crc ^= lsb
+                    data.append(msb)
+                    data.append(lsb)
+
+                data.append(crc)
+
+                for b in data:
+                    self.sp.write(bytes([b]))
+
+            self._wait_for_ack("0x44 erasing failed", timeout=self.GLOBAL_ERASE_TIMEOUT_SECONDS)
+            mdebug(10, "    Erase memory done")
+        else:
+            raise CmdException("Extended erase memory (0x44) failed")
+
+
+    def cmdWriteProtect(self, sectors):
+        if self.cmdGeneric(0x63):
+            mdebug(10, "*** Write protect command")
+            self.sp.write(chr((len(sectors)-1) & 0xFF))
+            crc = 0xFF
+            for c in sectors:
+                crc = crc ^ c
+                self.sp.write(chr(c))
+            self.sp.write(chr(crc))
+            self._wait_for_ack("0x63 write protect failed")
+            mdebug(10, "    Write protect done")
+        else:
+            raise CmdException("Write Protect memory (0x63) failed")
+
+    def cmdWriteUnprotect(self):
+        if self.cmdGeneric(0x73):
+            mdebug(10, "*** Write Unprotect command")
+            self._wait_for_ack("0x73 write unprotect failed")
+            self._wait_for_ack("0x73 write unprotect 2 failed")
+            mdebug(10, "    Write Unprotect done")
+        else:
+            raise CmdException("Write Unprotect (0x73) failed")
+
+    def cmdReadoutProtect(self):
+        if self.cmdGeneric(0x82):
+            mdebug(10, "*** Readout protect command")
+            self._wait_for_ack("0x82 readout protect failed")
+            self._wait_for_ack("0x82 readout protect 2 failed")
+            mdebug(10, "    Read protect done")
+        else:
+            raise CmdException("Readout protect (0x82) failed")
+
+    def cmdReadoutUnprotect(self):
+        if self.cmdGeneric(0x92):
+            mdebug(10, "*** Readout Unprotect command")
+            self._wait_for_ack("0x92 readout unprotect failed")
+            self._wait_for_ack("0x92 readout unprotect 2 failed")
+            mdebug(10, "    Read Unprotect done")
+        else:
+            raise CmdException("Readout unprotect (0x92) failed")
+
+
+# Complex commands section
+
+    def readMemory(self, addr, lng):
+        data = bytes([])
+        if usepbar:
+            widgets = ['Reading: ', Percentage(),', ', ETA(), ' ', Bar()]
+            pbar = ProgressBar(widgets=widgets,maxval=lng, term_width=79).start()
+
+        while lng > 256:
+            if usepbar:
+                pbar.update(pbar.maxval-lng)
+            else:
+                mdebug(5, "Read %(len)d bytes at 0x%(addr)X" % {'addr': addr, 'len': 256})
+            data += self.cmdReadMemory(addr, 256)
+            addr = addr + 256
+            lng = lng - 256
+        if usepbar:
+            pbar.update(pbar.maxval-lng)
+            pbar.finish()
+        else:
+            mdebug(5, "Read %(len)d bytes at 0x%(addr)X" % {'addr': addr, 'len': 256})
+        data += self.cmdReadMemory(addr, lng)
+        return data
+
+    def writeMemory(self, addr, data):
+        lng = len(data)
+
+        mdebug(5, "Writing %(lng)d bytes to start address 0x%(addr)X" %
+               { 'lng': lng, 'addr': addr})
+
+        if usepbar:
+            widgets = ['Writing: ', Percentage(),' ', ETA(), ' ', Bar()]
+            pbar = ProgressBar(widgets=widgets, maxval=lng, term_width=79).start()
+
+        offs = 0
+        while lng > 256:
+            if usepbar:
+                pbar.update(pbar.maxval-lng)
+            else:
+                mdebug(5, "Write %(len)d bytes at 0x%(addr)X" % {'addr': addr, 'len': 256})
+            self.cmdWriteMemory(addr, data[offs:offs+256])
+            offs = offs + 256
+            addr = addr + 256
+            lng = lng - 256
+        if usepbar:
+            pbar.update(pbar.maxval-lng)
+            pbar.finish()
+        else:
+            mdebug(5, "Write %(len)d bytes at 0x%(addr)X" % {'addr': addr, 'len': 256})
+        self.cmdWriteMemory(addr, data[offs:offs+lng] + bytes([0xFF] * (256-lng)) )
+
+    def PCLKHack(self):
+        RCC_CFGR = 0x40021004
+        mdebug(5, "Modifying PCLK speed at 0x%(addr)X" % {'addr': RCC_CFGR})
+#        reg = self.cmdReadMemory(RCC_CFGR, 4)
+#        reg[1] = (reg[1] & 0xF8) | 0x04
+        reg = [10, 60, 29, 0]
+#        self.cmdWriteMemory(RCC_CFGR, reg)
+        if self.cmdGeneric(0x31):
+          self.sp.write(self._encode_addr(RCC_CFGR))
+          self._wait_for_ack("0x31 address failed")
+          self.sp.write(chr(3)) # len really
+          self.sp.write(chr(reg[0]))
+          self.sp.write(chr(reg[1]))
+          self.sp.write(chr(reg[2]))
+          self.sp.write(chr(reg[3]))
+          crc = 3^reg[0]^reg[1]^reg[2]^reg[3];
+          self.sp.write(chr(crc))
+          self._wait_for_ack("0x31 programming failed")
+          mdebug(10, "    PCLK write memory done")
+
+    def resetDevice(self):
+        AIRCR = 0xE000ED0C
+        mdebug(5, "Writing to Reset Register")
+        reg = [0x04,0x00,0xFA,0x05]
+        if self.cmdGeneric(0x31):
+          self.sp.write(self._encode_addr(AIRCR))
+          self._wait_for_ack("0x31 address failed")
+          self.sp.write(chr(3)) # len really
+          self.sp.write(chr(reg[0]))
+          self.sp.write(chr(reg[1]))
+          self.sp.write(chr(reg[2]))
+          self.sp.write(chr(reg[3]))
+          crc = 3^reg[0]^reg[1]^reg[2]^reg[3];
+          self.sp.write(chr(crc))
+          # don't wait for ack - device will have rebooted
+          mdebug(10, "    reset done")
+
+
+def usage():
+    print("""Usage: %s [-hqVewvrXuS] [-l length] [-p port] [-b baud] [-a addr] [file.bin]
+    -h          This help
+    -q          Quiet
+    -V          Verbose
+    -e          Erase
+    -w          Write
+    -v          Verify
+    -X          Reset after
+    -r          Read
+    -u          Use sector erase instead of global erase. You need to specify the amount of sectors with '-l'
+    -l length   Length of read or to erase when using sector erase
+    -S          Swap RTS and DTR: use RTS for reset and DTR for boot0
+    -p port     Serial port (default: first USB-like port in /dev)
+    -b baud     Baud speed (default: 115200)
+    -a addr     Target address
+    -s n        Skip writing N bytes from beginning of the binary (does not affect start address)
+    -k          Change PCLK frequency to make USB stable on Espruino 1v43 bootloaders
+
+    Example: ./stm32loader.py -e -w -v example/main.bin
+
+    To use sector erase instead of global: ./stm32loader.py -e -u -w -v -l 0x1ff example/main.bin
+
+    """ % sys.argv[0])
+
+def read(filename):
+    """Read the file to be programmed and turn it into a binary"""
+    with open(filename, 'rb') as f:
+        bytes = f.read()
+
+    if bytes.startswith(b'\x7FELF'):
+        # Actually an ELF file.  Convert to binary
+        handle, path = tempfile.mkstemp(suffix='.bin', prefix='stm32loader')
+
+        try:
+            os.close(handle)
+
+            # Try a couple of options for objcopy
+            for name in ['arm-none-eabi-objcopy', 'arm-linux-gnueabi-objcopy']:
+                try:
+                    code = subprocess.call([name, '-Obinary', filename, path])
+
+                    if code == 0:
+                        return read(path)
+                except OSError:
+                    pass
+            else:
+                raise Exception('Error %d while converting to a binary file' % code)
+        finally:
+            # Remove the temporary file
+            os.unlink(path)
+    else:
+        return bytes
+
+if __name__ == "__main__":
+
+    had_error = False
+
+    conf = {
+            'port': 'auto',
+            'baud': 115200,
+            'address': 0x08000000,
+            'skip' : 0,
+            'erase': 0,
+            'useSectorErase': False,
+            'swapRtsDtr': False,
+            'write': 0,
+            'verify': 0,
+            'read': 0,
+            'reset': 0,
+            'len': 1000,
+            'fname':'',
+            'pclk_hack':0,
+        }
+
+# http://www.python.org/doc/2.5.2/lib/module-getopt.html
+
+    try:
+        opts, args = getopt.getopt(sys.argv[1:], "hqVewvrXudSp:b:a:c:s:l:k")
+    except getopt.GetoptError as err:
+        # print help information and exit:
+        print(str(err)) # will print something like "option -a not recognized"
+        usage()
+        sys.exit(2)
+
+    for o, a in opts:
+        if o == '-V':
+            QUIET = 10
+        elif o == '-q':
+            QUIET = 0
+        elif o == '-h':
+            usage()
+            sys.exit(0)
+        elif o == '-e':
+            conf['erase'] = 1
+        elif o == '-w':
+            conf['write'] = 1
+        elif o == '-v':
+            conf['verify'] = 1
+        elif o == '-r':
+            conf['read'] = 1
+        elif o == '-X':
+            conf['reset'] = 1
+        elif o == '-p':
+            conf['port'] = a
+        elif o == '-u':
+            conf['useSectorErase'] = True
+        elif o == '-b':
+            conf['baud'] = eval(a)
+        elif o == '-a':
+            conf['address'] = eval(a)
+        elif o == '-s':
+            conf['skip'] = eval(a)
+        elif o == '-l':
+            conf['len'] = eval(a)
+        elif o == '-k':
+            conf['pclk_hack'] = 1
+        elif o == '-S':
+            conf['swapRtsDtr'] = True
+        else:
+            assert False, "unhandled option"
+    # Try and find the port automatically
+    if conf['port'] == 'auto':
+        ports = []
+
+        # Get a list of all USB-like names in /dev
+        for name in ['tty.usbserial', 'ttyUSB']:
+            ports.extend(glob.glob('/dev/%s*' % name))
+
+        ports = sorted(ports)
+
+        if ports:
+            # Found something - take it
+            conf['port'] = ports[0]
+
+    cmd = CommandInterface()
+    cmd.open(conf['port'], conf['baud'])
+    mdebug(10, "Open port %(port)s, baud %(baud)d" % {'port':conf['port'],
+                                                      'baud':conf['baud']})
+    try:
+        if (conf['write'] or conf['verify']):
+            mdebug(5, "Reading data from %s" % args[0])
+            data = read(args[0])
+
+            if conf['skip']:
+                mdebug(5, "Skipping %d bytes" % conf['skip'])
+                data = data[conf['skip']:]
+
+        try:
+            cmd.initChip(conf['swapRtsDtr'])
+        except CmdException:
+            print("Can't init. Ensure BOOT0=1, BOOT1=0, and reset device")
+
+        bootversion = cmd.cmdGet()
+
+        mdebug(0, "Bootloader version 0x%X" % bootversion)
+
+        if bootversion < 20 or bootversion >= 100:
+            raise Exception('Unreasonable bootloader version %d' % bootversion)
+
+        chip_id = cmd.cmdGetID()
+        assert len(chip_id) == 2, "Unreasonable chip id: %s" % repr(chip_id)
+        chip_id_num = (chip_id[0] << 8) | chip_id[1]
+        chip_id_str = CHIP_ID_STRS.get(chip_id_num, None)
+
+        if chip_id_str is None:
+            mdebug(0, 'Warning: unrecognised chip ID 0x%x' % chip_id_num)
+        else:
+            mdebug(0, "Chip id 0x%x, %s" % (chip_id_num, chip_id_str))
+
+        if conf['pclk_hack']:
+            cmd.PCLKHack()
+
+        if conf['erase']:
+            # Pre-3.0 bootloaders use the erase memory
+            # command. Starting with 3.0, extended erase memory
+            # replaced this command.
+            if bootversion < 0x30:
+                cmd.cmdEraseMemory()
+            else:
+                cmd.cmdExtendedEraseMemory(conf['useSectorErase'], conf['len'])
+
+        if conf['write']:
+            print("Writing binary")
+            cmd.writeMemory(conf['address'], data)
+
+        if conf['verify']:
+            verify = cmd.readMemory(conf['address'], len(data))
+            if(data == verify):
+                print("Verification OK")
+            else:
+                print("Verification FAILED")
+                print(str(len(data)) + ' vs ' + str(len(verify)))
+                for i in range(0, len(data)):
+                    if data[i] != verify[i]:
+                        print(hex(i) + ': ' + hex(data[i]) + ' vs ' + hex(verify[i]))
+                had_error = True
+
+        if not conf['write'] and conf['read']:
+            rdata = cmd.readMemory(conf['address'], conf['len'])
+            file(args[0], 'wb').write(''.join(map(chr,rdata)))
+
+        if conf['reset']:
+            cmd.resetDevice()
+
+    finally:
+        if not conf['reset']:
+            cmd.releaseChip(conf['swapRtsDtr'])
+
+    if had_error: exit(1)

--- a/examples/javascript/Makefile
+++ b/examples/javascript/Makefile
@@ -8,13 +8,14 @@ BOARD ?= native
 RIOTBASE ?= $(CURDIR)/../..
 
 BOARD_INSUFFICIENT_MEMORY := airfy-beacon b-l072z-lrwan1 bluepill calliope-mini \
-                             cc2650-launchpad cc2650stk hifive1 maple-mini \
-                             microbit nrf51dongle nrf6310 nucleo-f030r8 nucleo-f070rb \
-                             nucleo-f072rb nucleo-f103rb nucleo-f302r8 nucleo-f334r8 nucleo-f410rb \
-                             nucleo-l053r8 nucleo-l073rz nucleo-f031k6 nucleo-f042k6 \
-                             nucleo-f303k8 nucleo-l031k6 opencm904 \
-                             spark-core stm32f0discovery stm32mindev \
-                             yunjia-nrf51822
+                             cc2650-launchpad cc2650stk hifive1 lobaro-lorabox \
+                             maple-mini microbit nrf51dongle nrf6310 \
+                             nucleo-f030r8 nucleo-f070rb nucleo-f072rb \
+                             nucleo-f103rb nucleo-f302r8 nucleo-f334r8 \
+                             nucleo-f410rb nucleo-l053r8 nucleo-l073rz \
+                             nucleo-f031k6 nucleo-f042k6 nucleo-f303k8 \
+                             nucleo-l031k6 opencm904 spark-core stm32f0discovery \
+                             stm32mindev yunjia-nrf51822
 
 BOARD_BLACKLIST := arduino-duemilanove arduino-mega2560 arduino-uno chronos \
                    msb-430 msb-430h telosb waspmote-pro wsn430-v1_3b \

--- a/examples/lua_REPL/Makefile
+++ b/examples/lua_REPL/Makefile
@@ -16,9 +16,9 @@ BOARD_INSUFFICIENT_MEMORY := bluepill calliope-mini cc2650-launchpad \
                              stm32mindev airfy-beacon  arduino-mkr1000 \
                              arduino-mkrfox1200 arduino-mkrzero arduino-zero \
                              b-l072z-lrwan1  cc2538dk ek-lm4f120xl  feather-m0 \
-                             ikea-tradfri limifrog-v1 mbed_lpc1768  nrf6310 \
-                             nucleo-f091rc  nucleo-l073rz  nz32-sc151 \
-                             openmote-cc2538 openmote-b pba-d-01-kw2x \
+                             ikea-tradfri limifrog-v1 lobaro-lorabox \
+                             mbed_lpc1768  nrf6310 nucleo-f091rc  nucleo-l073rz \
+                             nz32-sc151 openmote-cc2538 openmote-b pba-d-01-kw2x \
                              remote-pa remote-reva remote-revb samd21-xpro \
                              saml21-xpro samr21-xpro seeeduino_arch-pro \
                              sensebox_samd21 slstk3401a sltb001a slwstk6220a \

--- a/examples/lua_basic/Makefile
+++ b/examples/lua_basic/Makefile
@@ -7,12 +7,12 @@ BOARD ?= native
 RIOTBASE ?= $(CURDIR)/../..
 
 BOARD_INSUFFICIENT_MEMORY := bluepill calliope-mini cc2650-launchpad \
-                             cc2650stk maple-mini microbit nrf51dongle \
-                             nucleo-f030r8 nucleo-f031k6 nucleo-f042k6 \
-                             nucleo-f070rb nucleo-f072rb nucleo-f103rb \
-                             nucleo-f302r8 nucleo-f303k8 nucleo-f334r8 \
-                             nucleo-f410rb nucleo-l031k6 nucleo-l053r8 \
-                             opencm904 spark-core stm32f0discovery \
+                             cc2650stk lobaro-lorabox maple-mini microbit \
+                             nrf51dongle nucleo-f030r8 nucleo-f031k6 \
+                             nucleo-f042k6 nucleo-f070rb nucleo-f072rb \
+                             nucleo-f103rb nucleo-f302r8 nucleo-f303k8 \
+                             nucleo-f334r8 nucleo-f410rb nucleo-l031k6 \
+                             nucleo-l053r8 opencm904 spark-core stm32f0discovery \
                              stm32mindev
 
 BOARD_BLACKLIST := arduino-duemilanove arduino-mega2560 arduino-uno \

--- a/tests/unittests/Makefile
+++ b/tests/unittests/Makefile
@@ -21,6 +21,7 @@ BOARD_INSUFFICIENT_MEMORY := airfy-beacon \
                              feather-m0 \
                              ikea-tradfri \
                              limifrog-v1 maple-mini \
+                             lobaro-lorabox \
                              mbed_lpc1768 \
                              mega-xplained \
                              microbit \


### PR DESCRIPTION
### Contribution description
This adds support for the [Lobaro LoraBox](https://www.lobaro.com/portfolio/wireless-mbus-zu-lora-bridge-adapter-repeater) board. It is based on the stm32l151cb-a MCU.
![Lobaro LoraBox](https://www.lobaro.com/wp/wp-content/uploads/2017/03/Lobaro_wMBUS_LoRaWAN_Bridge.jpg)

### Testing procedure
With the provided UART-USB bridge connected to the "Config" port on the board run:
```
 BOARD=lobaro-lorabox make flash term -C examples/hello-world
```

### Issues/PRs references
Depends on  ~#9802~