### PR TITLE
git-lfs: add support for board documentation files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,3 +5,4 @@
 # when the heading is exactly 7 characters long.
 *.md conflict-marker-size=100
 *.txt conflict-marker-size=100
+boards/*/doc/* filter=lfs diff=lfs merge=lfs -text

--- a/doc/doxygen/Makefile
+++ b/doc/doxygen/Makefile
@@ -20,11 +20,11 @@ doc: html
 
 # by marking html as phony we force make to re-run Doxygen even if the directory exists.
 .PHONY: html
-html: src/css/riot.css src/changelog.md
+html: git-lfs src/css/riot.css src/changelog.md
 	( cat riot.doxyfile ; echo "GENERATE_HTML = yes" ) | doxygen -
 
 .PHONY: man
-man: src/changelog.md
+man: git-lfs src/changelog.md
 	( cat riot.doxyfile ; echo "GENERATE_MAN = yes" ) | doxygen -
 
 ifneq (,$(LESSC))
@@ -40,8 +40,19 @@ src/changelog.md: src/changelog.md.tmp ../../release-notes.txt
 	@./generate-changelog.py $+ $@
 
 .PHONY:
-latex: src/changelog.md
+latex: git-lfs src/changelog.md
 	( cat riot.doxyfile ; echo "GENERATE_LATEX= yes" ) | doxygen -
+
+RED=\033[0;31m
+NC=\033[0m
+
+git-lfs: git-lfs-check git-lfs-install
+
+git-lfs-check:
+	@git lfs --version > /dev/null 2>&1 || (echo -e "$(RED)Please install git lfs.$(NC)" && exit 1)
+
+git-lfs-install:
+	@git config --list | grep lfs > /dev/null || git lfs install --local
 
 clean:
 	-@rm -rf latex man html doxygen_objdb_*.tmp doxygen_entrydb_*.tmp src/changelog.md


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR adds support for using [git-lfs](https://git-lfs.github.com/) for board documentation images (and related files). It's IMO a good trade-off between having files closer to the code and not bloating the repository.

This PR tracks all files undes board/<board_name>/doc folder as git-lfs files.

### git-lfs in a nutshell

Assuming the git-lfs extension is installed (`apt-get install git-lfs`), simply install git-lfs in the RIOT repo:
```
git lfs install --local
```

Then, work with the github repo as you normally do. When pushing to `origin` or another remote, git-lfs will push a symlink-like file in the repo and upload the real file to another repo. This way the original repo doesn't bloat and only contains symlinks pointing to the actual file.

Github handles LFS files natively, [as seen here](https://github.com/jia200x/RIOT/blob/lfs_test_2/boards/samr21-xpro/doc/riot-logo.png) (there is a `Stored with Git LFS` message).

So if git-lfs is installed, is exactly the same as using standard git. Both from the local computer and from the github.com file viewer.

### FAQ
- **Where are LFS files stored?**: Github provides a LFS server in the same repo hidden under `RIOT.git/info/lfs`
- **If I push files to my origin, will the symlink file point to my repo?**: This seems to be handled by Github, the remote location is not included in the symlink file (only a hash and some references to git-lfs.github.com)
- **If someone doesn't have git-lfs, can still use the RIOT repo?** It's possible to use the repo without Git LFS. However, `make doc` will fail wih a `Please install git-lfs` message. The new `make doc` target not only checks if git-lfs is installed but also executes `git lfs install --local` as a dependency.
- **How does it work with Pull Requests?**: If someone uploads a picture without using git-lfs, Github will treat it as Git LFS file instead of Binary ([see different files here](https://github.com/jia200x/RIOT/pull/9/files#diff-82c1f73e53cdda3a5ce0938916841212)). It's up to maintainers to make sure only Git LFS file get to boards/<board_name>/doc (see Possible improvements)

### Possible improvements
- Git hook for detecting if LFS is installed when changing <board_name>/doc files.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Try running `make doc` with and without git-lfs.

Note this doesn't add <board_name>/doc to the RIOT doxygen file, it will be done in a further PR.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None so far.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
