### PR TITLE
tools/doccheck: Detect when `make doc` fails to run.

### DIFF
--- a/dist/tools/doccheck/check.sh
+++ b/dist/tools/doccheck/check.sh
@@ -20,15 +20,20 @@ else
     CRESET=
 fi
 
-ERRORS=$(make -C "${RIOTBASE}" doc 2>&1 | \
-            grep '.*warning' | \
-            sed "s#${PWD}/\([^:]*\)#\1#g")
+DOXY_OUTPUT=$(make -C "${RIOTBASE}" doc 2>&1)
+DOXY_ERRCODE=$?
 
-if [ -n "${ERRORS}" ]
-then
-    echo -e "${CERROR}ERROR: Doxygen generates the following warnings:${CRESET}"
-    echo "${ERRORS}"
+if [ "${DOXY_ERRCODE}" -ne 0 ] ; then
+    echo "'make doc' exited with non-zero code (${DOXY_ERRCODE})"
+    echo "${DOXY_OUTPUT}"
     exit 2
+else
+    ERRORS=$(echo "${DOXY_OUTPUT}" | grep '.*warning' | sed "s#${PWD}/\([^:]*\)#\1#g")
+    if [ -n "${ERRORS}" ] ; then
+        echo -e "${CERROR}ERROR: Doxygen generates the following warnings:${CRESET}"
+        echo "${ERRORS}"
+        exit 2
+    fi
 fi
 
 exclude_filter() {


### PR DESCRIPTION
The previous doccheck would give a false negative when doxygen does not even run (because of misconfiguration). Guess what? Doxygen was never running on Travis! That means our docchecks in the static tests were a lie.

### Issues/PRs references

For an example of why this is a problem, see #9818.

~Depends on #10237 (if we enable the check before fixing travis then everything will fail,)~
Depends on ~#10251~ (the old version of Doxygen currently in travis reports a lot of errors).