### PR TITLE
pkg/jerryscript: many cleanups (split PRs)

### DIFF
--- a/Makefile.base
+++ b/Makefile.base
@@ -7,7 +7,7 @@ DIRS := $(sort $(abspath $(DIRS)))
 
 MODULE ?= $(shell basename $(CURDIR))
 
-.PHONY: all $(DIRS:%=ALL--%) $(DIRS:%=CLEAN--%)
+.PHONY: all clean $(DIRS:%=ALL--%) $(DIRS:%=CLEAN--%)
 
 all: $(BINDIR)/$(MODULE).a ..nothing
 

--- a/pkg/jerryscript/Makefile
+++ b/pkg/jerryscript/Makefile
@@ -9,7 +9,7 @@ CFLAGS += -Wno-implicit-fallthrough
 
 # disable warnings when compiling with LLVM for board native
 ifeq ($(TOOLCHAIN)_$(BOARD),llvm_native)
-export CFLAGS += -Wno-macro-redefined -Wno-gnu-folding-constant
+  CFLAGS += -Wno-macro-redefined -Wno-gnu-folding-constant
 endif
 
 all: git-download

--- a/pkg/jerryscript/Makefile
+++ b/pkg/jerryscript/Makefile
@@ -13,7 +13,6 @@ export CFLAGS += -Wno-macro-redefined -Wno-gnu-folding-constant
 endif
 
 all: git-download
-	@cp Makefile.jerryscript $(PKG_BUILDDIR)/Makefile
-	"$(MAKE)" -C $(PKG_BUILDDIR)
+	"$(MAKE)" -C $(PKG_BUILDDIR) -f $(CURDIR)/Makefile.jerryscript
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/jerryscript/Makefile
+++ b/pkg/jerryscript/Makefile
@@ -16,7 +16,7 @@ all: git-download
 	"$(MAKE)" -C $(PKG_BUILDDIR) -f $(CURDIR)/Makefile.jerryscript
 
 clean::
-	test ! -d $(PKG_BUILDDIR) || "$(MAKE)" -C $(PKG_BUILDDIR) -f $(CURDIR)/Makefile.jerryscript clean
+	"$(MAKE)" -C $(PKG_BUILDDIR) -f $(CURDIR)/Makefile.jerryscript clean
 
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/jerryscript/Makefile
+++ b/pkg/jerryscript/Makefile
@@ -16,7 +16,7 @@ all: git-download
 	"$(MAKE)" -C $(PKG_BUILDDIR) -f $(CURDIR)/Makefile.jerryscript
 
 clean::
-	"$(MAKE)" -C $(PKG_BUILDDIR) -f $(CURDIR)/Makefile.jerryscript clean
+	test ! -d $(PKG_BUILDDIR) || "$(MAKE)" -C $(PKG_BUILDDIR) -f $(CURDIR)/Makefile.jerryscript clean
 
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/jerryscript/Makefile
+++ b/pkg/jerryscript/Makefile
@@ -16,7 +16,7 @@ all: git-download
 	"$(MAKE)" -C $(PKG_BUILDDIR) -f $(CURDIR)/Makefile.jerryscript
 
 clean::
-	$(Q)test ! -d $(PKG_BUILDDIR) || "$(MAKE)" -C $(PKG_BUILDDIR) -f $(CURDIR)/Makefile.jerryscript clean
+	test ! -d $(PKG_BUILDDIR) || "$(MAKE)" -C $(PKG_BUILDDIR) -f $(CURDIR)/Makefile.jerryscript clean
 
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/jerryscript/Makefile
+++ b/pkg/jerryscript/Makefile
@@ -15,8 +15,4 @@ endif
 all: git-download
 	"$(MAKE)" -C $(PKG_BUILDDIR) -f $(CURDIR)/Makefile.jerryscript
 
-clean::
-	"$(MAKE)" -C $(PKG_BUILDDIR) -f $(CURDIR)/Makefile.jerryscript clean
-
-
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/jerryscript/Makefile
+++ b/pkg/jerryscript/Makefile
@@ -15,4 +15,8 @@ endif
 all: git-download
 	"$(MAKE)" -C $(PKG_BUILDDIR) -f $(CURDIR)/Makefile.jerryscript
 
+clean::
+	"$(MAKE)" -C $(PKG_BUILDDIR) -f $(CURDIR)/Makefile.jerryscript clean
+
+
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/jerryscript/Makefile
+++ b/pkg/jerryscript/Makefile
@@ -16,7 +16,7 @@ all: git-download
 	"$(MAKE)" -C $(PKG_BUILDDIR) -f $(CURDIR)/Makefile.jerryscript
 
 clean::
-	test ! -d $(PKG_BUILDDIR) || "$(MAKE)" -C $(PKG_BUILDDIR) -f $(CURDIR)/Makefile.jerryscript clean
+	$(Q)test ! -d $(PKG_BUILDDIR) || "$(MAKE)" -C $(PKG_BUILDDIR) -f $(CURDIR)/Makefile.jerryscript clean
 
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/jerryscript/Makefile.jerryscript
+++ b/pkg/jerryscript/Makefile.jerryscript
@@ -1,4 +1,4 @@
-BUILD_DIR  ?= $(CURDIR)/riot
+BUILD_DIR  ?= $(BINDIR)/jerryscript
 
 JERRYHEAP  ?= 16
 

--- a/pkg/jerryscript/Makefile.jerryscript
+++ b/pkg/jerryscript/Makefile.jerryscript
@@ -4,9 +4,9 @@ JERRYHEAP  ?= 16
 
 EXT_CFLAGS :=-D__TARGET_RIOT
 
-.PHONY: libjerry riot-jerry flash clean
+.PHONY: libjerry
 
-# all: libjerry riot-jerry
+all: libjerry
 
 libjerry:
 	mkdir -p $(BUILD_DIR)

--- a/pkg/jerryscript/Makefile.jerryscript
+++ b/pkg/jerryscript/Makefile.jerryscript
@@ -22,7 +22,7 @@ libjerry:
 	 -DJERRY_LIBM=OFF \
 	 -DJERRY_CMDLINE=OFF \
 	 -DHAVE_TIME_H=0 \
-	 -DEXTERNAL_COMPILE_FLAGS="$(EXT_CFLAGS)" \
+	 -DEXTERNAL_COMPILE_FLAGS="$(INCLUDES) $(EXT_CFLAGS)" \
 	 -DMEM_HEAP_SIZE_KB=$(JERRYHEAP)
 
 	"$(MAKE)" -C $(BUILD_DIR) jerry-core jerry-ext jerry-port-default-minimal

--- a/pkg/jerryscript/Makefile.jerryscript
+++ b/pkg/jerryscript/Makefile.jerryscript
@@ -4,7 +4,7 @@ JERRYHEAP  ?= 16
 
 EXT_CFLAGS :=-D__TARGET_RIOT
 
-.PHONY: libjerry
+.PHONY: all libjerry
 
 all: libjerry
 

--- a/pkg/jerryscript/Makefile.jerryscript
+++ b/pkg/jerryscript/Makefile.jerryscript
@@ -25,7 +25,7 @@ libjerry:
 	 -DEXTERNAL_COMPILE_FLAGS="$(INCLUDES) $(EXT_CFLAGS)" \
 	 -DMEM_HEAP_SIZE_KB=$(JERRYHEAP)
 
-	"$(MAKE)" -C $(BUILD_DIR) jerry-core jerry-ext jerry-port-default-minimal
+	"$(MAKE)" -C $(BUILD_DIR) jerry-core jerry-ext jerry-port-default-minimal VERBOSE=1
 	cp $(BUILD_DIR)/lib/libjerry-core.a $(BINDIR)/jerryscript.a
 	cp $(BUILD_DIR)/lib/libjerry-ext.a $(BINDIR)/jerryscript-ext.a
 	cp $(BUILD_DIR)/lib/libjerry-port-default-minimal.a $(BINDIR)/jerryport-minimal.a

--- a/pkg/jerryscript/Makefile.jerryscript
+++ b/pkg/jerryscript/Makefile.jerryscript
@@ -4,7 +4,7 @@ JERRYHEAP  ?= 16
 
 EXT_CFLAGS :=-D__TARGET_RIOT
 
-.PHONY: libjerry
+.PHONY: libjerry libjerry-clean
 
 all: libjerry
 
@@ -29,5 +29,12 @@ libjerry:
 	cp $(BUILD_DIR)/lib/libjerry-core.a $(BINDIR)/jerryscript.a
 	cp $(BUILD_DIR)/lib/libjerry-ext.a $(BINDIR)/jerryscript-ext.a
 	cp $(BUILD_DIR)/lib/libjerry-port-default-minimal.a $(BINDIR)/jerryport-minimal.a
+
+
+clean:: libjerry-clean
+
+libjerry-clean:
+	$(Q)$(RM) -r $(BUILD_DIR)
+
 
 include $(RIOTBASE)/Makefile.base

--- a/pkg/jerryscript/Makefile.jerryscript
+++ b/pkg/jerryscript/Makefile.jerryscript
@@ -9,7 +9,6 @@ EXT_CFLAGS :=-D__TARGET_RIOT
 all: libjerry
 
 libjerry:
-	mkdir -p $(BUILD_DIR)
 	cmake -B$(BUILD_DIR) -H./ \
 	 -DCMAKE_SYSTEM_NAME=RIOT \
 	 -DCMAKE_SYSTEM_PROCESSOR="$(MCPU)" \

--- a/pkg/jerryscript/Makefile.jerryscript
+++ b/pkg/jerryscript/Makefile.jerryscript
@@ -29,5 +29,3 @@ libjerry:
 	cp $(BUILD_DIR)/lib/libjerry-core.a $(BINDIR)/jerryscript.a
 	cp $(BUILD_DIR)/lib/libjerry-ext.a $(BINDIR)/jerryscript-ext.a
 	cp $(BUILD_DIR)/lib/libjerry-port-default-minimal.a $(BINDIR)/jerryport-minimal.a
-
-include $(RIOTBASE)/Makefile.base

--- a/pkg/jerryscript/Makefile.jerryscript
+++ b/pkg/jerryscript/Makefile.jerryscript
@@ -4,7 +4,7 @@ JERRYHEAP  ?= 16
 
 EXT_CFLAGS :=-D__TARGET_RIOT
 
-.PHONY: libjerry libjerry-clean
+.PHONY: libjerry
 
 all: libjerry
 
@@ -29,12 +29,5 @@ libjerry:
 	cp $(BUILD_DIR)/lib/libjerry-core.a $(BINDIR)/jerryscript.a
 	cp $(BUILD_DIR)/lib/libjerry-ext.a $(BINDIR)/jerryscript-ext.a
 	cp $(BUILD_DIR)/lib/libjerry-port-default-minimal.a $(BINDIR)/jerryport-minimal.a
-
-
-clean:: libjerry-clean
-
-libjerry-clean:
-	$(Q)$(RM) -r $(BUILD_DIR)
-
 
 include $(RIOTBASE)/Makefile.base


### PR DESCRIPTION
### Contribution description

When debugging jerryscript issues with llvm I noticed it was not finding `stdio.h` on my arch linux computer:

```
/home/cladmi/git/work/RIOT/examples/javascript/bin/pkg/iotlab-m3/jerryscript/jerry-core/jrt/jrt.h:25:10: fatal error: 'stdio.h' file not found
#include <stdio.h>
```

I found out that jerryscript was not using `INCLUDES` and so not getting `newlib-nano` and `llvm` includes configuration.

This PR also includes many other fixes and I can split it in separate PRs

* [ ] Fix INCLUDES not being used https://github.com/RIOT-OS/RIOT/pull/9821
    * I know that maybe only the SYSTEM_INCLUDES should be passed to jerryscript but we do currently not have this in RIOT
* [ ] Fix 'clean' not cleaning anything https://github.com/RIOT-OS/RIOT/pull/9824
* [ ] cleanup https://github.com/RIOT-OS/RIOT/pull/9824
* [x] 'clean' not set as '.PHONY' in Makefile.base https://github.com/RIOT-OS/RIOT/pull/9822



~It may even fix the `HAVE_TIME_H` issue from https://github.com/RIOT-OS/RIOT/pull/9808 should investigate more on how to test this one.~ still does not work without it for ek-lm4f120xl

### Testing procedure

With gcc, we should get a 'nano' output that we don't have in master.

```
cd examples/javascript
make clean ${PWD}/bin/iotlab-m3/jerryscript.a  BOARD=iotlab-m3 VERBOSE=1 2>&1  | grep 'nano'

...  -isystem /usr/arm-none-eabi/include/newlib-nano ...
```

This fails on master with `stdio.h` not found on my computer.
```
rm -rf bin/; make -C examples/javascript all BOARD=iotlab-m3  TOOLCHAIN=llvm
```

### Issues/PRs references

https://github.com/RIOT-OS/RIOT/pull/9809
https://github.com/RIOT-OS/RIOT/pull/9808 