### PR TITLE
pkg/jerryscript: fix jerryscript not using system includes

### DIFF
--- a/pkg/jerryscript/Makefile.include
+++ b/pkg/jerryscript/Makefile.include
@@ -1,9 +1,2 @@
 INCLUDES += -I$(PKGDIRBASE)/jerryscript/jerry-core/include
 INCLUDES += -I$(PKGDIRBASE)/jerryscript/jerry-ext/include
-
-ifneq (,$(filter cortex-m%,$(CPU_ARCH)))
-  # jerryscript package package is not using system includes right now, so
-  # many newlib hearders (not even stdio.h) is found
-  # Fixed in #9821 (so remove when merged)
-  TOOLCHAINS_BLACKLIST += llvm
-endif

--- a/pkg/jerryscript/Makefile.jerryscript
+++ b/pkg/jerryscript/Makefile.jerryscript
@@ -6,6 +6,20 @@ EXT_CFLAGS :=-D__TARGET_RIOT
 
 ifeq ($(TOOLCHAIN)_$(BOARD),llvm_native)
   EXT_CFLAGS :=-D__TARGET_RIOT -Wno-conversion
+else ifeq (esp32,$(CPU))
+  # The esp32 C newlib version 2.2.0 has errors when compiling with warnings
+  # that are enabled by jerryscript build system so disable them for this cpu:
+  #  * -Wundef: stdio.h: `__GNU_VISIBLE` and `__BSD_VISIBLE` are not defined
+  EXT_CFLAGS += -Wno-undef -Wno-error=undef
+else ifeq (esp8266,$(CPU))
+  # The esp8266 C newlib version 3.0.0 has errors when compiling with warnings
+  # that are enabled by jerryscript build system so disable them for this cpu:
+  #  * -Wundef
+  #  * -Wconversion
+  #  * -Wsign-conversion
+  EXT_CFLAGS += -Wno-undef -Wno-error=undef
+  EXT_CFLAGS += -Wno-conversion -Wno-error=conversion
+  EXT_CFLAGS += -Wno-sign-conversion -Wno-error=sign-conversion
 endif
 
 .PHONY: all libjerry
@@ -25,7 +39,7 @@ libjerry:
 	 -DJERRY_LIBM=OFF \
 	 -DJERRY_CMDLINE=OFF \
 	 -DHAVE_TIME_H=0 \
-	 -DEXTERNAL_COMPILE_FLAGS="$(EXT_CFLAGS)" \
+	 -DEXTERNAL_COMPILE_FLAGS="$(INCLUDES) $(EXT_CFLAGS)" \
 	 -DMEM_HEAP_SIZE_KB=$(JERRYHEAP)
 
 	"$(MAKE)" -C $(BUILD_DIR) jerry-core jerry-ext jerry-port-default-minimal


### PR DESCRIPTION
### Contribution description

Jerryscript was never using INCLUDES so never having the 'newlib-nano' or llvm
includes.

On my computer it cannot even find `stdio.h`.

~It may even fix the `HAVE_TIME_H` issue from #9808 should investigate more on how to test this one.~ still required for ek-lm4f120xl

### Testing procedure

With gcc, we should get a 'nano' output that we don't have in master.

```
cd examples/javascript
make clean ${PWD}/bin/iotlab-m3/jerryscript.a  BOARD=iotlab-m3 VERBOSE=1 2>&1  | grep 'nano'

...  -isystem /usr/arm-none-eabi/include/newlib-nano ...
```

### Issues/PRs references

https://github.com/RIOT-OS/RIOT/pull/9820