### PR TITLE
Makefile.base: define 'clean' as .PHONY

### DIFF
--- a/Makefile.base
+++ b/Makefile.base
@@ -7,7 +7,7 @@ DIRS := $(sort $(abspath $(DIRS)))
 
 MODULE ?= $(shell basename $(CURDIR))
 
-.PHONY: all $(DIRS:%=ALL--%) $(DIRS:%=CLEAN--%)
+.PHONY: all clean $(DIRS:%=ALL--%) $(DIRS:%=CLEAN--%)
 
 all: $(BINDIR)/$(MODULE).a ..nothing
 


### PR DESCRIPTION
### Contribution description

Makefile.base was not defining 'clean' as a `.PHONY` target when it is not a file target.

### Testing procedure

Not really a nice way, but it should be .PHONY.

### Issues/PRs references

Found during https://github.com/RIOT-OS/RIOT/pull/9820