### PR TITLE
cpu/atmega_common/gpio_init: avoid pull-up in `GPIO_IN`

### DIFF
--- a/cpu/atmega_common/periph/gpio.c
+++ b/cpu/atmega_common/periph/gpio.c
@@ -127,16 +127,18 @@ static inline int8_t _int_num(gpio_t pin)
 
 int gpio_init(gpio_t pin, gpio_mode_t mode)
 {
+    uint8_t pin_mask = (1 << _pin_num(pin));
     switch (mode) {
         case GPIO_OUT:
-            _SFR_MEM8(_ddr_addr(pin)) |= (1 << _pin_num(pin));
+            _SFR_MEM8(_ddr_addr(pin)) |= pin_mask;
             break;
         case GPIO_IN:
-            _SFR_MEM8(_ddr_addr(pin)) &= ~(1 << _pin_num(pin));
-            _SFR_MEM8(_port_addr(pin)) &= ~(1 << _pin_num(pin));
+            _SFR_MEM8(_ddr_addr(pin)) &= ~pin_mask;
+            _SFR_MEM8(_port_addr(pin)) &= ~pin_mask;
             break;
         case GPIO_IN_PU:
-            _SFR_MEM8(_port_addr(pin)) |= (1 << _pin_num(pin));
+            _SFR_MEM8(_ddr_addr(pin)) &= ~pin_mask;
+            _SFR_MEM8(_port_addr(pin)) |= pin_mask;
             break;
         default:
             return -1;


### PR DESCRIPTION
This Patch makes gpio_init of atmega_common configure the pin as an Input and configure the pullup in the case of GPIO_IN_PU. 
This Patch makes gpio_init not change the state output and pullup (defaults to no pullup) in case of GPIO_IN.
This fix makes it more compliant to comments in periph/gpio.h