### PR TITLE
 pkg/jerryscript: build into '$(BINDIR)' and cleanups

### DIFF
--- a/pkg/jerryscript/Makefile
+++ b/pkg/jerryscript/Makefile
@@ -9,7 +9,7 @@ CFLAGS += -Wno-implicit-fallthrough
 
 # disable warnings when compiling with LLVM for board native
 ifeq ($(TOOLCHAIN)_$(BOARD),llvm_native)
-export CFLAGS += -Wno-macro-redefined -Wno-gnu-folding-constant
+  CFLAGS += -Wno-macro-redefined -Wno-gnu-folding-constant
 endif
 
 all: git-download

--- a/pkg/jerryscript/Makefile
+++ b/pkg/jerryscript/Makefile
@@ -13,7 +13,6 @@ export CFLAGS += -Wno-macro-redefined -Wno-gnu-folding-constant
 endif
 
 all: git-download
-	@cp Makefile.jerryscript $(PKG_BUILDDIR)/Makefile
-	"$(MAKE)" -C $(PKG_BUILDDIR)
+	"$(MAKE)" -C $(PKG_BUILDDIR) -f $(CURDIR)/Makefile.jerryscript
 
 include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/jerryscript/Makefile.jerryscript
+++ b/pkg/jerryscript/Makefile.jerryscript
@@ -1,4 +1,4 @@
-BUILD_DIR  ?= $(CURDIR)/riot
+BUILD_DIR  ?= $(BINDIR)/jerryscript
 
 JERRYHEAP  ?= 16
 

--- a/pkg/jerryscript/Makefile.jerryscript
+++ b/pkg/jerryscript/Makefile.jerryscript
@@ -4,9 +4,9 @@ JERRYHEAP  ?= 16
 
 EXT_CFLAGS :=-D__TARGET_RIOT
 
-.PHONY: libjerry riot-jerry flash clean
+.PHONY: libjerry
 
-# all: libjerry riot-jerry
+all: libjerry
 
 libjerry:
 	mkdir -p $(BUILD_DIR)


### PR DESCRIPTION
### Contribution description

Build into the BINDIR directory instead of the source repository.
This makes 'clean' work as expected without other intervention.

Also it goes in the direction of having the package source repository
board independent.

I also included cleanup for `jerryscript` makefiles self described in the commits messages.

### Testing procedure

Clean actually now cleans.
```
rm -rf bin; make; make clean
# Then check
ls bin; git -C bin/pkg/native/jerryscript/ status --porcelain
pkg
?? .git-downloaded
```

In master we had
```
ls bin; git -C bin/pkg/native/jerryscript/ status --porcelain
pkg
?? .git-downloaded
?? riot/
```

Where riot contained all the build files.

### Issues/PRs references

Part of https://github.com/RIOT-OS/RIOT/pull/9820
