### PR TITLE
core/byteorder: fix bebuftohs() / htobebufs() on big endian

### DIFF
--- a/core/include/byteorder.h
+++ b/core/include/byteorder.h
@@ -445,22 +445,13 @@ static inline uint64_t ntohll(uint64_t v)
 
 static inline uint16_t byteorder_bebuftohs(const uint8_t *buf)
 {
-#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
-    return (uint16_t)((buf[0] << 8) | buf[1]);
-#else
-    return (uint16_t)((buf[1] << 8) | buf[0]);
-#endif
+    return (uint16_t)((buf[0] << 8) | (buf[1] << 0));
 }
 
 static inline void byteorder_htobebufs(uint8_t *buf, uint16_t val)
 {
-#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
     buf[0] = (uint8_t)(val >> 8);
-    buf[1] = (uint8_t)(val & 0xff);
-#else
-    buf[0] = (uint8_t)(val & 0xff);
-    buf[1] = (uint8_t)(val >> 8);
-#endif
+    buf[1] = (uint8_t)(val >> 0);
 }
 
 #ifdef __cplusplus

--- a/tests/unittests/tests-core/tests-core-byteorder.c
+++ b/tests/unittests/tests-core/tests-core-byteorder.c
@@ -6,6 +6,8 @@
  * directory for more details.
  */
 
+#include <string.h>
+
 #include "embUnit.h"
 
 #include "byteorder.h"
@@ -78,6 +80,26 @@ static void test_byteorder_host_to_network_64(void)
     TEST_ASSERT_EQUAL_INT(host, byteorder_ntohll(network));
 }
 
+static void test_byteorder_bebuftohs(void)
+{
+    static const uint8_t bebuf[2] = { 0xAA, 0xBB };
+    static const uint16_t host = 0xAABB;
+
+    TEST_ASSERT_EQUAL_INT(host, byteorder_bebuftohs(bebuf));
+}
+
+static void test_byteorder_htobebufs(void)
+{
+    static const uint8_t bebuf[2] = { 0xAA, 0xBB };
+    static const uint16_t host = 0xAABB;
+
+    uint8_t tmp[2] = {0};
+
+    byteorder_htobebufs(tmp, host);
+
+    TEST_ASSERT_EQUAL_INT(0, memcmp(bebuf, tmp, sizeof(tmp)));
+}
+
 Test *tests_core_byteorder_tests(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
@@ -90,6 +112,8 @@ Test *tests_core_byteorder_tests(void)
         new_TestFixture(test_byteorder_host_to_network_16),
         new_TestFixture(test_byteorder_host_to_network_32),
         new_TestFixture(test_byteorder_host_to_network_64),
+        new_TestFixture(test_byteorder_bebuftohs),
+        new_TestFixture(test_byteorder_htobebufs),
     };
 
     EMB_UNIT_TESTCALLER(core_byteorder_tests, NULL, NULL, fixtures);


### PR DESCRIPTION
### Contribution description

byteorder_bebuftohs() / byteorder_htobebufs() where making a difference in big endian *output* depending on input endianness, essentially swapping endianness on big endian machines.

When writing *to* a BE buffer, the lower address always get's ```input << 8``` (the more significant byte).
When reading *from* a BE buffer, the lower address always contains ```value << 8```.
No need to make a difference depending on host endianness.

This PR fixes the issue (and adds a unittest).

Please double-check my thinking, endianness is something that my brain sometimes just sees the wrong way. ;)