### PR TITLE
makefiles/buildtests.inc.mk: use per board BINDIR

### DIFF
--- a/makefiles/buildtests.inc.mk
+++ b/makefiles/buildtests.inc.mk
@@ -2,6 +2,9 @@
 
 BUILDTEST_MAKE_REDIRECT ?= >/dev/null 2>&1
 
+# Do not propagate already BOARD specific BINDIR and PKGDIRBASE
+buildtest: MAKEOVERRIDES := $(filter-out BINDIR=% PKGDIRBASE=%, $(MAKEOVERRIDES))
+
 ifeq ($(BUILD_IN_DOCKER),1)
 buildtest: ..in-docker-container
 else
@@ -20,7 +23,7 @@ buildtest:
 				$(COLOR_ECHO) "$(COLOR_RED)failed!$(COLOR_RESET)" ; \
 				RESULT=false ; \
 			fi ; \
-			$(MAKE) clean-intermediates >/dev/null 2>&1 || true; \
+			BOARD=$${board} $(MAKE) clean-intermediates >/dev/null 2>&1 || true; \
 		fi; \
 	done ; \
 	$${RESULT}

--- a/makefiles/buildtests.inc.mk
+++ b/makefiles/buildtests.inc.mk
@@ -2,9 +2,6 @@
 
 BUILDTEST_MAKE_REDIRECT ?= >/dev/null 2>&1
 
-# Do not propagate already BOARD specific BINDIR and PKGDIRBASE
-buildtest: MAKEOVERRIDES := $(filter-out BINDIR=% PKGDIRBASE=%, $(MAKEOVERRIDES))
-
 ifeq ($(BUILD_IN_DOCKER),1)
 buildtest: ..in-docker-container
 else


### PR DESCRIPTION
### Contribution description

Fix all boards being built in the default application board bin directory.
With this, the 'clean-intermediates' should now also be done per board.

In general all boards were built in `bin/native/` and `bin/pkg/native`.


### Testing procedure

```
rm -rf examples/javascript/bin/; BOARDS="iotlab-m3 samr21-xpro" make -C examples/javascript buildtest ; find examples/javascript/bin/
```

In master we have:

```
find examples/javascript/bin/
examples/javascript/bin/
examples/javascript/bin/native
examples/javascript/bin/native/riot_javascript.elf
examples/javascript/bin/native/riot_javascript.bin
examples/javascript/bin/native/riot_javascript.map
examples/javascript/bin/pkg
examples/javascript/bin/pkg/native
```

With this PR:

```
find examples/javascript/bin/
examples/javascript/bin/
examples/javascript/bin/iotlab-m3
examples/javascript/bin/iotlab-m3/riot_javascript.hex
examples/javascript/bin/iotlab-m3/riot_javascript.elf
examples/javascript/bin/iotlab-m3/riot_javascript.map
examples/javascript/bin/native
examples/javascript/bin/pkg
examples/javascript/bin/pkg/iotlab-m3
examples/javascript/bin/pkg/samr21-xpro
examples/javascript/bin/samr21-xpro
examples/javascript/bin/samr21-xpro/riot_javascript.elf
examples/javascript/bin/samr21-xpro/riot_javascript.bin
examples/javascript/bin/samr21-xpro/riot_javascript.map
```

### Issues/PRs references

~Fixes~ ~https://github.com/RIOT-OS/RIOT/issues/9742~
Needed to test build size change using buildtest in https://github.com/RIOT-OS/RIOT/pull/8711