### PR TITLE
[RFC] net/netdev: New driver API

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -121,6 +121,15 @@ ifneq (,$(filter netdev_tap,$(USEMODULE)))
   USEMODULE += netif
   USEMODULE += netdev_eth
   USEMODULE += iolist
+  USEMODULE += netdev_driver_glue
+endif
+
+ifneq (,$(filter socket_zep,$(USEMODULE)))
+  USEMODULE += netdev_driver_glue
+endif
+
+ifneq (,$(filter cc2538_rf,$(USEMODULE)))
+  USEMODULE += netdev_driver_glue
 endif
 
 ifneq (,$(filter gnrc_tftp,$(USEMODULE)))
@@ -147,6 +156,10 @@ endif
 
 ifneq (,$(filter gnrc_netif,$(USEMODULE)))
   USEMODULE += netif
+endif
+
+ifneq (,$(filter nrfmin,$(USEMODULE)))
+  USEMODULE += netdev_driver_glue
 endif
 
 ifneq (,$(filter ieee802154 nrfmin,$(USEMODULE)))

--- a/cpu/cc2538/radio/cc2538_rf_netdev.c
+++ b/cpu/cc2538/radio/cc2538_rf_netdev.c
@@ -23,6 +23,7 @@
 
 #include "net/gnrc.h"
 #include "net/netdev.h"
+#include "net/netdev_driver_glue.h"
 
 #include "cc2538_rf.h"
 #include "cc2538_rf_netdev.h"
@@ -393,6 +394,8 @@ const netdev_driver_t cc2538_rf_driver = {
     .set  = _set,
     .send = _send,
     .recv = _recv,
+    .size = netdev_driver_glue_size,
+    .drop = netdev_driver_glue_drop,
     .isr  = _isr,
     .init = _init,
 };

--- a/cpu/native/netdev_tap/netdev_tap.c
+++ b/cpu/native/netdev_tap/netdev_tap.c
@@ -55,6 +55,7 @@
 #include "iolist.h"
 #include "net/eui64.h"
 #include "net/netdev.h"
+#include "net/netdev_driver_glue.h"
 #include "net/netdev/eth.h"
 #include "net/ethernet.h"
 #include "net/ethernet/hdr.h"
@@ -158,6 +159,8 @@ static int _set(netdev_t *dev, netopt_t opt, const void *value, size_t value_len
 static netdev_driver_t netdev_driver_tap = {
     .send = _send,
     .recv = _recv,
+    .size = netdev_driver_glue_size,
+    .drop = netdev_driver_glue_drop,
     .init = _init,
     .isr = _isr,
     .get = _get,

--- a/cpu/native/socket_zep/socket_zep.c
+++ b/cpu/native/socket_zep/socket_zep.c
@@ -31,6 +31,8 @@
 
 #include "socket_zep.h"
 
+#include "net/netdev_driver_glue.h"
+
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
 
@@ -332,6 +334,8 @@ static int _set(netdev_t *netdev, netopt_t opt, const void *value,
 static const netdev_driver_t socket_zep_driver = {
     .send = _send,
     .recv = _recv,
+    .size = netdev_driver_glue_size,
+    .drop = netdev_driver_glue_drop,
     .init = _init,
     .isr = _isr,
     .get = _get,

--- a/cpu/nrf5x_common/radio/nrfmin/nrfmin.c
+++ b/cpu/nrf5x_common/radio/nrfmin/nrfmin.c
@@ -30,6 +30,7 @@
 
 #include "nrfmin.h"
 #include "net/netdev.h"
+#include "net/netdev_driver_glue.h"
 
 #ifdef MODULE_GNRC_SIXLOWPAN
 #include "net/gnrc/nettype.h"
@@ -556,6 +557,8 @@ static int nrfmin_set(netdev_t *dev, netopt_t opt, const void *val, size_t len)
 const netdev_driver_t nrfmin_netdev = {
     .send = nrfmin_send,
     .recv = nrfmin_recv,
+    .size = netdev_driver_glue_size,
+    .drop = netdev_driver_glue_drop,
     .init = nrfmin_init,
     .isr  = nrfmin_isr,
     .get  = nrfmin_get,

--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -40,6 +40,7 @@ ifneq (,$(filter at86rf2%,$(USEMODULE)))
   USEMODULE += netif
   USEMODULE += ieee802154
   USEMODULE += netdev_ieee802154
+  USEMODULE += netdev_driver_glue
   FEATURES_REQUIRED += periph_gpio
   FEATURES_REQUIRED += periph_spi
 endif
@@ -75,6 +76,7 @@ ifneq (,$(filter cc110x,$(USEMODULE)))
   USEMODULE += ieee802154
   USEMODULE += luid
   USEMODULE += xtimer
+  USEMODULE += netdev_driver_glue
   ifneq (,$(filter gnrc_netdev_default,$(USEMODULE)))
     USEMODULE += gnrc_cc110x
   endif
@@ -87,6 +89,7 @@ ifneq (,$(filter cc2420,$(USEMODULE)))
   USEMODULE += netif
   USEMODULE += ieee802154
   USEMODULE += netdev_ieee802154
+  USEMODULE += netdev_driver_glue
   FEATURES_REQUIRED += periph_gpio
   FEATURES_REQUIRED += periph_spi
 endif
@@ -116,6 +119,7 @@ ifneq (,$(filter enc28j60,$(USEMODULE)))
   USEMODULE += netdev_eth
   USEMODULE += xtimer
   USEMODULE += luid
+  USEMODULE += netdev_driver_glue
 endif
 
 ifneq (,$(filter encx24j600,$(USEMODULE)))
@@ -123,6 +127,7 @@ ifneq (,$(filter encx24j600,$(USEMODULE)))
   FEATURES_REQUIRED += periph_spi
   USEMODULE += netdev_eth
   USEMODULE += xtimer
+  USEMODULE += netdev_driver_glue
 endif
 
 ifneq (,$(filter ethos,$(USEMODULE)))
@@ -131,6 +136,7 @@ ifneq (,$(filter ethos,$(USEMODULE)))
   USEMODULE += netdev_eth
   USEMODULE += random
   USEMODULE += tsrb
+  USEMODULE += netdev_driver_glue
 endif
 
 ifneq (,$(filter feetech,$(USEMODULE)))
@@ -186,6 +192,7 @@ ifneq (,$(filter kw2xrf,$(USEMODULE)))
   USEMODULE += ieee802154
   USEMODULE += netdev_ieee802154
   USEMODULE += core_thread_flags
+  USEMODULE += netdev_driver_glue
   FEATURES_REQUIRED += periph_spi
 endif
 
@@ -249,6 +256,7 @@ ifneq (,$(filter mrf24j40,$(USEMODULE)))
   USEMODULE += netif
   USEMODULE += ieee802154
   USEMODULE += netdev_ieee802154
+  USEMODULE += netdev_driver_glue
   FEATURES_REQUIRED += periph_gpio
   FEATURES_REQUIRED += periph_spi
 endif
@@ -331,6 +339,7 @@ endif
 
 ifneq (,$(filter slipdev,$(USEMODULE)))
   USEMODULE += tsrb
+  USEMODULE += netdev_driver_glue
   FEATURES_REQUIRED += periph_uart
 endif
 
@@ -355,6 +364,7 @@ ifneq (,$(filter sx127%,$(USEMODULE)))
   USEMODULE += sx127x
   USEMODULE += netif
   USEMODULE += lora
+  USEMODULE += netdev_driver_glue
 endif
 
 ifneq (,$(filter tcs37727,$(USEMODULE)))
@@ -380,12 +390,14 @@ ifneq (,$(filter w5100,$(USEMODULE)))
   FEATURES_REQUIRED += periph_spi
   USEMODULE += netdev_eth
   USEMODULE += luid
+  USEMODULE += netdev_driver_glue
 endif
 
 ifneq (,$(filter xbee,$(USEMODULE)))
   USEMODULE += ieee802154
   USEMODULE += xtimer
   USEMODULE += netif
+  USEMODULE += netdev_driver_glue
 endif
 
 ifneq (,$(filter lis3mdl,$(USEMODULE)))

--- a/drivers/at86rf2xx/at86rf2xx_netdev.c
+++ b/drivers/at86rf2xx/at86rf2xx_netdev.c
@@ -32,6 +32,7 @@
 #include "net/eui64.h"
 #include "net/ieee802154.h"
 #include "net/netdev.h"
+#include "net/netdev_driver_glue.h"
 #include "net/netdev/ieee802154.h"
 
 #include "at86rf2xx.h"
@@ -54,6 +55,8 @@ static int _set(netdev_t *netdev, netopt_t opt, const void *val, size_t len);
 const netdev_driver_t at86rf2xx_driver = {
     .send = _send,
     .recv = _recv,
+    .size = netdev_driver_glue_size,
+    .drop = netdev_driver_glue_drop,
     .init = _init,
     .isr = _isr,
     .get = _get,
@@ -145,6 +148,7 @@ static int _recv(netdev_t *netdev, void *buf, size_t len, void *info)
 
     /* just return length when buf == NULL */
     if (buf == NULL) {
+        /* FIXME: Dropping frame handled? */
         at86rf2xx_fb_stop(dev);
         return pkt_len;
     }

--- a/drivers/cc110x/cc110x-netdev.c
+++ b/drivers/cc110x/cc110x-netdev.c
@@ -32,6 +32,7 @@
 
 #include "periph/gpio.h"
 #include "net/netdev.h"
+#include "net/netdev_driver_glue.h"
 #include "net/gnrc/nettype.h"
 
 #define ENABLE_DEBUG    (0)
@@ -49,6 +50,7 @@ static int _send(netdev_t *dev, const iolist_t *iolist)
 
 static int _recv(netdev_t *dev, void *buf, size_t len, void *info)
 {
+    /* FIXME: This code doesn't handle the size and the drop case */
     DEBUG("%s:%u\n", __func__, __LINE__);
 
     cc110x_t *cc110x = &((netdev_cc110x_t*) dev)->cc110x;
@@ -213,12 +215,14 @@ static int _init(netdev_t *dev)
 }
 
 const netdev_driver_t netdev_cc110x_driver = {
-    .send=_send,
-    .recv=_recv,
-    .init=_init,
-    .get=_get,
-    .set=_set,
-    .isr=_isr
+    .send = _send,
+    .recv = _recv,
+    .size = netdev_driver_glue_size,
+    .drop = netdev_driver_glue_drop,
+    .init = _init,
+    .get  = _get,
+    .set  = _set,
+    .isr  = _isr
 };
 
 int netdev_cc110x_setup(netdev_cc110x_t *netdev_cc110x, const cc110x_params_t *params)

--- a/drivers/cc2420/cc2420.c
+++ b/drivers/cc2420/cc2420.c
@@ -168,6 +168,7 @@ int cc2420_rx(cc2420_t *dev, uint8_t *buf, size_t max_len, void *info)
 
     /* without a provided buffer, only readout the length and return it */
     if (buf == NULL) {
+        /* FIXME: Dropping frame not handled */
         /* get the packet length (without dropping it) (first byte in RX FIFO) */
         cc2420_ram_read(dev, CC2420_RAM_RXFIFO, &len, 1);
         len -= 2;   /* subtract RSSI and FCF */

--- a/drivers/cc2420/cc2420_netdev.c
+++ b/drivers/cc2420/cc2420_netdev.c
@@ -27,6 +27,7 @@
 #include "net/eui64.h"
 #include "net/ieee802154.h"
 #include "net/netdev.h"
+#include "net/netdev_driver_glue.h"
 #include "net/netdev/ieee802154.h"
 #include "xtimer.h"
 
@@ -50,6 +51,8 @@ static int _set(netdev_t *netdev, netopt_t opt, const void *val, size_t len);
 const netdev_driver_t cc2420_driver = {
     .send = _send,
     .recv = _recv,
+    .size = netdev_driver_glue_size,
+    .drop = netdev_driver_glue_drop,
     .init = _init,
     .isr = _isr,
     .get = _get,

--- a/drivers/enc28j60/enc28j60.c
+++ b/drivers/enc28j60/enc28j60.c
@@ -26,6 +26,7 @@
 #include "xtimer.h"
 #include "assert.h"
 #include "net/ethernet.h"
+#include "net/netdev_driver_glue.h"
 #include "net/netdev/eth.h"
 
 #include "enc28j60.h"
@@ -527,6 +528,8 @@ static int nd_set(netdev_t *netdev, netopt_t opt, const void *value, size_t valu
 static const netdev_driver_t netdev_driver_enc28j60 = {
     .send = nd_send,
     .recv = nd_recv,
+    .size = netdev_driver_glue_size,
+    .drop = netdev_driver_glue_drop,
     .init = nd_init,
     .isr = nd_isr,
     .get = nd_get,

--- a/drivers/encx24j600/encx24j600.c
+++ b/drivers/encx24j600/encx24j600.c
@@ -381,6 +381,7 @@ static int _recv(netdev_t *netdev, void *buf, size_t len, void *info)
 
         reg_set(dev, ENC_ERXTAIL, dev->rx_next_ptr - 2);
     }
+    /* FIXME: Dropping frame not handled */
 
     unlock(dev);
 

--- a/drivers/ethos/ethos.c
+++ b/drivers/ethos/ethos.c
@@ -29,6 +29,7 @@
 #include "irq.h"
 
 #include "net/netdev.h"
+#include "net/netdev_driver_glue.h"
 #include "net/netdev/eth.h"
 #include "net/eui64.h"
 #include "net/ethernet.h"
@@ -314,6 +315,7 @@ static int _recv(netdev_t *netdev, void *buf, size_t len, void* info)
         return (int)len;
     }
     else {
+        /* FIXME: Dropping frame unhandled? */
         return dev->last_framesize;
     }
 }
@@ -344,6 +346,8 @@ static int _get(netdev_t *dev, netopt_t opt, void *value, size_t max_len)
 static const netdev_driver_t netdev_driver_ethos = {
     .send = _send,
     .recv = _recv,
+    .size = netdev_driver_glue_size,
+    .drop = netdev_driver_glue_drop,
     .init = _init,
     .isr = _isr,
     .get = _get,

--- a/drivers/include/net/netdev.h
+++ b/drivers/include/net/netdev.h
@@ -315,21 +315,50 @@ typedef struct netdev_driver {
      * Supposed to be called from
      * @ref netdev_t::event_callback "netdev->event_callback()"
      *
-     * If buf == NULL and len == 0, returns the packet size without dropping it.
-     * If buf == NULL and len > 0, drops the packet and returns the packet size.
-     *
      * @param[in]   dev     network device descriptor
-     * @param[out]  buf     buffer to write into or NULL
+     * @param[out]  buf     buffer to write into
      * @param[in]   len     maximum number of bytes to read
      * @param[out] info     status information for the received packet. Might
      *                      be of different type for different netdev devices.
      *                      May be NULL if not needed or applicable.
      *
+     * @return The size of the received frame stored into @p buf
      * @return `< 0` on error
-     * @return number of bytes read if buf != NULL
-     * @return packet size if buf == NULL
      */
     int (*recv)(netdev_t *dev, void *buf, size_t len, void *info);
+
+    /**
+     * @brief Get the expected size of the received frame
+     *
+     * @pre `(dev != NULL)`
+     * @post The frame obtained by a subsequent call to
+     *       @ref netdev_driver::recv "netdev_driver_t->receive()"
+     *       must be equal in size or smaller than the returned size, or fail
+     *
+     * Supposed to be called from
+     * @ref netdev_t::event_callback "netdev->event_callback()"
+     *
+     * @param[in]   dev     network device descriptor
+     *
+     * @return The size of the received frame
+     * @return `< 0` on error
+     */
+    int (*size)(netdev_t *dev);
+
+    /**
+     * @brief Drop the received frame
+     *
+     * @pre `(dev != NULL)`
+     *
+     * Supposed to be called from
+     * @ref netdev_t::event_callback "netdev->event_callback()"
+     *
+     * The frame that could have been obtained by calling
+     * @ref netdev_driver::recv "netdev_driver_t->receive()" must be dropped
+     *
+     * @param[in]   dev     network device descriptor
+     */
+    void (*drop)(netdev_t *dev);
 
     /**
      * @brief the driver's initialization function

--- a/drivers/include/net/netdev_driver_glue.h
+++ b/drivers/include/net/netdev_driver_glue.h
@@ -1,0 +1,51 @@
+/*
+ * Copyright (C) 2018 Otto-von-Guericke-Universität Magdeburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for
+ * more details.
+ */
+
+/**
+ * @defgroup    drivers_netdev_driver_glue Glue for legacy netdev drivers
+ * @ingroup     drivers_netdev
+ * @brief       This provides helper functions to keep legacy network drivers
+ *              working
+ * @{
+ * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+ */
+
+#ifndef NET_NETDEV_DRIVER_GLUE_H
+#define NET_NETDEV_DRIVER_GLUE_H
+
+#include "net/netdev.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief A glue function to bridge between the new netdev_driver API and the
+ *        old
+ *
+ * Calls @ref netdev_driver::recv "dev->driver->recv()" with `NULL` as buffer
+ * and a non-zero length, which was previously used to drop frames.
+ */
+void netdev_driver_glue_drop(netdev_t *dev);
+
+/**
+ * @brief A glue function to bridge between the new netdev_driver API and the
+ *        old
+ *
+ * Calls @ref netdev_driver::recv "dev->driver->recv()" with `NULL` as buffer
+ * and a zero length, which was previously used to get the expected length of
+ * the received frame without dropping it.
+ */
+int netdev_driver_glue_size(netdev_t *dev);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* NET_NETDEV_DRIVER_GLUE_H */
+/** @} */

--- a/drivers/kw2xrf/kw2xrf_netdev.c
+++ b/drivers/kw2xrf/kw2xrf_netdev.c
@@ -29,6 +29,7 @@
 #include "net/eui64.h"
 #include "net/ieee802154.h"
 #include "net/netdev.h"
+#include "net/netdev_driver_glue.h"
 #include "net/netdev/ieee802154.h"
 
 #include "kw2xrf.h"
@@ -193,6 +194,7 @@ static int _recv(netdev_t *netdev, void *buf, size_t len, void *info)
 
     /* just return length when buf == NULL */
     if (buf == NULL) {
+        /* FIXME: Dropping frame not implemented? */
         return pkt_len + 1;
     }
 
@@ -815,6 +817,8 @@ const netdev_driver_t kw2xrf_driver = {
     .init = _init,
     .send = _send,
     .recv = _recv,
+    .size = netdev_driver_glue_size,
+    .drop = netdev_driver_glue_drop,
     .get = _get,
     .set = _set,
     .isr = _isr,

--- a/drivers/mrf24j40/mrf24j40_netdev.c
+++ b/drivers/mrf24j40/mrf24j40_netdev.c
@@ -27,6 +27,7 @@
 #include "net/eui64.h"
 #include "net/ieee802154.h"
 #include "net/netdev.h"
+#include "net/netdev_driver_glue.h"
 #include "net/netdev/ieee802154.h"
 
 #include "mrf24j40.h"
@@ -568,6 +569,8 @@ static void _isr(netdev_t *netdev)
 const netdev_driver_t mrf24j40_driver = {
     .send = _send,
     .recv = _recv,
+    .size = netdev_driver_glue_size,
+    .drop = netdev_driver_glue_drop,
     .init = _init,
     .isr = _isr,
     .get = _get,

--- a/drivers/netdev_driver_glue/Makefile
+++ b/drivers/netdev_driver_glue/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/drivers/netdev_driver_glue/netdev_driver_glue.c
+++ b/drivers/netdev_driver_glue/netdev_driver_glue.c
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2018 Otto-von-Guericke-Universität Magdeburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_netdev_driver_glue
+ * @{
+ *
+ * @file
+ * @brief       Glue code to keep legacy netdev drivers working
+ *
+ * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
+ *
+ * @}
+ */
+
+#include "net/netdev.h"
+#include "net/netdev_driver_glue.h"
+
+void netdev_driver_glue_drop(netdev_t *dev)
+{
+    dev->driver->recv(dev, NULL, 1, NULL);
+}
+
+int netdev_driver_glue_size(netdev_t *dev)
+{
+    return dev->driver->recv(dev, NULL, 0, NULL);
+}

--- a/drivers/slipdev/slipdev.c
+++ b/drivers/slipdev/slipdev.c
@@ -18,6 +18,7 @@
 
 #include "log.h"
 #include "slipdev.h"
+#include "net/netdev_driver_glue.h"
 
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
@@ -201,6 +202,8 @@ static int _set(netdev_t *netdev, netopt_t opt, const void *value,
 static const netdev_driver_t slip_driver = {
     .send = _send,
     .recv = _recv,
+    .size = netdev_driver_glue_size,
+    .drop = netdev_driver_glue_drop,
     .init = _init,
     .isr = _isr,
     .get = _get,

--- a/drivers/sx127x/sx127x_netdev.c
+++ b/drivers/sx127x/sx127x_netdev.c
@@ -23,6 +23,7 @@
 
 #include "net/netopt.h"
 #include "net/netdev.h"
+#include "net/netdev_driver_glue.h"
 #include "net/lora.h"
 
 #include "sx127x_registers.h"
@@ -182,6 +183,8 @@ static int _recv(netdev_t *netdev, void *buf, size_t len, void *info)
 
             size = sx127x_reg_read(dev, SX127X_REG_LR_RXNBBYTES);
             if (buf == NULL) {
+                /* FIXME: Dropping packet not handled? Also: Code could be
+                 * better structured ;-) */
                 return size;
             }
 
@@ -704,6 +707,8 @@ void _on_dio3_irq(void *arg)
 const netdev_driver_t sx127x_driver = {
     .send = _send,
     .recv = _recv,
+    .size = netdev_driver_glue_size,
+    .drop = netdev_driver_glue_drop,
     .init = _init,
     .isr = _isr,
     .get = _get,

--- a/drivers/w5100/w5100.c
+++ b/drivers/w5100/w5100.c
@@ -26,6 +26,7 @@
 #include "assert.h"
 
 #include "net/ethernet.h"
+#include "net/netdev_driver_glue.h"
 #include "net/netdev/eth.h"
 
 #include "w5100.h"
@@ -271,6 +272,7 @@ static int recv(netdev_t *netdev, void *buf, size_t len, void *info)
                 wreg(dev, S0_IR, IR_RECV);
             }
         }
+        /* FIXME: else if (len > 0): Drop frame */
     }
 
     /* release the SPI bus again */
@@ -326,6 +328,8 @@ static int get(netdev_t *netdev, netopt_t opt, void *value, size_t max_len)
 static const netdev_driver_t netdev_driver_w5100 = {
     .send = send,
     .recv = recv,
+    .size = netdev_driver_glue_size,
+    .drop = netdev_driver_glue_drop,
     .init = init,
     .isr = isr,
     .get = get,

--- a/drivers/xbee/xbee.c
+++ b/drivers/xbee/xbee.c
@@ -28,6 +28,7 @@
 #include "xtimer.h"
 #include "net/eui64.h"
 #include "net/netdev.h"
+#include "net/netdev_driver_glue.h"
 #include "net/ieee802154.h"
 #ifdef MODULE_GNRC
 #include "net/gnrc.h"
@@ -823,6 +824,8 @@ static int xbee_set(netdev_t *ndev, netopt_t opt, const void *value, size_t len)
 const netdev_driver_t xbee_driver = {
     .send = xbee_send,
     .recv = xbee_recv,
+    .size = netdev_driver_glue_size,
+    .drop = netdev_driver_glue_drop,
     .init = xbee_init,
     .isr  = xbee_isr,
     .get  = xbee_get,

--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -19,6 +19,7 @@
 #include <stdio.h>
 
 #include "auto_init.h"
+#include "log.h"
 
 #ifdef MODULE_MCI
 #include "diskio.h"
@@ -171,6 +172,10 @@ void auto_init(void)
 #ifdef MODULE_ASYMCUTE
     DEBUG("Auto init Asymcute\n");
     asymcute_handler_run();
+#endif
+
+#ifdef MODULE_NETDEV_DRIVER_GLUE
+    LOG_WARNING("Legacy netdev_driver API is used\n");
 #endif
 
 /* initialize network devices */

--- a/sys/net/gnrc/link_layer/gomach/gomach.c
+++ b/sys/net/gnrc/link_layer/gomach/gomach.c
@@ -84,13 +84,14 @@ static gnrc_pktsnip_t *_recv(gnrc_netif_t *netif)
     netdev_ieee802154_rx_info_t rx_info;
     netdev_ieee802154_t *state = (netdev_ieee802154_t *)netif->dev;
     gnrc_pktsnip_t *pkt = NULL;
-    int bytes_expected = dev->driver->recv(dev, NULL, 0, NULL);
+    int bytes_expected = dev->driver->size(dev);
 
     if (bytes_expected > 0) {
         int nread;
 
         pkt = gnrc_pktbuf_add(NULL, NULL, bytes_expected, GNRC_NETTYPE_UNDEF);
         if (pkt == NULL) {
+            /* FIXME: Is it correct to not drop the frame here!?! */
             DEBUG("_recv_ieee802154: cannot allocate pktsnip.\n");
             return NULL;
         }

--- a/sys/net/gnrc/link_layer/lwmac/lwmac.c
+++ b/sys/net/gnrc/link_layer/lwmac/lwmac.c
@@ -116,7 +116,7 @@ static gnrc_pktsnip_t *_recv(gnrc_netif_t *netif)
     netdev_ieee802154_rx_info_t rx_info;
     netdev_ieee802154_t *state = (netdev_ieee802154_t *)netif->dev;
     gnrc_pktsnip_t *pkt = NULL;
-    int bytes_expected = dev->driver->expected_bytes(dev);
+    int bytes_expected = dev->driver->size(dev);
 
     if (bytes_expected > 0) {
         int nread;

--- a/sys/net/gnrc/link_layer/lwmac/lwmac.c
+++ b/sys/net/gnrc/link_layer/lwmac/lwmac.c
@@ -116,13 +116,14 @@ static gnrc_pktsnip_t *_recv(gnrc_netif_t *netif)
     netdev_ieee802154_rx_info_t rx_info;
     netdev_ieee802154_t *state = (netdev_ieee802154_t *)netif->dev;
     gnrc_pktsnip_t *pkt = NULL;
-    int bytes_expected = dev->driver->recv(dev, NULL, 0, NULL);
+    int bytes_expected = dev->driver->expected_bytes(dev);
 
     if (bytes_expected > 0) {
         int nread;
 
         pkt = gnrc_pktbuf_add(NULL, NULL, bytes_expected, GNRC_NETTYPE_UNDEF);
         if (pkt == NULL) {
+            /* FIXME: Is it correct to not drop the frame here!?! */
             DEBUG("_recv_ieee802154: cannot allocate pktsnip.\n");
             return NULL;
         }

--- a/sys/net/gnrc/netif/gnrc_netif_ethernet.c
+++ b/sys/net/gnrc/netif/gnrc_netif_ethernet.c
@@ -160,7 +160,7 @@ static int _send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
 static gnrc_pktsnip_t *_recv(gnrc_netif_t *netif)
 {
     netdev_t *dev = netif->dev;
-    int bytes_expected = dev->driver->recv(dev, NULL, 0, NULL);
+    int bytes_expected = dev->driver->size(dev);
     gnrc_pktsnip_t *pkt = NULL;
 
     if (bytes_expected > 0) {
@@ -172,7 +172,7 @@ static gnrc_pktsnip_t *_recv(gnrc_netif_t *netif)
             DEBUG("gnrc_netif_ethernet: cannot allocate pktsnip.\n");
 
             /* drop the packet */
-            dev->driver->recv(dev, NULL, bytes_expected, NULL);
+            dev->driver->drop(dev);
 
             goto out;
         }

--- a/sys/net/gnrc/netif/gnrc_netif_ieee802154.c
+++ b/sys/net/gnrc/netif/gnrc_netif_ieee802154.c
@@ -80,7 +80,7 @@ static gnrc_pktsnip_t *_recv(gnrc_netif_t *netif)
     netdev_ieee802154_rx_info_t rx_info;
     netdev_ieee802154_t *state = (netdev_ieee802154_t *)netif->dev;
     gnrc_pktsnip_t *pkt = NULL;
-    int bytes_expected = dev->driver->recv(dev, NULL, 0, NULL);
+    int bytes_expected = dev->driver->size(dev);
 
     if (bytes_expected >= (int)IEEE802154_MIN_FRAME_LEN) {
         int nread;
@@ -89,7 +89,7 @@ static gnrc_pktsnip_t *_recv(gnrc_netif_t *netif)
         if (pkt == NULL) {
             DEBUG("_recv_ieee802154: cannot allocate pktsnip.\n");
             /* Discard packet on netdev device */
-            dev->driver->recv(dev, NULL, bytes_expected, NULL);
+            dev->driver->drop(dev);
             return NULL;
         }
         nread = dev->driver->recv(dev, pkt->data, bytes_expected, &rx_info);
@@ -159,7 +159,7 @@ static gnrc_pktsnip_t *_recv(gnrc_netif_t *netif)
         gnrc_pktbuf_realloc_data(pkt, nread);
     } else if (bytes_expected > 0) {
         DEBUG("_recv_ieee802154: received frame is too short\n");
-        dev->driver->recv(dev, NULL, bytes_expected, NULL);
+        dev->driver->drop_frame(dev);
     }
 
     return pkt;

--- a/sys/net/gnrc/netif/gnrc_netif_raw.c
+++ b/sys/net/gnrc/netif/gnrc_netif_raw.c
@@ -50,7 +50,7 @@ static inline uint8_t _get_version(uint8_t *data)
 static gnrc_pktsnip_t *_recv(gnrc_netif_t *netif)
 {
     netdev_t *dev = netif->dev;
-    int bytes_expected = dev->driver->recv(dev, NULL, 0, NULL);
+    int bytes_expected = dev->driver->size(dev);
     gnrc_pktsnip_t *pkt = NULL;
 
     if (bytes_expected > 0) {
@@ -61,7 +61,7 @@ static gnrc_pktsnip_t *_recv(gnrc_netif_t *netif)
         if (!pkt) {
             DEBUG("gnrc_netif_raw: cannot allocate pktsnip.\n");
             /* drop packet */
-            dev->driver->recv(dev, NULL, bytes_expected, NULL);
+            dev->driver->drop(dev);
             return pkt;
         }
         nread = dev->driver->recv(dev, pkt->data, bytes_expected, NULL);

--- a/sys/net/netdev_test/netdev_test.c
+++ b/sys/net/netdev_test/netdev_test.c
@@ -18,6 +18,7 @@
 #include <string.h>
 
 #include "net/netdev_test.h"
+#include "net/netdev_driver_glue.h"
 
 void netdev_test_reset(netdev_test_t *dev)
 {
@@ -117,6 +118,8 @@ static int _set(netdev_t *netdev, netopt_t opt, const void *value, size_t value_
 static const netdev_driver_t _driver = {
     .send   = _send,
     .recv   = _recv,
+    .size   = netdev_driver_glue_size,
+    .drop   = netdev_driver_glue_drop,
     .init   = _init,
     .isr    = _isr,
     .get    = _get,


### PR DESCRIPTION
### Contribution description
- Added `netdev_driver_t::drop` to drop the received frame
- Added `netdev_driver_t::size` to get the expected size of the received frame   without dropping it
- Added module `netdev_driver_glue` that implements those two functions by calling `netdev_driver_t::recv` for dropping the received frame and to get its size, which before this commit was the canonical API
- Added a `LOG_WARNING` to auto_init when this glue is used to motivate programmers to move to the new API
- Added this glue to all drivers
- Added comments to indicate where the dropping frame functionality is not implemented

### Issues/PRs references
https://github.com/RIOT-OS/RIOT/issues/9805