### PR TITLE
boards/nrf52840-mdk: initial support

### DIFF
--- a/boards/nrf52840-mdk/Makefile
+++ b/boards/nrf52840-mdk/Makefile
@@ -1,0 +1,3 @@
+MODULE = board
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/nrf52840-mdk/Makefile.dep
+++ b/boards/nrf52840-mdk/Makefile.dep
@@ -1,0 +1,5 @@
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += saul_gpio
+endif
+
+include $(RIOTBOARD)/common/nrf52/Makefile.dep

--- a/boards/nrf52840-mdk/Makefile.features
+++ b/boards/nrf52840-mdk/Makefile.features
@@ -1,0 +1,5 @@
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_uart
+
+include $(RIOTBOARD)/common/nrf52/Makefile.features

--- a/boards/nrf52840-mdk/Makefile.include
+++ b/boards/nrf52840-mdk/Makefile.include
@@ -1,0 +1,18 @@
+export CPU_MODEL = nrf52840xxaa
+
+# This board uses a DAP-Link programmer
+# Flashing support is provided through pyocd (default) and openocd.
+# For openocd, a version built against the development branch and containing
+# the support for nrf52 cpu is required.
+PROGRAMMER ?= pyocd
+ifeq (pyocd,$(PROGRAMMER))
+  # The board is not recognized automatically by pyocd, so the CPU target
+  # option is passed explicitly
+  export FLASH_TARGET_TYPE ?= -t $(CPU)
+  include $(RIOTMAKE)/tools/pyocd.inc.mk
+else ifeq (openocd,$(PROGRAMMER))
+  export DEBUG_ADAPTER ?= dap
+  include $(RIOTMAKE)/tools/openocd.inc.mk
+endif
+
+include $(RIOTBOARD)/common/nrf52/Makefile.include

--- a/boards/nrf52840-mdk/board.c
+++ b/boards/nrf52840-mdk/board.c
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2018 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_nrf52840-mdk
+ * @{
+ *
+ * @file
+ * @brief       Board initialization for the nRF52840-MDK
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ * @}
+ */
+
+#include "cpu.h"
+#include "board.h"
+
+#include "periph/gpio.h"
+
+void board_init(void)
+{
+    /* initialize the boards LEDs */
+    gpio_init(LED0_PIN, GPIO_OUT);
+    gpio_set(LED0_PIN);
+    gpio_init(LED1_PIN, GPIO_OUT);
+    gpio_set(LED1_PIN);
+    gpio_init(LED2_PIN, GPIO_OUT);
+    gpio_set(LED2_PIN);
+
+    /* initialize the CPU */
+    cpu_init();
+}

--- a/boards/nrf52840-mdk/dist/openocd.cfg
+++ b/boards/nrf52840-mdk/dist/openocd.cfg
@@ -1,0 +1,2 @@
+transport select swd
+source [find target/nrf52.cfg]

--- a/boards/nrf52840-mdk/doc.txt
+++ b/boards/nrf52840-mdk/doc.txt
@@ -1,0 +1,50 @@
+/**
+@defgroup    boards_nrf52840-mdk nRF52840-MDK
+@ingroup     boards
+@brief       Support for the nRF52840-MDK
+
+### General information
+
+The Makerdiary [nRF52840-MDK](https://github.com/makerdiary/nrf52840-mdk) board
+is an opensource, micro development kit using the nRF52840 SoC.
+This board provides 802.15.4 and BLE connectivity.
+
+### Pinout
+
+<img src="https://github.com/makerdiary/nrf52840-mdk/blob/master/docs/images/nrf52840-mdk-pinout.jpg"
+     alt="pinout" style="height:800px;"/>
+
+### Flash the board
+
+By default, the board is flashed with PyOCD programmer via a DAPLink.
+
+PyOCD can be installed using Python package manager:
+```
+    pip install pyocd --user -U
+```
+
+To flash the board `BOARD=nrf52840-mdk` with the `make` command.<br/>
+Example with `hello-world` application:
+```
+    make BOARD=nrf52840-mdk -C examples/hello-world flash
+```
+
+OpenOCD can also be used. For the moment, the latest stable version of OpenOCD
+(0.10) doesn't contain any support for nrf52 but versions built against the
+actual development version can be used.
+
+To flash the board with OpenOCD, use the `PROGRAMMER` variable:
+```
+    PROGRAMMER=openocd make BOARD=nrf52840-mdk -C examples/hello-world flash
+```
+
+### Accessing STDIO via UART
+
+The STDIO is directly accessible via the USB port. On a Linux host, it's
+generally mapped to `/dev/ttyACM0`.
+
+Use the `term` target to connect to the board serial port<br/>
+```
+    make BOARD=nrf52840-mdk -C examples/hello-world term
+```
+ */

--- a/boards/nrf52840-mdk/include/board.h
+++ b/boards/nrf52840-mdk/include/board.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2018 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_nrf52840-mdk
+ * @{
+ *
+ * @file
+ * @brief       Board specific configuration for the nRF52840-MDK
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include "cpu.h"
+#include "board_common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    LED pin configuration
+ * @{
+ */
+#define LED0_PIN            GPIO_PIN(0, 23)
+#define LED1_PIN            GPIO_PIN(0, 22)
+#define LED2_PIN            GPIO_PIN(0, 24)
+
+#define LED_PORT            (NRF_P0)
+#define LED0_MASK           (1 << 23)
+#define LED1_MASK           (1 << 22)
+#define LED2_MASK           (1 << 24)
+#define LED_MASK            (LED0_MASK | LED1_MASK | LED2_MASK)
+
+#define LED0_ON             (LED_PORT->OUTCLR = LED0_MASK)
+#define LED0_OFF            (LED_PORT->OUTSET = LED0_MASK)
+#define LED0_TOGGLE         (LED_PORT->OUT   ^= LED0_MASK)
+
+#define LED1_ON             (LED_PORT->OUTCLR = LED1_MASK)
+#define LED1_OFF            (LED_PORT->OUTSET = LED1_MASK)
+#define LED1_TOGGLE         (LED_PORT->OUT   ^= LED1_MASK)
+
+#define LED2_ON             (LED_PORT->OUTCLR = LED2_MASK)
+#define LED2_OFF            (LED_PORT->OUTSET = LED2_MASK)
+#define LED2_TOGGLE         (LED_PORT->OUT   ^= LED2_MASK)
+/** @} */
+
+/**
+ * @name    Button pin configuration
+ * @{
+ */
+#define BTN0_PIN            GPIO_PIN(1, 0)
+#define BTN0_MODE           GPIO_IN_PU
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/nrf52840-mdk/include/gpio_params.h
+++ b/boards/nrf52840-mdk/include/gpio_params.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2018 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_nrf52840-mdk
+ * @{
+ *
+ * @file
+ * @brief       Configuration of SAUL mapped GPIO pins
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ */
+
+#ifndef GPIO_PARAMS_H
+#define GPIO_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    LED configuration
+ */
+static const  saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name  = "Led Red",
+        .pin   = LED0_PIN,
+        .mode  = GPIO_OUT,
+        .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
+    },
+    {
+        .name  = "Led Green",
+        .pin   = LED1_PIN,
+        .mode  = GPIO_OUT,
+        .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
+    },
+    {
+        .name  = "Led Blue",
+        .pin   = LED2_PIN,
+        .mode  = GPIO_OUT,
+        .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
+    },
+    {
+        .name  = "Button 1",
+        .pin   = BTN0_PIN,
+        .mode  = BTN0_MODE,
+        .flags = SAUL_GPIO_INVERTED,
+    },
+};
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_PARAMS_H */
+/** @} */

--- a/boards/nrf52840-mdk/include/periph_conf.h
+++ b/boards/nrf52840-mdk/include/periph_conf.h
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2018 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_nrf52840-mdk
+ * @{
+ *
+ * @file
+ * @brief       Peripheral configuration for the nRF52840-MDK
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+#include "periph_cpu.h"
+#include "cfg_clock_32_1.h"
+#include "cfg_rtt_default.h"
+#include "cfg_timer_default.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    UART configuration
+ * @{
+ */
+static const uart_conf_t uart_config[] = {
+    {
+        .dev        = NRF_UARTE0,
+        .rx_pin     = GPIO_PIN(0,19),
+        .tx_pin     = GPIO_PIN(0,20),
+        .rts_pin    = (uint8_t)GPIO_UNDEF,
+        .cts_pin    = (uint8_t)GPIO_UNDEF,
+        .irqn       = UARTE0_UART0_IRQn,
+    },
+};
+
+#define UART_0_ISR          (isr_uart0)
+
+#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+/** @} */
+
+/**
+ * @name    SPI configuration
+ * @{
+ */
+static const spi_conf_t spi_config[] = {
+    {
+        .dev  = NRF_SPI0,
+        .sclk = 15,
+        .mosi = 13,
+        .miso = 14
+    }
+};
+
+#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_CONF_H */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR adds support for the Makerdiary [nrf52840-mdk](https://github.com/makerdiary/nrf52840-mdk) development kit.

Successfully tested:
- timer, xtimer
- examples/nimble_gatt
- saul with LEDs

The user button doesn't seem to work => fixed by #10158

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

run `make BOARD=nrf52840-mdk flash term` in the following application directories:
- examples/nimble_gatt: device should be visible from a BLE capable device
- tests/periph_timer: ends with success
- tests/periph_rtt: many hellos displayed every 10s
- examples/default: play with saul

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

requires #9847 (pyocd) and #10279 (and previously ~#10158 (user button fix)~)

Now this PR is based on #10621 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
