### PR TITLE
gnrc_netif: Check return value of netdev init during thread start

### DIFF
--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -1291,7 +1291,17 @@ static void *_gnrc_netif_thread(void *args)
     dev->event_callback = _event_cb;
     dev->context = netif;
     /* initialize low-level driver */
-    dev->driver->init(dev);
+    res = dev->driver->init(dev);
+    if (res < 0) {
+        LOG_ERROR("gnrc_netif: netdev init failed: %d\n", res);
+        /* unregister this netif instance */
+        netif->ops = NULL;
+        netif->pid = KERNEL_PID_UNDEF;
+        netif->dev = NULL;
+        dev->event_callback = NULL;
+        dev->context = NULL;
+        return NULL;
+    }
     _configure_netdev(dev);
     _init_from_device(netif);
     netif->cur_hl = GNRC_NETIF_DEFAULT_HL;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Add a check for the return value of netdev->init during initialization of the gnrc_netif threads. If initialization fails, the netif state will be cleared and the thread will terminate.
Without this check, the program may hang or misbehave later when the netif thread attempts to use the failed device.

### Testing procedure

Change the return value of the chosen netdev driver init function.
Example:  
```diff
diff --git a/drivers/at86rf2xx/at86rf2xx_netdev.c b/drivers/at86rf2xx/at86rf2xx_netdev.c
index 2533806b19..d418b3d422 100644
--- a/drivers/at86rf2xx/at86rf2xx_netdev.c
+++ b/drivers/at86rf2xx/at86rf2xx_netdev.c
@@ -94,7 +94,7 @@ static int _init(netdev_t *netdev)
     memset(&netdev->stats, 0, sizeof(netstats_t));
 #endif
 
-    return 0;
+    return -1;
 }
 
 static int _send(netdev_t *netdev, const iolist_t *iolist)
```

### Issues/PRs references

Found when debugging initialization errors in #7107 