### PR TITLE
WIP: Support PR for comparing size with 'ld -r' PR

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -562,6 +562,10 @@ ifneq (,$(filter pthread,$(USEMODULE)))
   USEMODULE += timex
 endif
 
+ifneq (,$(filter pthread_tls,$(USEMODULE)))
+  USEMODULE += pthread
+endif
+
 ifneq (,$(filter schedstatistics,$(USEMODULE)))
   USEMODULE += xtimer
 endif

--- a/cpu/cortexm_common/Makefile.include
+++ b/cpu/cortexm_common/Makefile.include
@@ -2,6 +2,9 @@
 INCLUDES += -I$(RIOTCPU)/cortexm_common/include
 INCLUDES += -I$(RIOTCPU)/cortexm_common/include/vendor
 
+# Explicitely tell the linker to link 'panic_arch'
+UNDEF += $(BINDIR)/cortexm_common/panic.o
+
 # All variables must be defined in the CPU configuration when using the common
 # `ldscripts/cortexm.ld`
 ifneq (,$(ROM_START_ADDR)$(RAM_START_ADDR)$(ROM_LEN)$(RAM_LEN))

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -58,6 +58,7 @@ PSEUDOMODULES += pktqueue
 PSEUDOMODULES += printf_float
 PSEUDOMODULES += prng
 PSEUDOMODULES += prng_%
+PSEUDOMODULES += pthread_tls
 PSEUDOMODULES += riotboot_%
 PSEUDOMODULES += saul_adc
 PSEUDOMODULES += saul_default

--- a/sys/posix/pthread/Makefile
+++ b/sys/posix/pthread/Makefile
@@ -1,1 +1,6 @@
+# exclude pthread_tls if not selected explicitly
+ifeq (,$(filter pthread_tls,$(USEMODULE)))
+  SRC := $(filter-out pthread_tls.c,$(wildcard *.c))
+endif
+
 include $(RIOTBASE)/Makefile.base

--- a/tests/pthread_tls/Makefile
+++ b/tests/pthread_tls/Makefile
@@ -8,6 +8,7 @@ BOARD_BLACKLIST := arduino-mega2560 waspmote-pro arduino-uno arduino-duemilanove
 
 USEMODULE += posix
 USEMODULE += pthread
+USEMODULE += pthread_tls
 
 TEST_ON_CI_WHITELIST += all
 


### PR DESCRIPTION
### Contribution description

This PR is here to helping testing the build size difference possibly introduced by #8711 

The sizes can be queried with:

`https://ci.riot-os.org/RIOT-OS/RIOT/<PR>/<SHA1>/sizes.json`

Found by checking https://github.com/bergzand/RIOT-graphs

For example:

https://ci.riot-os.org/RIOT-OS/RIOT/8711/0835f935907a4861daa2db7b2b058e190241b064/sizes.json

### Testing procedure

Nope


### Issues/PRs references

#8711 
