### PR TITLE
lora_serialization: add support for lora-serialization format

### DIFF
--- a/sys/Makefile
+++ b/sys/Makefile
@@ -136,6 +136,9 @@ endif
 ifneq (,$(filter rdcli_simple,$(USEMODULE)))
     DIRS += net/application_layer/rdcli_simple
 endif
+ifneq (,$(filter lora_serialization,$(USEMODULE)))
+    DIRS += lora_serialization
+endif
 
 DIRS += $(dir $(wildcard $(addsuffix /Makefile, $(USEMODULE))))
 

--- a/sys/include/lora_serialization.h
+++ b/sys/include/lora_serialization.h
@@ -1,0 +1,137 @@
+/*
+ * Copyright (C) 2018 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     sys_lora_serialization
+ * @{
+ * @file
+ * @brief       Lora serialization interface and definitions
+ *
+ * @author      Leandro Lanzieri <leandro.lanzieri@haw-hamburg.de>
+ * @author      Jose Ignacio Alamos <jose.alamos@haw-hamburg.de>
+ */
+
+#ifndef LORA_SERIALIZATION_H
+#define LORA_SERIALIZATION_H
+
+#include <inttypes.h>
+#include <stdbool.h>
+#include <string.h>
+#include <errno.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef LORA_SERIALIZATION_MAX_BUFFER_SIZE
+#define LORA_SERIALIZATION_MAX_BUFFER_SIZE (42U)
+#endif
+
+/**
+ * @name Lora Serialization data size
+ * @{
+ */
+#define LORA_SERIALIZATION_UNIX_TIME_SIZE    (4U)
+#define LORA_SERIALIZATION_LATITUDE_SIZE     (4U)
+#define LORA_SERIALIZATION_LONGITUDE_SIZE    (4U)
+#define LORA_SERIALIZATION_UINT8_SIZE        (1U)
+#define LORA_SERIALIZATION_UINT16_SIZE       (2U)
+#define LORA_SERIALIZATION_TEMPERATURE_SIZE  (2U)
+#define LORA_SERIALIZATION_HUMIDITY_SIZE     (2U)
+#define LORA_SERIALIZATION_BITMAP_SIZE       (1U)
+
+#define LORA_SERIALIZATION_GPS_SIZE            \
+    LORA_SERIALIZATION_LATITUDE_SIZE + LORA_SERIALIZATION_LONGITUDE_SIZE
+/** @} */
+
+/**
+ * @brief Lora Serialization descriptor
+ */
+typedef struct {
+    uint8_t buffer[LORA_SERIALIZATION_MAX_BUFFER_SIZE]; /**< data buffer */
+    uint8_t cursor;                                     /**< data cursor */
+} lora_serialization_t;
+
+/**
+ * @brief Clears the buffer and resets the cursor
+ *
+ * @param[in] serialization     lora serialization descriptor
+ */
+void lora_serialization_reset(lora_serialization_t *serialization);
+
+/**
+ * @brief Adds the encoded unix time to the buffer
+ *
+ * @param[in] serialization     lora serialization descriptor
+ * @param[in] unixtime          the unix time value
+ */
+int lora_serialization_write_unix_time(lora_serialization_t *serialization,
+                                       uint32_t unixtime);
+
+/**
+ * @brief Adds encoded coordinates to the buffer
+ *
+ * @param[in] serialization     lora serialization descriptor
+ * @param[in] latitude          latitude value
+ * @param[in] longitude         longitude value
+ */
+int lora_serialization_write_coordinates(lora_serialization_t *serialization,
+                                         double latitude, double longitude);
+
+/**
+ * @brief Adds an unsigned 16 bits integer to the buffer
+ *
+ * @param[in] serialization     lora serialization descriptor
+ * @param[in] value             integer value
+ */
+int lora_serialization_write_uint16(lora_serialization_t *serialization,
+                                    uint16_t value);
+
+/**
+ * @brief Adds an unsigned 8 bits integer to the buffer
+ *
+ * @param[in] serialization     lora serialization descriptor
+ * @param[in] value             integer value
+ */
+int lora_serialization_write_uint8(lora_serialization_t *serialization,
+                                   uint8_t value);
+
+/**
+ * @brief Adds encoded humidity value to the buffer
+ *
+ * @param[in] serialization     lora serialization descriptor
+ * @param[in] humidity          humidity value
+ */
+int lora_serialization_write_humidity(lora_serialization_t *serialization,
+                                      float humidity);
+
+/**
+ * @brief Adds encoded temperature value to the buffer
+ *
+ * @param[in] serialization     lora serialization descriptor
+ * @param[in] temperature       temperature value
+ */
+int lora_serialization_write_temperature(lora_serialization_t *serialization,
+                                         float temperature);
+
+/**
+ * @brief Adds a bitmap to the buffer. The bits are represented
+ * from letter `a` to `h`, with `a` being the most significant bit.
+ *
+ * @param[in] serialization     lora serialization descriptor
+ * @param[in] flags             flags encoded in a byte
+ */
+int lora_serialization_write_bitmap(lora_serialization_t *serialization,
+                                    uint8_t flags);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* LORA_SERIALIZATION_H */
+/** @} */

--- a/sys/lora_serialization/Makefile
+++ b/sys/lora_serialization/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/sys/lora_serialization/doc.txt
+++ b/sys/lora_serialization/doc.txt
@@ -1,0 +1,14 @@
+/**
+@defgroup    sys_lora_serialization Lora serialization library
+@ingroup     sys
+@brief       Utility functions for Lora serialization format.
+
+             This tests were adapted from the lora-serialization
+             library.
+
+@see         https://github.com/thesolarnomad/lora-serialization
+
+
+The lora-serialization format is a simple encoder for LoRaWAN that can be integrated with platform like The Things Network or OpenSenseMap.
+
+*/

--- a/sys/lora_serialization/lora_serialization.c
+++ b/sys/lora_serialization/lora_serialization.c
@@ -1,0 +1,150 @@
+/*
+ * Copyright (C) 2018 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @brief       Lora-serialization format implementation
+ *
+ * @author      Leandro Lanzieri <leandro.lanzieri@haw-hamburg.de>
+ * @author      Jose Ignacio Alamos <jose.alamos@haw-hamburg.de>
+ */
+
+#include "byteorder.h"
+#include "assert.h"
+#include "lora_serialization.h"
+
+void lora_serialization_reset(lora_serialization_t *serialization)
+{
+    memset(serialization->buffer, 0, LORA_SERIALIZATION_MAX_BUFFER_SIZE);
+    serialization->cursor = 0;
+}
+
+int lora_serialization_write_unix_time(lora_serialization_t *serialization,
+                                       uint32_t unixtime)
+{
+    le_uint32_t *value = (le_uint32_t *)
+                         (serialization->buffer + serialization->cursor);
+
+    if ((serialization->cursor + LORA_SERIALIZATION_UNIX_TIME_SIZE) >=
+        LORA_SERIALIZATION_MAX_BUFFER_SIZE) {
+        return -ENOBUFS;
+    }
+
+    *value = byteorder_btoll(byteorder_htonl(unixtime));
+    serialization->cursor += LORA_SERIALIZATION_UNIX_TIME_SIZE;
+
+    return 0;
+}
+
+int lora_serialization_write_coordinates(lora_serialization_t *serialization,
+                                         double latitude, double longitude)
+{
+    int32_t lat = latitude * 1e6;
+    int32_t lng = longitude * 1e6;
+    le_uint32_t *lat_value = (le_uint32_t *)
+                             (serialization->buffer + serialization->cursor);
+    le_uint32_t *lng_value = (le_uint32_t *)
+                             (serialization->buffer + serialization->cursor
+                              + LORA_SERIALIZATION_LATITUDE_SIZE);
+
+    if ((serialization->cursor + LORA_SERIALIZATION_GPS_SIZE) >=
+        LORA_SERIALIZATION_MAX_BUFFER_SIZE) {
+        return -ENOBUFS;
+    }
+
+    *lat_value = byteorder_btoll(byteorder_htonl(lat));
+    *lng_value = byteorder_btoll(byteorder_htonl(lng));
+
+    serialization->cursor += LORA_SERIALIZATION_GPS_SIZE;
+
+    return 0;
+}
+
+int lora_serialization_write_uint16(lora_serialization_t *serialization,
+                                    uint16_t i)
+{
+    le_uint16_t *value = (le_uint16_t *)
+                         (serialization->buffer + serialization->cursor);
+
+    if ((serialization->cursor + LORA_SERIALIZATION_UINT16_SIZE) >=
+        LORA_SERIALIZATION_MAX_BUFFER_SIZE) {
+        return -ENOBUFS;
+    }
+
+    *value = byteorder_btols(byteorder_htons(i));
+    serialization->cursor += LORA_SERIALIZATION_UINT16_SIZE;
+
+    return 0;
+}
+
+int lora_serialization_write_uint8(lora_serialization_t *serialization,
+                                   uint8_t i)
+{
+    if ((serialization->cursor + LORA_SERIALIZATION_UINT8_SIZE) >=
+        LORA_SERIALIZATION_MAX_BUFFER_SIZE) {
+        return -ENOBUFS;
+    }
+
+    (serialization->buffer)[serialization->cursor] = i;
+    serialization->cursor += LORA_SERIALIZATION_UINT8_SIZE;
+
+    return 0;
+}
+
+int lora_serialization_write_humidity(lora_serialization_t *serialization,
+                                      float humidity)
+{
+    int16_t h = (int16_t)(humidity * 100);
+    le_uint16_t *value = (le_uint16_t *)
+                         (serialization->buffer + serialization->cursor);
+
+    if ((serialization->cursor + LORA_SERIALIZATION_HUMIDITY_SIZE) >=
+        LORA_SERIALIZATION_MAX_BUFFER_SIZE) {
+        return -ENOBUFS;
+    }
+
+    *value = byteorder_btols(byteorder_htons(h));
+    serialization->cursor += LORA_SERIALIZATION_HUMIDITY_SIZE;
+
+    return 0;
+}
+
+/* The temperature has to be  written in Big Endian */
+int lora_serialization_write_temperature(lora_serialization_t *serialization,
+                                         float temperature)
+{
+    int16_t t = (int16_t) (temperature * 100);
+    network_uint16_t *value = (network_uint16_t *)
+                              (serialization->buffer + serialization->cursor);
+
+    if ((serialization->cursor + LORA_SERIALIZATION_TEMPERATURE_SIZE) >=
+        LORA_SERIALIZATION_MAX_BUFFER_SIZE) {
+        return -ENOBUFS;
+    }
+
+    if (temperature < 0) {
+        t = ~-t;
+        t++;
+    }
+
+    *value = byteorder_htons((uint16_t) t);
+    serialization->cursor += LORA_SERIALIZATION_TEMPERATURE_SIZE;
+
+    return 0;
+}
+
+int lora_serialization_write_bitmap(lora_serialization_t *serialization,
+                                    uint8_t flags)
+{
+    if ((serialization->cursor + 1U) >= LORA_SERIALIZATION_MAX_BUFFER_SIZE) {
+        return -ENOBUFS;
+    }
+
+    serialization->buffer[serialization->cursor] = flags;
+
+    return 0;
+}

--- a/tests/unittests/tests-lora_serialization/Makefile
+++ b/tests/unittests/tests-lora_serialization/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/tests/unittests/tests-lora_serialization/Makefile.include
+++ b/tests/unittests/tests-lora_serialization/Makefile.include
@@ -1,0 +1,1 @@
+USEMODULE += lora_serialization

--- a/tests/unittests/tests-lora_serialization/tests-lora_serialization.c
+++ b/tests/unittests/tests-lora_serialization/tests-lora_serialization.c
@@ -1,0 +1,251 @@
+/*
+ * Copyright (C) 2018 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     unittests
+ * @{
+ *
+ * @file
+ * @brief       lora-serialization tests
+ *
+ * @author      Leandro Lanzieri <leandro.lanzieri@haw-hamburg.de>
+ * @author      Jose Ignacio Alamos <jose.alamos@haw-hamburg.de>
+ *
+ * @}
+ */
+
+#include <string.h>
+#include "embUnit.h"
+#include "tests-lora_serialization.h"
+#include "lora_serialization.h"
+
+#define LORA_SERIALIZATION_FAKE_CURSOR              (20U)
+#define LORA_SERIALIZATION_UNIX_TIME_SIMPLE         (1)
+#define LORA_SERIALIZATION_UNIX_TIME                (1467632413)
+#define LORA_SERIALIZATION_LATITUDE                 (-33.905052)
+#define LORA_SERIALIZATION_LONGITUDE                (151.26641)
+#define LORA_SERIALIZATION_UINT8                    (10)
+#define LORA_SERIALIZATION_UINT16                   (23453)
+#define LORA_SERIALIZATION_TEMPERATURE              (80.12)
+#define LORA_SERIALIZATION_NEGATIVE_TEMPERATURE     (-123.45)
+#define LORA_SERIALIZATION_HUMIDITY                 (99.99)
+
+#define LORA_SERIALIZATION_EXPECTED_UNIX_TIME_SIMPLE        { 1, 0, 0, 0 }
+#define LORA_SERIALIZATION_EXPECTED_UNIX_TIME               { 0x1d, 0x4b, 0x7a, 0x57 }
+#define LORA_SERIALIZATION_EXPECTED_COORDS                  { 0x64, 0xa6, 0xfa, 0xfd, \
+                                                              0x6a, 0x24, 0x04, 0x09 }
+#define LORA_SERIALIZATION_EXPECTED_UINT8                   { 0x0A }
+#define LORA_SERIALIZATION_EXPECTED_UINT16                  { 0x9d, 0x5b }
+#define LORA_SERIALIZATION_EXPECTED_TEMPERATURE             { 0x1f, 0x4c }
+#define LORA_SERIALIZATION_EXPECTED_NEGATIVE_TEMPERATURE    { 0xcf, 0xc7 }
+#define LORA_SERIALIZATION_EXPECTED_HUMIDITY                { 0x0f, 0x27 }
+
+#define LORA_SERIALIZATION_EXPECTED_TEST {                \
+        0x1d, 0x4b, 0x7a, 0x57,                           \
+        0x64, 0xa6, 0xfa, 0xfd, 0x6a, 0x24, 0x04, 0x09,   \
+        0x0A,                                             \
+        0x9d, 0x5b,                                       \
+        0x1f, 0x4c,                                       \
+        0x0f, 0x27                                        \
+};
+
+static lora_serialization_t lora_serialization;
+
+static void setUp(void)
+{
+    /* Initialize */
+}
+
+static void tearDown(void)
+{
+    /* Finalize */
+}
+
+static void test_lora_serialization_01(void)
+{
+    lora_serialization.cursor = LORA_SERIALIZATION_FAKE_CURSOR;
+    lora_serialization_reset(&lora_serialization);
+
+    TEST_ASSERT_EQUAL_INT(0, lora_serialization.cursor);
+}
+
+static void test_lora_serialization_02(void)
+{
+    /* should transform a simple unixtime to a byte array */
+    lora_serialization_reset(&lora_serialization);
+
+    lora_serialization_write_unix_time(&lora_serialization,
+                                       LORA_SERIALIZATION_UNIX_TIME_SIMPLE);
+    uint8_t expected[] = LORA_SERIALIZATION_EXPECTED_UNIX_TIME_SIMPLE;
+
+    TEST_ASSERT_EQUAL_INT(0, memcmp(lora_serialization.buffer,
+                                    expected, sizeof(expected)));
+}
+
+static void test_lora_serialization_03(void)
+{
+    /* should transform a given unixtime to a byte array */
+    lora_serialization_reset(&lora_serialization);
+
+    uint32_t now = LORA_SERIALIZATION_UNIX_TIME;
+    uint8_t expected[] = LORA_SERIALIZATION_EXPECTED_UNIX_TIME;
+
+    lora_serialization_write_unix_time(&lora_serialization, now);
+
+    TEST_ASSERT_EQUAL_INT(0, memcmp(lora_serialization.buffer,
+                                    expected, sizeof(expected)));
+}
+
+static void test_lora_serialization_04(void)
+{
+    /* should transform a coordinate to a byte array */
+    lora_serialization_reset(&lora_serialization);
+    uint8_t expected[] = LORA_SERIALIZATION_EXPECTED_COORDS;
+
+    lora_serialization_write_coordinates(&lora_serialization,
+                                         LORA_SERIALIZATION_LATITUDE,
+                                         LORA_SERIALIZATION_LONGITUDE);
+
+    TEST_ASSERT_EQUAL_INT(0, memcmp(lora_serialization.buffer,
+                                    expected, sizeof(expected)));
+}
+
+static void test_lora_serialization_05(void)
+{
+    /* should transform an unsigned 8bit int to a byte array */
+    lora_serialization_reset(&lora_serialization);
+    uint8_t expected[] = LORA_SERIALIZATION_EXPECTED_UINT8;
+
+    lora_serialization_write_uint8(&lora_serialization,
+                                   LORA_SERIALIZATION_UINT8);
+
+    TEST_ASSERT_EQUAL_INT(0, memcmp(lora_serialization.buffer,
+                                    expected, sizeof(expected)));
+}
+
+static void test_lora_serialization_06(void)
+{
+    /* should transform an unsigned 16bit int to a byte array */
+    lora_serialization_reset(&lora_serialization);
+    uint8_t expected[] = LORA_SERIALIZATION_EXPECTED_UINT16;
+
+    lora_serialization_write_uint16(&lora_serialization,
+                                    LORA_SERIALIZATION_UINT16);
+
+    TEST_ASSERT_EQUAL_INT(0, memcmp(lora_serialization.buffer,
+                                    expected, sizeof(expected)));
+}
+
+static void test_lora_serialization_07(void)
+{
+    /* should transform a temperature to a byte array */
+    lora_serialization_reset(&lora_serialization);
+    uint8_t expected[] = LORA_SERIALIZATION_EXPECTED_TEMPERATURE;
+
+    lora_serialization_write_temperature(&lora_serialization,
+                                         LORA_SERIALIZATION_TEMPERATURE);
+
+    TEST_ASSERT_EQUAL_INT(0, memcmp(lora_serialization.buffer,
+                                    expected, sizeof(expected)));
+}
+
+static void test_lora_serialization_08(void)
+{
+    /* should transform a negative temperature to a byte array */
+    lora_serialization_reset(&lora_serialization);
+    uint8_t expected[] = LORA_SERIALIZATION_EXPECTED_NEGATIVE_TEMPERATURE;
+
+    lora_serialization_write_temperature(&lora_serialization,
+                                         LORA_SERIALIZATION_NEGATIVE_TEMPERATURE);
+
+    TEST_ASSERT_EQUAL_INT(0, memcmp(lora_serialization.buffer,
+                                    expected, sizeof(expected)));
+}
+
+static void test_lora_serialization_09(void)
+{
+    /* should transform a humidity to a byte array */
+    lora_serialization_reset(&lora_serialization);
+    uint8_t expected[] = LORA_SERIALIZATION_EXPECTED_HUMIDITY;
+
+    lora_serialization_write_humidity(&lora_serialization,
+                                      LORA_SERIALIZATION_HUMIDITY);
+
+    TEST_ASSERT_EQUAL_INT(0, memcmp(lora_serialization.buffer,
+                                    expected, sizeof(expected)));
+}
+
+static void test_lora_serialization_10(void)
+{
+    /* write multiple fields to one byte array */
+    lora_serialization_reset(&lora_serialization);
+
+    uint8_t expected[] = LORA_SERIALIZATION_EXPECTED_TEST;
+
+    lora_serialization_write_unix_time(&lora_serialization,
+                                       LORA_SERIALIZATION_UNIX_TIME);
+    lora_serialization_write_coordinates(&lora_serialization,
+                                         LORA_SERIALIZATION_LATITUDE,
+                                         LORA_SERIALIZATION_LONGITUDE);
+    lora_serialization_write_uint8(&lora_serialization,
+                                   LORA_SERIALIZATION_UINT8);
+    lora_serialization_write_uint16(&lora_serialization,
+                                    LORA_SERIALIZATION_UINT16);
+    lora_serialization_write_temperature(&lora_serialization,
+                                         LORA_SERIALIZATION_TEMPERATURE);
+    lora_serialization_write_humidity(&lora_serialization,
+                                      LORA_SERIALIZATION_HUMIDITY);
+
+    TEST_ASSERT_EQUAL_INT(0, memcmp(lora_serialization.buffer,
+                                    expected, sizeof(expected)));
+    TEST_ASSERT_EQUAL_INT(lora_serialization.cursor, sizeof(expected));
+}
+
+
+static void test_lora_serialization_11(void)
+{
+    /* fail to write more than LORA_SERIALIZATION_MAX_BUFFER_SIZE bytes */
+    lora_serialization_reset(&lora_serialization);
+    uint8_t iterations = LORA_SERIALIZATION_MAX_BUFFER_SIZE /
+                         LORA_SERIALIZATION_UINT8_SIZE;
+
+    for (uint8_t i = 0; i < iterations; i++) {
+        lora_serialization_write_uint8(&lora_serialization,
+                                       LORA_SERIALIZATION_UINT8);
+    }
+
+    TEST_ASSERT_EQUAL_INT(
+            lora_serialization_write_uint8(
+                &lora_serialization, LORA_SERIALIZATION_UINT8),
+            -ENOBUFS);
+}
+
+Test *tests_lora_serialization_all(void)
+{
+    EMB_UNIT_TESTFIXTURES(fixtures) {
+        new_TestFixture(test_lora_serialization_01),
+        new_TestFixture(test_lora_serialization_02),
+        new_TestFixture(test_lora_serialization_03),
+        new_TestFixture(test_lora_serialization_04),
+        new_TestFixture(test_lora_serialization_05),
+        new_TestFixture(test_lora_serialization_06),
+        new_TestFixture(test_lora_serialization_07),
+        new_TestFixture(test_lora_serialization_08),
+        new_TestFixture(test_lora_serialization_09),
+        new_TestFixture(test_lora_serialization_10),
+        new_TestFixture(test_lora_serialization_11),
+    };
+
+    EMB_UNIT_TESTCALLER(lora_serialization_tests, setUp, tearDown, fixtures);
+    return (Test *)&lora_serialization_tests;
+}
+
+void tests_lora_serialization(void)
+{
+    TESTS_RUN(tests_lora_serialization_all());
+}

--- a/tests/unittests/tests-lora_serialization/tests-lora_serialization.h
+++ b/tests/unittests/tests-lora_serialization/tests-lora_serialization.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2018 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @addtogroup  unittests
+ * @{
+ *
+ * @file
+ * @brief       Unittests for the ``lora-serialization`` module
+ *
+ * @author      Leandro Lanzieri <leandro.lanzieri@haw-hamburg.de>
+ * @author      Jose Ignacio Alamos <jose.alamos@haw-hamburg.de>
+ */
+
+#ifndef TESTS_LORA_SERIALIZATION_H
+#define TESTS_LORA_SERIALIZATION_H
+
+#include "embUnit/embUnit.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+*  @brief   The entry point of this test suite.
+*/
+void tests_lora_serialization(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* TESTS_LORA_SERIALIZATION_H */
+/** @} */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR adds support for the [lora-serialization](https://github.com/thesolarnomad/lora-serialization) format. The original library was not included as a pkg because it uses dynamic allocation and patching/writing interfaces was more complicate than just writing some the helpers.

An example showing the lora-serialization format integrated to [OpenSenseMap](http://opensensemap.org/) will be pushed in a further PR.

This work was done in conjunction with @leandrolanzieri.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
```
cd $(RIOTBASE)/tests/unittest
make tests-lora_serialization term
```
Should output:
```
main(): This is RIOT! (Version: 2018.10-devel-571-g07d139-archlinux-pr/lora-serialization)
..........
OK (10 tests)

```
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
