### PR TITLE
doc: add `math` group to Doxygen

### DIFF
--- a/pkg/libfixmath/doc.txt
+++ b/pkg/libfixmath/doc.txt
@@ -1,7 +1,7 @@
 /**
  * @defgroup pkg_libfixmath Cross platform fixed point maths library
  * @ingroup  pkg
- * @ingroup  sys
+ * @ingroup  sys_math
  * @brief    Provides a cross platform fixed point maths library to RIOT.
  * @see      https://github.com/PetteriAimonen/libfixmath
  */

--- a/sys/doc.txt
+++ b/sys/doc.txt
@@ -22,3 +22,9 @@
  * See http://wiki.osdev.org/Stack_Smashing_Protector for a more detailed
  * description.
  */
+
+/**
+ * @defgroup    sys_math Math libraries and utilities
+ * @ingroup     sys
+ * @brief       Provides math libraries and utilities for RIOT
+ */

--- a/sys/include/div.h
+++ b/sys/include/div.h
@@ -9,13 +9,13 @@
 
 /**
  * @defgroup  sys_div   Integer division functions
- * @ingroup   sys
+ * @ingroup   sys_math
  *
  * This header provides some integer division functions that can be used
  * to prevent linking in compiler-generated ones, which are often larger.
  *
  * @file
- * @ingroup   sys
+ * @ingroup   sys_div
  * @author    Kaspar Schleiser <kaspar@schleiser.de>
  * @author    Joakim Nohlgård <joakim.nohlgard@eistec.se>
  * @{

--- a/sys/include/matstat.h
+++ b/sys/include/matstat.h
@@ -7,9 +7,7 @@
  */
 
 /**
- * @defgroup    sys_matstat Matstat - Integer mathematical statistics library
- * @ingroup     sys
- * @brief       Library for computing 1-pass statistics
+ * @ingroup     sys_matstat
  *
  * The Matstat library uses single pass algorithms to compute statistic measures
  * such as mean and variance over many values. The values can be immediately

--- a/sys/include/seq.h
+++ b/sys/include/seq.h
@@ -7,9 +7,7 @@
  */
 
 /**
- * @defgroup    sys_seq     Serial Number Arithmetic
- * @ingroup     sys
- * @brief       Serial Number Arithmetic (RFC 1982)
+ * @ingroup     sys_seq
  * @{
  *
  * @file

--- a/sys/matstat/doc.txt
+++ b/sys/matstat/doc.txt
@@ -1,0 +1,5 @@
+/**
+ * @defgroup    sys_matstat Matstat - Integer mathematical statistics library
+ * @ingroup     sys_math
+ * @brief       Library for computing 1-pass statistics
+ */

--- a/sys/seq/doc.txt
+++ b/sys/seq/doc.txt
@@ -1,0 +1,5 @@
+/**
+ * @defgroup    sys_seq     Serial Number Arithmetic
+ * @ingroup     sys_math
+ * @brief       Serial Number Arithmetic (RFC 1982)
+ */


### PR DESCRIPTION
### Contribution description

This is yet another PR for improving the documentation structure.

Here I group several math modulesin a `Math libraries and utilities` group, so they are easier to find for the end user.

A `sys_math` group was defined under sys group.

The following modules where touched and added to the corresponding groups:

- sys/div.h: sys_math
- sys/matstat: sys_math
- sys/seq: sys_math
- pkg/libfixmath: sys_math, pkg

### Testing procedure

`make doc`. 

Go to `System>Math libraries and utilities` in the generated documentation and see how these components are grouped.

### Issues/PRs references

#8479