### PR TITLE
core: Mark openocd info variables read-only

### DIFF
--- a/core/sched.c
+++ b/core/sched.c
@@ -65,13 +65,13 @@ static uint32_t runqueue_bitcache = 0;
 #endif
 
 FORCE_USED_SECTION
-uint8_t max_threads = sizeof(sched_threads) / sizeof(thread_t*);
+const uint8_t max_threads = sizeof(sched_threads) / sizeof(thread_t*);
 
 #ifdef DEVELHELP
 /* OpenOCD can't determine struct offsets and additionally this member is only
  * available if compiled with DEVELHELP */
 FORCE_USED_SECTION
-uint8_t _tcb_name_offset = offsetof(thread_t, name);
+const uint8_t _tcb_name_offset = offsetof(thread_t, name);
 #endif
 
 #ifdef MODULE_SCHEDSTATISTICS


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

These are not changing during runtime, they are only accessed by openocd when debugging. Marking them const lets the linker place them in ROM.

### Testing procedure

1. Flash a binary
2. `make debug` with a RIOT patched openocd (https://github.com/daniel-k/openocd/tree/riot_patched, http://openocd.zylin.com/#/c/3000/)
3. `info threads` should show the running threads after the system has booted

### Issues/PRs references

split from #9104 to ease review