### PR TITLE
drivers: Add missing dependencies

### DIFF
--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -236,6 +236,10 @@ ifneq (,$(filter lpd8808,$(USEMODULE)))
   FEATURES_REQUIRED += periph_gpio
 endif
 
+ifneq (,$(filter lps331ap,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_i2c
+endif
+
 ifneq (,$(filter lsm6dsl,$(USEMODULE)))
   FEATURES_REQUIRED += periph_i2c
   USEMODULE += xtimer

--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -305,6 +305,12 @@ ifneq (,$(filter nrfmin,$(USEMODULE)))
   USEMODULE += netif
 endif
 
+ifneq (,$(filter nrf24l01p,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_gpio
+  FEATURES_REQUIRED += periph_spi
+  USEMODULE += xtimer
+endif
+
 ifneq (,$(filter nvram_spi,$(USEMODULE)))
   USEMODULE += nvram
   USEMODULE += xtimer

--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -13,6 +13,10 @@ ifneq (,$(filter ads101%,$(USEMODULE)))
   USEMODULE += xtimer
 endif
 
+ifneq (,$(filter adt7310,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_spi
+endif
+
 ifneq (,$(filter adxl345,$(USEMODULE)))
   FEATURES_REQUIRED += periph_i2c
 endif

--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -231,10 +231,6 @@ ifneq (,$(filter lis3dh,$(USEMODULE)))
   FEATURES_REQUIRED += periph_spi
 endif
 
-ifneq (,$(filter lm75a,$(USEMODULE)))
-  USEMODULE += xtimer
-endif
-
 ifneq (,$(filter lpd8808,$(USEMODULE)))
   USEMODULE += color
   FEATURES_REQUIRED += periph_gpio

--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -318,6 +318,8 @@ ifneq (,$(filter nvram_spi,$(USEMODULE)))
 endif
 
 ifneq (,$(filter pcd8544,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_gpio
+  FEATURES_REQUIRED += periph_spi
   USEMODULE += xtimer
 endif
 

--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -429,6 +429,8 @@ ifneq (,$(filter w5100,$(USEMODULE)))
 endif
 
 ifneq (,$(filter xbee,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_uart
+  FEATURES_REQUIRED += periph_gpio
   USEMODULE += ieee802154
   USEMODULE += xtimer
   USEMODULE += netif

--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -167,6 +167,7 @@ endif
 
 ifneq (,$(filter hih6130,$(USEMODULE)))
   USEMODULE += xtimer
+  FEATURES_REQUIRED += periph_i2c
 endif
 
 ifneq (,$(filter hts221,$(USEMODULE)))

--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -174,6 +174,10 @@ ifneq (,$(filter hts221,$(USEMODULE)))
   FEATURES_REQUIRED += periph_i2c
 endif
 
+ifneq (,$(filter ina220,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_i2c
+endif
+
 ifneq (,$(filter io1_xplained,$(USEMODULE)))
   FEATURES_REQUIRED += periph_gpio
   FEATURES_REQUIRED += periph_adc

--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -204,6 +204,7 @@ ifneq (,$(filter kw2xrf,$(USEMODULE)))
   USEMODULE += netdev_ieee802154
   USEMODULE += core_thread_flags
   FEATURES_REQUIRED += periph_spi
+  FEATURES_REQUIRED += periph_gpio
 endif
 
 ifneq (,$(filter l3g4200d,$(USEMODULE)))

--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -383,6 +383,11 @@ ifneq (,$(filter srf02,$(USEMODULE)))
   USEMODULE += xtimer
 endif
 
+ifneq (,$(filter srf02,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_i2c
+  USEMODULE += xtimer
+endif
+
 ifneq (,$(filter srf08,$(USEMODULE)))
   USEMODULE += xtimer
 endif

--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -270,6 +270,10 @@ ifneq (,$(filter mpu9150,$(USEMODULE)))
   USEMODULE += xtimer
 endif
 
+ifneq (,$(filter mq3,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_adc
+endif
+
 ifneq (,$(filter mrf24j40,$(USEMODULE)))
   USEMODULE += xtimer
   USEMODULE += luid

--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -240,6 +240,10 @@ ifneq (,$(filter lps331ap,$(USEMODULE)))
   FEATURES_REQUIRED += periph_i2c
 endif
 
+ifneq (,$(filter lsm303dlhc,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_i2c
+endif
+
 ifneq (,$(filter lsm6dsl,$(USEMODULE)))
   FEATURES_REQUIRED += periph_i2c
   USEMODULE += xtimer

--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -389,6 +389,7 @@ ifneq (,$(filter srf02,$(USEMODULE)))
 endif
 
 ifneq (,$(filter srf08,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_i2c
   USEMODULE += xtimer
 endif
 

--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -185,6 +185,10 @@ ifneq (,$(filter io1_xplained,$(USEMODULE)))
   USEMODULE += sdcard_spi
 endif
 
+ifneq (,$(filter isl29020,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_i2c
+endif
+
 ifneq (,$(filter jc42,$(USEMODULE)))
   FEATURES_REQUIRED += periph_i2c
 endif

--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -211,6 +211,11 @@ ifneq (,$(filter l3g4200d,$(USEMODULE)))
   FEATURES_REQUIRED += periph_i2c
 endif
 
+ifneq (,$(filter lc709203f,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_i2c
+  FEATURES_REQUIRED += periph_gpio
+endif
+
 ifneq (,$(filter lis2dh12%,$(USEMODULE)))
   ifneq (,$(filter lis2dh12_spi,$(USEMODULE)))
     FEATURES_REQUIRED += periph_gpio

--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -189,6 +189,10 @@ ifneq (,$(filter isl29020,$(USEMODULE)))
   FEATURES_REQUIRED += periph_i2c
 endif
 
+ifneq (,$(filter isl29125,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_i2c
+endif
+
 ifneq (,$(filter jc42,$(USEMODULE)))
   FEATURES_REQUIRED += periph_i2c
 endif

--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -312,6 +312,7 @@ ifneq (,$(filter nrf24l01p,$(USEMODULE)))
 endif
 
 ifneq (,$(filter nvram_spi,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_spi
   USEMODULE += nvram
   USEMODULE += xtimer
 endif

--- a/tests/driver_adcxx1c/Makefile
+++ b/tests/driver_adcxx1c/Makefile
@@ -1,7 +1,5 @@
 include ../Makefile.tests_common
 
-FEATURES_REQUIRED = periph_i2c
-
 USEMODULE += adc081c
 USEMODULE += xtimer
 

--- a/tests/driver_ads101x/Makefile
+++ b/tests/driver_ads101x/Makefile
@@ -1,7 +1,5 @@
 include ../Makefile.tests_common
 
-FEATURES_REQUIRED = periph_i2c
-
 USEMODULE += ads101x
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_adt7310/Makefile
+++ b/tests/driver_adt7310/Makefile
@@ -4,8 +4,6 @@ BOARD_INSUFFICIENT_MEMORY := arduino-mega2560 \
                              mega-xplained \
                              waspmote-pro
 
-FEATURES_REQUIRED = periph_spi periph_gpio
-
 USEMODULE += adt7310
 USEMODULE += xtimer
 

--- a/tests/driver_at30tse75x/Makefile
+++ b/tests/driver_at30tse75x/Makefile
@@ -1,7 +1,5 @@
 include ../Makefile.tests_common
 
-FEATURES_REQUIRED = periph_i2c
-
 USEMODULE += at30tse75x
 USEMODULE += shell
 USEMODULE += shell_commands

--- a/tests/driver_at86rf2xx/Makefile
+++ b/tests/driver_at86rf2xx/Makefile
@@ -3,8 +3,6 @@ include ../Makefile.tests_common
 # exclude boards with insufficient memory
 BOARD_INSUFFICIENT_MEMORY := nucleo-f031k6
 
-FEATURES_REQUIRED = periph_spi periph_gpio
-
 DISABLE_MODULE += auto_init
 
 USEMODULE += od

--- a/tests/driver_hdc1000/Makefile
+++ b/tests/driver_hdc1000/Makefile
@@ -1,7 +1,5 @@
 include ../Makefile.tests_common
 
-FEATURES_REQUIRED = periph_i2c
-
 USEMODULE += hdc1000
 USEMODULE += xtimer
 USEMODULE += fmt

--- a/tests/driver_hih6130/Makefile
+++ b/tests/driver_hih6130/Makefile
@@ -1,7 +1,5 @@
 include ../Makefile.tests_common
 
-FEATURES_REQUIRED = periph_i2c
-
 USEMODULE += hih6130
 USEMODULE += xtimer
 

--- a/tests/driver_hts221/Makefile
+++ b/tests/driver_hts221/Makefile
@@ -1,7 +1,5 @@
 include ../Makefile.tests_common
 
-FEATURES_REQUIRED = periph_i2c
-
 USEMODULE += hts221
 USEMODULE += xtimer
 

--- a/tests/driver_ina220/Makefile
+++ b/tests/driver_ina220/Makefile
@@ -1,7 +1,5 @@
 include ../Makefile.tests_common
 
-FEATURES_REQUIRED = periph_i2c
-
 USEMODULE += ina220
 USEMODULE += xtimer
 

--- a/tests/driver_isl29020/Makefile
+++ b/tests/driver_isl29020/Makefile
@@ -1,7 +1,5 @@
 include ../Makefile.tests_common
 
-FEATURES_REQUIRED = periph_i2c
-
 USEMODULE += isl29020
 USEMODULE += xtimer
 

--- a/tests/driver_isl29125/Makefile
+++ b/tests/driver_isl29125/Makefile
@@ -3,8 +3,6 @@ BOARD ?= samr21-xpro
 
 include ../Makefile.tests_common
 
-FEATURES_REQUIRED = periph_i2c
-
 USEMODULE += isl29125
 USEMODULE += xtimer
 

--- a/tests/driver_kw2xrf/Makefile
+++ b/tests/driver_kw2xrf/Makefile
@@ -1,7 +1,5 @@
 include ../Makefile.tests_common
 
-FEATURES_REQUIRED = periph_spi periph_gpio
-
 BOARD_INSUFFICIENT_MEMORY := nucleo-f031k6 nucleo-f042k6 nucleo-l031k6 \
                              nucleo-f334r8 nucleo-l053r8 stm32f0discovery
 

--- a/tests/driver_l3g4200d/Makefile
+++ b/tests/driver_l3g4200d/Makefile
@@ -1,7 +1,5 @@
 include ../Makefile.tests_common
 
-FEATURES_REQUIRED = periph_i2c periph_gpio
-
 USEMODULE += l3g4200d
 USEMODULE += xtimer
 

--- a/tests/driver_lc709203f/Makefile
+++ b/tests/driver_lc709203f/Makefile
@@ -1,13 +1,7 @@
-APPLICATION = driver_lc709203f
 include ../Makefile.tests_common
-
-FEATURES_REQUIRED += periph_i2c
-FEATURES_REQUIRED += periph_gpio
 
 USEMODULE += lc709203f
 USEMODULE += xtimer
-
-
 CFLAGS += -DDEVELHELP
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_lps331ap/Makefile
+++ b/tests/driver_lps331ap/Makefile
@@ -1,7 +1,5 @@
 include ../Makefile.tests_common
 
-FEATURES_REQUIRED = periph_i2c
-
 USEMODULE += lps331ap
 USEMODULE += xtimer
 

--- a/tests/driver_lsm303dlhc/Makefile
+++ b/tests/driver_lsm303dlhc/Makefile
@@ -1,7 +1,5 @@
 include ../Makefile.tests_common
 
-FEATURES_REQUIRED = periph_i2c
-
 USEMODULE += lsm303dlhc
 USEMODULE += xtimer
 

--- a/tests/driver_lsm6dsl/Makefile
+++ b/tests/driver_lsm6dsl/Makefile
@@ -1,7 +1,5 @@
 include ../Makefile.tests_common
 
-FEATURES_REQUIRED = periph_i2c
-
 USEMODULE += lsm6dsl
 USEMODULE += xtimer
 

--- a/tests/driver_mag3110/Makefile
+++ b/tests/driver_mag3110/Makefile
@@ -1,7 +1,5 @@
 include ../Makefile.tests_common
 
-FEATURES_REQUIRED = periph_i2c
-
 USEMODULE += mag3110
 USEMODULE += xtimer
 

--- a/tests/driver_mma8x5x/Makefile
+++ b/tests/driver_mma8x5x/Makefile
@@ -1,7 +1,5 @@
 include ../Makefile.tests_common
 
-FEATURES_REQUIRED = periph_i2c
-
 USEMODULE += mma8x5x
 USEMODULE += xtimer
 

--- a/tests/driver_mpl3115a2/Makefile
+++ b/tests/driver_mpl3115a2/Makefile
@@ -1,7 +1,5 @@
 include ../Makefile.tests_common
 
-FEATURES_REQUIRED = periph_i2c
-
 USEMODULE += mpl3115a2
 USEMODULE += xtimer
 

--- a/tests/driver_mq3/Makefile
+++ b/tests/driver_mq3/Makefile
@@ -1,7 +1,5 @@
 include ../Makefile.tests_common
 
-FEATURES_REQUIRED = periph_adc
-
 USEMODULE += mq3
 USEMODULE += xtimer
 

--- a/tests/driver_nrf24l01p_lowlevel/Makefile
+++ b/tests/driver_nrf24l01p_lowlevel/Makefile
@@ -3,8 +3,6 @@ include ../Makefile.tests_common
 # exclude boards with insufficient memory
 BOARD_INSUFFICIENT_MEMORY := nucleo-f031k6
 
-FEATURES_REQUIRED = periph_spi
-
 USEMODULE += shell
 USEMODULE += shell_commands
 USEMODULE += ps

--- a/tests/driver_nvram_spi/Makefile
+++ b/tests/driver_nvram_spi/Makefile
@@ -1,7 +1,5 @@
 include ../Makefile.tests_common
 
-FEATURES_REQUIRED = periph_spi periph_gpio
-
 USEMODULE += nvram_spi
 USEMODULE += xtimer
 

--- a/tests/driver_pcd8544/Makefile
+++ b/tests/driver_pcd8544/Makefile
@@ -1,7 +1,5 @@
 include ../Makefile.tests_common
 
-FEATURES_REQUIRED = periph_gpio periph_spi
-
 USEMODULE += shell
 USEMODULE += pcd8544
 

--- a/tests/driver_srf02/Makefile
+++ b/tests/driver_srf02/Makefile
@@ -1,7 +1,5 @@
 include ../Makefile.tests_common
 
-FEATURES_REQUIRED = periph_i2c
-
 USEMODULE += xtimer
 USEMODULE += srf02
 USEMODULE += shell

--- a/tests/driver_srf08/Makefile
+++ b/tests/driver_srf08/Makefile
@@ -1,7 +1,5 @@
 include ../Makefile.tests_common
 
-FEATURES_REQUIRED = periph_i2c
-
 USEMODULE += xtimer
 USEMODULE += srf08
 

--- a/tests/driver_sx127x/Makefile
+++ b/tests/driver_sx127x/Makefile
@@ -15,7 +15,4 @@ DRIVER ?= sx1276
 # use SX1276 by default
 USEMODULE += $(DRIVER)
 
-FEATURES_REQUIRED ?= periph_spi
-FEATURES_REQUIRED ?= periph_gpio
-
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_tcs37727/Makefile
+++ b/tests/driver_tcs37727/Makefile
@@ -1,7 +1,5 @@
 include ../Makefile.tests_common
 
-FEATURES_REQUIRED = periph_i2c
-
 USEMODULE += tcs37727
 USEMODULE += xtimer
 

--- a/tests/driver_tmp006/Makefile
+++ b/tests/driver_tmp006/Makefile
@@ -1,7 +1,5 @@
 include ../Makefile.tests_common
 
-FEATURES_REQUIRED = periph_i2c
-
 USEMODULE += tmp006
 USEMODULE += xtimer
 

--- a/tests/driver_xbee/Makefile
+++ b/tests/driver_xbee/Makefile
@@ -1,7 +1,5 @@
 include ../Makefile.tests_common
 
-FEATURES_REQUIRED = periph_uart periph_gpio
-
 BOARD_INSUFFICIENT_MEMORY := nucleo-f031k6 nucleo-f042k6 nucleo-f030r8 nucleo-f334r8 \
                              stm32f0discovery
 

--- a/tests/openthread/Makefile
+++ b/tests/openthread/Makefile
@@ -26,8 +26,8 @@ ifneq (,$(filter iotlab-m3 fox iotlab-a8-m3,$(BOARD)))
 endif
 
 ifneq (,$(filter at86rf2%,$(DRIVER)))
-  FEATURES_REQUIRED = periph_spi
-  FEATURES_REQUIRED = periph_gpio
+  FEATURES_REQUIRED += periph_spi
+  FEATURES_REQUIRED += periph_gpio
 endif
 
 USEMODULE += $(DRIVER)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Some drivers were missing dependencies on their periph interfaces or other modules. This PR fixes that problem. The issue was hidden by the tests/drivers_ applications defining FEATURES_REQUIRED even though it should not have been necessary.


### Testing procedure

Any failures should show up in the linking phase, if the dependency is missing, the link will fail with missing symbols.


### Issues/PRs references

none