### PR TITLE
sys/eepreg: EEPROM registration support (version 2)

### DIFF
--- a/sys/Makefile
+++ b/sys/Makefile
@@ -1,6 +1,9 @@
 ifneq (,$(filter csma_sender,$(USEMODULE)))
   DIRS += net/link_layer/csma_sender
 endif
+ifneq (,$(filter eepreg,$(USEMODULE)))
+  DIRS += eepreg
+endif
 ifneq (,$(filter posix_semaphore,$(USEMODULE)))
   DIRS += posix/semaphore
 endif

--- a/sys/eepreg/Makefile
+++ b/sys/eepreg/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/sys/eepreg/eepreg.c
+++ b/sys/eepreg/eepreg.c
@@ -1,0 +1,517 @@
+/*
+ * Copyright (C) 2018 Acutam Automation, LLC
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup   sys_eepreg
+ * @{
+ *
+ * @file
+ * @brief   eepreg implementation
+ *
+ * @author  Matthew Blue <matthew.blue.neuro@gmail.com>
+ * @}
+ */
+
+#include <errno.h>
+#include <limits.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "eepreg.h"
+#include "irq.h"
+#include "periph/eeprom.h"
+
+#define ENABLE_DEBUG 0
+#include "debug.h"
+
+/* EEPREG magic number */
+static const char eepreg_magic[] = "RIOTREG";
+
+/* constant lengths */
+#define MAGIC_SIZE      (sizeof(eepreg_magic))
+
+/* constant locations */
+#define REG_START        (EEPROM_RESERV_CPU_LOW + EEPROM_RESERV_BOARD_LOW)
+#define REG_MAGIC_LOC    (REG_START)
+#define REG_END_LOC      (REG_MAGIC_LOC + MAGIC_SIZE)
+#define REG_ENT1_LOC     (REG_END_LOC + EEPREG_LOC_LEN)
+#define DAT_START        (EEPROM_SIZE - EEPROM_RESERV_CPU_HI \
+                          - EEPROM_RESERV_BOARD_HI - 1)
+
+static inline uint32_t _read_meta_uint(uint32_t loc)
+{
+    uint8_t data[4];
+    uint32_t ret;
+
+    eeprom_read(loc, data, EEPREG_LOC_LEN);
+
+    /* unused array members will be discarded */
+    ret = ((uint32_t)data[0] << 24)
+          | ((uint32_t)data[1] << 16)
+          | ((uint32_t)data[2] << 8)
+          | ((uint32_t)data[3]);
+
+    /* bit shift to discard unused array members */
+    ret >>= 8 * (4 - EEPREG_LOC_LEN);
+
+    return ret;
+}
+
+static inline void _write_meta_uint(uint32_t loc, uint32_t val)
+{
+    uint8_t data[4];
+
+    val <<= 8 * (4 - EEPREG_LOC_LEN);
+
+    data[0] = (uint8_t)(val >> 24);
+    data[1] = (uint8_t)(val >> 16);
+    data[2] = (uint8_t)(val >> 8);
+    data[3] = (uint8_t)val;
+
+    eeprom_write(loc, data, EEPREG_LOC_LEN);
+}
+
+static inline uint32_t _get_reg_end(void)
+{
+    return _read_meta_uint(REG_END_LOC);
+}
+
+static inline void _set_reg_end(uint32_t loc)
+{
+    _write_meta_uint(REG_END_LOC, loc);
+}
+
+static inline uint32_t _get_free_loc(void)
+{
+    /* free location is stored at the end of the registry */
+    return _read_meta_uint(_get_reg_end() - EEPREG_LOC_LEN);
+}
+
+static inline void _set_free_loc(uint32_t loc)
+{
+    /* free location is stored at the end of the registry */
+    _write_meta_uint(_get_reg_end() - EEPREG_LOC_LEN, loc);
+}
+
+static inline uint32_t _get_free_space(void)
+{
+    return _get_free_loc() - _get_reg_end() + 1;
+}
+
+static inline uint32_t _get_data_loc(uint32_t meta_loc)
+{
+    /* data location is at the start of meta-data */
+    return _read_meta_uint(meta_loc);
+}
+
+static inline void _set_data_loc(uint32_t meta_loc, uint32_t loc)
+{
+    /* data location is at the start of meta-data */
+    _write_meta_uint(meta_loc, loc);
+}
+
+static inline uint8_t _get_name_len(uint32_t meta_loc)
+{
+    meta_loc += EEPREG_LOC_LEN;
+
+    for (uint8_t offset = 0; offset < (uint8_t)UINT_MAX; offset++) {
+        uint8_t byte = eeprom_read_byte(meta_loc + offset);
+
+        if (byte == '\0') {
+            return offset + 1;
+        }
+    }
+
+    return (uint8_t)UINT_MAX;
+}
+
+static inline void _get_name(uint32_t meta_loc, char *name, uint8_t len)
+{
+    meta_loc += EEPREG_LOC_LEN;
+
+    for (uint8_t offset = 0; offset < len; offset++) {
+        name[offset] = eeprom_read_byte(meta_loc + offset);
+
+        if (name[offset] == '\0') {
+            return;
+        }
+    }
+}
+
+static inline uint32_t _get_prev_meta_loc(uint32_t meta_loc)
+{
+    /* minimum entry size */
+    meta_loc -= EEPREG_LOC_LEN + 2;
+
+    for (uint32_t offset = 0; meta_loc - offset > REG_ENT1_LOC; offset++) {
+        uint8_t byte = eeprom_read_byte(meta_loc - offset);
+
+        if (byte == '\0') {
+            return meta_loc - offset + 1;
+        }
+    }
+
+    return REG_ENT1_LOC;
+}
+
+static inline uint32_t _get_next_meta_loc(uint32_t meta_loc)
+{
+    /* Note: returns where next entry would be, even if non-existent */
+    uint8_t name_len = _get_name_len(meta_loc);
+
+    if (name_len == (uint8_t)UINT_MAX) {
+        return _get_reg_end() - EEPREG_LOC_LEN;
+    }
+
+    return meta_loc + EEPREG_LOC_LEN + name_len;
+}
+
+static inline uint32_t _get_meta_loc(const char *name)
+{
+    uint32_t meta_loc = REG_ENT1_LOC;
+    uint32_t reg_end = _get_reg_end();
+    uint8_t len = (uint8_t)strlen(name) + 1;
+    char data[len + 1];
+
+    /* make sure string is always terminated */
+    data[len] = '\0';
+
+    while (meta_loc < reg_end - EEPREG_LOC_LEN) {
+        _get_name(meta_loc, data, len);
+
+        /* check for match */
+        if (strcmp(data, name) == 0) {
+            return meta_loc;
+        }
+
+        meta_loc = _get_next_meta_loc(meta_loc);
+    }
+
+    /* no meta-data found */
+    return (uint32_t)UINT_MAX;
+}
+
+static inline uint32_t _get_data_len(uint32_t meta_loc)
+{
+    uint32_t loc = _get_data_loc(meta_loc);
+
+    uint32_t prev_loc;
+    if (meta_loc == REG_ENT1_LOC) {
+        prev_loc = DAT_START;
+    }
+    else {
+        /* previous entry data location is end of name's data */
+        meta_loc = _get_prev_meta_loc(meta_loc);
+        prev_loc = _get_data_loc(meta_loc);
+    }
+
+    return prev_loc - loc;
+}
+
+static inline int _new_entry(const char *name, uint32_t len)
+{
+    uint8_t name_len = (uint8_t)strlen(name) + 1;
+
+    /* check to see if there is enough room */
+    if (_get_free_space() < EEPREG_LOC_LEN + name_len + len) {
+        return -ENOSPC;
+    }
+
+    /* don't allow interrupts when editing registry */
+    unsigned int irq_state = irq_disable();
+
+    uint32_t meta_loc = _get_reg_end() - EEPREG_LOC_LEN;
+    uint32_t free_loc = _get_free_loc();
+
+    /* set the location of the data */
+    _set_data_loc(meta_loc, free_loc - len);
+
+    /* write name of entry */
+    eeprom_write(meta_loc + EEPREG_LOC_LEN, (uint8_t *)name, name_len);
+
+    /* update end of the registry */
+    _set_reg_end(meta_loc + EEPREG_LOC_LEN + name_len + EEPREG_LOC_LEN);
+
+    /* update beginning of free space location */
+    _set_free_loc(free_loc - len);
+
+    irq_restore(irq_state);
+
+    return 0;
+}
+
+static inline void _move_data(uint32_t oldpos, uint32_t newpos, uint32_t len)
+{
+    for (uint32_t count = 0; count < len; count++) {
+        uint32_t offset;
+
+        if (newpos < oldpos) {
+            /* move from beginning of data */
+            offset = count;
+        }
+        else {
+            /* move from end of data */
+            offset = len - count;
+        }
+
+        uint8_t byte = eeprom_read_byte(oldpos + offset);
+
+        eeprom_write_byte(newpos + offset, byte);
+    }
+}
+
+int eepreg_add(uint32_t *pos, const char *name, uint32_t len)
+{
+    uint32_t meta_loc;
+
+    int ret = eepreg_check();
+    if (ret == -ENOENT) {
+        /* reg does not exist, so make a new one */
+        eepreg_reset();
+    }
+    else if (ret < 0) {
+        DEBUG("[eepreg_add] eepreg_check failed\n");
+        return ret;
+    }
+
+    meta_loc = _get_meta_loc(name);
+
+    if (meta_loc == (uint32_t)UINT_MAX) {
+        /* entry does not exist, so make a new one */
+
+        /* location of the new data */
+        *pos = _get_free_loc() - len;
+
+        if (_new_entry(name, len) < 0) {
+            DEBUG("[eepreg_add] not enough space for %s\n", name);
+            return -ENOSPC;
+        }
+
+        return 0;
+    }
+
+    *pos = _get_data_loc(meta_loc);
+
+    if (len != _get_data_len(meta_loc)) {
+        DEBUG("[eepreg_add] %s already exists with different length\n", name);
+        return -EADDRINUSE;
+    }
+
+    return 0;
+}
+
+int eepreg_read(uint32_t *pos, const char *name)
+{
+    uint32_t meta_loc;
+
+    int ret = eepreg_check();
+    if (ret < 0) {
+        DEBUG("[eepreg_read] eepreg_check failed\n");
+        return ret;
+    }
+
+    meta_loc = _get_meta_loc(name);
+
+    if (meta_loc == (uint32_t)UINT_MAX) {
+        DEBUG("[eepreg_read] no entry for %s\n", name);
+        return -ENOENT;
+    }
+
+    *pos = _get_data_loc(meta_loc);
+
+    return 0;
+}
+
+int eepreg_write(uint32_t *pos, const char *name, uint32_t len)
+{
+    int ret = eepreg_check();
+    if (ret == -ENOENT) {
+        /* reg does not exist, so make a new one */
+        eepreg_reset();
+    }
+    else if (ret < 0) {
+        DEBUG("[eepreg_write] eepreg_check failed\n");
+        return ret;
+    }
+
+    /* location of the new data */
+    *pos = _get_free_loc() - len;
+
+    if (_new_entry(name, len) < 0) {
+        DEBUG("[eepreg_write] not enough space for %s\n", name);
+        return -ENOSPC;
+    }
+
+    return 0;
+}
+
+int eepreg_rm(const char *name)
+{
+    uint32_t meta_loc, next_meta, meta_len,
+             len, loc, new_loc, tot_len,
+             new_reg_end, new_free_loc;
+
+    int ret = eepreg_check();
+    if (ret < 0) {
+        DEBUG("[eepreg_rm] eepreg_check failed\n");
+        return ret;
+    }
+
+    meta_loc = _get_meta_loc(name);
+
+    if (meta_loc == (uint32_t)UINT_MAX) {
+        DEBUG("[eepreg_rm] no entry for %s\n", name);
+        return -ENOENT;
+    }
+
+    next_meta = _get_next_meta_loc(meta_loc);
+    meta_len = _get_reg_end() - next_meta;
+
+    len = _get_data_len(meta_loc);
+    loc = _get_data_loc(meta_loc);
+    new_loc = loc + len;
+    tot_len = loc - _get_free_loc();
+
+    new_reg_end = meta_loc + meta_len;
+    new_free_loc = new_loc - tot_len;
+
+    /* don't allow interrupts when editing registry */
+    unsigned int irq_state = irq_disable();
+
+    _move_data(next_meta, meta_loc, meta_len);
+    _move_data(loc - tot_len, new_free_loc, tot_len);
+
+    _set_reg_end(new_reg_end);
+    _set_free_loc(new_free_loc);
+
+    while (meta_loc < new_reg_end - EEPREG_LOC_LEN) {
+        _set_data_loc(meta_loc, _get_data_loc(meta_loc) + len);
+        meta_loc = _get_next_meta_loc(meta_loc);
+    }
+
+    irq_restore(irq_state);
+
+    return 0;
+}
+
+int eepreg_iter(eepreg_iter_cb_t cb, void *arg)
+{
+    uint32_t meta_loc = REG_ENT1_LOC;
+    uint32_t reg_end = _get_reg_end();
+
+    int ret = eepreg_check();
+    if (ret < 0) {
+        DEBUG("[eepreg_len] eepreg_check failed\n");
+        return ret;
+    }
+
+    while (meta_loc < reg_end - EEPREG_LOC_LEN) {
+        /* size of memory allocation */
+        uint8_t name_len = _get_name_len(meta_loc);
+
+        char name[name_len];
+
+        _get_name(meta_loc, name, name_len);
+
+        /* execute callback */
+        ret = cb(name, arg);
+
+        if (ret < 0) {
+            DEBUG("[eepreg_iter] callback reports failure\n");
+            return ret;
+        }
+
+        meta_loc = _get_next_meta_loc(meta_loc);
+    }
+
+    return 0;
+}
+
+int eepreg_check(void)
+{
+    char magic[MAGIC_SIZE + 1];
+
+    /* make sure string is always terminated */
+    magic[MAGIC_SIZE] = '\0';
+
+    /* get magic number from EEPROM */
+    if (eeprom_read(REG_MAGIC_LOC, (uint8_t *)magic, MAGIC_SIZE)
+        != MAGIC_SIZE) {
+
+        DEBUG("[eepreg_check] EEPROM read error\n");
+        return -EIO;
+    }
+
+    /* check to see if magic number is the same */
+    if (strcmp(magic, eepreg_magic) != 0) {
+        DEBUG("[eepreg_check] No registry detected\n");
+        return -ENOENT;
+    }
+
+    return 0;
+}
+
+int eepreg_reset(void)
+{
+    /* don't allow interrupts when editing registry */
+    unsigned int irq_state = irq_disable();
+
+    /* write new registry magic number */
+    if (eeprom_write(REG_MAGIC_LOC, (uint8_t *)eepreg_magic, MAGIC_SIZE)
+        != MAGIC_SIZE) {
+
+        DEBUG("[eepreg_reset] EEPROM write error\n");
+        irq_restore(irq_state);
+        return -EIO;
+    }
+
+    /* new registry has no entries */
+    _set_reg_end(REG_ENT1_LOC + EEPREG_LOC_LEN);
+
+    /* new registry has no corresponding data */
+    _set_free_loc(DAT_START);
+
+    irq_restore(irq_state);
+
+    return 0;
+}
+
+int eepreg_len(uint32_t *len, const char *name)
+{
+    uint32_t meta_loc;
+
+    int ret = eepreg_check();
+    if (ret < 0) {
+        DEBUG("[eepreg_len] eepreg_check failed\n");
+        return ret;
+    }
+
+    meta_loc = _get_meta_loc(name);
+
+    if (meta_loc == (uint32_t)UINT_MAX) {
+        DEBUG("[eepreg_len] no entry for %s\n", name);
+        return -ENOENT;
+    }
+
+    *len = _get_data_len(meta_loc);
+
+    return 0;
+}
+
+int eepreg_free(uint32_t *len)
+{
+    int ret = eepreg_check();
+    if (ret < 0) {
+        DEBUG("[eepreg_free] eepreg_check failed\n");
+        return ret;
+    }
+
+    *len = _get_free_space();
+
+    return 0;
+}

--- a/sys/include/eepreg.h
+++ b/sys/include/eepreg.h
@@ -1,0 +1,260 @@
+/*
+ * Copyright (C) 2018 Acutam Automation, LLC
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    sys_eepreg EEPROM registration
+ * @ingroup     sys
+ * @brief       eepreg provides a facility to easily manage the locations of
+ *              data stored in EEPROM via a meta-data registry.
+ *
+ * The structure of the meta-data registry is intended to make it easy to
+ * detect the exact layout of existent data so that automatic tools may be
+ * written to migrate legacy data to new formats. It also allows the addition
+ * and removal of new entries dynamically.
+ *
+ * NOTE: Names are used as identifiers and must be unique! It is also
+ * recommended to keep them as short as possible (while still being unique and
+ * human readable), as many systems have very small amounts of EEPROM.
+ * Disemvowelment can shorten long names while still retaining readability.
+ *
+ * The layout of the EEPROM used looks like this:
+ *    EEPROM_RESERV_CPU_LOW
+ *    EEPROM_RESERV_BOARD_LOW
+ *    Registry magic number ("RIOTREG\0")
+ *    Registry end location info
+ *    Registry entry 1 data location info
+ *    Registry entry 1 name (null terminated)
+ *    Registry entry 2 data location info
+ *    Registry entry 2 name
+ *    ...
+ *    Registry start of unused space location info
+ *    ... (new registry meta-data may be added in ascending order)
+ *    unused space
+ *    ... (new data locations may be added in descending order)
+ *    Entry 2 data
+ *    Entry 1 data
+ *    EEPROM_RESERV_BOARD_HI
+ *    EEPROM_RESERV_CPU_HI
+ *
+ * @{
+ *
+ * @file
+ * @brief       eepreg interface definitions
+ *
+ * @author      Matthew Blue <matthew.blue.neuro@gmail.com>
+ */
+
+#ifndef EEPREG_H
+#define EEPREG_H
+
+#include <stdint.h>
+
+#include "periph_cpu.h"
+#include "periph_conf.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef EEPROM_RESERV_CPU_LOW
+/**
+ * @brief   EEPROM reserved near beginning for use by CPU and related
+ *
+ * Change with care, as it may make existing data difficult to migrate
+ */
+#define EEPROM_RESERV_CPU_LOW    (0U)
+#endif
+
+#ifndef EEPROM_RESERV_CPU_HI
+/**
+ * @brief   EEPROM reserved near end for use by CPU and related
+ *
+ * Change with care, as it may make existing data difficult to migrate
+ */
+#define EEPROM_RESERV_CPU_HI    (0U)
+#endif
+
+#ifndef EEPROM_RESERV_BOARD_LOW
+/**
+ * @brief   EEPROM reserved near beginning for use by board and related
+ *
+ * Change with care, as it may make existing data difficult to migrate
+ */
+#define EEPROM_RESERV_BOARD_LOW    (0U)
+#endif
+
+#ifndef EEPROM_RESERV_BOARD_HI
+/**
+ * @brief   EEPROM reserved near end for use by board and related
+ *
+ * Change with care, as it may make existing data difficult to migrate
+ */
+#define EEPROM_RESERV_BOARD_HI    (0U)
+#endif
+
+/**
+ * @brief   Size in bytes of location meta-data entries in EEPROM
+ */
+#if (EEPROM_SIZE > 0x1000000)
+#define EEPREG_LOC_LEN    (4U)
+#elif (EEPROM_SIZE > 0x10000)
+#define EEPREG_LOC_LEN    (3U)
+#elif (EEPROM_SIZE > 0x100)
+#define EEPREG_LOC_LEN    (2U)
+#else
+#define EEPREG_LOC_LEN    (1U)
+#endif
+
+/**
+ * @brief   Signature of callback for iterating over entries in EEPROM registry
+ *
+ * @param[in] name    name of an entry in the registry
+ * @param[in] arg     argument for cb
+ *
+ * @return    0 on success
+ * @return    < 0 on failure
+ */
+typedef int (*eepreg_iter_cb_t)(char *name, void *arg);
+
+/**
+ * @brief   Load or write meta-data in EEPROM registry
+ *
+ * This checks to see if relevant meta-data exists in the EEPROM registry, and
+ * returns that data position if it exists. If an entry does not exist in the
+ * registry, meta-data is written and allocated data space if there is enough
+ * remaining. Requesting a different length for an existent entry returns an
+ * error.
+ *
+ * @param[out] pos    pointer to position variable
+ * @param[in] name    name of entry to load or write
+ * @param[in] len     requested amount of data storage
+ *
+ * @return    0 on success
+ * @return    -EIO on EEPROM I/O error
+ * @return    -ENOSPC on insufficient EEPROM for entry
+ * @return    -EADDRINUSE on existing entry with different length
+ */
+int eepreg_add(uint32_t *pos, const char *name, uint32_t len);
+
+/**
+ * @brief   Read position meta-data from EEPROM registry
+ *
+ * This is similar to eepreg_add, except it never writes meta-data.
+ *
+ * @param[out] pos    pointer to position variable
+ * @param[in] name    name of entry to load
+ *
+ * @return    0 on success
+ * @return    -EIO on EEPROM I/O error
+ * @return    -ENOENT on non-existent registry or entry
+ */
+int eepreg_read(uint32_t *pos, const char *name);
+
+/**
+ * @brief   Write meta-data to EEPROM registry
+ *
+ * This ignores existing meta-data and always makes a new entry in the
+ * registry. Typical use should be through eepreg_add and not eepreg_write.
+ * Mainly intended for use by migration utilities.
+ *
+ * @param[out] pos    pointer to position variable
+ * @param[in] name    name of entry to write
+ * @param[in] len     requested amount of data storage
+ *
+ * @return    0 on success
+ * @return    -EIO on EEPROM I/O error
+ * @return    -ENOSPC on insufficient EEPROM for entry
+ */
+int eepreg_write(uint32_t *pos, const char *name, uint32_t len);
+
+/**
+ * @brief   Remove entry from EEPROM registry and free space
+ *
+ * This removes an entry from the EEPROM registry and its corresponding data
+ * and moves the data and meta-data of entries after removed entry to occupy
+ * the freed space. This preserves the structure of the EEPROM registry.
+ * Warning: this is a read/write intensive operation! Mainly intended for use
+ * by migration utilities.
+ *
+ * @param[in] name    name of entry to remove
+ *
+ * @return    0 on success
+ * @return    -EIO on EEPROM I/O error
+ * @return    -ENOENT on non-existent registry or entry
+ */
+int eepreg_rm(const char *name);
+
+/**
+ * @brief   Iterate over meta-data entries in EEPROM registry
+ *
+ * This executes a callback over each name in the EEPROM registry. Mainly
+ * intended for use by migration utilities.
+ *
+ * @param[in] cb     callback to iterate over entries
+ * @param[in] arg    argument for cb
+ *
+ * @return    0 on success
+ * @return    -EIO on EEPROM I/O error
+ * @return    -ENOENT on non-existent registry
+ * @return    return value of cb when cb returns < 0
+ */
+int eepreg_iter(eepreg_iter_cb_t cb, void *arg);
+
+/**
+ * @brief   Check for the presence of meta-data registry
+ *
+ * @return    0 on success
+ * @return    -EIO on EEPROM I/O error
+ * @return    -ENOENT on non-existent registry
+ */
+int eepreg_check(void);
+
+/**
+ * @brief   Clear existing meta-data registry
+ *
+ * This removes any existing meta-data registry by writing a new registry with
+ * no entries. Mainly intended for use by migration utilities.
+ *
+ * @return    0 on success
+ * @return    -EIO on EEPROM I/O error
+ */
+int eepreg_reset(void);
+
+/**
+ * @brief   Calculate data length from meta-data in EEPROM registry
+ *
+ * Note: this information is typically already available to code that has
+ * called eepreg_add.
+ *
+ * @param[out] len    pointer to length variable
+ * @param[in] name    name of entry to load or write
+ *
+ * @return    0 on success
+ * @return    -EIO on EEPROM I/O error
+ * @return    -ENOENT on non-existent registry or entry
+ */
+int eepreg_len(uint32_t *len, const char *name);
+
+/**
+ * @brief   Calculate length of remaining EEPROM free space
+ *
+ * @param[out] len    pointer to length variable
+ *
+ * @return    0 on success
+ * @return    -EIO on EEPROM I/O error
+ * @return    -ENOENT on non-existent registry
+ */
+int eepreg_free(uint32_t *len);
+
+#ifdef __cplusplus
+}
+#endif
+
+/** @} */
+
+#endif /* EEPREG_H */

--- a/tests/eepreg/Makefile
+++ b/tests/eepreg/Makefile
@@ -1,0 +1,8 @@
+include ../Makefile.tests_common
+
+USEMODULE += periph_eeprom eepreg
+
+include $(RIOTBASE)/Makefile.include
+
+test:
+	./tests/01-run.py

--- a/tests/eepreg/README.md
+++ b/tests/eepreg/README.md
@@ -1,0 +1,6 @@
+# EEPROM registry (eepreg) test
+
+This test will verify the functionality of the eepreg module.
+
+WARNING: This will write to your EEPROM and probably corrupt any data that is
+there!

--- a/tests/eepreg/main.c
+++ b/tests/eepreg/main.c
@@ -1,0 +1,203 @@
+/*
+ * Copyright (C) 2018 Acutam Automation, LLC
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       eepreg test application
+ *
+ * @author      Matthew Blue <matthew.blue.neuro@gmail.com>
+ * @}
+ */
+
+#include <errno.h>
+#include <stdint.h>
+#include <stdio.h>
+#include <string.h>
+
+#include "eepreg.h"
+#include "periph/eeprom.h"
+
+#define DAT_START    (EEPROM_SIZE - EEPROM_RESERV_CPU_HI \
+                      - EEPROM_RESERV_BOARD_HI - 1)
+
+#define ENT1_NAME    "foo"
+#define ENT1_SIZE    (12U)
+#define ENT2_NAME    "bar"
+#define ENT2_SIZE    (34U)
+#define DATA         "spam and eggs"
+
+int eepreg_iter_cb(char *name, void *arg)
+{
+    (void)arg;
+
+    printf("%s ", name);
+
+    return 0;
+}
+
+int main(void)
+{
+    int ret;
+    uint32_t tmp1, tmp2, tmp3;
+    char data[sizeof(DATA)];
+
+    puts("EEPROM registry (eepreg) test routine");
+
+    printf("Testing new registry creation: ");
+
+    printf("reset ");
+    ret = eepreg_reset();
+    if (ret < 0) {
+        puts("[FAILED]");
+        return 1;
+    }
+
+    printf("check ");
+    ret = eepreg_check();
+    if (ret < 0) {
+        puts("[FAILED]");
+        return 1;
+    }
+
+    puts("[SUCCESS]");
+
+    printf("Testing writing and reading entries: ");
+
+    printf("add ");
+    ret = eepreg_add(&tmp1, ENT1_NAME, ENT1_SIZE);
+    if (ret < 0 || tmp1 != DAT_START - ENT1_SIZE) {
+        puts("[FAILED]");
+        return 1;
+    }
+
+    printf("write ");
+    ret = eepreg_write(&tmp2, ENT2_NAME, ENT2_SIZE);
+    if (ret < 0 || tmp2 != DAT_START - ENT1_SIZE - ENT2_SIZE) {
+        puts("[FAILED]");
+        return 1;
+    }
+
+    /* read via add */
+    printf("add ");
+    ret = eepreg_add(&tmp3, ENT1_NAME, ENT1_SIZE);
+    if (ret < 0 || tmp1 != tmp3) {
+        puts("[FAILED]");
+        return 1;
+    }
+
+    printf("read ");
+    ret = eepreg_read(&tmp1, ENT2_NAME);
+    if (ret < 0 || tmp1 != tmp2) {
+        puts("[FAILED]");
+        return 1;
+    }
+
+    puts("[SUCCESS]");
+
+    printf("Testing detection of conflicting size: ");
+
+    printf("add ");
+    ret = eepreg_add(&tmp1, ENT1_NAME, ENT1_SIZE + 1);
+    if (ret != -EADDRINUSE) {
+        puts("[FAILED]");
+        return 1;
+    }
+
+    puts("[SUCCESS]");
+
+    printf("Testing calculation of lengths: ");
+
+    printf("len ");
+    ret = eepreg_len(&tmp1, ENT1_NAME);
+    if (ret < 0 || tmp1 != ENT1_SIZE) {
+        puts("[FAILED]");
+        return 1;
+    }
+
+    printf("len ");
+    ret = eepreg_len(&tmp2, ENT2_NAME);
+    if (ret < 0 || tmp2 != ENT2_SIZE) {
+        puts("[FAILED]");
+        return 1;
+    }
+
+    puts("[SUCCESS]");
+
+    printf("Testing of successful data move after rm: ");
+
+    printf("rm ");
+    eepreg_read(&tmp1, ENT1_NAME);
+    eepreg_read(&tmp2, ENT2_NAME);
+    eeprom_write(tmp2, (uint8_t *)DATA, sizeof(DATA));
+    ret = eepreg_rm(ENT1_NAME);
+    if (ret < 0) {
+        puts("[FAILED]");
+        return 1;
+    }
+
+    printf("read ");
+    ret = eepreg_read(&tmp3, ENT2_NAME);
+    if (ret < 0 || tmp3 != (DAT_START - ENT2_SIZE)) {
+        puts("[FAILED]");
+        return 1;
+    }
+
+    printf("data ");
+    eeprom_read(tmp3, (uint8_t *)data, sizeof(DATA));
+    if (strcmp(data, DATA) != 0) {
+        puts("[FAILED]");
+        return 1;
+    }
+
+    puts("[SUCCESS]");
+
+    printf("Testing of free space change after write: ");
+
+    printf("free ");
+    ret = eepreg_free(&tmp1);
+    if (ret < 0) {
+        puts("[FAILED]");
+        return 1;
+    }
+
+    printf("add ");
+    ret = eepreg_add(&tmp3, ENT1_NAME, ENT1_SIZE);
+    if (ret < 0) {
+        puts("[FAILED]");
+        return 1;
+    }
+
+    printf("free ");
+    ret = eepreg_free(&tmp2);
+    if (ret < 0
+        || tmp1 != (tmp2 + ENT1_SIZE + sizeof(ENT1_NAME) + EEPREG_LOC_LEN)) {
+
+        puts("[FAILED]");
+        return 1;
+    }
+
+    puts("[SUCCESS]");
+
+    printf("Testing of iteration over registry: ");
+
+    printf("iter ");
+    ret = eepreg_iter(eepreg_iter_cb, NULL);
+    if (ret < 0) {
+        puts("[FAILED]");
+        return 1;
+    }
+
+    puts("[SUCCESS]");
+
+    puts("Tests complete!");
+
+    return 0;
+}

--- a/tests/eepreg/tests/01-run.py
+++ b/tests/eepreg/tests/01-run.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2018 Acutam Automation, LLC
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import sys
+from testrunner import run
+
+
+def testfunc(child):
+    child.expect_exact("EEPROM registry (eepreg) test routine")
+    child.expect_exact("Testing new registry creation: reset check [SUCCESS]")
+    child.expect_exact("Testing writing and reading entries: add write add read [SUCCESS]")
+    child.expect_exact("Testing detection of conflicting size: add [SUCCESS]")
+    child.expect_exact("Testing calculation of lengths: len len [SUCCESS]")
+    child.expect_exact("Testing of successful data move after rm: rm read data [SUCCESS]")
+    child.expect_exact("Testing of free space change after write: free add free [SUCCESS]")
+    child.expect_exact("Testing of iteration over registry: iter bar foo [SUCCESS]")
+    child.expect_exact("Tests complete!")
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc))


### PR DESCRIPTION
### Contribution description

This provides an extensive facility to easily manage the locations of data stored in EEPROM via a meta-data registry. Entries are addressed via a string name and can be dynamically added, and the position easily retrieved. Additional facilities are provided to allow migration utilities to be built, permitting legacy data to be moved to new versions of RIOT.

### Testing procedure
Tests provided in ```tests/eepreg```. Currently passes with no problems on mega-xplained.

### Issues/PRs references
Previous version: #9537