### PR TITLE
gnrc_rpl: fix zeroing of RPL DIS fields

### DIFF
--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_control_messages.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_control_messages.c
@@ -314,7 +314,6 @@ void gnrc_rpl_send_DIS(gnrc_rpl_instance_t *inst, ipv6_addr_t *destination,
                        gnrc_rpl_internal_opt_t **options, size_t num_opts)
 {
     gnrc_pktsnip_t *pkt = NULL, *tmp;
-    icmpv6_hdr_t *icmp;
     gnrc_rpl_dis_t *dis;
 
     /* No options provided to be attached to the DIS, so we PadN 2 bytes */
@@ -358,6 +357,9 @@ void gnrc_rpl_send_DIS(gnrc_rpl_instance_t *inst, ipv6_addr_t *destination,
         return;
     }
     pkt = tmp;
+    dis = (gnrc_rpl_dis_t *)pkt->data;
+    dis->flags = 0;
+    dis->reserved = 0;
 
     if ((tmp = gnrc_icmpv6_build(pkt, ICMPV6_RPL_CTRL, GNRC_RPL_ICMPV6_CODE_DIS,
                                  sizeof(icmpv6_hdr_t))) == NULL) {
@@ -366,12 +368,6 @@ void gnrc_rpl_send_DIS(gnrc_rpl_instance_t *inst, ipv6_addr_t *destination,
         return;
     }
     pkt = tmp;
-
-    icmp = (icmpv6_hdr_t *)pkt->data;
-    dis = (gnrc_rpl_dis_t *)(icmp + 1);
-    dis->flags = 0;
-    dis->reserved = 0;
-
 #ifdef MODULE_NETSTATS_RPL
     gnrc_rpl_netstats_tx_DIS(&gnrc_rpl_netstats, gnrc_pkt_len(pkt),
                              (destination && !ipv6_addr_is_multicast(destination)));


### PR DESCRIPTION
### Contribution description

The code originally assumed that the location of DIS struct is directly
after the ICMPv6 struct. This is not necessarily true when both structs
are individually allocated by pktbuf. This commit fixes this issue by
directly accessing the location of the DIS struct.

### Testing procedure

A bit difficult to really reproduce as it requires that the memory holding the `gnrc_rpl_dis_t` struct already contains a non-zero value and some wiresharking. I can reproduce it by first setting up with two native nodes.
First set up a RPL border router with the gnrc_networking example (add a global address, then initialize a rpl root).

After starting the second node, ensure that it doesn't configure the DODAG by one of the DIO messages multicasted by the border router, instead quickly send a DIS message with `rpl send dis`. On my computer, the second (the unicast) DIS message has nonzero values for the flags and reserved field.

Might require my next PR to properly test this :man_shrugging: 

### Issues/PRs references

None