### PR TITLE
gnrc_rpl: Pass options length to msg validator

### DIFF
--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_control_messages.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_control_messages.c
@@ -606,8 +606,9 @@ void gnrc_rpl_recv_DIS(gnrc_rpl_dis_t *dis, kernel_pid_t iface, ipv6_addr_t *src
             if (gnrc_rpl_instances[i].state != 0) {
 
                 uint32_t included_opts = 0;
+                size_t opt_len = len - sizeof(gnrc_rpl_dis_t) - sizeof(icmpv6_hdr_t);
                 if(!_parse_options(GNRC_RPL_ICMPV6_CODE_DIS, &gnrc_rpl_instances[i],
-                                   (gnrc_rpl_opt_t *)(dis + 1), len, src, &included_opts)) {
+                                   (gnrc_rpl_opt_t *)(dis + 1), opt_len, src, &included_opts)) {
                     DEBUG("RPL: DIS option parsing error - skip processing the DIS\n");
                     continue;
                 }


### PR DESCRIPTION
### Contribution description

Currently the length of the full ICMPv6 packet is passed to the
validator function causing validation failures on valid packets. This
fixes that by passing the length of remaining RPL options of the packet instead.

Unicast RPL DIS packets are marked as invalid due to this bug. This effectively makes RPL unusable at the moment because any node that was unable to receive the initial DIO with the DODAG Configuration option is unable to send a unicast DIS packet to solicit this configuration option. Without this configuration option, the node won't be able to set up the RPL DODAG

### Testing procedure

Two native gnrc_networking instances required. One set up as RPL root node (add IPv6 ULA address, initialize RPL root). Add a second node after the first node is started and configured as root node. The second node should become part of the RPL DODAG. without this patch, this won't happen.

### Issues/PRs references

None