### PR TITLE
net/gcoap: add user ptr to response handler functions

### DIFF
--- a/examples/gcoap/gcoap_cli.c
+++ b/examples/gcoap/gcoap_cli.c
@@ -14,6 +14,7 @@
  * @brief       gcoap CLI support
  *
  * @author      Ken Bannister <kb2ma@runbox.com>
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  *
  * @}
  */
@@ -31,8 +32,8 @@
 
 static ssize_t _encode_link(const coap_resource_t *resource, char *buf,
                             size_t maxlen, coap_link_encoder_ctx_t *context);
-static void _resp_handler(unsigned req_state, coap_pkt_t* pdu,
-                          sock_udp_ep_t *remote);
+static void _resp_handler(const gcoap_request_memo_t *memo, coap_pkt_t* pdu,
+                          const sock_udp_ep_t *remote);
 static ssize_t _stats_handler(coap_pkt_t* pdu, uint8_t *buf, size_t len, void *ctx);
 static ssize_t _riot_board_handler(coap_pkt_t* pdu, uint8_t *buf, size_t len, void *ctx);
 
@@ -84,16 +85,16 @@ static ssize_t _encode_link(const coap_resource_t *resource, char *buf,
 /*
  * Response callback.
  */
-static void _resp_handler(unsigned req_state, coap_pkt_t* pdu,
-                          sock_udp_ep_t *remote)
+static void _resp_handler(const gcoap_request_memo_t *memo, coap_pkt_t* pdu,
+                          const sock_udp_ep_t *remote)
 {
     (void)remote;       /* not interested in the source currently */
 
-    if (req_state == GCOAP_MEMO_TIMEOUT) {
+    if (memo->state == GCOAP_MEMO_TIMEOUT) {
         printf("gcoap: timeout for msg ID %02u\n", coap_get_id(pdu));
         return;
     }
-    else if (req_state == GCOAP_MEMO_ERR) {
+    else if (memo->state == GCOAP_MEMO_ERR) {
         printf("gcoap: error in response\n");
         return;
     }

--- a/examples/gcoap/gcoap_cli.c
+++ b/examples/gcoap/gcoap_cli.c
@@ -145,7 +145,8 @@ static void _resp_handler(const gcoap_request_memo_t *memo, coap_pkt_t* pdu,
             block.blknum++;
             coap_opt_add_block2_control(pdu, &block);
             int len = coap_opt_finish(pdu, COAP_OPT_FINISH_NONE);
-            gcoap_req_send((uint8_t *)pdu->hdr, len, remote, _resp_handler);
+            gcoap_req_send((uint8_t *)pdu->hdr, len, remote,
+                           _resp_handler, memo->context);
         }
         else {
             puts("--- blockwise complete ---");
@@ -258,7 +259,7 @@ static size_t _send(uint8_t *buf, size_t len, char *addr_str, char *port_str)
         return 0;
     }
 
-    bytes_sent = gcoap_req_send(buf, len, &remote, _resp_handler);
+    bytes_sent = gcoap_req_send(buf, len, &remote, _resp_handler, NULL);
     if (bytes_sent > 0) {
         req_count++;
     }

--- a/sys/include/net/gcoap.h
+++ b/sys/include/net/gcoap.h
@@ -141,8 +141,8 @@
  *
  * Here is the expected sequence for handling a response in the callback.
  *
- * -# Test for a server response or timeout in the _req_state_ callback
- *    parameter. See the GCOAP_MEMO... constants.
+ * -# Test for a server response or timeout in the `state` field of the `memo`
+ *    callback parameter (`memo->state`). See the GCOAP_MEMO... constants.
  * -# Test the response with coap_get_code_class() and coap_get_code_detail().
  * -# Test the response payload with the coap_pkt_t _payload_len_ and
  *    _content_type_ attributes.
@@ -646,13 +646,20 @@ typedef struct gcoap_listener {
 } gcoap_listener_t;
 
 /**
+ * @brief   Forward declaration of the request memo type
+ *
+ */
+typedef struct gcoap_request_memo gcoap_request_memo_t;
+
+/**
  * @brief   Handler function for a server response, including the state for the
  *          originating request
  *
  * If request timed out, the packet header is for the request.
  */
-typedef void (*gcoap_resp_handler_t)(unsigned req_state, coap_pkt_t* pdu,
-                                     sock_udp_ep_t *remote);
+typedef void (*gcoap_resp_handler_t)(const gcoap_request_memo_t *memo,
+                                     coap_pkt_t* pdu,
+                                     const sock_udp_ep_t *remote);
 
 /**
  * @brief  Extends request memo for resending a confirmable request.
@@ -665,7 +672,7 @@ typedef struct {
 /**
  * @brief   Memo to handle a response for a request
  */
-typedef struct {
+struct gcoap_request_memo {
     unsigned state;                     /**< State of this memo, a GCOAP_MEMO... */
     int send_limit;                     /**< Remaining resends, 0 if none;
                                              GCOAP_SEND_LIMIT_NON if non-confirmable */
@@ -679,7 +686,7 @@ typedef struct {
     gcoap_resp_handler_t resp_handler;  /**< Callback for the response */
     xtimer_t response_timer;            /**< Limits wait for response */
     msg_t timeout_msg;                  /**< For response timer */
-} gcoap_request_memo_t;
+};
 
 /**
  * @brief   Memo for Observe registration and notifications

--- a/sys/include/net/gcoap.h
+++ b/sys/include/net/gcoap.h
@@ -647,7 +647,6 @@ typedef struct gcoap_listener {
 
 /**
  * @brief   Forward declaration of the request memo type
- *
  */
 typedef struct gcoap_request_memo gcoap_request_memo_t;
 
@@ -684,6 +683,7 @@ struct gcoap_request_memo {
                                              supports resending message */
     sock_udp_ep_t remote_ep;            /**< Remote endpoint */
     gcoap_resp_handler_t resp_handler;  /**< Callback for the response */
+    void *context;                      /**< ptr to user defined context data */
     xtimer_t response_timer;            /**< Limits wait for response */
     msg_t timeout_msg;                  /**< For response timer */
 };
@@ -782,13 +782,14 @@ static inline ssize_t gcoap_request(coap_pkt_t *pdu, uint8_t *buf, size_t len,
  * @param[in] len           Length of the buffer
  * @param[in] remote        Destination for the packet
  * @param[in] resp_handler  Callback when response received, may be NULL
+ * @param[in] context       User defined context passed to the response handler
  *
  * @return  length of the packet
  * @return  0 if cannot send
  */
 size_t gcoap_req_send(const uint8_t *buf, size_t len,
                       const sock_udp_ep_t *remote,
-                      gcoap_resp_handler_t resp_handler);
+                      gcoap_resp_handler_t resp_handler, void *context);
 
 /**
  * @brief   Sends a buffer containing a CoAP request to the provided endpoint
@@ -800,15 +801,17 @@ size_t gcoap_req_send(const uint8_t *buf, size_t len,
  * @param[in] len           Length of the buffer
  * @param[in] remote        Destination for the packet
  * @param[in] resp_handler  Callback when response received, may be NULL
+ * @param[in] context       User defined context passed to the response handler
  *
  * @return  length of the packet
  * @return  0 if cannot send
  */
 static inline size_t gcoap_req_send2(const uint8_t *buf, size_t len,
                                      const sock_udp_ep_t *remote,
-                                     gcoap_resp_handler_t resp_handler)
+                                     gcoap_resp_handler_t resp_handler,
+                                     void *context)
 {
-    return gcoap_req_send(buf, len, remote, resp_handler);
+    return gcoap_req_send(buf, len, remote, resp_handler, context);
 }
 
 /**

--- a/sys/net/application_layer/cord/epsim/cord_epsim.c
+++ b/sys/net/application_layer/cord/epsim/cord_epsim.c
@@ -37,12 +37,12 @@ static uint8_t buf[BUFSIZE];
 /* keep state of the latest registration attempt */
 static int _state = CORD_EPSIM_ERROR;
 
-static void _req_handler(unsigned req_state, coap_pkt_t* pdu,
-                         sock_udp_ep_t *remote)
+static void _req_handler(const gcoap_request_memo_t *memo, coap_pkt_t* pdu,
+                         const sock_udp_ep_t *remote)
 {
     (void)remote;
     (void)pdu;
-    _state = (req_state == GCOAP_MEMO_RESP) ? CORD_EPSIM_OK : CORD_EPSIM_ERROR;
+    _state = (memo->state == GCOAP_MEMO_RESP) ? CORD_EPSIM_OK : CORD_EPSIM_ERROR;
 }
 
 int cord_epsim_register(const sock_udp_ep_t *rd_ep)
@@ -67,7 +67,7 @@ int cord_epsim_register(const sock_udp_ep_t *rd_ep)
     /* finish, we don't have any payload */
     ssize_t len = gcoap_finish(&pkt, 0, COAP_FORMAT_NONE);
     _state = CORD_EPSIM_BUSY;
-    if (gcoap_req_send(buf, len, rd_ep, _req_handler) == 0) {
+    if (gcoap_req_send(buf, len, rd_ep, _req_handler, NULL) == 0) {
         return CORD_EPSIM_ERROR;
     }
 

--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (c) 2015-2017 Ken Bannister. All rights reserved.
+ *               2019 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -16,6 +17,7 @@
  * Runs a thread (_pid) to manage request/response messaging.
  *
  * @author      Ken Bannister <kb2ma@runbox.com>
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
 #include <errno.h>
@@ -721,7 +723,7 @@ ssize_t gcoap_finish(coap_pkt_t *pdu, size_t payload_len, unsigned format)
 
 size_t gcoap_req_send(const uint8_t *buf, size_t len,
                       const sock_udp_ep_t *remote,
-                      gcoap_resp_handler_t resp_handler)
+                      gcoap_resp_handler_t resp_handler, void *context)
 {
     gcoap_request_memo_t *memo = NULL;
     unsigned msg_type  = (*buf & 0x30) >> 4;
@@ -748,6 +750,7 @@ size_t gcoap_req_send(const uint8_t *buf, size_t len,
         }
 
         memo->resp_handler = resp_handler;
+        memo->context = context;
         memcpy(&memo->remote_ep, remote, sizeof(sock_udp_ep_t));
 
         switch (msg_type) {

--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -240,7 +240,7 @@ static void _listen(sock_udp_t *sock)
                 xtimer_remove(&memo->response_timer);
                 memo->state = GCOAP_MEMO_RESP;
                 if (memo->resp_handler) {
-                    memo->resp_handler(memo->state, &pdu, &remote);
+                    memo->resp_handler(memo, &pdu, &remote);
                 }
 
                 if (memo->send_limit >= 0) {        /* if confirmable */
@@ -488,7 +488,7 @@ static void _expire_request(gcoap_request_memo_t *memo)
             else {
                 req.hdr = (coap_hdr_t *)memo->msg.data.pdu_buf;
             }
-            memo->resp_handler(memo->state, &req, NULL);
+            memo->resp_handler(memo, &req, NULL);
         }
         if (memo->send_limit != GCOAP_SEND_LIMIT_NON) {
             *memo->msg.data.pdu_buf = 0;    /* clear resend buffer */


### PR DESCRIPTION
### Contribution description
This PR changes the `gcoap` API slightly to allow passing user defined pointers to response handler functions (`gcoap_resp_handler_t`). This is analog to the user context pointers that were added to the resource handler functions in nanocoap a while ago (`coap_resource_t`).

Adding these user context pointers is quite useful, when handling concurrent requests of a similar type (i.e. registration to multiple CoRE RD's at the same time in my case).

I actually can't remember if this change has been discussed before, or if this change does even already exist. A quick search through the open PRs and issue did not yield any results, so I guess not?!

### Testing procedure
So far, this is rather a request for comments, so all changes to the code are untested...

### Issues/PRs references
none
