### PR TITLE
periph/gpio: support for extension API

### DIFF
--- a/cpu/atmega_common/include/periph_cpu_common.h
+++ b/cpu/atmega_common/include/periph_cpu_common.h
@@ -35,14 +35,9 @@ extern "C" {
  * @{
  */
 #define HAVE_GPIO_T
-typedef uint8_t gpio_t;
+typedef uint16_t gpio_t;
 /** @} */
 #endif
-
-/**
- * @brief   Definition of a fitting UNDEF value
- */
-#define GPIO_UNDEF          (0xff)
 
 /**
  * @brief   Define a CPU specific GPIO pin generator macro

--- a/cpu/atmega_common/periph/gpio.c
+++ b/cpu/atmega_common/periph/gpio.c
@@ -112,7 +112,7 @@ static inline uint16_t _pin_addr(gpio_t pin)
     return (_port_addr(pin) - 0x02);
 }
 
-int gpio_init(gpio_t pin, gpio_mode_t mode)
+int gpio_init_ll(gpio_t pin, gpio_mode_t mode)
 {
     uint8_t pin_mask = (1 << _pin_num(pin));
     switch (mode) {
@@ -134,38 +134,38 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
     return 0;
 }
 
-int gpio_read(gpio_t pin)
+int gpio_read_ll(gpio_t pin)
 {
     return (_SFR_MEM8(_pin_addr(pin)) & (1 << _pin_num(pin)));
 }
 
-void gpio_set(gpio_t pin)
+void gpio_set_ll(gpio_t pin)
 {
     _SFR_MEM8(_port_addr(pin)) |= (1 << _pin_num(pin));
 }
 
-void gpio_clear(gpio_t pin)
+void gpio_clear_ll(gpio_t pin)
 {
     _SFR_MEM8(_port_addr(pin)) &= ~(1 << _pin_num(pin));
 }
 
-void gpio_toggle(gpio_t pin)
+void gpio_toggle_ll(gpio_t pin)
 {
-    if (gpio_read(pin)) {
-        gpio_clear(pin);
+    if (gpio_read_ll(pin)) {
+        gpio_clear_ll(pin);
     }
     else {
-        gpio_set(pin);
+        gpio_set_ll(pin);
     }
 }
 
-void gpio_write(gpio_t pin, int value)
+void gpio_write_ll(gpio_t pin, int value)
 {
     if (value) {
-        gpio_set(pin);
+        gpio_set_ll(pin);
     }
     else {
-        gpio_clear(pin);
+        gpio_clear_ll(pin);
     }
 }
 
@@ -185,8 +185,8 @@ static inline int8_t _int_num(gpio_t pin)
     return -1;
 }
 
-int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
-                  gpio_cb_t cb, void *arg)
+int gpio_init_int_ll(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
+                     gpio_cb_t cb, void *arg)
 {
     int8_t int_num = _int_num(pin);
 
@@ -205,7 +205,7 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
         return -1;
     }
 
-    gpio_init(pin, mode);
+    gpio_init_ll(pin, mode);
 
     /* clear global interrupt flag */
     cli();
@@ -236,13 +236,13 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     return 0;
 }
 
-void gpio_irq_enable(gpio_t pin)
+void gpio_irq_enable_ll(gpio_t pin)
 {
     EIFR |= (1 << _int_num(pin));
     EIMSK |= (1 << _int_num(pin));
 }
 
-void gpio_irq_disable(gpio_t pin)
+void gpio_irq_disable_ll(gpio_t pin)
 {
     EIMSK &= ~(1 << _int_num(pin));
 }

--- a/cpu/atmega_common/periph/gpio.c
+++ b/cpu/atmega_common/periph/gpio.c
@@ -112,7 +112,7 @@ static inline uint16_t _pin_addr(gpio_t pin)
     return (_port_addr(pin) - 0x02);
 }
 
-int gpio_init_ll(gpio_t pin, gpio_mode_t mode)
+int gpio_init_cpu(gpio_t pin, gpio_mode_t mode)
 {
     uint8_t pin_mask = (1 << _pin_num(pin));
     switch (mode) {
@@ -134,38 +134,38 @@ int gpio_init_ll(gpio_t pin, gpio_mode_t mode)
     return 0;
 }
 
-int gpio_read_ll(gpio_t pin)
+int gpio_read_cpu(gpio_t pin)
 {
     return (_SFR_MEM8(_pin_addr(pin)) & (1 << _pin_num(pin)));
 }
 
-void gpio_set_ll(gpio_t pin)
+void gpio_set_cpu(gpio_t pin)
 {
     _SFR_MEM8(_port_addr(pin)) |= (1 << _pin_num(pin));
 }
 
-void gpio_clear_ll(gpio_t pin)
+void gpio_clear_cpu(gpio_t pin)
 {
     _SFR_MEM8(_port_addr(pin)) &= ~(1 << _pin_num(pin));
 }
 
-void gpio_toggle_ll(gpio_t pin)
+void gpio_toggle_cpu(gpio_t pin)
 {
-    if (gpio_read_ll(pin)) {
-        gpio_clear_ll(pin);
+    if (gpio_read_cpu(pin)) {
+        gpio_clear_cpu(pin);
     }
     else {
-        gpio_set_ll(pin);
+        gpio_set_cpu(pin);
     }
 }
 
-void gpio_write_ll(gpio_t pin, int value)
+void gpio_write_cpu(gpio_t pin, int value)
 {
     if (value) {
-        gpio_set_ll(pin);
+        gpio_set_cpu(pin);
     }
     else {
-        gpio_clear_ll(pin);
+        gpio_clear_cpu(pin);
     }
 }
 
@@ -185,8 +185,8 @@ static inline int8_t _int_num(gpio_t pin)
     return -1;
 }
 
-int gpio_init_int_ll(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
-                     gpio_cb_t cb, void *arg)
+int gpio_init_int_cpu(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
+                      gpio_cb_t cb, void *arg)
 {
     int8_t int_num = _int_num(pin);
 
@@ -205,7 +205,7 @@ int gpio_init_int_ll(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
         return -1;
     }
 
-    gpio_init_ll(pin, mode);
+    gpio_init_cpu(pin, mode);
 
     /* clear global interrupt flag */
     cli();
@@ -236,13 +236,13 @@ int gpio_init_int_ll(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     return 0;
 }
 
-void gpio_irq_enable_ll(gpio_t pin)
+void gpio_irq_enable_cpu(gpio_t pin)
 {
     EIFR |= (1 << _int_num(pin));
     EIMSK |= (1 << _int_num(pin));
 }
 
-void gpio_irq_disable_ll(gpio_t pin)
+void gpio_irq_disable_cpu(gpio_t pin)
 {
     EIMSK &= ~(1 << _int_num(pin));
 }

--- a/cpu/cc2538/periph/gpio.c
+++ b/cpu/cc2538/periph/gpio.c
@@ -95,7 +95,7 @@ static inline uint8_t _pp_num(gpio_t pin)
     return (uint8_t)((_port_num(pin) * GPIO_BITS_PER_PORT) + _pin_num(pin));
 }
 
-int gpio_init_ll(gpio_t pin, gpio_mode_t mode)
+int gpio_init_cpu(gpio_t pin, gpio_mode_t mode)
 {
     /* check if mode is valid */
     if (mode == MODE_NOTSUP) {
@@ -120,27 +120,27 @@ int gpio_init_ll(gpio_t pin, gpio_mode_t mode)
     return 0;
 }
 
-int gpio_read_ll(gpio_t pin)
+int gpio_read_cpu(gpio_t pin)
 {
     return (int)(gpio(pin)->DATA & _pin_mask(pin));
 }
 
-void gpio_set_ll(gpio_t pin)
+void gpio_set_cpu(gpio_t pin)
 {
     gpio(pin)->DATA |= _pin_mask(pin);
 }
 
-void gpio_clear_ll(gpio_t pin)
+void gpio_clear_cpu(gpio_t pin)
 {
     gpio(pin)->DATA &= ~_pin_mask(pin);
 }
 
-void gpio_toggle_ll(gpio_t pin)
+void gpio_toggle_cpu(gpio_t pin)
 {
     gpio(pin)->DATA ^= _pin_mask(pin);
 }
 
-void gpio_write_ll(gpio_t pin, int value)
+void gpio_write_cpu(gpio_t pin, int value)
 {
     if (value) {
         gpio(pin)->DATA |= _pin_mask(pin);
@@ -151,10 +151,10 @@ void gpio_write_ll(gpio_t pin, int value)
 }
 
 #ifdef MODULE_PERIPH_GPIO_IRQ
-int gpio_init_int_ll(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
-                     gpio_cb_t cb, void *arg)
+int gpio_init_int_cpu(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
+                      gpio_cb_t cb, void *arg)
 {
-    if (gpio_init_ll(pin, mode) != 0) {
+    if (gpio_init_cpu(pin, mode) != 0) {
         return -1;
     }
 
@@ -196,12 +196,12 @@ int gpio_init_int_ll(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     return 0;
 }
 
-void gpio_irq_enable_ll(gpio_t pin)
+void gpio_irq_enable_cpu(gpio_t pin)
 {
     gpio(pin)->IE |= _pin_mask(pin);
 }
 
-void gpio_irq_disable_ll(gpio_t pin)
+void gpio_irq_disable_cpu(gpio_t pin)
 {
     gpio(pin)->IE &= ~_pin_mask(pin);
 }

--- a/cpu/cc2538/periph/gpio.c
+++ b/cpu/cc2538/periph/gpio.c
@@ -95,7 +95,7 @@ static inline uint8_t _pp_num(gpio_t pin)
     return (uint8_t)((_port_num(pin) * GPIO_BITS_PER_PORT) + _pin_num(pin));
 }
 
-int gpio_init(gpio_t pin, gpio_mode_t mode)
+int gpio_init_ll(gpio_t pin, gpio_mode_t mode)
 {
     /* check if mode is valid */
     if (mode == MODE_NOTSUP) {
@@ -120,27 +120,27 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
     return 0;
 }
 
-int gpio_read(gpio_t pin)
+int gpio_read_ll(gpio_t pin)
 {
     return (int)(gpio(pin)->DATA & _pin_mask(pin));
 }
 
-void gpio_set(gpio_t pin)
+void gpio_set_ll(gpio_t pin)
 {
     gpio(pin)->DATA |= _pin_mask(pin);
 }
 
-void gpio_clear(gpio_t pin)
+void gpio_clear_ll(gpio_t pin)
 {
     gpio(pin)->DATA &= ~_pin_mask(pin);
 }
 
-void gpio_toggle(gpio_t pin)
+void gpio_toggle_ll(gpio_t pin)
 {
     gpio(pin)->DATA ^= _pin_mask(pin);
 }
 
-void gpio_write(gpio_t pin, int value)
+void gpio_write_ll(gpio_t pin, int value)
 {
     if (value) {
         gpio(pin)->DATA |= _pin_mask(pin);
@@ -151,10 +151,10 @@ void gpio_write(gpio_t pin, int value)
 }
 
 #ifdef MODULE_PERIPH_GPIO_IRQ
-int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
-                  gpio_cb_t cb, void *arg)
+int gpio_init_int_ll(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
+                     gpio_cb_t cb, void *arg)
 {
-    if (gpio_init(pin, mode) != 0) {
+    if (gpio_init_ll(pin, mode) != 0) {
         return -1;
     }
 
@@ -196,12 +196,12 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     return 0;
 }
 
-void gpio_irq_enable(gpio_t pin)
+void gpio_irq_enable_ll(gpio_t pin)
 {
     gpio(pin)->IE |= _pin_mask(pin);
 }
 
-void gpio_irq_disable(gpio_t pin)
+void gpio_irq_disable_ll(gpio_t pin)
 {
     gpio(pin)->IE &= ~_pin_mask(pin);
 }

--- a/cpu/cc26x0/periph/gpio.c
+++ b/cpu/cc26x0/periph/gpio.c
@@ -124,8 +124,8 @@ void isr_edge(void)
 {
     for (unsigned pin = 0; pin < GPIO_ISR_CHAN_NUMOF; pin++) {
         /* doc claims EVFLAGS will only be set for pins that have edge detection enabled */
-        if (GPIO->EVFLAGS & (1 << pin)) {
-            GPIO->EVFLAGS |= (1 << pin);
+        if (GPIO->EVFLAGS & (1U << pin)) {
+            GPIO->EVFLAGS |= (1U << pin);
             gpio_chan[pin].cb(gpio_chan[pin].arg);
         }
     }

--- a/cpu/cc26x0/periph/gpio.c
+++ b/cpu/cc26x0/periph/gpio.c
@@ -33,7 +33,7 @@
 static gpio_isr_ctx_t gpio_chan[GPIO_ISR_CHAN_NUMOF];
 #endif /* MODULE_PERIPH_GPIO_IRQ */
 
-int gpio_init(gpio_t pin, gpio_mode_t mode)
+int gpio_init_ll(gpio_t pin, gpio_mode_t mode)
 {
     if ((unsigned int)pin > 31)
         return -1;
@@ -53,7 +53,7 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
     return 0;
 }
 
-int gpio_read(gpio_t pin)
+int gpio_read_ll(gpio_t pin)
 {
     if (GPIO->DOE & (1 << pin)) {
         return (GPIO->DOUT >> pin) & 1;
@@ -63,22 +63,22 @@ int gpio_read(gpio_t pin)
     }
 }
 
-void gpio_set(gpio_t pin)
+void gpio_set_ll(gpio_t pin)
 {
     GPIO->DOUTSET = (1 << pin);
 }
 
-void gpio_clear(gpio_t pin)
+void gpio_clear_ll(gpio_t pin)
 {
     GPIO->DOUTCLR = (1 << pin);
 }
 
-void gpio_toggle(gpio_t pin)
+void gpio_toggle_ll(gpio_t pin)
 {
     GPIO->DOUTTGL = (1 << pin);
 }
 
-void gpio_write(gpio_t pin, int value)
+void gpio_write_ll(gpio_t pin, int value)
 {
     if (value) {
         GPIO->DOUTSET = (1 << pin);
@@ -88,10 +88,10 @@ void gpio_write(gpio_t pin, int value)
 }
 
 #ifdef MODULE_PERIPH_GPIO_IRQ
-int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
-                   gpio_cb_t cb, void *arg)
+int gpio_init_int_ll(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
+                     gpio_cb_t cb, void *arg)
 {
-    int init = gpio_init(pin, mode);
+    int init = gpio_init_ll(pin, mode);
     if (init != 0)
         return init;
 
@@ -105,17 +105,17 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     /* clears the interrupt flag */
     GPIO->EVFLAGS |= (1 << pin);
 
-    gpio_irq_enable(pin);
+    gpio_irq_enable_ll(pin);
 
     return 0;
 }
 
-void gpio_irq_enable(gpio_t pin)
+void gpio_irq_enable_ll(gpio_t pin)
 {
     IOC->CFG[pin] |= IOCFG_EDGEIRQ_ENABLE;
 }
 
-void gpio_irq_disable(gpio_t pin)
+void gpio_irq_disable_ll(gpio_t pin)
 {
     IOC->CFG[pin] &= ~IOCFG_EDGEIRQ_ENABLE;
 }

--- a/cpu/cc26x0/periph/gpio.c
+++ b/cpu/cc26x0/periph/gpio.c
@@ -33,7 +33,7 @@
 static gpio_isr_ctx_t gpio_chan[GPIO_ISR_CHAN_NUMOF];
 #endif /* MODULE_PERIPH_GPIO_IRQ */
 
-int gpio_init_ll(gpio_t pin, gpio_mode_t mode)
+int gpio_init_cpu(gpio_t pin, gpio_mode_t mode)
 {
     if ((unsigned int)pin > 31)
         return -1;
@@ -53,7 +53,7 @@ int gpio_init_ll(gpio_t pin, gpio_mode_t mode)
     return 0;
 }
 
-int gpio_read_ll(gpio_t pin)
+int gpio_read_cpu(gpio_t pin)
 {
     if (GPIO->DOE & (1 << pin)) {
         return (GPIO->DOUT >> pin) & 1;
@@ -63,22 +63,22 @@ int gpio_read_ll(gpio_t pin)
     }
 }
 
-void gpio_set_ll(gpio_t pin)
+void gpio_set_cpu(gpio_t pin)
 {
     GPIO->DOUTSET = (1 << pin);
 }
 
-void gpio_clear_ll(gpio_t pin)
+void gpio_clear_cpu(gpio_t pin)
 {
     GPIO->DOUTCLR = (1 << pin);
 }
 
-void gpio_toggle_ll(gpio_t pin)
+void gpio_toggle_cpu(gpio_t pin)
 {
     GPIO->DOUTTGL = (1 << pin);
 }
 
-void gpio_write_ll(gpio_t pin, int value)
+void gpio_write_cpu(gpio_t pin, int value)
 {
     if (value) {
         GPIO->DOUTSET = (1 << pin);
@@ -88,10 +88,10 @@ void gpio_write_ll(gpio_t pin, int value)
 }
 
 #ifdef MODULE_PERIPH_GPIO_IRQ
-int gpio_init_int_ll(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
-                     gpio_cb_t cb, void *arg)
+int gpio_init_int_cpu(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
+                      gpio_cb_t cb, void *arg)
 {
-    int init = gpio_init_ll(pin, mode);
+    int init = gpio_init_cpu(pin, mode);
     if (init != 0)
         return init;
 
@@ -105,17 +105,17 @@ int gpio_init_int_ll(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     /* clears the interrupt flag */
     GPIO->EVFLAGS |= (1 << pin);
 
-    gpio_irq_enable_ll(pin);
+    gpio_irq_enable_cpu(pin);
 
     return 0;
 }
 
-void gpio_irq_enable_ll(gpio_t pin)
+void gpio_irq_enable_cpu(gpio_t pin)
 {
     IOC->CFG[pin] |= IOCFG_EDGEIRQ_ENABLE;
 }
 
-void gpio_irq_disable_ll(gpio_t pin)
+void gpio_irq_disable_cpu(gpio_t pin)
 {
     IOC->CFG[pin] &= ~IOCFG_EDGEIRQ_ENABLE;
 }

--- a/cpu/efm32/periph/gpio.c
+++ b/cpu/efm32/periph/gpio.c
@@ -49,7 +49,7 @@ static inline uint32_t _pin_num(gpio_t pin)
     return (pin & 0x0f);
 }
 
-int gpio_init(gpio_t pin, gpio_mode_t mode)
+int gpio_init_ll(gpio_t pin, gpio_mode_t mode)
 {
     /* check for valid pin */
     if (pin == GPIO_UNDEF) {
@@ -69,27 +69,27 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
     return 0;
 }
 
-int gpio_read(gpio_t pin)
+int gpio_read_ll(gpio_t pin)
 {
     return GPIO_PinInGet(_port_num(pin), _pin_num(pin));
 }
 
-void gpio_set(gpio_t pin)
+void gpio_set_ll(gpio_t pin)
 {
     GPIO_PinOutSet(_port_num(pin), _pin_num(pin));
 }
 
-void gpio_clear(gpio_t pin)
+void gpio_clear_ll(gpio_t pin)
 {
     GPIO_PinOutClear(_port_num(pin), _pin_num(pin));
 }
 
-void gpio_toggle(gpio_t pin)
+void gpio_toggle_ll(gpio_t pin)
 {
     GPIO_PinOutToggle(_port_num(pin), _pin_num(pin));
 }
 
-void gpio_write(gpio_t pin, int value)
+void gpio_write_ll(gpio_t pin, int value)
 {
     if (value) {
         GPIO_PinOutSet(_port_num(pin), _pin_num(pin));
@@ -105,10 +105,10 @@ static inline uint32_t _pin_mask(gpio_t pin)
     return (1 << _pin_num(pin));
 }
 
-int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
-                  gpio_cb_t cb, void *arg)
+int gpio_init_int_ll(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
+                     gpio_cb_t cb, void *arg)
 {
-    int result = gpio_init(pin, mode);
+    int result = gpio_init_ll(pin, mode);
 
     if (result != 0) {
         return result;
@@ -134,12 +134,12 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     return 0;
 }
 
-void gpio_irq_enable(gpio_t pin)
+void gpio_irq_enable_ll(gpio_t pin)
 {
     GPIO_IntEnable(_pin_mask(pin));
 }
 
-void gpio_irq_disable(gpio_t pin)
+void gpio_irq_disable_ll(gpio_t pin)
 {
     GPIO_IntDisable(_pin_mask(pin));
 }

--- a/cpu/efm32/periph/gpio.c
+++ b/cpu/efm32/periph/gpio.c
@@ -49,7 +49,7 @@ static inline uint32_t _pin_num(gpio_t pin)
     return (pin & 0x0f);
 }
 
-int gpio_init_ll(gpio_t pin, gpio_mode_t mode)
+int gpio_init_cpu(gpio_t pin, gpio_mode_t mode)
 {
     /* check for valid pin */
     if (pin == GPIO_UNDEF) {
@@ -69,27 +69,27 @@ int gpio_init_ll(gpio_t pin, gpio_mode_t mode)
     return 0;
 }
 
-int gpio_read_ll(gpio_t pin)
+int gpio_read_cpu(gpio_t pin)
 {
     return GPIO_PinInGet(_port_num(pin), _pin_num(pin));
 }
 
-void gpio_set_ll(gpio_t pin)
+void gpio_set_cpu(gpio_t pin)
 {
     GPIO_PinOutSet(_port_num(pin), _pin_num(pin));
 }
 
-void gpio_clear_ll(gpio_t pin)
+void gpio_clear_cpu(gpio_t pin)
 {
     GPIO_PinOutClear(_port_num(pin), _pin_num(pin));
 }
 
-void gpio_toggle_ll(gpio_t pin)
+void gpio_toggle_cpu(gpio_t pin)
 {
     GPIO_PinOutToggle(_port_num(pin), _pin_num(pin));
 }
 
-void gpio_write_ll(gpio_t pin, int value)
+void gpio_write_cpu(gpio_t pin, int value)
 {
     if (value) {
         GPIO_PinOutSet(_port_num(pin), _pin_num(pin));
@@ -105,10 +105,10 @@ static inline uint32_t _pin_mask(gpio_t pin)
     return (1 << _pin_num(pin));
 }
 
-int gpio_init_int_ll(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
-                     gpio_cb_t cb, void *arg)
+int gpio_init_int_cpu(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
+                      gpio_cb_t cb, void *arg)
 {
-    int result = gpio_init_ll(pin, mode);
+    int result = gpio_init_cpu(pin, mode);
 
     if (result != 0) {
         return result;
@@ -134,12 +134,12 @@ int gpio_init_int_ll(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     return 0;
 }
 
-void gpio_irq_enable_ll(gpio_t pin)
+void gpio_irq_enable_cpu(gpio_t pin)
 {
     GPIO_IntEnable(_pin_mask(pin));
 }
 
-void gpio_irq_disable_ll(gpio_t pin)
+void gpio_irq_disable_cpu(gpio_t pin)
 {
     GPIO_IntDisable(_pin_mask(pin));
 }

--- a/cpu/esp32/periph/gpio.c
+++ b/cpu/esp32/periph/gpio.c
@@ -245,7 +245,7 @@ const char* _gpio_pin_usage_str[] =
 #define GPIO_REG_BIT_XOR(l,h,b) if (b < 32) GPIO.l ^=  BIT(b); else GPIO.h.val ^=  BIT(b-32)
 #define REG_SET_CLR_BIT(c,r,f) if (c) REG_SET_BIT(r,f); else REG_CLR_BIT(r,f)
 
-int gpio_init_ll(gpio_t pin, gpio_mode_t mode)
+int gpio_init_cpu(gpio_t pin, gpio_mode_t mode)
 {
     CHECK_PARAM_RET(pin < GPIO_PIN_NUMOF, -1);
 
@@ -404,10 +404,10 @@ void IRAM gpio_int_handler (void* arg)
     irq_isr_exit();
 }
 
-int gpio_init_int_ll(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
-                     gpio_cb_t cb, void *arg)
+int gpio_init_int_cpu(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
+                      gpio_cb_t cb, void *arg)
 {
-    if (gpio_init_ll(pin, mode)) {
+    if (gpio_init_cpu(pin, mode)) {
         return -1;
     }
 
@@ -427,14 +427,14 @@ int gpio_init_int_ll(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     return 0;
 }
 
-void gpio_irq_enable_ll(gpio_t pin)
+void gpio_irq_enable_cpu(gpio_t pin)
 {
     CHECK_PARAM(pin < GPIO_PIN_NUMOF);
 
     gpio_int_enabled_table [pin] = true;
 }
 
-void gpio_irq_disable_ll(gpio_t pin)
+void gpio_irq_disable_cpu(gpio_t pin)
 {
     CHECK_PARAM(pin < GPIO_PIN_NUMOF);
 
@@ -443,13 +443,13 @@ void gpio_irq_disable_ll(gpio_t pin)
 
 #endif /* MODULE_PERIPH_GPIO_IRQ */
 
-int gpio_read_ll(gpio_t pin)
+int gpio_read_cpu(gpio_t pin)
 {
     CHECK_PARAM_RET(pin < GPIO_PIN_NUMOF, -1);
     return GPIO_REG_BIT_GET(in, in1, pin) ? 1 : 0;
 }
 
-void gpio_write_ll(gpio_t pin, int value)
+void gpio_write_cpu(gpio_t pin, int value)
 {
     DEBUG("%s gpio=%u val=%d\n", __func__, pin, value);
     CHECK_PARAM(pin < GPIO_PIN_NUMOF);
@@ -461,14 +461,14 @@ void gpio_write_ll(gpio_t pin, int value)
     }
 }
 
-void gpio_set_ll(gpio_t pin)
+void gpio_set_cpu(gpio_t pin)
 {
     DEBUG("%s gpio=%u\n", __func__, pin);
     CHECK_PARAM(pin < GPIO_PIN_NUMOF);
     GPIO_PIN_SET(pin);
 }
 
-void gpio_clear_ll(gpio_t pin)
+void gpio_clear_cpu(gpio_t pin)
 {
     DEBUG("%s gpio=%u\n", __func__, pin);
     CHECK_PARAM(pin < GPIO_PIN_NUMOF);
@@ -476,7 +476,7 @@ void gpio_clear_ll(gpio_t pin)
 
 }
 
-void gpio_toggle_ll(gpio_t pin)
+void gpio_toggle_cpu(gpio_t pin)
 {
     DEBUG("%s gpio=%u\n", __func__, pin);
     CHECK_PARAM(pin < GPIO_PIN_NUMOF);
@@ -527,5 +527,5 @@ int gpio_config_sleep_mode (gpio_t pin, bool mode, bool input)
 int gpio_set_direction(gpio_t pin, gpio_mode_t mode)
 {
     /* TODO implementation, for the moment we simply initialize the GPIO */
-    return gpio_init_ll(pin, mode);
+    return gpio_init_cpu(pin, mode);
 }

--- a/cpu/esp32/periph/gpio.c
+++ b/cpu/esp32/periph/gpio.c
@@ -245,7 +245,7 @@ const char* _gpio_pin_usage_str[] =
 #define GPIO_REG_BIT_XOR(l,h,b) if (b < 32) GPIO.l ^=  BIT(b); else GPIO.h.val ^=  BIT(b-32)
 #define REG_SET_CLR_BIT(c,r,f) if (c) REG_SET_BIT(r,f); else REG_CLR_BIT(r,f)
 
-int gpio_init(gpio_t pin, gpio_mode_t mode)
+int gpio_init_ll(gpio_t pin, gpio_mode_t mode)
 {
     CHECK_PARAM_RET(pin < GPIO_PIN_NUMOF, -1);
 
@@ -404,10 +404,10 @@ void IRAM gpio_int_handler (void* arg)
     irq_isr_exit();
 }
 
-int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
-                  gpio_cb_t cb, void *arg)
+int gpio_init_int_ll(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
+                     gpio_cb_t cb, void *arg)
 {
-    if (gpio_init(pin, mode)) {
+    if (gpio_init_ll(pin, mode)) {
         return -1;
     }
 
@@ -427,14 +427,14 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     return 0;
 }
 
-void gpio_irq_enable (gpio_t pin)
+void gpio_irq_enable_ll(gpio_t pin)
 {
     CHECK_PARAM(pin < GPIO_PIN_NUMOF);
 
     gpio_int_enabled_table [pin] = true;
 }
 
-void gpio_irq_disable (gpio_t pin)
+void gpio_irq_disable_ll(gpio_t pin)
 {
     CHECK_PARAM(pin < GPIO_PIN_NUMOF);
 
@@ -443,13 +443,13 @@ void gpio_irq_disable (gpio_t pin)
 
 #endif /* MODULE_PERIPH_GPIO_IRQ */
 
-int gpio_read (gpio_t pin)
+int gpio_read_ll(gpio_t pin)
 {
     CHECK_PARAM_RET(pin < GPIO_PIN_NUMOF, -1);
     return GPIO_REG_BIT_GET(in, in1, pin) ? 1 : 0;
 }
 
-void gpio_write (gpio_t pin, int value)
+void gpio_write_ll(gpio_t pin, int value)
 {
     DEBUG("%s gpio=%u val=%d\n", __func__, pin, value);
     CHECK_PARAM(pin < GPIO_PIN_NUMOF);
@@ -461,14 +461,14 @@ void gpio_write (gpio_t pin, int value)
     }
 }
 
-void gpio_set (gpio_t pin)
+void gpio_set_ll(gpio_t pin)
 {
     DEBUG("%s gpio=%u\n", __func__, pin);
     CHECK_PARAM(pin < GPIO_PIN_NUMOF);
     GPIO_PIN_SET(pin);
 }
 
-void gpio_clear (gpio_t pin)
+void gpio_clear_ll(gpio_t pin)
 {
     DEBUG("%s gpio=%u\n", __func__, pin);
     CHECK_PARAM(pin < GPIO_PIN_NUMOF);
@@ -476,7 +476,7 @@ void gpio_clear (gpio_t pin)
 
 }
 
-void gpio_toggle (gpio_t pin)
+void gpio_toggle_ll(gpio_t pin)
 {
     DEBUG("%s gpio=%u\n", __func__, pin);
     CHECK_PARAM(pin < GPIO_PIN_NUMOF);
@@ -527,5 +527,5 @@ int gpio_config_sleep_mode (gpio_t pin, bool mode, bool input)
 int gpio_set_direction(gpio_t pin, gpio_mode_t mode)
 {
     /* TODO implementation, for the moment we simply initialize the GPIO */
-    return gpio_init(pin, mode);
+    return gpio_init_ll(pin, mode);
 }

--- a/cpu/esp8266/periph/gpio.c
+++ b/cpu/esp8266/periph/gpio.c
@@ -75,7 +75,7 @@ _gpio_pin_usage_t _gpio_pin_usage [GPIO_PIN_NUMOF] =
    _GPIO    /* gpio16 */
 };
 
-int gpio_init(gpio_t pin, gpio_mode_t mode)
+int gpio_init_ll(gpio_t pin, gpio_mode_t mode)
 {
     DEBUG("%s: %d %d\n", __func__, pin, mode);
 
@@ -189,10 +189,10 @@ void IRAM gpio_int_handler (void* arg)
     irq_isr_exit();
 }
 
-int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
-                  gpio_cb_t cb, void *arg)
+int gpio_init_int_ll(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
+                     gpio_cb_t cb, void *arg)
 {
-    if (gpio_init(pin, mode)) {
+    if (gpio_init_ll(pin, mode)) {
         return -1;
     }
 
@@ -214,14 +214,14 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     return 0;
 }
 
-void gpio_irq_enable (gpio_t pin)
+void gpio_irq_enable_ll(gpio_t pin)
 {
     CHECK_PARAM(pin < GPIO_PIN_NUMOF);
 
     gpio_int_enabled_table [pin] = true;
 }
 
-void gpio_irq_disable (gpio_t pin)
+void gpio_irq_disable_ll(gpio_t pin)
 {
     CHECK_PARAM(pin < GPIO_PIN_NUMOF);
 
@@ -229,7 +229,7 @@ void gpio_irq_disable (gpio_t pin)
 }
 #endif /* MODULE_PERIPH_GPIO_IRQ */
 
-int gpio_read (gpio_t pin)
+int gpio_read_ll(gpio_t pin)
 {
     CHECK_PARAM_RET(pin < GPIO_PIN_NUMOF, -1);
 
@@ -241,7 +241,7 @@ int gpio_read (gpio_t pin)
     return (GPIO.IN & BIT(pin)) ? 1 : 0;
 }
 
-void gpio_write (gpio_t pin, int value)
+void gpio_write_ll(gpio_t pin, int value)
 {
     DEBUG("%s: %d %d\n", __func__, pin, value);
 
@@ -261,17 +261,17 @@ void gpio_write (gpio_t pin, int value)
     }
 }
 
-void gpio_set (gpio_t pin)
+void gpio_set_ll(gpio_t pin)
 {
-    gpio_write (pin, 1);
+    gpio_write_ll(pin, 1);
 }
 
-void gpio_clear (gpio_t pin)
+void gpio_clear_ll(gpio_t pin)
 {
-    gpio_write (pin, 0);
+    gpio_write_ll(pin, 0);
 }
 
-void gpio_toggle (gpio_t pin)
+void gpio_toggle_ll(gpio_t pin)
 {
     DEBUG("%s: %d\n", __func__, pin);
 

--- a/cpu/esp8266/periph/gpio.c
+++ b/cpu/esp8266/periph/gpio.c
@@ -75,7 +75,7 @@ _gpio_pin_usage_t _gpio_pin_usage [GPIO_PIN_NUMOF] =
    _GPIO    /* gpio16 */
 };
 
-int gpio_init_ll(gpio_t pin, gpio_mode_t mode)
+int gpio_init_cpu(gpio_t pin, gpio_mode_t mode)
 {
     DEBUG("%s: %d %d\n", __func__, pin, mode);
 
@@ -189,10 +189,10 @@ void IRAM gpio_int_handler (void* arg)
     irq_isr_exit();
 }
 
-int gpio_init_int_ll(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
-                     gpio_cb_t cb, void *arg)
+int gpio_init_int_cpu(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
+                      gpio_cb_t cb, void *arg)
 {
-    if (gpio_init_ll(pin, mode)) {
+    if (gpio_init_cpu(pin, mode)) {
         return -1;
     }
 
@@ -214,14 +214,14 @@ int gpio_init_int_ll(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     return 0;
 }
 
-void gpio_irq_enable_ll(gpio_t pin)
+void gpio_irq_enable_cpu(gpio_t pin)
 {
     CHECK_PARAM(pin < GPIO_PIN_NUMOF);
 
     gpio_int_enabled_table [pin] = true;
 }
 
-void gpio_irq_disable_ll(gpio_t pin)
+void gpio_irq_disable_cpu(gpio_t pin)
 {
     CHECK_PARAM(pin < GPIO_PIN_NUMOF);
 
@@ -229,7 +229,7 @@ void gpio_irq_disable_ll(gpio_t pin)
 }
 #endif /* MODULE_PERIPH_GPIO_IRQ */
 
-int gpio_read_ll(gpio_t pin)
+int gpio_read_cpu(gpio_t pin)
 {
     CHECK_PARAM_RET(pin < GPIO_PIN_NUMOF, -1);
 
@@ -241,7 +241,7 @@ int gpio_read_ll(gpio_t pin)
     return (GPIO.IN & BIT(pin)) ? 1 : 0;
 }
 
-void gpio_write_ll(gpio_t pin, int value)
+void gpio_write_cpu(gpio_t pin, int value)
 {
     DEBUG("%s: %d %d\n", __func__, pin, value);
 
@@ -261,17 +261,17 @@ void gpio_write_ll(gpio_t pin, int value)
     }
 }
 
-void gpio_set_ll(gpio_t pin)
+void gpio_set_cpu(gpio_t pin)
 {
-    gpio_write_ll(pin, 1);
+    gpio_write_cpu(pin, 1);
 }
 
-void gpio_clear_ll(gpio_t pin)
+void gpio_clear_cpu(gpio_t pin)
 {
-    gpio_write_ll(pin, 0);
+    gpio_write_cpu(pin, 0);
 }
 
-void gpio_toggle_ll(gpio_t pin)
+void gpio_toggle_cpu(gpio_t pin)
 {
     DEBUG("%s: %d\n", __func__, pin);
 

--- a/cpu/ezr32wg/periph/gpio.c
+++ b/cpu/ezr32wg/periph/gpio.c
@@ -57,7 +57,7 @@ static inline int _pin_mask(gpio_t pin)
     return (1 << _pin_pos(pin));
 }
 
-int gpio_init_ll(gpio_t pin, gpio_mode_t mode)
+int gpio_init_cpu(gpio_t pin, gpio_mode_t mode)
 {
     GPIO_P_TypeDef *port = _port(pin);
     uint32_t pin_pos = _pin_pos(pin);
@@ -82,27 +82,27 @@ int gpio_init_ll(gpio_t pin, gpio_mode_t mode)
     return 0;
 }
 
-int gpio_read_ll(gpio_t pin)
+int gpio_read_cpu(gpio_t pin)
 {
     return _port(pin)->DIN & _pin_mask(pin);
 }
 
-void gpio_set_ll(gpio_t pin)
+void gpio_set_cpu(gpio_t pin)
 {
     _port(pin)->DOUTSET = _pin_mask(pin);
 }
 
-void gpio_clear_ll(gpio_t pin)
+void gpio_clear_cpu(gpio_t pin)
 {
     _port(pin)->DOUTCLR = _pin_mask(pin);
 }
 
-void gpio_toggle_ll(gpio_t pin)
+void gpio_toggle_cpu(gpio_t pin)
 {
     _port(pin)->DOUTTGL = _pin_mask(pin);
 }
 
-void gpio_write_ll(gpio_t pin, int value)
+void gpio_write_cpu(gpio_t pin, int value)
 {
     if (value) {
         _port(pin)->DOUTSET = _pin_mask(pin);
@@ -113,13 +113,13 @@ void gpio_write_ll(gpio_t pin, int value)
 
 #ifdef MODULE_PERIPH_GPIO_IRQ
 
-int gpio_init_int_ll(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
-                     gpio_cb_t cb, void *arg)
+int gpio_init_int_cpu(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
+                      gpio_cb_t cb, void *arg)
 {
     uint32_t pin_pos = _pin_pos(pin);
 
     /* configure as input */
-    gpio_init_ll(pin, mode);
+    gpio_init_cpu(pin, mode);
 
     /* just in case, disable interrupt for this channel */
     GPIO->IEN &= ~(1 << pin_pos);
@@ -140,12 +140,12 @@ int gpio_init_int_ll(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     return 0;
 }
 
-void gpio_irq_enable_ll(gpio_t pin)
+void gpio_irq_enable_cpu(gpio_t pin)
 {
     GPIO->IEN |= _pin_mask(pin);
 }
 
-void gpio_irq_disable_ll(gpio_t pin)
+void gpio_irq_disable_cpu(gpio_t pin)
 {
     GPIO->IEN &= ~(_pin_mask(pin));
 }

--- a/cpu/ezr32wg/periph/gpio.c
+++ b/cpu/ezr32wg/periph/gpio.c
@@ -57,7 +57,7 @@ static inline int _pin_mask(gpio_t pin)
     return (1 << _pin_pos(pin));
 }
 
-int gpio_init(gpio_t pin, gpio_mode_t mode)
+int gpio_init_ll(gpio_t pin, gpio_mode_t mode)
 {
     GPIO_P_TypeDef *port = _port(pin);
     uint32_t pin_pos = _pin_pos(pin);
@@ -82,27 +82,27 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
     return 0;
 }
 
-int gpio_read(gpio_t pin)
+int gpio_read_ll(gpio_t pin)
 {
     return _port(pin)->DIN & _pin_mask(pin);
 }
 
-void gpio_set(gpio_t pin)
+void gpio_set_ll(gpio_t pin)
 {
     _port(pin)->DOUTSET = _pin_mask(pin);
 }
 
-void gpio_clear(gpio_t pin)
+void gpio_clear_ll(gpio_t pin)
 {
     _port(pin)->DOUTCLR = _pin_mask(pin);
 }
 
-void gpio_toggle(gpio_t pin)
+void gpio_toggle_ll(gpio_t pin)
 {
     _port(pin)->DOUTTGL = _pin_mask(pin);
 }
 
-void gpio_write(gpio_t pin, int value)
+void gpio_write_ll(gpio_t pin, int value)
 {
     if (value) {
         _port(pin)->DOUTSET = _pin_mask(pin);
@@ -113,13 +113,13 @@ void gpio_write(gpio_t pin, int value)
 
 #ifdef MODULE_PERIPH_GPIO_IRQ
 
-int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
-                    gpio_cb_t cb, void *arg)
+int gpio_init_int_ll(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
+                     gpio_cb_t cb, void *arg)
 {
     uint32_t pin_pos = _pin_pos(pin);
 
     /* configure as input */
-    gpio_init(pin, mode);
+    gpio_init_ll(pin, mode);
 
     /* just in case, disable interrupt for this channel */
     GPIO->IEN &= ~(1 << pin_pos);
@@ -140,12 +140,12 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     return 0;
 }
 
-void gpio_irq_enable(gpio_t pin)
+void gpio_irq_enable_ll(gpio_t pin)
 {
     GPIO->IEN |= _pin_mask(pin);
 }
 
-void gpio_irq_disable(gpio_t pin)
+void gpio_irq_disable_ll(gpio_t pin)
 {
     GPIO->IEN &= ~(_pin_mask(pin));
 }

--- a/cpu/fe310/periph/gpio.c
+++ b/cpu/fe310/periph/gpio.c
@@ -37,7 +37,7 @@ static gpio_flank_t isr_flank[GPIO_NUMOF];
 static gpio_isr_ctx_t isr_ctx[GPIO_NUMOF];
 #endif /* MODULE_PERIPH_GPIO_IRQ */
 
-int gpio_init(gpio_t pin, gpio_mode_t mode)
+int gpio_init_ll(gpio_t pin, gpio_mode_t mode)
 {
     /* Check for valid pin */
     if (pin >= GPIO_NUMOF) {
@@ -75,27 +75,27 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
     return 0;
 }
 
-int gpio_read(gpio_t pin)
+int gpio_read_ll(gpio_t pin)
 {
     return (GPIO_REG(GPIO_INPUT_VAL) & (1 << pin)) ? 1 : 0;
 }
 
-void gpio_set(gpio_t pin)
+void gpio_set_ll(gpio_t pin)
 {
     GPIO_REG(GPIO_OUTPUT_VAL) |= (1 << pin);
 }
 
-void gpio_clear(gpio_t pin)
+void gpio_clear_ll(gpio_t pin)
 {
     GPIO_REG(GPIO_OUTPUT_VAL) &= ~(1 << pin);
 }
 
-void gpio_toggle(gpio_t pin)
+void gpio_toggle_ll(gpio_t pin)
 {
     GPIO_REG(GPIO_OUTPUT_VAL) ^= (1 << pin);
 }
 
-void gpio_write(gpio_t pin, int value)
+void gpio_write_ll(gpio_t pin, int value)
 {
     if (value) {
         GPIO_REG(GPIO_OUTPUT_VAL) |= (1 << pin);
@@ -132,11 +132,11 @@ void gpio_isr(int num)
     }
 }
 
-int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
-                  gpio_cb_t cb, void *arg)
+int gpio_init_int_ll(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
+                     gpio_cb_t cb, void *arg)
 {
     /* Configure pin */
-    if (gpio_init(pin, mode) != 0) {
+    if (gpio_init_ll(pin, mode) != 0) {
         return -1;
     }
 
@@ -149,7 +149,7 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     PLIC_set_priority(INT_GPIO_BASE + pin, GPIO_INTR_PRIORITY);
 
     /*  Configure the active flank(s) */
-    gpio_irq_enable(pin);
+    gpio_irq_enable_ll(pin);
 
     /* Save callback */
     isr_ctx[pin].cb = cb;
@@ -162,7 +162,7 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     return 0;
 }
 
-void gpio_irq_enable(gpio_t pin)
+void gpio_irq_enable_ll(gpio_t pin)
 {
     /* Check for valid pin */
     if (pin >= GPIO_NUMOF) {
@@ -189,7 +189,7 @@ void gpio_irq_enable(gpio_t pin)
     }
 }
 
-void gpio_irq_disable(gpio_t pin)
+void gpio_irq_disable_ll(gpio_t pin)
 {
     /* Check for valid pin */
     if (pin >= GPIO_NUMOF) {

--- a/cpu/fe310/periph/gpio.c
+++ b/cpu/fe310/periph/gpio.c
@@ -37,7 +37,7 @@ static gpio_flank_t isr_flank[GPIO_NUMOF];
 static gpio_isr_ctx_t isr_ctx[GPIO_NUMOF];
 #endif /* MODULE_PERIPH_GPIO_IRQ */
 
-int gpio_init_ll(gpio_t pin, gpio_mode_t mode)
+int gpio_init_cpu(gpio_t pin, gpio_mode_t mode)
 {
     /* Check for valid pin */
     if (pin >= GPIO_NUMOF) {
@@ -75,27 +75,27 @@ int gpio_init_ll(gpio_t pin, gpio_mode_t mode)
     return 0;
 }
 
-int gpio_read_ll(gpio_t pin)
+int gpio_read_cpu(gpio_t pin)
 {
     return (GPIO_REG(GPIO_INPUT_VAL) & (1 << pin)) ? 1 : 0;
 }
 
-void gpio_set_ll(gpio_t pin)
+void gpio_set_cpu(gpio_t pin)
 {
     GPIO_REG(GPIO_OUTPUT_VAL) |= (1 << pin);
 }
 
-void gpio_clear_ll(gpio_t pin)
+void gpio_clear_cpu(gpio_t pin)
 {
     GPIO_REG(GPIO_OUTPUT_VAL) &= ~(1 << pin);
 }
 
-void gpio_toggle_ll(gpio_t pin)
+void gpio_toggle_cpu(gpio_t pin)
 {
     GPIO_REG(GPIO_OUTPUT_VAL) ^= (1 << pin);
 }
 
-void gpio_write_ll(gpio_t pin, int value)
+void gpio_write_cpu(gpio_t pin, int value)
 {
     if (value) {
         GPIO_REG(GPIO_OUTPUT_VAL) |= (1 << pin);
@@ -132,11 +132,11 @@ void gpio_isr(int num)
     }
 }
 
-int gpio_init_int_ll(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
-                     gpio_cb_t cb, void *arg)
+int gpio_init_int_cpu(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
+                      gpio_cb_t cb, void *arg)
 {
     /* Configure pin */
-    if (gpio_init_ll(pin, mode) != 0) {
+    if (gpio_init_cpu(pin, mode) != 0) {
         return -1;
     }
 
@@ -149,7 +149,7 @@ int gpio_init_int_ll(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     PLIC_set_priority(INT_GPIO_BASE + pin, GPIO_INTR_PRIORITY);
 
     /*  Configure the active flank(s) */
-    gpio_irq_enable_ll(pin);
+    gpio_irq_enable_cpu(pin);
 
     /* Save callback */
     isr_ctx[pin].cb = cb;
@@ -162,7 +162,7 @@ int gpio_init_int_ll(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     return 0;
 }
 
-void gpio_irq_enable_ll(gpio_t pin)
+void gpio_irq_enable_cpu(gpio_t pin)
 {
     /* Check for valid pin */
     if (pin >= GPIO_NUMOF) {
@@ -189,7 +189,7 @@ void gpio_irq_enable_ll(gpio_t pin)
     }
 }
 
-void gpio_irq_disable_ll(gpio_t pin)
+void gpio_irq_disable_cpu(gpio_t pin)
 {
     /* Check for valid pin */
     if (pin >= GPIO_NUMOF) {

--- a/cpu/kinetis/periph/gpio.c
+++ b/cpu/kinetis/periph/gpio.c
@@ -184,7 +184,7 @@ static inline void clk_en(gpio_t pin)
     bit_set32(&SIM->SCGC5, SIM_SCGC5_PORTA_SHIFT + port_num(pin));
 }
 
-int gpio_init(gpio_t pin, gpio_mode_t mode)
+int gpio_init_ll(gpio_t pin, gpio_mode_t mode)
 {
     /* set pin to analog mode while configuring it */
     gpio_init_port(pin, GPIO_AF_ANALOG);
@@ -225,7 +225,7 @@ void gpio_init_port(gpio_t pin, uint32_t pcr)
 #endif /* MODULE_PERIPH_GPIO_IRQ */
 }
 
-int gpio_read(gpio_t pin)
+int gpio_read_ll(gpio_t pin)
 {
     if (gpio(pin)->PDDR & (1 << pin_num(pin))) {
         return (gpio(pin)->PDOR & (1 << pin_num(pin))) ? 1 : 0;
@@ -235,22 +235,22 @@ int gpio_read(gpio_t pin)
     }
 }
 
-void gpio_set(gpio_t pin)
+void gpio_set_ll(gpio_t pin)
 {
     gpio(pin)->PSOR = (1 << pin_num(pin));
 }
 
-void gpio_clear(gpio_t pin)
+void gpio_clear_ll(gpio_t pin)
 {
     gpio(pin)->PCOR = (1 << pin_num(pin));
 }
 
-void gpio_toggle(gpio_t pin)
+void gpio_toggle_ll(gpio_t pin)
 {
     gpio(pin)->PTOR = (1 << pin_num(pin));
 }
 
-void gpio_write(gpio_t pin, int value)
+void gpio_write_ll(gpio_t pin, int value)
 {
     if (value) {
         gpio(pin)->PSOR = (1 << pin_num(pin));
@@ -261,10 +261,10 @@ void gpio_write(gpio_t pin, int value)
 }
 
 #ifdef MODULE_PERIPH_GPIO_IRQ
-int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
-                  gpio_cb_t cb, void *arg)
+int gpio_init_int_ll(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
+                     gpio_cb_t cb, void *arg)
 {
-    if (gpio_init(pin, mode) < 0) {
+    if (gpio_init_ll(pin, mode) < 0) {
         return -1;
     }
 
@@ -291,13 +291,13 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     return 0;
 }
 
-void gpio_irq_enable(gpio_t pin)
+void gpio_irq_enable_ll(gpio_t pin)
 {
     int ctx = get_ctx(port_num(pin), pin_num(pin));
     port(pin)->PCR[pin_num(pin)] |= isr_ctx[ctx].state;
 }
 
-void gpio_irq_disable(gpio_t pin)
+void gpio_irq_disable_ll(gpio_t pin)
 {
     int ctx = get_ctx(port_num(pin), pin_num(pin));
     isr_ctx[ctx].state = port(pin)->PCR[pin_num(pin)] & PORT_PCR_IRQC_MASK;

--- a/cpu/kinetis/periph/gpio.c
+++ b/cpu/kinetis/periph/gpio.c
@@ -184,7 +184,7 @@ static inline void clk_en(gpio_t pin)
     bit_set32(&SIM->SCGC5, SIM_SCGC5_PORTA_SHIFT + port_num(pin));
 }
 
-int gpio_init_ll(gpio_t pin, gpio_mode_t mode)
+int gpio_init_cpu(gpio_t pin, gpio_mode_t mode)
 {
     /* set pin to analog mode while configuring it */
     gpio_init_port(pin, GPIO_AF_ANALOG);
@@ -225,7 +225,7 @@ void gpio_init_port(gpio_t pin, uint32_t pcr)
 #endif /* MODULE_PERIPH_GPIO_IRQ */
 }
 
-int gpio_read_ll(gpio_t pin)
+int gpio_read_cpu(gpio_t pin)
 {
     if (gpio(pin)->PDDR & (1 << pin_num(pin))) {
         return (gpio(pin)->PDOR & (1 << pin_num(pin))) ? 1 : 0;
@@ -235,22 +235,22 @@ int gpio_read_ll(gpio_t pin)
     }
 }
 
-void gpio_set_ll(gpio_t pin)
+void gpio_set_cpu(gpio_t pin)
 {
     gpio(pin)->PSOR = (1 << pin_num(pin));
 }
 
-void gpio_clear_ll(gpio_t pin)
+void gpio_clear_cpu(gpio_t pin)
 {
     gpio(pin)->PCOR = (1 << pin_num(pin));
 }
 
-void gpio_toggle_ll(gpio_t pin)
+void gpio_toggle_cpu(gpio_t pin)
 {
     gpio(pin)->PTOR = (1 << pin_num(pin));
 }
 
-void gpio_write_ll(gpio_t pin, int value)
+void gpio_write_cpu(gpio_t pin, int value)
 {
     if (value) {
         gpio(pin)->PSOR = (1 << pin_num(pin));
@@ -261,10 +261,10 @@ void gpio_write_ll(gpio_t pin, int value)
 }
 
 #ifdef MODULE_PERIPH_GPIO_IRQ
-int gpio_init_int_ll(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
-                     gpio_cb_t cb, void *arg)
+int gpio_init_int_cpu(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
+                      gpio_cb_t cb, void *arg)
 {
-    if (gpio_init_ll(pin, mode) < 0) {
+    if (gpio_init_cpu(pin, mode) < 0) {
         return -1;
     }
 
@@ -291,13 +291,13 @@ int gpio_init_int_ll(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     return 0;
 }
 
-void gpio_irq_enable_ll(gpio_t pin)
+void gpio_irq_enable_cpu(gpio_t pin)
 {
     int ctx = get_ctx(port_num(pin), pin_num(pin));
     port(pin)->PCR[pin_num(pin)] |= isr_ctx[ctx].state;
 }
 
-void gpio_irq_disable_ll(gpio_t pin)
+void gpio_irq_disable_cpu(gpio_t pin)
 {
     int ctx = get_ctx(port_num(pin), pin_num(pin));
     isr_ctx[ctx].state = port(pin)->PCR[pin_num(pin)] & PORT_PCR_IRQC_MASK;

--- a/cpu/lm4f120/periph/gpio.c
+++ b/cpu/lm4f120/periph/gpio.c
@@ -96,7 +96,7 @@ static gpio_state_t gpio_config[NUM_OF_PORT][NUM_OF_PINS];
 #endif /* MODULE_PERIPH_GPIO_IRQ */
 
 
-int gpio_init_ll(gpio_t pin, gpio_mode_t mode)
+int gpio_init_cpu(gpio_t pin, gpio_mode_t mode)
 {
     const uint8_t port_num = _port_num(pin);
     const uint32_t port_addr = _port_base[port_num];
@@ -121,7 +121,7 @@ int gpio_init_ll(gpio_t pin, gpio_mode_t mode)
     return 0;
 }
 
-int gpio_read_ll(gpio_t pin)
+int gpio_read_cpu(gpio_t pin)
 {
     const uint8_t port_num = _port_num(pin);
     const uint32_t port_addr = _port_base[port_num];
@@ -130,7 +130,7 @@ int gpio_read_ll(gpio_t pin)
     return HWREG(port_addr + ((1<<pin_num) << 2)) != 0;
 }
 
-void gpio_set_ll(gpio_t pin)
+void gpio_set_cpu(gpio_t pin)
 {
     const uint8_t port_num = _port_num(pin);
     const uint32_t port_addr = _port_base[port_num];
@@ -140,7 +140,7 @@ void gpio_set_ll(gpio_t pin)
     ROM_GPIOPinWrite(port_addr, 1<<pin_num, 1<<pin_num);
 }
 
-void gpio_clear_ll(gpio_t pin)
+void gpio_clear_cpu(gpio_t pin)
 {
     const uint8_t port_num = _port_num(pin);
     const uint32_t port_addr = _port_base[port_num];
@@ -149,23 +149,23 @@ void gpio_clear_ll(gpio_t pin)
     HWREG(port_addr + ((1<<pin_num) << 2)) = 0;
 }
 
-void gpio_toggle_ll(gpio_t pin)
+void gpio_toggle_cpu(gpio_t pin)
 {
-    if (gpio_read_ll(pin)) {
-        gpio_clear_ll(pin);
+    if (gpio_read_cpu(pin)) {
+        gpio_clear_cpu(pin);
     }
     else {
-        gpio_set_ll(pin);
+        gpio_set_cpu(pin);
     }
 }
 
-void gpio_write_ll(gpio_t pin, int value)
+void gpio_write_cpu(gpio_t pin, int value)
 {
     if (value) {
-        gpio_set_ll(pin);
+        gpio_set_cpu(pin);
     }
     else {
-        gpio_clear_ll(pin);
+        gpio_clear_cpu(pin);
     }
 }
 
@@ -213,8 +213,8 @@ void isr_gpio_portf(void){
     _isr_gpio(5);
 }
 
-int gpio_init_int_ll(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
-                     gpio_cb_t cb, void *arg)
+int gpio_init_int_cpu(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
+                      gpio_cb_t cb, void *arg)
 {
     const uint8_t port_num = _port_num(pin);
     const uint32_t port_addr = _port_base[port_num];
@@ -246,7 +246,7 @@ int gpio_init_int_ll(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     HWREG(port_addr+GPIO_DEN_R_OFF) |= pin_bit;
     HWREG(port_addr+GPIO_LOCK_R_OFF) = 0;
 
-    gpio_irq_enable_ll(pin);
+    gpio_irq_enable_cpu(pin);
     ROM_IntEnable(int_num);
 
     ROM_IntMasterEnable();
@@ -254,7 +254,7 @@ int gpio_init_int_ll(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     return 0;
 }
 
-void gpio_irq_enable_ll(gpio_t pin)
+void gpio_irq_enable_cpu(gpio_t pin)
 {
     const uint8_t port_num = _port_num(pin);
     const uint32_t port_addr = _port_base[port_num];
@@ -265,7 +265,7 @@ void gpio_irq_enable_ll(gpio_t pin)
     HWREG(im_reg_addr) |= pin_bit;
 }
 
-void gpio_irq_disable_ll(gpio_t pin)
+void gpio_irq_disable_cpu(gpio_t pin)
 {
     const uint8_t port_num = _port_num(pin);
     const uint32_t port_addr = _port_base[port_num];

--- a/cpu/lm4f120/periph/gpio.c
+++ b/cpu/lm4f120/periph/gpio.c
@@ -96,7 +96,7 @@ static gpio_state_t gpio_config[NUM_OF_PORT][NUM_OF_PINS];
 #endif /* MODULE_PERIPH_GPIO_IRQ */
 
 
-int gpio_init(gpio_t pin, gpio_mode_t mode)
+int gpio_init_ll(gpio_t pin, gpio_mode_t mode)
 {
     const uint8_t port_num = _port_num(pin);
     const uint32_t port_addr = _port_base[port_num];
@@ -121,7 +121,7 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
     return 0;
 }
 
-int gpio_read(gpio_t pin)
+int gpio_read_ll(gpio_t pin)
 {
     const uint8_t port_num = _port_num(pin);
     const uint32_t port_addr = _port_base[port_num];
@@ -130,7 +130,7 @@ int gpio_read(gpio_t pin)
     return HWREG(port_addr + ((1<<pin_num) << 2)) != 0;
 }
 
-void gpio_set(gpio_t pin)
+void gpio_set_ll(gpio_t pin)
 {
     const uint8_t port_num = _port_num(pin);
     const uint32_t port_addr = _port_base[port_num];
@@ -140,7 +140,7 @@ void gpio_set(gpio_t pin)
     ROM_GPIOPinWrite(port_addr, 1<<pin_num, 1<<pin_num);
 }
 
-void gpio_clear(gpio_t pin)
+void gpio_clear_ll(gpio_t pin)
 {
     const uint8_t port_num = _port_num(pin);
     const uint32_t port_addr = _port_base[port_num];
@@ -149,23 +149,23 @@ void gpio_clear(gpio_t pin)
     HWREG(port_addr + ((1<<pin_num) << 2)) = 0;
 }
 
-void gpio_toggle(gpio_t pin)
+void gpio_toggle_ll(gpio_t pin)
 {
-    if (gpio_read(pin)) {
-        gpio_clear(pin);
+    if (gpio_read_ll(pin)) {
+        gpio_clear_ll(pin);
     }
     else {
-        gpio_set(pin);
+        gpio_set_ll(pin);
     }
 }
 
-void gpio_write(gpio_t pin, int value)
+void gpio_write_ll(gpio_t pin, int value)
 {
     if (value) {
-        gpio_set(pin);
+        gpio_set_ll(pin);
     }
     else {
-        gpio_clear(pin);
+        gpio_clear_ll(pin);
     }
 }
 
@@ -213,8 +213,8 @@ void isr_gpio_portf(void){
     _isr_gpio(5);
 }
 
-int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
-                  gpio_cb_t cb, void *arg)
+int gpio_init_int_ll(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
+                     gpio_cb_t cb, void *arg)
 {
     const uint8_t port_num = _port_num(pin);
     const uint32_t port_addr = _port_base[port_num];
@@ -246,7 +246,7 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     HWREG(port_addr+GPIO_DEN_R_OFF) |= pin_bit;
     HWREG(port_addr+GPIO_LOCK_R_OFF) = 0;
 
-    gpio_irq_enable(pin);
+    gpio_irq_enable_ll(pin);
     ROM_IntEnable(int_num);
 
     ROM_IntMasterEnable();
@@ -254,7 +254,7 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     return 0;
 }
 
-void gpio_irq_enable(gpio_t pin)
+void gpio_irq_enable_ll(gpio_t pin)
 {
     const uint8_t port_num = _port_num(pin);
     const uint32_t port_addr = _port_base[port_num];
@@ -265,7 +265,7 @@ void gpio_irq_enable(gpio_t pin)
     HWREG(im_reg_addr) |= pin_bit;
 }
 
-void gpio_irq_disable(gpio_t pin)
+void gpio_irq_disable_ll(gpio_t pin)
 {
     const uint8_t port_num = _port_num(pin);
     const uint32_t port_addr = _port_base[port_num];

--- a/cpu/lpc1768/include/periph_cpu.h
+++ b/cpu/lpc1768/include/periph_cpu.h
@@ -42,6 +42,11 @@ typedef uint8_t gpio_t;
 #define GPIO_PIN(port, pin)     (gpio_t)((port << 5) | pin)
 
 /**
+ * @brief   Custom device location in gpio_t for extensions
+ */
+#define GPIO_EXP_DEV_LOC    (4U)
+
+/**
  * @name    Override the default GPIO mode values
  * @{
  */

--- a/cpu/lpc1768/periph/gpio.c
+++ b/cpu/lpc1768/periph/gpio.c
@@ -53,7 +53,7 @@ static inline LPC_GPIO_TypeDef *_base(gpio_t pin)
     return (LPC_GPIO_TypeDef *) (LPC_GPIO_BASE + (_port(pin) * 0x20));
 }
 
-int gpio_init(gpio_t pin, gpio_mode_t mode)
+int gpio_init_ll(gpio_t pin, gpio_mode_t mode)
 {
     /* check for valid pin */
     if (pin == GPIO_UNDEF) {
@@ -90,35 +90,35 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
     return 0;
 }
 
-int gpio_read(gpio_t pin)
+int gpio_read_ll(gpio_t pin)
 {
     LPC_GPIO_TypeDef *base = _base(pin);
 
     return (base->FIOPIN & (1 << _pin(pin))) ? 1 : 0;
 }
 
-void gpio_set(gpio_t pin)
+void gpio_set_ll(gpio_t pin)
 {
     LPC_GPIO_TypeDef *base = _base(pin);
 
     base->FIOSET = (1 << _pin(pin));
 }
 
-void gpio_clear(gpio_t pin)
+void gpio_clear_ll(gpio_t pin)
 {
     LPC_GPIO_TypeDef *base = _base(pin);
 
     base->FIOCLR = (1 << _pin(pin));
 }
 
-void gpio_toggle(gpio_t pin)
+void gpio_toggle_ll(gpio_t pin)
 {
     LPC_GPIO_TypeDef *base = _base(pin);
 
     base->FIOPIN ^= (1 << _pin(pin));
 }
 
-void gpio_write(gpio_t pin, int value)
+void gpio_write_ll(gpio_t pin, int value)
 {
     LPC_GPIO_TypeDef *base = _base(pin);
 
@@ -170,8 +170,8 @@ static inline void _configure_flank(gpio_t pin, gpio_flank_t flank)
     }
 }
 
-int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
-                  gpio_cb_t cb, void *arg)
+int gpio_init_int_ll(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
+                     gpio_cb_t cb, void *arg)
 {
     /* only certain pins can be used as interrupt pins */
     if (_port(pin) != 0 && _port(pin) != 2) {
@@ -179,7 +179,7 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     }
 
     /* initialize the pin */
-    int result = gpio_init(pin, mode);
+    int result = gpio_init_ll(pin, mode);
 
     if (result != 0) {
         return result;
@@ -202,14 +202,14 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     return 0;
 }
 
-void gpio_irq_enable(gpio_t pin)
+void gpio_irq_enable_ll(gpio_t pin)
 {
     assert(_port(pin) == 0 || _port(pin) == 2);
 
     _configure_flank(pin, isr_state[_port(pin) >> 1][_pin(pin)]);
 }
 
-void gpio_irq_disable(gpio_t pin)
+void gpio_irq_disable_ll(gpio_t pin)
 {
     assert(_port(pin) == 0 || _port(pin) == 2);
 

--- a/cpu/lpc1768/periph/gpio.c
+++ b/cpu/lpc1768/periph/gpio.c
@@ -231,11 +231,11 @@ void isr_eint3(void)
 
     /* invoke all handlers */
     for (int i = 0; i < NUMOF_IRQS; i++) {
-        if (status & (1 << i)) {
+        if (status & (1U << i)) {
             isr_ctx[i].cb(isr_ctx[i].arg);
 
-            LPC_GPIOINT->IO0IntClr |= (1 << i);
-            LPC_GPIOINT->IO2IntClr |= (1 << i);
+            LPC_GPIOINT->IO0IntClr |= (1U << i);
+            LPC_GPIOINT->IO2IntClr |= (1U << i);
         }
     }
 

--- a/cpu/lpc1768/periph/gpio.c
+++ b/cpu/lpc1768/periph/gpio.c
@@ -53,7 +53,7 @@ static inline LPC_GPIO_TypeDef *_base(gpio_t pin)
     return (LPC_GPIO_TypeDef *) (LPC_GPIO_BASE + (_port(pin) * 0x20));
 }
 
-int gpio_init_ll(gpio_t pin, gpio_mode_t mode)
+int gpio_init_cpu(gpio_t pin, gpio_mode_t mode)
 {
     /* check for valid pin */
     if (pin == GPIO_UNDEF) {
@@ -90,35 +90,35 @@ int gpio_init_ll(gpio_t pin, gpio_mode_t mode)
     return 0;
 }
 
-int gpio_read_ll(gpio_t pin)
+int gpio_read_cpu(gpio_t pin)
 {
     LPC_GPIO_TypeDef *base = _base(pin);
 
     return (base->FIOPIN & (1 << _pin(pin))) ? 1 : 0;
 }
 
-void gpio_set_ll(gpio_t pin)
+void gpio_set_cpu(gpio_t pin)
 {
     LPC_GPIO_TypeDef *base = _base(pin);
 
     base->FIOSET = (1 << _pin(pin));
 }
 
-void gpio_clear_ll(gpio_t pin)
+void gpio_clear_cpu(gpio_t pin)
 {
     LPC_GPIO_TypeDef *base = _base(pin);
 
     base->FIOCLR = (1 << _pin(pin));
 }
 
-void gpio_toggle_ll(gpio_t pin)
+void gpio_toggle_cpu(gpio_t pin)
 {
     LPC_GPIO_TypeDef *base = _base(pin);
 
     base->FIOPIN ^= (1 << _pin(pin));
 }
 
-void gpio_write_ll(gpio_t pin, int value)
+void gpio_write_cpu(gpio_t pin, int value)
 {
     LPC_GPIO_TypeDef *base = _base(pin);
 
@@ -170,8 +170,8 @@ static inline void _configure_flank(gpio_t pin, gpio_flank_t flank)
     }
 }
 
-int gpio_init_int_ll(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
-                     gpio_cb_t cb, void *arg)
+int gpio_init_int_cpu(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
+                      gpio_cb_t cb, void *arg)
 {
     /* only certain pins can be used as interrupt pins */
     if (_port(pin) != 0 && _port(pin) != 2) {
@@ -179,7 +179,7 @@ int gpio_init_int_ll(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     }
 
     /* initialize the pin */
-    int result = gpio_init_ll(pin, mode);
+    int result = gpio_init_cpu(pin, mode);
 
     if (result != 0) {
         return result;
@@ -202,14 +202,14 @@ int gpio_init_int_ll(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     return 0;
 }
 
-void gpio_irq_enable_ll(gpio_t pin)
+void gpio_irq_enable_cpu(gpio_t pin)
 {
     assert(_port(pin) == 0 || _port(pin) == 2);
 
     _configure_flank(pin, isr_state[_port(pin) >> 1][_pin(pin)]);
 }
 
-void gpio_irq_disable_ll(gpio_t pin)
+void gpio_irq_disable_cpu(gpio_t pin)
 {
     assert(_port(pin) == 0 || _port(pin) == 2);
 

--- a/cpu/lpc2387/periph/gpio.c
+++ b/cpu/lpc2387/periph/gpio.c
@@ -67,7 +67,7 @@ void gpio_init_ports(void) {
 #endif /* MODULE_PERIPH_GPIO_IRQ */
 }
 
-int gpio_init_ll(gpio_t pin, gpio_mode_t mode)
+int gpio_init_cpu(gpio_t pin, gpio_mode_t mode)
 {
     unsigned _pin = pin & 31;
     unsigned port = pin >> 5;
@@ -98,7 +98,7 @@ int gpio_init_mux(unsigned pin, unsigned mux)
     return 0;
 }
 
-int gpio_read_ll(gpio_t pin)
+int gpio_read_cpu(gpio_t pin)
 {
     unsigned _pin = pin & 31;
     unsigned port = pin >> 5;
@@ -106,7 +106,7 @@ int gpio_read_ll(gpio_t pin)
     return (_port->PIN & (1 << _pin)) != 0;
 }
 
-void gpio_set_ll(gpio_t pin)
+void gpio_set_cpu(gpio_t pin)
 {
     unsigned _pin = pin & 31;
     unsigned port = pin >> 5;
@@ -114,7 +114,7 @@ void gpio_set_ll(gpio_t pin)
     _port->SET = 1 << _pin;
 }
 
-void gpio_clear_ll(gpio_t pin)
+void gpio_clear_cpu(gpio_t pin)
 {
     unsigned _pin = pin & 31;
     unsigned port = pin >> 5;
@@ -122,23 +122,23 @@ void gpio_clear_ll(gpio_t pin)
     _port->CLR = 1 << _pin;
 }
 
-void gpio_toggle_ll(gpio_t dev)
+void gpio_toggle_cpu(gpio_t dev)
 {
-    if (gpio_read_ll(dev)) {
-        gpio_clear_ll(dev);
+    if (gpio_read_cpu(dev)) {
+        gpio_clear_cpu(dev);
     }
     else {
-        gpio_set_ll(dev);
+        gpio_set_cpu(dev);
     }
 }
 
-void gpio_write_ll(gpio_t dev, int value)
+void gpio_write_cpu(gpio_t dev, int value)
 {
     if (value) {
-        gpio_set_ll(dev);
+        gpio_set_cpu(dev);
     }
     else {
-        gpio_clear_ll(dev);
+        gpio_clear_cpu(dev);
     }
 }
 
@@ -188,8 +188,8 @@ static void _gpio_configure(gpio_t pin, unsigned rising, unsigned falling)
     irq_restore(state);
 }
 
-int gpio_init_int_ll(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
-                     gpio_cb_t cb, void *arg)
+int gpio_init_int_cpu(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
+                      gpio_cb_t cb, void *arg)
 {
     (void)mode;
 
@@ -247,7 +247,7 @@ int gpio_init_int_ll(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     return 0;
 }
 
-void gpio_irq_enable_ll(gpio_t pin)
+void gpio_irq_enable_cpu(gpio_t pin)
 {
     int isr_map_entry =_isr_map_entry(pin);
     int _state_index = _gpio_isr_map[isr_map_entry];
@@ -262,7 +262,7 @@ void gpio_irq_enable_ll(gpio_t pin)
             bf_isset(_gpio_falling, _state_index));
 }
 
-void gpio_irq_disable_ll(gpio_t dev)
+void gpio_irq_disable_cpu(gpio_t dev)
 {
     _gpio_configure(dev, 0, 0);
 }

--- a/cpu/lpc2387/periph/gpio.c
+++ b/cpu/lpc2387/periph/gpio.c
@@ -67,7 +67,7 @@ void gpio_init_ports(void) {
 #endif /* MODULE_PERIPH_GPIO_IRQ */
 }
 
-int gpio_init(gpio_t pin, gpio_mode_t mode)
+int gpio_init_ll(gpio_t pin, gpio_mode_t mode)
 {
     unsigned _pin = pin & 31;
     unsigned port = pin >> 5;
@@ -98,7 +98,7 @@ int gpio_init_mux(unsigned pin, unsigned mux)
     return 0;
 }
 
-int gpio_read(gpio_t pin)
+int gpio_read_ll(gpio_t pin)
 {
     unsigned _pin = pin & 31;
     unsigned port = pin >> 5;
@@ -106,7 +106,7 @@ int gpio_read(gpio_t pin)
     return (_port->PIN & (1 << _pin)) != 0;
 }
 
-void gpio_set(gpio_t pin)
+void gpio_set_ll(gpio_t pin)
 {
     unsigned _pin = pin & 31;
     unsigned port = pin >> 5;
@@ -114,7 +114,7 @@ void gpio_set(gpio_t pin)
     _port->SET = 1 << _pin;
 }
 
-void gpio_clear(gpio_t pin)
+void gpio_clear_ll(gpio_t pin)
 {
     unsigned _pin = pin & 31;
     unsigned port = pin >> 5;
@@ -122,23 +122,23 @@ void gpio_clear(gpio_t pin)
     _port->CLR = 1 << _pin;
 }
 
-void gpio_toggle(gpio_t dev)
+void gpio_toggle_ll(gpio_t dev)
 {
-    if (gpio_read(dev)) {
-        gpio_clear(dev);
+    if (gpio_read_ll(dev)) {
+        gpio_clear_ll(dev);
     }
     else {
-        gpio_set(dev);
+        gpio_set_ll(dev);
     }
 }
 
-void gpio_write(gpio_t dev, int value)
+void gpio_write_ll(gpio_t dev, int value)
 {
     if (value) {
-        gpio_set(dev);
+        gpio_set_ll(dev);
     }
     else {
-        gpio_clear(dev);
+        gpio_clear_ll(dev);
     }
 }
 
@@ -188,8 +188,8 @@ static void _gpio_configure(gpio_t pin, unsigned rising, unsigned falling)
     irq_restore(state);
 }
 
-int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
-                  gpio_cb_t cb, void *arg)
+int gpio_init_int_ll(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
+                     gpio_cb_t cb, void *arg)
 {
     (void)mode;
 
@@ -247,7 +247,7 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     return 0;
 }
 
-void gpio_irq_enable(gpio_t pin)
+void gpio_irq_enable_ll(gpio_t pin)
 {
     int isr_map_entry =_isr_map_entry(pin);
     int _state_index = _gpio_isr_map[isr_map_entry];
@@ -262,7 +262,7 @@ void gpio_irq_enable(gpio_t pin)
             bf_isset(_gpio_falling, _state_index));
 }
 
-void gpio_irq_disable(gpio_t dev)
+void gpio_irq_disable_ll(gpio_t dev)
 {
     _gpio_configure(dev, 0, 0);
 }

--- a/cpu/mips_pic32_common/periph/gpio.c
+++ b/cpu/mips_pic32_common/periph/gpio.c
@@ -120,7 +120,7 @@ static inline int check_valid_port(uint8_t port)
         && base_address[port].gpio != NULL;
 }
 
-int gpio_init(gpio_t pin, gpio_mode_t mode)
+int gpio_init_ll(gpio_t pin, gpio_mode_t mode)
 {
     uint8_t port = GPIO_PORT(pin);
     uint32_t pin_no = GPIO_PIN_NO(pin);
@@ -172,38 +172,66 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
     return 0;
 }
 
-int gpio_read(gpio_t pin)
+int gpio_read_ll(gpio_t pin)
 {
     assert(check_valid_port(GPIO_PORT(pin)));
 
     return PORTx(GPIO_PORT(pin)) & GPIO_PIN_NO(pin);
 }
 
-void gpio_set(gpio_t pin)
+void gpio_set_ll(gpio_t pin)
 {
     assert(check_valid_port(GPIO_PORT(pin)));
 
     LATxSET(GPIO_PORT(pin)) = GPIO_PIN_NO(pin);
 }
 
-void gpio_clear(gpio_t pin)
+void gpio_clear_ll(gpio_t pin)
 {
     assert(check_valid_port(GPIO_PORT(pin)));
 
     LATxCLR(GPIO_PORT(pin)) = GPIO_PIN_NO(pin);
 }
 
-void gpio_toggle(gpio_t pin)
+void gpio_toggle_ll(gpio_t pin)
 {
     assert(check_valid_port(GPIO_PORT(pin)));
 
     LATxINV(GPIO_PORT(pin)) = GPIO_PIN_NO(pin);
 }
 
-void gpio_write(gpio_t pin, int value)
+void gpio_write_ll(gpio_t pin, int value)
 {
     if (value)
-        gpio_set(pin);
+        gpio_set_ll(pin);
     else
-        gpio_clear(pin);
+        gpio_clear_ll(pin);
+}
+
+#ifdef MODULE_PERIPH_GPIO_IRQ
+int gpio_init_int_ll(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
+                     gpio_cb_t cb, void *arg)
+{
+    (void)pin;
+    (void)mode;
+    (void)flank;
+    (void)cb;
+    (void)arg;
+
+    /* TODO: Not implemented yet */
+}
+#endif    /* MODULE_PERIPH_GPIO_IRQ */
+
+void gpio_irq_enable_ll(gpio_t pin)
+{
+    (void)pin;
+
+    /* TODO: Not implemented yet */
+}
+
+void gpio_irq_disable_ll(gpio_t pin)
+{
+    (void)pin;
+
+    /* TODO: Not implemented yet */
 }

--- a/cpu/mips_pic32_common/periph/gpio.c
+++ b/cpu/mips_pic32_common/periph/gpio.c
@@ -120,7 +120,7 @@ static inline int check_valid_port(uint8_t port)
         && base_address[port].gpio != NULL;
 }
 
-int gpio_init_ll(gpio_t pin, gpio_mode_t mode)
+int gpio_init_cpu(gpio_t pin, gpio_mode_t mode)
 {
     uint8_t port = GPIO_PORT(pin);
     uint32_t pin_no = GPIO_PIN_NO(pin);
@@ -172,45 +172,45 @@ int gpio_init_ll(gpio_t pin, gpio_mode_t mode)
     return 0;
 }
 
-int gpio_read_ll(gpio_t pin)
+int gpio_read_cpu(gpio_t pin)
 {
     assert(check_valid_port(GPIO_PORT(pin)));
 
     return PORTx(GPIO_PORT(pin)) & GPIO_PIN_NO(pin);
 }
 
-void gpio_set_ll(gpio_t pin)
+void gpio_set_cpu(gpio_t pin)
 {
     assert(check_valid_port(GPIO_PORT(pin)));
 
     LATxSET(GPIO_PORT(pin)) = GPIO_PIN_NO(pin);
 }
 
-void gpio_clear_ll(gpio_t pin)
+void gpio_clear_cpu(gpio_t pin)
 {
     assert(check_valid_port(GPIO_PORT(pin)));
 
     LATxCLR(GPIO_PORT(pin)) = GPIO_PIN_NO(pin);
 }
 
-void gpio_toggle_ll(gpio_t pin)
+void gpio_toggle_cpu(gpio_t pin)
 {
     assert(check_valid_port(GPIO_PORT(pin)));
 
     LATxINV(GPIO_PORT(pin)) = GPIO_PIN_NO(pin);
 }
 
-void gpio_write_ll(gpio_t pin, int value)
+void gpio_write_cpu(gpio_t pin, int value)
 {
     if (value)
-        gpio_set_ll(pin);
+        gpio_set_cpu(pin);
     else
-        gpio_clear_ll(pin);
+        gpio_clear_cpu(pin);
 }
 
 #ifdef MODULE_PERIPH_GPIO_IRQ
-int gpio_init_int_ll(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
-                     gpio_cb_t cb, void *arg)
+int gpio_init_int_cpu(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
+                      gpio_cb_t cb, void *arg)
 {
     (void)pin;
     (void)mode;
@@ -222,14 +222,14 @@ int gpio_init_int_ll(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
 }
 #endif    /* MODULE_PERIPH_GPIO_IRQ */
 
-void gpio_irq_enable_ll(gpio_t pin)
+void gpio_irq_enable_cpu(gpio_t pin)
 {
     (void)pin;
 
     /* TODO: Not implemented yet */
 }
 
-void gpio_irq_disable_ll(gpio_t pin)
+void gpio_irq_disable_cpu(gpio_t pin)
 {
     (void)pin;
 

--- a/cpu/msp430fxyz/periph/gpio.c
+++ b/cpu/msp430fxyz/periph/gpio.c
@@ -67,7 +67,7 @@ static inline msp_port_isr_t *_isr_port(gpio_t pin)
     return NULL;
 }
 
-int gpio_init(gpio_t pin, gpio_mode_t mode)
+int gpio_init_ll(gpio_t pin, gpio_mode_t mode)
 {
     msp_port_t *port = _port(pin);
 
@@ -111,7 +111,7 @@ void gpio_periph_mode(gpio_t pin, bool enable)
     }
 }
 
-int gpio_read(gpio_t pin)
+int gpio_read_ll(gpio_t pin)
 {
     msp_port_t *port = _port(pin);
     if (port->DIR & _pin(pin)) {
@@ -122,22 +122,22 @@ int gpio_read(gpio_t pin)
     }
 }
 
-void gpio_set(gpio_t pin)
+void gpio_set_ll(gpio_t pin)
 {
     _port(pin)->OD |= _pin(pin);
 }
 
-void gpio_clear(gpio_t pin)
+void gpio_clear_ll(gpio_t pin)
 {
     _port(pin)->OD &= ~(_pin(pin));
 }
 
-void gpio_toggle(gpio_t pin)
+void gpio_toggle_ll(gpio_t pin)
 {
     _port(pin)->OD ^= _pin(pin);
 }
 
-void gpio_write(gpio_t pin, int value)
+void gpio_write_ll(gpio_t pin, int value)
 {
     if (value) {
         _port(pin)->OD |= _pin(pin);
@@ -159,8 +159,8 @@ static int _ctx(gpio_t pin)
     return (_port(pin) == PORT_1) ? i : (i + 8);
 }
 
-int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
-                    gpio_cb_t cb, void *arg)
+int gpio_init_int_ll(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
+                     gpio_cb_t cb, void *arg)
 {
     msp_port_isr_t *port = _isr_port(pin);
 
@@ -172,7 +172,7 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     /* disable any activated interrupt */
     port->IE &= ~(_pin(pin));
     /* configure as input */
-    if (gpio_init(pin, mode) < 0) {
+    if (gpio_init_ll(pin, mode) < 0) {
         return -1;
     }
     /* save ISR context */
@@ -183,11 +183,11 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     port->IES |= (flank & _pin(pin));
     /* clear pending interrupts and enable the IRQ */
     port->IFG &= ~(_pin(pin));
-    gpio_irq_enable(pin);
+    gpio_irq_enable_ll(pin);
     return 0;
 }
 
-void gpio_irq_enable(gpio_t pin)
+void gpio_irq_enable_ll(gpio_t pin)
 {
     msp_port_isr_t *port = _isr_port(pin);
     if (port) {
@@ -195,7 +195,7 @@ void gpio_irq_enable(gpio_t pin)
     }
 }
 
-void gpio_irq_disable(gpio_t pin)
+void gpio_irq_disable_ll(gpio_t pin)
 {
     msp_port_isr_t *port = _isr_port(pin);
     if (port) {

--- a/cpu/msp430fxyz/periph/gpio.c
+++ b/cpu/msp430fxyz/periph/gpio.c
@@ -67,7 +67,7 @@ static inline msp_port_isr_t *_isr_port(gpio_t pin)
     return NULL;
 }
 
-int gpio_init_ll(gpio_t pin, gpio_mode_t mode)
+int gpio_init_cpu(gpio_t pin, gpio_mode_t mode)
 {
     msp_port_t *port = _port(pin);
 
@@ -111,7 +111,7 @@ void gpio_periph_mode(gpio_t pin, bool enable)
     }
 }
 
-int gpio_read_ll(gpio_t pin)
+int gpio_read_cpu(gpio_t pin)
 {
     msp_port_t *port = _port(pin);
     if (port->DIR & _pin(pin)) {
@@ -122,22 +122,22 @@ int gpio_read_ll(gpio_t pin)
     }
 }
 
-void gpio_set_ll(gpio_t pin)
+void gpio_set_cpu(gpio_t pin)
 {
     _port(pin)->OD |= _pin(pin);
 }
 
-void gpio_clear_ll(gpio_t pin)
+void gpio_clear_cpu(gpio_t pin)
 {
     _port(pin)->OD &= ~(_pin(pin));
 }
 
-void gpio_toggle_ll(gpio_t pin)
+void gpio_toggle_cpu(gpio_t pin)
 {
     _port(pin)->OD ^= _pin(pin);
 }
 
-void gpio_write_ll(gpio_t pin, int value)
+void gpio_write_cpu(gpio_t pin, int value)
 {
     if (value) {
         _port(pin)->OD |= _pin(pin);
@@ -159,8 +159,8 @@ static int _ctx(gpio_t pin)
     return (_port(pin) == PORT_1) ? i : (i + 8);
 }
 
-int gpio_init_int_ll(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
-                     gpio_cb_t cb, void *arg)
+int gpio_init_int_cpu(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
+                      gpio_cb_t cb, void *arg)
 {
     msp_port_isr_t *port = _isr_port(pin);
 
@@ -172,7 +172,7 @@ int gpio_init_int_ll(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     /* disable any activated interrupt */
     port->IE &= ~(_pin(pin));
     /* configure as input */
-    if (gpio_init_ll(pin, mode) < 0) {
+    if (gpio_init_cpu(pin, mode) < 0) {
         return -1;
     }
     /* save ISR context */
@@ -183,11 +183,11 @@ int gpio_init_int_ll(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     port->IES |= (flank & _pin(pin));
     /* clear pending interrupts and enable the IRQ */
     port->IFG &= ~(_pin(pin));
-    gpio_irq_enable_ll(pin);
+    gpio_irq_enable_cpu(pin);
     return 0;
 }
 
-void gpio_irq_enable_ll(gpio_t pin)
+void gpio_irq_enable_cpu(gpio_t pin)
 {
     msp_port_isr_t *port = _isr_port(pin);
     if (port) {
@@ -195,7 +195,7 @@ void gpio_irq_enable_ll(gpio_t pin)
     }
 }
 
-void gpio_irq_disable_ll(gpio_t pin)
+void gpio_irq_disable_cpu(gpio_t pin)
 {
     msp_port_isr_t *port = _isr_port(pin);
     if (port) {

--- a/cpu/native/periph/gpio.c
+++ b/cpu/native/periph/gpio.c
@@ -19,33 +19,56 @@
 
 #include "periph/gpio.h"
 
-int gpio_init(gpio_t pin, gpio_mode_t mode) {
+int gpio_init_ll(gpio_t pin, gpio_mode_t mode) {
   (void) pin;
   (void) mode;
 
   return -1;
 }
 
-int gpio_read(gpio_t pin) {
+int gpio_read_ll(gpio_t pin) {
   (void) pin;
 
   return 0;
 }
 
-void gpio_set(gpio_t pin) {
+void gpio_set_ll(gpio_t pin) {
   (void) pin;
 }
 
-void gpio_clear(gpio_t pin) {
+void gpio_clear_ll(gpio_t pin) {
   (void) pin;
 }
 
-void gpio_toggle(gpio_t pin) {
+void gpio_toggle_ll(gpio_t pin) {
   (void) pin;
 }
 
-void gpio_write(gpio_t pin, int value) {
+void gpio_write_ll(gpio_t pin, int value) {
   (void) pin;
   (void) value;
 }
+
+#ifdef MODULE_PERIPH_GPIO_IRQ
+int gpio_init_int_ll(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
+                     gpio_cb_t cb, void *arg)
+{
+    (void)pin;
+    (void)mode;
+    (void)flank;
+    (void)cb;
+    (void)arg;
+}
+#endif    /* MODULE_PERIPH_GPIO_IRQ */
+
+void gpio_irq_enable_ll(gpio_t pin)
+{
+    (void)pin;
+}
+
+void gpio_irq_disable_ll(gpio_t pin)
+{
+    (void)pin;
+}
+
 /** @} */

--- a/cpu/native/periph/gpio.c
+++ b/cpu/native/periph/gpio.c
@@ -19,39 +19,39 @@
 
 #include "periph/gpio.h"
 
-int gpio_init_ll(gpio_t pin, gpio_mode_t mode) {
+int gpio_init_cpu(gpio_t pin, gpio_mode_t mode) {
   (void) pin;
   (void) mode;
 
   return -1;
 }
 
-int gpio_read_ll(gpio_t pin) {
+int gpio_read_cpu(gpio_t pin) {
   (void) pin;
 
   return 0;
 }
 
-void gpio_set_ll(gpio_t pin) {
+void gpio_set_cpu(gpio_t pin) {
   (void) pin;
 }
 
-void gpio_clear_ll(gpio_t pin) {
+void gpio_clear_cpu(gpio_t pin) {
   (void) pin;
 }
 
-void gpio_toggle_ll(gpio_t pin) {
+void gpio_toggle_cpu(gpio_t pin) {
   (void) pin;
 }
 
-void gpio_write_ll(gpio_t pin, int value) {
+void gpio_write_cpu(gpio_t pin, int value) {
   (void) pin;
   (void) value;
 }
 
 #ifdef MODULE_PERIPH_GPIO_IRQ
-int gpio_init_int_ll(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
-                     gpio_cb_t cb, void *arg)
+int gpio_init_int_cpu(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
+                      gpio_cb_t cb, void *arg)
 {
     (void)pin;
     (void)mode;
@@ -61,12 +61,12 @@ int gpio_init_int_ll(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
 }
 #endif    /* MODULE_PERIPH_GPIO_IRQ */
 
-void gpio_irq_enable_ll(gpio_t pin)
+void gpio_irq_enable_cpu(gpio_t pin)
 {
     (void)pin;
 }
 
-void gpio_irq_disable_ll(gpio_t pin)
+void gpio_irq_disable_cpu(gpio_t pin)
 {
     (void)pin;
 }

--- a/cpu/nrf5x_common/periph/gpio.c
+++ b/cpu/nrf5x_common/periph/gpio.c
@@ -69,7 +69,7 @@ static inline int pin_num(gpio_t pin)
 #endif
 }
 
-int gpio_init_ll(gpio_t pin, gpio_mode_t mode)
+int gpio_init_cpu(gpio_t pin, gpio_mode_t mode)
 {
     switch (mode) {
         case GPIO_IN:
@@ -86,7 +86,7 @@ int gpio_init_ll(gpio_t pin, gpio_mode_t mode)
     return 0;
 }
 
-int gpio_read_ll(gpio_t pin)
+int gpio_read_cpu(gpio_t pin)
 {
     if (port(pin)->DIR & (1 << pin_num(pin))) {
         return (port(pin)->OUT & (1 << pin_num(pin))) ? 1 : 0;
@@ -96,22 +96,22 @@ int gpio_read_ll(gpio_t pin)
     }
 }
 
-void gpio_set_ll(gpio_t pin)
+void gpio_set_cpu(gpio_t pin)
 {
     port(pin)->OUTSET = (1 << pin_num(pin));
 }
 
-void gpio_clear_ll(gpio_t pin)
+void gpio_clear_cpu(gpio_t pin)
 {
     port(pin)->OUTCLR = (1 << pin_num(pin));
 }
 
-void gpio_toggle_ll(gpio_t pin)
+void gpio_toggle_cpu(gpio_t pin)
 {
     port(pin)->OUT ^= (1 << pin_num(pin));
 }
 
-void gpio_write_ll(gpio_t pin, int value)
+void gpio_write_cpu(gpio_t pin, int value)
 {
     if (value) {
         port(pin)->OUTSET = (1 << pin_num(pin));
@@ -122,8 +122,8 @@ void gpio_write_ll(gpio_t pin, int value)
 }
 
 #ifdef MODULE_PERIPH_GPIO_IRQ
-int gpio_init_int_ll(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
-                     gpio_cb_t cb, void *arg)
+int gpio_init_int_cpu(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
+                      gpio_cb_t cb, void *arg)
 {
     /* disable external interrupt in case one is active */
     NRF_GPIOTE->INTENSET &= ~(GPIOTE_INTENSET_IN0_Msk);
@@ -131,7 +131,7 @@ int gpio_init_int_ll(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     exti_chan.cb = cb;
     exti_chan.arg = arg;
     /* configure pin as input */
-    gpio_init_ll(pin, mode);
+    gpio_init_cpu(pin, mode);
     /* set interrupt priority and enable global GPIOTE interrupt */
     NVIC_EnableIRQ(GPIOTE_IRQn);
     /* configure the GPIOTE channel: set even mode, pin and active flank */
@@ -146,13 +146,13 @@ int gpio_init_int_ll(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     return 0;
 }
 
-void gpio_irq_enable_ll(gpio_t pin)
+void gpio_irq_enable_cpu(gpio_t pin)
 {
     (void) pin;
     NRF_GPIOTE->INTENSET |= GPIOTE_INTENSET_IN0_Msk;
 }
 
-void gpio_irq_disable_ll(gpio_t pin)
+void gpio_irq_disable_cpu(gpio_t pin)
 {
     (void) pin;
     NRF_GPIOTE->INTENCLR |= GPIOTE_INTENSET_IN0_Msk;

--- a/cpu/nrf5x_common/periph/gpio.c
+++ b/cpu/nrf5x_common/periph/gpio.c
@@ -69,7 +69,7 @@ static inline int pin_num(gpio_t pin)
 #endif
 }
 
-int gpio_init(gpio_t pin, gpio_mode_t mode)
+int gpio_init_ll(gpio_t pin, gpio_mode_t mode)
 {
     switch (mode) {
         case GPIO_IN:
@@ -86,7 +86,7 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
     return 0;
 }
 
-int gpio_read(gpio_t pin)
+int gpio_read_ll(gpio_t pin)
 {
     if (port(pin)->DIR & (1 << pin_num(pin))) {
         return (port(pin)->OUT & (1 << pin_num(pin))) ? 1 : 0;
@@ -96,22 +96,22 @@ int gpio_read(gpio_t pin)
     }
 }
 
-void gpio_set(gpio_t pin)
+void gpio_set_ll(gpio_t pin)
 {
     port(pin)->OUTSET = (1 << pin_num(pin));
 }
 
-void gpio_clear(gpio_t pin)
+void gpio_clear_ll(gpio_t pin)
 {
     port(pin)->OUTCLR = (1 << pin_num(pin));
 }
 
-void gpio_toggle(gpio_t pin)
+void gpio_toggle_ll(gpio_t pin)
 {
     port(pin)->OUT ^= (1 << pin_num(pin));
 }
 
-void gpio_write(gpio_t pin, int value)
+void gpio_write_ll(gpio_t pin, int value)
 {
     if (value) {
         port(pin)->OUTSET = (1 << pin_num(pin));
@@ -122,8 +122,8 @@ void gpio_write(gpio_t pin, int value)
 }
 
 #ifdef MODULE_PERIPH_GPIO_IRQ
-int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
-                  gpio_cb_t cb, void *arg)
+int gpio_init_int_ll(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
+                     gpio_cb_t cb, void *arg)
 {
     /* disable external interrupt in case one is active */
     NRF_GPIOTE->INTENSET &= ~(GPIOTE_INTENSET_IN0_Msk);
@@ -131,7 +131,7 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     exti_chan.cb = cb;
     exti_chan.arg = arg;
     /* configure pin as input */
-    gpio_init(pin, mode);
+    gpio_init_ll(pin, mode);
     /* set interrupt priority and enable global GPIOTE interrupt */
     NVIC_EnableIRQ(GPIOTE_IRQn);
     /* configure the GPIOTE channel: set even mode, pin and active flank */
@@ -146,13 +146,13 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     return 0;
 }
 
-void gpio_irq_enable(gpio_t pin)
+void gpio_irq_enable_ll(gpio_t pin)
 {
     (void) pin;
     NRF_GPIOTE->INTENSET |= GPIOTE_INTENSET_IN0_Msk;
 }
 
-void gpio_irq_disable(gpio_t pin)
+void gpio_irq_disable_ll(gpio_t pin)
 {
     (void) pin;
     NRF_GPIOTE->INTENCLR |= GPIOTE_INTENSET_IN0_Msk;

--- a/cpu/sam0_common/periph/gpio.c
+++ b/cpu/sam0_common/periph/gpio.c
@@ -70,7 +70,7 @@ void gpio_init_mux(gpio_t pin, gpio_mux_t mux)
     port->PMUX[pin_pos >> 1].reg |=  (mux << (4 * (pin_pos & 0x1)));
 }
 
-int gpio_init_ll(gpio_t pin, gpio_mode_t mode)
+int gpio_init_cpu(gpio_t pin, gpio_mode_t mode)
 {
     PortGroup* port = _port(pin);
     int pin_pos = _pin_pos(pin);
@@ -103,7 +103,7 @@ int gpio_init_ll(gpio_t pin, gpio_mode_t mode)
     return 0;
 }
 
-int gpio_read_ll(gpio_t pin)
+int gpio_read_cpu(gpio_t pin)
 {
     PortGroup *port = _port(pin);
     int mask = _pin_mask(pin);
@@ -116,22 +116,22 @@ int gpio_read_ll(gpio_t pin)
     }
 }
 
-void gpio_set_ll(gpio_t pin)
+void gpio_set_cpu(gpio_t pin)
 {
     _port(pin)->OUTSET.reg = _pin_mask(pin);
 }
 
-void gpio_clear_ll(gpio_t pin)
+void gpio_clear_cpu(gpio_t pin)
 {
     _port(pin)->OUTCLR.reg = _pin_mask(pin);
 }
 
-void gpio_toggle_ll(gpio_t pin)
+void gpio_toggle_cpu(gpio_t pin)
 {
     _port(pin)->OUTTGL.reg = _pin_mask(pin);
 }
 
-void gpio_write_ll(gpio_t pin, int value)
+void gpio_write_cpu(gpio_t pin, int value)
 {
     if (value) {
         _port(pin)->OUTSET.reg = _pin_mask(pin);
@@ -151,8 +151,8 @@ static int _exti(gpio_t pin)
     return exti_config[port_num][_pin_pos(pin)];
 }
 
-int gpio_init_int_ll(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
-                     gpio_cb_t cb, void *arg)
+int gpio_init_int_cpu(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
+                      gpio_cb_t cb, void *arg)
 {
     int exti = _exti(pin);
 
@@ -165,7 +165,7 @@ int gpio_init_int_ll(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     gpio_config[exti].cb = cb;
     gpio_config[exti].arg = arg;
     /* configure pin as input and set MUX to peripheral function A */
-    gpio_init_ll(pin, mode);
+    gpio_init_cpu(pin, mode);
     gpio_init_mux(pin, GPIO_MUX_A);
 #ifdef CPU_FAM_SAMD21
     /* enable clocks for the EIC module */
@@ -205,7 +205,7 @@ int gpio_init_int_ll(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     return 0;
 }
 
-void gpio_irq_enable_ll(gpio_t pin)
+void gpio_irq_enable_cpu(gpio_t pin)
 {
     int exti = _exti(pin);
     if (exti == -1) {
@@ -214,7 +214,7 @@ void gpio_irq_enable_ll(gpio_t pin)
     EIC->INTENSET.reg = (1 << exti);
 }
 
-void gpio_irq_disable_ll(gpio_t pin)
+void gpio_irq_disable_cpu(gpio_t pin)
 {
     int exti = _exti(pin);
     if (exti == -1) {

--- a/cpu/sam0_common/periph/gpio.c
+++ b/cpu/sam0_common/periph/gpio.c
@@ -70,7 +70,7 @@ void gpio_init_mux(gpio_t pin, gpio_mux_t mux)
     port->PMUX[pin_pos >> 1].reg |=  (mux << (4 * (pin_pos & 0x1)));
 }
 
-int gpio_init(gpio_t pin, gpio_mode_t mode)
+int gpio_init_ll(gpio_t pin, gpio_mode_t mode)
 {
     PortGroup* port = _port(pin);
     int pin_pos = _pin_pos(pin);
@@ -103,7 +103,7 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
     return 0;
 }
 
-int gpio_read(gpio_t pin)
+int gpio_read_ll(gpio_t pin)
 {
     PortGroup *port = _port(pin);
     int mask = _pin_mask(pin);
@@ -116,22 +116,22 @@ int gpio_read(gpio_t pin)
     }
 }
 
-void gpio_set(gpio_t pin)
+void gpio_set_ll(gpio_t pin)
 {
     _port(pin)->OUTSET.reg = _pin_mask(pin);
 }
 
-void gpio_clear(gpio_t pin)
+void gpio_clear_ll(gpio_t pin)
 {
     _port(pin)->OUTCLR.reg = _pin_mask(pin);
 }
 
-void gpio_toggle(gpio_t pin)
+void gpio_toggle_ll(gpio_t pin)
 {
     _port(pin)->OUTTGL.reg = _pin_mask(pin);
 }
 
-void gpio_write(gpio_t pin, int value)
+void gpio_write_ll(gpio_t pin, int value)
 {
     if (value) {
         _port(pin)->OUTSET.reg = _pin_mask(pin);
@@ -151,8 +151,8 @@ static int _exti(gpio_t pin)
     return exti_config[port_num][_pin_pos(pin)];
 }
 
-int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
-                  gpio_cb_t cb, void *arg)
+int gpio_init_int_ll(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
+                     gpio_cb_t cb, void *arg)
 {
     int exti = _exti(pin);
 
@@ -165,7 +165,7 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     gpio_config[exti].cb = cb;
     gpio_config[exti].arg = arg;
     /* configure pin as input and set MUX to peripheral function A */
-    gpio_init(pin, mode);
+    gpio_init_ll(pin, mode);
     gpio_init_mux(pin, GPIO_MUX_A);
 #ifdef CPU_FAM_SAMD21
     /* enable clocks for the EIC module */
@@ -205,7 +205,7 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     return 0;
 }
 
-void gpio_irq_enable(gpio_t pin)
+void gpio_irq_enable_ll(gpio_t pin)
 {
     int exti = _exti(pin);
     if (exti == -1) {
@@ -214,7 +214,7 @@ void gpio_irq_enable(gpio_t pin)
     EIC->INTENSET.reg = (1 << exti);
 }
 
-void gpio_irq_disable(gpio_t pin)
+void gpio_irq_disable_ll(gpio_t pin)
 {
     int exti = _exti(pin);
     if (exti == -1) {

--- a/cpu/sam3/periph/gpio.c
+++ b/cpu/sam3/periph/gpio.c
@@ -314,7 +314,7 @@ static inline void isr_handler(Pio *port, int port_num)
     uint32_t status = (port->PIO_ISR & port->PIO_IMR);
 
     for (int i = 0; i < 32; i++) {
-        if (status & (1 << i)) {
+        if (status & (1U << i)) {
             int ctx = _ctx(port_num, i);
             exti_ctx[ctx].cb(exti_ctx[ctx].arg);
         }

--- a/cpu/sam3/periph/gpio.c
+++ b/cpu/sam3/periph/gpio.c
@@ -147,7 +147,7 @@ static inline int _pin_num(gpio_t pin)
     return (pin & 0x1f);
 }
 
-int gpio_init(gpio_t pin, gpio_mode_t mode)
+int gpio_init_ll(gpio_t pin, gpio_mode_t mode)
 {
     Pio *port = _port(pin);
     int pin_num = _pin_num(pin);
@@ -206,26 +206,26 @@ void gpio_init_mux(gpio_t pin, gpio_mux_t mux)
     _port(pin)->PIO_ABSR |=  (mux << _pin_num(pin));
 }
 
-void gpio_set(gpio_t pin)
+void gpio_set_ll(gpio_t pin)
 {
     _port(pin)->PIO_SODR = (1 << _pin_num(pin));
 }
 
-void gpio_clear(gpio_t pin)
+void gpio_clear_ll(gpio_t pin)
 {
     _port(pin)->PIO_CODR = (1 << _pin_num(pin));
 }
 
-void gpio_toggle(gpio_t pin)
+void gpio_toggle_ll(gpio_t pin)
 {
-    if (gpio_read(pin)) {
+    if (gpio_read_ll(pin)) {
         _port(pin)->PIO_CODR = (1 << _pin_num(pin));
     } else {
         _port(pin)->PIO_SODR = (1 << _pin_num(pin));
     }
 }
 
-void gpio_write(gpio_t pin, int value)
+void gpio_write_ll(gpio_t pin, int value)
 {
     if (value) {
         _port(pin)->PIO_SODR = (1 << _pin_num(pin));
@@ -234,17 +234,17 @@ void gpio_write(gpio_t pin, int value)
     }
 }
 
-void gpio_irq_enable(gpio_t pin)
+void gpio_irq_enable_ll(gpio_t pin)
 {
     NVIC_EnableIRQ((1 << (_port_num(pin) + PIOA_IRQn)));
 }
 
-void gpio_irq_disable(gpio_t pin)
+void gpio_irq_disable_ll(gpio_t pin)
 {
     NVIC_DisableIRQ((1 << (_port_num(pin) + PIOA_IRQn)));
 }
 
-int gpio_read(gpio_t pin)
+int gpio_read_ll(gpio_t pin)
 {
     Pio *port = _port(pin);
     int pin_num = _pin_num(pin);
@@ -258,8 +258,8 @@ int gpio_read(gpio_t pin)
 }
 
 #ifdef MODULE_PERIPH_GPIO_IRQ
-int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
-                  gpio_cb_t cb, void *arg)
+int gpio_init_int_ll(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
+                     gpio_cb_t cb, void *arg)
 {
     Pio *port = _port(pin);
     int pin_num = _pin_num(pin);
@@ -271,7 +271,7 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     }
 
     /* configure pin as input */
-    gpio_init(pin, mode);
+    gpio_init_ll(pin, mode);
 
     /* try go grab a free spot in the context array */
     int ctx_num = _get_free_ctx();

--- a/cpu/sam3/periph/gpio.c
+++ b/cpu/sam3/periph/gpio.c
@@ -147,7 +147,7 @@ static inline int _pin_num(gpio_t pin)
     return (pin & 0x1f);
 }
 
-int gpio_init_ll(gpio_t pin, gpio_mode_t mode)
+int gpio_init_cpu(gpio_t pin, gpio_mode_t mode)
 {
     Pio *port = _port(pin);
     int pin_num = _pin_num(pin);
@@ -206,26 +206,26 @@ void gpio_init_mux(gpio_t pin, gpio_mux_t mux)
     _port(pin)->PIO_ABSR |=  (mux << _pin_num(pin));
 }
 
-void gpio_set_ll(gpio_t pin)
+void gpio_set_cpu(gpio_t pin)
 {
     _port(pin)->PIO_SODR = (1 << _pin_num(pin));
 }
 
-void gpio_clear_ll(gpio_t pin)
+void gpio_clear_cpu(gpio_t pin)
 {
     _port(pin)->PIO_CODR = (1 << _pin_num(pin));
 }
 
-void gpio_toggle_ll(gpio_t pin)
+void gpio_toggle_cpu(gpio_t pin)
 {
-    if (gpio_read_ll(pin)) {
+    if (gpio_read_cpu(pin)) {
         _port(pin)->PIO_CODR = (1 << _pin_num(pin));
     } else {
         _port(pin)->PIO_SODR = (1 << _pin_num(pin));
     }
 }
 
-void gpio_write_ll(gpio_t pin, int value)
+void gpio_write_cpu(gpio_t pin, int value)
 {
     if (value) {
         _port(pin)->PIO_SODR = (1 << _pin_num(pin));
@@ -234,17 +234,17 @@ void gpio_write_ll(gpio_t pin, int value)
     }
 }
 
-void gpio_irq_enable_ll(gpio_t pin)
+void gpio_irq_enable_cpu(gpio_t pin)
 {
     NVIC_EnableIRQ((1 << (_port_num(pin) + PIOA_IRQn)));
 }
 
-void gpio_irq_disable_ll(gpio_t pin)
+void gpio_irq_disable_cpu(gpio_t pin)
 {
     NVIC_DisableIRQ((1 << (_port_num(pin) + PIOA_IRQn)));
 }
 
-int gpio_read_ll(gpio_t pin)
+int gpio_read_cpu(gpio_t pin)
 {
     Pio *port = _port(pin);
     int pin_num = _pin_num(pin);
@@ -258,8 +258,8 @@ int gpio_read_ll(gpio_t pin)
 }
 
 #ifdef MODULE_PERIPH_GPIO_IRQ
-int gpio_init_int_ll(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
-                     gpio_cb_t cb, void *arg)
+int gpio_init_int_cpu(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
+                      gpio_cb_t cb, void *arg)
 {
     Pio *port = _port(pin);
     int pin_num = _pin_num(pin);
@@ -271,7 +271,7 @@ int gpio_init_int_ll(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     }
 
     /* configure pin as input */
-    gpio_init_ll(pin, mode);
+    gpio_init_cpu(pin, mode);
 
     /* try go grab a free spot in the context array */
     int ctx_num = _get_free_ctx();

--- a/cpu/stm32_common/periph/gpio.c
+++ b/cpu/stm32_common/periph/gpio.c
@@ -73,7 +73,7 @@ static inline int _pin_num(gpio_t pin)
     return (pin & 0x0f);
 }
 
-int gpio_init(gpio_t pin, gpio_mode_t mode)
+int gpio_init_ll(gpio_t pin, gpio_mode_t mode)
 {
     GPIO_TypeDef *port = _port(pin);
     int pin_num = _pin_num(pin);
@@ -141,52 +141,52 @@ void gpio_init_analog(gpio_t pin)
     _port(pin)->MODER |= (0x3 << (2 * _pin_num(pin)));
 }
 
-void gpio_irq_enable(gpio_t pin)
+void gpio_irq_enable_ll(gpio_t pin)
 {
     EXTI->IMR |= (1 << _pin_num(pin));
 }
 
-void gpio_irq_disable(gpio_t pin)
+void gpio_irq_disable_ll(gpio_t pin)
 {
     EXTI->IMR &= ~(1 << _pin_num(pin));
 }
 
-int gpio_read(gpio_t pin)
+int gpio_read_ll(gpio_t pin)
 {
     return (_port(pin)->IDR & (1 << _pin_num(pin)));
 }
 
-void gpio_set(gpio_t pin)
+void gpio_set_ll(gpio_t pin)
 {
     _port(pin)->BSRR = (1 << _pin_num(pin));
 }
 
-void gpio_clear(gpio_t pin)
+void gpio_clear_ll(gpio_t pin)
 {
     _port(pin)->BSRR = (1 << (_pin_num(pin) + 16));
 }
 
-void gpio_toggle(gpio_t pin)
+void gpio_toggle_ll(gpio_t pin)
 {
-    if (gpio_read(pin)) {
-        gpio_clear(pin);
+    if (gpio_read_ll(pin)) {
+        gpio_clear_ll(pin);
     } else {
-        gpio_set(pin);
+        gpio_set_ll(pin);
     }
 }
 
-void gpio_write(gpio_t pin, int value)
+void gpio_write_ll(gpio_t pin, int value)
 {
     if (value) {
-        gpio_set(pin);
+        gpio_set_ll(pin);
     } else {
-        gpio_clear(pin);
+        gpio_clear_ll(pin);
     }
 }
 
 #ifdef MODULE_PERIPH_GPIO_IRQ
-int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
-                  gpio_cb_t cb, void *arg)
+int gpio_init_int_ll(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
+                     gpio_cb_t cb, void *arg)
 {
     int pin_num = _pin_num(pin);
     int port_num = _port_num(pin);
@@ -203,7 +203,7 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
 #endif
 
     /* initialize pin as input */
-    gpio_init(pin, mode);
+    gpio_init_ll(pin, mode);
 
     /* enable global pin interrupt */
 #if defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32L0)

--- a/cpu/stm32_common/periph/gpio.c
+++ b/cpu/stm32_common/periph/gpio.c
@@ -73,7 +73,7 @@ static inline int _pin_num(gpio_t pin)
     return (pin & 0x0f);
 }
 
-int gpio_init_ll(gpio_t pin, gpio_mode_t mode)
+int gpio_init_cpu(gpio_t pin, gpio_mode_t mode)
 {
     GPIO_TypeDef *port = _port(pin);
     int pin_num = _pin_num(pin);
@@ -141,52 +141,52 @@ void gpio_init_analog(gpio_t pin)
     _port(pin)->MODER |= (0x3 << (2 * _pin_num(pin)));
 }
 
-void gpio_irq_enable_ll(gpio_t pin)
+void gpio_irq_enable_cpu(gpio_t pin)
 {
     EXTI->IMR |= (1 << _pin_num(pin));
 }
 
-void gpio_irq_disable_ll(gpio_t pin)
+void gpio_irq_disable_cpu(gpio_t pin)
 {
     EXTI->IMR &= ~(1 << _pin_num(pin));
 }
 
-int gpio_read_ll(gpio_t pin)
+int gpio_read_cpu(gpio_t pin)
 {
     return (_port(pin)->IDR & (1 << _pin_num(pin)));
 }
 
-void gpio_set_ll(gpio_t pin)
+void gpio_set_cpu(gpio_t pin)
 {
     _port(pin)->BSRR = (1 << _pin_num(pin));
 }
 
-void gpio_clear_ll(gpio_t pin)
+void gpio_clear_cpu(gpio_t pin)
 {
     _port(pin)->BSRR = (1 << (_pin_num(pin) + 16));
 }
 
-void gpio_toggle_ll(gpio_t pin)
+void gpio_toggle_cpu(gpio_t pin)
 {
-    if (gpio_read_ll(pin)) {
-        gpio_clear_ll(pin);
+    if (gpio_read_cpu(pin)) {
+        gpio_clear_cpu(pin);
     } else {
-        gpio_set_ll(pin);
+        gpio_set_cpu(pin);
     }
 }
 
-void gpio_write_ll(gpio_t pin, int value)
+void gpio_write_cpu(gpio_t pin, int value)
 {
     if (value) {
-        gpio_set_ll(pin);
+        gpio_set_cpu(pin);
     } else {
-        gpio_clear_ll(pin);
+        gpio_clear_cpu(pin);
     }
 }
 
 #ifdef MODULE_PERIPH_GPIO_IRQ
-int gpio_init_int_ll(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
-                     gpio_cb_t cb, void *arg)
+int gpio_init_int_cpu(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
+                      gpio_cb_t cb, void *arg)
 {
     int pin_num = _pin_num(pin);
     int port_num = _port_num(pin);
@@ -203,7 +203,7 @@ int gpio_init_int_ll(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
 #endif
 
     /* initialize pin as input */
-    gpio_init_ll(pin, mode);
+    gpio_init_cpu(pin, mode);
 
     /* enable global pin interrupt */
 #if defined(CPU_FAM_STM32F0) || defined(CPU_FAM_STM32L0)

--- a/cpu/stm32f1/periph/gpio.c
+++ b/cpu/stm32f1/periph/gpio.c
@@ -75,7 +75,7 @@ static inline int _pin_num(gpio_t pin)
 }
 
 
-int gpio_init_ll(gpio_t pin, gpio_mode_t mode)
+int gpio_init_cpu(gpio_t pin, gpio_mode_t mode)
 {
     GPIO_TypeDef *port = _port(pin);
     int pin_num = _pin_num(pin);
@@ -123,7 +123,7 @@ void gpio_init_analog(gpio_t pin)
     _port(pin)->CR[pin_num >= 8] &= ~(0xfl << (4 * (pin_num - ((pin_num >= 8) * 8))));
 }
 
-int gpio_read_ll(gpio_t pin)
+int gpio_read_cpu(gpio_t pin)
 {
     GPIO_TypeDef *port = _port(pin);
     int pin_num = _pin_num(pin);
@@ -138,27 +138,27 @@ int gpio_read_ll(gpio_t pin)
     }
 }
 
-void gpio_set_ll(gpio_t pin)
+void gpio_set_cpu(gpio_t pin)
 {
     _port(pin)->BSRR = (1 << _pin_num(pin));
 }
 
-void gpio_clear_ll(gpio_t pin)
+void gpio_clear_cpu(gpio_t pin)
 {
     _port(pin)->BRR = (1 << _pin_num(pin));
 }
 
-void gpio_toggle_ll(gpio_t pin)
+void gpio_toggle_cpu(gpio_t pin)
 {
-    if (gpio_read_ll(pin)) {
-        gpio_clear_ll(pin);
+    if (gpio_read_cpu(pin)) {
+        gpio_clear_cpu(pin);
     }
     else {
-        gpio_set_ll(pin);
+        gpio_set_cpu(pin);
     }
 }
 
-void gpio_write_ll(gpio_t pin, int value)
+void gpio_write_cpu(gpio_t pin, int value)
 {
     if (value) {
         _port(pin)->BSRR = (1 << _pin_num(pin));
@@ -169,15 +169,15 @@ void gpio_write_ll(gpio_t pin, int value)
 }
 
 #ifdef MODULE_PERIPH_GPIO_IRQ
-int gpio_init_int_ll(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
-                     gpio_cb_t cb, void *arg)
+int gpio_init_int_cpu(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
+                      gpio_cb_t cb, void *arg)
 {
     int pin_num = _pin_num(pin);
 
     /* disable interrupts on the channel we want to edit (just in case) */
     EXTI->IMR &= ~(1 << pin_num);
     /* configure pin as input */
-    gpio_init_ll(pin, mode);
+    gpio_init_cpu(pin, mode);
     /* set callback */
     exti_ctx[pin_num].cb = cb;
     exti_ctx[pin_num].arg = arg;
@@ -208,12 +208,12 @@ int gpio_init_int_ll(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     return 0;
 }
 
-void gpio_irq_enable_ll(gpio_t pin)
+void gpio_irq_enable_cpu(gpio_t pin)
 {
     EXTI->IMR |= (1 << _pin_num(pin));
 }
 
-void gpio_irq_disable_ll(gpio_t pin)
+void gpio_irq_disable_cpu(gpio_t pin)
 {
     EXTI->IMR &= ~(1 << _pin_num(pin));
 }

--- a/cpu/stm32f1/periph/gpio.c
+++ b/cpu/stm32f1/periph/gpio.c
@@ -75,7 +75,7 @@ static inline int _pin_num(gpio_t pin)
 }
 
 
-int gpio_init(gpio_t pin, gpio_mode_t mode)
+int gpio_init_ll(gpio_t pin, gpio_mode_t mode)
 {
     GPIO_TypeDef *port = _port(pin);
     int pin_num = _pin_num(pin);
@@ -123,7 +123,7 @@ void gpio_init_analog(gpio_t pin)
     _port(pin)->CR[pin_num >= 8] &= ~(0xfl << (4 * (pin_num - ((pin_num >= 8) * 8))));
 }
 
-int gpio_read(gpio_t pin)
+int gpio_read_ll(gpio_t pin)
 {
     GPIO_TypeDef *port = _port(pin);
     int pin_num = _pin_num(pin);
@@ -138,27 +138,27 @@ int gpio_read(gpio_t pin)
     }
 }
 
-void gpio_set(gpio_t pin)
+void gpio_set_ll(gpio_t pin)
 {
     _port(pin)->BSRR = (1 << _pin_num(pin));
 }
 
-void gpio_clear(gpio_t pin)
+void gpio_clear_ll(gpio_t pin)
 {
     _port(pin)->BRR = (1 << _pin_num(pin));
 }
 
-void gpio_toggle(gpio_t pin)
+void gpio_toggle_ll(gpio_t pin)
 {
-    if (gpio_read(pin)) {
-        gpio_clear(pin);
+    if (gpio_read_ll(pin)) {
+        gpio_clear_ll(pin);
     }
     else {
-        gpio_set(pin);
+        gpio_set_ll(pin);
     }
 }
 
-void gpio_write(gpio_t pin, int value)
+void gpio_write_ll(gpio_t pin, int value)
 {
     if (value) {
         _port(pin)->BSRR = (1 << _pin_num(pin));
@@ -169,15 +169,15 @@ void gpio_write(gpio_t pin, int value)
 }
 
 #ifdef MODULE_PERIPH_GPIO_IRQ
-int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
-                  gpio_cb_t cb, void *arg)
+int gpio_init_int_ll(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
+                     gpio_cb_t cb, void *arg)
 {
     int pin_num = _pin_num(pin);
 
     /* disable interrupts on the channel we want to edit (just in case) */
     EXTI->IMR &= ~(1 << pin_num);
     /* configure pin as input */
-    gpio_init(pin, mode);
+    gpio_init_ll(pin, mode);
     /* set callback */
     exti_ctx[pin_num].cb = cb;
     exti_ctx[pin_num].arg = arg;
@@ -208,12 +208,12 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     return 0;
 }
 
-void gpio_irq_enable(gpio_t pin)
+void gpio_irq_enable_ll(gpio_t pin)
 {
     EXTI->IMR |= (1 << _pin_num(pin));
 }
 
-void gpio_irq_disable(gpio_t pin)
+void gpio_irq_disable_ll(gpio_t pin)
 {
     EXTI->IMR &= ~(1 << _pin_num(pin));
 }

--- a/drivers/include/periph/gpio.h
+++ b/drivers/include/periph/gpio.h
@@ -173,7 +173,7 @@ void gpio_toggle_cpu(gpio_t pin);
 void gpio_write_cpu(gpio_t pin, int value);
 /** @} */
 
-#if MODULE_EXTEND_ADC || DOXYGEN
+#if MODULE_EXTEND_GPIO || DOXYGEN
 /**
  * @brief   Redirecting versions of the GPIO functions
  *
@@ -191,7 +191,7 @@ void gpio_clear_redir(gpio_t pin);
 void gpio_toggle_redir(gpio_t pin);
 void gpio_write_redir(gpio_t pin, int value);
 /** @} */
-#endif /* MODULE_EXTEND_ADC || DOXYGEN */
+#endif /* MODULE_EXTEND_GPIO || DOXYGEN */
 
 /**
  * @brief   Initialize the given pin as general purpose input or output

--- a/drivers/include/periph/gpio.h
+++ b/drivers/include/periph/gpio.h
@@ -161,18 +161,19 @@ typedef struct {
  * These are for cpu gpio.c implementation and should not be called directly.
  * @{
  */
-int gpio_init_ll(gpio_t pin, gpio_mode_t mode);
-int gpio_init_int_ll(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
-                     gpio_cb_t cb, void *arg);
-void gpio_irq_enable_ll(gpio_t pin);
-void gpio_irq_disable_ll(gpio_t pin);
-int gpio_read_ll(gpio_t pin);
-void gpio_set_ll(gpio_t pin);
-void gpio_clear_ll(gpio_t pin);
-void gpio_toggle_ll(gpio_t pin);
-void gpio_write_ll(gpio_t pin, int value);
+int gpio_init_cpu(gpio_t pin, gpio_mode_t mode);
+int gpio_init_int_cpu(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
+                      gpio_cb_t cb, void *arg);
+void gpio_irq_enable_cpu(gpio_t pin);
+void gpio_irq_disable_cpu(gpio_t pin);
+int gpio_read_cpu(gpio_t pin);
+void gpio_set_cpu(gpio_t pin);
+void gpio_clear_cpu(gpio_t pin);
+void gpio_toggle_cpu(gpio_t pin);
+void gpio_write_cpu(gpio_t pin, int value);
 /** @} */
 
+#if MODULE_EXTEND_ADC || DOXYGEN
 /**
  * @brief   Redirecting versions of the GPIO functions
  *
@@ -190,6 +191,7 @@ void gpio_clear_redir(gpio_t pin);
 void gpio_toggle_redir(gpio_t pin);
 void gpio_write_redir(gpio_t pin, int value);
 /** @} */
+#endif /* MODULE_EXTEND_ADC || DOXYGEN */
 
 /**
  * @brief   Initialize the given pin as general purpose input or output
@@ -212,7 +214,11 @@ static inline int gpio_init(gpio_t pin, gpio_mode_t mode)
     }
 #endif
 
-    return gpio_init_ll(pin, mode);
+#ifdef MODULE_PERIPH_GPIO
+    return gpio_init_cpu(pin, mode);
+#else
+    return -1;
+#endif
 }
 
 #if defined(MODULE_PERIPH_GPIO_IRQ) || defined(DOXYGEN)
@@ -245,7 +251,11 @@ static inline int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t
     }
 #endif
 
-    return gpio_init_int_ll(pin, mode, flank, cb, arg);
+#ifdef MODULE_PERIPH_GPIO
+    return gpio_init_int_cpu(pin, mode, flank, cb, arg);
+#else
+    return -1;
+#endif
 }
 
 /**
@@ -265,7 +275,9 @@ static inline void gpio_irq_enable(gpio_t pin)
     }
 #endif
 
-    gpio_irq_enable_ll(pin);
+#ifdef MODULE_PERIPH_GPIO
+    gpio_irq_enable_cpu(pin);
+#endif
 }
 
 /**
@@ -285,7 +297,9 @@ static inline void gpio_irq_disable(gpio_t pin)
     }
 #endif
 
-    gpio_irq_disable_ll(pin);
+#ifdef MODULE_PERIPH_GPIO
+    gpio_irq_disable_cpu(pin);
+#endif
 }
 
 #endif /* defined(MODULE_PERIPH_GPIO_IRQ) || defined(DOXYGEN) */
@@ -306,7 +320,11 @@ static inline int gpio_read(gpio_t pin)
     }
 #endif
 
-    return gpio_read_ll(pin);
+#ifdef MODULE_PERIPH_GPIO
+    return gpio_read_cpu(pin);
+#else
+    return 0;
+#endif
 }
 
 /**
@@ -323,7 +341,9 @@ static inline void gpio_set(gpio_t pin)
     }
 #endif
 
-    gpio_set_ll(pin);
+#ifdef MODULE_PERIPH_GPIO
+    gpio_set_cpu(pin);
+#endif
 }
 
 /**
@@ -340,7 +360,9 @@ static inline void gpio_clear(gpio_t pin)
     }
 #endif
 
-    gpio_clear_ll(pin);
+#ifdef MODULE_PERIPH_GPIO
+    gpio_clear_cpu(pin);
+#endif
 }
 
 /**
@@ -357,7 +379,9 @@ static inline void gpio_toggle(gpio_t pin)
     }
 #endif
 
-    gpio_toggle_ll(pin);
+#ifdef MODULE_PERIPH_GPIO
+    gpio_toggle_cpu(pin);
+#endif
 }
 
 /**
@@ -375,7 +399,9 @@ static inline void gpio_write(gpio_t pin, int value)
     }
 #endif
 
-    gpio_write_ll(pin, value);
+#ifdef MODULE_PERIPH_GPIO
+    gpio_write_cpu(pin, value);
+#endif
 }
 
 #ifdef __cplusplus

--- a/drivers/include/periph/gpio.h
+++ b/drivers/include/periph/gpio.h
@@ -206,7 +206,7 @@ void gpio_write_redir(gpio_t pin, int value);
  */
 static inline int gpio_init(gpio_t pin, gpio_mode_t mode)
 {
-#ifdef MODULE_GPIO_EXT
+#ifdef MODULE_EXTEND_GPIO
     if (pin > GPIO_EXT_THRESH) {
         return gpio_init_redir(pin, mode);
     }
@@ -239,7 +239,7 @@ static inline int gpio_init(gpio_t pin, gpio_mode_t mode)
 static inline int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t
                                 flank, gpio_cb_t cb, void *arg)
 {
-#ifdef MODULE_GPIO_EXT
+#ifdef MODULE_EXTEND_GPIO
     if (pin > GPIO_EXT_THRESH) {
         return gpio_init_int_redir(pin, mode, flank, cb, arg);
     }
@@ -258,7 +258,7 @@ static inline int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t
  */
 static inline void gpio_irq_enable(gpio_t pin)
 {
-#ifdef MODULE_GPIO_EXT
+#ifdef MODULE_EXTEND_GPIO
     if (pin > GPIO_EXT_THRESH) {
         gpio_irq_enable_redir(pin);
         return;
@@ -278,7 +278,7 @@ static inline void gpio_irq_enable(gpio_t pin)
  */
 static inline void gpio_irq_disable(gpio_t pin)
 {
-#ifdef MODULE_GPIO_EXT
+#ifdef MODULE_EXTEND_GPIO
     if (pin > GPIO_EXT_THRESH) {
         gpio_irq_disable_redir(pin);
         return;
@@ -300,7 +300,7 @@ static inline void gpio_irq_disable(gpio_t pin)
  */
 static inline int gpio_read(gpio_t pin)
 {
-#ifdef MODULE_GPIO_EXT
+#ifdef MODULE_EXTEND_GPIO
     if (pin > GPIO_EXT_THRESH) {
         return gpio_read_redir(pin);
     }
@@ -316,7 +316,7 @@ static inline int gpio_read(gpio_t pin)
  */
 static inline void gpio_set(gpio_t pin)
 {
-#ifdef MODULE_GPIO_EXT
+#ifdef MODULE_EXTEND_GPIO
     if (pin > GPIO_EXT_THRESH) {
         gpio_set_redir(pin);
         return;
@@ -333,7 +333,7 @@ static inline void gpio_set(gpio_t pin)
  */
 static inline void gpio_clear(gpio_t pin)
 {
-#ifdef MODULE_GPIO_EXT
+#ifdef MODULE_EXTEND_GPIO
     if (pin > GPIO_EXT_THRESH) {
         gpio_clear_redir(pin);
         return;
@@ -350,7 +350,7 @@ static inline void gpio_clear(gpio_t pin)
  */
 static inline void gpio_toggle(gpio_t pin)
 {
-#ifdef MODULE_GPIO_EXT
+#ifdef MODULE_EXTEND_GPIO
     if (pin > GPIO_EXT_THRESH) {
         gpio_toggle_redir(pin);
         return;
@@ -368,7 +368,7 @@ static inline void gpio_toggle(gpio_t pin)
  */
 static inline void gpio_write(gpio_t pin, int value)
 {
-#ifdef MODULE_GPIO_EXT
+#ifdef MODULE_EXTEND_GPIO
     if (pin > GPIO_EXT_THRESH) {
         gpio_write_redir(pin, value);
         return;

--- a/drivers/include/periph/gpio.h
+++ b/drivers/include/periph/gpio.h
@@ -204,7 +204,7 @@ void gpio_write_redir(gpio_t pin, int value);
  * @return              0 on success
  * @return              -1 on error
  */
-inline int gpio_init(gpio_t pin, gpio_mode_t mode)
+static inline int gpio_init(gpio_t pin, gpio_mode_t mode)
 {
 #ifdef MODULE_GPIO_EXT
     if (pin > GPIO_EXT_THRESH) {
@@ -236,8 +236,8 @@ inline int gpio_init(gpio_t pin, gpio_mode_t mode)
  * @return              0 on success
  * @return              -1 on error
  */
-inline int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
-                         gpio_cb_t cb, void *arg)
+static inline int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t
+                                flank, gpio_cb_t cb, void *arg)
 {
 #ifdef MODULE_GPIO_EXT
     if (pin > GPIO_EXT_THRESH) {
@@ -256,7 +256,7 @@ inline int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
  *
  * @param[in] pin       the pin to enable the interrupt for
  */
-inline void gpio_irq_enable(gpio_t pin)
+static inline void gpio_irq_enable(gpio_t pin)
 {
 #ifdef MODULE_GPIO_EXT
     if (pin > GPIO_EXT_THRESH) {
@@ -276,7 +276,7 @@ inline void gpio_irq_enable(gpio_t pin)
  *
  * @param[in] pin       the pin to disable the interrupt for
  */
-inline void gpio_irq_disable(gpio_t pin)
+static inline void gpio_irq_disable(gpio_t pin)
 {
 #ifdef MODULE_GPIO_EXT
     if (pin > GPIO_EXT_THRESH) {
@@ -298,7 +298,7 @@ inline void gpio_irq_disable(gpio_t pin)
  * @return              0 when pin is LOW
  * @return              >0 for HIGH
  */
-inline int gpio_read(gpio_t pin)
+static inline int gpio_read(gpio_t pin)
 {
 #ifdef MODULE_GPIO_EXT
     if (pin > GPIO_EXT_THRESH) {
@@ -314,7 +314,7 @@ inline int gpio_read(gpio_t pin)
  *
  * @param[in] pin       the pin to set
  */
-inline void gpio_set(gpio_t pin)
+static inline void gpio_set(gpio_t pin)
 {
 #ifdef MODULE_GPIO_EXT
     if (pin > GPIO_EXT_THRESH) {
@@ -331,7 +331,7 @@ inline void gpio_set(gpio_t pin)
  *
  * @param[in] pin       the pin to clear
  */
-inline void gpio_clear(gpio_t pin)
+static inline void gpio_clear(gpio_t pin)
 {
 #ifdef MODULE_GPIO_EXT
     if (pin > GPIO_EXT_THRESH) {
@@ -348,7 +348,7 @@ inline void gpio_clear(gpio_t pin)
  *
  * @param[in] pin       the pin to toggle
  */
-inline void gpio_toggle(gpio_t pin)
+static inline void gpio_toggle(gpio_t pin)
 {
 #ifdef MODULE_GPIO_EXT
     if (pin > GPIO_EXT_THRESH) {
@@ -366,7 +366,7 @@ inline void gpio_toggle(gpio_t pin)
  * @param[in] pin       the pin to set
  * @param[in] value     value to set the pin to, 0 for LOW, HIGH otherwise
  */
-inline void gpio_write(gpio_t pin, int value)
+static inline void gpio_write(gpio_t pin, int value)
 {
 #ifdef MODULE_GPIO_EXT
     if (pin > GPIO_EXT_THRESH) {

--- a/tests/periph_gpio_coll/Makefile
+++ b/tests/periph_gpio_coll/Makefile
@@ -1,0 +1,9 @@
+include ../Makefile.tests_common
+
+# The CPUs of these boards do not provide a gpio.c API.
+# CPUs: cc430, mips32r2_generic, native
+BOARD_BLACKLIST := chronos \
+                   mips-malta \
+                   native
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/periph_gpio_coll/main.c
+++ b/tests/periph_gpio_coll/main.c
@@ -1,0 +1,353 @@
+/*
+ * Copyright (C) 2018 Acutam Automation, LLC
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       GPIO extension compile time gpio_t collision test
+ *
+ * @author      Matthew Blue <matthew.blue.neuro@gmail.com>
+ * @}
+ */
+
+#include "assert.h"
+#include "periph/gpio.h"
+
+#if defined(CPU_MSP430FXYZ)
+#define COLL_PINMASK    (0x07)
+#else
+#define COLL_PINMASK    (0x0f)
+#endif
+
+#define COLL_TEST(port) \
+    (GPIO_PIN(port, COLL_PINMASK) > GPIO_EXT_THRESH)
+
+#if defined(CPU_ATMEGA1281)
+#define COLL_TEST_PORTS \
+    COLL_TEST(PORT_A) \
+    || COLL_TEST(PORT_B) \
+    || COLL_TEST(PORT_C) \
+    || COLL_TEST(PORT_D) \
+    || COLL_TEST(PORT_E) \
+    || COLL_TEST(PORT_F) \
+    || COLL_TEST(PORT_G)
+
+#elif defined(CPU_ATMEGA1284P)
+#define COLL_TEST_PORTS \
+    COLL_TEST(PORT_A) \
+    || COLL_TEST(PORT_B) \
+    || COLL_TEST(PORT_C) \
+    || COLL_TEST(PORT_D)
+
+#elif defined(CPU_ATMEGA2560)
+#define COLL_TEST_PORTS \
+    COLL_TEST(PORT_A) \
+    || COLL_TEST(PORT_B) \
+    || COLL_TEST(PORT_C) \
+    || COLL_TEST(PORT_D) \
+    || COLL_TEST(PORT_E) \
+    || COLL_TEST(PORT_F) \
+    || COLL_TEST(PORT_G) \
+    || COLL_TEST(PORT_H) \
+    || COLL_TEST(PORT_J) \
+    || COLL_TEST(PORT_K) \
+    || COLL_TEST(PORT_L)
+
+#elif defined(CPU_ATMEGA256RFR2)
+#define COLL_TEST_PORTS \
+    COLL_TEST(PORT_B) \
+    || COLL_TEST(PORT_D) \
+    || COLL_TEST(PORT_E) \
+    || COLL_TEST(PORT_F) \
+    || COLL_TEST(PORT_G)
+
+#elif defined(CPU_ATMEGA328P)
+#define COLL_TEST_PORTS \
+    COLL_TEST(PORT_B) \
+    || COLL_TEST(PORT_C) \
+    || COLL_TEST(PORT_D)
+
+#elif defined(CPU_CC2538)
+#define COLL_TEST_PORTS \
+    COLL_TEST(PORT_A) \
+    || COLL_TEST(PORT_B) \
+    || COLL_TEST(PORT_C) \
+    || COLL_TEST(PORT_D)
+
+#elif defined(CPU_CC26X0)
+/* CPU does have port definitions */
+#define COLL_TEST_PORTS \
+    COLL_TEST(0)
+
+#elif defined(CPU_EFM32)
+/* PORT_A */
+#if (_GPIO_PORT_A_PIN_COUNT > 0)
+#define COLL_TEST_PORTA (COLL_TEST(PA))
+#else
+#define COLL_TEST_PORTA (0)
+#endif
+/* PORT_B */
+#if (_GPIO_PORT_B_PIN_COUNT > 0)
+#define COLL_TEST_PORTB (COLL_TEST_PORTA || COLL_TEST(PB))
+#else
+#define COLL_TEST_PORTB (COLL_TEST_PORTA)
+#endif
+/* PORT_C */
+#if (_GPIO_PORT_C_PIN_COUNT > 0)
+#define COLL_TEST_PORTC (COLL_TEST_PORTB || COLL_TEST(PC))
+#else
+#define COLL_TEST_PORTC (COLL_TEST_PORTB)
+#endif
+/* PORT_D */
+#if (_GPIO_PORT_D_PIN_COUNT > 0)
+#define COLL_TEST_PORTD (COLL_TEST_PORTC || COLL_TEST(PD))
+#else
+#define COLL_TEST_PORTD (COLL_TEST_PORTC)
+#endif
+/* PORT_E */
+#if (_GPIO_PORT_E_PIN_COUNT > 0)
+#define COLL_TEST_PORTE (COLL_TEST_PORTD || COLL_TEST(PE))
+#else
+#define COLL_TEST_PORTE (COLL_TEST_PORTD)
+#endif
+/* PORT_F */
+#if (_GPIO_PORT_F_PIN_COUNT > 0)
+#define COLL_TEST_PORTF (COLL_TEST_PORTE || COLL_TEST(PF))
+#else
+#define COLL_TEST_PORTF (COLL_TEST_PORTE)
+#endif
+/* PORT_G */
+#if (_GPIO_PORT_G_PIN_COUNT > 0)
+#define COLL_TEST_PORTG (COLL_TEST_PORTF || COLL_TEST(PG))
+#else
+#define COLL_TEST_PORTG (COLL_TEST_PORTF)
+#endif
+/* PORT_H */
+#if (_GPIO_PORT_H_PIN_COUNT > 0)
+#define COLL_TEST_PORTH (COLL_TEST_PORTG || COLL_TEST(PH))
+#else
+#define COLL_TEST_PORTH (COLL_TEST_PORTG)
+#endif
+/* PORT_I */
+#if (_GPIO_PORT_I_PIN_COUNT > 0)
+#define COLL_TEST_PORTI (COLL_TEST_PORTH || COLL_TEST(PI))
+#else
+#define COLL_TEST_PORTI (COLL_TEST_PORTH)
+#endif
+/* PORT_J */
+#if (_GPIO_PORT_J_PIN_COUNT > 0)
+#define COLL_TEST_PORTJ (COLL_TEST_PORTI || COLL_TEST(PJ))
+#else
+#define COLL_TEST_PORTJ (COLL_TEST_PORTI)
+#endif
+/* PORT_K */
+#if (_GPIO_PORT_K_PIN_COUNT > 0)
+#define COLL_TEST_PORTK (COLL_TEST_PORTJ || COLL_TEST(PK))
+#else
+#define COLL_TEST_PORTK (COLL_TEST_PORTJ)
+#endif
+/* Combination of all existent ports  */
+#define COLL_TEST_PORTS (COLL_TEST_PORTK)
+
+#elif defined(CPU_EZR32WG)
+#define COLL_TEST_PORTS \
+    COLL_TEST(PA) \
+    || COLL_TEST(PB) \
+    || COLL_TEST(PC) \
+    || COLL_TEST(PD) \
+    || COLL_TEST(PE) \
+    || COLL_TEST(PF)
+
+#elif defined(CPU_FE310)
+/* CPU does not have port definitions */
+#define COLL_TEST_PORTS \
+    COLL_TEST(0)
+
+#elif defined(CPU_KINETIS)
+#define COLL_TEST_PORTS \
+    COLL_TEST(PORT_A) \
+    || COLL_TEST(PORT_B) \
+    || COLL_TEST(PORT_C) \
+    || COLL_TEST(PORT_D) \
+    || COLL_TEST(PORT_E) \
+    || COLL_TEST(PORT_F) \
+    || COLL_TEST(PORT_G)
+
+#elif defined(CPU_LM4F120)
+#define COLL_TEST_PORTS \
+    COLL_TEST(PORT_A) \
+    || COLL_TEST(PORT_B) \
+    || COLL_TEST(PORT_C) \
+    || COLL_TEST(PORT_D) \
+    || COLL_TEST(PORT_E) \
+    || COLL_TEST(PORT_F)
+
+#elif defined(CPU_LPC1768)
+/* CPU does not have port definitions */
+#define COLL_TEST_PORTS \
+    COLL_TEST(0)
+
+#elif defined(CPU_LPC2387)
+/* CPU does not have port definitions */
+#define COLL_TEST_PORTS \
+    COLL_TEST(0)
+
+#elif defined(CPU_MIPS_PIC32MX) || defined(CPU_MIPS_PIC32MZ)
+#define COLL_TEST_PORTS \
+    COLL_TEST(PORT_A) \
+    || COLL_TEST(PORT_B) \
+    || COLL_TEST(PORT_C) \
+    || COLL_TEST(PORT_D) \
+    || COLL_TEST(PORT_E) \
+    || COLL_TEST(PORT_F) \
+    || COLL_TEST(PORT_G)
+
+#elif defined(CPU_MSP430FXYZ)
+#define COLL_TEST_PORTS \
+    COLL_TEST(P1) \
+    || COLL_TEST(P2) \
+    || COLL_TEST(P3) \
+    || COLL_TEST(P4) \
+    || COLL_TEST(P5) \
+    || COLL_TEST(P6)
+
+#elif defined(CPU_NRF51) || defined(CPU_NRF52)
+/* CPU does not have port definitions */
+#define COLL_TEST_PORTS \
+    COLL_TEST(0)
+
+#elif defined(CPU_SAM3)
+#define COLL_TEST_PORTS \
+    COLL_TEST(PA) \
+    || COLL_TEST(PB) \
+    || COLL_TEST(PC) \
+    || COLL_TEST(PD)
+
+#elif defined(CPU_SAMD21) || defined(CPU_SAML21)
+#define COLL_TEST_PORTS \
+    COLL_TEST(PA) \
+    || COLL_TEST(PB) \
+    || COLL_TEST(PC)
+
+#elif defined(CPU_STM32F0)
+#define COLL_TEST_PORTS \
+    COLL_TEST(PORT_A) \
+    || COLL_TEST(PORT_B) \
+    || COLL_TEST(PORT_C) \
+    || COLL_TEST(PORT_D) \
+    || COLL_TEST(PORT_E) \
+    || COLL_TEST(PORT_F)
+
+#elif defined(CPU_STM32F1)
+#define COLL_TEST_PORTS \
+    COLL_TEST(PORT_A) \
+    || COLL_TEST(PORT_B) \
+    || COLL_TEST(PORT_C) \
+    || COLL_TEST(PORT_D) \
+    || COLL_TEST(PORT_E) \
+    || COLL_TEST(PORT_F) \
+    || COLL_TEST(PORT_G)
+
+#elif defined(CPU_STM32F2)
+#define COLL_TEST_PORTS \
+    COLL_TEST(PORT_A) \
+    || COLL_TEST(PORT_B) \
+    || COLL_TEST(PORT_C) \
+    || COLL_TEST(PORT_D) \
+    || COLL_TEST(PORT_E) \
+    || COLL_TEST(PORT_F) \
+    || COLL_TEST(PORT_G) \
+    || COLL_TEST(PORT_H) \
+    || COLL_TEST(PORT_I)
+
+#elif defined(CPU_STM32F3)
+#define COLL_TEST_PORTS \
+    COLL_TEST(PORT_A) \
+    || COLL_TEST(PORT_B) \
+    || COLL_TEST(PORT_C) \
+    || COLL_TEST(PORT_D) \
+    || COLL_TEST(PORT_E) \
+    || COLL_TEST(PORT_F) \
+    || COLL_TEST(PORT_G) \
+    || COLL_TEST(PORT_H)
+
+#elif defined(CPU_STM32F4)
+#define COLL_TEST_PORTS \
+    COLL_TEST(PORT_A) \
+    || COLL_TEST(PORT_B) \
+    || COLL_TEST(PORT_C) \
+    || COLL_TEST(PORT_D) \
+    || COLL_TEST(PORT_E) \
+    || COLL_TEST(PORT_F) \
+    || COLL_TEST(PORT_G) \
+    || COLL_TEST(PORT_H) \
+    || COLL_TEST(PORT_I)
+
+#elif defined(CPU_STM32F7)
+#define COLL_TEST_PORTS \
+    COLL_TEST(PORT_A) \
+    || COLL_TEST(PORT_B) \
+    || COLL_TEST(PORT_C) \
+    || COLL_TEST(PORT_D) \
+    || COLL_TEST(PORT_E) \
+    || COLL_TEST(PORT_F) \
+    || COLL_TEST(PORT_G) \
+    || COLL_TEST(PORT_H) \
+    || COLL_TEST(PORT_I) \
+    || COLL_TEST(PORT_J) \
+    || COLL_TEST(PORT_K)
+
+#elif defined(CPU_STM32L0)
+#define COLL_TEST_PORTS \
+    COLL_TEST(PORT_A) \
+    || COLL_TEST(PORT_B) \
+    || COLL_TEST(PORT_C) \
+    || COLL_TEST(PORT_D) \
+    || COLL_TEST(PORT_E) \
+    || COLL_TEST(PORT_H)
+
+#elif defined(CPU_STM32L1)
+#define COLL_TEST_PORTS \
+    COLL_TEST(PORT_A) \
+    || COLL_TEST(PORT_B) \
+    || COLL_TEST(PORT_C) \
+    || COLL_TEST(PORT_D) \
+    || COLL_TEST(PORT_E) \
+    || COLL_TEST(PORT_F) \
+    || COLL_TEST(PORT_G) \
+    || COLL_TEST(PORT_H)
+
+#elif defined(CPU_STM32L4)
+#define COLL_TEST_PORTS \
+    COLL_TEST(PORT_A) \
+    || COLL_TEST(PORT_B) \
+    || COLL_TEST(PORT_C) \
+    || COLL_TEST(PORT_D) \
+    || COLL_TEST(PORT_E) \
+    || COLL_TEST(PORT_F) \
+    || COLL_TEST(PORT_G) \
+    || COLL_TEST(PORT_H)
+
+#else
+
+/* unknown CPU (default to not testing port) */
+#define COLL_TEST_PORTS \
+    COLL_TEST(0)
+
+#endif /* defined(CPU) */
+
+#define COLL_RES (!(COLL_TEST_PORTS))
+
+static_assert(COLL_RES, "[periph_gpio_coll] Collision in GPIO_EXT_PIN");
+
+int main(void)
+{
+    return 0;
+}

--- a/tests/periph_gpio_coll/main.c
+++ b/tests/periph_gpio_coll/main.c
@@ -20,7 +20,11 @@
 #include "assert.h"
 #include "periph/gpio.h"
 
-#if defined(CPU_MSP430FXYZ)
+#if defined(CPU_ESP32)
+#define COLL_PINMASK    (0x3f)
+#elif defined(CPU_ESP8266)
+#define COLL_PINMASK    (0x1f)
+#elif defined(CPU_MSP430FXYZ)
 #define COLL_PINMASK    (0x07)
 #else
 #define COLL_PINMASK    (0x0f)
@@ -155,6 +159,16 @@
 #endif
 /* Combination of all existent ports  */
 #define COLL_TEST_PORTS (COLL_TEST_PORTK)
+
+#elif defined(CPU_ESP32)
+/* CPU does not have port definitions */
+#define COLL_TEST_PORTS \
+    COLL_TEST(0)
+
+#elif defined(CPU_ESP8266)
+/* CPU does not have port definitions */
+#define COLL_TEST_PORTS \
+    COLL_TEST(0)
 
 #elif defined(CPU_EZR32WG)
 #define COLL_TEST_PORTS \


### PR DESCRIPTION
### Contribution description
This is an implementation of the intercept method outlined by my proposal in [#9582](https://github.com/RIOT-OS/RIOT/issues/9582#issuecomment-410094702) (parts 1-4) for the periph/gpio interface. In short, it allows other drivers (such as GPIO expanders) to be addressed using gpio_t so that all existent code can easily gain support through those drivers. For non-implementation detail and discussion, please see #9582

At @kYc0o 's suggestion, I am breaking the implementation of #9582 / #9690 into several pieces to make it easier to review. This PR only contains the API intercept code.

### Testing procedure
A test case is provided for detecting collisions between use of ```GPIO_PIN``` and ```GPIO_EXT_PIN```. Otherwise the existing GPIO tests may be used to confirm CPU based pins work with the API change. This PR only contains API definitions for the redirection functions, so implementation of them will be tested in a follow-up PR.

### Issues/PRs references
Partially replaces and closes #9190 
Implements parts 1-4 of my proposal in #9582 
Part of work tracked by #9690