### PR TITLE
pkg/lora-serialization: add support for lora-serialization format

### DIFF
--- a/pkg/lora-serialization/Makefile
+++ b/pkg/lora-serialization/Makefile
@@ -1,0 +1,11 @@
+PKG_NAME=lora-serialization
+PKG_URL=https://github.com/leandrolanzieri/lora-serialization
+PKG_VERSION=90e49e4acd119f20ad2ad7b98751b88b08f564d7
+PKG_LICENSE=LGPLv2.1
+
+.PHONY: all
+
+all: git-download
+	"$(MAKE)" -C $(PKG_BUILDDIR) -f $(CURDIR)/Makefile.$(PKG_NAME)
+
+include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/lora-serialization/Makefile.include
+++ b/pkg/lora-serialization/Makefile.include
@@ -1,0 +1,1 @@
+INCLUDES += -I$(PKGDIRBASE)/lora-serialization

--- a/pkg/lora-serialization/Makefile.lora-serialization
+++ b/pkg/lora-serialization/Makefile.lora-serialization
@@ -1,0 +1,3 @@
+MODULE = lora-serialization
+
+include $(RIOTBASE)/Makefile.base

--- a/pkg/lora-serialization/doc.txt
+++ b/pkg/lora-serialization/doc.txt
@@ -1,0 +1,9 @@
+/**
+ * @defgroup pkg_lora-serialization Lora Serialization
+ * @ingroup  pkg
+ * @ingroup  sys
+ * @brief    Provides a RIOT support for Lora Serialization format
+ *
+ * For more details on the format see
+ * [this](https://github.com/thesolarnomad/lora-serialization).
+ */

--- a/tests/pkg_lora-serialization/Makefile
+++ b/tests/pkg_lora-serialization/Makefile
@@ -1,0 +1,9 @@
+include ../Makefile.tests_common
+
+USEPKG += lora-serialization
+
+TEST_ON_CI_WHITELIST += all
+include $(RIOTBASE)/Makefile.include
+
+test:
+	tests/01-run.py

--- a/tests/pkg_lora-serialization/main.c
+++ b/tests/pkg_lora-serialization/main.c
@@ -1,0 +1,127 @@
+/*
+ * Copyright (C) 2018 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       lora-serialization tests
+ *
+ * @author      Leandro Lanzieri <leandro.lanzieri@haw-hamburg.de>
+ * @author      Jose Ignacio Alamos <jose.alamos@haw-hamburg.de>
+ *
+ * @}
+ */
+
+#include <string.h>
+#include <stdio.h>
+#include "lora_serialization.h"
+
+#if defined(BOARD_NATIVE) && !defined(__clang__)
+#define TEST_01_EXPECTED    { 0x1f, 0x4c, 0x0e, 0x27 }
+#define TEST_02_EXPECTED    { 0x65, 0xa6, 0xfa, 0xfd, \
+                              0x6a, 0x24, 0x04, 0x09, \
+                              0x1d, 0x4b, 0x7a, 0x57 }
+#else
+#define TEST_01_EXPECTED    { 0x1f, 0x4c, 0x0f, 0x27 }
+#define TEST_02_EXPECTED    { 0x64, 0xa6, 0xfa, 0xfd, \
+                              0x6a, 0x24, 0x04, 0x09, \
+                              0x1d, 0x4b, 0x7a, 0x57 }
+#endif
+
+uint8_t test01Expected[] = TEST_01_EXPECTED;
+uint8_t test02Expected[] = TEST_02_EXPECTED;
+
+static void print_buffer(const uint8_t *buffer, size_t len)
+{
+    for (uint8_t i = 0; i < len; i++) {
+        printf(" %02x", buffer[i]);
+    }
+}
+
+/* Test 1: Add temperature and humidity */
+static void test01(lora_serialization_t *serialization)
+{
+    puts("Test 1");
+    puts("Temperature and humidity");
+    puts("---------------------------------");
+    lora_serialization_reset(serialization); // Always reset
+
+    puts("- Writing temperature: 80.12");
+    lora_serialization_write_temperature(serialization, 80.12);
+
+    puts("- Writing humidity: 99.99");
+    lora_serialization_write_humidity(serialization, 99.99);
+
+    printf("- Encoded: ");
+    print_buffer(serialization->buffer,
+                 LORA_SERIALIZATION_TEMPERATURE_SIZE +
+                 LORA_SERIALIZATION_HUMIDITY_SIZE);
+    puts("");
+
+    printf("- Expected:");
+    print_buffer(test01Expected, sizeof(test01Expected));
+    puts("");
+    puts("---------------------------------");
+
+    if (memcmp(serialization->buffer, test01Expected,
+               sizeof(test01Expected)) != 0) {
+        puts("FAILED");
+    }
+    else {
+        puts("SUCCESS");
+    }
+}
+
+/* Test 2: Add GPS coordinates and unix time */
+static void test02(lora_serialization_t *serialization)
+{
+    puts("Test 2");
+    puts("Coordinates and unix time");
+    puts("---------------------------------");
+    lora_serialization_reset(serialization); // Always reset
+
+    puts("- Writing coordinates: -33.905052, 151.26641");
+    lora_serialization_write_coordinates(serialization, -33.905052, 151.26641);
+
+    puts("- Writing unix time: 1467632413");
+    lora_serialization_write_unix_time(serialization, 1467632413);
+
+    printf("- Encoded: ");
+    print_buffer(serialization->buffer,
+                 LORA_SERIALIZATION_GPS_SIZE +
+                 LORA_SERIALIZATION_UNIX_TIME_SIZE);
+    puts("");
+
+    printf("- Expected:");
+    print_buffer(test02Expected, sizeof(test02Expected));
+    puts("");
+    puts("---------------------------------");
+
+    if (memcmp(serialization->buffer, test02Expected,
+               sizeof(test02Expected)) != 0) {
+        puts("FAILED");
+    }
+    else {
+        puts("SUCCESS");
+    }
+}
+
+int main(void)
+{
+    lora_serialization_t serialization;
+
+    puts("Lora Serialization test\n");
+
+    test01(&serialization);
+    puts("");
+    test02(&serialization);
+
+    return 0;
+}

--- a/tests/pkg_lora-serialization/tests/01-run.py
+++ b/tests/pkg_lora-serialization/tests/01-run.py
@@ -1,0 +1,16 @@
+#!/usr/bin/env python3
+
+import sys
+from testrunner import run
+
+NB_TESTS = 2
+
+
+def testfunc(child):
+    for test in range(NB_TESTS):
+        child.expect_exact('Test {}'.format(test + 1))
+        child.expect('SUCCESS')
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc))


### PR DESCRIPTION
### Contribution description
This PR adds support for the lora-serialization format, as a package ([found here](https://github.com/leandrolanzieri/lora-serialization)).

An example showing the lora-serialization format integrated to OpenSenseMap can be found here #9862.

This library is based on [this one](https://github.com/thesolarnomad/lora-serialization), but has been implemented withou using dynamic allocation.

**This work was done in conjunction with @jia200x.**

### Testing procedure
```
cd $(RIOTBASE)/tests/pkg_lora-serialization
make all term
```
Should output:
```
main(): This is RIOT! (Version: 2018.10-devel-569-gb199-X1-pr/lora-serialization)
Lora Serialization test

Test 1
Temperature and humidity
---------------------------------
- Writing temperature: 80.12
- Writing humidity: 99.99
- Encoded:  1f 4c 0e 27
- Expected: 1f 4c 0e 27
---------------------------------
SUCCESS

Test 2
Coordinates and unix time
---------------------------------
- Writing coordinates: -33.905052, 151.26641
- Writing unix time: 1467632413
- Encoded:  65 a6 fa fd 6a 24 04 09 1d 4b 7a 57
- Expected: 65 a6 fa fd 6a 24 04 09 1d 4b 7a 57
---------------------------------
SUCCESS
```