### PR TITLE
drivers/netdev_ieee802154: cleanup NETOPT_MAX_PACKET_SIZE

### DIFF
--- a/cpu/cc2538/radio/cc2538_rf_netdev.c
+++ b/cpu/cc2538/radio/cc2538_rf_netdev.c
@@ -31,8 +31,6 @@
 #define ENABLE_DEBUG        (0)
 #include "debug.h"
 
-#define _MAX_MHR_OVERHEAD   (25)
-
 /* Reference pointer for the IRQ handler */
 static netdev_t *_dev;
 
@@ -87,13 +85,6 @@ static int _get(netdev_t *netdev, netopt_t opt, void *value, size_t max_len)
 
         case NETOPT_IS_WIRED:
             return -ENOTSUP;
-
-        case NETOPT_MAX_PACKET_SIZE:
-            if (max_len < sizeof(int16_t)) {
-                return -EOVERFLOW;
-            }
-            *((uint16_t *)value) = CC2538_RF_MAX_DATA_LEN - _MAX_MHR_OVERHEAD;
-            return sizeof(uint16_t);
 
         case NETOPT_PROMISCUOUSMODE:
             if (cc2538_get_monitor()) {

--- a/cpu/native/include/socket_zep.h
+++ b/cpu/native/include/socket_zep.h
@@ -31,9 +31,6 @@
 extern "C" {
 #endif
 
-/* 127 - 25 as in at86rf2xx */
-#define SOCKET_ZEP_FRAME_PAYLOAD_LEN    (102)   /**< maximum possible payload size */
-
 /**
  * @brief   ZEP device state
  */

--- a/cpu/native/socket_zep/socket_zep.c
+++ b/cpu/native/socket_zep/socket_zep.c
@@ -304,21 +304,8 @@ static int _init(netdev_t *netdev)
 
 static int _get(netdev_t *netdev, netopt_t opt, void *value, size_t max_len)
 {
-    socket_zep_t *dev = (socket_zep_t *)netdev;
-    uint16_t *v = value;
-
-    assert((dev != NULL));
-    switch (opt) {
-        case NETOPT_MAX_PACKET_SIZE:
-            assert(value != NULL);
-            if (max_len != sizeof(uint16_t)) {
-                return -EOVERFLOW;
-            }
-            *v = SOCKET_ZEP_FRAME_PAYLOAD_LEN;
-            return sizeof(uint16_t);
-        default:
-            return netdev_ieee802154_get(&dev->netdev, opt, value, max_len);
-    }
+    assert(netdev != NULL);
+    return netdev_ieee802154_get((netdev_ieee802154_t *)netdev, opt, value, max_len);
 }
 
 static int _set(netdev_t *netdev, netopt_t opt, const void *value,

--- a/drivers/at86rf2xx/at86rf2xx_netdev.c
+++ b/drivers/at86rf2xx/at86rf2xx_netdev.c
@@ -42,8 +42,6 @@
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
-#define _MAX_MHR_OVERHEAD   (25)
-
 static int _send(netdev_t *netdev, const iolist_t *iolist);
 static int _recv(netdev_t *netdev, void *buf, size_t len, void *info);
 static int _init(netdev_t *netdev);
@@ -282,11 +280,6 @@ static int _get(netdev_t *netdev, netopt_t opt, void *val, size_t max_len)
             assert(max_len >= sizeof(uint16_t));
             ((uint8_t *)val)[1] = 0;
             ((uint8_t *)val)[0] = at86rf2xx_get_page(dev);
-            return sizeof(uint16_t);
-
-        case NETOPT_MAX_PACKET_SIZE:
-            assert(max_len >= sizeof(int16_t));
-            *((uint16_t *)val) = AT86RF2XX_MAX_PKT_LENGTH - _MAX_MHR_OVERHEAD;
             return sizeof(uint16_t);
 
         case NETOPT_STATE:

--- a/drivers/cc2420/cc2420_netdev.c
+++ b/drivers/cc2420/cc2420_netdev.c
@@ -38,8 +38,6 @@
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
 
-#define _MAX_MHR_OVERHEAD   (25)
-
 static int _send(netdev_t *netdev, const iolist_t *iolist);
 static int _recv(netdev_t *netdev, void *buf, size_t len, void *info);
 static int _init(netdev_t *netdev);
@@ -187,11 +185,6 @@ static int _get(netdev_t *netdev, netopt_t opt, void *val, size_t max_len)
             assert(max_len >= 8);
             cc2420_get_addr_long(dev, val);
             return 8;
-
-        case NETOPT_MAX_PACKET_SIZE:
-            assert(max_len >= sizeof(int16_t));
-            *((uint16_t *)val) = CC2420_PKT_MAXLEN - _MAX_MHR_OVERHEAD;
-            return sizeof(int16_t);
 
         case NETOPT_NID:
             assert(max_len >= sizeof(uint16_t));

--- a/drivers/kw2xrf/kw2xrf_netdev.c
+++ b/drivers/kw2xrf/kw2xrf_netdev.c
@@ -42,8 +42,6 @@
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
-#define _MAX_MHR_OVERHEAD           (25)
-
 #define _MACACKWAITDURATION         (864 / 16) /* 864us * 62500Hz */
 
 #define KW2XRF_THREAD_FLAG_ISR      (1 << 8)
@@ -260,14 +258,6 @@ int _get(netdev_t *netdev, netopt_t opt, void *value, size_t len)
     }
 
     switch (opt) {
-        case NETOPT_MAX_PACKET_SIZE:
-            if (len < sizeof(int16_t)) {
-                return -EOVERFLOW;
-            }
-
-            *((uint16_t *)value) = KW2XRF_MAX_PKT_LENGTH - _MAX_MHR_OVERHEAD;
-            return sizeof(uint16_t);
-
         case NETOPT_STATE:
             if (len < sizeof(netopt_state_t)) {
                 return -EOVERFLOW;

--- a/drivers/mrf24j40/mrf24j40_netdev.c
+++ b/drivers/mrf24j40/mrf24j40_netdev.c
@@ -37,8 +37,6 @@
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
-#define _MAX_MHR_OVERHEAD   (25)
-
 static void _irq_handler(void *arg)
 {
     netdev_t *dev = (netdev_t *) arg;
@@ -183,16 +181,6 @@ static int _get(netdev_t *netdev, netopt_t opt, void *val, size_t max_len)
             else {
                 ((uint8_t *)val)[1] = 0;
                 ((uint8_t *)val)[0] = 0;
-                res = sizeof(uint16_t);
-            }
-            break;
-
-        case NETOPT_MAX_PACKET_SIZE:
-            if (max_len < sizeof(int16_t)) {
-                res = -EOVERFLOW;
-            }
-            else {
-                *((uint16_t *)val) = IEEE802154_FRAME_LEN_MAX - _MAX_MHR_OVERHEAD;
                 res = sizeof(uint16_t);
             }
             break;

--- a/drivers/netdev_ieee802154/netdev_ieee802154.c
+++ b/drivers/netdev_ieee802154/netdev_ieee802154.c
@@ -151,6 +151,13 @@ int netdev_ieee802154_get(netdev_ieee802154_t *dev, netopt_t opt, void *value,
             res = sizeof(l2filter_t **);
             break;
 #endif
+        case NETOPT_MAX_PACKET_SIZE:
+            assert(max_len >= sizeof(int16_t));
+            *((uint16_t *)value) = (IEEE802154_FRAME_LEN_MAX -
+                                  IEEE802154_MAX_HDR_LEN) -
+                                  IEEE802154_FCS_LEN;
+            res = sizeof(uint16_t);
+            break;
         default:
             break;
     }


### PR DESCRIPTION
This PR relieves code duplications in netdev interfaces and unifies them in the shared, generic ieee802154 netdev driver.
I focused on NETOPT_MAX_PACKET_SIZE by intent, if there are more obvious duplications, I will fix those separately.