### PR TITLE
doc: add `memory management` group

### DIFF
--- a/pkg/tlsf/contrib/include/tlsf-malloc.h
+++ b/pkg/tlsf/contrib/include/tlsf-malloc.h
@@ -8,7 +8,7 @@
 /**
  * @defgroup pkg_tlsf_malloc TLSF-based malloc.
  * @ingroup  pkg
- * @ingroup  sys
+ * @ingroup  sys_memory_management
  *
  * @brief    TLSF-based global memory allocator.
  *

--- a/sys/doc.txt
+++ b/sys/doc.txt
@@ -28,3 +28,9 @@
  * @ingroup     sys
  * @brief       Provides math libraries and utilities for RIOT
  */
+
+/**
+ * @defgroup    sys_memory_management Memory management
+ * @ingroup     sys
+ * @brief       Provides memory management implementations and utilities
+ */

--- a/sys/include/memarray.h
+++ b/sys/include/memarray.h
@@ -7,7 +7,7 @@
  */
 /**
  * @defgroup    sys_memarray memory array allocator
- * @ingroup     sys
+ * @ingroup     sys_memory_management
  * @brief       memory array allocator
  * @{
  *

--- a/sys/oneway-malloc/include/malloc.h
+++ b/sys/oneway-malloc/include/malloc.h
@@ -8,7 +8,7 @@
 
 /**
  * @defgroup    oneway_malloc Oneway malloc
- * @ingroup     sys
+ * @ingroup     sys_memory_management
  *
  * @brief       A malloc implementation without free for boards where the
  *              toolchain does not implement dynamic memory allocation.

--- a/sys/oneway-malloc/oneway-malloc.c
+++ b/sys/oneway-malloc/oneway-malloc.c
@@ -7,8 +7,7 @@
  */
 
 /**
- * @addtogroup oneway_malloc
- * @ingroup sys
+ * @ingroup oneway_malloc
  * @{
  *
  * @file


### PR DESCRIPTION
### Contribution description
This PR does the following:

- Add `sys_memory_management` group
- Move TLSF malloc, oneway malloc and memarray to this new group

### Testing procedure
`make doc`. Go to `System>Memory management` in the generated documentation and see how these components are grouped.

### Issues/PRs references
#8479  

