### PR TITLE
make: unify app folder search (examples/*, tests/*, ...)

### DIFF
--- a/.murdock
+++ b/.murdock
@@ -72,9 +72,8 @@ _greplist() {
 
 # get list of all app directories
 get_apps() {
-    find tests/ examples/ \
-        -mindepth 2 -maxdepth 2 -name Makefile -type f \
-        | xargs dirname | $(_greplist $APPS) | sort
+    make -f makefiles/app_dirs.inc.mk info-applications \
+        | $(_greplist $APPS) | sort
 }
 
 # take app dir as parameter, print all boards that are supported

--- a/Makefile
+++ b/Makefile
@@ -20,11 +20,11 @@ docclean:
 
 clean:
 	@echo "Cleaning all build products for the current board"
-	@find ./examples/ ./tests/ -maxdepth 2 -mindepth 2 -type f -name Makefile -execdir "$(MAKE)" clean ';'
+	@for dir in $(APPLICATION_DIRS); do "$(MAKE)" -C$$dir clean; done
 
 distclean: docclean
 	@echo "Cleaning all build products"
-	@find ./examples/ ./tests/ -maxdepth 2 -mindepth 2 -type f -name Makefile -execdir "$(MAKE)" distclean ';'
+	@for dir in $(APPLICATION_DIRS); do "$(MAKE)" -C$$dir distclean; done
 
 welcome:
 	@echo "Welcome to RIOT - The friendly OS for IoT!"
@@ -36,5 +36,7 @@ welcome:
 	@echo "    https://doc.riot-os.org/getting-started.html"
 	@echo "Or ask questions on our mailing list:"
 	@echo "    users@riot-os.org (http://lists.riot-os.org/mailman/listinfo/users)"
+
+include makefiles/app_dirs.inc.mk
 
 -include makefiles/tests.inc.mk

--- a/makefiles/app_dirs.inc.mk
+++ b/makefiles/app_dirs.inc.mk
@@ -1,0 +1,14 @@
+# fallback so empty RIOTBASE won't lead to "/examples/"
+RIOTBASE ?= .
+
+# 1. use wildcard to find Makefiles
+# 2. use patsubst to drop trailing "/"
+# 3. use patsubst to drop possible leading "./"
+# 4. sort
+APPLICATION_DIRS := $(sort $(patsubst ./%,%,$(patsubst %/,%,$(dir $(wildcard \
+	$(RIOTBASE)/examples/*/Makefile \
+	$(RIOTBASE)/tests/*/Makefile    \
+	)))))
+
+info-applications:
+	@for dir in $(APPLICATION_DIRS); do echo $$dir; done


### PR DESCRIPTION
### Contribution description

There were at least three variants of getting a list of examples and tests application folders at even more places in the code.

This PR tries to unify this.

### Testing procedure

1. murdock total job count shouldn't change
2. complile_test output looks as before
3. main folder make clean / distclean works as before