### PR TITLE
tsrb: add drop function

### DIFF
--- a/sys/include/tsrb.h
+++ b/sys/include/tsrb.h
@@ -128,6 +128,14 @@ int tsrb_get_one(tsrb_t *rb);
 int tsrb_get(tsrb_t *rb, char *dst, size_t n);
 
 /**
+ * @brief       Drop bytes from ringbuffer
+ * @param[in]   rb  Ringbuffer to operate on
+ * @param[in]   n   max number of bytes to drop
+ * @return      nr of bytes dropped
+ */
+int tsrb_drop(tsrb_t *rb, size_t n);
+
+/**
  * @brief       Add a byte to ringbuffer
  * @param[in]   rb  Ringbuffer to operate on
  * @param[in]   c   Character to add to ringbuffer

--- a/sys/tsrb/tsrb.c
+++ b/sys/tsrb/tsrb.c
@@ -49,6 +49,16 @@ int tsrb_get(tsrb_t *rb, char *dst, size_t n)
     return (n - tmp);
 }
 
+int tsrb_drop(tsrb_t *rb, size_t n)
+{
+    size_t tmp = n;
+    while (tmp && !tsrb_empty(rb)) {
+        _pop(rb);
+        tmp--;
+    }
+    return (n - tmp);
+}
+
 int tsrb_add_one(tsrb_t *rb, char c)
 {
     if (!tsrb_full(rb)) {


### PR DESCRIPTION
### Contribution description

The get function does not support passing NULL as an input buffer. to be
able to drop bytes from the buffer, a dedicated drop function is
required

### Issues/PRs references

required for #9870