### PR TITLE
ethos: Add drop frame case to recv function

### DIFF
--- a/drivers/ethos/ethos.c
+++ b/drivers/ethos/ethos.c
@@ -314,7 +314,14 @@ static int _recv(netdev_t *netdev, void *buf, size_t len, void* info)
         return (int)len;
     }
     else {
-        return dev->last_framesize;
+        if (len) {
+            int dropsize = dev->last_framesize;
+            dev->last_framesize = 0;
+            return tsrb_drop(&dev->inbuf, dropsize);
+        }
+        else {
+            return dev->last_framesize;
+        }
     }
 }
 


### PR DESCRIPTION
### Contribution description

The ethos driver does not drop the received frame if the recv function
is called with NULL buffer and with a length. This PR fixes that.

### Issues/PRs references

depends on #9869 