### PR TITLE
net/nanocoap: allow empty uri/location path option

### DIFF
--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -603,7 +603,9 @@ size_t coap_opt_put_string(uint8_t *buf, uint16_t lastonum, uint16_t optnum,
 
         part_len = (uint8_t *)uripos - part_start;
 
-        if (part_len) {
+        /* Creates empty option if part for Uri-Path or Uri-Location contains only *
+         * a trailing slash, except for root path ("/"). */
+        if (part_len || ((separator == '/') && (lastonum == optnum))) {
             bufpos += coap_put_option(bufpos, lastonum, optnum, part_start, part_len);
             lastonum = optnum;
         }
@@ -658,7 +660,9 @@ ssize_t coap_opt_add_string(coap_pkt_t *pkt, uint16_t optnum, const char *string
 
         part_len = (uint8_t *)uripos - part_start;
 
-        if (part_len) {
+        /* Creates empty option if part for Uri-Path or Uri-Location contains
+         * only a trailing slash, except for root path ("/"). */
+        if (part_len || ((separator == '/') && write_len)) {
             if (pkt->options_len == NANOCOAP_NOPTS_MAX) {
                 return -ENOSPC;
             }

--- a/tests/unittests/tests-nanocoap/tests-nanocoap.c
+++ b/tests/unittests/tests-nanocoap/tests-nanocoap.c
@@ -152,6 +152,30 @@ static void test_nanocoap__get_multi_path(void)
 }
 
 /*
+ * Builds on get_req test, to test path with trailing slash.
+ */
+static void test_nanocoap__get_path_trailing_slash(void)
+{
+    uint8_t buf[128];
+    coap_pkt_t pkt;
+    uint16_t msgid = 0xABCD;
+    uint8_t token[2] = {0xDA, 0xEC};
+    char path[] = "/time/";
+    size_t uri_opt_len = 6;
+
+    size_t len = coap_build_hdr((coap_hdr_t *)&buf[0], COAP_TYPE_NON,
+                                &token[0], 2, COAP_METHOD_GET, msgid);
+
+    coap_pkt_init(&pkt, &buf[0], sizeof(buf), len);
+
+    len = coap_opt_add_string(&pkt, COAP_OPT_URI_PATH, &path[0], '/');
+    TEST_ASSERT_EQUAL_INT(uri_opt_len, len);
+
+    char uri[10] = {0};
+    coap_get_uri_path(&pkt, (uint8_t *)&uri[0]);
+    TEST_ASSERT_EQUAL_STRING((char *)path, (char *)uri);
+}
+/*
  * Builds on get_req test, to test '/' path. This path is the default when
  * otherwise not specified.
  */
@@ -233,6 +257,7 @@ Test *tests_nanocoap_tests(void)
         new_TestFixture(test_nanocoap__get_req),
         new_TestFixture(test_nanocoap__put_req),
         new_TestFixture(test_nanocoap__get_multi_path),
+        new_TestFixture(test_nanocoap__get_path_trailing_slash),
         new_TestFixture(test_nanocoap__get_root_path),
         new_TestFixture(test_nanocoap__get_max_path),
         new_TestFixture(test_nanocoap__get_path_too_long),


### PR DESCRIPTION
### Contribution description
For CoAP, there is actually a difference between `/some/path` and `/some/path/`. This needs to be reflected when parsing the URI and location path options from a given string.

This PR fixes `nanocoap` to allow appending the trailing `/`, which is for CoAP an empty option field.

I am unsure what to do when parsing query strings, as for that case IMHO an empty option does not really make sense. That is why I only skip the length check in case the separation character is a `/`...

Background: I encountered this problem with interfacing the the `aiocoap` resource directory, where it expects enpoints to update their entry on a resource that has to end with a `/`...

### Testing procedure
For example:
- run the `examples/gcoap` application on native
- make wireshark listen on the tap bridge, possibly filter for coap message
- make a simple GET request for some random resource, e.g.
```
coap get ff02::1 5683 /foo/bar
```
- look at the request in wireshark, it should have to uri-path option fields set
- make the request again, this time with a trailing `/`:
```
coap get ff02::1 5683 /foo/bar/
```
- now wireshark should show the request with a third, empty uri-path option field.

### Issues/PRs references
none