### PR TITLE
sam0_common: fix sercom_id return value for SERCOM5 (#9875)

### DIFF
--- a/cpu/sam0_common/include/periph_cpu_common.h
+++ b/cpu/sam0_common/include/periph_cpu_common.h
@@ -299,7 +299,8 @@ static inline int sercom_id(void *sercom)
 #if defined(CPU_FAM_SAMD21)
     return ((((uint32_t)sercom) >> 10) & 0x7) - 2;
 #elif defined(CPU_FAM_SAML21)
-    return ((((uint32_t)sercom) >> 10) & 0x7);
+    /* Left side handles SERCOM0-4 while right side handles unaligned address of SERCOM5 */
+    return ((((uint32_t)sercom) >> 10) & 0x7) + ((((uint32_t)sercom) >> 22) & 0x04);
 #endif
 }
 


### PR DESCRIPTION
### Contribution description

Fixes #9875 : sercom_id function did not return the correct value for sercom5 as the address of this is very different from other sercomX and the generic arithmetic function will not work.


### Testing procedure
A SAML21 board should be used and a device configured on sercom5.

### Issues/PRs references
Fixes #9875
