### PR TITLE
saml21: fix sercom_set_gen for sercom5

### DIFF
--- a/cpu/sam0_common/include/periph_cpu_common.h
+++ b/cpu/sam0_common/include/periph_cpu_common.h
@@ -352,8 +352,13 @@ static inline void sercom_set_gen(void *sercom, uint32_t gclk)
                          (SERCOM0_GCLK_ID_CORE + sercom_id(sercom)));
     while (GCLK->STATUS.reg & GCLK_STATUS_SYNCBUSY) {}
 #elif defined(CPU_FAM_SAML21)
-    GCLK->PCHCTRL[SERCOM0_GCLK_ID_CORE + sercom_id(sercom)].reg =
+    if (sercom_id(sercom) < 5) {
+        GCLK->PCHCTRL[SERCOM0_GCLK_ID_CORE + sercom_id(sercom)].reg =
                                                     (GCLK_PCHCTRL_CHEN | gclk);
+    } else {
+        GCLK->PCHCTRL[SERCOM5_GCLK_ID_CORE].reg =
+                                                    (GCLK_PCHCTRL_CHEN | gclk);
+    }
 #endif
 }
 


### PR DESCRIPTION



### Contribution description
While debugging #9874 on the SAML21 architecture I noticed that the SERCOM5 gen clock was not correctly activated. Analyzing the code I noticed that sercom_set_gen assumes that SERCOM5_GCLK_ID_CORE is in sequence with the other SERCOMx in this code:
```
static inline void sercom_set_gen(void *sercom, uint32_t gclk)
{
#if defined(CPU_FAM_SAMD21)
    GCLK->CLKCTRL.reg = (GCLK_CLKCTRL_CLKEN | gclk |
                         (SERCOM0_GCLK_ID_CORE + sercom_id(sercom)));
    while (GCLK->STATUS.reg & GCLK_STATUS_SYNCBUSY) {}
#elif defined(CPU_FAM_SAML21)
    GCLK->PCHCTRL[SERCOM0_GCLK_ID_CORE + sercom_id(sercom)].reg =
#endif
}
```

 but actually it is not:

```
saml21/include/instance/sercom0.h:#define SERCOM0_GCLK_ID_CORE        18      
saml21/include/instance/sercom1.h:#define SERCOM1_GCLK_ID_CORE        19      
saml21/include/instance/sercom2.h:#define SERCOM2_GCLK_ID_CORE        20      
saml21/include/instance/sercom3.h:#define SERCOM3_GCLK_ID_CORE        21      
saml21/include/instance/sercom4.h:#define SERCOM4_GCLK_ID_CORE        22      
saml21/include/instance/sercom5.h:#define SERCOM5_GCLK_ID_CORE        24   
```
And therefore the function touches the wrong clock and the device will not work.

### Testing procedure
Use a device on SERCOM5 and see that it will not work correctly, see for example #9874.

### Issues/PRs references
See also #9874.  
