### PR TITLE
cpu: efm32: add support for 32-bit timers

### DIFF
--- a/boards/slstk3402a/doc.txt
+++ b/boards/slstk3402a/doc.txt
@@ -55,19 +55,19 @@ This is the pinout of the expansion header on the right side of the board. PIN 1
 **Note:** some pins are connected to the board controller, when enabled!
 
 ### Peripheral mapping
-| Peripheral | Number  | Hardware        | Pins                            | Comments                                                  |
-|------------|---------|-----------------|---------------------------------|-----------------------------------------------------------|
-| ADC        | 0       | ADC0            | CHAN0: internal temperature     | Ports are fixed, 14/16-bit resolution not supported       |
-| I2C        | 0       | I2C0            | SDA: PC10, CLK: PC11            | `I2C_SPEED_LOW` and `I2C_SPEED_HIGH` clock speed deviate  |
-| HWCRYPTO   | &mdash; | &mdash;         |                                 | AES128/AES256, SHA1, SHA256                               |
-| HWRNG      | &mdash; | TNRG0           |                                 | Hardware-based true random number generator               |
-| RTT        | &mdash; | RTCC            |                                 | 1 Hz interval. Either RTT or RTC (see below)              |
-| RTC        | &mdash; | RTCC            |                                 | 1 Hz interval. Either RTC or RTT (see below)              |
-| SPI        | 0       | USART1          | MOSI: PC6, MISO: PC7, CLK: PC8  |                                                           |
-| Timer      | 0       | TIMER0 + TIMER1 |                                 | TIMER0 is used as prescaler (must be adjecent)            |
-| UART       | 0       | USART0          | RX: PA1, TX: PA0                | Default STDIO output                                      |
-|            | 1       | USART1          | RX: PC6, TX: PC7                |                                                           |
-|            | 2       | LEUART0         | RX: PD11, TX: PD10              | Baud rate limited (see below)                             |
+| Peripheral | Number  | Hardware          | Pins                            | Comments                                                  |
+|------------|---------|-------------------|---------------------------------|-----------------------------------------------------------|
+| ADC        | 0       | ADC0              | CHAN0: internal temperature     | Ports are fixed, 14/16-bit resolution not supported       |
+| I2C        | 0       | I2C0              | SDA: PC10, CLK: PC11            | `I2C_SPEED_LOW` and `I2C_SPEED_HIGH` clock speed deviate  |
+| HWCRYPTO   | &mdash; | &mdash;           |                                 | AES128/AES256, SHA1, SHA256                               |
+| HWRNG      | &mdash; | TNRG0             |                                 | Hardware-based true random number generator               |
+| RTT        | &mdash; | RTCC              |                                 | 1 Hz interval. Either RTT or RTC (see below)              |
+| RTC        | &mdash; | RTCC              |                                 | 1 Hz interval. Either RTC or RTT (see below)              |
+| SPI        | 0       | USART1            | MOSI: PC6, MISO: PC7, CLK: PC8  |                                                           |
+| Timer      | 0       | WTIMER0 + WTIMER1 |                                 | WTIMER0 is used as prescaler (must be adjecent)            |
+| UART       | 0       | USART0            | RX: PA1, TX: PA0                | Default STDIO output                                      |
+|            | 1       | USART1            | RX: PC6, TX: PC7                |                                                           |
+|            | 2       | LEUART0           | RX: PD11, TX: PD10              | Baud rate limited (see below)                             |
 
 ### User interface
 | Peripheral | Mapped to | Pin  | Comments   |

--- a/boards/slstk3402a/include/board.h
+++ b/boards/slstk3402a/include/board.h
@@ -31,12 +31,10 @@ extern "C" {
 
 /**
  * @name    Xtimer configuration
- *
- * The timer runs at 250 KHz to increase accuracy.
  * @{
  */
-#define XTIMER_HZ           (250000UL)
-#define XTIMER_WIDTH        (16)
+#define XTIMER_HZ           (1000000UL)
+#define XTIMER_WIDTH        (32)
 /** @} */
 
 /**

--- a/boards/slstk3402a/include/periph_conf.h
+++ b/boards/slstk3402a/include/periph_conf.h
@@ -150,19 +150,19 @@ static const spi_dev_t spi_config[] = {
 static const timer_conf_t timer_config[] = {
     {
         {
-            .dev = TIMER0,
-            .cmu = cmuClock_TIMER0
+            .dev = WTIMER0,
+            .cmu = cmuClock_WTIMER0
         },
         {
-            .dev = TIMER1,
-            .cmu = cmuClock_TIMER1
+            .dev = WTIMER1,
+            .cmu = cmuClock_WTIMER1
         },
-        .irq = TIMER1_IRQn
+        .irq = WTIMER1_IRQn
     }
 };
 
 #define TIMER_NUMOF         PERIPH_NUMOF(timer_config)
-#define TIMER_0_ISR         isr_timer1
+#define TIMER_0_ISR         isr_wtimer1
 /** @} */
 
 /**


### PR DESCRIPTION
### Contribution description

Newer EFM32 chips have dedicated 32-bit timers (they are register compatible). This PR allows one to make use of the 32-bit timers, which are already supported by the vendor library.

### Testing procedure
Take the SLSTK3402a board, and change the timer configuration as follows (originally, it was 250000 Hz and 16 bit):

```c
#define XTIMER_HZ           (1000000UL)
#define XTIMER_WIDTH        (32)
```

Then change the timer configuration to

```c
static const timer_conf_t timer_config[] = {
    {
        {
            .dev = WTIMER0,
            .cmu = cmuClock_WTIMER0
        },
        {
            .dev = WTIMER1,
            .cmu = cmuClock_WTIMER1
        },
        .irq = WTIMER1_IRQn
    }
};

#define TIMER_NUMOF         PERIPH_NUMOF(timer_config)
#define TIMER_0_ISR         isr_wtimer1
```

Observe that any timer test will still compile and work as intended.

### Issues/PRs references
None
