### PR TITLE
cpu: efm32: add support for no DC-DC converter

### DIFF
--- a/boards/slstk3401a/include/periph_conf.h
+++ b/boards/slstk3401a/include/periph_conf.h
@@ -55,6 +55,15 @@ extern "C" {
 /** @} */
 
 /**
+ * @name    DC-DC configuration
+ * @{
+ */
+#ifdef EMU_DCDCINIT_OFF
+#error "This option will soft-brick your board. Please remove it."
+#endif
+/** @} */
+
+/**
  * @name    ADC configuration
  * @{
  */

--- a/boards/sltb001a/include/periph_conf.h
+++ b/boards/sltb001a/include/periph_conf.h
@@ -55,6 +55,15 @@ extern "C" {
 /** @} */
 
 /**
+ * @name    DC-DC configuration
+ * @{
+ */
+#ifdef EMU_DCDCINIT_OFF
+#error "This option will soft-brick your board. Please remove it."
+#endif
+/** @} */
+
+/**
  * @name    ADC configuration
  * @{
  */

--- a/cpu/efm32/cpu.c
+++ b/cpu/efm32/cpu.c
@@ -56,9 +56,13 @@
  */
 static void dcdc_init(void)
 {
+#ifdef EMU_DCDCINIT_OFF
+    EMU_DCDCPowerOff();
+#else
     EMU_DCDCInit_TypeDef init_dcdc = EMU_DCDCINIT;
 
     EMU_DCDCInit(&init_dcdc);
+#endif
 }
 #endif
 


### PR DESCRIPTION
### Contribution description
EFM32 CPUs have an integrated DC-DC converter for optimizing power consumption for the IO part of the chip. This DC-DC converter must be disabled if it is not used (e.g. chip doesn't use battery power).

Current EFM32 board with DC-DC convert have this feature enabled, but for my own custom board, I need to be able to disable it.

### Testing procedure
Take any EFM32 board with a MCU that support DC-DC converter (e.g. the SLTB001a) and change the DC-DC configuration in `periph_conf.h` to:

```c
/**
 * @name    DC-DC configuration
 * @{
 */
#define EMU_DCDCINIT_OFF
/** @} */
```

It should still compile, and the board should still work (but uses more power).

### Issues/PRs references
None