### PR TITLE
boards/sensebox_samd21: Use PA_BOOST option on SX127X radios

### DIFF
--- a/boards/sensebox_samd21/include/board.h
+++ b/boards/sensebox_samd21/include/board.h
@@ -131,7 +131,7 @@ extern "C" {
 
 #define SX127X_PARAM_DIOMULTI               XBEE1_INT_PIN       /* D24 */
 
-#define SX127X_PARAM_PASELECT               (SX127X_PA_RFO)
+#define SX127X_PARAM_PASELECT               (SX127X_PA_BOOST)
 
 #define SX127X_PARAMS                     { .spi       = SX127X_PARAM_SPI,     \
                                             .nss_pin   = SX127X_PARAM_SPI_NSS, \


### PR DESCRIPTION
### Contribution description
This modifies the board configuration of the SX127X driver. Due to hardware limitations the PA_BOOST option should be used to get a decent SNR on the packages and reduce the considerably high amount of package loses.