### PR TITLE
pkg/lwip: fix `lwip_ethernet` dependency

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -466,6 +466,9 @@ ifneq (,$(filter lwip,$(USEMODULE)))
   ifeq (,$(filter lwip_tcp lwip_udp lwip_udplite,$(USEMODULE)))
     USEMODULE += lwip_raw
   endif
+  ifneq (,$(filter netdev_eth,$(USEMODULE)))
+    USEMODULE += lwip_ethernet
+  endif
 endif
 
 ifneq (,$(filter lwip_ppp,$(USEMODULE)))

--- a/tests/lwip/Makefile
+++ b/tests/lwip/Makefile
@@ -21,10 +21,6 @@ USEMODULE += ps
 USEMODULE += od
 USEMODULE += netdev_default
 
-ifeq ($(BOARD),native)
-  USEMODULE += lwip_ethernet
-endif
-
 include $(RIOTBASE)/Makefile.include
 
 # Test only implemented for native

--- a/tests/lwip_sock_ip/Makefile
+++ b/tests/lwip_sock_ip/Makefile
@@ -27,7 +27,7 @@ ifneq (0, $(LWIP_IPV6))
 endif
 
 USEMODULE += inet_csum
-USEMODULE += lwip_ethernet lwip_netdev
+USEMODULE += lwip_netdev
 USEMODULE += lwip_sock_ip
 USEMODULE += netdev_eth
 USEMODULE += netdev_test

--- a/tests/lwip_sock_tcp/Makefile
+++ b/tests/lwip_sock_tcp/Makefile
@@ -27,7 +27,7 @@ ifneq (0, $(LWIP_IPV6))
 endif
 
 USEMODULE += inet_csum
-USEMODULE += lwip_ethernet lwip_netdev
+USEMODULE += lwip_netdev
 USEMODULE += lwip_sock_tcp
 USEMODULE += netdev_eth
 USEMODULE += netdev_test

--- a/tests/lwip_sock_udp/Makefile
+++ b/tests/lwip_sock_udp/Makefile
@@ -27,7 +27,7 @@ ifneq (0, $(LWIP_IPV6))
 endif
 
 USEMODULE += inet_csum
-USEMODULE += lwip_ethernet lwip_netdev
+USEMODULE += lwip_netdev
 USEMODULE += lwip_sock_udp
 USEMODULE += netdev_eth
 USEMODULE += netdev_test


### PR DESCRIPTION
### Contribution description
With out this fix the application or device drivers need to add this module. Otherwise, compilation of the lwIP adaptation layer will fail for Ethernet devices.

This also makes the `tests/lwip` application more flexible for usage of non-`native` boards with Ethernet devices as the implicit of the `lwip_ethernet` module there can now be removed.

### Testing procedure
Take any non-`native` board (e.g. `arduino-due`) and try to compile `tests/lwip` with an Ethernet driver included (e.g. `enc28j60`). Without this PR the compilation will fail:

```
pkg/lwip/contrib/netdev/lwip_netdev.c: In function 'lwip_netdev_init':
pkg/lwip/contrib/netdev/lwip_netdev.c:122:33: error: 'ethip6_output' undeclared (first use in this function); did you mean '_eth_link_output'?
             netif->output_ip6 = ethip6_output;
                                 ^~~~~~~~~~~~~
                                 _eth_link_output
```

### Issues/PRs references
Found by @gschorcht when porting an ESP32 with on-board Ethernet (in #9426). He pointed this out to me offline.