### PR TITLE
sam0/spi: fix SPI mode assignment

### DIFF
--- a/cpu/sam0_common/periph/spi.c
+++ b/cpu/sam0_common/periph/spi.c
@@ -137,7 +137,7 @@ int spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t clk)
     dev(bus)->CTRLA.reg = (SERCOM_SPI_CTRLA_MODE(0x3) |     /* 0x3 -> master */
                            SERCOM_SPI_CTRLA_DOPO(spi_config[bus].mosi_pad) |
                            SERCOM_SPI_CTRLA_DIPO(spi_config[bus].miso_pad) |
-                           (mode <<  SERCOM_SPI_CTRLA_CPOL_Pos));
+                           (mode <<  SERCOM_SPI_CTRLA_CPHA_Pos));
     /* also no synchronization needed here, as CTRLA is write-synchronized */
 
     /* finally enable the device */


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR provides a fix for #9695 
The SPI mode selection is done using two bits in the SERCOM CTRLA register, bit 28 and bit 29.
The mode variable can be 0, 1, 2 or 3 but this variable was shifted to bit 29 instead of bit 28 (CPOL instead of CPHA) so the SPI mode was not set correctly.

More info in #9695 

Thanks @leandrolanzieri for spotting this issue.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
