### PR TITLE
ethos: Only accept frame if previous frame is read

### DIFF
--- a/drivers/ethos/ethos.c
+++ b/drivers/ethos/ethos.c
@@ -58,6 +58,7 @@ void ethos_setup(ethos_t *dev, const ethos_params_t *params)
     dev->framesize = 0;
     dev->frametype = 0;
     dev->last_framesize = 0;
+    dev->accept_new = true;
 
     tsrb_init(&dev->inbuf, (char*)params->buf, params->bufsize);
     mutex_init(&dev->out_mutex);
@@ -82,6 +83,7 @@ static void _reset_state(ethos_t *dev)
     dev->state = WAIT_FRAMESTART;
     dev->frametype = 0;
     dev->framesize = 0;
+    dev->accept_new = true;
 }
 
 static void _handle_char(ethos_t *dev, char c)
@@ -90,9 +92,12 @@ static void _handle_char(ethos_t *dev, char c)
         case ETHOS_FRAME_TYPE_DATA:
         case ETHOS_FRAME_TYPE_HELLO:
         case ETHOS_FRAME_TYPE_HELLO_REPLY:
-             if (tsrb_add_one(&dev->inbuf, c) == 0) {
-                dev->framesize++;
-            } else {
+            if (dev->accept_new) {
+                if (tsrb_add_one(&dev->inbuf, c) == 0) {
+                    dev->framesize++;
+                }
+            }
+            else {
                 //puts("lost frame");
                 dev->inbuf.reads = 0;
                 dev->inbuf.writes = 0;
@@ -112,6 +117,7 @@ static void _end_of_frame(ethos_t *dev)
     switch(dev->frametype) {
         case ETHOS_FRAME_TYPE_DATA:
             if (dev->framesize) {
+                assert(dev->last_framesize == 0);
                 dev->last_framesize = dev->framesize;
                 dev->netdev.event_callback((netdev_t*) dev, NETDEV_EVENT_ISR);
             }
@@ -137,6 +143,9 @@ static void ethos_isr(void *arg, uint8_t c)
         case WAIT_FRAMESTART:
             if (c == ETHOS_FRAME_DELIMITER) {
                 _reset_state(dev);
+                if (dev->last_framesize) {
+                    dev->accept_new = false;
+                }
                 dev->state = IN_FRAME;
             }
             break;
@@ -304,13 +313,14 @@ static int _recv(netdev_t *netdev, void *buf, size_t len, void* info)
         }
 
         len = dev->last_framesize;
-        dev->last_framesize = 0;
 
         if ((tsrb_get(&dev->inbuf, buf, len) != (int)len)) {
             DEBUG("ethos _recv(): inbuf doesn't contain enough bytes.\n");
+            dev->last_framesize = 0;
             return -1;
         }
 
+        dev->last_framesize = 0;
         return (int)len;
     }
     else {

--- a/drivers/include/ethos.h
+++ b/drivers/include/ethos.h
@@ -21,6 +21,8 @@
 #ifndef ETHOS_H
 #define ETHOS_H
 
+#include <stdbool.h>
+
 #include "kernel_types.h"
 #include "periph/uart.h"
 #include "net/netdev.h"
@@ -78,6 +80,7 @@ typedef struct {
     unsigned frametype;     /**< type of currently incoming frame */
     size_t last_framesize;  /**< size of last completed frame */
     mutex_t out_mutex;      /**< mutex used for locking concurrent sends */
+    bool accept_new;        /**< incoming frame can be stored or not */
 } ethos_t;
 
 /**


### PR DESCRIPTION
### Contribution description

This PR changes ethos to only accept a new frame if the previous frame is read. It only changes whether the bytes are actually stored to prevent disrupting the ethos state machine.

I've also included the assert from #9889 to prevent a similar breakage in the future.

### Testing procedure

same as #9889 (flood a gnrc_border_router with ping), but now it should keep working. 


### Issues/PRs references

Fixes #9889 