### PR TITLE
Makefile.dep: process cpu dependencies and fix stm32_common

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -782,6 +782,14 @@ ifneq (,$(filter tlsf-malloc,$(USEMODULE)))
   USEPKG += tlsf
 endif
 
+# HACK for test Remove me
+# Module that adds FEATURES_REQUIRED after 'cpu/stm32_common/Makefile.include'
+PSEUDOMODULES += trigger_periph_flashpage_include
+ifneq (,$(filter trigger_periph_flashpage_include,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_flashpage
+endif
+# HACK for test Remove me
+
 ifneq (,$(filter uuid,$(USEMODULE)))
   USEMODULE += hashes
   USEMODULE += random

--- a/Makefile.dep
+++ b/Makefile.dep
@@ -4,6 +4,8 @@ OLD_USEPKG := $(sort $(USEPKG))
 
 # include board dependencies
 -include $(RIOTBOARD)/$(BOARD)/Makefile.dep
+# include cpu dependencies
+-include $(RIOTCPU)/$(CPU)/Makefile.dep
 
 # pull dependencies from sys and drivers
 include $(RIOTBASE)/sys/Makefile.dep

--- a/cpu/stm32_common/Makefile.dep
+++ b/cpu/stm32_common/Makefile.dep
@@ -5,3 +5,9 @@ ifneq (,$(filter periph_i2c,$(USEMODULE)))
     USEMODULE += periph_i2c_2
   endif
 endif
+
+# flashpage and eeprom periph implementations share flash lock/unlock functions
+# in periph_flash_common
+ifneq (,$(filter periph_flashpage periph_eeprom,$(FEATURES_REQUIRED)))
+  FEATURES_REQUIRED += periph_flash_common
+endif

--- a/cpu/stm32_common/Makefile.include
+++ b/cpu/stm32_common/Makefile.include
@@ -8,12 +8,6 @@ USEMODULE += periph_common
 # include stm32 common functions and stm32 common periph drivers
 USEMODULE += stm32_common stm32_common_periph
 
-# flashpage and eeprom periph implementations share flash lock/unlock functions
-# in periph_flash_common
-ifneq (,$(filter periph_flashpage periph_eeprom,$(FEATURES_REQUIRED)))
-  FEATURES_REQUIRED += periph_flash_common
-endif
-
 # For stm32 cpu's we use the stm32_common.ld linker script
 export LINKFLAGS += -L$(RIOTCPU)/stm32_common/ldscripts
 LINKER_SCRIPT ?= stm32_common.ld

--- a/cpu/stm32_common/periph/Makefile
+++ b/cpu/stm32_common/periph/Makefile
@@ -1,5 +1,3 @@
 MODULE = stm32_common_periph
 
-include $(RIOTCPU)/stm32_common/Makefile.dep
-
 include $(RIOTMAKE)/periph.mk

--- a/cpu/stm32f0/Makefile.dep
+++ b/cpu/stm32f0/Makefile.dep
@@ -1,0 +1,1 @@
+include $(RIOTCPU)/stm32_common/Makefile.dep

--- a/cpu/stm32f1/Makefile.dep
+++ b/cpu/stm32f1/Makefile.dep
@@ -1,0 +1,1 @@
+include $(RIOTCPU)/stm32_common/Makefile.dep

--- a/cpu/stm32f2/Makefile.dep
+++ b/cpu/stm32f2/Makefile.dep
@@ -1,0 +1,1 @@
+include $(RIOTCPU)/stm32_common/Makefile.dep

--- a/cpu/stm32f3/Makefile.dep
+++ b/cpu/stm32f3/Makefile.dep
@@ -1,0 +1,1 @@
+include $(RIOTCPU)/stm32_common/Makefile.dep

--- a/cpu/stm32f4/Makefile.dep
+++ b/cpu/stm32f4/Makefile.dep
@@ -1,0 +1,1 @@
+include $(RIOTCPU)/stm32_common/Makefile.dep

--- a/cpu/stm32f7/Makefile.dep
+++ b/cpu/stm32f7/Makefile.dep
@@ -1,0 +1,1 @@
+include $(RIOTCPU)/stm32_common/Makefile.dep

--- a/cpu/stm32l0/Makefile.dep
+++ b/cpu/stm32l0/Makefile.dep
@@ -1,0 +1,1 @@
+include $(RIOTCPU)/stm32_common/Makefile.dep

--- a/cpu/stm32l1/Makefile.dep
+++ b/cpu/stm32l1/Makefile.dep
@@ -1,0 +1,1 @@
+include $(RIOTCPU)/stm32_common/Makefile.dep

--- a/cpu/stm32l4/Makefile.dep
+++ b/cpu/stm32l4/Makefile.dep
@@ -1,0 +1,1 @@
+include $(RIOTCPU)/stm32_common/Makefile.dep

--- a/tests/periph_flash_test_stm32_common/Makefile
+++ b/tests/periph_flash_test_stm32_common/Makefile
@@ -1,0 +1,7 @@
+BOARD ?= iotlab-m3
+include ../Makefile.tests_common
+
+USEMODULE += trigger_periph_flashpage_include
+USEMODULE += shell
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/periph_flash_test_stm32_common/main.c
+++ b/tests/periph_flash_test_stm32_common/main.c
@@ -1,0 +1,319 @@
+/*
+ * Copyright (C) 2015 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Manual test application for flashpage peripheral drivers
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ *
+ * @}
+ */
+
+#include <inttypes.h>
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "shell.h"
+#include "periph/flashpage.h"
+
+#define LINE_LEN            (16)
+
+/* When writing raw bytes on flash, data must be correctly aligned. */
+#ifdef MODULE_PERIPH_FLASHPAGE_RAW
+#define ALIGNMENT_ATTR __attribute__ ((aligned (FLASHPAGE_RAW_ALIGNMENT)))
+
+/*
+ * @brief   Allocate an aligned buffer for raw writings
+ */
+static char raw_buf[64] ALIGNMENT_ATTR;
+#else
+#define ALIGNMENT_ATTR
+#endif
+
+/**
+ * @brief   Allocate space for 1 flash page in RAM
+ *
+ * @note    The flash page in RAM must be correctly aligned, even in RAM, when
+ *          using flashpage_raw. This is because some architecture uses
+ *          32 bit alignment implicitly and there are cases (stm32l4) that
+ *          requires 64 bit alignment.
+ */
+static uint8_t page_mem[FLASHPAGE_SIZE] ALIGNMENT_ATTR;
+
+static int getpage(const char *str)
+{
+    int page = atoi(str);
+    if ((page >= (int)FLASHPAGE_NUMOF) || (page < 0)) {
+        printf("error: page %i is invalid\n", page);
+        return -1;
+    }
+    return page;
+}
+
+static void dumpchar(uint8_t mem)
+{
+    if (mem >= ' ' && mem <= '~') {
+        printf("  %c  ", mem);
+    }
+    else {
+        printf("  ?? ");
+    }
+}
+
+static void memdump(void *addr, size_t len)
+{
+    unsigned pos = 0;
+    uint8_t *mem = (uint8_t *)addr;
+
+    while (pos < (unsigned)len) {
+        for (unsigned i = 0; i < LINE_LEN; i++) {
+            printf("0x%02x ", mem[pos + i]);
+        }
+        puts("");
+        for (unsigned i = 0; i < LINE_LEN; i++) {
+            dumpchar(mem[pos++]);
+        }
+        puts("");
+    }
+}
+
+static void dump_local(void)
+{
+    puts("Local page buffer:");
+    memdump(page_mem, FLASHPAGE_SIZE);
+}
+
+static int cmd_info(int argc, char **argv)
+{
+    (void)argc;
+    (void)argv;
+
+    printf("Flash start addr:\t0x%08x\n", (int)CPU_FLASH_BASE);
+    printf("Page size:\t\t%i\n", (int)FLASHPAGE_SIZE);
+    printf("Number of pages:\t%i\n", (int)FLASHPAGE_NUMOF);
+
+    return 0;
+}
+
+static int cmd_dump(int argc, char **argv)
+{
+    int page;
+    void *addr;
+
+    if (argc < 2) {
+        printf("usage: %s <page>\n", argv[0]);
+        return 1;
+    }
+
+    page = getpage(argv[1]);
+    if (page < 0) {
+        return 1;
+    }
+    addr = flashpage_addr(page);
+
+    printf("Flash page %i at address %p\n", page, addr);
+    memdump(addr, FLASHPAGE_SIZE);
+
+    return 0;
+}
+
+static int cmd_dump_local(int argc, char **argv)
+{
+    (void)argc;
+    (void)argv;
+
+    dump_local();
+
+    return 0;
+}
+
+static int cmd_read(int argc, char **argv)
+{
+    int page;
+
+    if (argc < 2) {
+        printf("usage: %s <page>\n", argv[0]);
+        return 1;
+    }
+
+    page = getpage(argv[1]);
+    if (page < 0) {
+        return 1;
+    }
+
+    flashpage_read(page, page_mem);
+    printf("Read flash page %i into local page buffer\n", page);
+    dump_local();
+
+    return 0;
+}
+
+static int cmd_write(int argc, char **argv)
+{
+    int page;
+
+    if (argc < 2) {
+        printf("usage: %s <page>\n", argv[0]);
+        return 1;
+    }
+
+    page = getpage(argv[1]);
+    if (page < 0) {
+        return 1;
+    }
+
+    if (flashpage_write_and_verify(page, page_mem) != FLASHPAGE_OK) {
+        printf("error: verification for page %i failed\n", page);
+        return 1;
+    }
+
+    printf("wrote local page buffer to flash page %i at addr %p\n",
+           page, flashpage_addr(page));
+    return 0;
+}
+
+#ifdef MODULE_PERIPH_FLASHPAGE_RAW
+static uint32_t getaddr(const char *str)
+{
+    uint32_t addr = strtol(str, NULL, 16);
+
+    return addr;
+}
+
+static int cmd_write_raw(int argc, char **argv)
+{
+    uint32_t addr;
+
+    if (argc < 3) {
+        printf("usage: %s <addr> <data>\n", argv[0]);
+        return 1;
+    }
+
+    addr = getaddr(argv[1]);
+
+    /* try to align */
+    memcpy(raw_buf, argv[2], strlen(argv[2]));
+
+    flashpage_write_raw((void*)addr, raw_buf, strlen(raw_buf));
+
+    printf("wrote local data to flash address %#" PRIx32 " of len %u\n",
+           addr, strlen(raw_buf));
+    return 0;
+}
+#endif
+
+static int cmd_erase(int argc, char **argv)
+{
+    int page;
+
+    if (argc < 2) {
+        printf("usage: %s <page>\n", argv[0]);
+        return 1;
+    }
+
+    page = getpage(argv[1]);
+    if (page < 0) {
+        return 1;
+    }
+    flashpage_write(page, NULL);
+
+    printf("successfully erased page %i (addr %p)\n",
+           page, flashpage_addr(page));
+    return 0;
+}
+
+static int cmd_edit(int argc, char **argv)
+{
+    int offset;
+    size_t data_len;
+
+    if (argc < 3) {
+        printf("usage: %s <offset> <data>\n", argv[0]);
+        return 1;
+    }
+
+    offset = atoi(argv[1]);
+    if (offset >= (int)FLASHPAGE_SIZE) {
+        printf("error: given offset is out of bounce\n");
+        return -1;
+    }
+    data_len = strlen(argv[2]);
+    if ((data_len + offset) > FLASHPAGE_SIZE) {
+        data_len = FLASHPAGE_SIZE - offset;
+    }
+
+    memcpy(&page_mem[offset], argv[2], data_len);
+    dump_local();
+
+    return 0;
+}
+
+static int cmd_test(int argc, char **argv)
+{
+    int page;
+    char fill = 'a';
+
+    if (argc < 2) {
+        printf("usage: %s <page>\n", argv[0]);
+        return 1;
+    }
+
+    page = getpage(argv[1]);
+    if (page < 0) {
+        return 1;
+    }
+
+    for (unsigned i = 0; i < sizeof(page_mem); i++) {
+        page_mem[i] = (uint8_t)fill++;
+        if (fill > 'z') {
+            fill = 'a';
+        }
+    }
+
+    if (flashpage_write_and_verify(page, page_mem) != FLASHPAGE_OK) {
+        printf("error verifying the content of page %i\n", page);
+        return 1;
+    }
+
+    printf("wrote local page buffer to flash page %i at addr %p\n",
+           page, flashpage_addr(page));
+    return 0;
+}
+
+static const shell_command_t shell_commands[] = {
+    { "info", "Show information about pages", cmd_info },
+    { "dump", "Dump the selected page to STDOUT", cmd_dump },
+    { "dump_local", "Dump the local page buffer to STDOUT", cmd_dump_local },
+    { "read", "Copy the given page to the local page buffer and dump to STDOUT", cmd_read },
+    { "write", "Write the local page buffer to the given page", cmd_write },
+#ifdef MODULE_PERIPH_FLASHPAGE_RAW
+    { "write_raw", "Write (ASCII, max 64B) data to the given address", cmd_write_raw },
+#endif
+    { "erase", "Erase the given page buffer", cmd_erase },
+    { "edit", "Write bytes to the local page buffer", cmd_edit },
+    { "test", "Write and verify test pattern", cmd_test },
+    { NULL, NULL, NULL }
+};
+
+int main(void)
+{
+    puts("ROM flash read write test\n");
+    puts("Please refer to the README.md for further information\n");
+
+    cmd_info(0, NULL);
+
+    /* run the shell */
+    char line_buf[SHELL_DEFAULT_BUFSIZE];
+    shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
+    return 0;
+}


### PR DESCRIPTION
### Contribution description

This adds processing cpu dependencies and fixes for periph_flashpage with `stm32_common`.
The Makefile.dep include from `periph/Makefile.dep` has also been removed.

I can split them in different PRs if wanted.

I added a test commit that should be removed to show the problem.

### Testing procedure

Compiling the given test is fixed by the PR, it can be tested with the first commit alone:

```
make -C tests/periph_flash_test_stm32_common/ BOARD=iotlab-m3  RIOT_CI_BUILD=1

make: Entering directory '/home/cladmi/git/work/RIOT/tests/periph_flash_test_stm32_common'
Building application "tests_periph_flash_test_stm32_common" for "iotlab-m3" with MCU "stm32f1".

/usr/lib/gcc/arm-none-eabi/8.2.0/../../../../arm-none-eabi/bin/ld: /home/cladmi/git/work/RIOT/tests/periph_flash_test_stm32_common/bin/iotlab-m3/stm32_common_periph.a(flashpage.o): in function `_unlock_flash':
/home/cladmi/git/work/RIOT/cpu/stm32_common/periph/flashpage.c:58: undefined reference to `_unlock'
/usr/lib/gcc/arm-none-eabi/8.2.0/../../../../arm-none-eabi/bin/ld: /home/cladmi/git/work/RIOT/tests/periph_flash_test_stm32_common/bin/iotlab-m3/stm32_common_periph.a(flashpage.o): in function `flashpage_write_raw':
/home/cladmi/git/work/RIOT/cpu/stm32_common/periph/flashpage.c:202: undefined reference to `_lock'
/usr/lib/gcc/arm-none-eabi/8.2.0/../../../../arm-none-eabi/bin/ld: /home/cladmi/git/work/RIOT/tests/periph_flash_test_stm32_common/bin/iotlab-m3/stm32_common_periph.a(flashpage.o): in function `_unlock_flash':
/home/cladmi/git/work/RIOT/cpu/stm32_common/periph/flashpage.c:58: undefined reference to `_unlock'
/usr/lib/gcc/arm-none-eabi/8.2.0/../../../../arm-none-eabi/bin/ld: /home/cladmi/git/work/RIOT/tests/periph_flash_test_stm32_common/bin/iotlab-m3/stm32_common_periph.a(flashpage.o): in function `_erase_page':
/home/cladmi/git/work/RIOT/cpu/stm32_common/periph/flashpage.c:142: undefined reference to `_lock'
collect2: error: ld returned 1 exit status
make: *** [/home/cladmi/git/work/RIOT/tests/periph_flash_test_stm32_common/../../Makefile.include:431: /home/cladmi/git/work/RIOT/tests/periph_flash_test_stm32_common/bin/iotlab-m3/tests_periph_flash_test_stm32_common.elf] Error 1
make: Leaving directory '/home/cladmi/git/work/RIOT/tests/periph_flash_test_stm32_common'
```


Also, the `stm32_common/periph/i2c_X` handling is still working:

This works both in master and with this PR
```
make -C tests/periph_i2c/ BOARD=iotlab-m3
make -C tests/periph_i2c/ BOARD=nucleo-f070rb

ar t tests/periph_i2c/bin/nucleo-f070rb/stm32_common_periph.a  | grep 'i2c_..o'
i2c_1.o
ar t tests/periph_i2c/bin/iotlab-m3/stm32_common_periph.a  | grep 'i2c_2.o'
i2c_2.o
```

### Issues/PRs references

Found in https://github.com/RIOT-OS/RIOT/issues/9342 main PR
Part of the main issue "dependencies declared in cpu/board Makefile.include" https://github.com/RIOT-OS/RIOT/issues/8713