### PR TITLE
sys/hashes/sha256: replace include by stddef.h

### DIFF
--- a/sys/include/hashes/sha256.h
+++ b/sys/include/hashes/sha256.h
@@ -49,7 +49,7 @@
 #define HASHES_SHA256_H
 
 #include <inttypes.h>
-#include <unistd.h>
+#include <stddef.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
### Contribution description

stddef.h is enough for size_t, unistd.h adds a lot of other declarations as described in https://github.com/RIOT-OS/RIOT/pull/9891#issuecomment-419038441


### Testing procedure

Compile an application that only includes `"hashes/sha256.h"`

```
make
Building application "sha256" for "wsn430-v1_3b" with MCU "msp430fxyz".

In file included from /home/cladmi/git/work/RIOT_test/examples/sha256/main.c:1:0:
/home/cladmi/git/work/RIOT_test/sys/include/hashes/sha256.h:89:5: error: unknown type name 'size_t'
/home/cladmi/git/work/RIOT_test/sys/include/hashes/sha256.h:108:61: error: unknown type name 'size_t'
```

### Issues/PRs references

Comment https://github.com/RIOT-OS/RIOT/pull/9891#issuecomment-419038441