### PR TITLE
jlink.sh: remove duplicated check

### DIFF
--- a/dist/tools/jlink/jlink.sh
+++ b/dist/tools/jlink/jlink.sh
@@ -66,12 +66,6 @@ _JLINK_TERMFLAGS="-ts 19021"
 # a couple of tests for certain configuration options
 #
 test_config() {
-    if [ -z "${HEXFILE}" ]; then
-        echo "no hexfile"
-    else
-        echo "HEXFILE found"
-    fi
-
     if [ -z "${JLINK}" ]; then
         JLINK=${_JLINK}
     fi


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->
Currently, jlink.sh makes double check for the existance of an `HEXFILE`, one of this checks  is not necessary, as it already exists a function for checking it.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->
Flash a board using the jlink debugger/programmer.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
