### PR TITLE
Include pqm4 package

### DIFF
--- a/examples/pqm4/keygen/Makefile
+++ b/examples/pqm4/keygen/Makefile
@@ -1,0 +1,64 @@
+# name of your application
+APPLICATION = pqm4-keygen
+
+
+# If no BOARD is found in the environment, use this default:
+BOARD ?= native
+
+# This has to be the absolute path to the RIOT base directory:
+RIOTBASE ?= $(CURDIR)/../../..
+
+# Uncomment these lines if you want to use platform support from external
+# repositories:
+#RIOTCPU ?= $(CURDIR)/../../RIOT/thirdparty_cpu
+#RIOTBOARD ?= $(CURDIR)/../../RIOT/thirdparty_boards
+
+# Uncomment this to enable scheduler statistics for ps:
+#USEMODULE += schedstatistics
+
+# If you want to use native with valgrind, you should recompile native
+# with the target all-valgrind instead of all:
+# make -B clean all-valgrind
+
+# Comment this out to disable code in RIOT that does safety checking
+# which is not needed in a production environment but helps in the
+# development process:
+DEVELHELP ?= 0
+
+# Change this to 0 show compiler invocation lines by default:
+QUIET ?= 1
+
+# Modules to include:
+USEMODULE += random
+USEMODULE += xtimer
+
+USEPKG += pqm4
+
+CFLAGS += -DTHREAD_STACKSIZE_MAIN=\(4*THREAD_STACKSIZE_DEFAULT+THREAD_EXTRA_STACKSIZE_PRINTF\) # Same as for tweetnacl
+#CFLAGS += '-DTHREAD_STACKSIZE_MAIN=(THREAD_STACKSIZE_DEFAULT + 32768)'
+#CFLAGS += '-DTHREAD_STACKSIZE_MAIN=(THREAD_STACKSIZE_DEFAULT * 2000)'
+
+CFLAGS += -DNATIVE_AUTO_EXIT
+
+
+# Choose a key encapsulation scheme
+#
+#PQ_KEM=frodo640-cshake/opt # Segfault
+#PQ_KEM=frodo640-cshake/opt # Segfault
+#PQ_KEM=kindi256342
+#PQ_KEM=sntrup4591761
+#PQ_KEM=kyber768
+#PQ_KEM=newhope1024cca
+#PQ_KEM=ntruhrss701
+#PQ_KEM=saber
+#PQ_KEM=sikep751
+
+
+# Choose a signature scheme
+#PQ_SIGN=dilithium
+#PQ_SIGN=qTesla-I
+#PQ_SIGN=qTesla-III-speed
+#PQ_SIGN=qTesla-III-size
+#PQ_SIGN=sphincs-shake256-128s
+
+include $(RIOTBASE)/Makefile.include

--- a/examples/pqm4/keygen/keygen.sh
+++ b/examples/pqm4/keygen/keygen.sh
@@ -1,0 +1,8 @@
+#!/bin/bash
+
+PQ_KEMS="kindi256342 sntrup4591761 kyber768 newhope1024cca ntruhrss701 saber sikep751"
+
+for k in $PQ_KEMS; do
+  make PQ_IMPL=ref PQ_KEM="$k" all;
+  ./bin/native/pqm4-keygen.elf | tail -n +8 > "./pq_${k}_key.h";
+done

--- a/examples/pqm4/keygen/main.c
+++ b/examples/pqm4/keygen/main.c
@@ -1,0 +1,75 @@
+#include <stdio.h>
+#include <string.h>
+
+#include "pq_api.h"
+#include "api.h"
+#include "randombytes.h"
+#include <string.h>
+#include "stdio.h"
+
+
+#define NTESTS 1
+#define MLEN 32
+
+void cdump(const void* data, const char* name, size_t size) {
+  size_t i;
+  printf("static const unsigned char %s[%zu] = {\n\t", name, size);
+  for (i = 0; i < size; ++i) {
+    printf("0x%02X, ", ((unsigned char*)data)[i]);
+    if ((i+1) % 8 == 0) {
+      printf("\n\t");
+      if (i+1 == size) {
+        printf("\n");
+      }
+    }
+  }
+  printf("\n};\n\n");
+}
+
+#ifdef PQ_KEM
+static int keygen_kem(void)
+{
+  unsigned char pk[CRYPTO_PUBLICKEYBYTES];
+  unsigned char sk[CRYPTO_SECRETKEYBYTES];
+  crypto_kem_keypair(pk, sk);
+
+  printf("/* Post-quantum Key Encapsulation */\n\n");
+  printf("/* Public key */\n" );
+  cdump(pk, "public_key", CRYPTO_PUBLICKEYBYTES);
+  printf("\n\n/* Secret key */\n");
+  cdump(sk, "secret_key", CRYPTO_SECRETKEYBYTES);
+
+  return 0;
+}
+#endif
+
+
+#ifdef PQ_SIGN
+int keygen_sign(void)
+{
+  unsigned char pk[CRYPTO_PUBLICKEYBYTES];
+  unsigned char sk[CRYPTO_SECRETKEYBYTES];
+  crypto_sign_keypair(pk, sk);
+  printf("/* Post-quantum Signature Scheme*/\n\n");
+  printf("/* Public key */\n");
+  cdump(pk, "public_key", CRYPTO_PUBLICKEYBYTES);
+  printf("\n\n/* Secret key */\n");
+  cdump(sk, "secret_key", CRYPTO_SECRETKEYBYTES);
+  return 0;
+}
+#endif
+
+
+int main(void)
+{
+
+#ifdef PQ_KEM
+  keygen_kem();
+#endif
+
+#ifdef PQ_SIGN
+  keygen_sign();
+#endif
+
+  return 0;
+}

--- a/examples/pqm4/speed/Makefile
+++ b/examples/pqm4/speed/Makefile
@@ -1,0 +1,55 @@
+# name of your application
+APPLICATION = pqm4-speed
+
+
+# If no BOARD is found in the environment, use this default:
+BOARD ?= native
+
+# This has to be the absolute path to the RIOT base directory:
+RIOTBASE ?= $(CURDIR)/../../..
+
+# Uncomment these lines if you want to use platform support from external
+# repositories:
+#RIOTCPU ?= $(CURDIR)/../../RIOT/thirdparty_cpu
+#RIOTBOARD ?= $(CURDIR)/../../RIOT/thirdparty_boards
+
+# Uncomment this to enable scheduler statistics for ps:
+#USEMODULE += schedstatistics
+
+# If you want to use native with valgrind, you should recompile native
+# with the target all-valgrind instead of all:
+# make -B clean all-valgrind
+
+# Comment this out to disable code in RIOT that does safety checking
+# which is not needed in a production environment but helps in the
+# development process:
+DEVELHELP ?= 1
+
+# Change this to 0 show compiler invocation lines by default:
+QUIET ?= 0
+
+# Modules to include:
+USEMODULE += random
+USEMODULE += xtimer
+
+USEPKG += pqm4
+
+CFLAGS += '-DTHREAD_STACKSIZE_MAIN=(20 * THREAD_STACKSIZE_DEFAULT)'
+
+
+# Choose a key encapsulation scheme
+#PQ_KEM=frodo640-cshake
+#PQ_KEM=newhope1024cca
+#PQ_KEM=ntruhrss701
+#PQ_KEM=saber
+#PQ_KEM=kyber768
+#PQ_KEM=sikep751
+
+# Choose a signature scheme
+#PQ_SIGN=dilithium
+#PQ_SIGN=qTesla-I
+#PQ_SIGN=qTesla-III-speed
+#PQ_SIGN=qTesla-III-size
+#PQ_SIGN=sphincs-shake256-128s
+
+include $(RIOTBASE)/Makefile.include

--- a/examples/pqm4/speed/main.c
+++ b/examples/pqm4/speed/main.c
@@ -1,0 +1,118 @@
+#include <stdio.h>
+#include <string.h>
+
+#include "xtimer.h"
+#include "pq_api.h"
+#include "api.h"
+#include "randombytes.h"
+
+
+#define NTESTS 1
+#define MLEN 32
+
+void hexdump(const void* data, size_t size) {
+  char ascii[17];
+  size_t i, j;
+  ascii[16] = '\0';
+  for (i = 0; i < size; ++i) {
+    printf("%02X ", ((unsigned char*)data)[i]);
+    if (((unsigned char*)data)[i] >= ' ' && ((unsigned char*)data)[i] <= '~') {
+      ascii[i % 16] = ((unsigned char*)data)[i];
+    } else {
+      ascii[i % 16] = '.';
+    }
+    if ((i+1) % 8 == 0 || i+1 == size) {
+      printf(" ");
+      if ((i+1) % 16 == 0) {
+        printf("|  %s \n", ascii);
+      } else if (i+1 == size) {
+        ascii[(i+1) % 16] = '\0';
+        if ((i+1) % 16 <= 8) {
+          printf(" ");
+        }
+        for (j = (i+1) % 16; j < 16; ++j) {
+          printf("   ");
+        }
+        printf("|  %s \n", ascii);
+      }
+    }
+  }
+}
+
+static void printcycles(const char *s, xtimer_ticks32_t ticks)
+{
+  printf(s);
+  printf("\n\tticks: %d\n", ticks.ticks32);
+  printf("\tusec: %d\n", xtimer_usec_from_ticks(ticks));
+}
+
+
+int main(void)
+{
+#ifdef PQ_KEM
+  printf("Running KEM speed test.\n\n");
+  unsigned char ss[CRYPTO_BYTES];
+  unsigned char sk[CRYPTO_SECRETKEYBYTES];
+  unsigned char pk[CRYPTO_PUBLICKEYBYTES];
+  unsigned char ct[CRYPTO_CIPHERTEXTBYTES];
+  xtimer_ticks32_t t0, t1;
+
+  printf("==========================\n");
+
+  // Key-pair generation
+  t0 = xtimer_now();
+  crypto_kem_keypair(pk, sk);
+  t1 = xtimer_now();
+  printcycles("keypair gen",  xtimer_diff(t1, t0));
+
+  // Encapsulation
+  t0 = xtimer_now();
+  crypto_kem_enc(ct, ss, pk);
+  t1 = xtimer_now();
+  printcycles("encaps", xtimer_diff(t1, t0));
+
+  // Decapsulation
+  t0 = xtimer_now();
+  crypto_kem_dec(ss, ct, sk);
+  t1 = xtimer_now();
+  printcycles("decaps", xtimer_diff(t1, t0));
+
+  printf("All KEM tests run.\n\n");
+#endif
+
+#ifdef PQ_SIGN
+  printf("Running Sign speed test.\n\n");
+  unsigned char pk[CRYPTO_PUBLICKEYBYTES];
+  unsigned char sk[CRYPTO_SECRETKEYBYTES];
+  unsigned char sm[MLEN + CRYPTO_BYTES];
+  unsigned char m[MLEN];
+
+  unsigned long long mlen;
+  unsigned long long smlen;
+  xtimer_ticks32_t t0, t1;
+
+  printf("==========================\n");
+  // Key-pair generation
+  t0 = xtimer_now();
+  crypto_sign_keypair(pk, sk);
+  t1 = xtimer_now();
+  printcycles("keypair gen",  xtimer_diff(t1, t0));
+
+  //Signing
+  randombytes(m, MLEN);
+  t0 = xtimer_now();
+  crypto_sign(sm, &smlen, m, MLEN, sk);
+  t1 = xtimer_now();
+  printcycles("signing",  xtimer_diff(t1, t0));
+
+  //Verification
+  t0 = xtimer_now();
+  if (crypto_sign_open(sm, &mlen, sm, smlen, pk)) {
+    printf("Signature did not verify correctly!\n");
+  }
+  t1 = xtimer_now();
+  printcycles("signing",  xtimer_diff(t1, t0));
+#endif
+
+  return 0;
+}

--- a/examples/pqm4/test/Makefile
+++ b/examples/pqm4/test/Makefile
@@ -1,0 +1,55 @@
+# name of your application
+APPLICATION = pqm4-test
+
+
+# If no BOARD is found in the environment, use this default:
+BOARD ?= native
+
+# This has to be the absolute path to the RIOT base directory:
+RIOTBASE ?= $(CURDIR)/../../..
+
+# Uncomment these lines if you want to use platform support from external
+# repositories:
+#RIOTCPU ?= $(CURDIR)/../../RIOT/thirdparty_cpu
+#RIOTBOARD ?= $(CURDIR)/../../RIOT/thirdparty_boards
+
+# Uncomment this to enable scheduler statistics for ps:
+#USEMODULE += schedstatistics
+
+# If you want to use native with valgrind, you should recompile native
+# with the target all-valgrind instead of all:
+# make -B clean all-valgrind
+
+# Comment this out to disable code in RIOT that does safety checking
+# which is not needed in a production environment but helps in the
+# development process:
+DEVELHELP ?= 0
+
+# Change this to 0 show compiler invocation lines by default:
+QUIET ?= 1
+
+# Modules to include:
+USEMODULE += random
+USEMODULE += xtimer
+
+USEPKG += pqm4
+
+CFLAGS += -DTHREAD_STACKSIZE_MAIN=\(20*THREAD_STACKSIZE_DEFAULT+THREAD_EXTRA_STACKSIZE_PRINTF\) # Same as for tweetnacl
+
+
+# Choose a key encapsulation scheme
+#
+#PQ_KEM=frodo640-cshake
+#PQ_KEM=kindi256342
+#PQ_KEM=sntrup4591761
+#PQ_KEM=kyber768
+#PQ_KEM=newhope1024cca
+#PQ_KEM=ntruhrss701
+#PQ_KEM=saber
+#PQ_KEM=sikep751
+
+# Choose a signature scheme
+#PQ_SIGN=dilithium
+#PQ_SIGN=sphincs-shake256-128s
+
+include $(RIOTBASE)/Makefile.include

--- a/examples/pqm4/test/buildall.py
+++ b/examples/pqm4/test/buildall.py
@@ -1,0 +1,45 @@
+#!/bin/env python3
+import os
+import subprocess
+
+kems = [
+    'frodo640-cshake',
+    'kindi256342',
+    'kyber768',
+    'newhope1024cca',
+    'ntruhrss701',
+    'saber',
+    'sikep751',
+    'sntrup4591761'
+]
+
+
+signs = [
+    'dilithium',
+    'qTesla-I',
+    'qTesla-III-size',
+    'qTesla-III-speed',
+    'sphincs-shake256-128s'
+]
+
+makeflags = ['BOARD=native']
+
+
+def build(flags, name):
+    # Clean build dir
+    if os.path.exists('./bin'):
+        subprocess.call(['/bin/rm', '-rf', './bin'])
+    # Build
+    cmd = ['/bin/make'] + flags
+    print(cmd)
+    with open(name + '.log', 'w') as out:
+        subprocess.call(cmd, env=dict(os.environ, CFLAGS="-DNATIVE_AUTO_EXIT"), stdout=out, stderr=out)
+
+
+for kem in kems:
+    flags = makeflags + ["PQ_KEM=" + kem, 'all', 'term']
+    build(flags, kem.replace('/', '_'))
+
+for sign in signs:
+    flags = makeflags + ["PQ_SIGN=" + sign, 'all', 'term']
+    build(flags, sign.replace('/', '_'))

--- a/examples/pqm4/test/main.c
+++ b/examples/pqm4/test/main.c
@@ -1,0 +1,232 @@
+#include <stdio.h>
+#include <string.h>
+
+#include "pq_api.h"
+#include "api.h"
+#include "randombytes.h"
+#include <string.h>
+#include "stdio.h"
+
+
+#define NTESTS 1
+#define MLEN 32
+
+void hexdump(const void* data, size_t size) {
+  char ascii[17];
+  size_t i, j;
+  ascii[16] = '\0';
+  for (i = 0; i < size; ++i) {
+    printf("%02X ", ((unsigned char*)data)[i]);
+    if (((unsigned char*)data)[i] >= ' ' && ((unsigned char*)data)[i] <= '~') {
+      ascii[i % 16] = ((unsigned char*)data)[i];
+    } else {
+      ascii[i % 16] = '.';
+    }
+    if ((i+1) % 8 == 0 || i+1 == size) {
+      printf(" ");
+      if ((i+1) % 16 == 0) {
+        printf("|  %s \n", ascii);
+      } else if (i+1 == size) {
+        ascii[(i+1) % 16] = '\0';
+        if ((i+1) % 16 <= 8) {
+          printf(" ");
+        }
+        for (j = (i+1) % 16; j < 16; ++j) {
+          printf("   ");
+        }
+        printf("|  %s \n", ascii);
+      }
+    }
+  }
+}
+
+#ifdef PQ_KEM
+static int test_keys(void)
+{
+  unsigned char key_a[CRYPTO_BYTES], key_b[CRYPTO_BYTES];
+  unsigned char pk[CRYPTO_PUBLICKEYBYTES];
+  unsigned char sendb[CRYPTO_CIPHERTEXTBYTES];
+  unsigned char sk_a[CRYPTO_SECRETKEYBYTES];
+  int i;
+
+  for(i=0; i<NTESTS; i++)
+  {
+    //Alice generates a public key
+    crypto_kem_keypair(pk, sk_a);
+    printf("PASS key pair generation!\n");
+
+    //Bob derives a secret key and creates a response
+    crypto_kem_enc(sendb, key_b, pk);
+    printf("PASS encapsulation!\n");
+
+    //Alice uses Bobs response to get her secret key
+    crypto_kem_dec(key_a, sendb, sk_a);
+    printf("PASS decapsulation!\n");
+
+    if(memcmp(key_a, key_b, CRYPTO_BYTES)){
+      printf("ERROR KEYS\n");
+    }
+    printf("Key A:\n");
+    hexdump(key_a, CRYPTO_BYTES);
+    printf("Key B:\n");
+    hexdump(key_b, CRYPTO_BYTES);
+  }
+
+  return 0;
+}
+
+
+static int test_invalid_sk_a(void)
+{
+  unsigned char sk_a[CRYPTO_SECRETKEYBYTES];
+  unsigned char key_a[CRYPTO_BYTES], key_b[CRYPTO_BYTES];
+  unsigned char pk[CRYPTO_PUBLICKEYBYTES];
+  unsigned char sendb[CRYPTO_CIPHERTEXTBYTES];
+  int i;
+
+  for(i=0; i<NTESTS; i++)
+  {
+    //Alice generates a public key
+    crypto_kem_keypair(pk, sk_a);
+
+    //Bob derives a secret key and creates a response
+    crypto_kem_enc(sendb, key_b, pk);
+
+    //Replace secret key with random values
+    randombytes(sk_a, CRYPTO_SECRETKEYBYTES);
+
+    //Alice uses Bobs response to get her secre key
+    crypto_kem_dec(key_a, sendb, sk_a);
+
+    if(!memcmp(key_a, key_b, CRYPTO_BYTES))
+      printf("ERROR invalid sk_a\n");
+  }
+
+  return 0;
+}
+
+
+static int test_invalid_ciphertext(void)
+{
+  unsigned char sk_a[CRYPTO_SECRETKEYBYTES];
+  unsigned char key_a[CRYPTO_BYTES], key_b[CRYPTO_BYTES];
+  unsigned char pk[CRYPTO_PUBLICKEYBYTES];
+  unsigned char sendb[CRYPTO_CIPHERTEXTBYTES];
+  int i;
+  size_t pos;
+
+  for(i=0; i<NTESTS; i++)
+  {
+    randombytes((unsigned char *)&pos, sizeof(size_t));
+
+    //Alice generates a public key
+    crypto_kem_keypair(pk, sk_a);
+
+    //Bob derives a secret key and creates a response
+    crypto_kem_enc(sendb, key_b, pk);
+
+    //Change some byte in the ciphertext (i.e., encapsulated key)
+    sendb[pos % CRYPTO_CIPHERTEXTBYTES] ^= 23;
+
+    //Alice uses Bobs response to get her secret key
+    crypto_kem_dec(key_a, sendb, sk_a);
+
+    if(!memcmp(key_a, key_b, CRYPTO_BYTES))
+      printf("ERROR invalid ciphertext\n");
+  }
+
+  return 0;
+}
+#endif
+
+
+#ifdef PQ_SIGN
+int test_sign(void)
+{
+    unsigned char pk[CRYPTO_PUBLICKEYBYTES];
+    unsigned char sk[CRYPTO_SECRETKEYBYTES];
+    unsigned char sm[MLEN + CRYPTO_BYTES];
+    unsigned char m[MLEN];
+
+    unsigned long long mlen;
+    unsigned long long smlen;
+
+    //int i;
+
+    //for (i = 0; i < NTESTS; i++) {
+        crypto_sign_keypair(pk, sk);
+        printf("crypto_sign_keypair DONE.\n");
+
+        randombytes(m, MLEN);
+        crypto_sign(sm, &smlen, m, MLEN, sk);
+        printf("crypto_sign DONE.\n");
+
+        // By relying on m == sm we prevent having to allocate CRYPTO_BYTES twice
+        if (crypto_sign_open(sm, &mlen, sm, smlen, pk)) {
+            printf("Signature did not verify correctly!\n");
+        }
+        printf("crypto_sign_open DONE.\n");
+    //}
+
+    return 0;
+}
+
+int test_wrong_pk(void)
+{
+    unsigned char pk[CRYPTO_PUBLICKEYBYTES];
+    unsigned char pk2[CRYPTO_PUBLICKEYBYTES];
+    unsigned char sk[CRYPTO_SECRETKEYBYTES];
+    unsigned char sm[MLEN + CRYPTO_BYTES];
+    unsigned char m[MLEN];
+
+    unsigned long long mlen;
+    unsigned long long smlen;
+
+    int i;
+
+    for (i = 0; i < NTESTS; i++) {
+        crypto_sign_keypair(pk2, sk);
+        printf("crypto_sign_keypair DONE.\n");
+
+        crypto_sign_keypair(pk, sk);
+        printf("crypto_sign_keypair DONE.\n");
+
+
+        randombytes(m, MLEN);
+        crypto_sign(sm, &smlen, m, MLEN, sk);
+        printf("crypto_sign DONE.\n");
+
+        // By relying on m == sm we prevent having to allocate CRYPTO_BYTES twice
+        if (crypto_sign_open(sm, &mlen, sm, smlen, pk2)) {
+            printf("OK Signature did not verify correctly under wrong public key!\n");
+        } else {
+            printf("ERROR Signature did verify correctly under wrong public key!\n");
+        }
+        printf("crypto_sign_open DONE.\n");
+    }
+
+    return 0;
+}
+#endif
+
+
+int main(void)
+{
+
+#ifdef PQ_KEM
+  printf("Running KEM tests.\n\n");
+  test_keys();
+  test_invalid_sk_a();
+  test_invalid_ciphertext();
+  printf("All KEM tests run.\n\n");
+#endif
+
+#ifdef PQ_SIGN
+  printf("Running SIGN tests.\n\n");
+  test_sign();
+  test_wrong_pk();
+  printf("All SIGN tests run.\n\n");
+#endif
+
+  return 0;
+}

--- a/pkg/pqm4/Makefile
+++ b/pkg/pqm4/Makefile
@@ -1,0 +1,12 @@
+PKG_NAME=pqm4
+PKG_URL=https://github.com/jowlo/pqm4.git
+PKG_VERSION=riot-port
+PKG_LICENSE=PD
+
+.PHONY: all
+
+all: git-download
+	@cp $(RIOTBASE)/pkg/pqm4/src/* $(PKG_BUILDDIR)
+	"$(MAKE)" -C $(PKG_BUILDDIR) libs
+
+include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/pqm4/Makefile.include
+++ b/pkg/pqm4/Makefile.include
@@ -1,0 +1,38 @@
+ifeq ("$(CPU_ARCH)","cortex-m4f")
+	PQ_COMMON_IMPL?=m4
+	ifneq ("$(wildcard $(PKGDIRBASE)/pqm4/crypto_kem/$(PQ_KEM)/m4)","")
+		PQ_KEM_IMPL?=m4
+	endif
+	export PQ_COMMON_IMPL
+endif
+
+ifneq (,$(filter "cortex-m0" "cortex-m0plus", "$(CPU_ARCH)"))
+	PQ_COMMON_IMPL?=m0
+	export PQ_COMMON_IMPL
+endif
+
+ifeq ($(PQ_COMMON_IMPL),)
+	PQ_COMMON_IMPL=generic
+endif
+
+INCLUDES += -I$(PKGDIRBASE)/pqm4/common/$(PQ_COMMON_IMPL)/
+INCLUDES += -I$(PKGDIRBASE)/pqm4/common/
+
+
+ifdef PQ_KEM
+	export PQ_KEM
+	PQ_KEM_IMPL?=ref
+	export PQ_KEM_IMPL
+	CFLAGS += -DPQ_KEM=$(PQ_KEM)
+	INCLUDES += -I$(PKGDIRBASE)/pqm4/crypto_kem/$(PQ_KEM)/$(PQ_KEM_IMPL)
+endif
+
+ifdef PQ_SIGN
+	export PQ_SIGN
+	PQ_SIGN_IMPL?=ref
+	export PQ_SIGN_IMPL
+	CFLAGS += -DPQ_SIGN=$(PQ_SIGN)
+	INCLUDES += -I$(PKGDIRBASE)/pqm4/crypto_sign/$(PQ_SIGN)/$(PQ_SIGN_IMPL)
+endif
+
+INCLUDES += -I$(PKGDIRBASE)/pqm4/


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR adds a [fork](https://github.com/jowlo/pqm4) of the [pqm4](https://github.com/mupq/pqm4)-library as package to RIOT.

The pqm4 library includes quantum-resistant key encapsulation mechanisms (KEM) and signature algorithms that have been submitted for standardization to the [NIST Post-Quantum Standardization Process](https://csrc.nist.gov/Projects/Post-Quantum-Cryptography/Post-Quantum-Cryptography-Standardization).
I am not the author of the pqm4 library, nor are the maintainers of the library authors of the individual schemes included. See the [License Section of pqm4's Readme](https://github.com/mupq/pqm4/blob/master/README.md#license) for detailed copyright information.

**The included ciphers and schemes are not meant for production use and should only be used for evaluation purposes.**

The pqm4 library is targeted at the `stm32f4discovery` board only. The fork of the library that is pulled by this package uses `m4`-only code only for those targets that feature an `m4` CPU, adds target-specific code for `m0` targets and adds generic code for all others. 

This PR also adds examples for key-generation (`examples/pqm4/keygen`), tests (`examples/pqm4/test`) and speed evaluation (`examples/pqm4/speed`). The `test` and `speed` examples are mere ports of the original library's main benchmarking tools.

When executing any of the examples, it is neccessary to choose which key-encapsulation and/or signature scheme should be built by the library. This can be done via a Makefile variable `PQ_KEM` and/or `PQ_SIGN`. See the `Makefile` for possible schemes.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
The `example/pqm4/test` directory contains a python script `buildall.py` that builds all KEM and signature scheme tests and executes them on `native`. (You might want to exclude `sphincs-shake256-128s` as it takes about half an hour.) Each build and output is written to a corresponding logfile.

Some schemes need a quite large stack, for these it might be necessary to adapt the line in the Makefile defining `THREAD_STACKSIZE_MAIN`.
For testing implementation correctness on `native`, setting 
```
CFLAGS += -DTHREAD_STACKSIZE_MAIN=\(200*THREAD_STACKSIZE_DEFAULT\)
```
lets all tests pass for all schemes.


<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
