### PR TITLE
code-style/linelencheck: add line length check script

### DIFF
--- a/dist/tools/doccheck/check.sh
+++ b/dist/tools/doccheck/check.sh
@@ -69,3 +69,21 @@ then
     echo "${UNDEFINED_GROUPS_PRINT}"
     exit 2
 fi
+
+: "${RIOTTOOLS:=${RIOTBASE}/dist/tools}"
+. "${RIOTTOOLS}"/ci/changed_files.sh
+
+FILES=$(FILEREGEX='doc.txt|README|LICENSE' changed_files)
+
+ERR_CODE=0
+for file in $FILES;
+do
+    #Ignore Doxygen tables (starting with `|`)
+    LINEREGEX="^[^\|]" $RIOTBASE/dist/tools/linelencheck/check.sh $RIOTBASE/$file
+    if [ $? -ne 0 ]
+    then
+        ERR_CODE=1
+    fi
+done
+
+exit $ERR_CODE

--- a/dist/tools/linelencheck/check.sh
+++ b/dist/tools/linelencheck/check.sh
@@ -1,0 +1,35 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2018 HAW Hamburg
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+: "${WARNING_LIMIT:=80}"
+: "${ERROR_LIMIT:=100}"
+: "${LINEREGEX:='.*'}"
+
+if tput colors &> /dev/null && [ "$(tput colors)" -ge 8 ]; then
+    CERROR="\033[1;31m"
+    CWARN="\033[1;33m"
+    CRESET="\033[0m"
+else
+    CERROR=
+    CWARN=
+    CRESET=
+fi
+
+check_line_length () {
+    awk "!/$LINEREGEX/ {next} \
+        length(\$0) > $WARNING_LIMIT && length(\$0) < $ERROR_LIMIT \
+            {print \"${CWARN}warning${CRESET}:\" \"$1:\" NR \": \" \
+            \"Line longer than $WARNING_LIMIT characters\"} \
+        length(\$0) > $ERROR_LIMIT \
+            {print \"${CERROR}error${CRESET}:\" \"$1:\" NR \": \" \
+            \"Line longer than $ERROR_LIMIT characters\";err=1} \
+        END{exit err}" \
+        "$1"
+}
+
+check_line_length "$1"


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR adds a script for checking line length limits. The difference with solutions like #9778 is the fact it has a threshold for warnings and errors, and can also check other kind of documents (documentation, Makefiles, etc).

I added the script under `dist/tools/linelencheck`, and adopted the `doccheck` script to check documentation style.

The following env variables are defined:
- `WARNING_LIMIT`: The script raises `warning` for each line with length greater than this limit (default=80)
- `ERROR_LIMIT`: The script raises `error` for each line with length greater than this limit (default=100). The script throws `exit 1` here.
- `LINEREGEX`: Only check lines that match the given line regex (default="`.*`"). E.g Doxygen tables.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->
Call `dist/tools/linelencheck/check.sh` and check the output. Try changing the env variables values.

### Issues/PRs references
[#9881 (discussion)](https://github.com/RIOT-OS/RIOT/pull/9881#discussion_r215183908)
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
