### PR TITLE
periph/timer: extend API with timer_diff call

### DIFF
--- a/cpu/cc2538/include/periph_cpu.h
+++ b/cpu/cc2538/include/periph_cpu.h
@@ -242,6 +242,11 @@ typedef struct {
 } timer_conf_t;
 
 /**
+ * @brief Timer implementation provides custom timer_diff function
+ */
+#define PERIPH_TIMER_PROVIDES_DIFF
+
+/**
  * @name   Override resolution options
  * @{
  */

--- a/cpu/cc2538/periph/timer.c
+++ b/cpu/cc2538/periph/timer.c
@@ -213,6 +213,18 @@ unsigned int timer_read(tim_t tim)
     }
 }
 
+unsigned int timer_diff(tim_t tim, unsigned int begin, unsigned int until)
+{
+    unsigned int diff = 0;
+    if (tim < TIMER_NUMOF) {
+        diff = (until - begin);
+        if (timer_config[tim].cfg == GPTMCFG_16_BIT_TIMER) {
+            diff &= 0xffff;
+        }
+    }
+    return diff;
+}
+
 /*
  * For stopping the counting of all channels.
  */

--- a/cpu/cc26x0/include/periph_cpu.h
+++ b/cpu/cc26x0/include/periph_cpu.h
@@ -76,6 +76,11 @@ typedef struct {
     uint8_t     chn;    /**< number of channels [1,2] */
 } timer_conf_t;
 
+/**
+ * @brief Timer implementation provides custom timer_diff function
+ */
+#define PERIPH_TIMER_PROVIDES_DIFF
+
 #endif /* ifndef DOXYGEN */
 
 #ifdef __cplusplus

--- a/cpu/cc26x0/periph/timer.c
+++ b/cpu/cc26x0/periph/timer.c
@@ -211,6 +211,18 @@ unsigned int timer_read(tim_t tim)
     return LOAD_VALUE - (dev(tim)->TAV & 0xFFFF);
 }
 
+unsigned int timer_diff(tim_t tim, unsigned int begin, unsigned int until)
+{
+    unsigned int diff = 0;
+    if (tim < TIMER_NUMOF) {
+        diff = (until - begin);
+        if (timer_config[tim].cfg == GPT_CFG_16T) {
+            diff &= 0xffff;
+        }
+    }
+    return diff;
+}
+
 void timer_stop(tim_t tim)
 {
     DEBUG("timer_stop(%u)\n", tim);

--- a/cpu/esp8266/include/periph_cpu.h
+++ b/cpu/esp8266/include/periph_cpu.h
@@ -161,6 +161,11 @@ typedef enum {
 #endif /* MODULE_PERIPH_SPI */
 /** @} */
 
+/**
+ * @brief   Prevent shared timer functions from being used
+ */
+#define PERIPH_TIMER_PROVIDES_SET
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/fe310/Makefile.include
+++ b/cpu/fe310/Makefile.include
@@ -5,6 +5,7 @@ USEMODULE += newlib_syscalls_fe310
 USEMODULE += sifive_drivers_fe310
 
 USEMODULE += periph
+USEMODULE += periph_common
 USEMODULE += periph_pm
 
 CFLAGS += -Wno-pedantic

--- a/cpu/fe310/include/periph_cpu.h
+++ b/cpu/fe310/include/periph_cpu.h
@@ -29,6 +29,11 @@ extern "C" {
 #define CPUID_LEN           (12U)
 
 /**
+ * @brief Timer implementation provides custom timer_diff function
+ */
+#define PERIPH_TIMER_PROVIDES_SET
+
+/**
  * @brief   Timer ISR
  */
 void timer_isr(void);

--- a/cpu/samd21/include/periph_cpu.h
+++ b/cpu/samd21/include/periph_cpu.h
@@ -107,6 +107,12 @@ typedef enum {
     ADC_RES_16BIT = 0xfd                        /**< not supported */
 } adc_res_t;
 /** @} */
+
+/**
+ * @brief Timer implementation provides custom timer_diff function
+ */
+#define PERIPH_TIMER_PROVIDES_DIFF
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/samd21/periph/timer.c
+++ b/cpu/samd21/periph/timer.c
@@ -251,6 +251,24 @@ unsigned int timer_read(tim_t dev)
 
 }
 
+unsigned int timer_diff(tim_t dev, unsigned int begin, unsigned int until)
+{
+    unsigned int diff=0;
+    switch (dev) {
+#if TIMER_0_EN
+    case TIMER_0:
+        diff = ((until - begin) & TIMER_0_MAX_VALUE);
+        break;
+#endif
+#if TIMER_1_EN
+    case TIMER_1:
+        diff = ((until - begin) & TIMER_1_MAX_VALUE);
+        break;
+#endif
+    }
+    return diff;
+}
+
 void timer_stop(tim_t dev)
 {
     switch (dev) {

--- a/cpu/stm32_common/include/periph_cpu_common.h
+++ b/cpu/stm32_common/include/periph_cpu_common.h
@@ -291,6 +291,11 @@ typedef struct {
 } timer_conf_t;
 
 /**
+ * @brief Timer implementation provides custom timer_diff function
+ */
+#define PERIPH_TIMER_PROVIDES_DIFF
+
+/**
  * @brief   PWM channel
  */
 typedef struct {

--- a/cpu/stm32_common/periph/timer.c
+++ b/cpu/stm32_common/periph/timer.c
@@ -96,6 +96,15 @@ unsigned int timer_read(tim_t tim)
     return (unsigned int)dev(tim)->CNT;
 }
 
+unsigned int timer_diff(tim_t tim, unsigned int begin, unsigned int until)
+{
+    unsigned int diff = 0;
+    if (tim < TIMER_NUMOF) {
+        diff = ((until - begin) & timer_config[tim].max);
+    }
+    return diff;
+}
+
 void timer_start(tim_t tim)
 {
     dev(tim)->CR1 |= TIM_CR1_CEN;

--- a/drivers/include/periph/rtt.h
+++ b/drivers/include/periph/rtt.h
@@ -23,6 +23,8 @@
 #ifndef PERIPH_RTT_H
 #define PERIPH_RTT_H
 
+#include <stdint.h>
+
 #include "periph_conf.h"
 
 #ifdef __cplusplus

--- a/drivers/include/periph/timer.h
+++ b/drivers/include/periph/timer.h
@@ -147,6 +147,22 @@ int timer_clear(tim_t dev, int channel);
 unsigned int timer_read(tim_t dev);
 
 /**
+ * @brief Compare two timer values and return the difference
+ *
+ * Depending on the timer configuration the difference of two time values cannot
+ * be calculated by simple substraction, but needs to consider the max value the
+ * timer can reach. For instance, if the timer is set to 16-Bits running on a
+ * 32-Bits platform.
+ *
+ * @param[in] dev           the timer to compare values for
+ * @param[in] begin         first time value
+ * @param[in] until         second time value
+ *
+ * @return                  time difference, i.e., `until - begin`
+ */
+unsigned int timer_diff(tim_t dev, unsigned int begin, unsigned int until);
+
+/**
  * @brief Start the given timer
  *
  * This function is only needed if the timer was stopped manually before.

--- a/drivers/periph_common/timer.c
+++ b/drivers/periph_common/timer.c
@@ -26,3 +26,11 @@ int timer_set(tim_t dev, int channel, unsigned int timeout)
     return timer_set_absolute(dev, channel, timer_read(dev) + timeout);
 }
 #endif
+
+#ifndef PERIPH_TIMER_PROVIDES_DIFF
+unsigned int timer_diff(tim_t dev, unsigned int begin, unsigned int until)
+{
+    (void) dev;
+    return (until - begin);
+}
+#endif

--- a/tests/periph_timer_diff/Makefile
+++ b/tests/periph_timer_diff/Makefile
@@ -1,0 +1,10 @@
+include ../Makefile.tests_common
+
+FEATURES_REQUIRED = periph_timer
+
+TEST_ON_CI_WHITELIST += all
+
+include $(RIOTBASE)/Makefile.include
+
+test:
+	tests/01-run.py

--- a/tests/periph_timer_diff/README.md
+++ b/tests/periph_timer_diff/README.md
@@ -1,0 +1,8 @@
+# About
+
+This test compares the difference of two timer values t0 and t1 using timer_diff
+function and a simple subtraction, i.e., `t1 - t0`. Depending on the platform
+and timer configuration both values can differ, for instance when running a
+timer in 16-Bit mode/width on a 32-Bit platform.
+
+The test is run for all enabled timers, but only for the first channel.

--- a/tests/periph_timer_diff/main.c
+++ b/tests/periph_timer_diff/main.c
@@ -1,0 +1,121 @@
+/*
+ * Copyright (C) 2015 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Peripheral timer test application
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ *
+ * @}
+ */
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#include "periph/timer.h"
+
+/**
+ * @brief   Make sure, the maximum number of timers is defined
+ */
+#ifndef TIMER_NUMOF
+#error "TIMER_NUMOF not defined!"
+#endif
+
+#define MAX_LOOPS   (10U)
+#define TIMER_SPEED (1000000ul) /* try to run with 1MHz */
+#define TIMEOUT     (20000U)
+
+static volatile unsigned fired;
+static volatile uint32_t sw_count;
+static volatile unsigned timevals[MAX_LOOPS];
+
+static void cb(void *arg, int chan)
+{
+    (void) chan;
+    timevals[fired] = timer_read(TIMER_DEV((unsigned)arg));
+    fired++;
+    if (fired < MAX_LOOPS) {
+        timer_set(TIMER_DEV((unsigned)arg), 0, TIMEOUT);
+    }
+}
+
+static int test_timer(unsigned num)
+{
+    printf("\n*** Testing TIMER_%u ***\n", num);
+    /* reset state */
+    sw_count = 0;
+    fired = 0;
+    for (unsigned i = 0; i < MAX_LOOPS; i++) {
+        timevals[i] = 0;
+    }
+    printf("  timer_init(%u, %lu, cb, args) ", num, TIMER_SPEED);
+    /* initialize and halt timer */
+    if (timer_init(TIMER_DEV(num), TIMER_SPEED, cb, (void *)(num)) < 0) {
+        puts("FAIL");
+        return 0;
+    }
+    puts("DONE");
+    /* stop timer */
+    timer_stop(TIMER_DEV(num));
+    /* set first timeout */
+    printf("  timer_set(%u, 0, %u) ", num, TIMEOUT);
+    if (timer_set(TIMER_DEV(num), 0, TIMEOUT) < 0) {
+        puts("FAIL");
+        return 0;
+    }
+    puts("DONE");
+    /* (re)start timer */
+    timer_start(TIMER_DEV(num));
+    /* wait for all channels to fire */
+    do {
+        ++sw_count;
+    } while (fired < MAX_LOOPS);
+    bool match = true;
+    /* collect results */
+    printf("  fired %u times, offset %u [us], result table\n\n", fired, TIMEOUT);
+    printf("; num, begin, until, timer_diff, simple_diff\n");
+    for (unsigned i = 1; i < fired; i++) {
+        unsigned tdiff = timer_diff(TIMER_DEV(num), timevals[i-1], timevals[i]);
+        unsigned sdiff = (timevals[i] - timevals[i-1]);
+        if (tdiff != sdiff) {
+            match = false;
+        }
+        printf("  %u, %u, %u, %u, %u\n", i, timevals[i-1], timevals[i], tdiff, sdiff);
+    }
+    printf("\n  Note: timers max value is %s platform max value.\n",
+           ((match) ? "equal to" : "less than"));
+    return 1;
+}
+
+int main(void)
+{
+    int res = 0;
+
+    printf("TIMER_NUMOF=%i\n", TIMER_NUMOF);
+    printf("TIMER_SPEED=%lu\n", TIMER_SPEED);
+
+    /* test all configured timers */
+    for (unsigned i = 0; i < TIMER_NUMOF; i++) {
+        res += test_timer(i);
+    }
+    /* draw conclusion */
+    if (res == TIMER_NUMOF) {
+        puts("\nTEST SUCCEEDED");
+    }
+    else {
+        puts("\nTEST FAILED");
+    }
+
+    return 0;
+}

--- a/tests/periph_timer_diff/tests/01-run.py
+++ b/tests/periph_timer_diff/tests/01-run.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2016 Kaspar Schleiser <kaspar@schleiser.de>
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import sys
+from testrunner import run
+
+
+def testfunc(child):
+    child.expect('TIMER_NUMOF=(\d+)')
+    timer_numof = int(child.match.group(1))
+    child.expect('TIMER_SPEED=(\d+)')
+    timer_speed = int(child.match.group(1))
+    for timer in range(timer_numof):
+        child.expect_exact('*** Testing TIMER_{} ***'.format(timer))
+        child.expect_exact('  timer_init({}, {}, cb, args) DONE'.format(timer, timer_speed))
+    child.expect('TEST SUCCEEDED')
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc))


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR proposes an extension of the periph/timer API, namely to provide a `timer_diff` function that allows to calculate the difference of two time values (acquired by running `timer_read`) and also account for the timers configuration. Currently its not possible to generically calculate the difference without explicitly knowing the timers configuration, the problem arises when running a timer in 16-Bit mode on a 32-Bit platform.

If a platform only uses timers with same width as the platform, e.g. Kinetis, a common helper function is provided in `drivers/periph_common/timer.c`. Otherwise a platform may implement its own variant and also define MACRO `PERIPH_TIMER_PROVIDES_DIFF`. The latter is done for CPUs `stm32_common`, `cc2538`, `cc26x0`, and `samd21`.

Though this is actually an API extension I still set the label *API CHANGE* just in case.

### Testing procedure

This PR provides a test application see `tests/periph_timer_diff`.


### Issues/PRs references

Problem was discovered when reviewing #9283
