### PR TITLE
periph/rtt: add missing std header

### DIFF
--- a/drivers/include/periph/rtt.h
+++ b/drivers/include/periph/rtt.h
@@ -23,6 +23,8 @@
 #ifndef PERIPH_RTT_H
 #define PERIPH_RTT_H
 
+#include <stdint.h>
+
 #include "periph_conf.h"
 
 #ifdef __cplusplus


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

The periph/rtt.h uses `uintX_t` typedefs but misses the required
standard header file, namely `stdint.h`, which is added here.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

was found while working on #9900 