### PR TITLE
periph/timer: add missing PERIPH_TIMER_PROVIDES_SET

### DIFF
--- a/cpu/esp8266/include/periph_cpu.h
+++ b/cpu/esp8266/include/periph_cpu.h
@@ -159,6 +159,12 @@ typedef enum {
 #define PERIPH_SPI_NEEDS_TRANSFER_REGS
 
 #endif /* MODULE_PERIPH_SPI */
+
+/**
+ * @brief   Prevent shared timer functions from being used
+ */
+#define PERIPH_TIMER_PROVIDES_SET
+
 /** @} */
 
 #ifdef __cplusplus

--- a/cpu/fe310/include/periph_cpu.h
+++ b/cpu/fe310/include/periph_cpu.h
@@ -29,6 +29,11 @@ extern "C" {
 #define CPUID_LEN           (12U)
 
 /**
+ * @brief   Prevent shared timer functions from being used
+ */
+#define PERIPH_TIMER_PROVIDES_SET
+
+/**
  * @brief   Timer ISR
  */
 void timer_isr(void);

--- a/cpu/mips32r2_generic/include/periph_cpu.h
+++ b/cpu/mips32r2_generic/include/periph_cpu.h
@@ -27,7 +27,7 @@ extern "C" {
 /**
  * @brief   Prevent shared timer functions from being used
  */
-#define PERIPH_TIMER_PROVIDES_SET   1
+#define PERIPH_TIMER_PROVIDES_SET
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

The `PERIPH_TIMER_PROVIDES_SET` macro was missing for CPUs *esp8266* and *fe310*, this isn't a problem right now because both don't use the periph_common module. But I ran into this when working on additional periph timer functions. See #9900 for example.

Also fix an unnecessary and inconsistent usage where PERIPH_TIMER_PROVIDES_SET was set to `1`.


### Testing procedure

No issue in current master, but might cause trouble in future.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
