### PR TITLE
periph_common: add as dependency to periph drivers 

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -877,6 +877,11 @@ USEMODULE += $(filter periph_%,$(FEATURES_USED))
 # select cpu_check_address pseudomodule if the corresponding feature is used
 USEMODULE += $(filter cpu_check_address, $(FEATURES_USED))
 
+# include periph_common if any periph_* driver is used
+ifneq (,$(filter periph_%, $(USEMODULE)))
+  USEMODULE += periph_common
+endif
+
 # recursively catch transitive dependencies
 USEMODULE := $(sort $(USEMODULE))
 USEPKG := $(sort $(USEPKG))

--- a/cpu/cc2538/Makefile.include
+++ b/cpu/cc2538/Makefile.include
@@ -1,6 +1,3 @@
 export CPU_ARCH := cortex-m3
 
-# include common SPI functions
-USEMODULE += periph_common
-
 include $(RIOTMAKE)/arch/cortexm.inc.mk

--- a/cpu/cc26x0/Makefile.include
+++ b/cpu/cc26x0/Makefile.include
@@ -1,5 +1,3 @@
 export CPU_ARCH := cortex-m3
 
-USEMODULE += periph_common
-
 include $(RIOTMAKE)/arch/cortexm.inc.mk

--- a/cpu/cc430/Makefile.include
+++ b/cpu/cc430/Makefile.include
@@ -1,3 +1,3 @@
 include $(RIOTCPU)/msp430_common/Makefile.include
 
-export USEMODULE += periph periph_common
+export USEMODULE += periph

--- a/cpu/efm32/Makefile.include
+++ b/cpu/efm32/Makefile.include
@@ -20,9 +20,6 @@ USEMODULE += cpu_$(EFM32_FAMILY)
 # vectors.o is provided by 'cpu_$(EFM32_FAMILY)' and not by 'cpu'
 VECTORS_O := $(BINDIR)/cpu_$(EFM32_FAMILY)/vectors.o
 
-# include common periph module
-USEMODULE += periph_common
-
 # include layered power management
 USEMODULE += pm_layered
 

--- a/cpu/esp32/Makefile.include
+++ b/cpu/esp32/Makefile.include
@@ -69,7 +69,6 @@ USEMODULE += log
 USEMODULE += newlib_syscalls_default
 USEMODULE += periph
 USEMODULE += periph_adc_ctrl
-USEMODULE += periph_common
 USEMODULE += periph_hwrng
 USEMODULE += periph_flash
 USEMODULE += periph_rtc

--- a/cpu/esp8266/Makefile.include
+++ b/cpu/esp8266/Makefile.include
@@ -56,7 +56,6 @@ PSEUDOMODULES += esp_spiffs
 USEMODULE += esp
 USEMODULE += mtd
 USEMODULE += periph
-USEMODULE += periph_common
 USEMODULE += ps
 USEMODULE += random
 USEMODULE += sdk

--- a/cpu/fe310/Makefile.include
+++ b/cpu/fe310/Makefile.include
@@ -5,7 +5,6 @@ USEMODULE += newlib_syscalls_fe310
 USEMODULE += sifive_drivers_fe310
 
 USEMODULE += periph
-USEMODULE += periph_common
 USEMODULE += periph_pm
 
 CFLAGS += -Wno-pedantic

--- a/cpu/kinetis/Makefile.include
+++ b/cpu/kinetis/Makefile.include
@@ -36,9 +36,6 @@ LINKFLAGS += $(LINKFLAGPREFIX)--defsym=_ram_length=$(RAM_LEN)
 # add the CPU specific flash configuration field for the linker
 export UNDEF += $(BINDIR)/cpu/fcfield.o
 
-# include common periph drivers
-USEMODULE += periph_common
-
 # select kinetis periph drivers
 ifeq (EA,$(KINETIS_SERIES))
 USEMODULE += periph_ics

--- a/cpu/lm4f120/Makefile.include
+++ b/cpu/lm4f120/Makefile.include
@@ -2,7 +2,4 @@ export CPU_ARCH = cortex-m4f
 
 include $(RIOTMAKE)/arch/cortexm.inc.mk
 
-# use common periph functions
-USEMODULE += periph_common
-
 include $(RIOTCPU)/stellaris_common/Makefile.include

--- a/cpu/lpc2387/Makefile.include
+++ b/cpu/lpc2387/Makefile.include
@@ -1,3 +1,3 @@
 include $(RIOTCPU)/arm7_common/Makefile.include
 
-USEMODULE += arm7_common periph periph_common bitfield newlib
+USEMODULE += arm7_common periph bitfield newlib

--- a/cpu/mips32r2_common/Makefile.include
+++ b/cpu/mips32r2_common/Makefile.include
@@ -2,7 +2,6 @@ export INCLUDES += -I$(RIOTCPU)/mips32r2_common/include
 
 export USEMODULE += mips32r2_common
 export USEMODULE += mips32r2_common_periph
-export USEMODULE += periph_common
 export USEMODULE += newlib
 
 # mips32 needs periph_timer for its gettimeofday() implementation

--- a/cpu/mips_pic32_common/Makefile.include
+++ b/cpu/mips_pic32_common/Makefile.include
@@ -4,5 +4,3 @@ export INCLUDES += -I$(RIOTCPU)/mips_pic32_common/include
 
 USEMODULE += mips_pic32_common
 USEMODULE += mips_pic32_common_periph
-
-USEMODULE += periph_common

--- a/cpu/msp430_common/Makefile.include
+++ b/cpu/msp430_common/Makefile.include
@@ -7,7 +7,7 @@ MODEL = $(shell echo $(CPU_MODEL) | tr 'a-z' 'A-Z')
 export CFLAGS += -DCPU_MODEL_$(MODEL)
 
 export UNDEF += $(BINDIR)/msp430_common/startup.o
-export USEMODULE += msp430_common msp430_common_periph msp430_malloc periph_common
+export USEMODULE += msp430_common msp430_common_periph msp430_malloc
 
 DEFAULT_MODULE += oneway_malloc
 

--- a/cpu/msp430fxyz/Makefile.include
+++ b/cpu/msp430fxyz/Makefile.include
@@ -1,3 +1,3 @@
 include $(RIOTCPU)/msp430_common/Makefile.include
 
-export USEMODULE += periph periph_common stdio_uart
+export USEMODULE += periph stdio_uart

--- a/cpu/native/Makefile.include
+++ b/cpu/native/Makefile.include
@@ -8,7 +8,4 @@ endif
 USEMODULE += periph
 USEMODULE += periph_uart
 
-# include common peripheral initialization
-USEMODULE += periph_common
-
 TOOLCHAINS_SUPPORTED = gnu llvm

--- a/cpu/nrf5x_common/Makefile.include
+++ b/cpu/nrf5x_common/Makefile.include
@@ -2,9 +2,6 @@
 FAM = $(shell echo $(CPU_FAM) | tr 'a-z-' 'A-Z_')
 export CFLAGS += -DCPU_FAM_$(FAM)
 
-# use common periph functions
-USEMODULE += periph_common
-
 # include nrf5x common periph drivers
 USEMODULE += nrf5x_common_periph
 

--- a/cpu/sam0_common/Makefile.include
+++ b/cpu/sam0_common/Makefile.include
@@ -22,9 +22,6 @@ export CFLAGS += -DDONT_USE_PREDEFINED_PERIPHERALS_HANDLERS
 # For Cortex-M cpu we use the common cortexm.ld linker script
 LINKER_SCRIPT ?= cortexm.ld
 
-# use common periph functions
-USEMODULE += periph_common
-
 # include sam0 common periph drivers
 USEMODULE += sam0_common_periph
 

--- a/cpu/sam3/Makefile.include
+++ b/cpu/sam3/Makefile.include
@@ -1,8 +1,5 @@
 export CPU_ARCH = cortex-m3
 export CPU_FAM  = sam3
 
-# include common SPI functions
-USEMODULE += periph_common
-
 include $(RIOTCPU)/sam_common/Makefile.include
 include $(RIOTMAKE)/arch/cortexm.inc.mk

--- a/cpu/stm32_common/Makefile.include
+++ b/cpu/stm32_common/Makefile.include
@@ -2,9 +2,6 @@
 FAM = $(shell echo $(CPU_FAM) | tr 'a-z-' 'A-Z_')
 export CFLAGS += -DCPU_FAM_$(FAM)
 
-# include common periph module
-USEMODULE += periph_common
-
 # All stm32 families provide pm support
 USEMODULE += pm_layered
 

--- a/makefiles/arch/atmega.inc.mk
+++ b/makefiles/arch/atmega.inc.mk
@@ -16,7 +16,6 @@ USEMODULE += atmega_common
 
 # export the peripheral drivers to be linked into the final binary
 USEMODULE += atmega_common_periph
-USEMODULE += periph_common
 
 # Export the peripheral drivers to be linked into the final binary, for now
 # only atmega126rfr2 has periph drivers

--- a/makefiles/arch/cortexm.inc.mk
+++ b/makefiles/arch/cortexm.inc.mk
@@ -34,7 +34,6 @@ export USEMODULE += cortexm_common
 # Export the peripheral drivers to be linked into the final binary:
 export USEMODULE += periph
 # include common periph code
-export USEMODULE += periph_common
 export USEMODULE += cortexm_common_periph
 
 # all cortex MCU's use newlib as libc


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

 Rational: the periph_common module is included by each and every CPU/MCU
    via one way or the other, hence it can be activated by default. With this
    PR its added to the list of default modules.

Actually, the periph_common was missing for CPUs `esp8266` and `fe310` which would result in I2C or SPI not working for instance, because they rely on periph auto init by periph_common. This is fixed with this PR implicitly -> but requires #9905.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

~~based on #9905~~