### PR TITLE
README.md: move link to nightly build overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,6 +124,6 @@ http://www.riot-os.org
 
 
 [master-ci-badge]: https://ci.riot-os.org/RIOT-OS/RIOT/master/latest/badge.svg
-[master-ci-link]: https://ci.riot-os.org/RIOT-OS/RIOT/master/latest/output.html
+[master-ci-link]: https://ci.riot-os.org/nightlies.html#master
 [irc-badge]: https://img.shields.io/badge/IRC-join%20chat%20%E2%86%92-blue.svg
 [irc-link]: http://webchat.freenode.net?channels=%23riot-os


### PR DESCRIPTION
### Contribution description

Now that we have a nice [HTML view of all nightly builds][nightlies],
let's link to them!

[nightlies]: https://ci.riot-os.org/nightlies.html#master

### Testing procedure
Go to the [branch's README](https://github.com/miri64/RIOT/blob/doc/enh/README-nightlies/README.md), click on the CI badge on top. You will be led to the new [nightlies] view.

### Issues/PRs references
None