### PR TITLE
cpu/lpc1768: fix uninitialized variable

### DIFF
--- a/cpu/lpc1768/periph/uart.c
+++ b/cpu/lpc1768/periph/uart.c
@@ -140,7 +140,7 @@ static int init_base(uart_t uart, uint32_t baudrate)
 
 void uart_write(uart_t uart, const uint8_t *data, size_t len)
 {
-    LPC_UART_TypeDef *dev;
+    LPC_UART_TypeDef *dev = NULL;
 
     switch (uart) {
 #if UART_0_EN
@@ -157,9 +157,11 @@ void uart_write(uart_t uart, const uint8_t *data, size_t len)
             return;
     }
 
-    for (size_t i = 0; i < len; i++) {
-        while (!(dev->LSR & (1 << 5)));       /* wait for THRE bit to be set */
-        dev->THR = data[i];
+    if (dev) {
+        for (size_t i = 0; i < len; i++) {
+            while (!(dev->LSR & (1 << 5))) {}  /* wait for THRE bit to be set */
+            dev->THR = data[i];
+        }
     }
 }
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR fixes an `uninitialized variable` error in `cppcheck` when `UART_0_EN` and `UART_1_EN` are not defined, as pointed out in [#9245 (discussion)](https://github.com/RIOT-OS/RIOT/pull/9245#issuecomment-415762034).

### Issues/PRs references

#9245 
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
