### PR TITLE
gnrc_ipv6_nib: always configure 802.15.4 long address with IPv6 included

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/nib/nib.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib.c
@@ -112,6 +112,7 @@ void gnrc_ipv6_nib_init_iface(gnrc_netif_t *netif)
     _init_iface_router(netif);
 #if GNRC_IPV6_NIB_CONF_6LN
     netif->ipv6.rs_sent = 0;
+#endif  /* GNRC_IPV6_NIB_CONF_6LN */
     if (netif->device_type == NETDEV_TYPE_IEEE802154) {
         /* see https://tools.ietf.org/html/rfc6775#section-5.2 */
         uint16_t src_len = IEEE802154_LONG_ADDRESS_LEN;
@@ -123,7 +124,6 @@ void gnrc_ipv6_nib_init_iface(gnrc_netif_t *netif)
          * directly everything else would deadlock anyway */
         netif->ops->set(netif, &opt);
     }
-#endif  /* GNRC_IPV6_NIB_CONF_6LN */
     netif->ipv6.na_sent = 0;
     if (gnrc_netif_ipv6_group_join_internal(netif,
                                             &ipv6_addr_all_nodes_link_local) < 0) {


### PR DESCRIPTION
### Contribution description
Our `gnrc_minimal` example configures the link-local address from the IEEE 802.15.4 short address since it does not include 6Lo-ND.
This causes the application to be incompatible with our other GNRC application that do include 6Lo-ND, since it [assumes][1] the link-local address to be based on the EUI-64 for address resolution.

This enforces long addresses (aka EUI-64) for all IEEE 802.15.4 devices when IPv6 is compiled in so `gnrc_minimal` is compatible again to the rest.

[1]: https://tools.ietf.org/html/rfc6775#section-5.2


### Testing procedure
1. Take to boards with IEEE 802.15.4 radios, flash one with the `gnrc_networking`, one with the `gnrc_minimal` example.
2. Deactivate IPHC in the `gnrc_networking` example (`ifconfig <if_id> -iphc`)
3. Ping the link-local address of the `gnrc_minimal` with the `gnrc_networking` example \
  (`ping6 fe80::…`).

Without this fix you will only see ping-timeouts. With this fix it will work (note however that the link-local address changes of the `gnrc_minimal` address changes with this fix.

### Issues/PRs references
Fixes #9910
