### PR TITLE
isotp: advance protocol FSM when no confirmation is used

### DIFF
--- a/sys/can/isotp/isotp.c
+++ b/sys/can/isotp/isotp.c
@@ -646,6 +646,10 @@ static int _isotp_tx_send(struct isotp *isotp, struct can_frame *frame)
         return _isotp_dispatch_tx(isotp, isotp->tx.tx_handle);
     }
 
+    if (isotp->opt.flags & CAN_ISOTP_TX_DONT_WAIT) {
+      _isotp_tx_tx_conf(isotp);
+    }
+
     return 0;
 }
 


### PR DESCRIPTION
The user can specify CAN_ISOTP_TX_DONT_WAIT to ignore transmit
confirmations, _isotp_conf_tx_tx() should be called in this case
as if confirmation was received immediately.

Signed-off-by: Anton Gerasimov <tossel@gmail.com>

UPD:
by the way, sending with confirmation doesn't seem to work in general case.