### PR TITLE
Makefile.include: always include board Makefile.features

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -234,7 +234,7 @@ export PREFIX ?= $(if $(TARGET_ARCH),$(TARGET_ARCH)-)
 INCLUDES += -I$(RIOTBASE)/core/include -I$(RIOTBASE)/drivers/include -I$(RIOTBASE)/sys/include
 
 # process provided features
--include $(RIOTBOARD)/$(BOARD)/Makefile.features
+include $(RIOTBOARD)/$(BOARD)/Makefile.features
 
 # mandatory includes!
 include $(RIOTMAKE)/pseudomodules.inc.mk


### PR DESCRIPTION
### Contribution description

makefiles/info-global.inc.mk already includes this file unconditionally.
So it is misleading to say it is optional.

### Testing procedure

Murdock compiling everything means it is working

### Issues/PRs references

Found while working on https://github.com/RIOT-OS/RIOT/issues/9913