### PR TITLE
dist/tools/jlink.sh: fix testrunner on stdio_rtt based devices

### DIFF
--- a/dist/tools/jlink/jlink.sh
+++ b/dist/tools/jlink/jlink.sh
@@ -245,7 +245,7 @@ do_term() {
             -speed '${JLINK_SPEED}' \
             -if '${JLINK_IF}' \
             -jtagconf -1,-1 \
-            -commandfile '${RIOTTOOLS}/jlink/term.seg' & \
+            -commandfile '${RIOTTOOLS}/jlink/term.seg' >/dev/null & \
             echo  \$! > $JLINK_PIDFILE" &
 
     sh -c "${JLINK_TERMPROG} ${JLINK_TERMFLAGS}"

--- a/dist/tools/jlink/jlink.sh
+++ b/dist/tools/jlink/jlink.sh
@@ -240,7 +240,7 @@ do_term() {
     # don't trapon Ctrl+C, because JLink keeps running
     trap '' INT
     # start Jlink as RTT server
-    setsid sh -c "${JLINK} ${JLINK_SERIAL} \
+    sh -c "${JLINK} ${JLINK_SERIAL} \
             -device '${JLINK_DEVICE}' \
             -speed '${JLINK_SPEED}' \
             -if '${JLINK_IF}' \


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->
This PR enables to run `make test` on devices using jlink as a debugger/programmer, along with stdio_rtt.
Currently this is not possible due to two things:

  - testrunner executes `make term` + `make reset` while running the test scripts, triggering two executions of `JLinkExe`. `make term` executes `JLinkExe` in background to then connect through `pyterm` to a TCP port. `JLinkExe` sends a prompt expecting for commands, but nothing is send and it seems to block other executions of itself. This is problematic since `make reset` also needs `JLinkExe` but it's locked by the previous command, thus `make test` fails. Sending the output to /dev/null unlocks `JLinkExe` and other instances of it can be launched.

  - testrunner kills the processes needed for `make term` when it exits, sending the KILL signal through `os.killpg` which should kill the processes group. However, for stdio_rtt, the term process needs a connection to the target through `JLinkExe`, which is executed in background but using `setsid`. This leads to `JLinkExe` not being part of the group and thus is not killed. `make test` would succeed but every time it's executed an instance of `JLinkExe` is left running. By removing `setsid` from the call the problem is solved. It seems to me that is a copy/paste leftover, otherwise I'd like to know why `setsid` is needed in this case.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->
Do `make test` for any supported test on a stdio_rtt based device.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
This helps to solve `make test` in Hamilton boards, from #9013.