### PR TITLE
cpu/esp8266: esp-now network device support

### DIFF
--- a/cpu/esp8266/Makefile.include
+++ b/cpu/esp8266/Makefile.include
@@ -49,7 +49,6 @@ export TARGET_ARCH ?= xtensa-lx106-elf
 
 # ESP8266 pseudomodules
 PSEUDOMODULES += esp_gdb
-PSEUDOMODULES += esp_now
 PSEUDOMODULES += esp_sdk
 PSEUDOMODULES += esp_sdk_int_handling
 PSEUDOMODULES += esp_sw_timer

--- a/cpu/esp8266/doc.txt
+++ b/cpu/esp8266/doc.txt
@@ -30,37 +30,47 @@
     6. [Timers](#esp8266_timers)
     7. [SPIFFS Device](#esp8266_spiffs_device)
     8. [Other Peripherals](#esp8266_other_peripherals)
-6. [Network Interfaces](#esp8266_network_interfaces)
+7. [Network Interfaces](#esp8266_network_interfaces)
     1. [WiFi Network Interface](#esp8266_wifi_network_interface)
     2. [ESP-NOW Network Interface](#esp8266_esp_now_network_interface)
-7. [Preconfigured Devices](#esp8266_preconfigured_devices)
+8. [Preconfigured Devices](#esp8266_preconfigured_devices)
     1. [Network Devices](#esp8266_network_devices)
     2. [SD-Card Device](#esp8266_sd_card_device)
-8. [Application-Specific Configurations](#esp8266_application_specific_configurations)
+9. [Application-Specific Configurations](#esp8266_application_specific_configurations)
     1. [Application-Specific Board Configuration](#esp8266_application_specific_board_configuration)
     2. [Application-Specific Driver Configuration](#esp8266_application_specific_driver_configuration)
-9. [SDK Task Handling](#esp8266_sdk_task_handling)
-10. [QEMU Mode and GDB](#esp8266_qemu_mode_and_gdb)
+10. [SDK Task Handling](#esp8266_sdk_task_handling)
+11. [QEMU Mode and GDB](#esp8266_qemu_mode_and_gdb)
 
 
 # <a name="esp8266_overview"> Overview </a> &nbsp;&nbsp; [[TOC](#esp8266_toc)]
 
 There are two implementations that can be used:
 
-- the **SDK version** which is realized on top of an SDK (*esp-open-sdk* or *ESP8266_NONOS_SDK*) and
+- the **SDK version** which is realized on top of an SDK (*esp-open-sdk* or
+  *ESP8266_NONOS_SDK*) and
 - the **non-SDK version** which is realized without the SDK.
 
-The non-SDK version produces a much smaller code size than the SDK version and is more efficient in execution because it does not need to run additional SDK functions to keep the SDK system alive.
+The non-SDK version produces a much smaller code size than the SDK version and
+is more efficient in execution because it does not need to run additional SDK
+functions to keep the SDK system alive.
 
-The **non-SDK version** is probably the **best choice if you do not need the built-in WiFi module**, for example, when you plan to connect an IEEE 802.15.4 radio module to the MCU for communication.
+The **non-SDK version** is probably the **best choice if you do not need the
+built-in WiFi module**, for example, when you plan to connect an IEEE 802.15.4
+radio module to the MCU for communication.
 
-By **default**, the **non-SDK version** is compiled. To compile the SDK version, add ```USE_SDK=1``` to the make command line, e.g.,
+By **default**, the **non-SDK version** is compiled. To compile the SDK
+version, enable module `esp_wifi`, for example, at the make command line:
 
 ```
-make flash BOARD=esp8266-esp-12x -C tests/shell USE_SDK=1 ...
+USEMODULE=esp_sdk make flash BOARD=esp8266-esp-12x -C tests/shell ...
 ```
 
-For more information about the make command variables, see section [Compile Options](#esp8266_compile_options).
+The SDK version is compiled automatically if one of the modules `esp_wifi`,
+`esp_now` or `esp_sw_timers` is enabled.
+
+For more information about the make command variables, see section
+[Compile Options](#esp8266_compile_options).
 
 # <a name="esp8266_short_configuration_reference"> Short Configuration Reference </a> &nbsp;[[TOC](#esp8266_toc)]
 
@@ -80,17 +90,18 @@ Parameter | Short Description                      | Type*
 
 <b>Type:</b> m - mandatory, o - optional# <a name=esp8266_mcu_esp8266> MCU ESP8266 </a> &nbsp;[[TOC](#esp8266_toc)]
 
-The following table gives a short reference  in alphabetical order of modules that can be enabled/disabled by board configurations and/or application's makefile using ```USEMODULE``` and ```DISABLE_MODULE```.
+The following table gives a short reference  in alphabetical order of modules that can be enabled/disabled by board configurations and/or application's makefile using `USEMODULE` and `DISABLE_MODULE`.
 
 <center>
 
 Module    | Default  | Short description
 ----------|----------|-------------------
-[esp_gdb](#esp8266_qemu_mode_and_gdb) | not used | enable the compilation with debug information for debugging
-[esp_now](#esp8266_esp_now_network_interface) | not used  | enable the ESP-NOW network device
-[esp_sdk](#esp8266_sdk_task_handling) | not used | Enable the SDK version, which is equivalent to using ```USE_SDK=1```
-[esp_spiffs](#esp8266_spiffs_device) | not used  |  Enable the SPIFFS drive in on-board flash memory
-[esp_sw_timer](#esp8266_timers) | not used | Enable software timer implementation, implies the module ```esp_sdk```
+[esp_gdb](#esp8266_qemu_mode_and_gdb) | not used | Enable the compilation with debug information for debugging.
+[esp_now](#esp8266_esp_now_network_interface) | not used  | Enable the ESP-NOW network device, implies the module `esp_sdk`.
+[esp_sdk](#esp8266_sdk_task_handling) | not used | Enable the SDK version.
+[esp_spiffs](#esp8266_spiffs_device) | not used  |  Enable the SPIFFS drive in on-board flash memory.
+[esp_sw_timer](#esp8266_timers) | not used | Enable software timer implementation, implies the module `esp_sdk`.
+[esp_wifi](#esp8266_wifi_network_interface) | not used | Enable the built-in WiFi module as `netdev` network device, implies the module `esp_sdk`.
 
 </center>
 
@@ -146,13 +157,13 @@ The RIOT-OS for ESP8266 SoCs supports the following features at the moment:
 
 To compile RIOT for The ESP8266 SoC, the following software components are required:
 
-- **esp-open-sdk** which includes the **Xtensa GCC** compiler toolchain, the hardware abstraction library **libhal** for Xtensa LX106, and the flash programmer tool <b>```esptool.py```</b>
+- **esp-open-sdk** which includes the **Xtensa GCC** compiler toolchain, the hardware abstraction library **libhal** for Xtensa LX106, and the flash programmer tool <b>`esptool.py`</b>
 - **newlib-c** library for Xtensa (esp-open-rtos version)
-- **SDK (optional)**, either as part of <b>```esp-open-sdk```</b> or the <b>```ESP8266_NONOS_SDK```</b>
+- **SDK (optional)**, either as part of <b>`esp-open-sdk`</b> or the <b>`ESP8266_NONOS_SDK`</b>
 
 You have the following options to install the Toolchain:
 
-- <b>```riotdocker```</b> image and <b>```esptool.py```</b>, see section [RIOT Docker Toolchain (riotdocker)](#esp8266_riot_docker_toolchain)
+- <b>`riotdocker`</b> image and <b>`esptool.py`</b>, see section [RIOT Docker Toolchain (riotdocker)](#esp8266_riot_docker_toolchain)
 - **precompiled toolchain** installation from GIT, see section [Precompiled Toolchain](#esp8266_toolchain_installation)
 - **manual installation**, see section [Manual Toolchain Installation](#esp8266_manual_toolchain_installation)
 
@@ -164,21 +175,21 @@ The easiest way to use the toolchain is Docker.
 
 Using RIOT Docker requires at least the following software:
 
-- <b>```Docker```</b> container virtualization software
-- RIOT Docker (<b>```riotdocker```</b>) image
-- flasher tool <b>```esptool.py```</b>
+- <b>`Docker`</b> container virtualization software
+- RIOT Docker (<b>`riotdocker`</b>) image
+- flasher tool <b>`esptool.py`</b>
 
 For information about installing Docker on your host, refer to the appropriate manuals for your operating system. For example, the easiest way to install Docker on the Ubuntu/Debian system is:
 ```
 sudo apt-get install docker.io
 ```
 
-The ESP Flasher tool <b>```esptool.py```</b> is available at [GitHub](https://github.com/espressif/esptool). To install the tool, either Python 2.7 or Python 3.4 or later must be installed. The latest stable version of ```esptool.py``` can be installed with ```pip```:
+The ESP Flasher tool <b>`esptool.py`</b> is available at [GitHub](https://github.com/espressif/esptool). To install the tool, either Python 2.7 or Python 3.4 or later must be installed. The latest stable version of `esptool.py` can be installed with `pip`:
 ```
 pip install esptool
 ```
 
-<b>```esptool.py```</b> depends on ```pySerial``` which can be installed either using ```pip```
+<b>`esptool.py`</b> depends on `pySerial` which can be installed either using `pip`
 
 ```
 pip install pyserial
@@ -187,13 +198,13 @@ or the package manager of your OS, for example on Debian/Ubuntu systems:
 ```
 apt-get install pyserial
 ```
-For more information on ```esptool.py```, please refer the [git repository](https://github.com/espressif/esptool)
+For more information on `esptool.py`, please refer the [git repository](https://github.com/espressif/esptool)
 
-Please make sure that ```esptool.py``` is in your ```PATH``` variable.
+Please make sure that `esptool.py` is in your `PATH` variable.
 
 ### <a name="esp8266_generating_docker_image"> Generating a riotdocker Image </a> &nbsp;[[TOC](#esp8266_toc)]
 
-A ```riotdocker``` fork that only installs the ```RIOT-Xtensa-ESP8266-toolchain``` is available at [GitHub](https://github.com/gschorcht/riotdocker-Xtensa-ESP.git). After cloning this git repository, you can use branch ```esp8266_only``` to generate a Docker image with a size of "only" 990 MByte:
+A `riotdocker` fork that only installs the `RIOT-Xtensa-ESP8266-toolchain` is available at [GitHub](https://github.com/gschorcht/riotdocker-Xtensa-ESP.git). After cloning this git repository, you can use branch `esp8266_only` to generate a Docker image with a size of "only" 990 MByte:
 
 ```
 git clone https://github.com/gschorcht/riotdocker-Xtensa-ESP.git
@@ -201,20 +212,20 @@ cd riotdocker-Xtensa-ESP
 git checkout esp8266_only
 docker build -t riotbuild .
 ```
-A ```riotdocker``` version that contains the toolchains for all different RIOT platforms can be found at [GitHub](https://github.com/RIOT-OS/riotdocker). However, the Docker image generated from the this Docker file has a size of about 1.5 GByte.
+A `riotdocker` version that contains the toolchains for all different RIOT platforms can be found at [GitHub](https://github.com/RIOT-OS/riotdocker). However, the Docker image generated from the this Docker file has a size of about 1.5 GByte.
 
 Once a Docker image has been created, it can be started with the following commands while in the RIOT root directory:
 ```
 cd /path/to/RIOT
 docker run -i -t --privileged -v /dev:/dev -u $UID -v $(pwd):/data/riotbuild riotbuild
 ```
-@note RIOT's root directory ```/path/to/RIOT``` becomes visible as the home directory of the ```riotbuild``` user in the Docker image. That is, the output of compilations performed in RIOT Docker is also accessible on the host system.
+@note RIOT's root directory `/path/to/RIOT` becomes visible as the home directory of the `riotbuild` user in the Docker image. That is, the output of compilations performed in RIOT Docker is also accessible on the host system.
 
 Please refer the [RIOT wiki](https://github.com/RIOT-OS/RIOT/wiki/Use-Docker-to-build-RIOT) on how to use the Docker image to compile RIOT OS.
 
 ### <a name="esp8266_using_existing_docker_image"> Using an Existing riotdocker Image </a> &nbsp;[[TOC](#esp8266_toc)]
 
-Alternatively, an existing Docker image from Docker Hub can be used. You can either pull and start the [schorcht/riotbuild_esp8266](https://hub.docker.com/r/schorcht/riotbuild_esp8266) Docker image which only contains the ```RIOT-Xtensa-ESP8266-toolchain``` using
+Alternatively, an existing Docker image from Docker Hub can be used. You can either pull and start the [schorcht/riotbuild_esp8266](https://hub.docker.com/r/schorcht/riotbuild_esp8266) Docker image which only contains the `RIOT-Xtensa-ESP8266-toolchain` using
 ```
 cd /path/to/RIOT
 docker run -i -t --privileged -v /dev:/dev -u $UID -v $(pwd):/data/riotbuild schorcht/riotbuild_esp8266
@@ -238,9 +249,9 @@ make BOARD=esp8266-esp-12x -C tests/shell ...
 ```
 This will generate a RIOT binary in ELF format.
 
-@note You can't use the ```flash``` target inside the Docker image.
+@note You can't use the `flash` target inside the Docker image.
 
-The RIOT binary has to be flash outside docker on the host system. Since the Docker image was stared while in RIOT's root directory, the output of the compilations is also accessible on the host system. On the host system, the ```flash-only``` target can then be used to flash the binary.
+The RIOT binary has to be flash outside docker on the host system. Since the Docker image was stared while in RIOT's root directory, the output of the compilations is also accessible on the host system. On the host system, the `flash-only` target can then be used to flash the binary.
 ```
 make flash-only BOARD=esp8266-esp-12x -C tests/shell
 ```
@@ -250,37 +261,37 @@ make flash-only BOARD=esp8266-esp-12x -C tests/shell
 
 You can get a precompiled version of the whole toolchain from the GIT repository [RIOT-Xtensa-ESP8266-toolchain](https://github.com/gschorcht/RIOT-Xtensa-ESP8266-toolchain). This repository contains the precompiled toolchain including all libraries that are necessary to compile RIOT-OS for ESP8266.
 
-@note To use the precompiled toolchain the following packages (Debian/Ubuntu) have to be installed:<br> ```cppcheck``` ```coccinelle``` ```curl``` ```doxygen``` ```git``` ```graphviz``` ```make``` ```pcregrep``` ```python``` ```python-serial``` ```python3``` ```python3-flake8``` ```unzip``` ```wget```
+@note To use the precompiled toolchain the following packages (Debian/Ubuntu) have to be installed:<br> `cppcheck` `coccinelle` `curl` `doxygen` `git` `graphviz` `make` `pcregrep` `python` `python-serial` `python3` `python3-flake8` `unzip` `wget`
 
 To install the toolchain use the following commands:
 ```
 cd /opt
 sudo git clone https://github.com/gschorcht/RIOT-Xtensa-ESP8266-toolchain.git esp
 ```
-After the installation, all components of the toolchain are installed in directory ```/opt/esp```. Of course, you can use any other location for the installation.
+After the installation, all components of the toolchain are installed in directory `/opt/esp`. Of course, you can use any other location for the installation.
 
-To use the toolchain, you have to add the path of the binaries to your ```PATH``` variable according to your toolchain location
+To use the toolchain, you have to add the path of the binaries to your `PATH` variable according to your toolchain location
 
 ```
 export PATH=$PATH:/path/to/toolchain/esp-open-sdk/xtensa-lx106-elf/bin
 ```
-where ```/path/to/toolchain/``` is the directory you selected for the installation of the toolchain. For the default installation in ```/opt/esp``` this would be:
+where `/path/to/toolchain/` is the directory you selected for the installation of the toolchain. For the default installation in `/opt/esp` this would be:
 ```
 export PATH=$PATH:/opt/esp/esp-open-sdk/xtensa-lx106-elf/bin
 ```
 
-Furthermore, you have to set variables ```ESP8266_SDK_DIR``` and ```ESP8266_NEWLIB_DIR``` according to the location of the toolchain.
+Furthermore, you have to set variables `ESP8266_SDK_DIR` and `ESP8266_NEWLIB_DIR` according to the location of the toolchain.
 ```
 export ESP8266_SDK_DIR=/path/to/toolchain/esp-open-sdk/sdk
 export ESP8266_NEWLIB_DIR=/path/to/toolchain/newlib-xtensa
 ```
-If you have used ```/opt/esp``` as installation directory, it is not necessary to set these variables since makefiles use them as default directories.
+If you have used `/opt/esp` as installation directory, it is not necessary to set these variables since makefiles use them as default directories.
 
 ## <a name="esp8266_manual_toolchain_installation"> Manual Toolchain Installation </a> &nbsp;[[TOC](#esp8266_toc)]
 
 The most difficult way to install the toolchain is the manual installation of required components as described below.
 
-@note Manual toolchain installation requires that the following packages (Debian/Ubuntu) are installed: ```autoconf``` ```automake``` ```bash``` ```bison``` ```build-essential``` ```bzip2``` ```coccinelle``` ```cppcheck``` ```curl``` ```doxygen``` ```g++``` ```gperf``` ```gawk``` ```gcc``` ```git``` ```graphviz``` ```help2man``` ```flex``` ```libexpat-dev``` ```libtool``` ```libtool-bin``` ```make``` ```ncurses-dev``` ```pcregrep``` ```python``` ```python-dev``` ```python-serial``` ```python3``` ```python3-flake8``` ```sed``` ```texinfo``` ```unrar-free``` ```unzip wget```
+@note Manual toolchain installation requires that the following packages (Debian/Ubuntu) are installed: `autoconf` `automake` `bash` `bison` `build-essential` `bzip2` `coccinelle` `cppcheck` `curl` `doxygen` `g++` `gperf` `gawk` `gcc` `git` `graphviz` `help2man` `flex` `libexpat-dev` `libtool` `libtool-bin` `make` `ncurses-dev` `pcregrep` `python` `python-dev` `python-serial` `python3` `python3-flake8` `sed` `texinfo` `unrar-free` `unzip wget`
 
 ### <a name="esp8266_installation_of_esp_open_sdk"> Installation of esp-open-sdk </a> &nbsp;[[TOC](#esp8266_toc)]
 
@@ -305,13 +316,13 @@ If you only plan to use the non-SDK version of the RIOT port or if you want to u
 make toolchain esptool libhal STANDALONE=n
 ```
 
-Once compilation has been finished, the toolchain is available in ```$PWD/xtensa-lx106-elf/bin```. To use it, set the ```PATH``` variable accordingly.
+Once compilation has been finished, the toolchain is available in `$PWD/xtensa-lx106-elf/bin`. To use it, set the `PATH` variable accordingly.
 
 ```
 export PATH=$ESP_OPEN_SDK_DIR/xtensa-lx106-elf/bin:$PATH
 ```
 
-If you have compiled the standalone version of esp-open-sdk and you plan to use this SDK version, set additionally the ```ESP8266_SDK_DIR``` variable.
+If you have compiled the standalone version of esp-open-sdk and you plan to use this SDK version, set additionally the `ESP8266_SDK_DIR` variable.
 
 ```
 export ESP8266_SDK_DIR=$ESP_OPEN_SDK_DIR/sdk
@@ -325,7 +336,7 @@ First, set the target directory for the installation.
 export ESP8266_NEWLIB_DIR=/path/to/esp/newlib-xtensa
 ```
 
-Please take care, to use the newlib-c version that was modified for esp-open-rtos since it includes ```stdatomic.h```.
+Please take care, to use the newlib-c version that was modified for esp-open-rtos since it includes `stdatomic.h`.
 
 ```
 cd /my/source/dir
@@ -353,7 +364,7 @@ cd /path/to/esp
 tar xvfz /downloads/ESP8266_NONOS_SDK-2.1.0.tar.gz
 ```
 
-To use the installed SDK, set variable ```ESP8266_SDK_DIR``` accordingly.
+To use the installed SDK, set variable `ESP8266_SDK_DIR` accordingly.
 
 ```
 export ESP8266_SDK_DIR=/path/to/esp/ESP8266_NONOS_SDK-2.1.0
@@ -395,30 +406,30 @@ The compilation process can be controlled by a number of variables for the make 
 
 Option | Values | Default | Description
 -------|--------|---------|------------
-ENABLE_GDB | 0, 1 | 0 | Enable compilation with debug information for debugging with QEMU (```QEMU=1```), see section [QEMU Mode and GDB](#esp8266_qemu_mode_and_gdb)
+ENABLE_GDB | 0, 1 | 0 | Enable compilation with debug information for debugging with QEMU (`QEMU=1`), see section [QEMU Mode and GDB](#esp8266_qemu_mode_and_gdb)
 FLASH_MODE | dout, dio, qout, qio | dout | Set the flash mode, please take care with your module, see section [Flash Modes](#esp8266_flash_modes)
 PORT | /dev/ttyUSBx | /dev/* | Set the USB port for flashing the firmware
 QEMU | 0, 1 | 0 | Generate an image for QEMU, see section [QEMU Mode and GDB](#esp8266_qemu_mode_and_gdb).
-USE_SDK | 0, 1 | 0 | Compile the SDK version (```USE_SDK=1```), see section [SDK Task Handling](#esp8266_sdk_task_handling)
+USE_SDK | 0, 1 | 0 | Compile the SDK version (`USE_SDK=1`), see section [SDK Task Handling](#esp8266_sdk_task_handling)
 
 </center><br>
 
-Optional features of ESP8266 can be enabled by ```USEMODULE``` definitions in the makefile of the application. These are:
+Optional features of ESP8266 can be enabled by `USEMODULE` definitions in the makefile of the application. These are:
 
 <center>
 
 Module | Description
 -------|------------
-[esp_gdb](#esp8266_qemu_mode_and_gdb) | Enable the compilation with debug information, which is equivalent to using ```ENABLE_GDB=1```
-[esp_now](#esp8266_esp_now_network_interface) | Enable the built-in WiFi module with the ESP-NOW protocol as `netdev` network device
-[esp_sdk](#esp8266_sdk_task_handling) | Enable the SDK version, which is equivalent to using ```USE_SDK=1```
+[esp_gdb](#esp8266_qemu_mode_and_gdb) | Enable the compilation with debug information, which is equivalent to using `ENABLE_GDB=1`.
+[esp_now](#esp8266_esp_now_network_interface) | Enable the built-in WiFi module with the ESP-NOW protocol as `netdev` network device, implies the setting module `esp_sdk`.
+[esp_sdk](#esp8266_sdk_task_handling) | Enable the SDK version, which is equivalent to using `USE_SDK=1`.
 [esp_spiffs](#esp8266_spiffs_device) | Enable the SPIFFS drive in on-board flash memory
-[esp_sw_timer](#esp8266_timers) | Enable software timer implementation, implies the setting ```USE_SDK=1``` (module ```esp_sdk```)
-[esp_wifi](#esp8266_wifi_network_interface) | Use the built-in WiFi module as `netdev` network device
+[esp_sw_timer](#esp8266_timers) | Enable software timer implementation, implies the setting module `esp_sdk`.
+[esp_wifi](#esp8266_wifi_network_interface) | Use the built-in WiFi module as `netdev` network device, implies the setting module `esp_sdk`.
 
 </center><br>
 
-For example, to activate the SPIFFS drive in on-board flash memory, the makefile of application has simply to add the ```esp_spiffs``` module to ```USEMODULE``` make variable:
+For example, to activate the SPIFFS drive in on-board flash memory, the makefile of application has simply to add the `esp_spiffs` module to `USEMODULE` make variable:
 ```
 USEMODULE += esp_spiffs
 ```
@@ -430,13 +441,13 @@ USEMODULE="esp_spiffs" make BOARD=...
 
 ## <a name="esp8266_flash_modes"> Flash Modes </a> &nbsp;[[TOC](#esp8266_toc)]
 
-The ```FLASH_MODE``` make command variable determines the mode that is used for flash access in normal operation.
+The `FLASH_MODE` make command variable determines the mode that is used for flash access in normal operation.
 
-The flash mode determines whether 2 data lines (```dio``` and ```dout```) or 4 data lines (```qio``` and ```qout```) for addressing and data access. For each data line, one GPIO is required. Therefore, using ```qio``` or ```qout``` increases the performance of SPI Flash data transfers, but uses two additional GPIOs (GPIO9 and GPIO10). That is, in this flash modes these GPIOs are not available for other purposes. If you can live with lower flash data transfer rates, you should always use ```dio``` or ```dout``` to keep GPIO9 and GPIO10 free for other purposes.
+The flash mode determines whether 2 data lines (`dio` and `dout`) or 4 data lines (`qio` and `qout`) for addressing and data access. For each data line, one GPIO is required. Therefore, using `qio` or `qout` increases the performance of SPI Flash data transfers, but uses two additional GPIOs (GPIO9 and GPIO10). That is, in this flash modes these GPIOs are not available for other purposes. If you can live with lower flash data transfer rates, you should always use `dio` or `dout` to keep GPIO9 and GPIO10 free for other purposes.
 
 For more information about these flash modes, refer the documentation of [esptool.py](https://github.com/espressif/esptool/wiki/SPI-Flash-Modes).
 
-@note While ESP8266 modules can be flashed with ```qio```, ```qout```, ```dio``` and ```dout```, ESP8285 modules have to be always flashed in ```dout``` mode. The default flash mode is ```dout```.
+@note While ESP8266 modules can be flashed with `qio`, `qout`, `dio` and `dout`, ESP8285 modules have to be always flashed in `dout` mode. The default flash mode is `dout`.
 
 ## <a name="esp8266_erasing"> Erasing the Device </a> &nbsp;[[TOC](#esp8266_toc)]
 
@@ -454,9 +465,9 @@ esptool.py erase_flash
 esptool.py write_flash <address> $RIOTBASE/cpu/esp8266/bin/esp_init_data_default.bin
 ```
 
-where ```address``` depends on ESP8266 chip version.
+where `address` depends on ESP8266 chip version.
 
-Chip version | ```address``` | Module examples
+Chip version | `address` | Module examples
 ------------ | ------------- | ----------------
 512 kByte | 0x07c000 | ESP-01, ESP-03, ESP-07, etc.
 1 MByte   | 0x0fc000 | ESP8285-based modules like Wemos D1 mini lite, PSF-A85, some ESP-01, ESP-03 etc.
@@ -485,8 +496,8 @@ GPIO5  | |
 GPIO6  | Flash SPI
 GPIO7  | Flash SPI
 GPIO8  | Flash SPI
-GPIO9  | Flash SPI in ```qout``` and ```qio``` mode, see section [Flash Modes](#esp8266_flash_modes)
-GPIO10 | Flash SPI in ```qout``` and ```qio``` mode, see section [Flash Modes](#esp8266_flash_modes)
+GPIO9  | Flash SPI in `qout` and `qio` mode, see section [Flash Modes](#esp8266_flash_modes)
+GPIO10 | Flash SPI in `qout` and `qio` mode, see section [Flash Modes](#esp8266_flash_modes)
 GPIO11 | Flash SPI
 GPIO12 | |
 GPIO13 | |
@@ -516,15 +527,15 @@ ESP8266 has **one dedicated ADC** pin with a resolution of 10 bits. This ADC pin
 
 ## <a name="esp8266_pwm_channels"> PWM Channels </a> &nbsp;[[TOC](#esp8266_toc)]
 
-The hardware implementation of ESP8266 PWM supports only frequencies as power of two. Therefore, a **software implementation** of **one PWM device** (```PWM_DEV(0)```) with up to **8 PWM channels** (```PWM_CHANNEL_NUM_MAX```) is used.
+The hardware implementation of ESP8266 PWM supports only frequencies as power of two. Therefore, a **software implementation** of **one PWM device** (`PWM_DEV(0)`) with up to **8 PWM channels** (`PWM_CHANNEL_NUM_MAX`) is used.
 
 @note The minimum PWM period that can be realized with this software implementation is 10 us or 100.000 PWM clock cycles per second. Therefore, the product of frequency and resolution should not be greater than 100.000. Otherwise the frequency is scaled down automatically.
 
-GPIOs that can be used as channels of the PWM device ```PWM_DEV(0)``` are defined by ```PWM0_CHANNEL_GPIOS```. By default, GPIOs 2, 4 and 5 are defined as PWM channels. As long as these channels are not started with function ```pwm_set```, they can be used as normal GPIOs for other purposes.
+GPIOs that can be used as channels of the PWM device `PWM_DEV(0)` are defined by `PWM0_CHANNEL_GPIOS`. By default, GPIOs 2, 4 and 5 are defined as PWM channels. As long as these channels are not started with function `pwm_set`, they can be used as normal GPIOs for other purposes.
 
-GPIOs in ```PWM0_CHANNEL_GPIOS``` with a duty cycle value of 0 can be used as normal GPIOs for other purposes. GPIOs in ```PWM0_CHANNEL_GPIOS``` that are used for other purposes, e.g., I2C or SPI, are no longer available as PWM channels.
+GPIOs in `PWM0_CHANNEL_GPIOS` with a duty cycle value of 0 can be used as normal GPIOs for other purposes. GPIOs in `PWM0_CHANNEL_GPIOS` that are used for other purposes, e.g., I2C or SPI, are no longer available as PWM channels.
 
-To define other GPIOs as PWM channels, just overwrite the definition of ```PWM_CHANNEL_GPIOS``` in an [application-specific board configuration](#esp8266_application_specific_board_configuration)
+To define other GPIOs as PWM channels, just overwrite the definition of `PWM_CHANNEL_GPIOS` in an [application-specific board configuration](#esp8266_application_specific_board_configuration)
 
 ```
 #define PWM0_CHANNEL_GPIOS { GPIO12, GPIO13, GPIO14, GPIO15 }
@@ -532,15 +543,15 @@ To define other GPIOs as PWM channels, just overwrite the definition of ```PWM_C
 
 ## <a name="esp8266_i2c_interfaces"> I2C Interfaces </a> &nbsp;[[TOC](#esp8266_toc)]
 
-Since the ESP8266 does not or only partially support the I2C in hardware, I2C interfaces are realized as **bit-banging protocol in software**. The maximum usable bus speed is ```I2C_SPEED_FAST_PLUS```. The maximum number of buses that can be defined is 2, ```I2C_DEV(0)``` ... ```I2C_DEV(1)```.
+Since the ESP8266 does not or only partially support the I2C in hardware, I2C interfaces are realized as **bit-banging protocol in software**. The maximum usable bus speed is `I2C_SPEED_FAST_PLUS`. The maximum number of buses that can be defined is 2, `I2C_DEV(0)` ... `I2C_DEV(1)`.
 
-The board-specific configuration of the I2C interface <b>```I2C_DEV(n)```</b> requires the definition of
+The board-specific configuration of the I2C interface <b>`I2C_DEV(n)`</b> requires the definition of
 
-- <b>```I2Cn_SPEED```</b>, the bus speed,
-- <b>```I2Cn_SCL```</b>, the GPIO used as SCL signal, and
-- <b>```I2Cn_SDA```</b>, the GPIO used as SDA signal,
+- <b>`I2Cn_SPEED`</b>, the bus speed,
+- <b>`I2Cn_SCL`</b>, the GPIO used as SCL signal, and
+- <b>`I2Cn_SDA`</b>, the GPIO used as SDA signal,
 
-where ```n``` can be 0 or 1. If they are not defined, the I2C interface ```I2C_DEV(n)``` is not used.
+where `n` can be 0 or 1. If they are not defined, the I2C interface `I2C_DEV(n)` is not used.
 
 In the following example, only one I2C bus is defined:
 
@@ -574,7 +585,7 @@ ESP8266 provides two hardware SPI interfaces:
 - _FSPI_ for flash memory access that is usually simply referred to as _SPI_
 - _HSPI_ for peripherals
 
-Even though _FSPI_ (or simply _SPI_) is a normal SPI interface, it is not possible to use it for peripherals. **HSPI is therefore the only usable SPI interface** available for peripherals as RIOT's ```SPI_DEV(0)```.
+Even though _FSPI_ (or simply _SPI_) is a normal SPI interface, it is not possible to use it for peripherals. **HSPI is therefore the only usable SPI interface** available for peripherals as RIOT's `SPI_DEV(0)`.
 
 The pin configuration of the _HSPI_ interface is defined as shown in the following table. Only the CS signal can be configured and overridden by [application-specific card configuration] (# esp8266_application_specific_board_configuration).
 
@@ -589,14 +600,14 @@ CS   | GPIO15
 
 </center>
 
-When SPI is enabled using module ```periph_spi```, these GPIOs cannot be used for any other purpose. The given CS pin is used when ```spi_acquire``` is called with ```cs=GPIO_UNDEF``` parameter.
+When SPI is enabled using module `periph_spi`, these GPIOs cannot be used for any other purpose. The given CS pin is used when `spi_acquire` is called with `cs=GPIO_UNDEF` parameter.
 
 To the default CS can be overridden as following:
 ```
 #define SPI0_CS0_GPIO    GPIO15     /* HSPI/SPI_DEV(0) CS default pin */
 ```
 
-GPIOs 0, 2, 4, 5, 15, and 16 can be used as CS signal. In ```dio``` and ```dout``` flash modes (see section [Flash Modes](#esp8266_flash_modes)), GPIOs 9 and 10 can also be used as CS signal.
+GPIOs 0, 2, 4, 5, 15, and 16 can be used as CS signal. In `dio` and `dout` flash modes (see section [Flash Modes](#esp8266_flash_modes)), GPIOs 9 and 10 can also be used as CS signal.
 
 ## <a name="esp8266_timers"> Timers </a> &nbsp;[[TOC](#esp8266_toc)]
 
@@ -607,50 +618,22 @@ There are two timer implementations:
 
 By default, the **hardware timer implementation** is used.
 
-When the SDK version of the RIOT port (```USE_SDK=1```) is used, the **software timer** implementation is activated by using module ```esp_sw_timer```.
+When the SDK version of the RIOT port (`USE_SDK=1`) is used, the **software timer** implementation is activated by using module `esp_sw_timer`.
 
 The software timer uses SDK's software timers to implement the timer channels. Although these SDK timers usually have a precision of a few microseconds, they can deviate up to 500 microseconds. So if you need a timer with high accuracy, you'll need to use the hardware timer with only one timer channel.
 
-@note When module ```esp_sw_timer``` is used, the SDK version is automatically compiled (```USE_SDK=1```).
+@note When module `esp_sw_timer` is used, the SDK version is automatically compiled (`USE_SDK=1`).
 
 ## <a name="esp8266_spiffs_device"> SPIFFS Device </a> &nbsp;[[TOC](#esp8266_toc)]
 
-If SPIFFS module is enabled (```USEMODULE += esp_spiffs```), the implemented MTD system drive ```mtd0``` for the on-board SPI flash memory is used together with modules ```spiffs``` and ```vfs``` to realize a persistent file system.
+If SPIFFS module is enabled (`USEMODULE += esp_spiffs`), the implemented MTD system drive `mtd0` for the on-board SPI flash memory is used together with modules `spiffs` and `vfs` to realize a persistent file system.
 
-For this purpose, the flash memory is formatted as SPIFFS starting at the address ```0x80000``` (512 kByte) on first boot. All sectors up to the last 5 sectors of the flash memory are then used for the file system. With a fixed sector size of 4096 bytes, the top address of the SPIFF is ```flash_size - 5 * 4096```, e.g., ```0xfb000``` for a flash memory of 1 MByte. The size of the SPIFF then results from:
+For this purpose, the flash memory is formatted as SPIFFS starting at the address `0x80000` (512 kByte) on first boot. All sectors up to the last 5 sectors of the flash memory are then used for the file system. With a fixed sector size of 4096 bytes, the top address of the SPIFF is `flash_size - 5 * 4096`, e.g., `0xfb000` for a flash memory of 1 MByte. The size of the SPIFF then results from:
 ```
 flash_size - 5 * 4096 - 512 kByte
 ```
 
-Please refer file ```$RIOTBASE/tests/unittests/test-spiffs/tests-spiffs.c``` for more information on how to use SPIFFS and VFS together with a MTD device ```mtd0``` alias ```MTD_0```.
-
-## <a name="esp8266_esp_now_network_interface"> ESP-NOW Network Interface </a> &nbsp;[[TOC](#esp8266_toc)]
-
-With ESP-NOW, the ESP8266 provides a connectionless communication technology, featuring short packet transmission. It applies the IEEE802.11 Action Vendor frame technology, along with the IE function developed by Espressif, and CCMP encryption technology, realizing a secure, connectionless communication solution.
-
-The RIOT port for ESP8266 implements in module ```esp_now``` a ```netdev``` driver which uses ESP-NOW to provide a link layer interface to a meshed network of ESP8266 nodes. In this network, each node can send short packets with up to 250 data bytes to all other nodes that are visible in its range.
-
-@note Due to symbol conflicts in the ```esp_idf_wpa_supplicant_crypto``` module used by the ```esp_now``` with RIOT's ```crypto``` and ```hashes``` modules, ESP-NOW cannot be used for application that use these modules.
-
-Therefore, the module ```esp_now``` is not enabled automatically if the ```netdev_default``` module is used. Instead, the application has to add the ```esp_now``` module in its makefile when needed.
-```
-USEMODULE += esp_now
-```
-
-For ESP-NOW, ESP8266 nodes are used in WiFi SoftAP + Station mode to advertise their SSID and become visible to other ESP8266 nodes. The SSID of an ESP8266 node is the concatenation of the prefix ```RIOT_ESP_``` with the MAC address of its SoftAP WiFi interface. The driver periodically scans all visible ESP8266 nodes.
-
-The following parameters are defined for ESP-NOW nodes. These parameters can be overriden by [application-specific board configurations](#esp8266_application_specific_board_configuration).
-
-<center>
-
-Parameter | Default | Description
-:---------|:--------|:-----------
-ESP_NOW_SCAN_PERIOD | 10000000UL | Defines the period in us at which an node scans for other nodes in its range. The default period is 10 s.
-ESP_NOW_SOFT_AP_PASSPHRASE | ThisistheRIOTporttoESP | Defines the passphrase (max. 64 chars) that is used for the SoftAP interface of an nodes. It has to be same for all nodes in one network.
-ESP_NOW_CHANNEL | 6 | Defines the channel that is used as the broadcast medium by all nodes together.
-ESP_NOW_KEY | NULL | Defines a key that is used for encrypted communication between nodes. If it is NULL, encryption is disabled. The key has to be of type ```uint8_t[16]``` and has to be exactly 16 bytes long.
-
-</center>
+Please refer file `$RIOTBASE/tests/unittests/test-spiffs/tests-spiffs.c` for more information on how to use SPIFFS and VFS together with a MTD device `mtd0` alias `MTD_0`.
 
 ## <a name="esp8266_other_peripherals"> Other Peripherals </a> &nbsp;[[TOC](#esp8266_toc)]
 
@@ -667,7 +650,7 @@ RTC is not yet implemented.
 
 ESP8266 provides different built-in possibilities to realize network devices:
 
-- <b>ESP WiFi</b>, usual AP-based wireless LAN (not yet supported)
+- <b>ESP WiFi</b>, usual AP-based infrastructure mode wireless LAN
 - <b>ESP-NOW</b>, a WiFi based AP-less and connectionless peer to peer communication protocol
 
 \anchor esp8266_wifi_network_interface
@@ -679,7 +662,7 @@ the built-in WiFi interface.
 @note Due to symbol conflicts with the `crypto` and `hash` modules of RIOT
 in vendor library `libwpa.so`, which is required by module
 `esp_wifi`, `esp_wifi` cannot be used for applications that use these modules.
-Therefore, module `esp_wifi` is not automatically enabled when module
+Therefore, module **`esp_wifi` is not automatically enabled** when module
 `netdev_default` is used. Instead, if necessary, the application has to add
 the module `esp_wifi` in the Makefile.
 
@@ -695,14 +678,13 @@ Parameter          | Default                   | Description
 :------------------|:--------------------------|:------------
 ESP_WIFI_SSID      | "RIOT_AP"                 | SSID of the AP to be used.
 ESP_WIFI_PASS      | "ThisistheRIOTporttoESP"  | Passphrase used for the AP as clear text (max. 64 chars).
-ESP_WIFI_STACKSIZE | #THREAD_STACKSIZE_DEFAULT |Stack size used for the WiFi netdev driver thread.
+ESP_WIFI_STACKSIZE | 1536                      | Stack size used for the WiFi netdev driver thread.
 
 </center>
 
 These configuration parameter definitions, as well as enabling the `esp_wifi`
 module, can be done either in the makefile of the project or at make command
 line, e.g.:
-
 ```
 USEMODULE=esp_wifi \
 CFLAGS='-DESP_WIFI_SSID=\"MySSID\" -DESP_WIFI_PASS=\"MyPassphrase\"' \
@@ -729,8 +711,8 @@ ESP8266 nodes. In this network, each node can send short packets with up to
 
 @note Due to symbol conflicts in vendor library `libwpa.so` used by the
 `esp_now` with RIOT's `crypto` and `hashes` modules, ESP-NOW cannot be used
-for application that use these modules. Therefore, the module `esp_now` is
-not enabled automatically if the `netdev_default` module is used. Instead,
+for application that use these modules. Therefore, the module **`esp_now` is
+not enabled automatically** if the `netdev_default` module is used. Instead,
 the application has to add the `esp_now` module in its makefile when needed.<br>
 ```
 USEMODULE += esp_now
@@ -752,9 +734,20 @@ Parameter | Default | Description
 ESP_NOW_SCAN_PERIOD | 10000000UL | Defines the period in us at which an node scans for other nodes in its range. The default period is 10 s.
 ESP_NOW_SOFT_AP_PASS | "ThisistheRIOTporttoESP" | Defines the passphrase as clear text (max. 64 chars) that is used for the SoftAP interface of ESP-NOW nodes. It has to be same for all nodes in one network.
 ESP_NOW_CHANNEL | 6 | Defines the channel that is used as the broadcast medium by all nodes together.
-ESP_NOW_KEY | NULL | Defines a key that is used for encrypted communication between nodes. If it is NULL, encryption is disabled. The key has to be of type ```uint8_t[16]``` and has to be exactly 16 bytes long.
+ESP_NOW_KEY | NULL | Defines a key that is used for encrypted communication between nodes. If it is NULL, encryption is disabled. The key has to be of type `uint8_t[16]` and has to be exactly 16 bytes long.
+ESP_WIFI_STACKSIZE | @ref THREAD_STACKSIZE_DEFAULT | Stack size used for the WiFi netdev driver thread.
 
 </center>
+
+These configuration parameter definitions, as well as enabling the `esp_wifi`
+module, can be done either in the makefile of the project or at make command
+line, e.g.:
+
+```
+USEMODULE=esp_now \
+CFLAGS='-DESP_NOW_CHANNEL=8 -DESP_NOW_SOFT_AP_PASS=\"MyPassphrase\"' \
+make -C examples/gnrc_networking BOARD=...
+```
 
 @note The ESP-NOW network interface (module `esp_now`) and the
 [Wifi network interface](#esp8266_wifi_network_interface) (module `esp_wifi`)
@@ -772,15 +765,15 @@ RIOT provides a number of driver modules for different types of network devices,
 - [mrf24j40](https://riot-os.org/api/group__drivers__mrf24j40.html) (driver for Microchip MRF24j40 based IEEE 802.15.4
 - [enc28j60](https://riot-os.org/api/group__drivers__enc28j60.html) (driver for Microchip ENC28J60 based Ethernet modules)
 
-### <a name="esp8266_using_mrf24j40"> Using MRF24J40 (module ```mrf24j40```) </a> &nbsp;[[TOC](#esp8266_toc)]
+### <a name="esp8266_using_mrf24j40"> Using MRF24J40 (module `mrf24j40`) </a> &nbsp;[[TOC](#esp8266_toc)]
 
-To use MRF24J40 based IEEE 802.15.4 modules as network device, the ```mrf24j40``` driver module has to be added to the makefile of the application:
+To use MRF24J40 based IEEE 802.15.4 modules as network device, the `mrf24j40` driver module has to be added to the makefile of the application:
 
 ```
 USEMODULE += mrf24j40
 ```
 
-The ```mrf24j40``` driver module uses the following preconfigured interface parameters for ESP8266 boards:
+The `mrf24j40` driver module uses the following preconfigured interface parameters for ESP8266 boards:
 
 <center>
 
@@ -796,15 +789,15 @@ MRF24J40_PARAM_RESET   | GPIO2        | can be overridden
 
 The GPIOs in this configuration can be overridden by [application-specific board configurations](#esp8266_application_specific_board_configuration).
 
-### <a name="esp8266_using_enc28j60"> Using ENC28J60 (module ```enc28j60```) </a> &nbsp;[[TOC](#esp8266_toc)]
+### <a name="esp8266_using_enc28j60"> Using ENC28J60 (module `enc28j60`) </a> &nbsp;[[TOC](#esp8266_toc)]
 
-To use ENC28J60 Ethernet modules as network device, the ```enc28j60``` driver module has to be added to the makefile of the application:
+To use ENC28J60 Ethernet modules as network device, the `enc28j60` driver module has to be added to the makefile of the application:
 
 ```
 USEMODULE += enc28j60
 ```
 
-The ```enc28j60``` driver module uses the following preconfigured interface parameters for ESP8266 boards:
+The `enc28j60` driver module uses the following preconfigured interface parameters for ESP8266 boards:
 
 <center>
 
@@ -821,13 +814,13 @@ The GPIOs in this configuration can be overridden by [application-specific board
 
 ## <a name="esp8266_sd_card_device"> SD-Card Device </a> &nbsp;[[TOC](#esp8266_toc)]
 
-ESP8266 port of RIOT is preconfigured for RIOT applications that use the [SPI SD-Card driver](https://riot-os.org/api/group__drivers__sdcard__spi.html). To use SPI SD-Card driver, the ```sdcard_spi``` module has to be added to a makefile:
+ESP8266 port of RIOT is preconfigured for RIOT applications that use the [SPI SD-Card driver](https://riot-os.org/api/group__drivers__sdcard__spi.html). To use SPI SD-Card driver, the `sdcard_spi` module has to be added to a makefile:
 
 ```
 USEMODULE += sdcard_spi
 ```
 
-The ```sdcard_spi``` driver module uses the following preconfigured interface parameters for ESP8266 boards:
+The `sdcard_spi` driver module uses the following preconfigured interface parameters for ESP8266 boards:
 
 <center>
 
@@ -844,15 +837,15 @@ The GPIO used as CS signal can be overridden by [application-specific board conf
 \anchor esp8266_app_spec_conf
 # <a name="esp8266_application_specific_configurations"> Application-Specific Configurations </a> &nbsp;[[TOC](#esp8266_toc)]
 
-The board-specific configuration files ```board.h``` and ```periph_conf.h``` as well as the driver parameter configuration files ```<driver>_params.h``` define the default configurations for peripherals and device driver modules. These are, for example, the GPIOs used, bus interfaces used or available bus speeds. Because there are many possible configurations and many different application requirements, these default configurations are usually only a compromise between different requirements.
+The board-specific configuration files `board.h` and `periph_conf.h` as well as the driver parameter configuration files `<driver>_params.h` define the default configurations for peripherals and device driver modules. These are, for example, the GPIOs used, bus interfaces used or available bus speeds. Because there are many possible configurations and many different application requirements, these default configurations are usually only a compromise between different requirements.
 
 Therefore, it is often necessary to change some of these default configurations for individual applications. For example, while many PWM channels are needed in one application, another application does not need PWM channels, but many ADC channels.
 
 ## <a name="esp8266_application_specific_board_configuration"> Application-Specific Board Configuration </a> &nbsp;[[TOC](#esp8266_toc)]
 
-To override default board configurations, simply create an application-specific board configuration file ```$APPDIR/board.h``` in the source directory ```$APPDIR``` of the application and add the definitions to be overridden. To force the preprocessor to include board's original ```board.h``` after that, add the ```include_next``` preprocessor directive as the <b>last</b> line.
+To override default board configurations, simply create an application-specific board configuration file `$APPDIR/board.h` in the source directory `$APPDIR` of the application and add the definitions to be overridden. To force the preprocessor to include board's original `board.h` after that, add the `include_next` preprocessor directive as the <b>last</b> line.
 
-For example to override the default definition of the GPIOs that are used as PWM channels, the application-specific board configuration file ```$APPDIR/board.h``` could look like the following:
+For example to override the default definition of the GPIOs that are used as PWM channels, the application-specific board configuration file `$APPDIR/board.h` could look like the following:
 ```
 #ifdef CPU_ESP8266
 #define PWM0_CHANNEL_GPIOS { GPIO12, GPIO13, GPIO14, GPIO15 }
@@ -861,7 +854,7 @@ For example to override the default definition of the GPIOs that are used as PWM
 #include_next "board.h"
 ```
 
-It is important to ensure that the application-specific board configuration ```$APPDIR/board.h``` is included first. Insert the following line as the <b>first</b> line to the application makefile ```$APPDIR/Makefile```.
+It is important to ensure that the application-specific board configuration `$APPDIR/board.h` is included first. Insert the following line as the <b>first</b> line to the application makefile `$APPDIR/Makefile`.
 ```
 INCLUDES += -I$(APPDIR)
 ```
@@ -879,9 +872,9 @@ INCLUDES += -I$(APPDIR)
 
 ## <a name="esp8266_application_specific_driver_configuration"> Application-Specific Driver Configuration </a> &nbsp;[[TOC](#esp8266_toc)]
 
-Using the approach for overriding board configurations, the parameters of drivers that are typically defined in ```drivers/<device>/include/<device>_params.h``` can be overridden. For that purpose just create an application-specific driver parameter file ```$APPDIR/<device>_params.h``` in the source directory ```$APPDIR``` of the application and add the definitions to be overridden. To force the preprocessor to include driver's original ```<device>_params.h``` after that, add the ```include_next``` preprocessor directive as the <b>last</b> line.
+Using the approach for overriding board configurations, the parameters of drivers that are typically defined in `drivers/<device>/include/<device>_params.h` can be overridden. For that purpose just create an application-specific driver parameter file `$APPDIR/<device>_params.h` in the source directory `$APPDIR` of the application and add the definitions to be overridden. To force the preprocessor to include driver's original `<device>_params.h` after that, add the `include_next` preprocessor directive as the <b>last</b> line.
 
-For example, to override a GPIO used for LIS3DH sensor, the application-specific driver parameter file ```$APPDIR/<device>_params.h``` could look like the following:
+For example, to override a GPIO used for LIS3DH sensor, the application-specific driver parameter file `$APPDIR/<device>_params.h` could look like the following:
 ```
 #ifdef CPU_ESP8266
 #define LIS3DH_PARAM_INT2           (GPIO_PIN(0, 4))
@@ -890,7 +883,7 @@ For example, to override a GPIO used for LIS3DH sensor, the application-specific
 #include_next "lis3dh_params.h"
 ```
 
-It is important to ensure that the application-specific driver parameter file ```$APPDIR/<device>_params.h``` is included first. Insert the following line as the <b>first</b> line to the application makefile ```$APPDIR/Makefile```.
+It is important to ensure that the application-specific driver parameter file `$APPDIR/<device>_params.h` is included first. Insert the following line as the <b>first</b> line to the application makefile `$APPDIR/Makefile`.
 ```
 INCLUDES += -I$(APPDIR)
 ```
@@ -944,13 +937,13 @@ then calls function `ets_run` to process pending events.
 
 @note Since the non-SDK version of RIOT is much smaller and faster than the
 SDK version, you should always compile your application without the SDK
-(```USE_SDK=0```, the default) if you don't need the built-in WiFi module.
+(`USE_SDK=0`, the default) if you don't need the built-in WiFi module.
 
 # <a name="esp8266_qemu_mode_and_gdb"> QEMU Mode and GDB </a> &nbsp;[[TOC](#esp8266_toc)]
 
-When QEMU mode is enabled (```QEMU=1```), instead of loading the image to the target hardware, a binary image ```$ELFFILE.bin``` is created in the target directory. This binary image file can be used together with QEMU to debug the code in GDB.
+When QEMU mode is enabled (`QEMU=1`), instead of loading the image to the target hardware, a binary image `$ELFFILE.bin` is created in the target directory. This binary image file can be used together with QEMU to debug the code in GDB.
 
-The binary image can be compiled with debugging information (```ENABLE_GDB=1``` or module ```esp_gdb```) or optimized without debugging information (```ENABLE_GDB=0```). The latter one is the default. The version with debugging information can be debugged in source code while the optimized version can only be debugged in assembler mode.
+The binary image can be compiled with debugging information (`ENABLE_GDB=1` or module `esp_gdb`) or optimized without debugging information (`ENABLE_GDB=0`). The latter one is the default. The version with debugging information can be debugged in source code while the optimized version can only be debugged in assembler mode.
 
 To use QEMU, you have to install QEMU for Xtensa with ESP8266 machine implementation as following.
 
@@ -965,13 +958,13 @@ make
 make install
 ```
 
-Once the compilation has been finished, QEMU for Xtensa with ESP8266 machine implementation should be available in ```/path/to/esp/qemu/bin``` and you can start it with
+Once the compilation has been finished, QEMU for Xtensa with ESP8266 machine implementation should be available in `/path/to/esp/qemu/bin` and you can start it with
 
 ```
 $QEMU/bin/qemu-system-xtensa -M esp8266 -nographic -serial stdio -monitor none -s -S -kernel /path/to/the/target/image.elf.bin
 ```
 
-where ```/path/to/the/target/image.elf.bin``` is the path to the binary image as generated by the ```make``` command as ```$ELFFILE.bin```. After that you can start GDB in another terminal window using command:
+where `/path/to/the/target/image.elf.bin` is the path to the binary image as generated by the `make` command as `$ELFFILE.bin`. After that you can start GDB in another terminal window using command:
 
 ```
 xtensa-lx106-elf-gdb

--- a/cpu/esp8266/doc.txt
+++ b/cpu/esp8266/doc.txt
@@ -8,22 +8,25 @@
 ## <a name="esp8266_toc"> Table of Contents </a>
 
 1. [Overview](#esp8266_overview)
-2. [MCU ESP8266](#esp8266_mcu_esp8266)
-3. [Toolchain](#esp8266_toolchain)
+2. [Short Configuration Reference](#esp8266_short_configuration_reference)
+3. [MCU ESP8266](#esp8266_mcu_esp8266)
+    1. [Features of ESP8266](#esp8266_features)
+    2. [Features Supported by RIOT-OS](#esp8266_supported_features)
+4. [Toolchain](#esp8266_toolchain)
     1. [RIOT Docker Toolchain (riotdocker)](#esp8266_riot_docker_toolchain)
     2. [Precompiled Toolchain](#esp8266_precompiled_toolchain)
     3. [Manual Toolchain Installation](#esp8266_manual_toolchain_installation)
-4. [Flashing the Device](#esp8266_flashing_the_device)
+5. [Flashing the Device](#esp8266_flashing_the_device)
     1. [Toolchain Usage](#esp8266_toolchain_usage)
     2. [Compile Options](#esp8266_compile_options)
     3. [Flash Modes](#esp8266_flash_modes)
     4. [Erasing the Device](#esp8266_erasing)
-5. [Peripherals](#esp8266_peripherals)
+6. [Peripherals](#esp8266_peripherals)
     1. [GPIO pins](#esp8266_gpio_pins)
     2. [ADC Channels](#esp8266_adc_channels)
-    3. [SPI Interfaces](#esp8266_spi_interfaces)
+    3. [PWM Channels](#esp8266_pwm_channels)
     4. [I2C Interfaces](#esp8266_i2c_interfaces)
-    5. [PWM Channels](#esp8266_pwm_channels)
+    5. [SPI Interfaces](#esp8266_spi_interfaces)
     6. [Timers](#esp8266_timers)
     7. [SPIFFS Device](#esp8266_spiffs_device)
     8. [Other Peripherals](#esp8266_other_peripherals)
@@ -38,6 +41,7 @@
     2. [Application-Specific Driver Configuration](#esp8266_application_specific_driver_configuration)
 9. [SDK Task Handling](#esp8266_sdk_task_handling)
 10. [QEMU Mode and GDB](#esp8266_qemu_mode_and_gdb)
+
 
 # <a name="esp8266_overview"> Overview </a> &nbsp;&nbsp; [[TOC](#esp8266_toc)]
 
@@ -58,9 +62,43 @@ make flash BOARD=esp8266-esp-12x -C tests/shell USE_SDK=1 ...
 
 For more information about the make command variables, see section [Compile Options](#esp8266_compile_options).
 
-# <a name=esp8266_mcu_esp8266> MCU ESP8266 </a> &nbsp;[[TOC](#esp8266_toc)]
+# <a name="esp8266_short_configuration_reference"> Short Configuration Reference </a> &nbsp;[[TOC](#esp8266_toc)]
+
+The following table gives a short reference of all board configuration parameters used by the ESP8266 port in alphabetical order.
+
+<center>
+
+Parameter | Short Description                      | Type*
+----------|----------------------------------------|------
+[I2C0_SPEED](#esp8266_i2c_interfaces)| Bus speed of I2C_DEV(0)         | o
+[I2C0_SCL](#esp8266_i2c_interfaces)  | GPIO used as SCL for I2C_DEV(0) | o
+[I2C0_SDA](#esp8266_i2c_interfaces)  | GPIO used as SCL for I2C_DEV(0 | o
+[PWM0_GPIOS](#esp8266_pwm_channels)       | GPIOs that can be used at channels of PWM_DEV(0) | o
+[SPI0_CS0](#esp8266_spi_interfaces)  | GPIO used as default CS for SPI_DEV(0) | o
+
+</center>
+
+<b>Type:</b> m - mandatory, o - optional# <a name=esp8266_mcu_esp8266> MCU ESP8266 </a> &nbsp;[[TOC](#esp8266_toc)]
+
+The following table gives a short reference  in alphabetical order of modules that can be enabled/disabled by board configurations and/or application's makefile using ```USEMODULE``` and ```DISABLE_MODULE```.
+
+<center>
+
+Module    | Default  | Short description
+----------|----------|-------------------
+[esp_gdb](#esp8266_qemu_mode_and_gdb) | not used | enable the compilation with debug information for debugging
+[esp_now](#esp8266_esp_now_network_interface) | not used  | enable the ESP-NOW network device
+[esp_sdk](#esp8266_sdk_task_handling) | not used | Enable the SDK version, which is equivalent to using ```USE_SDK=1```
+[esp_spiffs](#esp8266_spiffs_device) | not used  |  Enable the SPIFFS drive in on-board flash memory
+[esp_sw_timer](#esp8266_timers) | not used | Enable software timer implementation, implies the module ```esp_sdk```
+
+</center>
 
 ESP8266 is a low-cost, ultra-low-power, single-core SoCs with an integrated WiFi module from Espressif Systems. The processor core is based on the Tensilica Xtensa Diamond Standard 106Micro 32-bit Controller Processor Core, which Espressif calls L106. The key features of ESP8266 are:
+
+## <a name=esp8266_features> Features of ESP8266 </a> &nbsp;[[TOC](#esp8266_toc)]
+
+The key features of ESP8266 are:
 
 <center>
 
@@ -87,6 +125,22 @@ Technical Reference | [Technical Reference](https://www.espressif.com/sites/defa
 </center><br>
 
 @note ESP8285 is simply an ESP8266 SoC with 1 MB built-in flash. Therefore, the documentation also applies to the SoC ESP8285, even if only the ESP8266 SoC is described below.
+
+## <a name="esp8266_supported_features"> Features Supported by RIOT-OS </a> &nbsp;[[TOC](#esp8266_toc)]
+
+The RIOT-OS for ESP8266 SoCs supports the following features at the moment:
+
+- I2C interfaces
+- SPI interfaces
+- UART interfaces
+- CPU ID access
+- ADC channel
+- PWM channels
+- SPI Flash Drive (MTD with SPIFFS and VFS)
+- Hardware number generator
+- Hardware timer devices
+- ESP-NOW netdev interface
+
 
 # <a name="esp8266_toolchain"> Toolchain</a> &nbsp;[[TOC](#esp8266_toc)]
 
@@ -460,35 +514,33 @@ ESP8266 has **one dedicated ADC** pin with a resolution of 10 bits. This ADC pin
 
 @note Some boards have voltage dividers to scale this range to a maximum of 3.3 V. For more information, see the hardware manual for the board.
 
-## <a name="esp8266_spi_interfaces"> SPI Interfaces </a> &nbsp;[[TOC](#esp8266_toc)]
+## <a name="esp8266_pwm_channels"> PWM Channels </a> &nbsp;[[TOC](#esp8266_toc)]
 
-ESP8266 provides two hardware SPI interfaces:
+The hardware implementation of ESP8266 PWM supports only frequencies as power of two. Therefore, a **software implementation** of **one PWM device** (```PWM_DEV(0)```) with up to **8 PWM channels** (```PWM_CHANNEL_NUM_MAX```) is used.
 
-- _FSPI_ for flash memory access that is usually simply referred to as _SPI_
-- _HSPI_ for peripherals
+@note The minimum PWM period that can be realized with this software implementation is 10 us or 100.000 PWM clock cycles per second. Therefore, the product of frequency and resolution should not be greater than 100.000. Otherwise the frequency is scaled down automatically.
 
-Even though _FSPI_ (or simply _SPI_) is a normal SPI interface, it is not possible to use it for peripherals. **HSPI is therefore the only usable SPI interface** available for peripherals as RIOT's ```SPI_DEV(0)```.
+GPIOs that can be used as channels of the PWM device ```PWM_DEV(0)``` are defined by ```PWM0_CHANNEL_GPIOS```. By default, GPIOs 2, 4 and 5 are defined as PWM channels. As long as these channels are not started with function ```pwm_set```, they can be used as normal GPIOs for other purposes.
 
-The pin configuration of the _HSPI_ interface ```SPI_DEV(0)``` is fixed. The only pin definition that can be overridden by an [application-specific board configuration](#esp8266_application_specific_board_configuration) is the CS signal defined by ```SPI0_CS0_GPIO```.
+GPIOs in ```PWM0_CHANNEL_GPIOS``` with a duty cycle value of 0 can be used as normal GPIOs for other purposes. GPIOs in ```PWM0_CHANNEL_GPIOS``` that are used for other purposes, e.g., I2C or SPI, are no longer available as PWM channels.
 
-<center>
+To define other GPIOs as PWM channels, just overwrite the definition of ```PWM_CHANNEL_GPIOS``` in an [application-specific board configuration](#esp8266_application_specific_board_configuration)
 
-Signal of _HSPI_ | Pin
------------------|-------
-MISO | GPIO12
-MOSI | GPIO13
-SCK  | GPIO14
-CS   | GPIOn with n = 0, 2, 4, 5, 15, 16 (additionally 9, 10 in ```dout``` and ```dio``` flash mode)
-
-</center>
-
-When the SPI is enabled using module ```periph_spi```, these GPIOs cannot be used for any other purpose. GPIOs 0, 2, 4, 5, 15, and 16 can be used as CS signal. In ```dio``` and ```dout``` flash modes (see section [Flash Modes](#esp8266_flash_modes)), GPIOs 9 and 10 can also be used as CS signal.
+```
+#define PWM0_CHANNEL_GPIOS { GPIO12, GPIO13, GPIO14, GPIO15 }
+```
 
 ## <a name="esp8266_i2c_interfaces"> I2C Interfaces </a> &nbsp;[[TOC](#esp8266_toc)]
 
-Since the ESP8266 does not or only partially support the I2C in hardware, I2C interfaces are realized as **bit-banging protocol in software**. The maximum usable bus speed is therefore ```I2C_SPEED_FAST_PLUS```. The maximum number of buses that can be defined is 2, ```I2C_DEV(0)``` ... ```I2C_DEV(1)```.
+Since the ESP8266 does not or only partially support the I2C in hardware, I2C interfaces are realized as **bit-banging protocol in software**. The maximum usable bus speed is ```I2C_SPEED_FAST_PLUS```. The maximum number of buses that can be defined is 2, ```I2C_DEV(0)``` ... ```I2C_DEV(1)```.
 
-Number of I2C buses (```I2C_NUMOF```) and used GPIO pins (```I2Cx_SCL``` and ```I2Cx_SDA``` where ```x``` stands for the bus device ```x```) have to be defined in the board-specific peripheral configuration in ```$BOARD/periph_conf.h```. Furthermore, the default I2C bus speed (```I2Cx_SPEED```) that is used for bus ```x``` has to be defined.
+The board-specific configuration of the I2C interface <b>```I2C_DEV(n)```</b> requires the definition of
+
+- <b>```I2Cn_SPEED```</b>, the bus speed,
+- <b>```I2Cn_SCL```</b>, the GPIO used as SCL signal, and
+- <b>```I2Cn_SDA```</b>, the GPIO used as SDA signal,
+
+where ```n``` can be 0 or 1. If they are not defined, the I2C interface ```I2C_DEV(n)``` is not used.
 
 In the following example, only one I2C bus is defined:
 
@@ -515,21 +567,36 @@ A configuration with two I2C buses would look like the following:
 
 All these configurations can be overridden by an [application-specific board configuration](#esp8266_application_specific_board_configuration).
 
-## <a name="esp8266_pwm_channels"> PWM Channels </a> &nbsp;[[TOC](#esp8266_toc)]
+## <a name="esp8266_spi_interfaces"> SPI Interfaces </a> &nbsp;[[TOC](#esp8266_toc)]
 
-The hardware implementation of ESP8266 PWM supports only frequencies as power of two. Therefore, a **software implementation** of **one PWM device** (```PWM_DEV(0)```) with up to **8 PWM channels** (```PWM_CHANNEL_NUM_MAX```) is used.
+ESP8266 provides two hardware SPI interfaces:
 
-@note The minimum PWM period that can be realized with this software implementation is 10 us or 100.000 PWM clock cycles per second. Therefore, the product of frequency and resolution should not be greater than 100.000. Otherwise the frequency is scaled down automatically.
+- _FSPI_ for flash memory access that is usually simply referred to as _SPI_
+- _HSPI_ for peripherals
 
-GPIOs that can be used as channels of the PWM device ```PWM_DEV(0)``` are defined by ```PWM0_CHANNEL_GPIOS```. By default, GPIOs 2, 4 and 5 are defined as PWM channels. As long as these channels are not started with function ```pwm_set```, they can be used as normal GPIOs for other purposes.
+Even though _FSPI_ (or simply _SPI_) is a normal SPI interface, it is not possible to use it for peripherals. **HSPI is therefore the only usable SPI interface** available for peripherals as RIOT's ```SPI_DEV(0)```.
 
-GPIOs in ```PWM0_CHANNEL_GPIOS``` with a duty cycle value of 0 can be used as normal GPIOs for other purposes. GPIOs in ```PWM0_CHANNEL_GPIOS``` that are used for other purposes, e.g., I2C or SPI, are no longer available as PWM channels.
+The pin configuration of the _HSPI_ interface is defined as shown in the following table. Only the CS signal can be configured and overridden by [application-specific card configuration] (# esp8266_application_specific_board_configuration).
 
-To define other GPIOs as PWM channels, just overwrite the definition of ```PWM_CHANNEL_GPIOS``` in an [application-specific board configuration](#esp8266_application_specific_board_configuration)
+<center>
 
+Signal of _HSPI_ | Pin
+-----------------|-------
+MISO | GPIO12
+MOSI | GPIO13
+SCK  | GPIO14
+CS   | GPIO15
+
+</center>
+
+When SPI is enabled using module ```periph_spi```, these GPIOs cannot be used for any other purpose. The given CS pin is used when ```spi_acquire``` is called with ```cs=GPIO_UNDEF``` parameter.
+
+To the default CS can be overridden as following:
 ```
-#define PWM0_CHANNEL_GPIOS { GPIO12, GPIO13, GPIO14, GPIO15 }
+#define SPI0_CS0_GPIO    GPIO15     /* HSPI/SPI_DEV(0) CS default pin */
 ```
+
+GPIOs 0, 2, 4, 5, 15, and 16 can be used as CS signal. In ```dio``` and ```dout``` flash modes (see section [Flash Modes](#esp8266_flash_modes)), GPIOs 9 and 10 can also be used as CS signal.
 
 ## <a name="esp8266_timers"> Timers </a> &nbsp;[[TOC](#esp8266_toc)]
 
@@ -556,6 +623,34 @@ flash_size - 5 * 4096 - 512 kByte
 ```
 
 Please refer file ```$RIOTBASE/tests/unittests/test-spiffs/tests-spiffs.c``` for more information on how to use SPIFFS and VFS together with a MTD device ```mtd0``` alias ```MTD_0```.
+
+## <a name="esp8266_esp_now_network_interface"> ESP-NOW Network Interface </a> &nbsp;[[TOC](#esp8266_toc)]
+
+With ESP-NOW, the ESP8266 provides a connectionless communication technology, featuring short packet transmission. It applies the IEEE802.11 Action Vendor frame technology, along with the IE function developed by Espressif, and CCMP encryption technology, realizing a secure, connectionless communication solution.
+
+The RIOT port for ESP8266 implements in module ```esp_now``` a ```netdev``` driver which uses ESP-NOW to provide a link layer interface to a meshed network of ESP8266 nodes. In this network, each node can send short packets with up to 250 data bytes to all other nodes that are visible in its range.
+
+@note Due to symbol conflicts in the ```esp_idf_wpa_supplicant_crypto``` module used by the ```esp_now``` with RIOT's ```crypto``` and ```hashes``` modules, ESP-NOW cannot be used for application that use these modules.
+
+Therefore, the module ```esp_now``` is not enabled automatically if the ```netdev_default``` module is used. Instead, the application has to add the ```esp_now``` module in its makefile when needed.
+```
+USEMODULE += esp_now
+```
+
+For ESP-NOW, ESP8266 nodes are used in WiFi SoftAP + Station mode to advertise their SSID and become visible to other ESP8266 nodes. The SSID of an ESP8266 node is the concatenation of the prefix ```RIOT_ESP_``` with the MAC address of its SoftAP WiFi interface. The driver periodically scans all visible ESP8266 nodes.
+
+The following parameters are defined for ESP-NOW nodes. These parameters can be overriden by [application-specific board configurations](#esp8266_application_specific_board_configuration).
+
+<center>
+
+Parameter | Default | Description
+:---------|:--------|:-----------
+ESP_NOW_SCAN_PERIOD | 10000000UL | Defines the period in us at which an node scans for other nodes in its range. The default period is 10 s.
+ESP_NOW_SOFT_AP_PASSPHRASE | ThisistheRIOTporttoESP | Defines the passphrase (max. 64 chars) that is used for the SoftAP interface of an nodes. It has to be same for all nodes in one network.
+ESP_NOW_CHANNEL | 6 | Defines the channel that is used as the broadcast medium by all nodes together.
+ESP_NOW_KEY | NULL | Defines a key that is used for encrypted communication between nodes. If it is NULL, encryption is disabled. The key has to be of type ```uint8_t[16]``` and has to be exactly 16 bytes long.
+
+</center>
 
 ## <a name="esp8266_other_peripherals"> Other Peripherals </a> &nbsp;[[TOC](#esp8266_toc)]
 

--- a/cpu/esp8266/include/common.h
+++ b/cpu/esp8266/include/common.h
@@ -83,6 +83,12 @@ extern "C" {
 #define CHECK_PARAM(cond)         if (!(cond)) return;
 #endif
 
+
+#define LOG_TAG_ERROR(tag, fmt, ...)   LOG_ERROR("[%s] " fmt, tag, ##__VA_ARGS__)
+#define LOG_TAG_WARNING(tag, fmt, ...) LOG_WARNING("[%s] " fmt, tag, ##__VA_ARGS__)
+#define LOG_TAG_INFO(tag, fmt, ...)    LOG_INFO("[%s] " fmt, tag, ##__VA_ARGS__)
+#define LOG_TAG_DEBUG(tag, fmt, ...)   LOG_DEBUG("[%s] " fmt, tag, ##__VA_ARGS__)
+
 /** @} */
 
 #ifdef __cplusplus

--- a/cpu/esp8266/sdk/lwip.c
+++ b/cpu/esp8266/sdk/lwip.c
@@ -210,4 +210,11 @@ uint32_t espconn_init(uint32 arg)
     return 1;
 }
 
+extern struct netif * eagle_lwip_getif(uint8_t index);
+
+void esp_lwip_init(void)
+{
+    netif_set_default((struct netif *)eagle_lwip_getif(0));
+}
+
 #endif /* MODULE_ESP_SDK */

--- a/cpu/esp8266/startup.c
+++ b/cpu/esp8266/startup.c
@@ -123,6 +123,10 @@ void ets_run(void)
     ets_isr_unmask(BIT(ETS_SOFT_INUM));
     #endif
 
+    /* initialize dummy lwIP library to link it even if esp_wifi is not used */
+    extern void esp_lwip_init(void);
+    esp_lwip_init();
+
     thread_create(ets_task_stack, sizeof(ets_task_stack),
             ETS_TASK_PRIORITY,
             THREAD_CREATE_WOUT_YIELD | THREAD_CREATE_STACKTEST,

--- a/cpu/esp_common/esp-now/doc.txt
+++ b/cpu/esp_common/esp-now/doc.txt
@@ -15,16 +15,16 @@
 
 This module realizes a netdev interface using Espressif's ESP-NOW technology which uses the built-in WiFi module.
 
-With ESP-NOW, the ESP32 provides a connectionless communication technology, featuring short packet transmission. It applies the IEEE802.11 Action Vendor frame technology, along with the IE function developed by Espressif, and CCMP encryption technology, realizing a secure, connectionless communication solution.
+With ESP-NOW, the ESP nodes (ESP32 and ESP8266) provide a connectionless communication technology, featuring short packet transmission. It applies the IEEE802.11 Action Vendor frame technology, along with the IE function developed by Espressif, and CCMP encryption technology, realizing a secure, connectionless communication solution.
 
-The RIOT port for ESP32 implements in module ```esp_now``` a ```netdev``` driver which uses ESP-NOW to provide a link layer interface to a meshed network of ESP32 nodes. In this network, each node can send short packets with up to 250 data bytes to all other nodes that are visible in its range.
+The RIOT port for ESP implements in module ```esp_now``` a ```netdev``` driver which uses ESP-NOW to provide a link layer interface to a meshed network of ESP nodes. In this network, each node can send short packets with up to 250 data bytes to all other nodes that are visible in its range.
 
 @note Due to symbol conflicts in the ```esp_idf_wpa_supplicant_crypto``` module used by the ```esp_now``` with RIOT's ```crypto``` and ```hashes``` modules, ESP-NOW cannot be used for application that use these modules. Therefore, the module ```esp_now``` is not enabled automatically if the ```netdev_default``` module is used. Instead, the application has to add the ```esp_now``` module in its makefile when needed.<br>
 ```
 USEMODULE += esp_now
 ```
 
-For ESP-NOW, ESP32 nodes are used in WiFi SoftAP + Station mode to advertise their SSID and become visible to other ESP32 nodes. The SSID of an ESP32 node is the concatenation of the prefix ```RIOT_ESP_``` with the MAC address of its SoftAP WiFi interface. The driver periodically scans all visible ESP32 nodes.
+For ESP-NOW, ESP nodes are used in WiFi SoftAP + Station mode to advertise their SSID and become visible to other ESP nodes. The SSID of an ESP node is the concatenation of the prefix ```RIOT_ESP_``` with the MAC address of its SoftAP WiFi interface. The driver periodically scans all visible ESP nodes.
 
 The following parameters are defined for ESP-NOW nodes.
 

--- a/cpu/esp_common/esp-now/esp_now_gnrc.c
+++ b/cpu/esp_common/esp-now/esp_now_gnrc.c
@@ -21,12 +21,18 @@
 
 #include <sys/uio.h>
 
+#include "cpu_conf.h"
 #include "net/netdev.h"
 #include "net/gnrc.h"
 #include "esp_now_params.h"
 #include "esp_now_netdev.h"
 #include "esp_now_gnrc.h"
 #include "net/gnrc/netif.h"
+
+#ifdef MCU_ESP8266
+#include "log.h"
+#include "common.h"
+#endif
 
 #define ENABLE_DEBUG    (0)
 #include "debug.h"

--- a/cpu/esp_common/esp-now/esp_now_params.h
+++ b/cpu/esp_common/esp-now/esp_now_params.h
@@ -27,12 +27,12 @@
  */
 #ifndef ESP_NOW_STACKSIZE
 /** The size of the stack used for the ESP-NOW netdev driver thread */
-#define ESP_NOW_STACKSIZE       THREAD_STACKSIZE_DEFAULT
+#define ESP_NOW_STACKSIZE       (THREAD_STACKSIZE_DEFAULT)
 #endif
 
 #ifndef ESP_NOW_PRIO
 /** The priority of the ESP-NOW netdev driver thread */
-#define ESP_NOW_PRIO            GNRC_NETIF_PRIO
+#define ESP_NOW_PRIO            (GNRC_NETIF_PRIO)
 #endif
 
 #ifndef ESP_NOW_SCAN_PERIOD
@@ -70,7 +70,8 @@
 #define ESP_NOW_PARAMS   { .key = ESP_NOW_KEY, \
                            .scan_period = ESP_NOW_SCAN_PERIOD, \
                            .softap_pass = ESP_NOW_SOFT_AP_PASS, \
-                           .channel = ESP_NOW_CHANNEL }
+                           .channel = ESP_NOW_CHANNEL \
+                         }
 #endif
 
 /**


### PR DESCRIPTION
### Contribution description

This PR introduces the ESP-NOW netdev device driver. The ESP-NOW netdev device allows ESP8266 nodes module to communicate using the built-in WiFi interface and the GNRC stack.

### Test procedure

Since ESP-NOW is a technology that only works between ESP nodes, at least two esp8266 boards are needed for testing. The easiest way to test is to use ```examples/gnrc_networking```. Once the boards have been flashed with the following make command
```
USEMODULE=esp_now make flash -C examples/gnrc_networking BOARD=...
```
the commands ```ifconfig``` and ```ping6``` can be used for testing.

### Issues/PRs references

This PR depends on ~#10126~, ~#10536~, ~#10581~, ~#10656~,  ~#10700~.