### PR TITLE
net/gcoap: fix doc for order of server resources

### DIFF
--- a/sys/include/net/gcoap.h
+++ b/sys/include/net/gcoap.h
@@ -45,9 +45,10 @@
  *
  * gcoap allows an application to specify a collection of request resource paths
  * it wants to be notified about. Create an array of resources (coap_resource_t
- * structs). Note that the elements must be ordered alphabetically with respect
- * to the resource path. Use gcoap_register_listener() at application startup
- * to pass in these resources, wrapped in a gcoap_listener_t.
+ * structs) ordered by the resource path, specifically the ASCII encoding of
+ * the path characters (digit and capital precede lower case). Use
+ * gcoap_register_listener() at application startup to pass in these resources,
+ * wrapped in a gcoap_listener_t.
  *
  * gcoap itself defines a resource for `/.well-known/core` discovery, which
  * lists all of the registered paths.


### PR DESCRIPTION
### Contribution description

Simple fix to gcoap module documentation for the required order of server resources. Specifies use of ASCII order rather than alphabetic. Thanks to @pokgak for pointing this out in #9888.

### Testing procedure

N/A, just compare the documentation

### Issues/PRs references

fixes #9888