### PR TITLE
nanocoap/example: fix resource order

### DIFF
--- a/examples/nanocoap_server/coap_handler.c
+++ b/examples/nanocoap_server/coap_handler.c
@@ -104,12 +104,12 @@ ssize_t _sha256_handler(coap_pkt_t* pkt, uint8_t *buf, size_t len, void *context
     return pkt_pos - (uint8_t*)pkt->hdr;
 }
 
-/* must be sorted by path (alphabetically) */
+/* must be sorted by path (ASCII order) */
 const coap_resource_t coap_resources[] = {
     COAP_WELL_KNOWN_CORE_DEFAULT_HANDLER,
-    { "/sha256", COAP_POST, _sha256_handler, NULL },
     { "/riot/board", COAP_GET, _riot_board_handler, NULL },
     { "/riot/value", COAP_GET | COAP_PUT | COAP_POST, _riot_value_handler, NULL },
+    { "/sha256", COAP_POST, _sha256_handler, NULL },
 };
 
 const unsigned coap_resources_numof = sizeof(coap_resources) / sizeof(coap_resources[0]);


### PR DESCRIPTION
### Contribution description

Fix order of resources in nanocoap server example. Must be in ASCII order. Also updated inline comment based on #9888.

### Testing procedure

Build/run nanocoap_server example.

Send a POST for /riot/value, like the following in libcoap CLI:
```
$ echo 1 |./coap-client -m post -T 5a -U coap://[fe80::200:bbff:febb:2%tap0]/riot/value -f -
```

We do not expect any response from coap-client, but instead we see `4.04` because the nanocoap server was unable to find the resource. Also, verify the fix with a 'get' request to be sure the value was set.

```
$ ./coap-client -m get -T 5a -U coap://[fe80::200:bbff:febb:2%tap0]/riot/value
1
```
### Issues/PRs references

Related to #9888 for gcoap, but not strictly a fix for it. I just checked nanocoap to be sure no similar issues.
