### PR TITLE
pba-d-01-kw2x: remove duplicate MCPU

### DIFF
--- a/boards/pba-d-01-kw2x/Makefile.include
+++ b/boards/pba-d-01-kw2x/Makefile.include
@@ -6,8 +6,6 @@ export CPU = kinetis
 # cpu if needed.
 export CPU_MODEL ?= mkw21d256vha5
 
-export MCPU = cortex-m4
-
 # set default port depending on operating system
 PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))


### PR DESCRIPTION
### Contribution description

MCPU is already defined to `CPU_ARCH` which is `cortex-m4`.
Removing this line does not change the value:

    make --no-print-directory -C examples/hello-world/ BOARD=pba-d-01-kw2x \
        info-debug-variable-CPU_ARCH info-debug-variable-MCPU
    cortex-m4
    cortex-m4

The board was the only board defining `MCPU` 

```
git grep MCPU boards/                                                                                                                   
boards/pba-d-01-kw2x/Makefile.include:export MCPU = cortex-m4
```

### Testing procedure

Run this command in master and this PR:
```
make --no-print-directory -C examples/hello-world/ BOARD=pba-d-01-kw2x \
        info-debug-variable-CPU_ARCH info-debug-variable-MCPU
```

You should get the same output

    cortex-m4
    cortex-m4

### Issues/PRs references

Found while working in https://github.com/RIOT-OS/RIOT/issues/9913

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
