### PR TITLE
bench_timers: Fix mixup in trace output

### DIFF
--- a/tests/bench_timers/main.c
+++ b/tests/bench_timers/main.c
@@ -403,10 +403,10 @@ static void run_test(test_ctx_t *ctx, uint32_t interval, unsigned int variant)
                 break;
         }
         if (variant & TEST_PARALLEL) {
-            print_str("- ");
+            print_str("= ");
         }
         else {
-            print_str("= ");
+            print_str("- ");
         }
         print_u32_dec(interval);
         print("\n", 1);


### PR DESCRIPTION
Trivial change
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

The equal sign was intended to be a symbol for parallel timers (two
lines), the minus was intended to be a single timer (one line).


### Testing procedure

N/A


### Issues/PRs references

none
