### PR TITLE
boards/cpu: cleanup duplicate includes

### DIFF
--- a/boards/arduino-mkr1000/Makefile.include
+++ b/boards/arduino-mkr1000/Makefile.include
@@ -5,6 +5,3 @@ ifeq ($(PROGRAMMER),jlink)
 endif
 
 include $(RIOTBOARD)/common/arduino-mkr/Makefile.include
-
-# add arduino-mkr1000 include path
-INCLUDES += -I$(RIOTBOARD)/$(BOARD)/include

--- a/boards/arduino-mkrfox1200/Makefile.include
+++ b/boards/arduino-mkrfox1200/Makefile.include
@@ -5,6 +5,3 @@ ifeq ($(PROGRAMMER),jlink)
 endif
 
 include $(RIOTBOARD)/common/arduino-mkr/Makefile.include
-
-# add arduino-mkrfox1200 include path
-INCLUDES += -I$(RIOTBOARD)/$(BOARD)/include

--- a/boards/arduino-mkrzero/Makefile.include
+++ b/boards/arduino-mkrzero/Makefile.include
@@ -5,6 +5,3 @@ ifeq ($(PROGRAMMER),jlink)
 endif
 
 include $(RIOTBOARD)/common/arduino-mkr/Makefile.include
-
-# add arduino-mkrzero include path
-INCLUDES += -I$(RIOTBOARD)/$(BOARD)/include

--- a/boards/iotlab-a8-m3/Makefile.include
+++ b/boards/iotlab-a8-m3/Makefile.include
@@ -1,6 +1,3 @@
 USEMODULE += boards_common_iotlab
 
 include $(RIOTBOARD)/common/iotlab/Makefile.include
-
-# add iotlab-a8-m3 include path
-INCLUDES += -I$(RIOTBOARD)/$(BOARD)/include

--- a/boards/iotlab-m3/Makefile.include
+++ b/boards/iotlab-m3/Makefile.include
@@ -1,6 +1,3 @@
 USEMODULE += boards_common_iotlab
 
 include $(RIOTBOARD)/common/iotlab/Makefile.include
-
-# add iotlab-m3 include path
-INCLUDES += -I$(RIOTBOARD)/$(BOARD)/include

--- a/boards/mips-malta/Makefile.include
+++ b/boards/mips-malta/Makefile.include
@@ -1,5 +1,4 @@
 export CPU = mips32r2_generic
-export INCLUDES += -I$(RIOTBOARD)/$(BOARD)/include/
 #export USE_HARD_FLOAT = 1
 export USE_DSP = 1
 export USE_UHI_SYSCALLS = 1

--- a/boards/nz32-sc151/Makefile.include
+++ b/boards/nz32-sc151/Makefile.include
@@ -17,7 +17,5 @@ HEXFILE = $(BINFILE)
 export FFLAGS = -d $(ID) -a 0 -s 0x08000000:leave -D "$(HEXFILE)"
 export TERMFLAGS = -p $(PORT)
 
-export INCLUDES += -I$(RIOTCPU)/$(CPU)/include/ -I$(RIOTBOARD)/$(BOARD)/include/
-
 # setup serial terminal
 include $(RIOTMAKE)/tools/serial.inc.mk

--- a/boards/pic32-clicker/Makefile.include
+++ b/boards/pic32-clicker/Makefile.include
@@ -1,5 +1,4 @@
 export CPU = mips_pic32mx
 export CPU_MODEL=p32mx470f512h
-export INCLUDES += -I$(RIOTBOARD)/$(BOARD)/include/
 export APPDEPS += $(RIOTCPU)/$(CPU)/$(CPU_MODEL)/$(CPU_MODEL).S
 export USE_UHI_SYSCALLS = 1

--- a/boards/pic32-wifire/Makefile.include
+++ b/boards/pic32-wifire/Makefile.include
@@ -1,5 +1,4 @@
 export CPU = mips_pic32mz
 export CPU_MODEL=p32mz2048efg100
-export INCLUDES += -I$(RIOTBOARD)/$(BOARD)/include/
 export APPDEPS += $(RIOTCPU)/$(CPU)/$(CPU_MODEL)/$(CPU_MODEL).S
 export USE_UHI_SYSCALLS = 1

--- a/boards/spark-core/Makefile.include
+++ b/boards/spark-core/Makefile.include
@@ -14,8 +14,6 @@ export RESET = # dfu-util has no support for resetting the device
 HEXFILE = $(BINFILE)
 export FFLAGS = -d 1d50:607f -a 0 -s 0x08005000:leave -D "$(HEXFILE)"
 
-export INCLUDES += -I$(RIOTCPU)/$(CPU)/include/ -I$(RIOTBOARD)/$(BOARD)/include/
-
 # Skip the space needed by the embedded bootloader
 export ROM_OFFSET ?= 0x5000
 

--- a/cpu/cc430/Makefile.include
+++ b/cpu/cc430/Makefile.include
@@ -1,5 +1,3 @@
-INCLUDES += -I$(RIOTBASE)/cpu/cc430/include/
-
 include $(RIOTCPU)/msp430_common/Makefile.include
 
 export USEMODULE += periph periph_common


### PR DESCRIPTION
### Contribution description

Remove duplicate includes of $(CPU)/include and $(BOARD)/include.

Includes of $(CPU)/include and $(BOARD)/include and already added in the
main Makefile.include.

### Testing procedure

I tested that no header conflict in cpu and boards:

```
find cpu -name \*.h -exec basename {} \; | sort -u > cpu_includes
find boards/ -name \*.h -exec basename {} \; | sort -u > boards_includes
```

There is only one filename in common:

```
cat cpu_includes boards_includes  | sort -u | wc -l
907
cat cpu_includes boards_includes  | wc -l
908
```

```
find cpu/ -name periph_conf.h 
cpu/native/include/periph_conf.h
```

### Issues/PRs references

Part of https://github.com/RIOT-OS/RIOT/issues/8713
Found when working on https://github.com/RIOT-OS/RIOT/issues/9913