### PR TITLE
tests/bench_runtime_coreapis: remove unnecessary test target

### DIFF
--- a/tests/bench_runtime_coreapis/Makefile
+++ b/tests/bench_runtime_coreapis/Makefile
@@ -7,6 +7,3 @@ USEMODULE += benchmark
 TEST_ON_CI_WHITELIST += all
 
 include $(RIOTBASE)/Makefile.include
-
-test:
-	tests/01-run.py


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR removes the `test` target of the `bench_runtime_coreapis` test application. This kind of targets have been factorized recently and are not needed anymore.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

run make test in this application, it should work:

```shell
make -C tests/bench_runtime_coreapis/ all test
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

leftover from #9348

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
