### PR TITLE
net/nanocoap: factor out generic CoAP defines

### DIFF
--- a/sys/include/net/coap.h
+++ b/sys/include/net/coap.h
@@ -1,0 +1,188 @@
+/*
+ * Copyright (C) 2018 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    net_coap CoAP defines
+ * @ingroup     net
+ * @brief       Generic CoAP values as defined by RFC7252
+ * @{
+ *
+ * @file
+ * @brief       Generic CoAP values as defined by RFC7252
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ *
+ */
+
+#ifndef NET_COAP_H
+#define NET_COAP_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Default CoAP port
+ */
+#define COAP_PORT               (5683)
+
+/**
+ * @name    CoAP option numbers
+ * @{
+ */
+#define COAP_OPT_URI_HOST       (3)
+#define COAP_OPT_OBSERVE        (6)
+#define COAP_OPT_LOCATION_PATH  (8)
+#define COAP_OPT_URI_PATH       (11)
+#define COAP_OPT_CONTENT_FORMAT (12)
+#define COAP_OPT_URI_QUERY      (15)
+#define COAP_OPT_LOCATION_QUERY (20)
+#define COAP_OPT_BLOCK2         (23)
+#define COAP_OPT_BLOCK1         (27)
+/** @} */
+
+/**
+ * @name    Message types -- confirmable, non-confirmable, etc.
+ * @{
+ */
+#define COAP_TYPE_CON           (0)
+#define COAP_TYPE_NON           (1)
+#define COAP_TYPE_ACK           (2)
+#define COAP_TYPE_RST           (3)
+/** @} */
+
+/**
+ * @name    CoAP method codes used in header
+ * @{
+ */
+#define COAP_CLASS_REQ          (0)
+#define COAP_METHOD_GET         (1)
+#define COAP_METHOD_POST        (2)
+#define COAP_METHOD_PUT         (3)
+#define COAP_METHOD_DELETE      (4)
+/** @} */
+
+/**
+ * @name    Empty CoAP message code
+ * @{
+ */
+#define COAP_CODE_EMPTY         (0)
+/** @} */
+
+/**
+ * @name    Response message codes: success
+ * @{
+ */
+#define COAP_CLASS_SUCCESS      (2)
+#define COAP_CODE_CREATED      ((2 << 5) | 1)
+#define COAP_CODE_DELETED      ((2 << 5) | 2)
+#define COAP_CODE_VALID        ((2 << 5) | 3)
+#define COAP_CODE_CHANGED      ((2 << 5) | 4)
+#define COAP_CODE_204          ((2 << 5) | 4)
+#define COAP_CODE_CONTENT      ((2 << 5) | 5)
+#define COAP_CODE_205          ((2 << 5) | 5)
+#define COAP_CODE_231          ((2 << 5) | 31)
+/** @} */
+
+/**
+ * @name    Response message codes: client error
+ * @{
+ */
+#define COAP_CLASS_CLIENT_FAILURE             (4)
+#define COAP_CODE_BAD_REQUEST                ((4 << 5) | 0)
+#define COAP_CODE_UNAUTHORIZED               ((4 << 5) | 1)
+#define COAP_CODE_BAD_OPTION                 ((4 << 5) | 2)
+#define COAP_CODE_FORBIDDEN                  ((4 << 5) | 3)
+#define COAP_CODE_PATH_NOT_FOUND             ((4 << 5) | 4)
+#define COAP_CODE_404                        ((4 << 5) | 4)
+#define COAP_CODE_METHOD_NOT_ALLOWED         ((4 << 5) | 5)
+#define COAP_CODE_NOT_ACCEPTABLE             ((4 << 5) | 6)
+#define COAP_CODE_REQUEST_ENTITY_INCOMPLETE  ((4 << 5) | 8)
+#define COAP_CODE_PRECONDITION_FAILED        ((4 << 5) | 0xC)
+#define COAP_CODE_REQUEST_ENTITY_TOO_LARGE   ((4 << 5) | 0xD)
+#define COAP_CODE_UNSUPPORTED_CONTENT_FORMAT ((4 << 5) | 0xF)
+/** @} */
+
+/**
+ * @name    Response message codes: server error
+ * @{
+ */
+#define COAP_CLASS_SERVER_FAILURE             (5)
+#define COAP_CODE_INTERNAL_SERVER_ERROR      ((5 << 5) | 0)
+#define COAP_CODE_NOT_IMPLEMENTED            ((5 << 5) | 1)
+#define COAP_CODE_BAD_GATEWAY                ((5 << 5) | 2)
+#define COAP_CODE_SERVICE_UNAVAILABLE        ((5 << 5) | 3)
+#define COAP_CODE_GATEWAY_TIMEOUT            ((5 << 5) | 4)
+#define COAP_CODE_PROXYING_NOT_SUPPORTED     ((5 << 5) | 5)
+/** @} */
+
+/**
+ * @name    Content types
+ * @{
+ */
+#define COAP_CT_LINK_FORMAT     (40)
+#define COAP_CT_XML             (41)
+#define COAP_CT_OCTET_STREAM    (42)
+#define COAP_CT_EXI             (47)
+#define COAP_CT_JSON            (50)
+/** @} */
+
+/**
+ * @name    Content-Format option codes
+ * @{
+ */
+#define COAP_FORMAT_TEXT         (0)
+#define COAP_FORMAT_LINK        (40)
+#define COAP_FORMAT_OCTET       (42)
+#define COAP_FORMAT_JSON        (50)
+#define COAP_FORMAT_CBOR        (60)
+/** @} */
+
+/**
+ * @name    Observe (RFC 7641) constants
+ * @{
+ */
+#define COAP_OBS_REGISTER        (0)
+#define COAP_OBS_DEREGISTER      (1)
+/** @} */
+
+/**
+ * @name    Timing parameters
+ * @{
+ */
+#define COAP_ACK_TIMEOUT        (2U)
+#define COAP_RANDOM_FACTOR      (1.5)
+/**
+ * @brief   Maximum variation for confirmable timeout.
+ *
+ * Must be an integer, defined as:
+ *
+ *     (COAP_ACK_TIMEOUT * COAP_RANDOM_FACTOR) - COAP_ACK_TIMEOUT
+ */
+#define COAP_ACK_VARIANCE       (1U)
+#define COAP_MAX_RETRANSMIT     (4)
+#define COAP_NSTART             (1)
+#define COAP_DEFAULT_LEISURE    (5)
+/** @} */
+
+/**
+ * @name Blockwise transfer (RFC7959)
+ * @{
+ */
+#define COAP_BLOCKWISE_NUM_OFF  (4)
+#define COAP_BLOCKWISE_MORE_OFF (3)
+#define COAP_BLOCKWISE_SZX_MASK (0x07)
+#define COAP_BLOCKWISE_SZX_MAX  (7)
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* NET_COAP_H */
+/** @} */

--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -33,7 +33,9 @@
 
 #ifdef RIOT_VERSION
 #include "byteorder.h"
+#include "net/coap.h"
 #else
+#include "coap.h"
 #include <arpa/inet.h>
 #endif
 
@@ -42,9 +44,19 @@ extern "C" {
 #endif
 
 /**
- * @brief   CoAP port to use
+ * @name    Nanocoap specific CoAP method flags used in coap_handlers array
+ * @{
  */
-#define COAP_PORT               (5683)
+#define COAP_GET                (0x1)
+#define COAP_POST               (0x2)
+#define COAP_PUT                (0x4)
+#define COAP_DELETE             (0x8)
+/** @} */
+
+/**
+ * @brief   Nanocoap-specific value to indicate no format specified
+ */
+#define COAP_FORMAT_NONE        (65535)
 
 /**
  * @name    Nanocoap specific maximum values
@@ -58,176 +70,6 @@ extern "C" {
 #define NANOCOAP_URL_MAX        NANOCOAP_URI_MAX
 #define NANOCOAP_QS_MAX         (64)
 #endif
-
-/**
- * @name    CoAP option numbers
- * @{
- */
-#define COAP_OPT_URI_HOST       (3)
-#define COAP_OPT_OBSERVE        (6)
-#define COAP_OPT_LOCATION_PATH  (8)
-#define COAP_OPT_URI_PATH       (11)
-#define COAP_OPT_CONTENT_FORMAT (12)
-#define COAP_OPT_URI_QUERY      (15)
-#define COAP_OPT_LOCATION_QUERY (20)
-#define COAP_OPT_BLOCK2         (23)
-#define COAP_OPT_BLOCK1         (27)
-/** @} */
-
-/**
- * @name    CoAP packet types
- * @{
- */
-#define COAP_REQ                (0)
-#define COAP_RESP               (2)
-#define COAP_RST                (3)
-
-/**
- * @name    Message types -- confirmable, non-confirmable, etc.
- * @{
- */
-#define COAP_TYPE_CON           (0)
-#define COAP_TYPE_NON           (1)
-#define COAP_TYPE_ACK           (2)
-#define COAP_TYPE_RST           (3)
-/** @} */
-
-/**
- * @name    CoAP method codes used in header
- * @{
- */
-#define COAP_CLASS_REQ          (0)
-#define COAP_METHOD_GET         (1)
-#define COAP_METHOD_POST        (2)
-#define COAP_METHOD_PUT         (3)
-#define COAP_METHOD_DELETE      (4)
-/** @} */
-
-/**
- * @name    CoAP method flags used in coap_handlers array
- * @{
- */
-#define COAP_GET                (0x1)
-#define COAP_POST               (0x2)
-#define COAP_PUT                (0x4)
-#define COAP_DELETE             (0x8)
-/** @} */
-
-/**
- * @name    Empty CoAP message code
- * @{
- */
-#define COAP_CODE_EMPTY         (0)
-/** @} */
-
-/**
- * @name    Response message codes: success
- * @{
- */
-#define COAP_CLASS_SUCCESS      (2)
-#define COAP_CODE_CREATED      ((2 << 5) | 1)
-#define COAP_CODE_DELETED      ((2 << 5) | 2)
-#define COAP_CODE_VALID        ((2 << 5) | 3)
-#define COAP_CODE_CHANGED      ((2 << 5) | 4)
-#define COAP_CODE_204          ((2 << 5) | 4)
-#define COAP_CODE_CONTENT      ((2 << 5) | 5)
-#define COAP_CODE_205          ((2 << 5) | 5)
-#define COAP_CODE_231          ((2 << 5) | 31)
-/** @} */
-
-/**
- * @name    Response message codes: client error
- * @{
- */
-#define COAP_CLASS_CLIENT_FAILURE             (4)
-#define COAP_CODE_BAD_REQUEST                ((4 << 5) | 0)
-#define COAP_CODE_UNAUTHORIZED               ((4 << 5) | 1)
-#define COAP_CODE_BAD_OPTION                 ((4 << 5) | 2)
-#define COAP_CODE_FORBIDDEN                  ((4 << 5) | 3)
-#define COAP_CODE_PATH_NOT_FOUND             ((4 << 5) | 4)
-#define COAP_CODE_404                        ((4 << 5) | 4)
-#define COAP_CODE_METHOD_NOT_ALLOWED         ((4 << 5) | 5)
-#define COAP_CODE_NOT_ACCEPTABLE             ((4 << 5) | 6)
-#define COAP_CODE_REQUEST_ENTITY_INCOMPLETE  ((4 << 5) | 8)
-#define COAP_CODE_PRECONDITION_FAILED        ((4 << 5) | 0xC)
-#define COAP_CODE_REQUEST_ENTITY_TOO_LARGE   ((4 << 5) | 0xD)
-#define COAP_CODE_UNSUPPORTED_CONTENT_FORMAT ((4 << 5) | 0xF)
-/** @} */
-
-/**
- * @name    Response message codes: server error
- * @{
- */
-#define COAP_CLASS_SERVER_FAILURE             (5)
-#define COAP_CODE_INTERNAL_SERVER_ERROR      ((5 << 5) | 0)
-#define COAP_CODE_NOT_IMPLEMENTED            ((5 << 5) | 1)
-#define COAP_CODE_BAD_GATEWAY                ((5 << 5) | 2)
-#define COAP_CODE_SERVICE_UNAVAILABLE        ((5 << 5) | 3)
-#define COAP_CODE_GATEWAY_TIMEOUT            ((5 << 5) | 4)
-#define COAP_CODE_PROXYING_NOT_SUPPORTED     ((5 << 5) | 5)
-/** @} */
-
-/**
- * @name    Content types
- * @{
- */
-#define COAP_CT_LINK_FORMAT     (40)
-#define COAP_CT_XML             (41)
-#define COAP_CT_OCTET_STREAM    (42)
-#define COAP_CT_EXI             (47)
-#define COAP_CT_JSON            (50)
-/** @} */
-
-/**
- * @name    Content-Format option codes
- * @{
- */
-#define COAP_FORMAT_TEXT         (0)
-#define COAP_FORMAT_LINK        (40)
-#define COAP_FORMAT_OCTET       (42)
-#define COAP_FORMAT_JSON        (50)
-#define COAP_FORMAT_CBOR        (60)
-/** @brief   nanocoap-specific value to indicate no format specified. */
-#define COAP_FORMAT_NONE     (65535)
-/** @} */
-
-/**
- * @name    Observe (RFC 7641) constants
- * @{
- */
-#define COAP_OBS_REGISTER        (0)
-#define COAP_OBS_DEREGISTER      (1)
-/** @} */
-
-/**
- * @name    Timing parameters
- * @{
- */
-#define COAP_ACK_TIMEOUT        (2U)
-#define COAP_RANDOM_FACTOR      (1.5)
-
-/**
- * @brief Maximum variation for confirmable timeout.
- *
- * Must be an integer, defined as:
- *
- *     (COAP_ACK_TIMEOUT * COAP_RANDOM_FACTOR) - COAP_ACK_TIMEOUT
- */
-#define COAP_ACK_VARIANCE       (1U)
-#define COAP_MAX_RETRANSMIT     (4)
-#define COAP_NSTART             (1)
-#define COAP_DEFAULT_LEISURE    (5)
-/** @} */
-
-/**
- * @name Blockwise transfer (RFC7959)
- * @{
- */
-#define COAP_BLOCKWISE_NUM_OFF  (4)
-#define COAP_BLOCKWISE_MORE_OFF (3)
-#define COAP_BLOCKWISE_SZX_MASK (0x07)
-#define COAP_BLOCKWISE_SZX_MAX  (7)
-/** @} */
 
 /**
  * @name coap_opt_finish() flag parameter values

--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -30,6 +30,15 @@
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
+/**
+ * @name    Internally used CoAP packet types
+ * @{
+ */
+#define COAP_REQ                (0)
+#define COAP_RESP               (2)
+#define COAP_RST                (3)
+/** @} */
+
 static int _decode_value(unsigned val, uint8_t **pkt_pos_ptr, uint8_t *pkt_end);
 int coap_get_option_uint(coap_pkt_t *pkt, unsigned opt_num, uint32_t *target);
 static uint32_t _decode_uint(uint8_t *pkt_pos, unsigned nbytes);


### PR DESCRIPTION
### Contribution description
As of now, `nanocoap` defines a number of constants, that are given by RFC7252. It seems to me, it would be a bit cleaner to factor out these 'global' constants into a more generic coap header, which can be re-used by other coap implementations, and for keeping certain (sub)modules independent of a coap implementation. 

This would also be in line with the approach taken for other network related models (e.g. BLE, ip, etc), having a generic header holding constants defined by the standard and basing the actual implementations on these.

### Testing procedure
Buildtest should be sufficient

### Issues/PRs references
none