### PR TITLE
bench_timers: Split test implementations into separate files

### DIFF
--- a/tests/bench_timers/Makefile
+++ b/tests/bench_timers/Makefile
@@ -22,6 +22,7 @@ FEATURES_REQUIRED = periph_timer
 # Use RTT as a wall clock reference, if available
 FEATURES_OPTIONAL = periph_rtt
 
+USEMODULE += core_thread_flags
 USEMODULE += random
 USEMODULE += fmt
 USEMODULE += matstat

--- a/tests/bench_timers/test_periph_timer.c
+++ b/tests/bench_timers/test_periph_timer.c
@@ -1,0 +1,164 @@
+/*
+ * Copyright (C) 2018 Eistec AB
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Another peripheral timer test application
+ *
+ * @author      Joakim Nohlgård <joakim.nohlgard@eistec.se>
+ *
+ * @}
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+#include "board.h"
+#include "cpu.h"
+#include "periph/timer.h"
+
+#include "fmt.h"
+#include "print_results.h"
+#include "spin_random.h"
+#include "bench_timers_config.h"
+#include "thread_flags.h"
+
+#ifndef TEST_TRACE
+#define TEST_TRACE 0
+#endif
+
+/*
+ * Results will be grouped by function, rescheduling yes/no, start/stop.
+ * functions: timer_set, timer_set_absolute
+ * reschedule: yes/no, when yes: first set one target time, before that time has
+ *             passed, set the real target time
+ * start/stop: if stop: call timer_stop before setting the target time, then call timer_start
+ */
+enum test_periph_timer_variants {
+    TEST_RESCHEDULE         = 1,
+    TEST_STOPPED            = 2,
+    TEST_ABSOLUTE           = 4,
+};
+
+/* Number of variant groups, used when printing results */
+#define TEST_VARIANT_GROUPS 2
+
+const result_presentation_t test_periph_timer_presentation = {
+    .groups = (const result_group_t[TEST_VARIANT_GROUPS]) {
+        {
+            .label = "timer_set",
+            .sub_labels = (const char *[]){
+                [0] = "running",
+                [TEST_RESCHEDULE] = "resched",
+                [TEST_STOPPED] = "stopped",
+                [TEST_STOPPED | TEST_RESCHEDULE] = "stopped, resched",
+            },
+            .num_sub_labels = (TEST_VARIANT_NUMOF / TEST_VARIANT_GROUPS),
+        },
+        {
+            .label = "timer_set_absolute",
+            .sub_labels = (const char *[]){
+                [0] = "running",
+                [TEST_RESCHEDULE] = "resched",
+                [TEST_STOPPED] = "stopped",
+                [TEST_STOPPED | TEST_RESCHEDULE] = "stopped, resched",
+            },
+            .num_sub_labels = (TEST_VARIANT_NUMOF / TEST_VARIANT_GROUPS),
+        },
+    },
+    .num_groups = TEST_VARIANT_GROUPS,
+    .ref_limits = &bench_timers_ref_limits,
+    .int_limits = &bench_timers_int_limits,
+    .offsets = (const unsigned[]) {
+        [0] =                                               TEST_MIN_REL,
+        [TEST_RESCHEDULE] =                                 TEST_MIN_REL,
+        [TEST_STOPPED] =                                    TEST_MIN_REL,
+        [TEST_STOPPED | TEST_RESCHEDULE] =                  TEST_MIN_REL,
+        [TEST_ABSOLUTE] =                                   TEST_MIN,
+        [TEST_ABSOLUTE | TEST_RESCHEDULE] =                 TEST_MIN,
+        [TEST_ABSOLUTE | TEST_STOPPED] =                    TEST_MIN,
+        [TEST_ABSOLUTE | TEST_STOPPED | TEST_RESCHEDULE] =  TEST_MIN,
+    },
+};
+
+void test_periph_timer_run(test_ctx_t *ctx, uint32_t interval, unsigned int variant)
+{
+    if (variant & TEST_ABSOLUTE) {
+        interval += TEST_MIN;
+    }
+    else {
+        interval += TEST_MIN_REL;
+    }
+    unsigned int interval_ref = TIM_TEST_TO_REF(interval);
+
+    if (TEST_TRACE) {
+        if (variant & TEST_ABSOLUTE) {
+            print_str("A");
+        }
+        else {
+            print_str("_");
+        }
+        if (variant & TEST_RESCHEDULE) {
+            print_str("R");
+        }
+        else {
+            print_str("_");
+        }
+        if (variant & TEST_STOPPED) {
+            print_str("S ");
+        }
+        else {
+            print_str("_ ");
+        }
+        print_u32_dec(interval);
+        print_str("   ");
+        print_u64_hex(TUT_READ());
+        print("\n", 1);
+    }
+
+    spin_random_delay();
+    if (variant & TEST_RESCHEDULE) {
+        timer_set(TIM_TEST_DEV, TIM_TEST_CHAN, interval + RESCHEDULE_MARGIN);
+        spin_random_delay();
+    }
+    if (variant & TEST_STOPPED) {
+        timer_stop(TIM_TEST_DEV);
+        spin_random_delay();
+    }
+    ctx->target_ref = timer_read(TIM_REF_DEV) + interval_ref;
+    ctx->target_tut = TUT_READ() + interval;
+    if (variant & TEST_ABSOLUTE) {
+        timer_set_absolute(TIM_TEST_DEV, TIM_TEST_CHAN, ctx->target_tut);
+    }
+    else {
+        timer_set(TIM_TEST_DEV, TIM_TEST_CHAN, interval);
+    }
+    if (variant & TEST_STOPPED) {
+        spin_random_delay();
+        /* do not update ctx->target_tut, because TUT should have been stopped
+         * and not incremented during spin_random_delay */
+        ctx->target_ref = timer_read(TIM_REF_DEV) + interval_ref;
+        timer_start(TIM_TEST_DEV);
+    }
+    thread_flags_wait_any(THREAD_FLAG_TEST);
+}
+
+/* Wrapper for periph_timer callbacks */
+static void cb_timer_periph(void *arg, int chan)
+{
+    (void)chan;
+    bench_timers_cb(arg);
+}
+
+int test_periph_timer_init(test_ctx_t *ctx)
+{
+    int res = timer_init(TIM_TEST_DEV, TIM_TEST_FREQ, cb_timer_periph, ctx);
+    return res;
+}

--- a/tests/bench_timers/test_xtimer.c
+++ b/tests/bench_timers/test_xtimer.c
@@ -1,0 +1,161 @@
+/*
+ * Copyright (C) 2018 Eistec AB
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Another peripheral timer test application
+ *
+ * @author      Joakim Nohlgård <joakim.nohlgard@eistec.se>
+ *
+ * @}
+ */
+
+#include <stddef.h>
+#include <stdint.h>
+#include "board.h"
+#include "cpu.h"
+#include "periph/timer.h"
+
+#include "thread_flags.h"
+#include "fmt.h"
+#include "xtimer.h"
+#include "print_results.h"
+#include "spin_random.h"
+#include "bench_timers_config.h"
+
+#ifndef TEST_TRACE
+#define TEST_TRACE 0
+#endif
+
+enum test_xtimer_variants {
+    TEST_XTIMER_SET             = 0,
+    TEST_PARALLEL               = 1,
+    TEST_XTIMER_SET_ABSOLUTE    = 2,
+    TEST_XTIMER_PERIODIC_WAKEUP = 4,
+    TEST_XTIMER_SPIN            = 6,
+    TEST_XTIMER_VARIANT_NUMOF   = 8,
+};
+
+const result_presentation_t test_xtimer_presentation = {
+    .groups = (const result_group_t[1]) {
+        {
+            .label = "xtimer",
+            .sub_labels = (const char *[]){
+                [TEST_XTIMER_SET] = "_xt_set",
+                [TEST_XTIMER_SET | TEST_PARALLEL] = "_xt_set race",
+                [TEST_XTIMER_SET_ABSOLUTE] = "_xt_set_abs",
+                [TEST_XTIMER_SET_ABSOLUTE | TEST_PARALLEL] = "_xt_set_abs race",
+                [TEST_XTIMER_PERIODIC_WAKEUP] = "_xt_periodic",
+                [TEST_XTIMER_PERIODIC_WAKEUP | TEST_PARALLEL] = "_xt_periodic race",
+                [TEST_XTIMER_SPIN] = "_xt_spin",
+                [TEST_XTIMER_SPIN | TEST_PARALLEL] = "_xt_spin race",
+            },
+            .num_sub_labels = TEST_VARIANT_NUMOF,
+        },
+    },
+    .num_groups = 1,
+    .ref_limits = &bench_timers_ref_limits,
+    .int_limits = &bench_timers_int_limits,
+    .offsets = (const unsigned[]) {
+        [TEST_XTIMER_SET]                               = TEST_MIN_REL,
+        [TEST_XTIMER_SET | TEST_PARALLEL]               = TEST_MIN_REL,
+        [TEST_XTIMER_SET_ABSOLUTE]                      = TEST_MIN,
+        [TEST_XTIMER_SET_ABSOLUTE | TEST_PARALLEL]      = TEST_MIN,
+        [TEST_XTIMER_PERIODIC_WAKEUP]                   = TEST_MIN_REL,
+        [TEST_XTIMER_PERIODIC_WAKEUP | TEST_PARALLEL]   = TEST_MIN_REL,
+        [TEST_XTIMER_SPIN]                              = TEST_MIN_REL,
+        [TEST_XTIMER_SPIN | TEST_PARALLEL]              = TEST_MIN_REL,
+    },
+};
+
+
+static void cb_nop(void *arg)
+{
+    (void)arg;
+}
+
+void test_xtimer_run(test_ctx_t *ctx, uint32_t interval, unsigned int variant)
+{
+    interval += TEST_MIN;
+    unsigned int interval_ref = TIM_TEST_TO_REF(interval);
+    xtimer_t xt = {
+        .target = 0,
+        .long_target = 0,
+        .callback = bench_timers_cb,
+        .arg = ctx,
+    };
+    xtimer_t xt_parallel = {
+        .target = 0,
+        .long_target = 0,
+        .callback = cb_nop,
+        .arg = NULL,
+    };
+    if (TEST_TRACE) {
+        switch (variant & ~TEST_PARALLEL) {
+            case TEST_XTIMER_SET:
+                print_str("rel ");
+                break;
+            case TEST_XTIMER_SET_ABSOLUTE:
+                print_str("abs ");
+                break;
+            case TEST_XTIMER_PERIODIC_WAKEUP:
+                print_str("per ");
+                break;
+            case TEST_XTIMER_SPIN:
+                print_str("spn ");
+                break;
+            default:
+                break;
+        }
+        if (variant & TEST_PARALLEL) {
+            print_str("= ");
+        }
+        else {
+            print_str("- ");
+        }
+        print_u32_dec(interval);
+        print("\n", 1);
+    }
+
+    spin_random_delay();
+    if (variant & TEST_PARALLEL) {
+        _xtimer_set(&xt_parallel, interval);
+        spin_random_delay();
+    }
+    ctx->target_ref = timer_read(TIM_REF_DEV) + interval_ref;
+    uint32_t now = TUT_READ();
+    ctx->target_tut = now + interval;
+    switch (variant & ~TEST_PARALLEL) {
+        case TEST_XTIMER_SET:
+            _xtimer_set(&xt, interval);
+            break;
+        case TEST_XTIMER_SET_ABSOLUTE:
+            now = TUT_READ();
+            ctx->target_tut = now + interval;
+            _xtimer_set_absolute(&xt, ctx->target_tut);
+            break;
+        case TEST_XTIMER_PERIODIC_WAKEUP:
+            _xtimer_periodic_wakeup(&now, interval);
+            /* xtimer_periodic_wakeup sleeps the thread, no automatic callback */
+            bench_timers_cb(xt.arg);
+            break;
+        case TEST_XTIMER_SPIN:
+            _xtimer_spin(interval);
+            /* xtimer_spin sleeps the thread, no automatic callback */
+            bench_timers_cb(xt.arg);
+            break;
+        default:
+            break;
+    }
+    thread_flags_wait_any(THREAD_FLAG_TEST);
+    xtimer_remove(&xt_parallel);
+    xtimer_remove(&xt);
+}


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Reduce the amount of preprocessor conditionals in the main.c file of the test to make it easier to extend in the future.

### Testing procedure

```
cd tests/bench_timers
make test-xtimer
make clean
make all
```

All should compile cleanly.

### Issues/PRs references

Depends on #9922 