### PR TITLE
examples/default: remove unnecessary dependency to sht11

### DIFF
--- a/examples/default/Makefile
+++ b/examples/default/Makefile
@@ -61,11 +61,7 @@ endif
 
 FEATURES_OPTIONAL += periph_rtc
 
-ifneq (,$(filter msb-430,$(BOARD)))
-  USEMODULE += sht11
-endif
 ifneq (,$(filter msba2,$(BOARD)))
-  USEMODULE += sht11
   USEMODULE += mci
   USEMODULE += random
 endif


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

The `examples/default` application makefike contains unnecessary inclusion of the `sht11` driver module for msba1 and msb430 boards.
But these boards already include this module when `saul_default` is loaded (see their `Makefile.dep`). And the `examples/default` application includes `saul_default`.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Build `examples/default` for msba2 and msb-430 boards and check that sht1x module is built:
```
make BOARD=msba2 -C examples/default
make BOARD=msb-430 -C examples/default
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Maybe #9317

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
