### PR TITLE
frdm-k64f: Add LPTMR configuration

### DIFF
--- a/boards/frdm-k64f/include/periph_conf.h
+++ b/boards/frdm-k64f/include/periph_conf.h
@@ -70,18 +70,25 @@ static const clock_config_t clock_config = {
  * @{
  */
 #define PIT_NUMOF               (2U)
-#define PIT_CONFIG {                 \
-        {                            \
-            .prescaler_ch = 0,       \
-            .count_ch = 1,           \
-        },                           \
-        {                            \
-            .prescaler_ch = 2,       \
-            .count_ch = 3,           \
-        },                           \
+#define PIT_CONFIG {            \
+        {                       \
+            .prescaler_ch = 0,  \
+            .count_ch = 1,      \
+        },                      \
+        {                       \
+            .prescaler_ch = 2,  \
+            .count_ch = 3,      \
+        },                      \
     }
-#define LPTMR_NUMOF             (0U)
-#define LPTMR_CONFIG {}
+#define LPTMR_NUMOF             (1U)
+#define LPTMR_CONFIG {          \
+    {                           \
+        .dev = LPTMR0,          \
+        .irqn = LPTMR0_IRQn,    \
+        .src = 2,               \
+        .base_freq = 32768u,    \
+    },                          \
+}
 #define TIMER_NUMOF             ((PIT_NUMOF) + (LPTMR_NUMOF))
 
 #define PIT_BASECLOCK           (CLOCK_BUSCLOCK)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Add a 32.768 kHz configuration for the low power timer. This config matches the configuration of the other Kinetis development boards.


### Testing procedure

```
cd tests/bench_timers
make BOARD=frdm-k64f test-kinetis-lptmr flash
```

The benchmark program should run and display some results every 30 seconds. Without this configuration change, the program will fail to initialize the timer under test (`Error -1 intializing timer under test`)

### Issues/PRs references

Not yet, will be useful later for low power modes.