### PR TITLE
cpu/esp8266: fixes the compilation problem in pkg/jerryscript

### DIFF
--- a/cpu/esp8266/include/sys/features.h
+++ b/cpu/esp8266/include/sys/features.h
@@ -1,0 +1,533 @@
+/*
+ *  Written by Joel Sherrill <joel@OARcorp.com>.
+ *
+ *  COPYRIGHT (c) 1989-2014.
+ *
+ *  On-Line Applications Research Corporation (OAR).
+ *
+ *  Permission to use, copy, modify, and distribute this software for any
+ *  purpose without fee is hereby granted, provided that this entire notice
+ *  is included in all copies of any software which is or includes a copy
+ *  or modification of this software.
+ *
+ *  THIS SOFTWARE IS BEING PROVIDED "AS IS", WITHOUT ANY EXPRESS OR IMPLIED
+ *  WARRANTY.  IN PARTICULAR,  THE AUTHOR MAKES NO REPRESENTATION
+ *  OR WARRANTY OF ANY KIND CONCERNING THE MERCHANTABILITY OF THIS
+ *  SOFTWARE OR ITS FITNESS FOR ANY PARTICULAR PURPOSE.
+ *
+ *  $Id$
+ */
+
+#ifndef SYS_FEATURES_H
+#define SYS_FEATURES_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <_newlib_version.h>
+
+/* Macro to test version of GCC.  Returns 0 for non-GCC or too old GCC. */
+#ifndef __GNUC_PREREQ
+# if defined __GNUC__ && defined __GNUC_MINOR__
+#  define __GNUC_PREREQ(maj, min) \
+          ((__GNUC__ << 16) + __GNUC_MINOR__ >= ((maj) << 16) + (min))
+# else
+#  define __GNUC_PREREQ(maj, min) 0
+# endif
+#endif /* __GNUC_PREREQ */
+/* Version with trailing underscores for BSD compatibility. */
+#define    __GNUC_PREREQ__(ma, mi)    __GNUC_PREREQ(ma, mi)
+
+
+/*
+ * Feature test macros control which symbols are exposed by the system
+ * headers.  Any of these must be defined before including any headers.
+ *
+ * __STRICT_ANSI__ (defined by gcc -ansi, -std=c90, -std=c99, or -std=c11)
+ *  ISO C
+ *
+ * _POSIX_SOURCE (deprecated by _POSIX_C_SOURCE=1)
+ * _POSIX_C_SOURCE >= 1
+ *  POSIX.1-1990
+ *
+ * _POSIX_C_SOURCE >= 2
+ *  POSIX.2-1992
+ *
+ * _POSIX_C_SOURCE >= 199309L
+ *  POSIX.1b-1993 Real-time extensions
+ *
+ * _POSIX_C_SOURCE >= 199506L
+ *  POSIX.1c-1995 Threads extensions
+ *
+ * _POSIX_C_SOURCE >= 200112L
+ *  POSIX.1-2001 and C99
+ *
+ * _POSIX_C_SOURCE >= 200809L
+ *  POSIX.1-2008
+ *
+ * _XOPEN_SOURCE
+ *  POSIX.1-1990 and XPG4
+ *
+ * _XOPEN_SOURCE_EXTENDED
+ *  SUSv1 (POSIX.2-1992 plus XPG4v2)
+ *
+ * _XOPEN_SOURCE >= 500
+ *  SUSv2 (POSIX.1c-1995 plus XSI)
+ *
+ * _XOPEN_SOURCE >= 600
+ *  SUSv3 (POSIX.1-2001 plus XSI) and C99
+ *
+ * _XOPEN_SOURCE >= 700
+ *  SUSv4 (POSIX.1-2008 plus XSI)
+ *
+ * _ISOC99_SOURCE or gcc -std=c99 or g++
+ *  ISO C99
+ *
+ * _ISOC11_SOURCE or gcc -std=c11 or g++ -std=c++11
+ *  ISO C11
+ *
+ * _ATFILE_SOURCE (implied by _POSIX_C_SOURCE >= 200809L)
+ *  "at" functions
+ *
+ * _LARGEFILE_SOURCE (deprecated by _XOPEN_SOURCE >= 500)
+ *  fseeko, ftello
+ *
+ * _GNU_SOURCE
+ *  All of the above plus GNU extensions
+ *
+ * _BSD_SOURCE (deprecated by _DEFAULT_SOURCE)
+ * _SVID_SOURCE (deprecated by _DEFAULT_SOURCE)
+ * _DEFAULT_SOURCE (or none of the above)
+ *  POSIX-1.2008 with BSD and SVr4 extensions
+ *
+ * _FORTIFY_SOURCE = 1 or 2
+ *  Object Size Checking function wrappers
+ */
+
+#ifdef _GNU_SOURCE
+#undef _ATFILE_SOURCE
+#define _ATFILE_SOURCE      1
+#undef  _DEFAULT_SOURCE
+#define _DEFAULT_SOURCE     1
+#undef _ISOC99_SOURCE
+#define _ISOC99_SOURCE      1
+#undef _ISOC11_SOURCE
+#define _ISOC11_SOURCE      1
+#undef _POSIX_SOURCE
+#define _POSIX_SOURCE       1
+#undef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE     200809L
+#undef _XOPEN_SOURCE
+#define _XOPEN_SOURCE       700
+#undef _XOPEN_SOURCE_EXTENDED
+#define _XOPEN_SOURCE_EXTENDED  1
+#endif /* _GNU_SOURCE */
+
+#if defined(_BSD_SOURCE) || defined(_SVID_SOURCE) || \
+    (!defined(__STRICT_ANSI__) && !defined(_ANSI_SOURCE) && \
+    !defined(_ISOC99_SOURCE) && !defined(_POSIX_SOURCE) && \
+    !defined(_POSIX_C_SOURCE) && !defined(_XOPEN_SOURCE))
+#undef _DEFAULT_SOURCE
+#define _DEFAULT_SOURCE     1
+#endif
+
+#if defined(_DEFAULT_SOURCE)
+#undef _POSIX_SOURCE
+#define _POSIX_SOURCE       1
+#undef _POSIX_C_SOURCE
+#define _POSIX_C_SOURCE     200809L
+#endif
+
+#if !defined(_POSIX_SOURCE) && !defined(_POSIX_C_SOURCE) && \
+    ((!defined(__STRICT_ANSI__) && !defined(_ANSI_SOURCE)) || \
+    (defined(_XOPEN_SOURCE) && (_XOPEN_SOURCE - 0) >= 500))
+#define _POSIX_SOURCE       1
+#if !defined(_XOPEN_SOURCE) || (_XOPEN_SOURCE - 0) >= 700
+#define _POSIX_C_SOURCE     200809L
+#elif (_XOPEN_SOURCE - 0) >= 600
+#define _POSIX_C_SOURCE     200112L
+#elif (_XOPEN_SOURCE - 0) >= 500
+#define _POSIX_C_SOURCE     199506L
+#elif (_XOPEN_SOURCE - 0) < 500
+#define _POSIX_C_SOURCE     2
+#endif
+#endif
+
+#if defined(_POSIX_C_SOURCE) && _POSIX_C_SOURCE >= 200809
+#undef _ATFILE_SOURCE
+#define _ATFILE_SOURCE      1
+#endif
+
+/*
+ * The following private macros are used throughout the headers to control
+ * which symbols should be exposed.  They are for internal use only, as
+ * indicated by the leading double underscore, and must never be used outside
+ * of these headers.
+ *
+ * __POSIX_VISIBLE
+ *  any version of POSIX.1; enabled by default, or with _POSIX_SOURCE,
+ *  any value of _POSIX_C_SOURCE, or _XOPEN_SOURCE >= 500.
+ *
+ * __POSIX_VISIBLE >= 2
+ *  POSIX.2-1992; enabled by default, with _POSIX_C_SOURCE >= 2,
+ *  or _XOPEN_SOURCE >= 500.
+ *
+ * __POSIX_VISIBLE >= 199309
+ *  POSIX.1b-1993; enabled by default, with _POSIX_C_SOURCE >= 199309L,
+ *  or _XOPEN_SOURCE >= 500.
+ *
+ * __POSIX_VISIBLE >= 199506
+ *  POSIX.1c-1995; enabled by default, with _POSIX_C_SOURCE >= 199506L,
+ *  or _XOPEN_SOURCE >= 500.
+ *
+ * __POSIX_VISIBLE >= 200112
+ *  POSIX.1-2001; enabled by default, with _POSIX_C_SOURCE >= 200112L,
+ *  or _XOPEN_SOURCE >= 600.
+ *
+ * __POSIX_VISIBLE >= 200809
+ *  POSIX.1-2008; enabled by default, with _POSIX_C_SOURCE >= 200809L,
+ *  or _XOPEN_SOURCE >= 700.
+ *
+ * __XSI_VISIBLE
+ *  XPG4 XSI extensions; enabled with any version of _XOPEN_SOURCE.
+ *
+ * __XSI_VISIBLE >= 4
+ *  SUSv1 XSI extensions; enabled with both _XOPEN_SOURCE and
+ *  _XOPEN_SOURCE_EXTENDED together.
+ *
+ * __XSI_VISIBLE >= 500
+ *  SUSv2 XSI extensions; enabled with _XOPEN_SOURCE >= 500.
+ *
+ * __XSI_VISIBLE >= 600
+ *  SUSv3 XSI extensions; enabled with _XOPEN_SOURCE >= 600.
+ *
+ * __XSI_VISIBLE >= 700
+ *  SUSv4 XSI extensions; enabled with _XOPEN_SOURCE >= 700.
+ *
+ * __ISO_C_VISIBLE >= 1999
+ *  ISO C99; enabled with gcc -std=c99 or newer (on by default since GCC 5),
+ *  any version of C++, or with _ISOC99_SOURCE, _POSIX_C_SOURCE >= 200112L,
+ *  or _XOPEN_SOURCE >= 600.
+ *
+ * __ISO_C_VISIBLE >= 2011
+ *  ISO C11; enabled with gcc -std=c11 or newer (on by default since GCC 5),
+ *  g++ -std=c++11 or newer (on by default since GCC 6), or with
+ *  _ISOC11_SOURCE.
+ *
+ * __ATFILE_VISIBLE
+ *  "at" functions; enabled by default, with _ATFILE_SOURCE,
+ *  _POSIX_C_SOURCE >= 200809L, or _XOPEN_SOURCE >= 700.
+ *
+ * __LARGEFILE_VISIBLE
+ *  fseeko, ftello; enabled with _LARGEFILE_SOURCE or _XOPEN_SOURCE >= 500.
+ *
+ * __BSD_VISIBLE
+ *  BSD extensions; enabled by default, or with _BSD_SOURCE.
+ *
+ * __SVID_VISIBLE
+ *  SVr4 extensions; enabled by default, or with _SVID_SOURCE.
+ *
+ * __MISC_VISIBLE
+ *  Extensions found in both BSD and SVr4 (shorthand for
+ *  (__BSD_VISIBLE || __SVID_VISIBLE)), or newlib-specific
+ *  extensions; enabled by default.
+ *
+ * __GNU_VISIBLE
+ *  GNU extensions; enabled with _GNU_SOURCE.
+ *
+ * __SSP_FORTIFY_LEVEL
+ *  Object Size Checking; defined to 0 (off), 1, or 2.
+ *
+ * In all cases above, "enabled by default" means either by defining
+ * _DEFAULT_SOURCE, or by not defining any of the public feature test macros.
+ */
+
+#ifdef _ATFILE_SOURCE
+#define __ATFILE_VISIBLE    1
+#else
+#define __ATFILE_VISIBLE    0
+#endif
+
+#ifdef _DEFAULT_SOURCE
+#define __BSD_VISIBLE       1
+#else
+#define __BSD_VISIBLE       0
+#endif
+
+#ifdef _GNU_SOURCE
+#define __GNU_VISIBLE       1
+#else
+#define __GNU_VISIBLE       0
+#endif
+
+#if defined(_ISOC11_SOURCE) || \
+    (__STDC_VERSION__ - 0) >= 201112L || (__cplusplus - 0) >= 201103L
+#define __ISO_C_VISIBLE     2011
+#elif defined(_ISOC99_SOURCE) || (_POSIX_C_SOURCE - 0) >= 200112L || \
+    (__STDC_VERSION__ - 0) >= 199901L || defined(__cplusplus)
+#define __ISO_C_VISIBLE     1999
+#else
+#define __ISO_C_VISIBLE     1990
+#endif
+
+#if defined(_LARGEFILE_SOURCE) || (_XOPEN_SOURCE - 0) >= 500
+#define __LARGEFILE_VISIBLE 1
+#else
+#define __LARGEFILE_VISIBLE 0
+#endif
+
+#ifdef _DEFAULT_SOURCE
+#define __MISC_VISIBLE      1
+#else
+#define __MISC_VISIBLE      0
+#endif
+
+#if (_POSIX_C_SOURCE - 0) >= 200809L
+#define __POSIX_VISIBLE     200809
+#elif (_POSIX_C_SOURCE - 0) >= 200112L
+#define __POSIX_VISIBLE     200112
+#elif (_POSIX_C_SOURCE - 0) >= 199506L
+#define __POSIX_VISIBLE     199506
+#elif (_POSIX_C_SOURCE - 0) >= 199309L
+#define __POSIX_VISIBLE     199309
+#elif (_POSIX_C_SOURCE - 0) >= 2 || defined(_XOPEN_SOURCE)
+#define __POSIX_VISIBLE     199209
+#elif defined(_POSIX_SOURCE) || defined(_POSIX_C_SOURCE)
+#define __POSIX_VISIBLE     199009
+#else
+#define __POSIX_VISIBLE     0
+#endif
+
+#ifdef _DEFAULT_SOURCE
+#define __SVID_VISIBLE      1
+#else
+#define __SVID_VISIBLE      0
+#endif
+
+#if (_XOPEN_SOURCE - 0) >= 700
+#define __XSI_VISIBLE       700
+#elif (_XOPEN_SOURCE - 0) >= 600
+#define __XSI_VISIBLE       600
+#elif (_XOPEN_SOURCE - 0) >= 500
+#define __XSI_VISIBLE       500
+#elif defined(_XOPEN_SOURCE) && defined(_XOPEN_SOURCE_EXTENDED)
+#define __XSI_VISIBLE       4
+#elif defined(_XOPEN_SOURCE)
+#define __XSI_VISIBLE       1
+#else
+#define __XSI_VISIBLE       0
+#endif
+
+#if _FORTIFY_SOURCE > 0 && !defined(__cplusplus) && !defined(__lint__) && \
+    (__OPTIMIZE__ > 0 || defined(__clang__)) && __GNUC_PREREQ__(4, 1)
+#  if _FORTIFY_SOURCE > 1
+#    define __SSP_FORTIFY_LEVEL 2
+#  else
+#    define __SSP_FORTIFY_LEVEL 1
+#  endif
+#else
+#  define __SSP_FORTIFY_LEVEL   0
+#endif
+
+/* RTEMS adheres to POSIX -- 1003.1b with some features from annexes.  */
+
+#ifdef __rtems__
+#define _POSIX_JOB_CONTROL              1
+#define _POSIX_SAVED_IDS                1
+#define _POSIX_VERSION                  199309L
+#define _POSIX_ASYNCHRONOUS_IO          1
+#define _POSIX_FSYNC                    1
+#define _POSIX_MAPPED_FILES             1
+#define _POSIX_MEMLOCK                  1
+#define _POSIX_MEMLOCK_RANGE            1
+#define _POSIX_MEMORY_PROTECTION        1
+#define _POSIX_MESSAGE_PASSING          1
+#define _POSIX_MONOTONIC_CLOCK          200112L
+#define _POSIX_CLOCK_SELECTION          200112L
+#define _POSIX_PRIORITIZED_IO           1
+#define _POSIX_PRIORITY_SCHEDULING      1
+#define _POSIX_REALTIME_SIGNALS         1
+#define _POSIX_SEMAPHORES               1
+#define _POSIX_SHARED_MEMORY_OBJECTS    1
+#define _POSIX_SYNCHRONIZED_IO          1
+#define _POSIX_TIMERS                   1
+#define _POSIX_BARRIERS                 200112L
+#define _POSIX_READER_WRITER_LOCKS      200112L
+#define _POSIX_SPIN_LOCKS               200112L
+
+
+/* In P1003.1b but defined by drafts at least as early as P1003.1c/D10  */
+#define _POSIX_THREADS                      1
+#define _POSIX_THREAD_ATTR_STACKADDR        1
+#define _POSIX_THREAD_ATTR_STACKSIZE        1
+#define _POSIX_THREAD_PRIORITY_SCHEDULING   1
+#define _POSIX_THREAD_PRIO_INHERIT          1
+#define _POSIX_THREAD_PRIO_PROTECT          1
+#define _POSIX_THREAD_PROCESS_SHARED        1
+#define _POSIX_THREAD_SAFE_FUNCTIONS        1
+
+/* P1003.4b/D8 defines the constants below this comment. */
+#define _POSIX_SPAWN                    1
+#define _POSIX_TIMEOUTS                 1
+#define _POSIX_CPUTIME                  1
+#define _POSIX_THREAD_CPUTIME           1
+#define _POSIX_SPORADIC_SERVER          1
+#define _POSIX_THREAD_SPORADIC_SERVER   1
+#define _POSIX_DEVICE_CONTROL           1
+#define _POSIX_DEVCTL_DIRECTION         1
+#define _POSIX_INTERRUPT_CONTROL        1
+#define _POSIX_ADVISORY_INFO            1
+
+/* UNIX98 added some new pthread mutex attributes */
+#define _UNIX98_THREAD_MUTEX_ATTRIBUTES         1
+
+/* POSIX 1003.26-2003 defined device control method */
+#define _POSIX_26_VERSION           200312L
+
+#endif
+
+/* XMK loosely adheres to POSIX -- 1003.1 */
+#ifdef __XMK__
+#define _POSIX_THREADS                      1
+#define _POSIX_THREAD_PRIORITY_SCHEDULING   1
+#endif
+
+
+#ifdef __svr4__
+# define _POSIX_JOB_CONTROL     1
+# define _POSIX_SAVED_IDS       1
+# define _POSIX_VERSION         199009L
+#endif
+
+#ifdef __CYGWIN__
+
+#if __POSIX_VISIBLE >= 200809
+#define _POSIX_VERSION              200809L
+#define _POSIX2_VERSION             200809L
+#elif __POSIX_VISIBLE >= 200112
+#define _POSIX_VERSION              200112L
+#define _POSIX2_VERSION             200112L
+#elif __POSIX_VISIBLE >= 199506
+#define _POSIX_VERSION              199506L
+#define _POSIX2_VERSION             199506L
+#elif __POSIX_VISIBLE >= 199309
+#define _POSIX_VERSION              199309L
+#define _POSIX2_VERSION             199209L
+#elif __POSIX_VISIBLE >= 199209
+#define _POSIX_VERSION              199009L
+#define _POSIX2_VERSION             199209L
+#elif __POSIX_VISIBLE
+#define _POSIX_VERSION              199009L
+#endif
+#if __XSI_VISIBLE >= 4
+#define _XOPEN_VERSION              __XSI_VISIBLE
+#endif
+
+#define _POSIX_ADVISORY_INFO                200809L
+/* #define _POSIX_ASYNCHRONOUS_IO           -1 */
+#define _POSIX_BARRIERS                     200809L
+#define _POSIX_CHOWN_RESTRICTED             1
+#define _POSIX_CLOCK_SELECTION              200809L
+#define _POSIX_CPUTIME                      200809L
+#define _POSIX_FSYNC                        200809L
+#define _POSIX_IPV6                         200809L
+#define _POSIX_JOB_CONTROL                  1
+#define _POSIX_MAPPED_FILES                 200809L
+/* #define _POSIX_MEMLOCK                   -1 */
+#define _POSIX_MEMLOCK_RANGE                200809L
+#define _POSIX_MEMORY_PROTECTION            200809L
+#define _POSIX_MESSAGE_PASSING              200809L
+#define _POSIX_MONOTONIC_CLOCK              200809L
+#define _POSIX_NO_TRUNC                     1
+/* #define _POSIX_PRIORITIZED_IO            -1 */
+#define _POSIX_PRIORITY_SCHEDULING          200809L
+#define _POSIX_RAW_SOCKETS                  200809L
+#define _POSIX_READER_WRITER_LOCKS          200809L
+#define _POSIX_REALTIME_SIGNALS             200809L
+#define _POSIX_REGEXP                       1
+#define _POSIX_SAVED_IDS                    1
+#define _POSIX_SEMAPHORES                   200809L
+#define _POSIX_SHARED_MEMORY_OBJECTS        200809L
+#define _POSIX_SHELL                        1
+#define _POSIX_SPAWN                        200809L
+#define _POSIX_SPIN_LOCKS                   200809L
+/* #define _POSIX_SPORADIC_SERVER           -1 */
+#define _POSIX_SYNCHRONIZED_IO              200809L
+#define _POSIX_THREAD_ATTR_STACKADDR        200809L
+#define _POSIX_THREAD_ATTR_STACKSIZE        200809L
+#define _POSIX_THREAD_CPUTIME               200809L
+/* #define _POSIX_THREAD_PRIO_INHERIT       -1 */
+/* #define _POSIX_THREAD_PRIO_PROTECT       -1 */
+#define _POSIX_THREAD_PRIORITY_SCHEDULING   200809L
+#define _POSIX_THREAD_PROCESS_SHARED        200809L
+#define _POSIX_THREAD_SAFE_FUNCTIONS        200809L
+/* #define _POSIX_THREAD_SPORADIC_SERVER    -1 */
+#define _POSIX_THREADS                      200809L
+#define _POSIX_TIMEOUTS                     200809L
+#define _POSIX_TIMERS                       200809L
+/* #define _POSIX_TRACE                     -1 */
+/* #define _POSIX_TRACE_EVENT_FILTER        -1 */
+/* #define _POSIX_TRACE_INHERIT             -1 */
+/* #define _POSIX_TRACE_LOG                 -1 */
+/* #define _POSIX_TYPED_MEMORY_OBJECTS      -1 */
+#define _POSIX_VDISABLE                     '\0'
+
+#if __POSIX_VISIBLE >= 2
+#define _POSIX2_C_VERSION           _POSIX2_VERSION
+#define _POSIX2_C_BIND              _POSIX2_VERSION
+#define _POSIX2_C_DEV               _POSIX2_VERSION
+#define _POSIX2_CHAR_TERM           _POSIX2_VERSION
+/* #define _POSIX2_FORT_DEV         -1 */
+/* #define _POSIX2_FORT_RUN         -1 */
+/* #define _POSIX2_LOCALEDEF        -1 */
+/* #define _POSIX2_PBS              -1 */
+/* #define _POSIX2_PBS_ACCOUNTING   -1 */
+/* #define _POSIX2_PBS_CHECKPOINT   -1 */
+/* #define _POSIX2_PBS_LOCATE       -1 */
+/* #define _POSIX2_PBS_MESSAGE      -1 */
+/* #define _POSIX2_PBS_TRACK        -1 */
+#define _POSIX2_SW_DEV              _POSIX2_VERSION
+#define _POSIX2_UPE                 _POSIX2_VERSION
+#endif /* __POSIX_VISIBLE >= 2 */
+
+#define _POSIX_V6_ILP32_OFF32       -1
+#ifdef __LP64__
+#define _POSIX_V6_ILP32_OFFBIG      -1
+#define _POSIX_V6_LP64_OFF64         1
+#define _POSIX_V6_LPBIG_OFFBIG       1
+#else
+#define _POSIX_V6_ILP32_OFFBIG       1
+#define _POSIX_V6_LP64_OFF64        -1
+#define _POSIX_V6_LPBIG_OFFBIG      -1
+#endif
+#define _POSIX_V7_ILP32_OFF32       _POSIX_V6_ILP32_OFF32
+#define _POSIX_V7_ILP32_OFFBIG      _POSIX_V6_ILP32_OFFBIG
+#define _POSIX_V7_LP64_OFF64        _POSIX_V6_LP64_OFF64
+#define _POSIX_V7_LPBIG_OFFBIG      _POSIX_V6_LPBIG_OFFBIG
+#define _XBS5_ILP32_OFF32           _POSIX_V6_ILP32_OFF32
+#define _XBS5_ILP32_OFFBIG          _POSIX_V6_ILP32_OFFBIG
+#define _XBS5_LP64_OFF64            _POSIX_V6_LP64_OFF64
+#define _XBS5_LPBIG_OFFBIG          _POSIX_V6_LPBIG_OFFBIG
+
+#if __XSI_VISIBLE
+#define _XOPEN_CRYPT                 1
+#define _XOPEN_ENH_I18N              1
+/* #define _XOPEN_LEGACY            -1 */
+/* #define _XOPEN_REALTIME          -1 */
+/* #define _XOPEN_REALTIME_THREADS  -1 */
+#define _XOPEN_SHM                   1
+/* #define _XOPEN_STREAMS           -1 */
+/* #define _XOPEN_UNIX              -1 */
+#endif /* __XSI_VISIBLE */
+
+/* The value corresponds to UNICODE version 5.2, which is the current
+   state of newlib's wide char conversion functions. */
+#define __STDC_ISO_10646__ 200910L
+
+#endif /* __CYGWIN__ */
+
+#ifdef __cplusplus
+}
+#endif
+#endif /* SYS_FEATURES_H */


### PR DESCRIPTION
This PR adds a slightly modified yersion of ```newlib-xtensa/xtensa-lx106-els/include/sys/features.h``` which replaces the original one during compilation. It fixes the compilation problem for esp8266 boards of PR #9821.

Related to PR #9821.