### PR TITLE
boards: Add two KW41Z-based boards

### DIFF
--- a/boards/beduino-pro-mini/Makefile
+++ b/boards/beduino-pro-mini/Makefile
@@ -1,0 +1,5 @@
+MODULE = board
+
+DIRS = $(RIOTBOARD)/common/kw41z
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/beduino-pro-mini/Makefile.dep
+++ b/boards/beduino-pro-mini/Makefile.dep
@@ -1,0 +1,1 @@
+include $(RIOTBOARD)/common/kw41z/Makefile.dep

--- a/boards/beduino-pro-mini/Makefile.features
+++ b/boards/beduino-pro-mini/Makefile.features
@@ -1,0 +1,1 @@
+include $(RIOTBOARD)/common/kw41z/Makefile.features

--- a/boards/beduino-pro-mini/Makefile.include
+++ b/boards/beduino-pro-mini/Makefile.include
@@ -1,0 +1,10 @@
+export CPU_MODEL = mkw41z256vht4
+
+USEMODULE += boards_common_kw41z
+include $(RIOTBOARD)/common/kw41z/Makefile.include
+
+export DEBUG_ADAPTER ?= dap
+
+# this board uses openocd
+include $(RIOTMAKE)/tools/openocd.inc.mk
+

--- a/boards/beduino-pro-mini/board.c
+++ b/boards/beduino-pro-mini/board.c
@@ -1,0 +1,36 @@
+/*
+ * Copyright (C) 2018 Tristan Bruns
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     boards_beduino-pro-mini
+ * @{
+ *
+ * @file
+ * @brief       Board specific initialization for the Beduino Pro Mini
+ *
+ * @author      Joakim Nohlgård <joakim.nohlgard@eistec.se>
+ * @author      Maximilian Luenert <malu@uni-bremen.de>
+ * @author      Tristan Bruns <tbruns@uni-bremen.de>
+ *
+ * @}
+ */
+
+#include "board.h"
+#include "periph/gpio.h"
+
+void board_init(void)
+{
+    /* initialize the CPU core */
+    cpu_init();
+
+    /* initialize and turn off LEDs */
+    gpio_init(LED0_PIN, GPIO_OUT);
+    gpio_set(LED0_PIN);
+    gpio_init(LED1_PIN, GPIO_OUT);
+    gpio_set(LED1_PIN);
+}

--- a/boards/beduino-pro-mini/dist/openocd.cfg
+++ b/boards/beduino-pro-mini/dist/openocd.cfg
@@ -1,0 +1,6 @@
+source [find target/kx.cfg]
+reset_config srst_only
+$_TARGETNAME configure -rtos auto
+$_TARGETNAME configure -event gdb-attach {
+  halt
+}

--- a/boards/beduino-pro-mini/doc.txt
+++ b/boards/beduino-pro-mini/doc.txt
@@ -1,0 +1,5 @@
+/**
+ * @defgroup    boards_beduino-pro-mini Beduino Pro Mini Board
+ * @ingroup     boards
+ * @brief       Support for the Beduino Pro Mini
+ */

--- a/boards/beduino-pro-mini/include/board.h
+++ b/boards/beduino-pro-mini/include/board.h
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2018 Tristan Bruns
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     boards_beduino-pro-mini
+ * @{
+ *
+ * @file
+ * @brief       Board specific definitions for the Beduino Pro Mini
+ *
+ * @author      Joakim Nohlgård <joakim.nohlgard@eistec.se>
+ * @author      Maximilian Luenert <malu@uni-bremen.de>
+ * @author      Tristan Bruns <tbruns@uni-bremen.de>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include "cpu.h"
+#include "periph_conf.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/**
+ * @name    LED pin definitions and handlers
+ * @{
+ */
+#define LED0_PIN            GPIO_PIN(PORT_B,  0)
+#define LED0_MASK           (1 << 0)
+#define LED0_ON             (GPIOB->PCOR = LED0_MASK)
+#define LED0_OFF            (GPIOB->PSOR = LED0_MASK)
+#define LED0_TOGGLE         (GPIOB->PTOR = LED0_MASK)
+#define LED1_PIN            GPIO_PIN(PORT_C,  5)
+#define LED1_MASK           (1 << 5)
+#define LED1_ON             (GPIOC->PCOR = LED1_MASK)
+#define LED1_OFF            (GPIOC->PSOR = LED1_MASK)
+#define LED1_TOGGLE         (GPIOC->PTOR = LED1_MASK)
+/** @} */
+
+/**
+ * @name    xtimer configuration
+ * @{
+ */
+#if KINETIS_XTIMER_SOURCE_PIT
+/* PIT xtimer configuration */
+#define XTIMER_DEV                  (TIMER_PIT_DEV(0))
+#define XTIMER_CHAN                 (0)
+/* Default xtimer settings should work on the PIT */
+#else
+/* LPTMR xtimer configuration */
+#define XTIMER_DEV                  (TIMER_LPTMR_DEV(0))
+#define XTIMER_CHAN                 (0)
+/* LPTMR is 16 bits wide and runs at 32768 Hz (clocked by the RTC) */
+#define XTIMER_WIDTH                (16)
+#define XTIMER_BACKOFF              (5)
+#define XTIMER_ISR_BACKOFF          (5)
+#define XTIMER_OVERHEAD             (4)
+#define XTIMER_HZ                   (32768ul)
+#endif
+/** @} */
+
+/**
+ * @brief   Initialize board specific hardware, including clock, LEDs and standard I/O
+ */
+void board_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/beduino-pro-mini/include/gpio_params.h
+++ b/boards/beduino-pro-mini/include/gpio_params.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2018 Tristan Bruns
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup   boards_beduino-pro-mini
+ * @{
+ *
+ * @file
+ * @brief     Board specific configuration of direct mapped GPIOs
+ *
+ * @author    Joakim Nohlgård <joakim.nohlgard@eistec.se>
+ * @author    Maximilian Luenert <malu@uni-bremen.de>
+ * @author    Tristan Bruns <tbruns@uni-bremen.de>
+ */
+
+#ifndef GPIO_PARAMS_H
+#define GPIO_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    LED configuration
+ */
+static const  saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name = "LED0",
+        .pin = LED0_PIN,
+        .mode = GPIO_OUT,
+        .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
+    },
+    {
+        .name = "LED1",
+        .pin = LED1_PIN,
+        .mode = GPIO_OUT,
+        .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_PARAMS_H */
+/** @} */

--- a/boards/common/kw41z/Makefile
+++ b/boards/common/kw41z/Makefile
@@ -1,0 +1,3 @@
+MODULE = boards_common_kw41z
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/common/kw41z/Makefile.dep
+++ b/boards/common/kw41z/Makefile.dep
@@ -1,0 +1,6 @@
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += saul_gpio
+  USEMODULE += saul_adc
+endif
+
+include $(RIOTCPU)/kinetis/Makefile.dep

--- a/boards/common/kw41z/Makefile.features
+++ b/boards/common/kw41z/Makefile.features
@@ -1,0 +1,16 @@
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_adc
+FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_rtc
+FEATURES_PROVIDED += periph_rtt
+FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart
+
+# The board MPU family (used for grouping by the CI system)
+FEATURES_MCU_GROUP = cortex_m0_2
+
+include $(RIOTCPU)/kinetis/Makefile.features
+
+# Remove this line after TRNG driver is implemented
+FEATURES_PROVIDED := $(filter-out periph_hwrng,$(FEATURES_PROVIDED))

--- a/boards/common/kw41z/Makefile.include
+++ b/boards/common/kw41z/Makefile.include
@@ -1,0 +1,11 @@
+export CPU = kinetis
+
+# OpenOCD v0.10.0-dev (current development version) or later is required for
+# flashing KW41Z devices
+# See http://openocd.zylin.com/#/c/4104/ for the upstreaming process
+export USE_OLD_OPENOCD ?= 0
+
+# Check the flash configuration field before flashing
+export PRE_FLASH_CHECK_SCRIPT = $(RIOTCPU)/$(CPU)/dist/check-fcfield-elf.sh
+
+INCLUDES += -I$(RIOTBOARD)/common/kw41z/include

--- a/boards/common/kw41z/include/adc_params.h
+++ b/boards/common/kw41z/include/adc_params.h
@@ -7,7 +7,7 @@
  */
 
 /**
- * @ingroup   boards_frdm-kw41z
+ * @ingroup   boards_common_kw41z
  * @{
  *
  * @file

--- a/boards/common/kw41z/include/periph_conf.h
+++ b/boards/common/kw41z/include/periph_conf.h
@@ -11,7 +11,7 @@
  * @{
  *
  * @file
- * @name        Peripheral MCU configuration for the FRDM-KW41Z
+ * @name        Peripheral MCU configuration for KW41Z-based boards
  *
  * @author      Joakim Nohlgård <joakim.nohlgard@eistec.se>
  */

--- a/boards/frdm-kw41z/Makefile
+++ b/boards/frdm-kw41z/Makefile
@@ -1,3 +1,5 @@
 MODULE = board
 
+DIRS = $(RIOTBOARD)/common/kw41z
+
 include $(RIOTBASE)/Makefile.base

--- a/boards/frdm-kw41z/Makefile.dep
+++ b/boards/frdm-kw41z/Makefile.dep
@@ -1,6 +1,1 @@
-ifneq (,$(filter saul_default,$(USEMODULE)))
-  USEMODULE += saul_gpio
-  USEMODULE += saul_adc
-endif
-
-include $(RIOTCPU)/kinetis/Makefile.dep
+include $(RIOTBOARD)/common/kw41z/Makefile.dep

--- a/boards/frdm-kw41z/Makefile.features
+++ b/boards/frdm-kw41z/Makefile.features
@@ -1,15 +1,1 @@
-# Put defined MCU peripherals here (in alphabetical order)
-FEATURES_PROVIDED += periph_adc
-FEATURES_PROVIDED += periph_i2c
-FEATURES_PROVIDED += periph_rtc
-FEATURES_PROVIDED += periph_rtt
-FEATURES_PROVIDED += periph_spi
-FEATURES_PROVIDED += periph_timer
-FEATURES_PROVIDED += periph_uart
-
-# The board MPU family (used for grouping by the CI system)
-FEATURES_MCU_GROUP = cortex_m0_2
-
-include $(RIOTCPU)/kinetis/Makefile.features
-# Remove this line after TRNG driver is implemented
-FEATURES_PROVIDED := $(filter-out periph_hwrng,$(FEATURES_PROVIDED))
+include $(RIOTBOARD)/common/kw41z/Makefile.features

--- a/boards/frdm-kw41z/Makefile.include
+++ b/boards/frdm-kw41z/Makefile.include
@@ -1,11 +1,8 @@
-# define the cpu used by the board
-export CPU = kinetis
 export CPU_MODEL = mkw41z512vht4
 
-# OpenOCD v0.10.0-dev (current development version) or later is required for
-# flashing KW41Z devices
-# See http://openocd.zylin.com/#/c/4104/ for the upstreaming process
-export USE_OLD_OPENOCD ?= 0
+USEMODULE += boards_common_kw41z
+include $(RIOTBOARD)/common/kw41z/Makefile.include
+
 # This board comes with OpenSDA configured for JLink compatibility
 export DEBUG_ADAPTER ?= jlink
 

--- a/boards/kw41z-mini/Makefile
+++ b/boards/kw41z-mini/Makefile
@@ -1,0 +1,5 @@
+MODULE = board
+
+DIRS = $(RIOTBOARD)/common/kw41z
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/kw41z-mini/Makefile.dep
+++ b/boards/kw41z-mini/Makefile.dep
@@ -1,0 +1,1 @@
+include $(RIOTBOARD)/common/kw41z/Makefile.dep

--- a/boards/kw41z-mini/Makefile.features
+++ b/boards/kw41z-mini/Makefile.features
@@ -1,0 +1,1 @@
+include $(RIOTBOARD)/common/kw41z/Makefile.features

--- a/boards/kw41z-mini/Makefile.include
+++ b/boards/kw41z-mini/Makefile.include
@@ -1,0 +1,12 @@
+export CPU_MODEL = mkw41z256vht4
+
+USEMODULE += boards_common_kw41z
+include $(RIOTBOARD)/common/kw41z/Makefile.include
+
+# no on-board programming capabilities. default to stlink
+export DEBUG_ADAPTER ?= stlink
+export STLINK_VERSION ?= 2
+
+# this board uses openocd
+include $(RIOTMAKE)/tools/openocd.inc.mk
+

--- a/boards/kw41z-mini/board.c
+++ b/boards/kw41z-mini/board.c
@@ -1,0 +1,34 @@
+/*
+ * Copyright (C) 2018 Tristan Bruns
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     boards_kw41z-mini
+ * @{
+ *
+ * @file
+ * @brief       Board specific initialization for the kw41z-mini
+ *
+ * @author      Joakim Nohlgård <joakim.nohlgard@eistec.se>
+ * @author      Maximilian Luenert <malu@uni-bremen.de>
+ * @author      Tristan Bruns <tbruns@uni-bremen.de>
+ *
+ * @}
+ */
+
+#include "board.h"
+#include "periph/gpio.h"
+
+void board_init(void)
+{
+    /* initialize the CPU core */
+    cpu_init();
+
+    /* initialize and turn off LEDs */
+    gpio_init(LED0_PIN, GPIO_OUT);
+    gpio_set(LED0_PIN);
+}

--- a/boards/kw41z-mini/dist/openocd.cfg
+++ b/boards/kw41z-mini/dist/openocd.cfg
@@ -1,0 +1,6 @@
+source [find target/kx.cfg]
+reset_config srst_only
+$_TARGETNAME configure -rtos auto
+$_TARGETNAME configure -event gdb-attach {
+  halt
+}

--- a/boards/kw41z-mini/doc.txt
+++ b/boards/kw41z-mini/doc.txt
@@ -1,0 +1,5 @@
+/**
+ * @defgroup    boards_kw41z-mini kw41z-mini Board
+ * @ingroup     boards
+ * @brief       Support for the kw41z-mini
+ */

--- a/boards/kw41z-mini/include/board.h
+++ b/boards/kw41z-mini/include/board.h
@@ -1,0 +1,75 @@
+/*
+ * Copyright (C) 2018 Tristan Bruns
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     boards_kw41z-mini
+ * @{
+ *
+ * @file
+ * @brief       Board specific definitions for the kw41z-mini
+ *
+ * @author      Joakim Nohlgård <joakim.nohlgard@eistec.se>
+ * @author      Maximilian Luenert <malu@uni-bremen.de>
+ * @author      Tristan Bruns <tbruns@uni-bremen.de>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include "cpu.h"
+#include "periph_conf.h"
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/**
+ * @name    LED pin definitions and handlers
+ * @{
+ */
+#define LED0_PIN            GPIO_PIN(PORT_B,  0)
+#define LED0_MASK           (1 << 0)
+#define LED0_ON             (GPIOB->PCOR = LED0_MASK)
+#define LED0_OFF            (GPIOB->PSOR = LED0_MASK)
+#define LED0_TOGGLE         (GPIOB->PTOR = LED0_MASK)
+/** @} */
+
+/**
+ * @name    xtimer configuration
+ * @{
+ */
+#if KINETIS_XTIMER_SOURCE_PIT
+/* PIT xtimer configuration */
+#define XTIMER_DEV                  (TIMER_PIT_DEV(0))
+#define XTIMER_CHAN                 (0)
+/* Default xtimer settings should work on the PIT */
+#else
+/* LPTMR xtimer configuration */
+#define XTIMER_DEV                  (TIMER_LPTMR_DEV(0))
+#define XTIMER_CHAN                 (0)
+/* LPTMR is 16 bits wide and runs at 32768 Hz (clocked by the RTC) */
+#define XTIMER_WIDTH                (16)
+#define XTIMER_BACKOFF              (5)
+#define XTIMER_ISR_BACKOFF          (5)
+#define XTIMER_OVERHEAD             (4)
+#define XTIMER_HZ                   (32768ul)
+#endif
+/** @} */
+
+/**
+ * @brief   Initialize board specific hardware, including clock, LEDs and standard I/O
+ */
+void board_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/kw41z-mini/include/gpio_params.h
+++ b/boards/kw41z-mini/include/gpio_params.h
@@ -1,0 +1,49 @@
+/*
+ * Copyright (C) 2018 Tristan Bruns
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup   boards_kw41z-mini
+ * @{
+ *
+ * @file
+ * @brief     Board specific configuration of direct mapped GPIOs
+ *
+ * @author    Joakim Nohlgård <joakim.nohlgard@eistec.se>
+ * @author    Maximilian Luenert <malu@uni-bremen.de>
+ * @author    Tristan Bruns <tbruns@uni-bremen.de>
+ */
+
+#ifndef GPIO_PARAMS_H
+#define GPIO_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    LED configuration
+ */
+static const  saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name = "LED0",
+        .pin = LED0_PIN,
+        .mode = GPIO_OUT,
+        .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_PARAMS_H */
+/** @} */


### PR DESCRIPTION
### Contribution description

This PR refactors the FRDM-KW41Z boards support to allow for code sharing with other KW41Z-based boards and then adds two of them:

* kw41z-mini: https://openlabs.co/store/kw41z-mini (Basically a KW41Z breakout board with quarzes, reset button, one LED, and a 1.27mm 2x5 ARM Cortex-M debug connector)
* Beduino Pro Mini: Our kw41z-mini clone with integrated DAPLink programmer and a second LED (To be published)

The first board is commercially available (for now, at least) and the second one is completely unpublished at the moment. We finished producing the first 15 prototype boards by hand yesterday and we will now look into commercial manufacture (and acquiring funds). We are aiming to publish our KICAD source files under a permissive license. I would not be insulted if the limited availability of the boards was reason to reject (parts of) this pull request.

This is the first time I introduced a `boards/common` directory, so I probably made some errors.


### TODO

* [ ] Add documentation for both boards

