### PR TITLE
 Makefile.include: replace $(USEPKG:%=$(BINDIR)/%.a) target 

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -475,9 +475,9 @@ endif
 pkg-prepare:
 	-@for i in $(USEPKG) ; do "$(MAKE)" -C $(RIOTPKG)/$$i prepare ; done
 
-$(USEPKG:%=$(BINDIR)/%.a): $(BUILDDEPS) FORCE
+$(USEPKG:%=$(BINDIR)/%.a): $(BINDIR)/%.a: $(BUILDDEPS) FORCE
 	@mkdir -p $(BINDIR)
-	$(QQ)"$(MAKE)" -C $(RIOTPKG)/$(patsubst $(BINDIR)/%.a,%,$@)
+	$(QQ)"$(MAKE)" -C $(RIOTPKG)/$*
 
 clean:
 	-@for i in $(USEPKG) ; do "$(MAKE)" -C $(RIOTPKG)/$$i clean ; done

--- a/Makefile.include
+++ b/Makefile.include
@@ -476,7 +476,6 @@ pkg-prepare:
 	-@for i in $(USEPKG) ; do "$(MAKE)" -C $(RIOTPKG)/$$i prepare ; done
 
 $(USEPKG:%=$(BINDIR)/%.a): $(BINDIR)/%.a: $(BUILDDEPS) FORCE
-	@mkdir -p $(BINDIR)
 	$(QQ)"$(MAKE)" -C $(RIOTPKG)/$*
 
 clean:

--- a/Makefile.include
+++ b/Makefile.include
@@ -430,13 +430,13 @@ endif # RIOTNOLINK
 $(ELFFILE): $(BASELIBS)
 	$(Q)$(_LINK) -o $@
 
-$(BINDIR)/$(APPLICATION_MODULE).a: $(USEPKG:%=$(BINDIR)/%.a) $(BUILDDEPS)
+$(BINDIR)/$(APPLICATION_MODULE).a: pkg-build $(BUILDDEPS)
 	$(Q)DIRS="$(DIRS)" "$(MAKE)" -C $(APPDIR) -f $(RIOTMAKE)/application.inc.mk
 $(BINDIR)/$(APPLICATION_MODULE).a: FORCE
 
 # Other modules are built by application.inc.mk and packages building
-_SUBMAKE_LIBS = $(filter-out $(BINDIR)/$(APPLICATION_MODULE).a $(USEPKG:%=$(BINDIR)/%.a) $(APPDEPS), $(BASELIBS))
-$(_SUBMAKE_LIBS): $(BINDIR)/$(APPLICATION_MODULE).a $(USEPKG:%=$(BINDIR)/%.a)
+_SUBMAKE_LIBS = $(filter-out $(BINDIR)/$(APPLICATION_MODULE).a $(APPDEPS), $(BASELIBS))
+$(_SUBMAKE_LIBS): $(BINDIR)/$(APPLICATION_MODULE).a pkg-build
 
 # 'print-size' triggers a rebuild. Use 'info-buildsize' if you do not need to rebuild.
 print-size: $(ELFFILE)
@@ -471,11 +471,12 @@ ifneq (, $(filter clean, $(MAKECMDGOALS)))
     all $(BASELIBS) $(USEPKG:%=$(RIOTPKG)/%/Makefile.include) $(BUILDDEPS): clean
 endif
 
-.PHONY: pkg-prepare
+.PHONY: pkg-prepare pkg-build pkg-build-%
 pkg-prepare:
 	-@for i in $(USEPKG) ; do "$(MAKE)" -C $(RIOTPKG)/$$i prepare ; done
 
-$(USEPKG:%=$(BINDIR)/%.a): $(BINDIR)/%.a: $(BUILDDEPS) FORCE
+pkg-build: $(USEPKG:%=pkg-build-%)
+pkg-build-%: $(BUILDDEPS)
 	$(QQ)"$(MAKE)" -C $(RIOTPKG)/$*
 
 clean:


### PR DESCRIPTION
### Contribution description

Replace the per package archive file target by phony targets.

This allows at the same time to correctly describe PSEUDOMODULES packages as they should not be file targets and prepares for build system changes where some packages could produce objects
instead of archives for the 'ld -r' PR.

Having an explicit file target here was not adding anything.

### Testing procedure

If all applications build without problem even in parallel mode and the test application commit also build, everything should be ok.

### Issues/PRs references

* Mentioned the problem of packages generating objects in a [comment](https://github.com/RIOT-OS/RIOT/pull/8711/files#r192727184)  in ld -r PR https://github.com/RIOT-OS/RIOT/pull/8711
* Noticed the PSEUDOMODULES issue when working on wolfssl https://github.com/RIOT-OS/RIOT/pull/9894