### PR TITLE
drivers/tsl2561: add missing acquire∕release functions

### DIFF
--- a/drivers/tsl2561/tsl2561.c
+++ b/drivers/tsl2561/tsl2561.c
@@ -84,6 +84,7 @@ int tsl2561_init(tsl2561_t *dev, const tsl2561_params_t *params)
 #endif
 
     _disable(dev);
+    i2c_release(DEV_I2C);
 
     return TSL2561_OK;
 }
@@ -212,6 +213,8 @@ static void _disable(const tsl2561_t *dev)
 
 static void _read_data(const tsl2561_t *dev, uint16_t *full, uint16_t *ir)
 {
+    /* acquire bus */
+    i2c_acquire(DEV_I2C);
     /* Enable the device */
     _enable(dev);
 
@@ -247,6 +250,8 @@ static void _read_data(const tsl2561_t *dev, uint16_t *full, uint16_t *ir)
 
     /* Turn the device off to save power */
     _disable(dev);
+    /* release bus */
+    i2c_release(DEV_I2C);
 }
 
 static void _print_init_info(const tsl2561_t *dev)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR adds missing i2c_acquire/i2c_release function to the tsl2561 driver.
The init function acquired the I2C dev but it was never released, so it prevent the system from reading other sensors on the same bus.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Thanks @jcarrano for spotting this in #9920 
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
