### PR TITLE
sys/color/color.c: Fix a typo

### DIFF
--- a/sys/color/color.c
+++ b/sys/color/color.c
@@ -51,7 +51,7 @@ void color_rgb2hsv(color_rgb_t *rgb, color_hsv_t *hsv)
     }
 
     /* find the saturation from value and delta */
-    hsv->s = (hsv->v != 0.0f) ? (delta / hsv->v) : 0x0f;
+    hsv->s = (hsv->v != 0.0f) ? (delta / hsv->v) : 0.0f;
 
     /* compute hue */
     hsv->h = 0.0f;


### PR DESCRIPTION
### Contribution description

Fixes a trivial typo in `sys/color/color.c`   I found this by chance while seeing how to convert the HSV colour handling to fixed point.

### Testing procedure

I am not aware of any test case for the bug, nor did I write one.  Hence, fixing this should not change the test results.

### Issues/PRs references
