### PR TITLE
tests/unittests: test black corner case for color_rgb2hsv()

### DIFF
--- a/tests/unittests/tests-color/tests-color.c
+++ b/tests/unittests/tests-color/tests-color.c
@@ -20,6 +20,8 @@
 
 #include "tests-color.h"
 
+#define HSV_EPSILON     (1E-10f)
+
 static void test_str2rgb_upper_case__success(void)
 {
     const char *color_str = "F09A1D";
@@ -73,6 +75,22 @@ static void test_rgb2hex__success(void)
     TEST_ASSERT_EQUAL_INT(0x000AB13C, hex);
 }
 
+static void test_rgb2hsv__black(void)
+{
+    color_hsv_t hsv;
+    color_rgb_t rgb = { .r = 0x00, .g = 0x00, .b = 0x00 };
+
+    color_rgb2hsv(&rgb, &hsv);
+
+    /* XXX floats should never be compared for equality, so we check if we
+     * are within HSV_EPSILON of tolerance */
+    TEST_ASSERT(-HSV_EPSILON <= hsv.s);
+    TEST_ASSERT(-HSV_EPSILON <= hsv.v);
+    TEST_ASSERT( HSV_EPSILON >= hsv.s);
+    TEST_ASSERT( HSV_EPSILON >= hsv.v);
+    /* Hue for black is undefined so we don't check it */
+}
+
 static void test_rgb_invert__success(void)
 {
     const color_rgb_t col = {.r = 100, .g = 128, .b =   0};
@@ -109,6 +127,7 @@ Test *tests_color_tests(void)
         new_TestFixture(test_hex2rgb__success),
         new_TestFixture(test_rgb2hex__success),
         new_TestFixture(test_rgb2str__success),
+        new_TestFixture(test_rgb2hsv__black),
         new_TestFixture(test_rgb_invert__success),
         new_TestFixture(test_rgb_complementary__success),
     };


### PR DESCRIPTION
### Contribution description
Tests a (currently undocumented) behavior of `color_rgb2hsv()`, that a
black RGB value (all zero) causes the HSV value to be all zero.

### Testing procedure
Run the unittests for `color` (`make -C tests/unittests tests-color test`). With current master they will fail, but #9939 fixes them. 

### Issues/PRs references
Requires #9939 for the test to succeed.