### PR TITLE
pkg/monocypher: bump version to 2.0.5

### DIFF
--- a/pkg/monocypher/Makefile
+++ b/pkg/monocypher/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME=monocypher
 PKG_URL=https://github.com/LoupVaillant/Monocypher
-PKG_VERSION=6c2edbb48a61f43452c48c5f1e3ddabb19af3111
+PKG_VERSION=d9cc2aea29158971ed4b7dc074efdcb35e7183d5
 PKG_LICENSE=CC-0
 
 .PHONY: all

--- a/pkg/monocypher/doc.txt
+++ b/pkg/monocypher/doc.txt
@@ -16,14 +16,14 @@
  *
  * @note    Monocypher only supports 32bit platforms.
  *
- * Monocypher requires around 3K of stack space depending slightly on the
+ * Monocypher requires around 4K of stack space depending slightly on the
  * platform, so beware that you're allocating at
- * least `THREAD_STACKSIZE_DEFAULT + 3072` bytes.
+ * least `THREAD_STACKSIZE_DEFAULT + 4096` bytes.
  *
  * You can do it easily by adding:
  *
  * ```makefile
- * CFLAGS += '-DTHREAD_STACKSIZE_MAIN=(THREAD_STACKSIZE_DEFAULT + 3072)'
+ * CFLAGS += '-DTHREAD_STACKSIZE_MAIN=(THREAD_STACKSIZE_DEFAULT + 4096)'
  * ```
  *
  * to your makefile.

--- a/tests/pkg_monocypher/Makefile
+++ b/tests/pkg_monocypher/Makefile
@@ -8,7 +8,7 @@ BOARD_BLACKLIST := arduino-duemilanove arduino-mega2560 arduino-uno chronos \
 BOARD_INSUFFICIENT_MEMORY := nucleo-f031k6 nucleo-f042k6
 
 # required for Monocypher (as described in the package documentation)
-CFLAGS += "-DTHREAD_STACKSIZE_MAIN=(3072 + THREAD_STACKSIZE_DEFAULT + THREAD_EXTRA_STACKSIZE_PRINTF)"
+CFLAGS += "-DTHREAD_STACKSIZE_MAIN=(4096 + THREAD_STACKSIZE_DEFAULT + THREAD_EXTRA_STACKSIZE_PRINTF)"
 
 USEMODULE += embunit
 USEMODULE += random


### PR DESCRIPTION
### Contribution description

Version bump of the monocypher crypto package.
From the changelog:
 - Faster EdDSA signatures and verification. Like, 4 times as fast.

Stack usage unfortunately increased a bit so the docs and tests are changed to reflect this

### Measurements

I did some quick and dirty measurements based on the test application and the timings from the serial line. Not a lot of accuracy, but good enough to show the speed difference:

samr21-xpro, monocypher v2.0.4:
```
2018-09-15 15:01:26,656 - INFO # main(): This is RIOT! (Version: 2018.10-devel-725-g474d0-gisteren-pr/ethos/sync)
2018-09-15 15:01:31,881 - INFO # ..
2018-09-15 15:01:31,884 - INFO # OK (2 tests)
```
samr21-xpro, monocypher v2.0.5:
```
2018-09-15 15:37:33,897 - INFO # main(): This is RIOT! (Version: 2018.10-devel-723-g0c1a2-gisteren-HEAD)
2018-09-15 15:37:34,785 - INFO # ..
2018-09-15 15:37:34,788 - INFO # OK (2 tests)
```

nrf52dk, monocypher v2.0.4:
```
2018-09-15 16:07:27,736 - INFO # main(): This is RIOT! (Version: 2018.10-devel-725-g474d0-gisteren-pr/ethos/sync)
2018-09-15 16:07:28,281 - INFO # ..
2018-09-15 16:07:28,283 - INFO # OK (2 tests)
```

nrf52dk, monocypher v2.0.5:
```
2018-09-15 15:54:58,007 - INFO # main(): This is RIOT! (Version: 2018.10-devel-723-g0c1a2-gisteren-HEAD)
2018-09-15 15:54:58,136 - INFO # ..
2018-09-15 15:54:58,138 - INFO # OK (2 tests)
```

Flash size for only the monocypher code increased from 12068B to 15770B on the samr21-xpro.

### Testing procedure

run tests/pkg_monocypher

### Issues/PRs references

None
