### PR TITLE
Adding additional information about the default uart configuration to the bluepill docs

### DIFF
--- a/boards/bluepill/doc.txt
+++ b/boards/bluepill/doc.txt
@@ -79,6 +79,7 @@ flash or use this [stlink fork][caboStlink] which has a
 ## Connecting via Serial
 
 The default UART port used is UART2, which uses pins A2 (TX) and A3 (RX).
+To use it, configure your UART to operate at a baudrate of 115200/8N1.
 
 ## Using PWM
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->
This PR only affects the documentation of the bluepill board.
It adds the default baudrate of the board to the docs.