### PR TITLE
boards/sensebox_samd21: Add ADC configuration

### DIFF
--- a/boards/sensebox_samd21/Makefile.features
+++ b/boards/sensebox_samd21/Makefile.features
@@ -1,4 +1,5 @@
 # Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_rtc

--- a/boards/sensebox_samd21/include/periph_conf.h
+++ b/boards/sensebox_samd21/include/periph_conf.h
@@ -186,6 +186,38 @@ static const i2c_conf_t i2c_config[] = {
 
 /** @} */
 
+/**
+ * @name    ADC configuration
+ * @{
+ */
+#define ADC_0_EN                           1
+/* ADC 0 device configuration */
+#define ADC_0_DEV                          ADC
+#define ADC_0_IRQ                          ADC_IRQn
+
+/* ADC 0 Default values */
+#define ADC_0_CLK_SOURCE                   0 /* GCLK_GENERATOR_0 */
+#define ADC_0_PRESCALER                    ADC_CTRLB_PRESCALER_DIV512
+
+#define ADC_0_NEG_INPUT                    ADC_INPUTCTRL_MUXNEG_GND
+#define ADC_0_GAIN_FACTOR_DEFAULT          ADC_INPUTCTRL_GAIN_1X
+#define ADC_0_REF_DEFAULT                  ADC_REFCTRL_REFSEL_INT1V
+
+/* Digital pins (1 to 6) on the board can be configured as analog inputs */
+static const adc_conf_chan_t adc_channels[] = {
+    /* port, pin, muxpos */
+    { GPIO_PIN(PA, 4), ADC_INPUTCTRL_MUXPOS_PIN4 },     /* Digital 1 */
+    { GPIO_PIN(PA, 5), ADC_INPUTCTRL_MUXPOS_PIN5 },     /* Digital 2 */
+    { GPIO_PIN(PA, 6), ADC_INPUTCTRL_MUXPOS_PIN6 },     /* Digital 3 */
+    { GPIO_PIN(PA, 7), ADC_INPUTCTRL_MUXPOS_PIN7 },     /* Digital 4 */
+    { GPIO_PIN(PA, 3), ADC_INPUTCTRL_MUXPOS_PIN1 },     /* Digital 5 */
+    { GPIO_PIN(PA, 2), ADC_INPUTCTRL_MUXPOS_PIN0 },     /* Digital 6 */
+};
+
+#define ADC_0_CHANNELS                     (6U)
+#define ADC_NUMOF                          ADC_0_CHANNELS
+/** @} */
+
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This adds support for the ADC available on the sensebox samd21 board. The ADC pins are labeled as digital pins on the board but can be configured as analog if needed.

### Analog lines mapping
|   ADC Line   |  Digital Pin  |
| :---------: | :-----------: |
|      0      |       D1      |
|      1      |       D2      |
|      2      |       D3      |
|      3      |       D4      |
|      4      |       D5      |
|      5      |       D6      |

### Testing procedure
1. Connect known voltage levels to the D1 - D6 pins. **Note:** ADC is using the internal 1V reference.
2. Get the board into bootloader mode by quickly pushing twice the reset button.
3. Run ```BOARD=sensebox_samd21 make flash -C tests/periph_adc```
4. Connect a UART-USB bridge to UART1 (stdout)
5. Open the terminal by running ```BOARD=sensebox_samd21 make term PORT=/dev/ttyUSB0 -C tests/periph_adc```
6. Compare the output of the ADCs to the actual voltages.

### Issues/PRs references
None
