### PR TITLE
at driver: allow using same buffer for command and response in at_send_cmd_get_lines()

### DIFF
--- a/drivers/at/at.c
+++ b/drivers/at/at.c
@@ -121,14 +121,16 @@ ssize_t at_send_cmd_get_lines(at_dev_t *dev, const char *command,
     size_t bytes_left = len - 1;
     char *pos = resp_buf;
 
-    memset(resp_buf, '\0', len);
-
     at_drain(dev);
 
     res = at_send_cmd(dev, command, timeout);
     if (res) {
         goto out;
     }
+
+    /* only clear the response buffer after sending the command,
+     * so the same buffer can be used for command and response */
+    memset(resp_buf, '\0', len);
 
     while (1) {
         res = at_readline(dev, pos, bytes_left, keep_eol, timeout);


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
When reusing the same buffer for the at command and response, no command would be sent because the buffer was cleared. This is fixed by only clearing the buffer after the command has been sent.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->
Can be tested by using the same buffer in the `at_send_cmd_get_lines()` call for command and response:
```
char buf[16];
char *pos = buf;
int res;
pos += fmt_str(pos, "AT");
*pos = '\0';
res = at_send_cmd_get_lines(&at_dev, buf, buf, sizeof(buf), true, 10 * US_PER_SEC);
if (res < 0) {
    puts("Failed");
}
else {
    puts("Succeeded");
}
```