### PR TITLE
boards/sensebox_samd21: Add BMP280 I2C address

### DIFF
--- a/boards/sensebox_samd21/include/board.h
+++ b/boards/sensebox_samd21/include/board.h
@@ -159,6 +159,11 @@ extern "C" {
 #define TSL2561_PARAM_ADDR           TSL2561_ADDR_LOW
 
 /**
+ * @brief    BMP280 Pressure and temperature sensor
+ */
+#define BMX280_PARAM_I2C_ADDR        (0x76)
+
+/**
  * @brief   Initialize board specific hardware, including clock, LEDs and std-IO
  */
 void board_init(void);


### PR DESCRIPTION
### Contribution description
The sensebox samd21 board comes with many attachable sensor boards. By default the **BMP280** pressure and temperature breakout board places the sensor on the address ```0x76``` (this can be modified with a jumper).

### Testing procedure
1. Connect the Bosch BMP280 board to the I2C bus on the sensebox samd21 board.
2. Get the board into bootloader mode by quickly pushing twice the reset button.
3. Run ```BOARD=sensebox_samd21 make flash -C tests/driver_bmx280```.
4. Connect a UART-USB bridge to UART1 (stdout) and reset.
5. Open the terminal by running ```BOARD=sensebox_samd21 make term PORT=/dev/ttyUSB0 -C tests/driver_bmx280```.
6. Output should be something like:
```
# BMX280 test application
# 
# +------------Initializing------------+
# Initialization successful
# 
# +------------Calibration Data------------+
# dig_T1: 27630
# dig_T2: 25794
# dig_T3: 50
# dig_P1: 37085
# dig_P2: -10806
# dig_P3: 3024
# dig_P4: 3931
# dig_P5: 31
# dig_P6: -7
# dig_P7: 15500
# dig_P8: -14600
# dig_P9: 6000
# dig_H1: 0
# dig_H2: 0
# dig_H3: 0
# dig_H4: 0
# dig_H5: 0
# dig_H6: 0
# 
# +--------Starting Measurements--------+
# Temperature [°C]: 29.2
# Pressure [Pa]: 100705
# Humidity [%rH]: 0.00
```
### Issues/PRs references
None
