### PR TITLE
Makefile.include: also detect features and blacklist on flash

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -567,7 +567,7 @@ include $(RIOTMAKE)/vars.inc.mk
 include $(RIOTMAKE)/tools/targets.inc.mk
 
 # Warn if the selected board and drivers don't provide all needed features:
-ifneq (, $(filter all, $(if $(MAKECMDGOALS), $(MAKECMDGOALS), all)))
+ifneq (, $(filter all flash, $(if $(MAKECMDGOALS), $(MAKECMDGOALS), all)))
   EXPECT_ERRORS :=
   EXPECT_CONFLICT :=
 


### PR DESCRIPTION
### Contribution description

Now also print warnings if there are missing features or a blacklisted
board when doing 'make flash'

Before, only when doing 'make' or 'make all' the FEATURES_REQUIRED,
BOARD_BLACKLIST/WHITELIST and TOOLCHAINS were checked and a warning was printed.

However as 'flash' triggers 'all' it is a common case to do 'make flash'
directly instead of 'make all flash'. So better also print warnings in
this case.

### Testing procedure

Choose an application / board tuple that prints a warning because of board blacklist, missing features.

I use `tests/pkg_tinycbor/ BOARD=wsn430-v1_3b` here:

In master, you have a warning as expected when doing `make all`

```
make -C tests/pkg_tinycbor/ BOARD=wsn430-v1_3b all                                                                                                                                                                                                                                    
make: Entering directory '/home/cladmi/git/work/RIOT/tests/pkg_tinycbor'                                                                                                                                                                                                                  
The selected BOARD=wsn430-v1_3b is blacklisted: arduino-duemilanove arduino-mega2560 arduino-uno chronos jiminy-mega256rfr2 mega-xplained msb-430 msb-430h telosb waspmote-pro wsn430-v1_3b wsn430-v1_4 z1                                                                                
                                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                          
EXPECT ERRORS!                                                                                                                                                                                                                                                                            
                                                                                                                                                                                                                                                                                          
                                                                                                                                                                                                                                                                                          
make[1]: Nothing to be done for 'Makefile.include'.                                                                                                                                                                                                                                       
Building application "tests_pkg_tinycbor" for "wsn430-v1_3b" with MCU "msp430fxyz".  
```

However, for flash you have nothing

```
make -C tests/pkg_tinycbor/ BOARD=wsn430-v1_3b flash
make: Entering directory '/home/cladmi/git/work/RIOT/tests/pkg_tinycbor'
make[1]: Nothing to be done for 'Makefile.include'.
Building application "tests_pkg_tinycbor" for "wsn430-v1_3b" with MCU "msp430fxyz".
```

With this PR you now also have a warning for `flash`:

```
make -C tests/pkg_tinycbor/ BOARD=wsn430-v1_3b flash
make: Entering directory '/home/cladmi/git/work/RIOT/tests/pkg_tinycbor'
The selected BOARD=wsn430-v1_3b is blacklisted: arduino-duemilanove arduino-mega2560 arduino-uno chronos jiminy-mega256rfr2 mega-xplained msb-430 msb-430h telosb waspmote-pro wsn430-v1_3b wsn430-v1_4 z1


EXPECT ERRORS!


make[1]: Nothing to be done for 'Makefile.include'.
Building application "tests_pkg_tinycbor" for "wsn430-v1_3b" with MCU "msp430fxyz".
```

### Issues/PRs references

No reference.