### PR TITLE
periph/gpio: support for extension API (part 2)

### DIFF
--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -160,7 +160,6 @@ ifneq (,$(filter ethos,$(USEMODULE)))
 endif
 
 ifneq (,$(filter extend_gpio,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_gpio
   USEMODULE += extend
 endif
 

--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -159,6 +159,11 @@ ifneq (,$(filter ethos,$(USEMODULE)))
   USEMODULE += tsrb
 endif
 
+ifneq (,$(filter extend_gpio,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_gpio
+  USEMODULE += extend
+endif
+
 ifneq (,$(filter feetech,$(USEMODULE)))
   USEMODULE += uart_half_duplex
 endif
@@ -166,11 +171,6 @@ endif
 ifneq (,$(filter fxos8700,$(USEMODULE)))
   USEMODULE += xtimer
   FEATURES_REQUIRED += periph_i2c
-endif
-
-ifneq (,$(filter extend_gpio,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_gpio
-  USEMODULE += extend
 endif
 
 ifneq (,$(filter grove_ledbar,$(USEMODULE)))

--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -170,7 +170,6 @@ endif
 
 ifneq (,$(filter extend_gpio,$(USEMODULE)))
   FEATURES_REQUIRED += periph_gpio
-  FEATURES_REQUIRED += periph_gpio_irq
   USEMODULE += extend
 endif
 

--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -168,6 +168,12 @@ ifneq (,$(filter fxos8700,$(USEMODULE)))
   FEATURES_REQUIRED += periph_i2c
 endif
 
+ifneq (,$(filter extend_gpio,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_gpio
+  FEATURES_REQUIRED += periph_gpio_irq
+  USEMODULE += extend
+endif
+
 ifneq (,$(filter grove_ledbar,$(USEMODULE)))
   USEMODULE += my9221
 endif

--- a/drivers/Makefile.include
+++ b/drivers/Makefile.include
@@ -86,6 +86,10 @@ ifneq (,$(filter fxos8700,$(USEMODULE)))
   USEMODULE_INCLUDES += $(RIOTBASE)/drivers/fxos8700/include
 endif
 
+ifneq (,$(filter extend_gpio,$(USEMODULE)))
+  USEMODULE_INCLUDES += $(RIOTBASE)/drivers/extend/include
+endif
+
 ifneq (,$(filter grove_ledbar,$(USEMODULE)))
   USEMODULE_INCLUDES += $(RIOTBASE)/drivers/grove_ledbar/include
 endif

--- a/drivers/Makefile.include
+++ b/drivers/Makefile.include
@@ -78,16 +78,16 @@ ifneq (,$(filter encx24j600,$(USEMODULE)))
   USEMODULE_INCLUDES += $(RIOTBASE)/drivers/encx24j600/include
 endif
 
+ifneq (,$(filter extend_,$(USEMODULE)))
+  USEMODULE_INCLUDES += $(RIOTBASE)/drivers/extend/include
+endif
+
 ifneq (,$(filter feetech,$(USEMODULE)))
   USEMODULE_INCLUDES += $(RIOTBASE)/drivers/feetech/include
 endif
 
 ifneq (,$(filter fxos8700,$(USEMODULE)))
   USEMODULE_INCLUDES += $(RIOTBASE)/drivers/fxos8700/include
-endif
-
-ifneq (,$(filter extend_gpio,$(USEMODULE)))
-  USEMODULE_INCLUDES += $(RIOTBASE)/drivers/extend/include
 endif
 
 ifneq (,$(filter grove_ledbar,$(USEMODULE)))

--- a/drivers/extend/Makefile
+++ b/drivers/extend/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/drivers/extend/gpio_notsup.c
+++ b/drivers/extend/gpio_notsup.c
@@ -19,6 +19,8 @@
  * @}
  */
 
+#if MODULE_EXTEND_GPIO
+
 #include "periph/gpio.h"
 #include "extend/gpio.h"
 
@@ -122,3 +124,5 @@ const gpio_ext_driver_t gpio_ext_notsup_driver = {
     .toggle = gpio_ext_toggle_notsup,
     .write = gpio_ext_write_notsup,
 };
+
+#endif /* MODULE_EXTEND_GPIO */

--- a/drivers/extend/gpio_notsup.c
+++ b/drivers/extend/gpio_notsup.c
@@ -1,0 +1,124 @@
+/*
+ * Copyright (C) 2018 Acutam Automation, LLC
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_extend_gpio
+ *
+ * @{
+ *
+ * @file
+ * @brief       GPIO extension not-supported functions
+ *
+ * @author      Matthew Blue <matthew.blue.neuro@gmail.com>
+ *
+ * @}
+ */
+
+#include "periph/gpio.h"
+#include "extend/gpio.h"
+
+#define ENABLE_DEBUG (0)
+#include "debug.h"
+
+int gpio_ext_init_notsup(void *dev, gpio_t pin, gpio_mode_t mode)
+{
+    (void)dev;
+    (void)pin;
+    (void)mode;
+
+    DEBUG("[gpio_ext_init_notsup] call for dev %p\n", dev);
+
+    return -1;
+}
+
+int gpio_ext_init_int_notsup(void *dev, gpio_t pin, gpio_mode_t mode,
+                             gpio_flank_t flank, gpio_cb_t cb, void *arg)
+{
+    (void)dev;
+    (void)pin;
+    (void)mode;
+    (void)flank;
+    (void)cb;
+    (void)arg;
+
+    DEBUG("[gpio_ext_init_int_notsup] call for dev %p\n", dev);
+
+    return -1;
+}
+
+void gpio_ext_irq_enable_notsup(void *dev, gpio_t pin)
+{
+    (void)dev;
+    (void)pin;
+
+    DEBUG("[gpio_ext_irq_enable_notsup] call for dev %p\n", dev);
+}
+
+void gpio_ext_irq_disable_notsup(void *dev, gpio_t pin)
+{
+    (void)dev;
+    (void)pin;
+
+    DEBUG("[gpio_ext_irq_disable_notsup] call for dev %p\n", dev);
+}
+
+int gpio_ext_read_notsup(void *dev, gpio_t pin)
+{
+    (void)dev;
+    (void)pin;
+
+    DEBUG("[gpio_ext_read_notsup] call for dev %p\n", dev);
+
+    return 0;
+}
+
+void gpio_ext_set_notsup(void *dev, gpio_t pin)
+{
+    (void)dev;
+    (void)pin;
+
+    DEBUG("[gpio_ext_set_notsup] call for dev %p\n", dev);
+}
+
+void gpio_ext_clear_notsup(void *dev, gpio_t pin)
+{
+    (void)dev;
+    (void)pin;
+
+    DEBUG("[gpio_ext_clear_notsup] call for dev %p\n", dev);
+}
+
+void gpio_ext_toggle_notsup(void *dev, gpio_t pin)
+{
+    (void)dev;
+    (void)pin;
+
+    DEBUG("[gpio_ext_toggle_notsup] call for dev %p\n", dev);
+}
+
+void gpio_ext_write_notsup(void *dev, gpio_t pin, int value)
+{
+    (void)dev;
+    (void)pin;
+    (void)value;
+
+    DEBUG("[gpio_ext_write_notsup] call for dev %p\n", dev);
+}
+
+/* not-supported driver */
+const gpio_ext_driver_t gpio_ext_notsup_driver = {
+    .init = gpio_ext_init_notsup,
+    .init_int = gpio_ext_init_int_notsup,
+    .irq_enable = gpio_ext_irq_enable_notsup,
+    .irq_disable = gpio_ext_irq_disable_notsup,
+    .read = gpio_ext_read_notsup,
+    .set = gpio_ext_set_notsup,
+    .clear = gpio_ext_clear_notsup,
+    .toggle = gpio_ext_toggle_notsup,
+    .write = gpio_ext_write_notsup,
+};

--- a/drivers/extend/gpio_redir.c
+++ b/drivers/extend/gpio_redir.c
@@ -37,7 +37,7 @@ gpio_ext_t *gpio_ext_entry(gpio_t gpio)
     DEBUG("[gpio_ext_entry] list entry is %u\n", devnum);
 
     /* device is greater than number of listed entries */
-    if (devnum > (sizeof(gpio_ext_list) / sizeof(gpio_ext_list[0]))) {
+    if (devnum >= (sizeof(gpio_ext_list) / sizeof(gpio_ext_list[0]))) {
         return NULL;
     }
 

--- a/drivers/extend/gpio_redir.c
+++ b/drivers/extend/gpio_redir.c
@@ -1,0 +1,173 @@
+/*
+ * Copyright (C) 2018 Acutam Automation, LLC
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_extend_gpio
+ *
+ * @{
+ *
+ * @file
+ * @brief       GPIO extension redirection functions
+ *
+ * @author      Matthew Blue <matthew.blue.neuro@gmail.com>
+ *
+ * @}
+ */
+
+#include "periph/gpio.h"
+#include "extend/gpio.h"
+#include "gpio_ext_conf.h"
+
+#define ENABLE_DEBUG (0)
+#include "debug.h"
+
+gpio_ext_t *gpio_ext_entry(gpio_t gpio)
+{
+    if (gpio == GPIO_UNDEF) {
+        return NULL;
+    }
+
+    gpio_t devnum = gpio_ext_dev(gpio);
+
+    DEBUG("[gpio_ext_entry] list entry is %u\n", devnum);
+
+    /* device is greater than number of listed entries */
+    if (devnum > (sizeof(gpio_ext_list) / sizeof(gpio_ext_list[0]))) {
+        return NULL;
+    }
+
+    /* Cast to discard const */
+    return (gpio_ext_t *)&gpio_ext_list[devnum];
+}
+
+int gpio_init_redir(gpio_t pin, gpio_mode_t mode)
+{
+    gpio_ext_t *entry = gpio_ext_entry(pin);
+
+    if (entry == NULL) {
+        DEBUG("[gpio_init_redir] ext entry doesn't exist for %X\n", pin);
+        return -1;
+    }
+
+    pin = gpio_ext_pin(pin);
+
+    return entry->driver->init(entry->dev, pin, mode);
+}
+
+int gpio_init_int_redir(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
+                        gpio_cb_t cb, void *arg)
+{
+    gpio_ext_t *entry = gpio_ext_entry(pin);
+
+    if (entry == NULL) {
+        DEBUG("[gpio_init_int_redir] ext entry doesn't exist for %X\n", pin);
+        return -1;
+    }
+
+    pin = gpio_ext_pin(pin);
+
+    return entry->driver->init_int(entry->dev, pin, mode, flank, cb, arg);
+}
+
+void gpio_irq_enable_redir(gpio_t pin)
+{
+    gpio_ext_t *entry = gpio_ext_entry(pin);
+
+    if (entry == NULL) {
+        DEBUG("[gpio_irq_enable_redir] ext entry doesn't exist for %X\n", pin);
+        return;
+    }
+
+    pin = gpio_ext_pin(pin);
+
+    entry->driver->irq_enable(entry->dev, pin);
+}
+
+void gpio_irq_disable_redir(gpio_t pin)
+{
+    gpio_ext_t *entry = gpio_ext_entry(pin);
+
+    if (entry == NULL) {
+        DEBUG("[gpio_irq_disable_redir] ext entry doesn't exist for %X\n", pin);
+        return;
+    }
+
+    pin = gpio_ext_pin(pin);
+
+    entry->driver->irq_disable(entry->dev, pin);
+}
+
+int gpio_read_redir(gpio_t pin)
+{
+    gpio_ext_t *entry = gpio_ext_entry(pin);
+
+    if (entry == NULL) {
+        DEBUG("[gpio_read_redir] ext entry doesn't exist for %X\n", pin);
+        return 0;
+    }
+
+    pin = gpio_ext_pin(pin);
+
+    return entry->driver->read(entry->dev, pin);
+}
+
+void gpio_set_redir(gpio_t pin)
+{
+    gpio_ext_t *entry = gpio_ext_entry(pin);
+
+    if (entry == NULL) {
+        DEBUG("[gpio_set_redir] ext entry doesn't exist for %X\n", pin);
+        return;
+    }
+
+    pin = gpio_ext_pin(pin);
+
+    entry->driver->set(entry->dev, pin);
+}
+
+void gpio_clear_redir(gpio_t pin)
+{
+    gpio_ext_t *entry = gpio_ext_entry(pin);
+
+    if (entry == NULL) {
+        DEBUG("[gpio_clear_redir] ext entry doesn't exist for %X\n", pin);
+        return;
+    }
+
+    pin = gpio_ext_pin(pin);
+
+    entry->driver->clear(entry->dev, pin);
+}
+
+void gpio_toggle_redir(gpio_t pin)
+{
+    gpio_ext_t *entry = gpio_ext_entry(pin);
+
+    if (entry == NULL) {
+        DEBUG("[gpio_toggle_redir] ext entry doesn't exist for %X\n", pin);
+        return;
+    }
+
+    pin = gpio_ext_pin(pin);
+
+    entry->driver->toggle(entry->dev, pin);
+}
+
+void gpio_write_redir(gpio_t pin, int value)
+{
+    gpio_ext_t *entry = gpio_ext_entry(pin);
+
+    if (entry == NULL) {
+        DEBUG("[gpio_write_redir] ext entry doesn't exist for %X\n", pin);
+        return;
+    }
+
+    pin = gpio_ext_pin(pin);
+
+    entry->driver->write(entry->dev, pin, value);
+}

--- a/drivers/extend/gpio_redir.c
+++ b/drivers/extend/gpio_redir.c
@@ -19,6 +19,8 @@
  * @}
  */
 
+#if MODULE_EXTEND_GPIO
+
 #include "periph/gpio.h"
 #include "extend/gpio.h"
 #include "gpio_ext_conf.h"
@@ -173,3 +175,5 @@ void gpio_write_redir(gpio_t pin, int value)
 
     entry->driver->write(entry->dev, pin, value);
 }
+
+#endif /* MODULE_EXTEND_GPIO */

--- a/drivers/extend/gpio_redir.c
+++ b/drivers/extend/gpio_redir.c
@@ -59,6 +59,7 @@ int gpio_init_redir(gpio_t pin, gpio_mode_t mode)
     return entry->driver->init(entry->dev, pin, mode);
 }
 
+#ifdef MODULE_PERIPH_GPIO_IRQ
 int gpio_init_int_redir(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
                         gpio_cb_t cb, void *arg)
 {
@@ -73,6 +74,7 @@ int gpio_init_int_redir(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
 
     return entry->driver->init_int(entry->dev, pin, mode, flank, cb, arg);
 }
+#endif /* MODULE_PERIPH_GPIO_IRQ */
 
 void gpio_irq_enable_redir(gpio_t pin)
 {

--- a/drivers/extend/include/gpio_ext_conf.h
+++ b/drivers/extend/include/gpio_ext_conf.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2018 Acutam Automation, LLC
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_extend_gpio
+ *
+ * @{
+ *
+ * @file
+ * @brief       GPIO extension default / example list
+ *
+ * @author      Matthew Blue <matthew.blue.neuro@gmail.com>
+ *
+ * @}
+ */
+
+#ifndef GPIO_EXT_CONF_H
+#define GPIO_EXT_CONF_H
+
+#include <stddef.h>
+
+#include "extend/gpio.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Reference the driver struct
+ */
+extern gpio_ext_driver_t gpio_ext_notsup_driver;
+
+/**
+ * @brief   GPIO expansion default list if not defined
+ */
+static const gpio_ext_t gpio_ext_list[] =
+{
+    {
+        .driver = &gpio_ext_notsup_driver,
+        .dev = NULL,
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_EXT_CONF_H */
+/** @} */

--- a/drivers/include/extend/doc.txt
+++ b/drivers/include/extend/doc.txt
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2018 Acutam Automation, LLC
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    drivers_extend Peripheral Driver Extension Interface
+ * @ingroup     drivers
+ * @brief       Peripheral extensions for intercepting API calls and redirecting
+ *              to non-peripheral drivers
+ *
+ * The extension interface makes handling of non-CPU devices invisible to code
+ * using the periph APIs (periph/*.h). This is accomplished by reserving part of
+ * the range of values of that API's identifier. When a call to the periph API
+ * uses an identifier that falls within this range, it is parsed into a device
+ * ID that is looked up in an extension list and the call is redirected to the
+ * corresponding device.
+ *
+ */

--- a/drivers/include/extend/gpio.h
+++ b/drivers/include/extend/gpio.h
@@ -57,14 +57,14 @@ extern "C" {
 /**
  * @brief   Callback typedef for gpio_init
  *
- * @see @ref drivers_periph_gpio
+ * @see @ref #gpio_init
  */
 typedef int (*gpio_ext_init_t)(void *dev, gpio_t pin, gpio_mode_t mode);
 
 /**
  * @brief   Callback typedef for gpio_init_int
  *
- * @see @ref drivers_periph_gpio
+ * @see @ref #gpio_init_int
  */
 typedef int (*gpio_ext_init_int_t)(void *dev, gpio_t pin, gpio_mode_t mode,
                                    gpio_flank_t flank, gpio_cb_t cb, void *arg);
@@ -72,49 +72,49 @@ typedef int (*gpio_ext_init_int_t)(void *dev, gpio_t pin, gpio_mode_t mode,
 /**
  * @brief   Callback typedef for gpio_irq_enable
  *
- * @see @ref drivers_periph_gpio
+ * @see @ref #gpio_irq_enable
  */
 typedef void (*gpio_ext_irq_enable_t)(void *dev, gpio_t pin);
 
 /**
  * @brief   Callback typedef for gpio_irq_disable
  *
- * @see @ref drivers_periph_gpio
+ * @see @ref #gpio_irq_disable
  */
 typedef void (*gpio_ext_irq_disable_t)(void *dev, gpio_t pin);
 
 /**
  * @brief   Callback typedef for gpio_read
  *
- * @see @ref drivers_periph_gpio
+ * @see @ref #gpio_read
  */
 typedef int (*gpio_ext_read_t)(void *dev, gpio_t pin);
 
 /**
  * @brief   Callback typedef for gpio_set
  *
- * @see @ref drivers_periph_gpio
+ * @see @ref #gpio_set
  */
 typedef void (*gpio_ext_set_t)(void *dev, gpio_t pin);
 
 /**
  * @brief   Callback typedef for gpio_clear
  *
- * @see @ref drivers_periph_gpio
+ * @see @ref #gpio_clear
  */
 typedef void (*gpio_ext_clear_t)(void *dev, gpio_t pin);
 
 /**
  * @brief   Callback typedef for gpio_toggle
  *
- * @see @ref drivers_periph_gpio
+ * @see @ref #gpio_toggle
  */
 typedef void (*gpio_ext_toggle_t)(void *dev, gpio_t pin);
 
 /**
  * @brief   Callback typedef for gpio_write
  *
- * @see @ref drivers_periph_gpio
+ * @see @ref #gpio_write
  */
 typedef void (*gpio_ext_write_t)(void *dev, gpio_t pin, int value);
 

--- a/drivers/include/extend/gpio.h
+++ b/drivers/include/extend/gpio.h
@@ -1,0 +1,201 @@
+/*
+ * Copyright (C) 2018 Acutam Automation, LLC
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    drivers_extend_gpio GPIO extension
+ * @ingroup     drivers_extend
+ * @brief       GPIO peripheral extension handling
+ *
+ * The GPIO extension interface makes handling of non-CPU GPIO devices invisible
+ * to code using the GPIO periph API (periph/gpio.h). This is accomplished by
+ * reserving part of the range of values of gpio_t. When a call to the GPIO API
+ * uses a pin that falls within this range, it is parsed into a device ID that
+ * is looked up in the GPIO extension list and the call is redirected to the
+ * corresponding device.
+ *
+ * @{
+ *
+ * @file
+ * @brief       GPIO extension interface definitions
+ *
+ * @author      Matthew Blue <matthew.blue.neuro@gmail.com>
+ */
+
+#ifndef EXTEND_GPIO_H
+#define EXTEND_GPIO_H
+
+#include <limits.h>
+#include <stdint.h>
+
+#include "periph_conf.h"
+#include "periph/gpio.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef GPIO_EXT_DEV_MASK
+/**
+ * @brief   Set device mask in gpio_t
+ */
+#define GPIO_EXT_DEV_MASK    (gpio_t)((UINT_MAX << GPIO_EXT_DEV_LOC) \
+                                      & GPIO_EXT_THRESH)
+#endif
+
+#ifndef GPIO_EXT_PIN_MASK
+/**
+ * @brief   Set pin mask in gpio_t
+ */
+#define GPIO_EXT_PIN_MASK    (gpio_t)(~(UINT_MAX << GPIO_EXT_DEV_LOC))
+#endif
+
+/**
+ * @brief   Callback typedef for gpio_init
+ *
+ * @see @ref drivers_periph_gpio
+ */
+typedef int (*gpio_ext_init_t)(void *dev, gpio_t pin, gpio_mode_t mode);
+
+/**
+ * @brief   Callback typedef for gpio_init_int
+ *
+ * @see @ref drivers_periph_gpio
+ */
+typedef int (*gpio_ext_init_int_t)(void *dev, gpio_t pin, gpio_mode_t mode,
+                                   gpio_flank_t flank, gpio_cb_t cb, void *arg);
+
+/**
+ * @brief   Callback typedef for gpio_irq_enable
+ *
+ * @see @ref drivers_periph_gpio
+ */
+typedef void (*gpio_ext_irq_enable_t)(void *dev, gpio_t pin);
+
+/**
+ * @brief   Callback typedef for gpio_irq_disable
+ *
+ * @see @ref drivers_periph_gpio
+ */
+typedef void (*gpio_ext_irq_disable_t)(void *dev, gpio_t pin);
+
+/**
+ * @brief   Callback typedef for gpio_read
+ *
+ * @see @ref drivers_periph_gpio
+ */
+typedef int (*gpio_ext_read_t)(void *dev, gpio_t pin);
+
+/**
+ * @brief   Callback typedef for gpio_set
+ *
+ * @see @ref drivers_periph_gpio
+ */
+typedef void (*gpio_ext_set_t)(void *dev, gpio_t pin);
+
+/**
+ * @brief   Callback typedef for gpio_clear
+ *
+ * @see @ref drivers_periph_gpio
+ */
+typedef void (*gpio_ext_clear_t)(void *dev, gpio_t pin);
+
+/**
+ * @brief   Callback typedef for gpio_toggle
+ *
+ * @see @ref drivers_periph_gpio
+ */
+typedef void (*gpio_ext_toggle_t)(void *dev, gpio_t pin);
+
+/**
+ * @brief   Callback typedef for gpio_write
+ *
+ * @see @ref drivers_periph_gpio
+ */
+typedef void (*gpio_ext_write_t)(void *dev, gpio_t pin, int value);
+
+/**
+ * @brief   Default not supported functions
+ * @{
+ */
+int gpio_ext_init_notsup(void *dev, gpio_t pin, gpio_mode_t mode);
+int gpio_ext_init_int_notsup(void *dev, gpio_t pin, gpio_mode_t mode,
+                             gpio_flank_t flank, gpio_cb_t cb, void *arg);
+void gpio_ext_irq_enable_notsup(void *dev, gpio_t pin);
+void gpio_ext_irq_disable_notsup(void *dev, gpio_t pin);
+int gpio_ext_read_notsup(void *dev, gpio_t pin);
+void gpio_ext_set_notsup(void *dev, gpio_t pin);
+void gpio_ext_clear_notsup(void *dev, gpio_t pin);
+void gpio_ext_toggle_notsup(void *dev, gpio_t pin);
+void gpio_ext_write_notsup(void *dev, gpio_t pin, int value);
+/** @} */
+
+/**
+ * @brief   GPIO extension driver entry
+ */
+typedef struct gpio_ext_driver {
+    gpio_ext_init_t const init;           /**< callback for gpio_init */
+    gpio_ext_init_int_t const init_int;   /**< callback for gpio_init_int */
+    gpio_ext_irq_enable_t const irq_enable;
+                                          /**< callback for gpio_irq_enable */
+    gpio_ext_irq_disable_t const irq_disable;
+                                          /**< callback for gpio_irq_disable */
+    gpio_ext_read_t const read;           /**< callback for read */
+    gpio_ext_set_t const set;             /**< callback for set */
+    gpio_ext_clear_t const clear;         /**< callback for clear */
+    gpio_ext_toggle_t const toggle;       /**< callback for toggle */
+    gpio_ext_write_t const write;         /**< callback for write */
+} gpio_ext_driver_t;
+
+/**
+ * @brief   GPIO extension list entry
+ */
+typedef struct gpio_ext {
+    gpio_ext_driver_t const *driver;    /**< pointer to driver */
+    void *dev;                          /**< pointer to device descriptor */
+} gpio_ext_t;
+
+/**
+ * @brief   Find an entry in the extension list by GPIO pin number
+ *
+ * @param[in] gpio    GPIO to look up
+ *
+ * @return      pointer to the list entry
+ * @return      NULL if no device is listed
+ */
+gpio_ext_t *gpio_ext_entry(gpio_t gpio);
+
+/**
+ * @brief   Strip encoding from a GPIO and return device number
+ *
+ * @param[in] gpio    GPIO to strip
+ *
+ * @return      device number
+ */
+static inline gpio_t gpio_ext_dev(gpio_t gpio)
+{
+    return ((gpio & GPIO_EXT_DEV_MASK) >> GPIO_EXT_DEV_LOC);
+}
+
+/**
+ * @brief   Strip encoding from a GPIO and return pin number
+ *
+ * @param[in] gpio    GPIO to strip
+ *
+ * @return      pin number
+ */
+static inline gpio_t gpio_ext_pin(gpio_t gpio)
+{
+    return (gpio & GPIO_EXT_PIN_MASK);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* EXTEND_GPIO_H */
+/** @} */

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -123,6 +123,9 @@ PSEUDOMODULES += stm32_periph_%
 PSEUDOMODULES += periph_%
 NO_PSEUDOMODULES += periph_common
 
+# periph extention interface pseudomodules
+PSEUDOMODULES += extend_%
+
 # Submodules and auto-init code provided by Skald
 PSEUDOMODULES += auto_init_skald
 PSEUDOMODULES += skald_ibeacon

--- a/tests/extend_gpio/Makefile
+++ b/tests/extend_gpio/Makefile
@@ -14,6 +14,3 @@ TEST_ON_CI_WHITELIST += all
 
 include ./Makefile.include
 include $(RIOTBASE)/Makefile.include
-
-test:
-	./tests/01-run.py

--- a/tests/extend_gpio/Makefile
+++ b/tests/extend_gpio/Makefile
@@ -1,0 +1,17 @@
+include ../Makefile.tests_common
+
+# The CPUs of these boards do not provide a gpio.c API.
+# CPUs: cc430, mips32r2_generic, native
+BOARD_BLACKLIST := chronos \
+                   mips-malta \
+                   native
+
+USEMODULE += extend_gpio
+
+TEST_ON_CI_WHITELIST += all
+
+include ./Makefile.include
+include $(RIOTBASE)/Makefile.include
+
+test:
+	./tests/01-run.py

--- a/tests/extend_gpio/Makefile
+++ b/tests/extend_gpio/Makefile
@@ -6,6 +6,8 @@ BOARD_BLACKLIST := chronos \
                    mips-malta \
                    native
 
+FEATURES_REQUIRED += periph_gpio_irq
+
 USEMODULE += extend_gpio
 
 TEST_ON_CI_WHITELIST += all

--- a/tests/extend_gpio/Makefile.include
+++ b/tests/extend_gpio/Makefile.include
@@ -1,0 +1,2 @@
+# include test specific includes
+export INCLUDES += -I$(CURDIR)/include

--- a/tests/extend_gpio/include/gpio_ext_conf.h
+++ b/tests/extend_gpio/include/gpio_ext_conf.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2018 Acutam Automation, LLC
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ *
+ * @{
+ *
+ * @file
+ * @brief       GPIO extension test list
+ *
+ * @author      Matthew Blue <matthew.blue.neuro@gmail.com>
+ *
+ * @}
+ */
+
+#ifndef GPIO_EXT_CONF_H
+#define GPIO_EXT_CONF_H
+
+#include <stddef.h>
+
+#include "extend/gpio.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Reference the driver structs
+ *
+ * @{
+ */
+extern gpio_ext_driver_t tests_extend_gpio_driver;
+extern gpio_ext_driver_t gpio_ext_notsup_driver;
+/** @} */
+
+/**
+ * @brief   GPIO extension test list
+ */
+static const gpio_ext_t gpio_ext_list[] =
+{
+    {
+        .driver = &tests_extend_gpio_driver,
+        .dev = (void *)0xbeef,
+    },
+    {
+        .driver = &gpio_ext_notsup_driver,
+        .dev = NULL,
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_EXT_CONF_H */
+/** @} */

--- a/tests/extend_gpio/main.c
+++ b/tests/extend_gpio/main.c
@@ -1,0 +1,191 @@
+/*
+ * Copyright (C) 2018 Acutam Automation, LLC
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       GPIO extension test routine
+ *
+ * @author      Matthew Blue <matthew.blue.neuro@gmail.com>
+ * @}
+ */
+
+#include <stdio.h>
+
+#include "extend/gpio.h"
+#include "periph/gpio.h"
+
+/* GPIO extension test functions */
+int test_gpio_init(void *dev, gpio_t pin, gpio_mode_t mode);
+int test_gpio_init_int(void *dev, gpio_t pin, gpio_mode_t mode,
+                       gpio_flank_t flank, gpio_cb_t cb, void *arg);
+void test_gpio_irq_enable(void *dev, gpio_t pin);
+void test_gpio_irq_disable(void *dev, gpio_t pin);
+int test_gpio_read(void *dev, gpio_t pin);
+void test_gpio_set(void *dev, gpio_t pin);
+void test_gpio_clear(void *dev, gpio_t pin);
+void test_gpio_toggle(void *dev, gpio_t pin);
+void test_gpio_write(void *dev, gpio_t pin, int value);
+
+/* GPIO extension test driver */
+const gpio_ext_driver_t tests_extend_gpio_driver = {
+    .init = test_gpio_init,
+    .init_int = test_gpio_init_int,
+    .irq_enable = test_gpio_irq_enable,
+    .irq_disable = test_gpio_irq_disable,
+    .read = test_gpio_read,
+    .set = test_gpio_set,
+    .clear = test_gpio_clear,
+    .toggle = test_gpio_toggle,
+    .write = test_gpio_write,
+};
+
+int test_gpio_init(void *dev, gpio_t pin, gpio_mode_t mode)
+{
+    (void)mode;
+
+    printf("init on dev 0x%x with pin %u\n",
+        (uint16_t)(uintptr_t)dev, (unsigned int)pin);
+
+    return 0;
+}
+
+int test_gpio_init_int(void *dev, gpio_t pin, gpio_mode_t mode,
+                       gpio_flank_t flank, gpio_cb_t cb, void *arg)
+{
+    (void)mode;
+    (void)flank;
+    (void)cb;
+    (void)arg;
+
+    printf("init_int on dev 0x%x with pin %u\n",
+        (uint16_t)(uintptr_t)dev, (unsigned int)pin);
+
+    return 0;
+}
+
+void test_gpio_irq_enable(void *dev, gpio_t pin)
+{
+    printf("irq_enable on dev 0x%x with pin %u\n",
+        (uint16_t)(uintptr_t)dev, (unsigned int)pin);
+}
+
+void test_gpio_irq_disable(void *dev, gpio_t pin)
+{
+    printf("irq_disable on dev 0x%x with pin %u\n",
+        (uint16_t)(uintptr_t)dev, (unsigned int)pin);
+}
+
+int test_gpio_read(void *dev, gpio_t pin)
+{
+    printf("read on dev 0x%x with pin %u\n",
+        (uint16_t)(uintptr_t)dev, (unsigned int)pin);
+
+    return 0;
+}
+
+void test_gpio_set(void *dev, gpio_t pin)
+{
+    printf("set on dev 0x%x with pin %u\n",
+        (uint16_t)(uintptr_t)dev, (unsigned int)pin);
+}
+
+void test_gpio_clear(void *dev, gpio_t pin)
+{
+    printf("clear on dev 0x%x with pin %u\n",
+        (uint16_t)(uintptr_t)dev, (unsigned int)pin);
+}
+
+void test_gpio_toggle(void *dev, gpio_t pin)
+{
+    printf("toggle on dev 0x%x with pin %u\n",
+        (uint16_t)(uintptr_t)dev, (unsigned int)pin);
+}
+
+void test_gpio_write(void *dev, gpio_t pin, int value)
+{
+    (void)value;
+
+    printf("write on dev 0x%x with pin %u\n",
+        (uint16_t)(uintptr_t)dev, (unsigned int)pin);
+}
+
+int main(void)
+{
+    uint16_t num;
+    gpio_t pin;
+
+    puts("gpio extension test routine");
+
+    for (num = 0; num < 4; num++) {
+        pin = (1 << num);
+        printf("Running gpio.h functions on pin %u\n", (unsigned int)pin);
+
+        if (gpio_init(GPIO_EXT_PIN(0, pin), 0x0)) {
+            puts("[FAILED]");
+            return 1;
+        }
+
+        if (gpio_init_int(GPIO_EXT_PIN(0, pin), 0x0, 0x0, NULL, NULL)) {
+            puts("[FAILED]");
+            return 1;
+        }
+
+        gpio_irq_enable(GPIO_EXT_PIN(0, pin));
+        gpio_irq_disable(GPIO_EXT_PIN(0, pin));
+        gpio_read(GPIO_EXT_PIN(0, pin));
+        gpio_set(GPIO_EXT_PIN(0, pin));
+        gpio_clear(GPIO_EXT_PIN(0, pin));
+        gpio_toggle(GPIO_EXT_PIN(0, pin));
+        gpio_write(GPIO_EXT_PIN(0, pin), 0);
+    }
+
+    puts("Running notsup functions");
+    puts("(they should not print output)");
+
+    for (num = 0; num < 4; num++) {
+        pin = (1 << num);
+        printf("Running notsup gpio.h functions on pin %u\n",
+            (unsigned int)pin);
+
+        if (!gpio_init(GPIO_EXT_PIN(1, pin), 0x0)) {
+            puts("[FAILED]");
+            return 1;
+        }
+
+        if (!gpio_init_int(GPIO_EXT_PIN(1, pin), 0x0, 0x0, NULL, NULL)) {
+            puts("[FAILED]");
+            return 1;
+        }
+
+        gpio_irq_enable(GPIO_EXT_PIN(1, pin));
+        gpio_irq_disable(GPIO_EXT_PIN(1, pin));
+        gpio_read(GPIO_EXT_PIN(1, pin));
+        gpio_set(GPIO_EXT_PIN(1, pin));
+        gpio_clear(GPIO_EXT_PIN(1, pin));
+        gpio_toggle(GPIO_EXT_PIN(1, pin));
+        gpio_write(GPIO_EXT_PIN(1, pin), 0);
+    }
+
+    puts("Checking that all pins in range have init error using notsup");
+    puts("(lack of init error implies improper redirection)");
+
+    for (num = 0; num <= GPIO_EXT_PIN_MASK; num++) {
+        if (gpio_init(GPIO_EXT_PIN(1, num), 0x0) >= 0) {
+            printf("init succeeded on pin %u\n", num);
+            puts("[FAILED]");
+            return 1;
+        }
+    }
+
+    puts("[SUCCESS]");
+
+    return 0;
+}

--- a/tests/extend_gpio/main.c
+++ b/tests/extend_gpio/main.c
@@ -119,8 +119,7 @@ void test_gpio_write(void *dev, gpio_t pin, int value)
 
 int main(void)
 {
-    uint16_t num;
-    gpio_t pin;
+    gpio_t num, pin;
 
     puts("gpio extension test routine");
 

--- a/tests/extend_gpio/tests/01-run.py
+++ b/tests/extend_gpio/tests/01-run.py
@@ -12,7 +12,7 @@ import sys
 
 def testfunc(child):
     child.expect_exact("gpio extension test routine")
-    for i in range(4):
+    for _ in range(4):
         child.expect('Running gpio.h functions on pin \d+')
         child.expect('init on dev 0xbeef with pin \d+')
         child.expect('init_int on dev 0xbeef with pin \d+')
@@ -25,7 +25,7 @@ def testfunc(child):
         child.expect('write on dev 0xbeef with pin \d+')
     child.expect_exact("Running notsup functions")
     child.expect_exact("(they should not print output)")
-    for i in range(4):
+    for _ in range(4):
         child.expect('Running notsup gpio.h functions on pin \d+')
     child.expect_exact("Checking that all pins in range have init error using notsup")
     child.expect_exact("(lack of init error implies improper redirection)")

--- a/tests/extend_gpio/tests/01-run.py
+++ b/tests/extend_gpio/tests/01-run.py
@@ -1,0 +1,38 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2018 Acutam Automation, LLC
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import os
+import sys
+
+
+def testfunc(child):
+    child.expect_exact("gpio extension test routine")
+    for i in range(4):
+        child.expect('Running gpio.h functions on pin \d+')
+        child.expect('init on dev 0xbeef with pin \d+')
+        child.expect('init_int on dev 0xbeef with pin \d+')
+        child.expect('irq_enable on dev 0xbeef with pin \d+')
+        child.expect('irq_disable on dev 0xbeef with pin \d+')
+        child.expect('read on dev 0xbeef with pin \d+')
+        child.expect('set on dev 0xbeef with pin \d+')
+        child.expect('clear on dev 0xbeef with pin \d+')
+        child.expect('toggle on dev 0xbeef with pin \d+')
+        child.expect('write on dev 0xbeef with pin \d+')
+    child.expect_exact("Running notsup functions")
+    child.expect_exact("(they should not print output)")
+    for i in range(4):
+        child.expect('Running notsup gpio.h functions on pin \d+')
+    child.expect_exact("Checking that all pins in range have init error using notsup")
+    child.expect_exact("(lack of init error implies improper redirection)")
+    child.expect_exact("[SUCCESS]")
+
+
+if __name__ == "__main__":
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc))


### PR DESCRIPTION
### Contribution description
This is an implementation of GPIO redirection outlined by my proposal in [#9582](https://github.com/RIOT-OS/RIOT/issues/9582#issuecomment-410094702) (items 5-6) for the periph/gpio interface. In short, it allows other drivers (such as GPIO expanders) to be addressed using gpio_t so that all existent code can easily gain support through those drivers. For non-implementation detail and discussion, please see #9582

At @kYc0o 's suggestion, I am breaking the implementation of #9582 / #9690 into several pieces to make it easier to review. This PR only contains the API redirection code. For the intercept code (part 1) see #9860 

### Dependencies
This depends on #9860

### Testing procedure
A test case is provided that implements a soft-driver for the GPIO extension interface. The test case uses this driver to confirm that interception and redirection of the API call are working properly. This has been tested and is working properly on mega-xplained.

### Issues/PRs references
Partially replaces and closes #9190 
Implements items 5-6 (redirection) of my proposal in #9582 
For implementation of items 1-4 (interception) see #9860
Part of work tracked by #9690