### PR TITLE
pkg.mk: do not use user identidy when applying patches

### DIFF
--- a/pkg/pkg.mk
+++ b/pkg/pkg.mk
@@ -19,12 +19,13 @@ else
 git-download: $(PKG_BUILDDIR)/.git-downloaded
 endif
 
+GITFLAGS ?= -c user.email=buildsystem@riot -c user.name="RIOT buildsystem"
 GITAMFLAGS ?= --no-gpg-sign --ignore-whitespace
 
 ifneq (,$(wildcard $(PKG_DIR)/patches))
 $(PKG_BUILDDIR)/.git-patched: $(PKG_BUILDDIR)/.git-downloaded $(PKG_DIR)/Makefile $(PKG_DIR)/patches/*.patch
 	git -C $(PKG_BUILDDIR) checkout -f $(PKG_VERSION)
-	git -C $(PKG_BUILDDIR) am $(GITAMFLAGS) "$(PKG_DIR)"/patches/*.patch
+	git $(GITFLAGS) -C $(PKG_BUILDDIR) am $(GITAMFLAGS) "$(PKG_DIR)"/patches/*.patch
 	touch $@
 endif
 


### PR DESCRIPTION
### Contribution description

Use fixed identity when applying patches, it fixes issues when they are not set in the build computer or if HOME is not exported.

The commits are only used in the build system so adding the building user information is useless.



The committer name and email can be adapted, I am bad at naming.

### Testing procedure

Compile while setting `HOME` to an empty value.
It fails on my computer but this may also be configuration specific and work on others.


In master the compilation fail during `pkg-prepare`:

```
$ make --no-print-directory -C tests/lwip distclean pkg-prepare HOME=
...
git -C /home/cladmi/git/work/RIOT/tests/lwip/bin/pkg/native/lwip am --no-gpg-sign --ignore-whitespace "/home/cladmi/git/work/RIOT/pkg/lwip"/patches/*.patch

*** Please tell me who you are.

Run

  git config --global user.email "you@example.com"
  git config --global user.name "Your Name"

to set your account's default identity.
Omit --global to set the identity only in this repository.

fatal: unable to auto-detect email address (got 'cladmi@hostname.(none)')
make[1]: *** [/home/cladmi/git/work/RIOT/pkg/pkg.mk:27: /home/cladmi/git/work/RIOT/tests/lwip/bin/pkg/native/lwip/.git-patched] Error 128
make: [/home/cladmi/git/work/RIOT/tests/lwip/../../Makefile.include:476: pkg-prepare] Error 2 (ignored)
```

With this PR:

```
$ make --no-print-directory -C tests/lwip distclean pkg-prepare HOME=
...
git -c user.email=buildsystem@riot -c user.name="RIOT buildsystem" -C /home/cladmi/git/work/RIOT/tests/lwip/bin/pkg/native/lwip am --no-gpg-sign --ignore-whitespace "/home/cladmi/git/work/RIOT/pkg/lwip"/patches/*.patch
Applying: Fix warnings
Applying: Add RIOT Makefiles
touch /home/cladmi/git/work/RIOT/tests/lwip/bin/pkg/native/lwip/.git-patched
```

And we can check the committer name:

```
$ git -C tests/lwip/bin/pkg/native/lwip/ show --summary --format=fuller
commit 44557ae63aa93ff02f3bc882193799a045094602 (HEAD)
Author:     Martine Lenders <mail@martine-lenders.eu>
AuthorDate: Thu Nov 12 15:43:31 2015 +0100
Commit:     RIOT buildsystem <buildsystem@riot>
CommitDate: Wed Sep 19 12:03:26 2018 +0200

    Add RIOT Makefiles
...
```

### Issues/PRs references

Found while building examples in https://github.com/RIOT-OS/RIOT/issues/9342#issuecomment-421960288 that invoke a second instance of the build system to build the bootloader while removing all env variables using `env -i`.


#### Possible next steps

I am thinking about overwriting the committer date.
By using the author date, `--committer-date-is-author-date` the applied patches `sha1` could be made reproducible across computers. But I am not sure what could be the best value for the build system yet.