### PR TITLE
tests/netdev_test: remove non required feature periph_timer

### DIFF
--- a/tests/netdev_test/Makefile
+++ b/tests/netdev_test/Makefile
@@ -8,8 +8,6 @@ BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno nucleo-f031k6
 
 DISABLE_MODULE = auto_init
 
-FEATURES_REQUIRED += periph_timer # xtimer required for this application
-
 USEMODULE += gnrc
 USEMODULE += gnrc_neterr
 USEMODULE += gnrc_netif


### PR DESCRIPTION
### Contribution description

Remove the non used periph_timer in test

Found out it is not actually linked.

### Testing procedure

If building works in murdock, everything should be ok.

### Issues/PRs references

Found while working on https://github.com/RIOT-OS/RIOT/pull/8711.
As the PR actually links `periph_timer` even if unused it resulted in an increased code size.