### PR TITLE
tinycbor: add doc.txt file

### DIFF
--- a/pkg/tinycbor/doc.txt
+++ b/pkg/tinycbor/doc.txt
@@ -1,0 +1,29 @@
+/**
+ * @defgroup pkg_tinycbor TinyCBOR library
+ * @ingroup  pkg
+ * @brief    Provides the TinyCBOR (Concise Binary Object Representation)
+ * library
+ * @see https://github.com/intel/tinycbor/
+ *
+ * # TinyCBOR
+ *
+ * TinyCBOR is a CBOR encoder and decoder with a very small footprint, optimized
+ * for very fast operation.
+ *
+ * The main encoder and decoder functions don't use dynamic memory allocation.
+ *
+ * # Usage
+ *
+ * Just add it as a package in your application's Makefile:
+ *
+ * ```makefile
+ * USEPKG += tinycbor
+ * ```
+ *
+ * TinyCBOR has optional floating point support. In RIOT-OS this is enabled by
+ * adding the following line to your application's Makefile:
+ *
+ * ```makefile
+ * USEMODULE += tinycbor_float
+ * ```
+ */


### PR DESCRIPTION
### Contribution description

I noticed that the tinycbor package was missing a doc.txt, so here it is.

### Testing procedure

Read the documentation. Nagging on grammatical and spelling mistakes is fully allowed here!

### Issues/PRs references

depends on #9947 
