### PR TITLE
Cleanup: drivers/makefile.dep

### DIFF
--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -396,10 +396,6 @@ ifneq (,$(filter soft_spi,$(USEMODULE)))
 endif
 
 ifneq (,$(filter srf02,$(USEMODULE)))
-  USEMODULE += xtimer
-endif
-
-ifneq (,$(filter srf02,$(USEMODULE)))
   FEATURES_REQUIRED += periph_i2c
   USEMODULE += xtimer
 endif

--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -234,6 +234,11 @@ ifneq (,$(filter lis3dh,$(USEMODULE)))
   FEATURES_REQUIRED += periph_spi
 endif
 
+ifneq (,$(filter lis3mdl,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_i2c
+  USEMODULE += xtimer
+endif
+
 ifneq (,$(filter lpd8808,$(USEMODULE)))
   USEMODULE += color
   FEATURES_REQUIRED += periph_gpio
@@ -420,7 +425,17 @@ ifneq (,$(filter tcs37727,$(USEMODULE)))
   FEATURES_REQUIRED += periph_i2c
 endif
 
+ifneq (,$(filter tja1042,$(USEMODULE)))
+  USEMODULE += can_trx
+  FEATURES_REQUIRED += periph_gpio
+endif
+
 ifneq (,$(filter tmp006,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_i2c
+  USEMODULE += xtimer
+endif
+
+ifneq (,$(filter tsl2561,$(USEMODULE)))
   FEATURES_REQUIRED += periph_i2c
   USEMODULE += xtimer
 endif
@@ -448,19 +463,4 @@ ifneq (,$(filter xbee,$(USEMODULE)))
   USEMODULE += ieee802154
   USEMODULE += xtimer
   USEMODULE += netif
-endif
-
-ifneq (,$(filter lis3mdl,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_i2c
-  USEMODULE += xtimer
-endif
-
-ifneq (,$(filter tja1042,$(USEMODULE)))
-  USEMODULE += can_trx
-  FEATURES_REQUIRED += periph_gpio
-endif
-
-ifneq (,$(filter tsl2561,$(USEMODULE)))
-  FEATURES_REQUIRED += periph_i2c
-  USEMODULE += xtimer
 endif


### PR DESCRIPTION
This PR reorders modules in Makefile.dep alphabetically. 
Also it deletes code duplication of the srf02 module.