### PR TITLE
cpu/mips: remove `periph_gpio_irq` feature and stub

### DIFF
--- a/boards/pic32-clicker/Makefile.features
+++ b/boards/pic32-clicker/Makefile.features
@@ -1,5 +1,5 @@
 # Put defined MCU peripherals here (in alphabetical order)
-FEATURES_PROVIDED += periph_gpio periph_gpio_irq
+FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 

--- a/boards/pic32-wifire/Makefile.features
+++ b/boards/pic32-wifire/Makefile.features
@@ -1,5 +1,5 @@
 # Put defined MCU peripherals here (in alphabetical order)
-FEATURES_PROVIDED += periph_gpio periph_gpio_irq
+FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 

--- a/cpu/mips_pic32_common/periph/gpio.c
+++ b/cpu/mips_pic32_common/periph/gpio.c
@@ -172,20 +172,6 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
     return 0;
 }
 
-int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
-                  gpio_cb_t cb, void *arg)
-{
-    (void)pin;
-    (void)mode;
-    (void)flank;
-    (void)cb;
-    (void)arg;
-
-    /* TODO: Not implemented yet */
-
-    return -1;
-}
-
 int gpio_read(gpio_t pin)
 {
     assert(check_valid_port(GPIO_PORT(pin)));


### PR DESCRIPTION
### Contribution description
The `gpio` driver for the `pic32` does not implement external interrupts (feature ´periph_gpio_irq`), it had simply a stub function for it. With #9035 the clean way to handle this is however to remove the stub and the feature declaration from the boards using that CPU, so applications that depend no this GPIO feature do not event build for those boards anymore...

### Testing procedure
build #9035 with and without this PR

### Issues/PRs references
Stumbled upon this while finalizing #9035
#9845 broke it :-)
