### PR TITLE
native: remove feature `periph_gpio_irq`

### DIFF
--- a/boards/native/Makefile.features
+++ b/boards/native/Makefile.features
@@ -2,7 +2,7 @@
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
-FEATURES_PROVIDED += periph_gpio periph_gpio_irq
+FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_qdec
 
 # Various other features (if any)

--- a/cpu/native/periph/gpio.c
+++ b/cpu/native/periph/gpio.c
@@ -26,25 +26,6 @@ int gpio_init(gpio_t pin, gpio_mode_t mode) {
   return -1;
 }
 
-int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
-                  gpio_cb_t cb, void *arg){
-  (void) pin;
-  (void) mode;
-  (void) flank;
-  (void) cb;
-  (void) arg;
-
-  return -1;
-}
-
-void gpio_irq_enable(gpio_t pin) {
-  (void) pin;
-}
-
-void gpio_irq_disable(gpio_t pin) {
-  (void) pin;
-}
-
 int gpio_read(gpio_t pin) {
   (void) pin;
 


### PR DESCRIPTION
### Contribution description
See #9974. `native` does not implement any GPIO irq features, so it should not declare that feature in the board, and also the function stubs are not longer needed.

### Testing procedure
Buildtest should suffice.

### Issues/PRs references
#9974