### PR TITLE
periph/gpio: fix doc of `periph_gpio_irq` submodule

### DIFF
--- a/drivers/include/periph/gpio.h
+++ b/drivers/include/periph/gpio.h
@@ -148,7 +148,7 @@ typedef struct {
  */
 int gpio_init(gpio_t pin, gpio_mode_t mode);
 
-#ifdef MODULE_PERIPH_GPIO_IRQ
+#if defined(MODULE_PERIPH_GPIO_IRQ) || defined(DOXYGEN)
 /**
  * @brief   Initialize a GPIO pin for external interrupt usage
  *
@@ -156,6 +156,9 @@ int gpio_init(gpio_t pin, gpio_mode_t mode);
  * time the defined flank(s) are detected.
  *
  * The interrupt is activated automatically after the initialization.
+ *
+ * @note    You have to add the module `periph_gpio_irq` to your project to
+ *          enable this function
  *
  * @param[in] pin       pin to initialize
  * @param[in] mode      mode of the pin, see @c gpio_mode_t
@@ -174,12 +177,18 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
 /**
  * @brief   Enable pin interrupt if configured as interrupt source
  *
+ * @note    You have to add the module `periph_gpio_irq` to your project to
+ *          enable this function
+ *
  * @param[in] pin       the pin to enable the interrupt for
  */
 void gpio_irq_enable(gpio_t pin);
 
 /**
  * @brief   Disable the pin interrupt if configured as interrupt source
+ *
+ * @note    You have to add the module `periph_gpio_irq` to your project to
+ *          enable this function
  *
  * @param[in] pin       the pin to disable the interrupt for
  */


### PR DESCRIPTION
### Contribution description
The changes in #9845 seem oddly half-baked to me: it seems like the scope of the `periph_gpio_irq` submodule was put wrong: IMO the `gpio_irq_enable/disable()` functions should clearly also only be build in if the `periph_gpio_irq` submodule is included, right?! At least the adaption for the `msp430` as included in #9845 does apply this already...

Further more, the changes in #9845 made the function documentation for `gpio_init_int` disappear from the generated documentation.

This PR adapts the scope for the `irq` submodule in the header file and re-adds the documentation.

Again: we need to be more careful when doing these kind of API changes. If not done cleanly, it always causes a lot of trouble down the line, and these things **must** be caught by the reviewers! So next time...

### Testing procedure
Build doc to check for doxygen, buildtest should do the trick for the scope change.

### Issues/PRs references
#9845