### PR TITLE
pkg: add libhydrogen

### DIFF
--- a/pkg/libhydrogen/Makefile
+++ b/pkg/libhydrogen/Makefile
@@ -1,0 +1,15 @@
+PKG_NAME    = libhydrogen
+PKG_URL     = https://github.com/jedisct1/libhydrogen
+PKG_VERSION = 39eb529905ce118b674a7723c0d2b48074b9986d
+PKG_LICENSE = ISC
+
+# This warning is triggered on non-32bit platforms
+CFLAGS += -Wno-type-limits
+
+.PHONY: all
+
+all: git-download
+	"$(MAKE)" -C $(PKG_BUILDDIR) \
+			  -f $(RIOTPKG)/libhydrogen/Makefile.$(PKG_NAME)
+
+include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/libhydrogen/Makefile.dep
+++ b/pkg/libhydrogen/Makefile.dep
@@ -1,0 +1,1 @@
+USEMODULE += random

--- a/pkg/libhydrogen/Makefile.include
+++ b/pkg/libhydrogen/Makefile.include
@@ -1,0 +1,1 @@
+INCLUDES += -I$(PKGDIRBASE)/libhydrogen

--- a/pkg/libhydrogen/Makefile.libhydrogen
+++ b/pkg/libhydrogen/Makefile.libhydrogen
@@ -1,0 +1,3 @@
+MODULE = libhydrogen
+
+include $(RIOTBASE)/Makefile.base

--- a/pkg/libhydrogen/doc.txt
+++ b/pkg/libhydrogen/doc.txt
@@ -1,0 +1,30 @@
+/**
+ * @defgroup pkg_libhydrogen LibHydrogen cryptographic library
+ * @ingroup  pkg
+ * @brief    A lightweight, secure, easy-to-use crypto library suitable for constrained environments.
+ *
+ * # LibHydrogen RIOT package
+ *
+ * The Hydrogen library is a small, easy-to-use, hard-to-misuse cryptographic
+ * library. It provides functions for random numbers, generic hashing, key
+ * derivation, secret-key encryption, public-key signatures, key exchange and
+ * password hashing.
+ *
+ * Full documentation can be found on the [LibHydrogen wiki](https://github.com/jedisct1/libhydrogen/wiki).
+ *
+ * ## Usage
+ *
+ * Add it as a package in your application's Makefile:
+ *
+ * ```makefile
+ * USEPKG += libhydrogen
+ * ```
+ *
+ * Include the LibHydrogen header in your code:
+ *
+ * ```c
+ * #include "hydrogen.h"
+ * ```
+ *
+ * @see https://github.com/jedisct1/libhydrogen
+ */

--- a/pkg/libhydrogen/patches/0001-Add-support-for-RIOT-OS.patch
+++ b/pkg/libhydrogen/patches/0001-Add-support-for-RIOT-OS.patch
@@ -1,0 +1,35 @@
+From 59ba85698386d2d55c86a00557169f3f5efad502 Mon Sep 17 00:00:00 2001
+From: Silke Hofstra <silke@slxh.eu>
+Date: Thu, 20 Sep 2018 16:32:40 +0200
+Subject: [PATCH] Add support for RIOT OS
+
+---
+ impl/random.h | 12 ++++++++++++
+ 1 file changed, 12 insertions(+)
+
+diff --git a/impl/random.h b/impl/random.h
+index f2ca1a4..2c09e02 100644
+--- a/impl/random.h
++++ b/impl/random.h
+@@ -99,6 +99,18 @@ hydro_random_init(void)
+     return 0;
+ }
+ 
++#elif defined(RIOT_VERSION) && !defined(__unix__)
++
++#include <random.h>
++
++static int
++hydro_random_init(void)
++{
++    random_bytes(hydro_random_context.state, sizeof hydro_random_context.state);
++    hydro_random_context.counter = ~LOAD64_LE(hydro_random_context.state);
++    return 0;
++}
++
+ #elif defined(_WIN32)
+ 
+ #include <windows.h>
+-- 
+2.18.0
+

--- a/tests/pkg_libhydrogen/Makefile
+++ b/tests/pkg_libhydrogen/Makefile
@@ -1,0 +1,14 @@
+include ../Makefile.tests_common
+
+# AVR boards: require avr-gcc >= 7.0 (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=60040)
+# MSP430 boards: invalid alignment of 'hydro_random_context'
+BOARD_BLACKLIST := arduino-duemilanove arduino-mega2560 arduino-uno \
+                   jiminy-mega256rfr2 mega-xplained waspmote-pro \
+                   chronos msb-430 msb-430h telosb wsn430-v1_3b wsn430-v1_4 z1
+
+TEST_ON_CI_WHITELIST += all
+
+USEPKG += libhydrogen
+USEMODULE += embunit
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/pkg_libhydrogen/main.c
+++ b/tests/pkg_libhydrogen/main.c
@@ -1,0 +1,88 @@
+/*
+ * Copyright (C) 2018 Silke Hofstra
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Test the libhydrogen package
+ *
+ * @author      Silke Hofstra <silke@slxh.eu>
+ *
+ * @}
+ */
+
+#include "embUnit.h"
+#include "hydrogen.h"
+
+static char context[] = "examples";
+static char message[] = "0123456789abcdef";
+
+/* This performs setup, but should never fail */
+static void test_hydro_init(void)
+{
+    TEST_ASSERT(hydro_init() == 0);
+}
+
+/* Test public-key signatures */
+static void test_hydro_signverify(void)
+{
+    hydro_sign_keypair key_pair;
+
+    hydro_sign_keygen(&key_pair);
+
+    uint8_t signature[hydro_sign_BYTES];
+
+    hydro_sign_create(signature, message, sizeof message, context, key_pair.sk);
+
+    int res = hydro_sign_verify(signature, message, sizeof message, context, key_pair.pk);
+
+    TEST_ASSERT(res == 0);
+}
+
+/* Test secret-key encryption */
+static void test_hydro_secretbox_encryptdecrypt(void)
+{
+    uint8_t key[hydro_secretbox_KEYBYTES];
+    uint8_t ciphertext[hydro_secretbox_HEADERBYTES + sizeof message];
+
+    hydro_secretbox_keygen(key);
+    hydro_secretbox_encrypt(ciphertext, message, sizeof message, 0, context, key);
+
+    char decrypted[sizeof message];
+    int res = hydro_secretbox_decrypt(
+        decrypted,
+        ciphertext,
+        hydro_secretbox_HEADERBYTES + sizeof message,
+        0,
+        context,
+        key
+        );
+
+    TEST_ASSERT(res == 0);
+}
+
+Test *tests_libhydrogen(void)
+{
+    EMB_UNIT_TESTFIXTURES(fixtures) {
+        new_TestFixture(test_hydro_init),
+        new_TestFixture(test_hydro_signverify),
+        new_TestFixture(test_hydro_secretbox_encryptdecrypt),
+    };
+    EMB_UNIT_TESTCALLER(libhydrogen_tests, NULL, NULL, fixtures);
+    return (Test *)&libhydrogen_tests;
+}
+
+int main(void)
+{
+    TESTS_START();
+    TESTS_RUN(tests_libhydrogen());
+    TESTS_END();
+    return 0;
+}

--- a/tests/pkg_libhydrogen/tests/01-run.py
+++ b/tests/pkg_libhydrogen/tests/01-run.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2017 Freie Universität Berlin
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import sys
+from testrunner import run
+
+
+def testfunc(child):
+    child.expect_exact('OK (3 tests)')
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc))


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR adds [LibHydrogen](https://github.com/jedisct1/libhydrogen) as a package to RIOT. LibHydrogen is a lightweight and simple cryptographic library suitable for constrained environments. 

At least some functionality seems to work on the Arduino Uno, though both `avr-gcc` and the board itself gave me some trouble testing this.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

### Testing procedure

A test is included that tests the loading of the package and it's main cryptographic functionality.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

none
