### PR TITLE
tests/periph_gpio: make IRQ related functionality optional

### DIFF
--- a/tests/periph_gpio/Makefile
+++ b/tests/periph_gpio/Makefile
@@ -3,7 +3,7 @@ include ../Makefile.tests_common
 BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno
 
 FEATURES_REQUIRED = periph_gpio
-FEATURES_REQUIRED = periph_gpio_irq
+FEATURES_OPTIONAL = periph_gpio_irq
 
 USEMODULE += shell
 USEMODULE += benchmark

--- a/tests/periph_gpio/main.c
+++ b/tests/periph_gpio/main.c
@@ -28,10 +28,12 @@
 
 #define BENCH_RUNS_DEFAULT      (1000UL * 1000)
 
+#ifdef MODULE_PERIPH_GPIO_IRQ
 static void cb(void *arg)
 {
     printf("INT: external interrupt from pin %i\n", (int)arg);
 }
+#endif
 
 static int init_pin(int argc, char **argv, gpio_mode_t mode)
 {
@@ -83,6 +85,7 @@ static int init_od_pu(int argc, char **argv)
     return init_pin(argc, argv, GPIO_OD_PU);
 }
 
+#ifdef MODULE_PERIPH_GPIO_IRQ
 static int init_int(int argc, char **argv)
 {
     int po, pi;
@@ -148,6 +151,7 @@ static int init_int(int argc, char **argv)
 
     return 0;
 }
+#endif
 
 static int read(int argc, char **argv)
 {
@@ -238,7 +242,9 @@ static const shell_command_t shell_commands[] = {
     { "init_in_pd", "init as input with pull-down", init_in_pd },
     { "init_od", "init as output (open-drain without pull resistor)", init_od },
     { "init_od_pu", "init as output (open-drain with pull-up)", init_od_pu },
+#ifdef MODULE_PERIPH_GPIO_IRQ
     { "init_int", "init as external INT w/o pull resistor", init_int },
+#endif
     { "read", "read pin status", read },
     { "set", "set pin to HIGH", set },
     { "clear", "set pin to LOW", clear },


### PR DESCRIPTION
### Contribution description
A quick fix for the `tests/periph_gpio` test app, to only include the irq related shell commands in case the irq feature is selected.

### Testing procedure
Build the `tests/periph_gpio` app as is and also without the `USEMODULE += periph_gpio_irq`. Both should compile fine.

### Issues/PRs references
Tracker: #9977 