### PR TITLE
sys: add missing <string.h> includes

### DIFF
--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -21,6 +21,7 @@
 #include <errno.h>
 #include <stdint.h>
 #include <stdatomic.h>
+#include <string.h>
 
 #include "assert.h"
 #include "net/gcoap.h"

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -15,6 +15,8 @@
  * @author  Oliver Hahm <oliver.hahm@inria.fr>
  */
 
+#include <string.h>
+
 #include "bitfield.h"
 #include "net/ethernet.h"
 #include "net/ipv6.h"

--- a/sys/net/gnrc/netif/gnrc_netif_ethernet.c
+++ b/sys/net/gnrc/netif/gnrc_netif_ethernet.c
@@ -15,6 +15,8 @@
  * @author  Kaspar Schleiser <kaspar@schleiser.de>
  */
 
+#include <string.h>
+
 #ifdef MODULE_NETDEV_ETH
 #include "net/ethernet/hdr.h"
 #include "net/gnrc.h"

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.h
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.h
@@ -22,6 +22,7 @@
 #include <assert.h>
 #include <stdbool.h>
 #include <stdint.h>
+#include <string.h>
 
 #include "bitfield.h"
 #include "evtimer_msg.h"

--- a/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
+++ b/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
@@ -13,6 +13,8 @@
  * @author  Martine Lenders <m.lenders@fu-berlin.de>
  */
 
+#include <string.h>
+
 #include "net/gnrc/icmpv6.h"
 #include "net/gnrc/ipv6.h"
 #include "net/gnrc/netif/internal.h"

--- a/sys/net/gnrc/network_layer/sixlowpan/nd/gnrc_sixlowpan_nd.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/nd/gnrc_sixlowpan_nd.c
@@ -12,6 +12,8 @@
  * @file
  */
 
+#include <string.h>
+
 #include "net/eui64.h"
 #include "net/icmpv6.h"
 #include "net/gnrc/ipv6.h"

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl.c
@@ -15,6 +15,8 @@
  * @author  Cenk Gündoğan <cenk.guendogan@haw-hamburg.de>
  */
 
+#include <string.h>
+
 #include "net/icmpv6.h"
 #include "net/ipv6.h"
 #include "net/gnrc/netif/internal.h"

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_control_messages.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_control_messages.c
@@ -16,6 +16,8 @@
  * @author Cenk Gündoğan <cenk.guendogan@haw-hamburg.de>
  */
 
+#include <string.h>
+
 #include "net/af.h"
 #include "net/icmpv6.h"
 #include "net/ipv6/hdr.h"

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_dodag.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_dodag.c
@@ -17,6 +17,8 @@
  */
 
 #include <stdbool.h>
+#include <string.h>
+
 #include "net/af.h"
 #include "net/gnrc/ipv6.h"
 #include "net/gnrc/netif/internal.h"

--- a/sys/net/gnrc/routing/rpl/p2p/gnrc_rpl_p2p.c
+++ b/sys/net/gnrc/routing/rpl/p2p/gnrc_rpl_p2p.c
@@ -14,6 +14,8 @@
  * @author  Cenk Gündoğan <cenk.guendogan@haw-hamburg.de>
  */
 
+#include <string.h>
+
 #include "net/icmpv6.h"
 #include "net/gnrc/ipv6.h"
 #include "net/gnrc/icmpv6.h"

--- a/sys/net/gnrc/sock/ip/gnrc_sock_ip.c
+++ b/sys/net/gnrc/sock/ip/gnrc_sock_ip.c
@@ -16,6 +16,7 @@
  */
 
 #include <errno.h>
+#include <string.h>
 
 #include "byteorder.h"
 #include "net/af.h"

--- a/sys/net/gnrc/sock/udp/gnrc_sock_udp.c
+++ b/sys/net/gnrc/sock/udp/gnrc_sock_udp.c
@@ -16,6 +16,7 @@
  */
 
 #include <errno.h>
+#include <string.h>
 
 #include "byteorder.h"
 #include "net/af.h"

--- a/sys/net/gnrc/transport_layer/tcp/gnrc_tcp.c
+++ b/sys/net/gnrc/transport_layer/tcp/gnrc_tcp.c
@@ -18,8 +18,9 @@
  */
 
 #include <errno.h>
-#include <utlist.h>
 #include <string.h>
+#include <utlist.h>
+
 #include "net/af.h"
 #include "net/gnrc.h"
 #include "net/gnrc/tcp.h"

--- a/sys/net/routing/nhdp/iib_table.c
+++ b/sys/net/routing/nhdp/iib_table.c
@@ -18,6 +18,8 @@
  * @}
  */
 
+#include <string.h>
+
 #include "mutex.h"
 #include "timex.h"
 #include "xtimer.h"

--- a/sys/net/routing/nhdp/nhdp.c
+++ b/sys/net/routing/nhdp/nhdp.c
@@ -18,6 +18,8 @@
  * @}
  */
 
+#include <string.h>
+
 #include "net/sock/udp.h"
 #include "msg.h"
 #include "net/gnrc/netapi.h"

--- a/sys/random/fortuna.c
+++ b/sys/random/fortuna.c
@@ -17,6 +17,8 @@
  * @}
  */
 
+#include <string.h>
+
 #include "log.h"
 #include "mutex.h"
 

--- a/sys/random/fortuna/fortuna.c
+++ b/sys/random/fortuna/fortuna.c
@@ -5,6 +5,8 @@
  * for more information.
  */
 
+#include <string.h>
+
 #include "fortuna.h"
 
 /**

--- a/sys/shell/commands/sc_ccnl.c
+++ b/sys/shell/commands/sc_ccnl.c
@@ -18,6 +18,8 @@
  * @}
  */
 
+#include <string.h>
+
 #include "random.h"
 #include "sched.h"
 #include "net/gnrc/netif.h"

--- a/sys/shell/commands/sc_gnrc_netif.c
+++ b/sys/shell/commands/sc_gnrc_netif.c
@@ -19,6 +19,7 @@
  */
 
 #include <stdio.h>
+#include <string.h>
 
 #include "net/ipv6/addr.h"
 #include "net/gnrc.h"


### PR DESCRIPTION
Some .c files were using functions defined in string.h, but not including the
header. This PR adds the necessary includes.


In order to find a string.h function, grep the file for memset, memcpy, strcpy,
...