### PR TITLE
sys: saul: add missing stddef.h include (for NULL)

### DIFF
--- a/sys/saul_reg/saul_reg.c
+++ b/sys/saul_reg/saul_reg.c
@@ -18,6 +18,7 @@
  * @}
  */
 
+#include <stddef.h>
 #include <stdio.h>
 #include <stdint.h>
 #include <string.h>

--- a/sys/shell/commands/sc_saul_reg.c
+++ b/sys/shell/commands/sc_saul_reg.c
@@ -19,6 +19,7 @@
  * @}
  */
 
+#include <stddef.h>
 #include <stdio.h>
 #include <string.h>
 #include <stdlib.h>


### PR DESCRIPTION
saul is using NULL, but not including the corresponding stddef.h header.