### PR TITLE
periph/gpio: fix scope of GPIO_IRQ submodule

### DIFF
--- a/drivers/include/periph/gpio.h
+++ b/drivers/include/periph/gpio.h
@@ -169,8 +169,6 @@ int gpio_init(gpio_t pin, gpio_mode_t mode);
 int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
                   gpio_cb_t cb, void *arg);
 
-#endif /* MODULE_PERIPH_GPIO_IRQ */
-
 /**
  * @brief   Enable pin interrupt if configured as interrupt source
  *
@@ -184,6 +182,8 @@ void gpio_irq_enable(gpio_t pin);
  * @param[in] pin       the pin to disable the interrupt for
  */
 void gpio_irq_disable(gpio_t pin);
+
+#endif /* MODULE_PERIPH_GPIO_IRQ */
 
 /**
  * @brief   Get the current value of the given pin


### PR DESCRIPTION
### Contribution description
See #9978

Move the gpio_irq_enable() and gpio_irq_disable() functions into the scope of the PERIPH_GPIO_IRQ submodule.

NOTE: this PR need all CPUs to be adapted to work correctly:
- [x] #9993
- [x] #9994
- [x] #9995
- [x] #9996
- [x] #9997
- [x] #9998
- [x] #9999
- [x] #10000
- [x] #10001
- [x] #10002
- [x] #10003
- [x] #10004
- [x] #10005
- [x] #10006
- [x] #10007
- [x] #10008

### Testing procedure
Build and run `tests/periph_gpio` in the default configuration and also with `DISABLE_MODULE += periph_gpio_irq`.

### Issues/PRs references
See #9978 for some context
#9845 for the changed that triggered this PR