### PR TITLE
dist/cppcheck: fix missing cppcheck-suppression reasons

### DIFF
--- a/core/clist.c
+++ b/core/clist.c
@@ -78,6 +78,8 @@ clist_node_t *_clist_sort(clist_node_t *list, clist_cmp_func_t cmp)
             for (i = 0; i < insize; i++) {
                 psize++;
                 q = (q->next == oldhead) ? NULL : q->next;
+                /* cppcheck-suppress nullPointer
+                 * (reason: possible bug in cppcheck 1.6x) */
                 if (!q) {
                     break;
                 }

--- a/core/clist.c
+++ b/core/clist.c
@@ -134,7 +134,8 @@ clist_node_t *_clist_sort(clist_node_t *list, clist_cmp_func_t cmp)
             p = q;
         }
 
-        /* cppcheck-suppress nullPointer */
+        /* cppcheck-suppress nullPointer
+         * (reason: tail cannot be NULL at this point, because list != NULL) */
         tail->next = list;
 
         /* If we have done only one merge, we're finished. */

--- a/cpu/cortexm_common/vectors_cortexm.c
+++ b/cpu/cortexm_common/vectors_cortexm.c
@@ -237,7 +237,7 @@ __attribute__((used)) void hard_fault_handler(uint32_t* sp, uint32_t corrupted, 
      * Fixes wrong compiler warning by gcc < 6.0. */
     uint32_t pc = 0;
     /* cppcheck-suppress variableScope
-     * variable used in assembly-code below */
+     * (reason: used within __asm__ which cppcheck doesn't pick up) */
     uint32_t* orig_sp = NULL;
 
     /* Check if the ISR stack overflowed previously. Not possible to detect

--- a/cpu/fe310/periph/uart.c
+++ b/cpu/fe310/periph/uart.c
@@ -80,7 +80,8 @@ int uart_init(uart_t dev, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
     /* Calculate buadrate divisor given current CPU clk rate
      * Ignore the first run (icache needs to be warm) */
     uartDiv = PRCI_measure_mcycle_freq(1000, RTC_FREQ);
-    /* cppcheck-suppress redundantAssignment */
+    /* cppcheck-suppress redundantAssignment
+     * (reason: should ignore first cycle to get correct values) */
     uartDiv = PRCI_measure_mcycle_freq(1000, RTC_FREQ);
     uartDiv = uartDiv / baudrate;
 

--- a/cpu/kinetis/periph/i2c.c
+++ b/cpu/kinetis/periph/i2c.c
@@ -170,7 +170,7 @@ static uint8_t i2c_find_divider(unsigned freq, unsigned speed)
 static inline void i2c_clear_irq_flags(I2C_Type *i2c)
 {
     /* cppcheck-suppress selfAssignment
-     * reason: intentional self assignment to clear all pending IRQs */
+     * (reason: intentional self assignment to clear all pending IRQs) */
     i2c->S = i2c->S;
 }
 

--- a/cpu/kinetis/periph/timer.c
+++ b/cpu/kinetis/periph/timer.c
@@ -436,7 +436,7 @@ static inline int lptmr_set(uint8_t dev, uint16_t timeout)
         hw->CNR = 0;
         hw->CMR = timeout + hw->CNR;
         /* cppcheck-suppress selfAssignment
-         * Clear IRQ flags */
+         * (reason: intentional self assignment to clear all pending IRQs) */
         hw->CSR = hw->CSR;
         /* Enable timer and IRQ */
         hw->CSR = LPTMR_CSR_TEN_MASK | LPTMR_CSR_TFC_MASK | LPTMR_CSR_TIE_MASK;
@@ -469,7 +469,7 @@ static inline int lptmr_set_absolute(uint8_t dev, uint16_t target)
         /* TCF is set, safe to update CMR live */
         hw->CMR = target - lptmr[dev].cnr;
         /* cppcheck-suppress selfAssignment
-         * Clear IRQ flags */
+         * (reason: intentional self assignment to clear all pending IRQs) */
         hw->CSR = hw->CSR;
         /* Enable timer and IRQ */
         hw->CSR = LPTMR_CSR_TEN_MASK | LPTMR_CSR_TFC_MASK | LPTMR_CSR_TIE_MASK;

--- a/cpu/mips32r2_common/newlib_syscalls_mips_uhi/syscalls.c
+++ b/cpu/mips32r2_common/newlib_syscalls_mips_uhi/syscalls.c
@@ -69,11 +69,8 @@ void _exit(int n)
 {
     exit(n);
 
-    /*
-     * Disable unreachableCode cppcheck as pm_off spins indefinately after
-     * pulling the plug
-     */
-    /* cppcheck-suppress unreachableCode */
+    /* cppcheck-suppress unreachableCode
+     * (reason: pm_off spins indefinately after pulling the plug) */
     pm_off();
 }
 

--- a/dist/tools/cppcheck/README.md
+++ b/dist/tools/cppcheck/README.md
@@ -33,7 +33,9 @@ you want to get warnings about "unusedStructMembers" run the script with the
 
 You should read the code carefully. While cppcheck certainly produces
 valuable information, it can also warn about code that is actually OK.
-If this happens, you can add an "inline suppression" like this:
+If this happens, you can add an "inline suppression" and briefly state
+why this is required like this:
 
-    /* cppcheck-suppress passedByValue */
+    /* cppcheck-suppress passedByValue
+     * (reason: <add rationale on why it is necessary to suppress this here>) */
     timex_t timex_add(const timex_t a, const timex_t b);

--- a/dist/tools/tunslip/tunslip6.c
+++ b/dist/tools/tunslip/tunslip6.c
@@ -191,7 +191,7 @@ serial_to_tun(FILE *inslip, int outfd)
     } uip;
     static unsigned int inbufptr = 0;
     /* cppcheck-suppress variableScope
-     * rationale: cannot be reduced if built on linux */
+     * (reason: cannot be reduced if built on linux) */
     int ret;
     unsigned char c;
 

--- a/dist/tools/tunslip/tunslip6.c
+++ b/dist/tools/tunslip/tunslip6.c
@@ -651,7 +651,7 @@ devopen(const char *dev, int flags)
     char t[1024];
     strcpy(t, "/dev/");
     /* cppcheck-suppress bufferAccessOutOfBounds
-     * reason: seems to be a cppcheck bug */
+     * (reason: seems to be a bug in cppcheck 1.7x) */
     strncat(t, dev, sizeof(t) - 5);
     return open(t, flags);
 }

--- a/drivers/adt7310/adt7310.c
+++ b/drivers/adt7310/adt7310.c
@@ -218,8 +218,8 @@ float adt7310_read_float(const adt7310_t *dev)
 {
     int16_t raw = adt7310_read_raw(dev);
     if (raw == INT16_MIN) {
-        /* ignore cppcheck: we want to create a NaN here */
-        /* cppcheck-suppress duplicateExpression */
+        /* cppcheck-suppress duplicateExpression
+         * (reason: we want to create a NaN here) */
         return (0.0f / 0.0f); /* return NaN */
     }
     if (!dev->high_res) {

--- a/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_eventloop.c
+++ b/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_eventloop.c
@@ -55,7 +55,8 @@ static int _send(gnrc_pktsnip_t *pkt)
 
     /* Search for TCP header */
     LL_SEARCH_SCALAR(pkt, tcp, type, GNRC_NETTYPE_TCP);
-    /* cppcheck-suppress knownConditionTrueFalse */
+    /* cppcheck-suppress knownConditionTrueFalse
+     * (reason: tcp *can* be != NULL after LL_SEARCH_SCALAR) */
     if (tcp == NULL) {
         DEBUG("gnrc_tcp_eventloop : _send() : tcp header missing.\n");
         gnrc_pktbuf_release(pkt);

--- a/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_fsm.c
+++ b/sys/net/gnrc/transport_layer/tcp/gnrc_tcp_fsm.c
@@ -482,7 +482,8 @@ static int _fsm_rcvd_pkt(gnrc_tcp_tcb_t *tcb, gnrc_pktsnip_t *in_pkt)
                 if (ipv6_addr_is_link_local((ipv6_addr_t *) tcb->peer_addr)) {
                     gnrc_pktsnip_t *tmp = NULL;
                     LL_SEARCH_SCALAR(in_pkt, tmp, type, GNRC_NETTYPE_NETIF);
-                    /* cppcheck-suppress knownConditionTrueFalse */
+                    /* cppcheck-suppress knownConditionTrueFalse
+                     * (reason: tmp *can* be != NULL after LL_SEARCH_SCALAR) */
                     if (tmp == NULL) {
                         DEBUG("gnrc_tcp_fsm.c : _fsm_rcvd_pkt() :\
                                incomming packet had no netif header\n");

--- a/sys/quad_math/qdivrem.c
+++ b/sys/quad_math/qdivrem.c
@@ -79,7 +79,7 @@ __qdivrem(u_quad_t uq, u_quad_t vq, u_quad_t *arq)
         static volatile const unsigned int zero = 0;
 
         /* cppcheck-suppress zerodiv
-         * Divission by zero is on purpose here */
+         * (reason: division by zero is on purpose here) */
         tmp.ul[H] = tmp.ul[L] = 1 / zero;
 
         if (arq) {

--- a/sys/universal_address/universal_address.c
+++ b/sys/universal_address/universal_address.c
@@ -98,7 +98,8 @@ static universal_address_container_t *universal_address_get_next_unused_entry(vo
      * (reason: UNIVERSAL_ADDRESS_MAX_ENTRIES may be zero in which case this
      * code is optimized out) */
     if (universal_address_table_filled < UNIVERSAL_ADDRESS_MAX_ENTRIES) {
-        /* cppcheck-suppress unsignedLessThanZero */
+        /* cppcheck-suppress unsignedLessThanZero
+         * (reason: UNIVERSAL_ADDRESS_MAX_ENTRIES may be zero, see above) */
         for (size_t i = 0; i < UNIVERSAL_ADDRESS_MAX_ENTRIES; ++i) {
             if (universal_address_table[i].use_count == 0) {
                 return &(universal_address_table[i]);

--- a/tests/buttons/main.c
+++ b/tests/buttons/main.c
@@ -69,7 +69,7 @@ int main(void)
 
     puts("On-board button test\n");
     /* cppcheck-suppress knownConditionTrueFalse
-     * rationale: board-dependent ifdefs */
+     * (reason: board-dependent ifdefs) */
     if (cnt == 0) {
         puts("[FAILED] no buttons available!");
         return 2;

--- a/tests/cpp11_condition_variable/main.cpp
+++ b/tests/cpp11_condition_variable/main.cpp
@@ -53,7 +53,7 @@ int main() {
     {
       lock_guard<mutex> lk(m);
       /* cppcheck-suppress unreadVariable
-       * (reason variable is read in the thread created above) */
+       * (reason: variable is read in the thread created above) */
       ready = true;
       cv.notify_one();
     }

--- a/tests/leds/main.c
+++ b/tests/leds/main.c
@@ -78,7 +78,7 @@ int main(void)
 
     puts("On-board LED test\n");
     /* cppcheck-suppress knownConditionTrueFalse
-     * rationale: board-dependent ifdefs */
+     * (reason: board-dependent ifdefs) */
     if (numof == 0) {
         puts("NO LEDs AVAILABLE");
     }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Fixes #1895

This adds or corrects missing rationale on existing cppcheck-suppression comments.

### Testing procedure

run `git grep -A1 cppcheck-suppression` on master and review if the line below `cppcheck-suppress <something>` looks like ` * (reason: <explanation>) */` and compare with this PR, which should fix all mismatches.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
