### PR TITLE
tests/libc_newlib: fix pointers comparison for llvm

### DIFF
--- a/tests/libc_newlib/main.c
+++ b/tests/libc_newlib/main.c
@@ -23,6 +23,7 @@
  */
 #define _DEFAULT_SOURCE 1
 
+#include <string.h>
 #include <stdio.h>
 #include "embUnit.h"
 
@@ -59,14 +60,24 @@ static void test_newlib(void)
      * Be sure `iprintf` and `printf` are used when `newlib` is included as
      * they should be visible in the final elf file for compile time tests
      */
-
+    int (*iprintf_addr)(const char*, ...) = &iprintf;
+    int (*printf_addr)(const char*, ...) = &printf;
+    /* With llvm and samr21-xpro, I could not directly do 'printf == iprintf'.
+     * And I could not cast them to an integer value in a portable way.
+     * So I use real function pointers for this.
+     * However comparing `printf_addr` with `iprintf_addr` does not work if
+     * there is not the memcmp to somehow 'force them' to be pointers...
+     * So I used the 'memcmp' for the comparison.
+     */
+    unsigned iprintf_cmp_printf = memcmp(&iprintf_addr, &printf_addr,
+                                         sizeof(void (*)(void)));
 #ifdef MODULE_NEWLIB
 #ifdef MODULE_NEWLIB_NANO
     /* Nano maps iprintf to printf */
-    TEST_ASSERT(iprintf == printf);
+    TEST_ASSERT_MESSAGE(iprintf_cmp_printf == 0, "iprintf == printf");
 #else
     /* Normal newlib does not */
-    TEST_ASSERT(iprintf != printf);
+    TEST_ASSERT_MESSAGE(iprintf_cmp_printf != 0, "iprintf != printf");
 #endif
 #endif
 }


### PR DESCRIPTION
### Contribution description

With llvm and samr21-xpro, I could not directly do 'printf == iprintf'.
And I could not cast them to an integer value in a portable way.
So I use real function pointers for this.
However comparing `printf_addr` with `iprintf_addr` does not work if
there is not the memcmp to somehow 'force them' to be pointers...
So I used the 'memcmp' for the comparison.


### Testing procedure

Run `make clean flash test BOARD=samr21-xpro TOOLCHAIN=llvm` and it should work.

I tested with `pic32-wifire` and also tested to disable `newlib-nano` or `nano.specs` for the samr21-xpro to test the error cases.

### Issues/PRs references

Found by https://github.com/RIOT-OS/RIOT/pull/9809