### PR TITLE
mips: Fix deps for MIPS newlib

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -391,7 +391,14 @@ endif
 
 ifneq (,$(filter stdio_uart,$(USEMODULE)))
   USEMODULE += isrpipe
-  FEATURES_REQUIRED += periph_uart
+  ifneq (,$(filter newlib_syscalls_mips_uhi,$(USEMODULE)))
+    # The periph_uart driver is optional when using MIPS UHI syscalls (debug
+    # UART is used on PIC32 boards, but not on mips-malta)
+    FEATURES_OPTIONAL += periph_uart
+  else
+    # All other UART implementations require the periph_uart driver.
+    FEATURES_REQUIRED += periph_uart
+  endif
 endif
 
 ifneq (,$(filter isrpipe,$(USEMODULE)))

--- a/cpu/mips32r2_common/newlib_syscalls_mips_uhi/syscalls.c
+++ b/cpu/mips32r2_common/newlib_syscalls_mips_uhi/syscalls.c
@@ -46,6 +46,8 @@ extern char _sheap; /* start of the heap */
 extern char _eheap; /* end of the heap */
 char *heap_top = &_sheap + 4;
 
+/* MIPS newlib crt implements _init, _fini, and _exit, and manages the heap */
+#ifndef __mips__
 /**
  * @brief Free resources on NewLib de-initialization, not used for RIOT
  */
@@ -97,6 +99,8 @@ void *_sbrk_r(struct _reent *r, ptrdiff_t incr)
     irq_restore(state);
     return res;
 }
+
+#endif /*__mips__*/
 
 /**
 * @brief Get the process-ID of the current thread


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Adjust dependencies and fix some duplicate symbol definitions in certain situations for MIPS


### Testing procedure

 - [ ] Check that all mips boards still build (CI)
 - [ ] Run some test application on a mips board (preferably mips-malta, but any pic32 works too)

### Issues/PRs references

Split from #8711 