### PR TITLE
gnrc_netif: Fix l2addr_len > 0, but no l2addr edge-case

### DIFF
--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -1192,6 +1192,11 @@ static void _update_l2addr_from_dev(gnrc_netif_t *netif)
     if (res != -ENOTSUP) {
         netif->flags |= GNRC_NETIF_FLAGS_HAS_L2ADDR;
     }
+    else {
+        /* If no address is provided but still an address length given above,
+         * we are in an invalid state */
+        assert(netif->l2addr_len == 0);
+    }
     if (res > 0) {
         netif->l2addr_len = res;
     }

--- a/tests/gnrc_sixlowpan/main.c
+++ b/tests/gnrc_sixlowpan/main.c
@@ -37,9 +37,16 @@
 #include "xtimer.h"
 
 #define IEEE802154_MAX_FRAG_SIZE    (102)
+#define IEEE802154_LOCAL_EUI64     { \
+        0x02, 0x00, 0x00, 0xFF, 0xFE, 0x00, 0x00, 0x01 \
+    }
+#define IEEE802154_REMOTE_EUI64     { \
+        0x02, 0x00, 0x00, 0xFF, 0xFE, 0x00, 0x00, 0x02 \
+    }
 
 static char _netif_stack[THREAD_STACKSIZE_DEFAULT];
 static netdev_test_t _ieee802154_dev;
+static const uint8_t _ieee802154_local_eui64[] = IEEE802154_LOCAL_EUI64;
 
 static int _get_netdev_device_type(netdev_t *netdev, void *value, size_t max_len)
 {
@@ -64,9 +71,18 @@ static int _get_netdev_src_len(netdev_t *netdev, void *value, size_t max_len)
 {
     (void)netdev;
     assert(max_len == sizeof(uint16_t));
-    *((uint16_t *)value) = sizeof(eui64_t);
+    *((uint16_t *)value) = sizeof(_ieee802154_local_eui64);
     return sizeof(uint16_t);
 }
+
+static int _get_netdev_addr_long(netdev_t *netdev, void *value, size_t max_len)
+{
+    (void)netdev;
+    assert(max_len >= sizeof(_ieee802154_local_eui64));
+    memcpy(value, _ieee802154_local_eui64, sizeof(_ieee802154_local_eui64));
+    return sizeof(_ieee802154_local_eui64);
+}
+
 
 static void _init_interface(void)
 {
@@ -79,6 +95,8 @@ static void _init_interface(void)
                            _get_netdev_max_packet_size);
     netdev_test_set_get_cb(&_ieee802154_dev, NETOPT_SRC_LEN,
                            _get_netdev_src_len);
+    netdev_test_set_get_cb(&_ieee802154_dev, NETOPT_ADDRESS_LONG,
+                           _get_netdev_addr_long);
     netif = gnrc_netif_ieee802154_create(
             _netif_stack, THREAD_STACKSIZE_DEFAULT, GNRC_NETIF_PRIO,
             "dummy_netif", (netdev_t *)&_ieee802154_dev);
@@ -106,8 +124,8 @@ static void _send_packet(void)
         uint8_t src[8];
         uint8_t dst[8];
     } netif_hdr = {
-        .src = { 0x02, 0x00, 0x00, 0xFF, 0xFE, 0x00, 0x00, 0x02 },
-        .dst = { 0x02, 0x00, 0x00, 0xFF, 0xFE, 0x00, 0x00, 0x01 },
+        .src = IEEE802154_REMOTE_EUI64,
+        .dst = IEEE802154_LOCAL_EUI64,
     };
 
     gnrc_netif_hdr_init(&(netif_hdr.netif_hdr), 8, 8);


### PR DESCRIPTION
### Contribution description
A device that provides an address length but no address doesn't make sense, so fail address initialization if this edge-case is encountered.

### Testing procedure
Run `tests/gnrc_sixlowpan` without the fix and it will pass (when compiled with GCC, see https://github.com/RIOT-OS/RIOT/pull/9809#issuecomment-423936518). Run it with the fix (but without the adaptation) and it will fail. Run it again with the adaption provided in this PR, and it will pass again.


### Issues/PRs references
Discovered but not really related to #9809