### PR TITLE
tests/gnrc_sixlowpan: fix stacksize of dummy device

### DIFF
--- a/tests/gnrc_sixlowpan/main.c
+++ b/tests/gnrc_sixlowpan/main.c
@@ -38,7 +38,7 @@
 
 #define IEEE802154_MAX_FRAG_SIZE    (102)
 
-static char _netif_stack[THREAD_STACKSIZE_SMALL];
+static char _netif_stack[THREAD_STACKSIZE_DEFAULT];
 static netdev_test_t _ieee802154_dev;
 
 static int _get_netdev_device_type(netdev_t *netdev, void *value, size_t max_len)
@@ -80,7 +80,7 @@ static void _init_interface(void)
     netdev_test_set_get_cb(&_ieee802154_dev, NETOPT_SRC_LEN,
                            _get_netdev_src_len);
     netif = gnrc_netif_ieee802154_create(
-            _netif_stack, THREAD_STACKSIZE_SMALL, GNRC_NETIF_PRIO,
+            _netif_stack, THREAD_STACKSIZE_DEFAULT, GNRC_NETIF_PRIO,
             "dummy_netif", (netdev_t *)&_ieee802154_dev);
     ipv6_addr_t addr = IPV6_ADDR_UNSPECIFIED;
 


### PR DESCRIPTION
### Contribution description
This was already too small in #9648 so it should have been properly
tested. Now that we are testing it on CI with binaries compiled by LLVM
this leads to crashes with this "new" platform.

### Testing procedure
Compile `tests/sixlowpan` for `samr21-xpro` with LLVM, flash to board and run tests:

```sh
TOOLCHAIN=llvm BOARD=samr21-xpro make -C tests/gnrc_sixlowpan flash test
```

Without this fix you should have a failed test / a crash with no/limited output. This PR fixes that.

### Issues/PRs references
Discovered in #9809.