### PR TITLE
cpu/stm32_common: EEPROM speedup

### DIFF
--- a/cpu/stm32_common/periph/eeprom.c
+++ b/cpu/stm32_common/periph/eeprom.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2018 Inria
+ * Copyright (C) 2018 Unwired Devices LLC
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -15,11 +16,13 @@
  * @brief       Low-level eeprom driver implementation
  *
  * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ * @author      Oleg Artamonov <oleg@unwds.com>
  *
  * @}
  */
 
 #include <assert.h>
+#include <string.h>
 
 #include "cpu.h"
 
@@ -30,17 +33,47 @@
 
 extern void _lock(void);
 extern void _unlock(void);
+extern void _wait_for_pending_operations(void);
 
 #ifndef EEPROM_START_ADDR
 #error "periph/eeprom: EEPROM_START_ADDR is not defined"
 #endif
 
-uint8_t eeprom_read_byte(uint32_t pos)
+static union {
+    uint32_t data_word;
+    uint8_t  data_bytes[4];
+} eeprom_data;
+
+static void _eeprom_write_byte(uint32_t pos, uint8_t byte)
 {
     assert(pos < EEPROM_SIZE);
 
-    DEBUG("Reading data from EEPROM at pos %" PRIu32 "\n", pos);
-    return *(uint8_t *)(EEPROM_START_ADDR + pos);
+    _wait_for_pending_operations();
+    *(__IO uint8_t *)(EEPROM_START_ADDR + pos) = byte;
+}
+
+static void _eeprom_write_word(uint32_t pos, uint32_t word)
+{
+    assert(pos <= EEPROM_SIZE - sizeof(uint32_t));
+
+    _wait_for_pending_operations();
+    *(__IO uint32_t *)(EEPROM_START_ADDR + pos) = word;
+}
+
+static uint8_t _eeprom_read_byte(uint32_t pos)
+{
+    assert(pos < EEPROM_SIZE);
+
+    _wait_for_pending_operations();
+    return *(__IO uint8_t *)(EEPROM_START_ADDR + pos);
+}
+
+static uint32_t _eeprom_read_word(uint32_t pos)
+{
+    assert(pos <= EEPROM_SIZE - sizeof(uint32_t));
+
+    _wait_for_pending_operations();
+    return *(__IO uint32_t *)(EEPROM_START_ADDR + pos);
 }
 
 void eeprom_write_byte(uint32_t pos, uint8_t data)
@@ -49,6 +82,120 @@ void eeprom_write_byte(uint32_t pos, uint8_t data)
 
     DEBUG("Writing data '%c' to EEPROM at pos %" PRIu32 "\n", data, pos);
     _unlock();
-    *(uint8_t *)(EEPROM_START_ADDR + pos) = data;
+    _eeprom_write_byte(pos, data);
     _lock();
+}
+
+size_t eeprom_write(uint32_t pos, const uint8_t *data, size_t len)
+{
+    assert((pos + len) <= EEPROM_SIZE);
+
+    DEBUG("[EEPROM] write %d bytes\n", len);
+    _unlock();
+    uint32_t i;
+    uint32_t bytes = 0;
+
+    /* write first bytes in case of unaligned access */
+    uint32_t shift = pos & 0x3;
+    if (shift > 0) {
+        /* read-modify-write */
+        eeprom_data.data_word = _eeprom_read_word(pos - shift);
+        bytes = 4 - shift;
+        if (len < bytes) {
+            bytes = len;
+        }
+        if (data) {
+            memcpy(&eeprom_data.data_bytes[shift], data, bytes);
+        } else {
+            /* if data is NULL just clear EEPROM */
+            memset(&eeprom_data.data_bytes[shift], 0, bytes);
+        }
+        _eeprom_write_word(pos - shift, eeprom_data.data_word);
+    }
+
+    /* write by words to speed up the process */
+    uint32_t words = (len - bytes) / 4;
+    uint32_t remnant = (len - bytes) % 4;
+    for (i = 0; i < words; i++) {
+        if (data) {
+            /* memcpy to fix possible unaligned access to data array */
+            memcpy((void *)&eeprom_data.data_word, (void *)&data[bytes], 4);
+            _eeprom_write_word(pos + bytes, eeprom_data.data_word);
+        } else {
+            /* if data is NULL just clear EEPROM */
+            _eeprom_write_word(pos + bytes, 0);
+        }
+        bytes += 4;
+    }
+
+    /* write last bytes in case of unaligned access */
+    if (remnant) {
+        /* read-modify-write */
+        eeprom_data.data_word = _eeprom_read_word(pos + bytes);
+        if (data) {
+            memcpy(eeprom_data.data_bytes, &data[bytes], remnant);
+        } else {
+            memset(eeprom_data.data_bytes, 0, remnant);
+        }
+        _eeprom_write_word(pos + bytes, eeprom_data.data_word);
+        bytes += remnant;
+    }
+    _lock();
+
+    return bytes;
+}
+
+uint8_t eeprom_read_byte(uint32_t pos)
+{
+    assert(pos < EEPROM_SIZE);
+
+    DEBUG("Reading data from EEPROM at pos %" PRIu32 "\n", pos);
+    _unlock();
+    uint8_t byte = _eeprom_read_byte(pos);
+    _lock();
+
+    return byte;
+}
+
+size_t eeprom_read(uint32_t pos, uint8_t *data, size_t len)
+{
+    assert((pos + len) <= EEPROM_SIZE);
+
+    DEBUG("[EEPROM] read %d bytes\n", len);
+    _unlock();
+    uint32_t i;
+    uint32_t bytes = 0;
+
+    /* read first bytes in case of unaligned access */
+    uint32_t shift = pos & 0x3;
+    if (shift > 0) {
+        /* read a word and discard unneded bytes */
+        eeprom_data.data_word = _eeprom_read_word(pos - shift);
+        bytes = (4 - shift);
+        if (len < bytes) {
+            bytes = len;
+        }
+        memcpy(data, &eeprom_data.data_bytes[shift], bytes);
+    }
+
+    /* read by words to speed up the process */
+    uint32_t words = (len - bytes) / 4;
+    uint32_t remnant = (len - bytes) % 4;
+    for (i = 0; i < words; i++) {
+        eeprom_data.data_word = _eeprom_read_word(pos + bytes);
+        /* memcpy to fix possible unaligned access to data array */
+        memcpy((void *)&data[bytes], (void *)&eeprom_data.data_word, 4);
+        bytes += 4;
+    }
+
+    /* read last bytes in case of unaligned access */
+    if (remnant) {
+        /* read a word and discard unneded bytes */
+        eeprom_data.data_word = _eeprom_read_word(pos + bytes);
+        memcpy((void *)&data[bytes], (void *)&eeprom_data.data_word, remnant);
+        bytes += remnant;
+    }
+    _lock();
+
+    return bytes;
 }

--- a/cpu/stm32_common/periph/flash_common.c
+++ b/cpu/stm32_common/periph/flash_common.c
@@ -56,3 +56,23 @@ void _lock(void)
         CNTRL_REG |= CNTRL_REG_LOCK;
     }
 }
+
+void _wait_for_pending_operations(void)
+{
+    if ((FLASH->SR & FLASH_SR_BSY) == FLASH_SR_BSY) {
+        DEBUG("[flash-common] waiting for any pending operation to finish\n");
+        while (FLASH->SR & FLASH_SR_BSY) {}
+    }
+    else {
+        if ((FLASH->SR & (uint32_t)FLASH_SR_WRPERR) != (uint32_t)0x00) {
+            DEBUG("[flash-common] resettng previously occured flash error\n");
+            FLASH->SR |= (uint32_t)FLASH_SR_WRPERR;
+            while (FLASH->SR & FLASH_SR_BSY) {}
+        }
+    }
+
+    /* Clear 'end of operation' bit in status register */
+    if (FLASH->SR & FLASH_SR_EOP) {
+        FLASH->SR &= ~(FLASH_SR_EOP);
+    }
+}

--- a/cpu/stm32_common/periph/flashpage.c
+++ b/cpu/stm32_common/periph/flashpage.c
@@ -52,6 +52,7 @@
 
 extern void _lock(void);
 extern void _unlock(void);
+extern void _wait_for_pending_operations(void);
 
 static void _unlock_flash(void)
 {
@@ -67,17 +68,6 @@ static void _unlock_flash(void)
         }
     }
 #endif
-}
-
-static void _wait_for_pending_operations(void)
-{
-    DEBUG("[flashpage] waiting for any pending operation to finish\n");
-    while (FLASH->SR & FLASH_SR_BSY) {}
-
-    /* Clear 'end of operation' bit in status register */
-    if (FLASH->SR & FLASH_SR_EOP) {
-        FLASH->SR &= ~(FLASH_SR_EOP);
-    }
 }
 
 static void _erase_page(void *page_addr)

--- a/tests/periph_eeprom/Makefile
+++ b/tests/periph_eeprom/Makefile
@@ -3,6 +3,7 @@ include ../Makefile.tests_common
 
 FEATURES_REQUIRED += periph_eeprom
 
+USEMODULE += xtimer
 USEMODULE += shell
 USEMODULE += shell_commands  # provides reboot command
 

--- a/tests/periph_eeprom/README.md
+++ b/tests/periph_eeprom/README.md
@@ -10,6 +10,9 @@ internal EEPROM memory.
     # Write HelloWorld starting from the 10th position in the eeprom
     > write 10 HelloWorld
 
+    # Test EEPROM access speed (TEST_BUFFER_SIZE bytes starting from 0)
+    > test
+
 Background
 ==========
 


### PR DESCRIPTION
### Contribution description

Changing EEPROM access from byte to 32-bit word improves access speed by up to 8 times. Unaligned and less than 4 bytes access still possible using same functions.

P.S. _wait_for_pending_operations moved from flashpage to flash_common and used in eeprom.c to prevent flash controller busy errors.

### Testing procedure

'test' command was added to tests/periph_eeprom

Before (STM32L151CCU6 @ 32 MHz):
Writing 256 bytes to clean EEPROM: 1709029 usec
Writing 256 bytes to dirty EEPROM: 1728992 usec
Reading 256 bytes from EEPROM: 408 usec

After:
Writing 256 bytes to clean EEPROM: 216165 usec
Writing 256 bytes to dirty EEPROM: 432014 usec
Reading 256 bytes from EEPROM: 242 usec