### PR TITLE
pkg/openthread: use predefined env paths

### DIFF
--- a/pkg/openthread/Makefile
+++ b/pkg/openthread/Makefile
@@ -1,7 +1,7 @@
 PKG_NAME=openthread
 PKG_URL=https://github.com/openthread/openthread.git
 PKG_VERSION=fbfd76a990b81f007957e1bd774e51bce742e53e
-PKG_BUILDDIR ?= $(BINDIRBASE)/pkg/$(BOARD)/$(PKG_NAME)
+PKG_BUILDDIR ?= $(PKGDIRBASE)/$(PKG_NAME)
 
 $(info Compile OpenThread for FTD device)
 OPENTHREAD_ARGS+= --enable-cli-app=ftd --enable-application-coap

--- a/pkg/openthread/Makefile.include
+++ b/pkg/openthread/Makefile.include
@@ -1,8 +1,8 @@
 OPENTHREAD_DIR = $(RIOTBASE)/pkg/openthread
 
 INCLUDES += -I$(OPENTHREAD_DIR)/include \
-            -I$(BINDIRBASE)/pkg/$(BOARD)/openthread/output/include \
-            -I$(BINDIRBASE)/pkg/$(BOARD)/openthread/include/openthread \
+            -I$(PKGDIRBASE)/openthread/output/include \
+            -I$(PKGDIRBASE)/openthread/include/openthread \
 
 ifneq (,$(filter openthread_contrib,$(USEMODULE)))
   DIRS += $(OPENTHREAD_DIR)/contrib


### PR DESCRIPTION
Adapt Makefiles to use already defined environment paths instead
of redefining them.

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This adapt Makefiles of the OpenThread package to use predefined path from RIOT build system, similar to all other packages.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
