### PR TITLE
tests: enhance bench_sizeof_coretypes

### DIFF
--- a/tests/bench_sizeof_coretypes/main.c
+++ b/tests/bench_sizeof_coretypes/main.c
@@ -94,8 +94,10 @@ int main(void)
     P(flags);
 #endif
     P(rq_entry);
-#ifdef MODULE_CORE_MSG
+#if defined(MODULE_CORE_MSG) || defined(MODULE_CORE_THREAD_FLAGS) || defined(MODULE_CORE_MBOX)
     P(wait_data);
+#endif
+#ifdef MODULE_CORE_MSG
     P(msg_waiters);
     P(msg_queue);
     P(msg_array);

--- a/tests/bench_sizeof_coretypes/main.c
+++ b/tests/bench_sizeof_coretypes/main.c
@@ -100,11 +100,12 @@ int main(void)
     P(msg_queue);
     P(msg_array);
 #endif
-#ifdef DEVELHELP
-    P(name);
-#endif
 #if defined(DEVELHELP) || defined(SCHED_TEST_STACK) || defined(MODULE_MPU_STACK_GUARD)
     P(stack_start);
+#endif
+#ifdef DEVELHELP
+    P(name);
+    P(stack_size);
 #endif
 
     puts("\n[SUCCESS]");

--- a/tests/bench_sizeof_coretypes/tests/01-run.py
+++ b/tests/bench_sizeof_coretypes/tests/01-run.py
@@ -6,8 +6,8 @@
 # General Public License v2.1. See the file LICENSE in the top level
 # directory for more details.
 
-import os
 import sys
+from testrunner import run
 
 
 def testfunc(child):
@@ -15,6 +15,4 @@ def testfunc(child):
 
 
 if __name__ == "__main__":
-    sys.path.append(os.path.join(os.environ['RIOTTOOLS'], 'testrunner'))
-    from testrunner import run
     sys.exit(run(testfunc))


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR fixes/enhances the `tests/bench_sizeof_coretypes` in two ways:

1. add missing attribute `stack_size` to be printed (if DEVELHELP=1)
2. simplify test script by using testrunner from pylibs (similar to how its done in all other test scripts)


### Testing procedure

Compare output of `tests/bench_sizeof_coretypes` of this PR with master, should see extra line for `tcb->stack_size` if DEVELHELP=1.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->