### PR TITLE
drivers/l3g4200d: fix typo in src file header

### DIFF
--- a/drivers/l3g4200d/l3g4200d.c
+++ b/drivers/l3g4200d/l3g4200d.c
@@ -1,4 +1,4 @@
-#/*
+/*
  * Copyright (C) 2014 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser


### PR DESCRIPTION
### Contribution description
Simple one: this `#` char should not be there...

### Testing procedure
Murdock should be sufficient (as it builds `drivers/l3g4200d`)

### Issues/PRs references
none