### PR TITLE
cpu/msp430: increase default stacksize for gnrc_ipv6 thread

### DIFF
--- a/cpu/msp430_common/include/cpu_conf.h
+++ b/cpu/msp430_common/include/cpu_conf.h
@@ -71,6 +71,10 @@ extern "C" {
 /* TODO: Make this value overall MTU dependent */
 #   define GNRC_PKTBUF_SIZE                 (2560)
 #endif
+
+#ifndef GNRC_IPV6_STACK_SIZE
+#   define GNRC_IPV6_STACK_SIZE             (512)
+#endif
 /** @} */
 
 #ifdef __cplusplus


### PR DESCRIPTION
### Contribution description

By default the `gnrc_ipv6` thread initializes with `THREAD_STACKSIZE_DEFAULT` bytes. For msp40 platforms this is 256 which is insufficient for `gnrc_ipv6`. This PR increases the stacksize to 512 bytes.

### Testing procedure

Flash *examples/gnrc_minimal* on a z1 board. It will get stuck somewhere [here](https://github.com/RIOT-OS/RIOT/blob/master/examples/gnrc_minimal/main.c#L37) (without a hard fault). Flash *examples/gnrc_networking* on an other board (e.g., samr21-xpro), disable IPHC  (`ifconfig 7 -iphc`) and ping the z1 node. It will not answer. Include this fix on the z1 node, re-flash and it will answer.

An other thing you might want to consider:

```patch
diff --git a/examples/gnrc_minimal/Makefile b/examples/gnrc_minimal/Makefile
index bc63da397..f0f70a43a 100644
--- a/examples/gnrc_minimal/Makefile
+++ b/examples/gnrc_minimal/Makefile
@@ -24,7 +24,9 @@ USEMODULE += gnrc_ipv6
 USEMODULE += gnrc_icmpv6_echo
 # Use minimal standard PRNG
 USEMODULE += prng_minstd
+USEMODULE += ps
 
+CFLAGS += -DGNRC_IPV6_STACK_SIZE=512
 CFLAGS += -DGNRC_PKTBUF_SIZE=512 -DGNRC_NETIF_IPV6_ADDRS_NUMOF=2 \
           -DGNRC_NETIF_IPV6_GROUPS_NUMOF=2 -DGNRC_IPV6_NIB_NUMOF=1 \
           -DGNRC_IPV6_NIB_OFFL_NUMOF=1 # be able to configure at least one route
diff --git a/examples/gnrc_minimal/main.c b/examples/gnrc_minimal/main.c
index 4dbcae539..03b48d545 100644
--- a/examples/gnrc_minimal/main.c
+++ b/examples/gnrc_minimal/main.c
@@ -24,6 +24,7 @@
 #include "net/ipv6/addr.h"
 #include "net/gnrc.h"
 #include "net/gnrc/netif.h"
+#include "ps.h"
 
 int main(void)
 {
@@ -32,11 +33,13 @@ int main(void)
 
     /* get interfaces and print their addresses */
     gnrc_netif_t *netif = NULL;
+    ps();
     while ((netif = gnrc_netif_iter(netif))) {
         ipv6_addr_t ipv6_addrs[GNRC_NETIF_IPV6_ADDRS_NUMOF];
         int res = gnrc_netapi_get(netif->pid, NETOPT_IPV6_ADDR, 0, ipv6_addrs,
                                   sizeof(ipv6_addrs));
 
+        ps();
         if (res < 0) {
             continue;
         }
@@ -48,6 +51,7 @@ int main(void)
         }
     }
 
+    ps();
     /* main thread exits */
     return 0;
 }
```


Results in:
```
RIOT network stack example application
	pid | name                 | state    Q | pri | stack  ( used) | base addr  | current     
	  - | isr_stack            | -        - |   - |    256 (   -1) |     0xffff |     0xffff
	  1 | idle                 | pending  Q |  15 |     96 (   54) |     0x111e |     0x1146 
	  2 | main                 | running  Q |   7 |    512 (  284) |     0x117e |     0x1338 
	  3 | 6lo                  | bl rx    _ |   3 |    256 (  164) |     0x1cc0 |     0x1d1e 
	  4 | ipv6                 | bl rx    _ |   4 |    512 (  290) |     0x1762 |     0x18a0 
	  5 | cc2420               | bl rx    _ |   2 |    512 (  272) |     0x1560 |     0x16c2 
	    | SUM                  |            |     |   2144 ( 1064)

```
`ipv6` used 290 bytes.