### PR TITLE
net/nanocoap: use correct type param for _bulid_hdr()

### DIFF
--- a/sys/include/net/nanocoap_sock.h
+++ b/sys/include/net/nanocoap_sock.h
@@ -44,7 +44,7 @@ extern "C" {
 int nanocoap_server(sock_udp_ep_t *local, uint8_t *buf, size_t bufsize);
 
 /**
- * @brief   Simple synchronous CoAP get
+ * @brief   Simple synchronous CoAP (confirmable) get
  *
  * @param[in]   remote  remote UDP endpoint
  * @param[in]   path    remote path

--- a/sys/net/application_layer/nanocoap/sock.c
+++ b/sys/net/application_layer/nanocoap/sock.c
@@ -94,7 +94,7 @@ ssize_t nanocoap_get(sock_udp_ep_t *remote, const char *path, uint8_t *buf, size
     uint8_t *pktpos = buf;
 
     pkt.hdr = (coap_hdr_t*)buf;
-    pktpos += coap_build_hdr(pkt.hdr, COAP_REQ, NULL, 0, COAP_METHOD_GET, 1);
+    pktpos += coap_build_hdr(pkt.hdr, COAP_TYPE_CON, NULL, 0, COAP_METHOD_GET, 1);
     pktpos += coap_opt_put_uri_path(pktpos, 0, path);
     pkt.payload = pktpos;
     pkt.payload_len = 0;

--- a/tests/unittests/tests-nanocoap/tests-nanocoap.c
+++ b/tests/unittests/tests-nanocoap/tests-nanocoap.c
@@ -34,7 +34,7 @@ static void test_nanocoap__hdr(void)
     unsigned char path_tmp[64] = {0};
 
     uint8_t *pktpos = &buf[0];
-    pktpos += coap_build_hdr((coap_hdr_t *)pktpos, COAP_REQ, NULL, 0,
+    pktpos += coap_build_hdr((coap_hdr_t *)pktpos, COAP_TYPE_CON, NULL, 0,
                              COAP_METHOD_GET, msgid);
     pktpos += coap_opt_put_location_path(pktpos, 0, loc_path);
     pktpos += coap_opt_put_uri_path(pktpos, COAP_OPT_LOCATION_PATH, path);


### PR DESCRIPTION
### Contribution description
While cleaning up #9926 I noticed the unclean usage of the `COAP_REQ` define. As `coap_build_hdr()`'s second parameter is used as the actual message type value (e.g. CON/NON/ACK/RST), the define used for this parameter should be `COAP_TYPE_x`. As it happens, the value of `COAP_REQ` is equal to `COAP_TYPE_CON`, so the existing code worked just fine. But syntactically, I think this should be fixed :-)

### Testing procedure
Simple build test aka Murdock, as simply one define was exchanged with another one while both have the same value.

### Issues/PRs references
Noticed this while working on #9926
