### PR TITLE
cpu/cortexm_common: add function to check address for validity

### DIFF
--- a/cpu/cortexm_common/include/cpu.h
+++ b/cpu/cortexm_common/include/cpu.h
@@ -189,6 +189,17 @@ static inline void cortexm_isr_end(void)
     }
 }
 
+/**
+ * @brief   Checks is memory address valid or not
+ *
+ * This function can be used to check for memory size,
+ * peripherals availability, etc.
+ *
+ * @param[in]	address     Address to check
+ * @return                  true if address is valid
+ */
+bool cpu_check_address(volatile const char *address);
+
 #ifdef __cplusplus
 }
 #endif

--- a/tests/cpu_cortexm_address_check/Makefile
+++ b/tests/cpu_cortexm_address_check/Makefile
@@ -1,0 +1,10 @@
+APPLICATION = cortexm_address_check
+
+BOARD ?= nucleo-l152re
+
+USEMODULE += shell
+USEMODULE += shell_commands
+
+include ../Makefile.tests_common
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/cpu_cortexm_address_check/README.md
+++ b/tests/cpu_cortexm_address_check/README.md
@@ -1,0 +1,12 @@
+# Cortex-M check for memory address validity
+
+## Introduction
+Cortex-M3/M4/M7-based MCUs allow to check memory address validity
+by temporarily blocking BusFault handler.
+
+Validity check can be used to determine RAM/flash/EEPROM sizes,
+peripherals availability, etc., to create firmware that runs
+effectively on different MCUs without recompiling.
+
+NB: Cortex-M0 and Cortex-M0+ don't have BusFault events, all
+bus errors escalate to HardFault immediately.

--- a/tests/cpu_cortexm_address_check/main.c
+++ b/tests/cpu_cortexm_address_check/main.c
@@ -1,0 +1,65 @@
+/*
+ * Copyright (C) 2018 Unwired Devices LLC
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Test application for Cortex-M address checks
+ *
+ * @author      Oleg Artamonov <oleg@unwds.com>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "cpu.h"
+#include "shell.h"
+
+static int cmd_check(int argc, char **argv)
+{
+    if (argc < 2) {
+        printf("usage: %s <hex address>\n", argv[0]);
+        printf("\t example: %s 0x08080000\n", argv[0]);
+        return 1;
+    }
+
+    char *address;
+    uint32_t address_value = strtol(argv[1], NULL, 0);
+
+    address = (char *)address_value;
+
+    if (cpu_check_address(address))
+        printf("Address 0x%08" PRIx32 " is valid. Feel free to access it\n", address_value);
+    else
+        printf("Address 0x%08" PRIx32 " is NOT valid. Accessing it will result in BusFault\n", address_value);
+
+    return 0;
+}
+
+static const shell_command_t shell_commands[] = {
+    { "check", "Check address", cmd_check},
+    { NULL, NULL, NULL }
+};
+
+int main(void)
+{
+    puts("Address check test\n");
+    puts("Please refer to the README.md for more details\n");
+    puts("usage: check <hex address>");
+    puts("\texample: check 0x08080000");
+
+    /* run the shell */
+    char line_buf[SHELL_DEFAULT_BUFSIZE];
+    shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
+    return 0;
+}


### PR DESCRIPTION
### Contribution description

Adds extremely useful function to check memory addresses for validity on Cortex-M3/M4/M7 MCUs.

Can be used to determine memory sizes, peripherals availability, etc. in runtime to build firmware that runs effectively on a differenent MCUs without recompiling.

### Testing procedure

Build and run tests/cpu_cortexm_address_check for your board, then type 'check address' in the shell, where address is a memory address in hex notation (with '0x' prefix). Check your MCUs' datasheet for memory map.

E.g. on STM32L152RET6:
> check 0x1FF02000
Address 0x1ff02000 is NOT valid. Accessing it will result in BusFault

> check 0x1FF01999
Address 0x1ff01999 is valid. Feel free to access it

(0x1FF01999 is an upper address of the System Memory section)

### Issues/PRs references

~Cortex-M0 not supported, it needs completely different approach.~

P.S. Will provide real-world usage example in the next PR.