### PR TITLE
cpu/stm32_common: minimize power consumption on STM32L1

### DIFF
--- a/cpu/cortexm_common/cortexm_init.c
+++ b/cpu/cortexm_common/cortexm_init.c
@@ -72,3 +72,40 @@ void cortexm_init(void)
     cortexm_init_isr_priorities();
     cortexm_init_misc();
 }
+
+static const uint32_t BFARVALID_MASK = (0x80 << SCB_CFSR_BUSFAULTSR_Pos);
+
+bool cpu_check_address(volatile const char *address)
+{
+#if defined(CPU_ARCH_CORTEX_M3) || defined(CPU_ARCH_CORTEX_M4) || \
+    defined(CPU_ARCH_CORTEX_M4F) || defined(CPU_ARCH_CORTEX_M7)
+    bool is_valid = true;
+
+    /* Clear BFARVALID flag */
+    SCB->CFSR |= BFARVALID_MASK;
+
+    /* Ignore BusFault by enabling BFHFNMIGN */
+    SCB->CCR |= SCB_CCR_BFHFNMIGN_Msk;
+    __asm volatile ("cpsid f;");
+
+    *address;
+    /* Check BFARVALID flag */
+    if ((SCB->CFSR & BFARVALID_MASK) != 0)
+    {
+        /* Bus Fault occured reading the address */
+        is_valid = false;
+    }
+
+    __asm volatile ("cpsie f;");
+    /* Reenable BusFault by clearing  BFHFNMIGN */
+    SCB->CCR &= ~SCB_CCR_BFHFNMIGN_Msk;
+
+    return is_valid;
+#else
+    /* Cortex-M0 doesn't have BusFault */
+    (void) address;
+
+    printf("[warning] %s: Cortex-M0 doesn't have BusFault\n", __func__);
+    return true;
+#endif
+}

--- a/cpu/cortexm_common/include/cpu.h
+++ b/cpu/cortexm_common/include/cpu.h
@@ -189,6 +189,17 @@ static inline void cortexm_isr_end(void)
     }
 }
 
+/**
+ * @brief   Checks is memory address valid or not
+ *
+ * This function can be used to check for memory size,
+ * peripherals availability, etc.
+ *
+ * @param[in]	address     Address to check
+ * @return                  true if address is valid
+ */
+bool cpu_check_address(volatile const char *address);
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/stm32_common/cpu_init.c
+++ b/cpu/stm32_common/cpu_init.c
@@ -56,10 +56,27 @@ void cpu_init(void)
     for (int i = 0; i < 12; i++) {
         GPIO_TypeDef *port;
         port = (GPIO_TypeDef *)(GPIOA_BASE + i*(GPIOB_BASE - GPIOA_BASE));
-        if (cpu_check_address((char *)port))
-            port->MODER = 0xffffffff;
-        else
+        if (cpu_check_address((char *)port)) {
+#if !defined (DISABLE_JTAG)
+            switch (i) {
+                /* preserve JTAG pins on PORTA and PORTB */
+                case 0:
+                    port->MODER = 0xABFFFFFF;
+                    break;
+                case 1:
+                    port->MODER = 0xFFFFFEBF;
+                    break;
+                default:
+                    port->MODER = 0xFFFFFFFF;
+                    break;
+            }
+#else
+            port->MODER = 0xFFFFFFFF;
+#endif
+        }
+        else {
             break;
+        }
     }
 #endif
 

--- a/cpu/stm32_common/cpu_init.c
+++ b/cpu/stm32_common/cpu_init.c
@@ -49,6 +49,20 @@ void cpu_init(void)
     periph_clk_en(APB1, BIT_APB_PWREN);
     /* initialize the system clock as configured in the periph_conf.h */
     stmclk_init_sysclk();
+
+#if defined(CPU_FAM_STM32L1)
+    /* switch all GPIOs to AIN mode to minimize power consumption */
+    /* can't be more than 12 ports on STM32L1 */
+    for (int i = 0; i < 12; i++) {
+        GPIO_TypeDef *port;
+        port = (GPIO_TypeDef *)(GPIOA_BASE + i*(GPIOB_BASE - GPIOA_BASE));
+        if (cpu_check_address((char *)port))
+            port->MODER = 0xffffffff;
+        else
+            break;
+    }
+#endif
+
 #ifdef MODULE_PERIPH_DMA
     /*  initialize DMA streams */
     dma_init();

--- a/tests/cpu_cortexm_address_check/Makefile
+++ b/tests/cpu_cortexm_address_check/Makefile
@@ -1,0 +1,8 @@
+include ../Makefile.tests_common
+
+BOARD = nucleo-l152re
+
+USEMODULE += shell
+USEMODULE += shell_commands
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/cpu_cortexm_address_check/README.md
+++ b/tests/cpu_cortexm_address_check/README.md
@@ -1,0 +1,12 @@
+# Cortex-M check for memory address validity
+
+## Introduction
+Cortex-M3/M4/M7-based MCUs allow to check memory address validity
+by temporarily blocking BusFault handler.
+
+Validity check can be used to determine RAM/flash/EEPROM sizes,
+peripherals availability, etc., to create firmware that runs
+effectively on different MCUs without recompiling.
+
+NB: Cortex-M0 and Cortex-M0+ don't have BusFault events, all
+bus errors escalate to HardFault immediately.

--- a/tests/cpu_cortexm_address_check/main.c
+++ b/tests/cpu_cortexm_address_check/main.c
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2018 Unwired Devices LLC
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Test application for Cortex-M address checks
+ *
+ * @author      Oleg Artamonov <oleg@unwds.com>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "cpu.h"
+#include "shell.h"
+
+static int cmd_check(int argc, char **argv)
+{
+    if (argc < 2) {
+        printf("usage: %s <hex address>\n", argv[0]);
+        printf("\t example: %s 0x08080000\n", argv[0]);
+        return 1;
+    }
+
+    char *address;
+    uint32_t address_value;
+
+    sscanf(argv[1] + 2, "%lx", &address_value); /* ignore 0x prefix */
+
+    address = (char *)address_value;
+
+    if (cpu_check_address(address))
+        printf("Address 0x%08" PRIx32 " is valid. Feel free to access it\n", address_value);
+    else
+        printf("Address 0x%08" PRIx32 " is NOT valid. Accessing it will result in BusFault\n", address_value);
+
+    return 0;
+}
+
+static const shell_command_t shell_commands[] = {
+    { "check", "Check address", cmd_check},
+    { NULL, NULL, NULL }
+};
+
+int main(void)
+{
+    puts("Address check test\n");
+    puts("Please refer to the README.md for more details\n");
+    puts("usage: check <hex address>");
+    puts("\texample: check 0x08080000");
+
+    /* run the shell */
+    char line_buf[SHELL_DEFAULT_BUFSIZE];
+    shell_run(shell_commands, line_buf, SHELL_DEFAULT_BUFSIZE);
+    return 0;
+}


### PR DESCRIPTION
### Contribution description

Automatically configure all STM32L1 GPIOs as analog inputs.

GPIOs on STM32L1 MCUs are configured as digital inputs with Schmitt triggers, which means, if they are left floating, their power consumption is not 0 but few microamperes per GPIO due to random noise on high-impedance pin and constant random trigger switching.

To achieve minimum possible consumption, GPIOs must be reconfigured as analog inputs. It can be done automatically during MCU initialization.

Function needs cpu_check_address to check what GPIOs are available (it depends on MCU package and so can't be deduced from MCU model data available to RIOT).

Newer STM32 energy-efficient series (L0, L4) already have GPIO configured as AIN by default.

### Testing procedure

STM32L1 power consumption without this patch in STOP+RTC mode and GPIOs left floating may be as high as 100 uA. With the patch, it should be < 2 uA.

### Issues/PRs references

Depends on PR #10051 