### PR TITLE
make: fix info-objsize column name position

### DIFF
--- a/makefiles/info.inc.mk
+++ b/makefiles/info.inc.mk
@@ -13,7 +13,7 @@ info-objsize:
 	  "") SORTROW=4 ;; \
 	  *) echo "Usage: $(MAKE) info-objsize SORTROW=[text|data|bss|dec]" ; return ;; \
 	esac; \
-	echo -e '   text\t   data\t    bss\t    dec\t    hex\tfilename'; \
+	printf '   text\t   data\t    bss\t    dec\t    hex\tfilename\n'; \
 	$(SIZE) -d -B $(BASELIBS) | \
 	  tail -n+2 | \
 	  sed -e 's#$(BINDIR)##' | \


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Correctly aligns the column names of `make info-objsize` output. 
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Tested on ubuntu, someone should try if it works on mac as well.
run `make info-objsize`

output before:
```
$ make info-objsize 
-e    text	   data	    bss	    dec	    hex	filename
   5555	      0	  18056	  23611	   5c3b	irq_cpu.o (ex /cpu.a)
    488	      8	  20480	  20976	   51f0	kernel_init.o (ex /core.a)
  11343	      0	      0	  11343	   2c4f	atomic_c11.o (ex /core.a)
   2162	      0	   8540	  10702	   29ce	native_cpu.o (ex /cpu.a)
  10185	      0	      0	  10185	   27c9	atomic_sync.o (ex /core.a)
   6033	      0	    208	   6241	   1861	syscalls.o (ex /cpu.a)
```
output after fix:
```
$ make info-objsize 
   text	   data	    bss	    dec	    hex	filename
   5555	      0	  18056	  23611	   5c3b	irq_cpu.o (ex /cpu.a)
    488	      8	  20480	  20976	   51f0	kernel_init.o (ex /core.a)
  11343	      0	      0	  11343	   2c4f	atomic_c11.o (ex /core.a)
   2162	      0	   8540	  10702	   29ce	native_cpu.o (ex /cpu.a)
  10185	      0	      0	  10185	   27c9	atomic_sync.o (ex /core.a)
   6033	      0	    208	   6241	   1861	syscalls.o (ex /cpu.a)
```
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
