### PR TITLE
drivers/periph_eeprom: add clear and erase functions

### DIFF
--- a/cpu/atmega_common/include/periph_cpu_common.h
+++ b/cpu/atmega_common/include/periph_cpu_common.h
@@ -146,6 +146,11 @@ typedef struct {
 } pwm_conf_t;
 /** @} */
 
+/**
+ * @brief   EEPROM clear byte
+ */
+#define EEPROM_CLEAR_BYTE              (0xff)
+
 #ifdef __cplusplus
 }
 #endif

--- a/drivers/include/periph/eeprom.h
+++ b/drivers/include/periph/eeprom.h
@@ -35,6 +35,13 @@ extern "C" {
 #endif
 
 /**
+ * @brief   Default value of the EEPROM clear byte
+ */
+#ifndef EEPROM_CLEAR_BYTE
+#define EEPROM_CLEAR_BYTE 0x00
+#endif
+
+/**
  * @brief   Read a byte at the given position in eeprom
  *
  * @param[in]  pos      position to read
@@ -78,6 +85,17 @@ void eeprom_write_byte(uint32_t pos, uint8_t data);
  * @return the number of bytes written
  */
 size_t eeprom_write(uint32_t pos, const uint8_t *data, size_t len);
+
+/**
+ * @brief   Set @p len bytes from the given position @p pos with value @p val
+ *
+ * @param[in] pos       start position in eeprom
+ * @param[in] val       the value to set
+ * @param[in] len       the number of bytes to set
+ *
+ * @return the number of bytes set
+ */
+size_t eeprom_set(uint32_t pos, uint8_t val, size_t len);
 
 /**
  * @brief   Clear @p len bytes from the given position @p pos

--- a/drivers/include/periph/eeprom.h
+++ b/drivers/include/periph/eeprom.h
@@ -79,6 +79,25 @@ void eeprom_write_byte(uint32_t pos, uint8_t data);
  */
 size_t eeprom_write(uint32_t pos, const uint8_t *data, size_t len);
 
+/**
+ * @brief   Clear @p len bytes from the given position @p pos
+ *
+ * Clearing a byte in EEPROM simply consists in setting it to 0
+ *
+ * @param[in] pos       start position in eeprom
+ * @param[in] len       the number of bytes to clear
+ *
+ * @return the number of bytes cleared
+ */
+size_t eeprom_clear(uint32_t pos, size_t len);
+
+/**
+ * @brief   Erase the whole EEPROM content
+ *
+ * @return the EEPROM_SIZE
+ */
+size_t eeprom_erase(void);
+
 #ifdef __cplusplus
 }
 #endif

--- a/drivers/periph_common/eeprom.c
+++ b/drivers/periph_common/eeprom.c
@@ -40,15 +40,20 @@ void eeprom_write_byte(uint32_t pos, uint8_t byte)
     eeprom_write(pos, &byte, 1);
 }
 
-size_t eeprom_clear(uint32_t pos, size_t len)
+size_t eeprom_set(uint32_t pos, uint8_t val, size_t len)
 {
     assert(pos + len <= EEPROM_SIZE);
 
     for (size_t i = 0; i < len; i++) {
-        eeprom_write_byte(pos++, 0);
+        eeprom_write_byte(pos++, val);
     }
 
     return len;
+}
+
+size_t eeprom_clear(uint32_t pos, size_t len)
+{
+    return eeprom_set(pos, EEPROM_CLEAR_BYTE, len);
 }
 
 size_t eeprom_erase(void)

--- a/drivers/periph_common/eeprom.c
+++ b/drivers/periph_common/eeprom.c
@@ -40,4 +40,19 @@ void eeprom_write_byte(uint32_t pos, uint8_t byte)
     eeprom_write(pos, &byte, 1);
 }
 
+size_t eeprom_clear(uint32_t pos, size_t len)
+{
+    assert(pos + len <= EEPROM_SIZE);
+
+    for (size_t i = 0; i < len; i++) {
+        eeprom_write_byte(pos++, 0);
+    }
+
+    return len;
+}
+
+size_t eeprom_erase(void)
+{
+    return eeprom_clear(0, EEPROM_SIZE);
+}
 #endif

--- a/tests/periph_eeprom/main.c
+++ b/tests/periph_eeprom/main.c
@@ -139,6 +139,46 @@ static int cmd_write_byte(int argc, char **argv)
     return 0;
 }
 
+static int cmd_clear(int argc, char **argv)
+{
+    if (argc < 3) {
+        printf("usage: %s <pos> <count>\n", argv[0]);
+        return 1;
+    }
+
+    uint32_t pos = atoi(argv[1]);
+    uint32_t count = atoi(argv[2]);
+
+    if (pos + count > EEPROM_SIZE) {
+        puts("Failed: cannot clear out of eeprom bounds");
+        return 1;
+    }
+
+    size_t ret = eeprom_clear(pos, count);
+    printf("%d bytes cleared in EEPROM\n", (int)ret);
+
+    return 0;
+}
+
+static int cmd_erase(int argc, char **argv)
+{
+    if (argc != 1) {
+        printf("usage: %s\n", argv[0]);
+        return 1;
+    }
+
+    size_t ret = eeprom_erase();
+    if (ret == EEPROM_SIZE) {
+        puts("EEPROM erased with success");
+    }
+    else {
+        puts("EEPROM erase failed");
+        return 1;
+    }
+
+    return 0;
+}
+
 static int cmd_test(int argc, char **argv)
 {
     (void)argv;
@@ -187,6 +227,8 @@ static const shell_command_t shell_commands[] = {
     { "write", "Write bytes to eeprom", cmd_write },
     { "read_byte", "Read a single byte from eeprom", cmd_read_byte },
     { "write_byte", "Write a single byte to eeprom", cmd_write_byte },
+    { "clear", "Clear bytes to eeprom", cmd_clear},
+    { "erase", "Erase whole eeprom", cmd_erase},
     { "test", "Test the EEPROM implementation", cmd_test },
     { NULL, NULL, NULL }
 };

--- a/tests/periph_eeprom/main.c
+++ b/tests/periph_eeprom/main.c
@@ -150,7 +150,7 @@ static int cmd_set(int argc, char **argv)
     uint32_t count = atoi(argv[3]);
 
     if (strlen(argv[2]) != 1) {
-        puts("Failed: char must a single digit");
+        puts("Failed: char must be a single digit");
         return 1;
     }
 
@@ -216,24 +216,25 @@ static int cmd_test(int argc, char **argv)
         return 1;
     }
 
-    const char *test = "test";
+    const char *expected = "test";
 
     /* test read/write function */
 
     /* read/write from beginning of EEPROM */
-    size_t ret = eeprom_write(0, (uint8_t *)test, 4);
+    size_t ret = eeprom_write(0, (uint8_t *)expected, 4);
     assert(ret == 4);
 
-    char *expected[4];
-    ret = eeprom_read(0, (uint8_t *)expected, 4);
-    assert(strncmp((const char *)expected, (const char *)test, 4) == 0);
+    char *result[4];
+    ret = eeprom_read(0, (uint8_t *)result, 4);
+    assert(strncmp((const char *)result, (const char *)expected, 4) == 0);
     assert(ret == 4);
 
     /* read/write at end of EEPROM */
-    ret = eeprom_write(EEPROM_SIZE - 4, (uint8_t *)test, 4);
+    ret = eeprom_write(EEPROM_SIZE - 4, (uint8_t *)expected, 4);
     assert(ret == 4);
-    ret = eeprom_read(EEPROM_SIZE - 4, (uint8_t *)expected, 4);
-    assert(strncmp((const char *)expected, test, 4) == 0);
+    memset(result, 0, 4);
+    ret = eeprom_read(EEPROM_SIZE - 4, (uint8_t *)result, 4);
+    assert(strncmp((const char *)result, expected, 4) == 0);
     assert(ret == 4);
 
     /* read/write single byte */
@@ -243,6 +244,30 @@ static int cmd_test(int argc, char **argv)
     assert(eeprom_read_byte(EEPROM_SIZE - 1) == 'A');
     eeprom_write_byte(EEPROM_SIZE / 2, 'A');
     assert(eeprom_read_byte(EEPROM_SIZE / 2) == 'A');
+
+    /* clear some bytes */
+    eeprom_clear(0, 4);
+    memset(result, 0, 4);
+    ret = eeprom_read(0, (uint8_t *)result, 4);
+    assert(strncmp((const char *)result, "", 4) == 0);
+    assert(ret == 4);
+
+    eeprom_clear(EEPROM_SIZE - 4, 4);
+    ret = eeprom_read(EEPROM_SIZE - 4, (uint8_t *)result, 4);
+    assert(strncmp((const char *)result, "", 4) == 0);
+    assert(ret == 4);
+
+    /* set some bytes */
+    eeprom_set(0, 'A', 4);
+    ret = eeprom_read(0, (uint8_t *)result, 4);
+    assert(strncmp((const char *)result, "AAAA", 4) == 0);
+    assert(ret == 4);
+
+    memset(result, 0, 4);
+    eeprom_set(EEPROM_SIZE - 4, 'A', 4);
+    ret = eeprom_read(EEPROM_SIZE - 4, (uint8_t *)result, 4);
+    assert(strncmp((const char *)result, "AAAA", 4) == 0);
+    assert(ret == 4);
 
     puts("SUCCESS");
     return 0;

--- a/tests/periph_eeprom/main.c
+++ b/tests/periph_eeprom/main.c
@@ -139,6 +139,34 @@ static int cmd_write_byte(int argc, char **argv)
     return 0;
 }
 
+static int cmd_set(int argc, char **argv)
+{
+    if (argc < 4) {
+        printf("usage: %s <pos> <char> <count>\n", argv[0]);
+        return 1;
+    }
+
+    uint32_t pos = atoi(argv[1]);
+    uint32_t count = atoi(argv[3]);
+
+    if (strlen(argv[2]) != 1) {
+        puts("Failed: char must a single digit");
+        return 1;
+    }
+
+    uint8_t c = (uint8_t)argv[2][0];
+
+    if (pos + count > EEPROM_SIZE) {
+        puts("Failed: cannot clear out of eeprom bounds");
+        return 1;
+    }
+
+    size_t ret = eeprom_set(pos, c, count);
+    printf("%d bytes set to %c in EEPROM\n", (int)ret, c);
+
+    return 0;
+}
+
 static int cmd_clear(int argc, char **argv)
 {
     if (argc < 3) {
@@ -227,6 +255,7 @@ static const shell_command_t shell_commands[] = {
     { "write", "Write bytes to eeprom", cmd_write },
     { "read_byte", "Read a single byte from eeprom", cmd_read_byte },
     { "write_byte", "Write a single byte to eeprom", cmd_write_byte },
+    { "set", "Set bytes to eeprom", cmd_set},
     { "clear", "Clear bytes to eeprom", cmd_clear},
     { "erase", "Erase whole eeprom", cmd_erase},
     { "test", "Test the EEPROM implementation", cmd_test },


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR adds 2 new functions, `clear` and `erase` functions to the periph_eeprom API. These 2 functions are here as helper since clearing a byte in EEPROM simply consists in writing a 0 at its position.

In the meantime, this PR provides a couple of commits that fix the maximum position asserts in read and write functions.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Build and flash `tests/periph_eeprom` on a STM32 L0,  L1 or AVR based board.

- For testing the EEPROM maximum bounds access (example with an EEPROM of 6144 bytes, nucleo-l073rz case), write and read the last byte:

```sh
> write 6143 Z  => one byte written
> read 6143 1   => one byte read, 'Z'
```

- For clear and erase functions:
```sh
> clear 6143 1 => one byte cleared
> read 6143 1 => byte read is empty
> write 1 A
> write 6143 Z
> erase  => this command can take a lot of time!
> read <any position> 1 => any byte read is empty
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Removed from #10026 but could be useful.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
