### PR TITLE
[RFC] [PoC] Configuration generation

### DIFF
--- a/dist/tools/config_generator/config_generator.py
+++ b/dist/tools/config_generator/config_generator.py
@@ -1,0 +1,136 @@
+#!/usr/bin/env python
+
+import yaml
+import argparse
+
+DEFINE_PREVIOUS = '#ifndef {0}\n'
+DEFINE_STRING = '#define {0} {1}\n'
+DEFINE_NEXT = '#endif\n\n'
+DEFAULT_OUTPUT_FILE = 'config.h'
+
+class ConfigGenerator():
+    """ A configuration file generator """
+
+    def __init__(self, configuration, output_file = DEFAULT_OUTPUT_FILE):
+        """ """
+        self.configuration = configuration
+        self.module_name = configuration.get('name')
+        self.output_file = output_file
+
+    def generate_configuration(self):
+        if self.module_name == None:
+            print('[ERROR] No module name defined')
+            return
+
+        module_config = self.configuration.get('configuration')
+        output = ''
+
+        output += self.parse_configuration_group(module_config)
+        self.write_output_file(output)
+
+    def parse_configuration_group(self, group_parameters, group_name = []):
+        """ Parses a configuration group and returns the generated string. """
+        output = ''
+
+        for parameter in group_parameters:
+            if parameter.get('group'):
+                _group_name = group_name + [parameter['group']['name']]
+                output += self.parse_configuration_group( \
+                    parameter['group']['parameters'],     \
+                    _group_name)
+            else:
+                output += self.parse_configuration_parameter(parameter, \
+                                                             group_name)
+
+        return output
+
+    def parse_configuration_parameter(self, parameter, group_name = []):
+        output = ''
+        
+        name = self.format_parameter_name(parameter['name'], group_name, \
+                                          parameter.get('macro'))
+
+        value = self.format_parameter_value(parameter['value'], \
+                                            parameter['type'],  \
+                                            parameter.get('properties', {}))
+
+        output += DEFINE_PREVIOUS.format(name)
+        output += DEFINE_STRING.format(name, value)
+        output += DEFINE_NEXT
+        return output
+
+    def write_output_file(self, content = ''):
+        output = (
+        '/* This is an automatically generated configuration file\n'
+         '* DO NOT EDIT, the content will be overwritten.\n'
+         '*/\n'
+         '#ifndef {0}_CONFIG_H\n'
+         '#define {0}_CONFIG_H\n\n'
+         '{1}'
+         '#endif /* {0}_CONFIG_H */\n'
+        )
+        output_name = self.output_file.split('/')
+        output_name = output_name[-1].split('.')[0].replace('-', '_').upper()
+        output = output.format(output_name, content)
+
+        try:
+            with open(self.output_file, 'w') as out_file:
+                out_file.write(output)
+                out_file.close()
+        except expression as identifier:
+            print('[ERROR] Could not generate configuration file')
+        else:
+            print('[INFO] Configuration file generated in {}' \
+                  .format(self.output_file))
+
+    def format_parameter_name(self, name, group_name = [], macro = None):
+        output = ['CONFIG']
+
+        if macro:
+            output += [macro]
+        else:
+            output += [self.module_name]
+            output += group_name
+            output += [name]
+
+        return '_'.join(output).replace('-','_').upper()
+
+    def format_parameter_value(self, value, type, properties):
+        if type == 'byte':
+            if properties.get('size'):
+                # If the amount of bytes is defined pad with zeros
+                size = properties['size']
+                return '"{0:0{1}X}"'.format(value, size * 2)
+            else:
+                return hex(value)
+        else:
+            return value
+
+
+if __name__ == '__main__':
+
+    parser = argparse.ArgumentParser( \
+        description= '''Configuration file generator.''')
+
+    parser.add_argument('configuration_file', \
+        help='File containing the configuration to parse')
+    parser.add_argument('output_file', \
+        help='Path to the file where to output the configuration')
+
+    args = parser.parse_args()
+
+    try:
+        with open(args.configuration_file) as f:
+            text = f.read()
+            f.close()
+    except:
+        print('[ERROR] Could not open configuration file {}' \
+              .format(args.configuration_file))
+    else:
+        output = ''
+
+        configuration = yaml.load(text)
+
+        generator = ConfigGenerator(configuration, args.output_file)
+
+        generator.generate_configuration()

--- a/examples/lorawan/Makefile
+++ b/examples/lorawan/Makefile
@@ -9,10 +9,6 @@ RIOTBASE ?= $(CURDIR)/../..
 
 BOARD_INSUFFICIENT_MEMORY := nucleo-f031k6 nucleo-f042k6 nucleo-l031k6
 
-DEVEUI ?= 0000000000000000
-APPEUI ?= 0000000000000000
-APPKEY ?= 00000000000000000000000000000000
-
 # Default radio driver is Semtech SX1276 (used by the B-L072Z-LRWAN1 board)
 DRIVER ?= sx1276
 
@@ -38,3 +34,12 @@ DEVELHELP ?= 1
 QUIET ?= 1
 
 include $(RIOTBASE)/Makefile.include
+
+RIOT_CONFIG_FILE = riot.yaml
+
+APP_H = app_config.h
+
+$(APP_H): $(RIOT_CONFIG_FILE)
+	$(RIOTTOOLS)/config_generator/config_generator.py $(RIOT_CONFIG_FILE) $(APP_H)
+
+$(RIOTBUILD_CONFIG_HEADER_C): $(APP_H)

--- a/examples/lorawan/app_config.h
+++ b/examples/lorawan/app_config.h
@@ -1,0 +1,23 @@
+/* This is an automatically generated configuration file
+* DO NOT EDIT, the content will be overwritten.
+*/
+#ifndef APP_CONFIG_CONFIG_H
+#define APP_CONFIG_CONFIG_H
+
+#ifndef CONFIG_APPKEY
+#define CONFIG_APPKEY "AAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA"
+#endif
+
+#ifndef CONFIG_APPEUI
+#define CONFIG_APPEUI "BBBBBBBBBBBBBBBB"
+#endif
+
+#ifndef CONFIG_DEVEUI
+#define CONFIG_DEVEUI "CCCCCCCCCCCCCCCC"
+#endif
+
+#ifndef CONFIG_LORAWAN_EXAMPLE_PERIOD
+#define CONFIG_LORAWAN_EXAMPLE_PERIOD 20
+#endif
+
+#endif /* APP_CONFIG_CONFIG_H */

--- a/examples/lorawan/main.c
+++ b/examples/lorawan/main.c
@@ -32,8 +32,7 @@
 #include "net/loramac.h"
 #include "semtech_loramac.h"
 
-/* Messages are sent every 20s to respect the duty cycle on each channel */
-#define PERIOD              (20U)
+#include "app_config.h"
 
 #define SENDER_PRIO         (THREAD_PRIORITY_MAIN - 1)
 static kernel_pid_t sender_pid;
@@ -59,7 +58,7 @@ static void _prepare_next_alarm(void)
     struct tm time;
     rtc_get_time(&time);
     /* set initial alarm */
-    time.tm_sec += PERIOD;
+    time.tm_sec += CONFIG_LORAWAN_EXAMPLE_PERIOD;
     mktime(&time);
     rtc_set_alarm(&time, rtc_cb, NULL);
 }
@@ -101,9 +100,9 @@ int main(void)
     puts("=====================================");
 
     /* Convert identifiers and application key */
-    fmt_hex_bytes(deveui, DEVEUI);
-    fmt_hex_bytes(appeui, APPEUI);
-    fmt_hex_bytes(appkey, APPKEY);
+    fmt_hex_bytes(deveui, CONFIG_DEVEUI);
+    fmt_hex_bytes(appeui, CONFIG_APPEUI);
+    fmt_hex_bytes(appkey, CONFIG_APPKEY);
 
     /* Initialize the loramac stack */
     semtech_loramac_init(&loramac);

--- a/examples/lorawan/riot.yaml
+++ b/examples/lorawan/riot.yaml
@@ -1,0 +1,36 @@
+version: 0.1.0
+name: lorawan-example
+authors:
+- name: Alexandre Abadie
+  email: alexandre.abadie@inria.fr
+license: LGPL-2.1
+copyright: [2018 Inria]
+configuration:
+- group:
+    name: lorawan
+    parameters:
+    - name: appkey
+      macro: APPKEY
+      description: LoRaWAN Application Key
+      value: 0xAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAAA
+      type: byte
+      properties:
+        size: 16
+    - name: appeui
+      macro: APPEUI
+      description: LoRaWAN Application EUI
+      value: 0xBBBBBBBBBBBBBBBB
+      type: byte
+      properties:
+        size: 8
+    - name: deveui
+      macro: DEVEUI
+      description: LoRaWAN Device EUI
+      value: 0xCCCCCCCCCCCCCCCC
+      type: byte
+      properties:
+        size: 8
+- name: period
+  description: Seconds to wait between messages
+  type: int
+  value: 20


### PR DESCRIPTION
# What's the goal of this PR and its scope?
This PR to proposes a first workaround on **"How to handle the configuration of modules in RIOT?"**. 

This work is in conjuction with @jia200x 

Here we are presenting an idea of what a solution to some of the issues found at the RIOT summit might look like. 

This is a PoC intended to find consensus on **the usage of configuration files** (which generate header files as output), **the YAML serialization format**, and **the proposed schema**.

The scope of this PR is **configuration format and mechanism** (not how to integrate it to the build system), and only defines application configurations (but can be extended to all RIOT modules). We took the LoRaWAN example as a reference.

This PR is **not** by any means intended to be merged.

# What's the proposal?

Draft 2:
1. **Declare and describe configurations in a well-known data structure (YAML is proposed)**:
  Define name, default values, description, types and properties. See [here](https://github.com/leandrolanzieri/RIOT/blob/pr/rfc_configuration_generation/examples/lorawan/riot.yaml) for an example. (The purpose of the header file on the PR is just to show the output of the configuration generator) 
2. **Generate `xxx_config.h` files** from these Configuration file with `#ifndef CONFIG_XXX #define CONFIG_XXX VALUE #endif`.

3.  Either:
    3a. **RIOT is shipped with these `xxx_config.h` files in modules directories**: They are regenerated _only_ if the configuration file changes, and the config header is _never_ meant to be edited by developers.
    3b. **`xxx_config.h` files are generated on every build (`make all`)**  in the `build` directory .
 
Please note adding tools on top (e.g CLI/GUI for exposing configurations) is almost straightforward if we parse from Configuration Files instead of header files.

How to override default configuration values is the next discussions. With 3a and 3b is possible to use CFLAGS, a standard header file, `riotbuild.h`, or any other mechanism.

**Important**: `xxx_config.h` are a subset of the information in the Configuration files (YAML). All metadata should be included in the YAML file, and the `xxx_config.h` file is **only the interface for injecting configurations in the corresponding C files**.
## FAQ
### What's the problem with declaring configurations in header files?

We started working with the following proposal:

```
/**
 * @brief maximum number of cooks per soup
 *
 * fmt:int:min=1:max=10
 */
#ifndef CONFIG_KITCHEN_MAX_COOKS_PER_SOUP
#define CONFIG_KITCHEN_MAX_COOKS_PER_SOUP 1U
#endif
```

We were planning to add these configurations in `xxx_config.h` files on each module, so they can be included in C files that require these configurations. 

These files were supposed to be used to extract information about params (name, default values, restrictions)  and override values via CFLAGS or another header file.

However, we found some issues:

- **Extracting params information is not straightforward**. In general C files are not intended to be parsed. E.g there's mixed Doxygen and a meta-configuration for each parameter, there can be corner cases.
- **Documentation generation**. With this format we would need to replace the `fmt` line with the configuration description, and probably add `| defined(DOXYGEN)`. Also, the proposed format is dependent to Doxygen.
- **It's hard to override in a multiple hierarchy** (e.g CPU defines configurations that could be overridden by the board, and then also by the application)
- **It's not easy to describe dependencies** with this format (e.g current configuration needs another configuration to have a certain value).
- **Validation of the format doesn't come out of the box** and we would need to add a custom tool.
- **This doesn't prevent naming collisions**.

### Why YAML?

- **It's 100% *standard*, well known and tested (and easy to replace to another serialization format)**:
 [YAML](http://yaml.org/) is a serialization standard across multiple languages, and wide used on different projects. Has multiple features such as comments, support for many data types and field reference. It can be easily transform to [JSON](http://json.org/).
- **There are off-the-shelf solutions to parse**:
  There is support for: C/C++/Crystal/Ruby/Python/Java/Pearl/C#/.NET/Golang/PHP/JavaScript/OCaml/ActionScript/Haskell/Dart/Rust/Nim
- **There's a standard mechanism for semantics validation (Schema)**:
  By defining a SCHEMA (on another YAML of JSON file) you can validate the format of the configuration, document and version any changes that may by applied in the future. There are standard tools like [Rx](https://github.com/rjbs/Rx).
- **It's extensible and human-readable**:
  Can be easily read and modified. Also easy to generate.
  ```
  version: 0.1.1
  name: my-lib
  authors: [just me]
  license: LGPL-2.1
  copyright: [2018 just]
  configuration:
  -group:
      name: timing
      parameters:
      -name: measurement_period
        description: Perior for reading sensor in seconds
        value: 10
        type: int
        properties:
          max: 60
  ```
  In the future more types, restriction or other metadata can be added in an easy way.
- **Supports multiple lines and comments**:
  ```
  name: period
  value: 10
  properties:
      max: 60 # Something bad happens if it's more than 1 minute
  ```
### Some possible features (for further discussions)

- **Configuration parameter validations**:
  Indicating constraints on the accepted parameters.
- **Configuration of dependencies**:
    - `value: othermodule.parameter`
- **Declare dependencies (USEMODULEs) in that same file**:
  Also any configuration options for those dependencies.
- **All modules have a configuration file**:
  This way it's easy to declare metadata such as versions.
- **Group configuration modules**:
    - Use wildcards (e.g enable debug in gnrc.* modules)
- **Have configuration values generated as `static const` instead of preprocessor `#defines`**.
## Archived drafts:
### Draft 1
- **Declare configurations in YAML files for each module**:
  Define name, default values, description, types and properties. See [here](https://github.com/leandrolanzieri/RIOT/blob/pr/rfc_configuration_generation/examples/lorawan/riot.yaml) for an example. (The purpose of the header file on the PR is just to show the output of the configuration generator)   
- **Be able to override params from configuration files**:
  By using an `override` parent instead of `configuration` (could taste like `override: gnrc.ieee802154.default_channel=11`). The inheritance priority is not in the scope of this PR. The key feature, however, is that we will be able to handle coflicts in a well-defined and safe way.
- **Generate header_files during `make all`**:
  We were thinking of keeping `module_config.h` format, and these files should be imported with `#include module_config.h`.
- **Optional: Generate YAML files with a GUI/CLI**:
  Such as ncurses, ENV vars, etc. Here we are limiting ourselves to defining a core mechanism, not an interface.