### PR TITLE
static_tests: add build system checks

### DIFF
--- a/dist/tools/ci/build_and_test.sh
+++ b/dist/tools/ci/build_and_test.sh
@@ -93,6 +93,7 @@ then
         run ./dist/tools/coccinelle/check.sh
         run ./dist/tools/flake8/check.sh
         run ./dist/tools/headerguards/check.sh
+        run ./dist/tools/buildsystem_sanity_check/check.sh
         exit $RESULT
     fi
 

--- a/pkg/fatfs/Makefile.dep
+++ b/pkg/fatfs/Makefile.dep
@@ -2,11 +2,5 @@ USEMODULE += fatfs_diskio_mtd
 USEMODULE += auto_init_storage
 USEMODULE += mtd
 
-include $(RIOTBASE)/boards/$(BOARD)/Makefile.features
-
-#if periph_rtc is available use it. Otherwise use static timestamps
-ifneq (, $(filter periph_rtc, $(FEATURES_PROVIDED)))
-  CFLAGS += -DFATFS_FFCONF_OPT_FS_NORTC=0
-else
-  CFLAGS += -DFATFS_FFCONF_OPT_FS_NORTC=1
-endif
+# Use RTC for timestamps if available
+FEATURES_OPTIONAL += periph_rtc

--- a/pkg/fatfs/Makefile.include
+++ b/pkg/fatfs/Makefile.include
@@ -9,6 +9,13 @@ ifneq (,$(filter fatfs_vfs,$(USEMODULE)))
   DIRS += $(RIOTBASE)/pkg/fatfs/fatfs_vfs
 endif
 
+#if periph_rtc is available use it. Otherwise use static timestamps
+ifneq (,$(filter periph_rtc,$(USEMODULE)))
+  CFLAGS += -DFATFS_FFCONF_OPT_FS_NORTC=0
+else
+  CFLAGS += -DFATFS_FFCONF_OPT_FS_NORTC=1
+endif
+
 ifeq ($(shell uname -s),Darwin)
   CFLAGS += -Wno-empty-body
 endif

--- a/sys/shell/commands/Makefile
+++ b/sys/shell/commands/Makefile
@@ -70,7 +70,7 @@ ifneq (,$(filter cord_ep,$(USEMODULE)))
   SRC += sc_cord_ep.c
 endif
 
-ifneq (,$(filter periph_rtc,$(FEATURES_PROVIDED)))
+ifneq (,$(filter periph_rtc,$(USEMODULE)))
   SRC += sc_rtc.c
 endif
 


### PR DESCRIPTION
### Contribution description

Add a script to execute sanity checks on build system files.
It should prevent bad patterns to re-appear after being cleaned.

Currently adds a check for using the content of `FEATURES` instead of
`USEMODULE`.

~There is one case currently ignored as fixing it requires handing
CPU dependencies and the script could go in without it.~ Fixed by https://github.com/RIOT-OS/RIOT/pull/10153


#### Fixes

This PR also include fixes for the test that can be split in separate PRs.

I think mainly the `hifive1/fe310` changes should have a separate review as they are a bit specific.

### Testing procedure

The script can be run directly with:

    ./dist/tools/buildsystem_sanity_check/check.sh

To test on master, it requires to cherry-picking just the commit adding the script and running it.

### Issues/PRs references

It is part of issues found while working on https://github.com/RIOT-OS/RIOT/issues/9913
The `fatfs` issue was also found in https://github.com/RIOT-OS/RIOT/pull/9307

Depending on commits regarding `hifive1` ~https://github.com/RIOT-OS/RIOT/pull/10062~ and the script split in ~https://github.com/RIOT-OS/RIOT/pull/10179~