### PR TITLE
cpu/esp8266: remove duplicate 'CPU' variable

### DIFF
--- a/cpu/esp8266/Makefile.include
+++ b/cpu/esp8266/Makefile.include
@@ -29,7 +29,6 @@ endif
 
 # regular Makefile
 
-export CPU ?= esp8266
 export TARGET_ARCH ?= xtensa-lx106-elf
 
 # ESP8266 pseudomodules


### PR DESCRIPTION
### Contribution description

CPU is already defined as `cpu/$(CPU)` points to `cpu/esp8266`.

This is a minor change I found while looking which files defined 'CPU'.

### Testing procedure

The CPU value is unchanged

```
make --no-print-directory -C examples/hello-world/ info-debug-variable-CPU BOARD=esp8266-esp-12x
esp8266
```

Building in CI should still work.

### Issues/PRs references

Found while working on https://github.com/RIOT-OS/RIOT/issues/9913
