### PR TITLE
 cpu/fe310: rtc depend on the rtt feature and hifive1 update

### DIFF
--- a/boards/hifive1/Makefile.features
+++ b/boards/hifive1/Makefile.features
@@ -8,9 +8,5 @@ FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
-ifneq (,$(filter periph_rtc,$(FEATURES_REQUIRED)))
-  FEATURES_REQUIRED += periph_rtt
-endif
-
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = risc_v

--- a/cpu/fe310/Makefile.dep
+++ b/cpu/fe310/Makefile.dep
@@ -1,3 +1,3 @@
 ifneq (,$(filter periph_rtc,$(USEMODULE)))
-  USEMODULE += periph_rtt
+  FEATURES_REQUIRED += periph_rtt
 endif


### PR DESCRIPTION
### Contribution description

It is the role of boards based on 'cpu/fe310' to give the configuration
for the rtc/rtt.

The fe310/periph/rtc implementation depends on having periph/rtt configured
by the board so depends on the board 'providing' the periph_rtt feature
and declaring the required macros.

It should not simply depend of the 'periph_rtt' module as this does not
enforce having a configuration for the module in the board.

In practice, when compiling, it would result in undefined 'RTT' symbols,
instead of the build system detecting it.


This also updates `board/hifive1` as it does not need to handle this anymore.

### Testing procedure

To test this, you can modify the `hifive1` board as if it did not support `periph_rtt`:

``` diff
diff --git a/boards/hifive1/Makefile.features b/boards/hifive1/Makefile.features
index 3920db679..a40f0c0e2 100644
--- a/boards/hifive1/Makefile.features
+++ b/boards/hifive1/Makefile.features
@@ -3,14 +3,9 @@ FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 #FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc
-FEATURES_PROVIDED += periph_rtt
 #FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
-ifneq (,$(filter periph_rtc,$(FEATURES_REQUIRED)))
-  FEATURES_REQUIRED += periph_rtt
-endif
-
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = risc_v
diff --git a/boards/hifive1/include/periph_conf.h b/boards/hifive1/include/periph_conf.h
index e0dd67612..cae1eca9f 100644
--- a/boards/hifive1/include/periph_conf.h
+++ b/boards/hifive1/include/periph_conf.h
@@ -54,15 +54,10 @@ extern "C" {
 /** @} */
 
 /**
- * @name    RTT/RTC configuration
+ * @name    RTC configuration
  *
  * @{
  */
-#define RTT_NUMOF                   (1)
-#define RTT_FREQUENCY               (1)             /* in Hz */
-#define RTT_MAX_VALUE               (0xFFFFFFFF)
-#define RTT_INTR_PRIORITY           (2)
-
 #define RTC_NUMOF                   (1)
 /** @} */
 ```

And when compiling you get `error RTT_ undeclared` errors

With this PR and the diff you correctly get the missing features error

```
make -C examples/default/ BOARD=hifive1 info-debug-variable-FEATURES_USED all
make: Entering directory '/home/cladmi/git/work/riot_test/examples/default'
There are unsatisfied feature requirements: periph_rtt


EXPECT ERRORS!
```

### Issues/PRs references

This is part of https://github.com/RIOT-OS/RIOT/pull/10060 and was found while working on https://github.com/RIOT-OS/RIOT/issues/9913