### PR TITLE
boards/hifive1: include cpu/fe310 features

### DIFF
--- a/boards/hifive1/Makefile.features
+++ b/boards/hifive1/Makefile.features
@@ -1,5 +1,4 @@
 # Put defined MCU peripherals here (in alphabetical order)
-FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 #FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc
@@ -14,3 +13,5 @@ endif
 
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = risc_v
+
+include $(RIOTCPU)/fe310/Makefile.features


### PR DESCRIPTION
### Contribution description

The board should process its CPU features.
This has the consequence to make 'periph_pm' visible to the board.

I also removed the duplicate FEATURES_PROVIDED from the board defined in
the cpu.


### Testing procedure

#### Verify its ok to have `periph_pm` for `hifive1`:

Verify that indeed board `hifive1` provides `periph_pm`, by design and in the implementation. 
I can correctly build `tests_pm` with this PR but not sure if I should test something else.

#### List features provided

We now also see `periph_pm` for hifive1 provided features (cpuid moved but is still there).

```
make --no-print-directory -C examples/hello-world info-debug-variable-FEATURES_PROVIDED BOARD=hifive1
periph_gpio periph_gpio_irq periph_rtc periph_rtt periph_timer periph_uart periph_cpuid periph_pm

# No `periph_pm` in riot/master
git checkout riot/master
make --no-print-directory -C examples/hello-world info-debug-variable-FEATURES_PROVIDED BOARD=hifive1
periph_cpuid periph_gpio periph_gpio_irq periph_rtc periph_rtt periph_timer periph_uart
```

### Issues/PRs references

Found while working on https://github.com/RIOT-OS/RIOT/issues/9913