### PR TITLE
board/mips-malta: include the cpu features instead of common cpu

### DIFF
--- a/boards/mips-malta/Makefile.features
+++ b/boards/mips-malta/Makefile.features
@@ -4,4 +4,4 @@ FEATURES_PROVIDED += periph_timer
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = mips32r2
 
--include $(RIOTCPU)/mips32r2_common/Makefile.features
+-include $(RIOTCPU)/mips32r2_generic/Makefile.features


### PR DESCRIPTION
### Contribution description

board/mips-malta: include the cpu features instead of common cpu

This change was missed when the cpu 'mips32r2_generic' was separated
from 'mips32r2_common'. The target file already includes 'mips32r2_common'.

### Testing procedure

The `FEATURES_PROVIDED` do not change between master and this PR for `mips-malta`:

    make --no-print-directory -C examples/hello-world/ info-debug-variable-FEATURES_PROVIDED BOARD=mips-malta
    periph_timer cpp periph_pm


### Issues/PRs references

Inconsistency found while working on https://github.com/RIOT-OS/RIOT/issues/9913