### PR TITLE
bootloader: add riotboot minimal bootloader

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -787,6 +787,10 @@ ifneq (,$(filter periph_gpio_irq,$(USEMODULE)))
   FEATURES_REQUIRED += periph_gpio
 endif
 
+ifneq (,$(RIOTBOOT_SLOT0_SIZE))
+  FEATURES_PROVIDED += riotboot
+endif
+
 # always select gpio (until explicit dependencies are sorted out)
 FEATURES_OPTIONAL += periph_gpio
 

--- a/Makefile.dep
+++ b/Makefile.dep
@@ -791,6 +791,10 @@ ifneq (,$(RIOTBOOT_SLOT0_SIZE))
   FEATURES_PROVIDED += riotboot
 endif
 
+ifneq (,$(filter riot_hdr,$(USEMODULE)))
+  USEMODULE += checksum
+endif
+
 # always select gpio (until explicit dependencies are sorted out)
 FEATURES_OPTIONAL += periph_gpio
 

--- a/Makefile.include
+++ b/Makefile.include
@@ -705,6 +705,9 @@ CFLAGS += -include '$(RIOTBUILD_CONFIG_HEADER_C)'
 # include mcuboot support
 include $(RIOTMAKE)/mcuboot.mk
 
+# include bootlaoders support
+include $(RIOTMAKE)/boot/riotboot.mk
+
 # include Murdock helpers
 include $(RIOTMAKE)/murdock.inc.mk
 

--- a/bootloaders/riotboot/Makefile
+++ b/bootloaders/riotboot/Makefile
@@ -1,0 +1,26 @@
+# Default RIOT bootloader
+APPLICATION = riotboot
+
+# Default testing board
+BOARD ?= samr21-xpro
+
+# Select the boards that were tested and work with riotboot
+BOARD_WHITELIST += samr21-xpro iotlab-m3
+
+# Disable unused modules
+CFLAGS += -DNDEBUG -DLOG_LEVEL=LOG_NONE
+DISABLE_MODULE += auto_init
+
+# Shared interface to read RIOT header
+USEMODULE += riot_hdr
+USEMODULE += slot_util
+
+# RIOT codebase
+RIOTBASE ?= $(CURDIR)/../../
+
+include $(RIOTBASE)/Makefile.include
+
+# limit bootloader size
+# TODO: Manage to set this variable for boards which already embed a
+# bootloader, currently it will be overwritten
+ROM_LEN := $(RIOTBOOT_SLOT0_SIZE)

--- a/bootloaders/riotboot/README.md
+++ b/bootloaders/riotboot/README.md
@@ -1,0 +1,26 @@
+# Overview
+This folder contains a simple bootloader called "riotboot".
+A header with metadata, of length `RIOT_HDR_LEN` precedes
+the actual image. The header contains "RIOT" as a magic
+number to recognise a RIOT firmware image, a checksum, and
+the version of the RIOT firmware `APP_VER`.
+This bootloader verifies the checksum of the image which is located
+at an offset (`ROM_OFFSET`) with respect to  the `ROM_START_ADDR`
+defined by the CPU, just after the space allocated for riotboot.
+
+# Usage
+Just compile your application using the target `riotboot`. The header
+is generated automatically according to your `APP_VER`, which can be
+optionally set (0 by default) in your makefile.
+
+## Flashing
+The image can be flashed using `riotboot/flash` which flashes also
+the bootloader.
+
+e.g. `BOARD=samr21-xpro APP_VER=$(date +%s) make -C examples/hello-world riotboot/flash`
+
+The command compiles both the hello-world example and riotboot,
+generates the header and attaches it at the beginning of the example
+binary.
+
+A comprehensive test is available at tests/riotboot.

--- a/bootloaders/riotboot/main.c
+++ b/bootloaders/riotboot/main.c
@@ -1,0 +1,48 @@
+/*
+ * Copyright (C) 2017 Kaspar Schleiser <kaspar@schleiser.de>
+ *                    Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     bootloader
+ * @{
+ *
+ * @file
+ * @brief       RIOT Bootloader
+ *
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ * @author      Francisco Acosta <francisco.acosta@inria.fr>
+ *
+ * @}
+ */
+
+#include "cpu.h"
+#include "panic.h"
+#include "riot_hdr.h"
+#include "slot_util.h"
+
+void kernel_init(void)
+{
+    /* read the header for slot 1 (slot 0 is the bootlaoder) */
+    riot_hdr_t *slot_hdr = slot_util_get_hdr(1);
+
+    /* if the header is valid, jump to it */
+    if (riot_hdr_validate(slot_hdr) == 0) {
+        /* jump to slot 1 where the firmware image is */
+        slot_util_jump(1);
+    }
+
+    /* serious trouble! */
+    while (1) {}
+}
+
+NORETURN void core_panic(core_panic_t crash_code, const char *message)
+{
+    (void)crash_code;
+    (void)message;
+    while (1) {}
+}

--- a/cpu/cortexm_common/Makefile.include
+++ b/cpu/cortexm_common/Makefile.include
@@ -24,3 +24,9 @@ TOOLCHAINS_SUPPORTED = gnu llvm
 LINKFLAGS += $(if $(ROM_OFFSET),$(LINKFLAGPREFIX)--defsym=_rom_offset=$(ROM_OFFSET))
 # FW_ROM_LEN: rom length to use for firmware linking. Allows linking only in a section of the rom.
 LINKFLAGS += $(if $(FW_ROM_LEN),$(LINKFLAGPREFIX)--defsym=_fw_rom_length=$(FW_ROM_LEN))
+
+
+# Configure bootloader and slot lengths
+RIOTBOOT_SLOT0_SIZE ?= 0x1000
+RIOTBOOT_FW_SLOT_SIZE ?= $(shell printf "0x%x" $$((($(ROM_LEN:%K=%*1024)-$(RIOTBOOT_SLOT0_SIZE)) / 2 )))
+RIOTBOOT_FW_SLOT_SIZE := $(RIOTBOOT_FW_SLOT_SIZE)

--- a/cpu/cortexm_common/include/cpu.h
+++ b/cpu/cortexm_common/include/cpu.h
@@ -189,6 +189,44 @@ static inline void cortexm_isr_end(void)
     }
 }
 
+/**
+ * @brief   Jumps to another image in flash
+ *
+ * This function is supposed to be called by a bootloader application.
+ *
+ * @param[in]   image_address   address in flash of other image
+ */
+static inline void cpu_jump_to_image(uint32_t image_address)
+{
+    /* Disable IRQ */
+    __disable_irq();
+
+    /* set MSP */
+    __set_MSP(*(uint32_t*)image_address);
+
+    /* skip stack pointer */
+    image_address += 4;
+
+    /* load the images reset_vector address */
+    uint32_t destination_address = *(uint32_t*)image_address;
+
+    /* Make sure the Thumb State bit is set. */
+    destination_address |= 0x1;
+
+    /* Branch execution */
+    __asm("BX %0" :: "r" (destination_address));
+}
+
+/* The following register is only present for Cortex-M0+, -M3, -M4 and -M7 CPUs */
+#if defined(CPU_ARCH_CORTEX_M0PLUS) || defined(CPU_ARCH_CORTEX_M3) || \
+    defined(CPU_ARCH_CORTEX_M4) || defined(CPU_ARCH_CORTEX_M4F) || \
+    defined(CPU_ARCH_CORTEX_M7)
+static inline uint32_t cpu_get_image_baseaddr(void)
+{
+    return SCB->VTOR;
+}
+#endif
+
 #ifdef __cplusplus
 }
 #endif

--- a/dist/tools/riot_hdr/Makefile
+++ b/dist/tools/riot_hdr/Makefile
@@ -1,0 +1,29 @@
+RIOTBASE       := ../../..
+RIOT_INCLUDE   := $(RIOTBASE)/sys/include
+COMMON_SRC     := common.c
+COMMON_HDR     := common.h
+
+RIOT_HDR_SRC := \
+	$(RIOTBASE)/sys/checksum/fletcher32.c \
+	$(RIOTBASE)/sys/riot_hdr/riot_hdr.c
+
+RIOT_HDR_HDR := $(RIOT_INCLUDE)/riot_hdr.h \
+	$(RIOT_INCLUDE)/checksum/fletcher32.h
+
+GENHDR_SRC := $(COMMON_SRC) $(RIOT_HDR_SRC) \
+	main.c genhdr.c
+
+GENHDR_HDR := $(COMMON_HDR) $(RIOT_HDR_HDR)
+
+CFLAGS += -g -I. -O3 -Wall -Wextra -pedantic -std=c99
+
+all: bin/genhdr
+
+bin/:
+	mkdir -p bin
+
+bin/genhdr: $(GENHDR_HDR) $(GENHDR_SRC) Makefile | bin/
+	$(CC) $(CFLAGS) -I$(RIOT_INCLUDE) $(GENHDR_SRC) -o $@
+
+clean::
+	rm -rf bin/genhdr

--- a/dist/tools/riot_hdr/common.c
+++ b/dist/tools/riot_hdr/common.c
@@ -1,0 +1,32 @@
+/*
+ * Copyright (C) 2017 Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * This file is subject to the terms and conditions of the GNU General Public
+ * License v2. See the file LICENSE for more details.
+ */
+
+#include <fcntl.h>
+#include <string.h>
+#include <sys/stat.h>
+#include <unistd.h>
+
+int to_file(const char *filename, void *buf, size_t len)
+{
+    int fd;
+
+    if (strcmp("-", filename)) {
+        fd = open(filename, O_CREAT | O_WRONLY, S_IRUSR | S_IWUSR);
+    }
+    else {
+        fd = STDOUT_FILENO;
+    }
+
+    if (fd > 0) {
+        ssize_t res = write(fd, buf, len);
+        close(fd);
+        return res == (ssize_t)len;
+    }
+    else {
+        return fd;
+    }
+}

--- a/dist/tools/riot_hdr/common.h
+++ b/dist/tools/riot_hdr/common.h
@@ -1,0 +1,24 @@
+/*
+ * Copyright (C) 2017 Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * This file is subject to the terms and conditions of the GNU General Public
+ * License v2. See the file LICENSE for more details.
+ */
+
+#ifndef COMMON_H
+#define COMMON_H
+
+#include <unistd.h>
+#include <sys/types.h>
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+int to_file(const char *filename, void *buf, size_t len);
+
+#ifdef __cplusplus
+} /* end extern "C" */
+#endif
+
+#endif /* COMMON_H */

--- a/dist/tools/riot_hdr/genhdr.c
+++ b/dist/tools/riot_hdr/genhdr.c
@@ -1,0 +1,66 @@
+/*
+ * Copyright (c) 2016 Inria
+ *               2017 Kaspar Schleiser <kaspar@schleiser.de>
+ *
+ * This file is subject to the terms and conditions of the GNU General Public
+ * License v2. See the file LICENSE for more details.
+ *
+ */
+
+/**
+ * @ingroup     tools
+ * @file
+ * @brief       Header generation tool for RIOT firmware images
+ *
+ * @author      Francisco Acosta <francisco.acosta@inria.fr>
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ */
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <string.h>
+
+#include "riot_hdr.h"
+#include "common.h"
+
+const char generate_usage[] = "genhdr generate <FIRMWARE> <VERSION> <START-ADDR> <outfile|->";
+
+int genhdr(int argc, char *argv[])
+{
+    riot_hdr_t riot_hdr;
+    uint8_t buf[RIOT_HDR_SIZE];
+
+    memset(&riot_hdr, '\0', sizeof(riot_hdr_t));
+    memset(buf, '\0', RIOT_HDR_SIZE);
+
+    if (argc < 5) {
+        fprintf(stderr, "usage: %s\n", generate_usage);
+        return -1;
+    }
+
+    /* Generate image header */
+    memcpy(&riot_hdr.magic_number, "RIOT", 4);
+    sscanf(argv[2], "%x", (unsigned int *)&(riot_hdr.version));
+    sscanf(argv[3], "%u", &(riot_hdr.start_addr));
+
+    /* calculate header checksum */
+    riot_hdr.chksum = riot_hdr_checksum(&riot_hdr);
+
+    /* save to buffer of RIOT_HDR_SIZE len */
+    memcpy(buf, &riot_hdr, sizeof(riot_hdr_t));
+
+    /* talk to the user */
+    if (strcmp(argv[4], "-")) {
+        riot_hdr_print(&riot_hdr);
+        printf("RIOT header size: %lu\n", sizeof(riot_hdr_t));
+    }
+
+    /* Write the header */
+    if (!to_file(argv[4], buf, RIOT_HDR_SIZE)) {
+        fprintf(stderr, "Error: cannot write output\n");
+        return(1);
+    }
+
+    return 0;
+}

--- a/dist/tools/riot_hdr/main.c
+++ b/dist/tools/riot_hdr/main.c
@@ -1,0 +1,27 @@
+/*
+ * Copyright (C) 2017 Kaspar Schleiser <kaspar@schleiser.de>
+ *               2018 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU General Public
+ * License v2. See the file LICENSE for more details.
+ */
+
+#include <stdio.h>
+#include <string.h>
+
+int genhdr(int argc, char *argv[]);
+extern const char generate_usage[];
+
+int main(int argc, char *argv[])
+{
+    if (argc < 2) {
+        goto usage;
+    }
+    else if (!strcmp(argv[1], "generate")) {
+        return genhdr(argc - 1, &argv[1]);
+    }
+
+usage:
+    fprintf(stderr, "usage: %s\n", generate_usage);
+    return 1;
+}

--- a/makefiles/boot/riotboot.mk
+++ b/makefiles/boot/riotboot.mk
@@ -1,0 +1,101 @@
+ifneq (,$(filter riotboot,$(FEATURES_PROVIDED)))
+
+.PHONY: riotboot/flash riotboot/flash-bootloader riotboot/flash-slot1 riotboot/bootloader/%
+
+RIOTBOOT_DIR = $(RIOTBASE)/bootloaders/riotboot
+RIOTBOOT ?= $(RIOTBOOT_DIR)/bin/$(BOARD)/riotboot.elf
+CFLAGS += -I$(BINDIR)/riotbuild
+
+HEADER_TOOL ?= $(RIOTBASE)/dist/tools/riot_hdr/bin/genhdr
+RIOTBOOT_HDR_LEN ?= 0x100
+
+# TODO 'genhdr' should be rebuilt here at the same time with the same
+# compilation options, to keep them synchronised
+CFLAGS += -DRIOT_HDR_SIZE=$(RIOTBOOT_HDR_LEN)
+
+# export variables for 'slot_util'
+export RIOTBOOT_SLOT0_SIZE
+export RIOTBOOT_FW_SLOT_SIZE
+
+# Mandatory APP_VER, set to 0 by default
+APP_VER ?= 0
+
+# For slot generation, one needs only to link
+$(BINDIR)/$(APPLICATION)-%.elf: link
+	$(Q)$(_LINK) -o $@
+
+# slot 1 targets
+SLOT1_OFFSET := $$(($(RIOTBOOT_SLOT0_SIZE) + $(RIOTBOOT_HDR_LEN)))
+$(BINDIR)/$(APPLICATION)-slot%.elf: FW_ROM_LEN=$(RIOTBOOT_FW_SLOT_SIZE - $(RIOTBOOT_HDR_LEN))
+$(BINDIR)/$(APPLICATION)-slot1.elf: ROM_OFFSET=$(SLOT1_OFFSET)
+
+# create binary target with RIOT header
+$(BINDIR)/$(APPLICATION)-slot1.riot.bin: %.riot.bin: %.hdr %.bin
+	@echo "creating $@..."
+	$(Q)cat $^ > $@
+
+# Generate RIOT header and keep the original binary file
+.PRECIOUS: %.bin
+%.hdr: %.bin FORCE
+	$(Q)$(HEADER_TOOL) generate $< $(APP_VER) $$(($(ROM_START_ADDR)+$(OFFSET))) - > $@
+
+$(BINDIR)/$(APPLICATION)-slot1.hdr: OFFSET=$(SLOT1_OFFSET)
+
+# Generic target to create a binary file from the image with header
+riotboot: $(BINDIR)/$(APPLICATION)-slot1.riot.bin
+
+# riotboot compile target
+riotboot/flash-bootloader: riotboot/bootloader/flash
+riotboot/bootloader/%:
+	$(Q)/usr/bin/env -i \
+		QUIET=$(QUIET)\
+		PATH=$(PATH) BOARD=$(BOARD) \
+			make --no-print-directory -C $(RIOTBOOT_DIR) $*
+
+# Generate a binary file from the bootloader which fills all the
+# allocated space. This is used afterwards to create a combined
+# binary with both bootloader and RIOT image
+BOOTLOADER_BIN = $(RIOTBASE)/riotboot/bin/$(BOARD)
+$(BOOTLOADER_BIN)/riotboot.extended.bin: $(BOOTLOADER_BIN)/riotboot.bin
+	cp $^ $@.tmp
+	truncate -s $$(($(RIOTBOOT_SLOT0_SIZE))) $@.tmp
+	mv $@.tmp $@
+
+# Only call sub make if not already in riotboot
+ifneq ($(BOOTLOADER_BIN)/riotboot.bin,$(BINFILE))
+  $(BOOTLOADER_BIN)/riotboot.bin: riotboot/bootloader/binfile
+endif
+
+# Create combined binary booloader + RIOT image
+riotboot/combined-slot1: $(BINDIR)/$(APPLICATION)-slot1-combined.bin
+$(BINDIR)/$(APPLICATION)-slot1-combined.bin: $(BOOTLOADER_BIN)/riotboot.extended.bin $(BINDIR)/$(APPLICATION)-slot1.riot.bin
+	cat $^ > $@
+
+# Flashing rule for edbg to flash combined binaries
+riotboot/flash-combined-slot1: HEXFILE=$(BINDIR)/$(APPLICATION)-slot1-combined.bin
+# Flashing rule for openocd to flash combined binaries
+riotboot/flash-combined-slot1: export IMAGE_FILE=$(BINDIR)/$(APPLICATION)-slot1-combined.bin
+riotboot/flash-combined-slot1: $(BINDIR)/$(APPLICATION)-slot1-combined.bin
+	$(FLASHER) $(FFLAGS)
+
+# Flashing rule for slot 1
+riotboot/flash-slot1: export IMAGE_OFFSET=$(RIOTBOOT_SLOT0_SIZE)
+# Flashing rule for edbg to flash only slot 1
+riotboot/flash-slot1: HEXFILE=$(BINDIR)/$(APPLICATION)-slot1.riot.bin
+# openocd
+riotboot/flash-slot1: export IMAGE_FILE=$(BINDIR)/$(APPLICATION)-slot1.riot.bin
+riotboot/flash-slot1: $(BINDIR)/$(APPLICATION)-slot1.riot.bin riotboot/flash-bootloader
+	$(FLASHER) $(FFLAGS)
+
+# Targets to generate only slot 1 binary
+riotboot/slot1: $(BINDIR)/$(APPLICATION)-slot1.riot.bin
+
+# Default flashing rule for bootloader + slot 1
+riotboot/flash: riotboot/flash-slot1
+
+else
+riotboot:
+	$(Q)echo "error: riotboot feature not selected! (try FEATURES_REQUIRED += riotboot)"
+	$(Q)false
+
+endif # (,$(filter riotboot,$(FEATURES_USED)))

--- a/sys/include/riot_hdr.h
+++ b/sys/include/riot_hdr.h
@@ -1,0 +1,135 @@
+/*
+ * Copyright (C) 2018 Kaspar Schleiser <kaspar@schleiser.de>
+ *                    Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    sys_riot_hdr RIOT header helpers and tools
+ * @ingroup     sys
+ * @{
+ *
+ * # RIOT image header for riotboot bootloader
+ *
+ * ## Overview
+ *
+ * riotboot is the name of a minimal bootloader application and infrastructure.
+ * It consists of
+ *
+ * - the application "riotboot" in the bootloaders folder which serves as
+ *   minimal bootloader
+ *
+ * - the module "riot_hdr" used to recognise RIOT firmware images
+ *   which riotboot can boot.
+ * 
+ * - the module "slot_util" used to manage the images (slots) with a
+ *   RIOT header attached to them
+ *
+ * - a tool in dist/tools/riot_hdr for header generation.
+ *
+ * - several make targets to glue everything together
+ *
+ * ## Concept
+ *
+ * riotboot expects the flash to be separated in slots: slot 0 contains
+ * the bootloader and slot 1 a firmware image.
+ *
+ * A RIOT image with a single slot looks like:
+ * 
+ * |------------------------------- FLASH -------------------------------------|
+ * |- RIOTBOOT_SLOT0_SIZE -|-------- RIOTBOOT_FW_SLOT_SIZE (slot 1) -----------|
+ *        (slot 0)         |---- RIOT_HDR_SIZE ------|
+ *  ---------------------------------------------------------------------------
+ * |       bootloader      | riot_hdr_t + filler (0) |     RIOT firmware       |
+ *  ---------------------------------------------------------------------------
+ * 
+ * Please note that `RIOT_HDR_SIZE` depends on the architecture of the
+ * MCU, since it needs to be aligned to either 256B or 512B. This is
+ * fixed regardless of `sizeof(riot_hdr_t)`
+ * 
+ * The bootloader will, on reset, verify the checksum of the first slot, then
+ * boot it. If the slot doesn't have a valid checksum, no image will be
+ * booted and the bootloader will enter "while(1);".
+ *
+ * The header contains
+ *
+ * - "RIOT" as magic number
+ * - an application version
+ * - a checksum
+ *
+ * The bootloader "riotboot" only cares about checksum.
+ *
+ * @file
+ * @brief       RIOT images header and tools
+ *
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ * @author      Francisco Acosta <francisco.acosta@inria.fr>
+ *
+ * @}
+ */
+
+#ifndef RIOT_HDR_H
+#define RIOT_HDR_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+
+/**
+ *  @brief Number of header bytes that get checksummed
+ */
+#define RIOT_HDR_CHECKSUM_LEN      (12)
+
+/**
+ *  @brief Reserved space for the header prefixed to image binaries
+ */
+#ifndef RIOT_HDR_SIZE
+#define RIOT_HDR_SIZE              (256)
+#endif
+
+/**
+ * @brief Structure to store image header - All members are little endian
+ * @{
+ */
+typedef struct {
+    uint32_t magic_number;         /**< header magic_number (always "RIOT")    */
+    uint32_t version;              /**< Integer representing firmware version  */
+    uint32_t start_addr;           /**< Start address in flash                 */
+    uint32_t chksum;               /**< checksum of riot_hdr                   */
+} riot_hdr_t;
+/** @} */
+
+/**
+ * @brief  Print formatted riot_hdr_t to STDIO
+ *
+ * @param[in] riot_hdr  ptr to image header
+ *
+ */
+void riot_hdr_print(riot_hdr_t *riot_hdr);
+
+/**
+ * @brief  Validate image header
+ *
+ * @param[in] riot_hdr  ptr to image header
+ *
+ */
+int riot_hdr_validate(riot_hdr_t *riot_hdr);
+
+/**
+ * @brief  Calculate header checksum
+ *
+ * @param[in] riot_hdr  ptr to image header
+ *
+ */
+uint32_t riot_hdr_checksum(riot_hdr_t *riot_hdr);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* RIOT_HDR_H */

--- a/sys/include/slot_util.h
+++ b/sys/include/slot_util.h
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2018 Kaspar Schleiser <kaspar@schleiser.de>
+ *                    Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    sys_slot_utils  Helpers to manipulate partitions (slots)
+ *                              on internal flash
+ * @ingroup     sys
+ * @{
+ *
+ * @file
+ * @brief       Slot management tools
+ *
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ * @author      Francisco Acosta <francisco.acosta@inria.fr>
+ *
+ * @}
+ */
+
+#ifndef SLOT_UTIL_H
+#define SLOT_UTIL_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include "riot_hdr.h"
+
+/**
+ * @brief  Jump to image
+ *
+ * @param[in] riot_hdr  ptr to image header
+ *
+ */
+void slot_util_jump_to_image(riot_hdr_t *riot_hdr);
+
+/**
+ * @brief  Get currently running image slot
+ *
+ * returns nr of currently active slot
+ */
+int slot_util_current_slot(void);
+
+/**
+ * @brief  Get jump-to address of image slot
+ *
+ * @param[in]   slot    slot nr to work on
+ *
+ * @returns address of first byte of @p slot
+ */
+uint32_t slot_util_get_image_startaddr(unsigned slot);
+
+/**
+ * @brief  Boot into image in slot @p slot
+ *
+ * @param[in]   slot    slot nr to jump to
+ */
+void slot_util_jump(unsigned slot);
+
+/**
+ * @brief  Get header from a given flash slot
+ *
+ * @param[in]   slot    slot nr to work on
+ *
+ * returns header of image slot nr @p slot
+ */
+riot_hdr_t *slot_util_get_hdr(unsigned slot);
+
+/**
+ * @brief   Number of configured firmware slots (incl. bootloader slot)
+ */
+extern const unsigned slot_util_num_slots;
+
+extern const uint32_t slot_util_slots[];
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SLOT_UTIL_H */

--- a/sys/riot_hdr/Makefile
+++ b/sys/riot_hdr/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/sys/riot_hdr/riot_hdr.c
+++ b/sys/riot_hdr/riot_hdr.c
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2017 Kaspar Schleiser <kaspar@schleiser.de>
+ *                    Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     sys_riot_hdr
+ * @{
+ *
+ * @file
+ * @brief       RIOT header helpers and tools
+ *
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ * @author      Francisco Acosta <francisco.acosta@inria.fr>
+ *
+ * @}
+ */
+
+#include <string.h>
+
+#ifdef RIOT_VERSION
+#include "cpu.h"
+#include "log.h"
+#else
+#include <stdio.h>
+#define LOG_INFO(...) printf(__VA_ARGS__)
+#endif
+
+#include "riot_hdr.h"
+#include "checksum/fletcher32.h"
+
+void riot_hdr_print(riot_hdr_t *riot_hdr)
+{
+    printf("Image magic_number: 0x%08x\n", (unsigned)riot_hdr->magic_number);
+    printf("Image Version: %#x\n", (unsigned)riot_hdr->version);
+    printf("Image start address: 0x%08x\n", (unsigned)riot_hdr->start_addr);
+    printf("Image chksum: 0x%08x\n", (unsigned)riot_hdr->chksum);
+    printf("\n");
+}
+
+int riot_hdr_validate(riot_hdr_t *riot_hdr)
+{
+    if (memcmp(riot_hdr, "RIOT", 4)) {
+        LOG_INFO("%s: riot_hdr magic number invalid\n", __func__);
+        return -1;
+    }
+
+    int res = riot_hdr_checksum(riot_hdr) == riot_hdr->chksum ? 0 : -1;
+    if (res) {
+        LOG_INFO("%s: riot_hdr checksum invalid\n", __func__);
+    }
+
+    return res;
+}
+
+uint32_t riot_hdr_checksum(riot_hdr_t *riot_hdr)
+{
+    return fletcher32((uint16_t *)riot_hdr, RIOT_HDR_CHECKSUM_LEN / 2);
+}

--- a/sys/slot_util/Makefile
+++ b/sys/slot_util/Makefile
@@ -1,0 +1,3 @@
+CFLAGS += -DSLOT0_SIZE=$(RIOTBOOT_SLOT0_SIZE)
+
+include $(RIOTBASE)/Makefile.base

--- a/sys/slot_util/slot_util.c
+++ b/sys/slot_util/slot_util.c
@@ -1,0 +1,134 @@
+/*
+ * Copyright (C) 2017 Kaspar Schleiser <kaspar@schleiser.de>
+ *                    Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     sys_slot_util
+ * @{
+ *
+ * @file
+ * @brief       Slot management functions
+ *
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ * @author      Francisco Acosta <francisco.acosta@inria.fr>
+ *
+ * @}
+ */
+#include <string.h>
+
+#include "cpu.h"
+#include "slot_util.h"
+#include "riot_hdr.h"
+
+#ifdef RIOT_VERSION
+#ifndef BOARD_NATIVE
+const uint32_t slot_util_slots[] = {
+    CPU_FLASH_BASE,                /* Slot 0 -> bootloader */
+    CPU_FLASH_BASE + SLOT0_SIZE,   /* Slot 1 -> firmware image */
+};
+
+/* Calculate the number of slots */
+const unsigned slot_util_num_slots = sizeof(slot_util_slots) / sizeof(uint8_t*);
+
+static void _assert_slot(unsigned slot)
+{
+    assert(slot < slot_util_num_slots);
+    assert(slot >= 1);
+    (void)slot;
+}
+
+void slot_util_jump_to_image(riot_hdr_t *riot_hdr)
+{
+    uint32_t addr = (uint32_t)riot_hdr + RIOT_HDR_SIZE;
+
+    cpu_jump_to_image(addr);
+}
+
+int slot_util_current_slot(void)
+{
+    uint32_t base_addr = cpu_get_image_baseaddr() - RIOT_HDR_SIZE;
+
+    for (unsigned i = 1; i < slot_util_num_slots; i++) {
+        if (base_addr == slot_util_slots[i]) {
+            return i;
+        }
+    }
+
+    return -1;
+}
+
+void slot_util_jump(unsigned slot)
+{
+    _assert_slot(slot);
+    slot_util_jump_to_image(slot_util_get_hdr(slot));
+}
+
+uint32_t slot_util_get_image_startaddr(unsigned slot)
+{
+    _assert_slot(slot);
+    return slot_util_slots[slot] + RIOT_HDR_SIZE;
+}
+
+void slot_util_dump_addrs(void)
+{
+    for (unsigned i = 1; i < slot_util_num_slots; i++) {
+        printf("slot %u: metadata: 0x%08x image: 0x%08x\n", i,
+               (unsigned)slot_util_slots[i],
+               (unsigned)slot_util_get_image_startaddr(i));
+    }
+}
+
+riot_hdr_t *slot_util_get_hdr(unsigned slot)
+{
+    _assert_slot(slot);
+    return (riot_hdr_t*)slot_util_slots[slot];
+}
+
+#else /* BOARD_NATIVE */
+const unsigned slot_util_num_slots = 1;
+
+void slot_util_jump_to_image(riot_hdr_t *riot_hdr)
+{
+    (void)riot_hdr;
+    printf("%s native stub\n", __func__);
+}
+
+int slot_util_current_slot(void)
+{
+    printf("%s native stub\n", __func__);
+
+    return 1;
+}
+
+unsigned slot_util_get_image_startaddr(unsigned slot)
+{
+    (void)slot;
+    printf("%s native stub\n", __func__);
+    return 0;
+}
+
+void slot_util_jump(unsigned slot)
+{
+    (void)slot;
+    printf("%s native stub\n", __func__);
+}
+
+void slot_util_dump_addrs(void)
+{
+    printf("%s native stub\n", __func__);
+}
+
+riot_hdr_t *slot_util_get_hdr(unsigned slot)
+{
+    (void)slot;
+    printf("%s native stub\n", __func__);
+    return NULL;
+}
+
+#endif /* BOARD_NATIVE */
+#endif /* RIOT_VERSION */

--- a/tests/riotboot/Makefile
+++ b/tests/riotboot/Makefile
@@ -1,0 +1,20 @@
+include ../Makefile.tests_common
+
+# If no BOARD is found in the environment, use this default:
+BOARD ?= samr21-xpro
+
+# Include modules to test the bootloader
+USEMODULE += slot_util
+USEMODULE += riot_hdr
+
+# Comment this out to disable code in RIOT that does safety checking
+# which is not needed in a production environment but helps in the
+# development process:
+DEVELHELP ?= 1
+
+# Change this to 0 show compiler invocation lines by default:
+QUIET ?= 1
+
+all: riotboot
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/riotboot/README.md
+++ b/tests/riotboot/README.md
@@ -1,0 +1,18 @@
+RIOT bootloader test
+====================
+
+This is a basic example how to use RIOT bootloader in your embedded
+application.
+
+This test should foremost give you an overview how to use riotboot:
+
+  - `make all` build the test using the target riotboot, which generates
+  a binary file of the application with a header on top of it, used by
+  the bootloader to recognise a bootable image.
+
+  - `make riotboot/flash` creates the binary files and flashes both 
+  riotboot and the RIOT image with headers included. This should boot
+  as a normal application.
+
+In this test two modules `riot_hdr` and `slot_util` are used to showcase
+the access to riotboot shared functions.

--- a/tests/riotboot/main.c
+++ b/tests/riotboot/main.c
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2014 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     examples
+ * @{
+ *
+ * @file
+ * @brief       Hello World application
+ *
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ * @author      Ludwig Knüpfer <ludwig.knuepfer@fu-berlin.de>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+
+#include "slot_util.h"
+#include "riot_hdr.h"
+
+int main(void)
+{
+    puts("Hello riotboot!");
+
+    printf("You are running RIOT on a(n) %s board.\n", RIOT_BOARD);
+    printf("This board features a(n) %s MCU.\n", RIOT_MCU);
+
+    /* print some information about the running image */
+    unsigned current_slot = slot_util_current_slot();
+    riot_hdr_t *riot_hdr = slot_util_get_hdr(current_slot);
+    printf("riot_hdr: running from slot %u\n", current_slot);
+    riot_hdr_print(riot_hdr);
+
+    return 0;
+}


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

### Contribution description
#### RIOT image header for riotboot bootloader
##### Overview
 
`riotboot` is the name of a minimal bootloader application and infrastructure.
 It consists of
  - the application "riotboot" in the bootloaders folder which serves as
    minimal bootloader
  - the module "riot_hdr" used to recognise RIOT firmware images
    which riotboot can boot.
  - the module "slot_util" used to manage the images (slots) with a
    RIOT header attached to them
  - a tool in dist/tools/riot_hdr for header generation.
  - several make targets to glue everything together

##### Concept
`riotboot` expects the flash to be separated in slots: slot 0 contains
 the bootloader and slot 1 a firmware image.

A RIOT image with a single slot looks like:
```
|------------------------------- FLASH -------------------------------------|
|- RIOTBOOT_SLOT0_SIZE -|-------- RIOTBOOT_FW_SLOT_SIZE (slot 1) -----------|
       (slot 0)         |---- RIOT_HDR_SIZE ------|
 ---------------------------------------------------------------------------
|       bootloader      | riot_hdr_t + filler (0) |     RIOT firmware       |
 ---------------------------------------------------------------------------
```
Please note that `RIOT_HDR_SIZE` depends on the architecture of the
MCU, since it needs to be aligned to either 256B or 512B. This is
fixed regardless of `sizeof(riot_hdr_t)`

The bootloader will, on reset, verify the checksum of the first slot, then
boot it. If the slot doesn't have a valid checksum, no image will be
booted and the bootloader will enter "while(1);".

The header contains

  - "RIOT" as magic number
  - an application version
  - a checksum

The bootloader "riotboot" only cares about checksum.


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->
There's a test provided in tests/riotboot. This has only tested for now in:
  - [x] samr21-xpro
  - [x] iotlab-m3 (desk)

Please add above the boards that you have tested and worked.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
#9342 
#9969 