### PR TITLE
native/netdev_tap: Rename variable to fix -Wshadow warning

### DIFF
--- a/cpu/native/netdev_tap/netdev_tap.c
+++ b/cpu/native/netdev_tap/netdev_tap.c
@@ -222,9 +222,9 @@ static int _recv(netdev_t *netdev, void *buf, size_t len, void *info)
             }
             */
 
-            static uint8_t buf[ETHERNET_FRAME_LEN];
+            static uint8_t nullbuf[ETHERNET_FRAME_LEN];
 
-            real_read(dev->tap_fd, buf, sizeof(buf));
+            real_read(dev->tap_fd, nullbuf, sizeof(nullbuf));
 
             _continue_reading(dev);
         }


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

`buf` is already used in the outer scope. Trivially fixed by renaming the inner variable.


### Testing procedure

Check that gnrc_networking runs on native.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
