### PR TITLE
color: Fix -Wdouble-promotion warnings

### DIFF
--- a/sys/color/color.c
+++ b/sys/color/color.c
@@ -55,7 +55,7 @@ void color_rgb2hsv(color_rgb_t *rgb, color_hsv_t *hsv)
 
     /* compute hue */
     hsv->h = 0.0f;
-    if (hsv->s != 0.0) {
+    if (hsv->s != 0.0f) {
         float rc, gc, bc;
 
         rc = (hsv->v - rd) / delta;
@@ -73,7 +73,7 @@ void color_rgb2hsv(color_rgb_t *rgb, color_hsv_t *hsv)
         }
         hsv->h *= 60.0f;
         if (hsv->h < 0.0f) {
-            hsv->h += 360.0;
+            hsv->h += 360.0f;
         }
     }
 }
@@ -90,7 +90,7 @@ void color_hsv2rgb(color_hsv_t *hsv, color_rgb_t *rgb)
         return;
     }
 
-    h = (hsv->h == 360.0f) ? 0.0 : hsv->h;
+    h = (hsv->h == 360.0f) ? 0.0f : hsv->h;
     h /= 60.0f;
     i = (int)h;
     f = h - i;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Fix some warnings in the color module where double was accidentally used instead of float.

### Testing procedure

Run unit tests.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
