### PR TITLE
sam0 flashpage_write: correct translation from RIOT pages to CPU pages writing

### DIFF
--- a/cpu/sam0_common/include/cpu_conf.h
+++ b/cpu/sam0_common/include/cpu_conf.h
@@ -43,8 +43,10 @@ extern "C" {
  */
 /* a flashpage in RIOT is mapped to a flash row on the SAM0s */
 #define FLASHPAGE_SIZE             (256U)
-/* one SAM0 row contains 4 SAM0 pages -> 4x the amount of RIOT flashpages */
-#define FLASHPAGE_NUMOF            (FLASH_NB_OF_PAGES / 4)
+/* one SAM0 row contains 4 SAM0 pages, so 4 SAM0 pages contain the amount of a RIOT flashpage */
+#define FLASHPAGE_PAGES_PER_ROW    (4)
+/* number of RIOT flashpages on device */
+#define FLASHPAGE_NUMOF            (FLASH_NB_OF_PAGES / FLASHPAGE_PAGES_PER_ROW)
 /* The minimum block size which can be written is 16B. However, the erase
  * block is always FLASHPAGE_SIZE (SAM0 row).
  */

--- a/cpu/sam0_common/include/cpu_conf.h
+++ b/cpu/sam0_common/include/cpu_conf.h
@@ -43,7 +43,9 @@ extern "C" {
  */
 /* a flashpage in RIOT is mapped to a flash row on the SAM0s */
 #define FLASHPAGE_SIZE             (256U)
-/* one SAM0 row contains 4 SAM0 pages, so 4 SAM0 pages contain the amount of a RIOT flashpage */
+/* one SAM0 row contains 4 SAM0 pages, so 4 SAM0 pages contain
+ * the amount of a RIOT flashpage
+ */
 #define FLASHPAGE_PAGES_PER_ROW    (4)
 /* number of RIOT flashpages on device */
 #define FLASHPAGE_NUMOF            (FLASH_NB_OF_PAGES / FLASHPAGE_PAGES_PER_ROW)

--- a/cpu/sam0_common/periph/flashpage.c
+++ b/cpu/sam0_common/periph/flashpage.c
@@ -103,7 +103,16 @@ void flashpage_write(int page, const void *data)
 
     /* write data to page */
     if (data != NULL) {
-        flashpage_write_raw(page_addr, data, FLASHPAGE_SIZE);
+        /* One RIOT page is FLASHPAGE_PAGES_PER_ROW SAM0 flash pages (a row) as
+         * defined in the file cpu/sam0_common/include/cpu_conf.h, therefore we
+         * have to split the write into FLASHPAGE_PAGES_PER_ROW raw calls
+         * underneath, each writing a physical page in chunks of 4 bytes (see
+         * flashpage_write_raw)
+         * The erasing is done once as a full row is always reased.
+         */
+        for (unsigned curpage = 0; curpage < FLASHPAGE_PAGES_PER_ROW; curpage++) {
+            flashpage_write_raw(page_addr + (curpage * NVMCTRL_PAGE_SIZE / 4), (void *) ((uint32_t *) data + (curpage * NVMCTRL_PAGE_SIZE / 4)), NVMCTRL_PAGE_SIZE);
+        }
     }
 
 }

--- a/cpu/sam0_common/periph/flashpage.c
+++ b/cpu/sam0_common/periph/flashpage.c
@@ -68,7 +68,7 @@ void flashpage_write_raw(void *target_addr, const void *data, size_t len)
             ((unsigned)data % FLASHPAGE_RAW_ALIGNMENT)));
 
     /* ensure the length doesn't exceed the actual flash size */
-    assert(((unsigned)target_addr + len) <
+    assert(((unsigned)target_addr + len) <=
            (CPU_FLASH_BASE + (FLASHPAGE_SIZE * FLASHPAGE_NUMOF)));
 
     uint32_t *dst = (uint32_t *)target_addr;
@@ -111,7 +111,9 @@ void flashpage_write(int page, const void *data)
          * The erasing is done once as a full row is always reased.
          */
         for (unsigned curpage = 0; curpage < FLASHPAGE_PAGES_PER_ROW; curpage++) {
-            flashpage_write_raw(page_addr + (curpage * NVMCTRL_PAGE_SIZE / 4), (void *) ((uint32_t *) data + (curpage * NVMCTRL_PAGE_SIZE / 4)), NVMCTRL_PAGE_SIZE);
+            flashpage_write_raw(page_addr + (curpage * NVMCTRL_PAGE_SIZE / 4),
+                                (void *) ((uint32_t *) data + (curpage * NVMCTRL_PAGE_SIZE / 4)),
+                                NVMCTRL_PAGE_SIZE);
         }
     }
 

--- a/tests/periph_flashpage/main.c
+++ b/tests/periph_flashpage/main.c
@@ -335,6 +335,9 @@ static int cmd_test_last_raw(int argc, char **argv)
     /* try to align */
     memcpy(raw_buf, "test12344321tset", 16);
 
+    /* erase the page first */
+    flashpage_write(((int)FLASHPAGE_NUMOF - 2), NULL);
+
     flashpage_write_raw((void*) ((int)CPU_FLASH_BASE + (int)FLASHPAGE_SIZE * ((int)FLASHPAGE_NUMOF - 2)), raw_buf, strlen(raw_buf));
 
     puts("wrote raw short buffer to last flash page");


### PR DESCRIPTION
### Contribution description
Solve erroneous writing on flash with sam0 boards because of wrong assumption of page sizing. Discovered on a saml21-xpro board.
A "RIOT page" is 256 bytes but a physical page on sam0 is 64, therefore the write has to be translated into four 64 writes.

### Testing procedure
The automated test `tests/periph_flashpage` can be used to verify the correctness of the PR.

### Issues/PRs references
Fixes: #10068 
