### PR TITLE
gnrc: Use existing utility function to extract IPv6 header

### DIFF
--- a/sys/include/net/gnrc/ipv6.h
+++ b/sys/include/net/gnrc/ipv6.h
@@ -158,6 +158,8 @@ void gnrc_ipv6_demux(gnrc_netif_t *netif, gnrc_pktsnip_t *current,
  *
  *          This function may be used with e.g. a pointer to a (full) UDP datagram.
  *
+ * @pre Any @ref GNRC_NETTYPE_IPV6 snip in pkt is contains a full IPv6 header.
+ *
  * @param[in] pkt    The pointer to the first @ref gnrc_pktsnip_t of the
  *                   packet.
  *

--- a/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
+++ b/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
@@ -195,13 +195,16 @@ void gnrc_ipv6_demux(gnrc_netif_t *netif, gnrc_pktsnip_t *current,
 
 ipv6_hdr_t *gnrc_ipv6_get_header(gnrc_pktsnip_t *pkt)
 {
-    ipv6_hdr_t *hdr = NULL;
     gnrc_pktsnip_t *tmp = gnrc_pktsnip_search_type(pkt, GNRC_NETTYPE_IPV6);
-    if ((tmp != NULL) && (tmp->data != NULL) && ipv6_hdr_is(tmp->data)) {
-        hdr = ((ipv6_hdr_t*) tmp->data);
+    if (tmp == NULL) {
+        return NULL;
     }
 
-    return hdr;
+    assert(tmp->data != NULL);
+    assert(tmp->size >= sizeof(ipv6_hdr_t));
+    assert(ipv6_hdr_is(tmp->data));
+
+    return ((ipv6_hdr_t*) tmp->data);
 }
 
 /* internal functions */

--- a/sys/net/gnrc/sock/gnrc_sock.c
+++ b/sys/net/gnrc/sock/gnrc_sock.c
@@ -17,6 +17,7 @@
 
 #include "net/af.h"
 #include "net/ipv6/hdr.h"
+#include "net/gnrc/ipv6.h"
 #include "net/gnrc/ipv6/hdr.h"
 #include "net/gnrc/netreg.h"
 #include "net/udp.h"
@@ -53,7 +54,7 @@ void gnrc_sock_create(gnrc_sock_reg_t *reg, gnrc_nettype_t type, uint32_t demux_
 ssize_t gnrc_sock_recv(gnrc_sock_reg_t *reg, gnrc_pktsnip_t **pkt_out,
                        uint32_t timeout, sock_ip_ep_t *remote)
 {
-    gnrc_pktsnip_t *pkt, *ip, *netif;
+    gnrc_pktsnip_t *pkt, *netif;
     msg_t msg;
 
     if (reg->mbox.cib.mask != (SOCK_MBOX_SIZE - 1)) {
@@ -95,10 +96,8 @@ ssize_t gnrc_sock_recv(gnrc_sock_reg_t *reg, gnrc_pktsnip_t **pkt_out,
     }
     /* TODO: discern NETTYPE from remote->family (set in caller), when IPv4
      * was implemented */
-    ipv6_hdr_t *ipv6_hdr;
-    ip = gnrc_pktsnip_search_type(pkt, GNRC_NETTYPE_IPV6);
-    assert((ip != NULL) && (ip->size >= 40));
-    ipv6_hdr = ip->data;
+    ipv6_hdr_t *ipv6_hdr = gnrc_ipv6_get_header(pkt);
+    assert(ipv6_hdr != NULL);
     memcpy(&remote->addr, &ipv6_hdr->src, sizeof(ipv6_addr_t));
     remote->family = AF_INET6;
     netif = gnrc_pktsnip_search_type(pkt, GNRC_NETTYPE_NETIF);


### PR DESCRIPTION
Different checks were applied in the two places, and got unioned into the utility function.

---

### Contribution description

This change to GNRC socks is mainly motivated by seeing that the different places (gnrc_sock_recv and the utility function gnrc_ipv6_get_header) used different checks when pulling a ipv6_hdr out of a pktsnip. The new version adds a check in public function (replacing a hard-coded constant with a sizeof).

I'm not sure all those checks are actually necessary, so it might be worth checking with the GNRC architectural decisions whether a GNRC_NETTYPE_IPV6 marked snip can actually have its data NULL and a size of < 40, but without that checked, I'd err on the side of caution.

Impact-wise, this might add a few bytes of text as gnrc_ipv6_get_header is so far not used in the rest of the code; if that's a concern, we might consider making it inline-able (how's -flto coming?).

### Testing procedure

Tested on native with a custom application that has both direct netapi threads and a gcoap server running. I did not try to produce situations in which any of the additional checks are triggered (see above: I'm not sure they're all necessary)