### PR TITLE
boards: always include cpu features

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -246,6 +246,13 @@ include $(RIOTBOARD)/$(BOARD)/Makefile.include
 INCLUDES += -I$(RIOTCPU)/$(CPU)/include
 include $(RIOTCPU)/$(CPU)/Makefile.include
 
+# Sanity check
+# The check is only done after 'include $(RIOTBOARD)/$(BOARD)/Makefile.include'
+# because we need to have the 'CPU' variable defined
+ifeq (,$(filter $(RIOTCPU)/$(CPU)/Makefile.features,$(MAKEFILE_LIST)))
+  $(error $$(RIOTCPU)/$$(CPU)/Makefile.features must have been included by the board / board common Makefile.features)
+endif
+
 # Assume GCC/GNU as supported toolchain if CPU's Makefile.include doesn't
 # provide this macro
 TOOLCHAINS_SUPPORTED ?= gnu

--- a/boards/airfy-beacon/Makefile.features
+++ b/boards/airfy-beacon/Makefile.features
@@ -12,4 +12,4 @@ FEATURES_PROVIDED += periph_uart
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m0_2
 
--include $(RIOTCPU)/nrf51/Makefile.features
+include $(RIOTCPU)/nrf51/Makefile.features

--- a/boards/arduino-duemilanove/Makefile.features
+++ b/boards/arduino-duemilanove/Makefile.features
@@ -1,3 +1,3 @@
 include $(RIOTBOARD)/common/arduino-atmega/Makefile.features
 
--include $(RIOTCPU)/atmega328p/Makefile.features
+include $(RIOTCPU)/atmega328p/Makefile.features

--- a/boards/arduino-mega2560/Makefile.features
+++ b/boards/arduino-mega2560/Makefile.features
@@ -1,3 +1,3 @@
 include $(RIOTBOARD)/common/arduino-atmega/Makefile.features
 
--include $(RIOTCPU)/atmega2560/Makefile.features
+include $(RIOTCPU)/atmega2560/Makefile.features

--- a/boards/arduino-mkr1000/Makefile.features
+++ b/boards/arduino-mkr1000/Makefile.features
@@ -1,3 +1,3 @@
 include $(RIOTBOARD)/common/arduino-mkr/Makefile.features
 
--include $(RIOTCPU)/samd21/Makefile.features
+include $(RIOTCPU)/samd21/Makefile.features

--- a/boards/arduino-mkrfox1200/Makefile.features
+++ b/boards/arduino-mkrfox1200/Makefile.features
@@ -1,3 +1,3 @@
 include $(RIOTBOARD)/common/arduino-mkr/Makefile.features
 
--include $(RIOTCPU)/samd21/Makefile.features
+include $(RIOTCPU)/samd21/Makefile.features

--- a/boards/arduino-mkrzero/Makefile.features
+++ b/boards/arduino-mkrzero/Makefile.features
@@ -1,3 +1,3 @@
 include $(RIOTBOARD)/common/arduino-mkr/Makefile.features
 
--include $(RIOTCPU)/samd21/Makefile.features
+include $(RIOTCPU)/samd21/Makefile.features

--- a/boards/arduino-uno/Makefile.features
+++ b/boards/arduino-uno/Makefile.features
@@ -1,3 +1,3 @@
 include $(RIOTBOARD)/common/arduino-atmega/Makefile.features
 
--include $(RIOTCPU)/atmega328p/Makefile.features
+include $(RIOTCPU)/atmega328p/Makefile.features

--- a/boards/arduino-zero/Makefile.features
+++ b/boards/arduino-zero/Makefile.features
@@ -14,4 +14,4 @@ FEATURES_PROVIDED += arduino
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m0_2
 
--include $(RIOTCPU)/samd21/Makefile.features
+include $(RIOTCPU)/samd21/Makefile.features

--- a/boards/avsextrem/Makefile.features
+++ b/boards/avsextrem/Makefile.features
@@ -10,4 +10,4 @@ FEATURES_PROVIDED += periph_uart
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = arm7
 
--include $(RIOTCPU)/lpc2387/Makefile.features
+include $(RIOTCPU)/lpc2387/Makefile.features

--- a/boards/b-l072z-lrwan1/Makefile.features
+++ b/boards/b-l072z-lrwan1/Makefile.features
@@ -9,4 +9,4 @@ FEATURES_PROVIDED += periph_uart
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m0_1
 
--include $(RIOTCPU)/stm32l0/Makefile.features
+include $(RIOTCPU)/stm32l0/Makefile.features

--- a/boards/b-l475e-iot01a/Makefile.features
+++ b/boards/b-l475e-iot01a/Makefile.features
@@ -9,4 +9,4 @@ FEATURES_PROVIDED += periph_uart
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m4_2
 
--include $(RIOTCPU)/stm32l4/Makefile.features
+include $(RIOTCPU)/stm32l4/Makefile.features

--- a/boards/calliope-mini/Makefile.features
+++ b/boards/calliope-mini/Makefile.features
@@ -11,4 +11,4 @@ FEATURES_PROVIDED += periph_pwm
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m0_1
 
--include $(RIOTCPU)/nrf51/Makefile.features
+include $(RIOTCPU)/nrf51/Makefile.features

--- a/boards/cc2538dk/Makefile.features
+++ b/boards/cc2538dk/Makefile.features
@@ -12,4 +12,4 @@ FEATURES_PROVIDED += emulator_renode
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m3_1
 
--include $(RIOTCPU)/cc2538/Makefile.features
+include $(RIOTCPU)/cc2538/Makefile.features

--- a/boards/cc2650-launchpad/Makefile.features
+++ b/boards/cc2650-launchpad/Makefile.features
@@ -6,4 +6,4 @@ FEATURES_PROVIDED += periph_uart
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m3_1
 
--include $(RIOTCPU)/cc26x0/Makefile.features
+include $(RIOTCPU)/cc26x0/Makefile.features

--- a/boards/cc2650stk/Makefile.features
+++ b/boards/cc2650stk/Makefile.features
@@ -6,4 +6,4 @@ FEATURES_PROVIDED += periph_uart
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m3_1
 
--include $(RIOTCPU)/cc26x0/Makefile.features
+include $(RIOTCPU)/cc26x0/Makefile.features

--- a/boards/chronos/Makefile.features
+++ b/boards/chronos/Makefile.features
@@ -7,4 +7,4 @@ FEATURES_PROVIDED += periph_rtc
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = msp430
 
--include $(RIOTCPU)/cc430/Makefile.features
+include $(RIOTCPU)/cc430/Makefile.features

--- a/boards/common/arduino-due/Makefile.features
+++ b/boards/common/arduino-due/Makefile.features
@@ -13,4 +13,4 @@ FEATURES_PROVIDED += arduino
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m3_1
 
--include $(RIOTCPU)/sam3/Makefile.features
+include $(RIOTCPU)/sam3/Makefile.features

--- a/boards/common/msb-430/Makefile.features
+++ b/boards/common/msb-430/Makefile.features
@@ -1,1 +1,1 @@
--include $(RIOTCPU)/msp430fxyz/Makefile.features
+include $(RIOTCPU)/msp430fxyz/Makefile.features

--- a/boards/common/nrf52xxxdk/Makefile.features
+++ b/boards/common/nrf52xxxdk/Makefile.features
@@ -13,4 +13,4 @@ FEATURES_PROVIDED += radio_nrfble
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m4_3
 
--include $(RIOTCPU)/nrf52/Makefile.features
+include $(RIOTCPU)/nrf52/Makefile.features

--- a/boards/common/stm32f103c8/Makefile.features
+++ b/boards/common/stm32f103c8/Makefile.features
@@ -10,4 +10,4 @@ FEATURES_PROVIDED += periph_uart
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m3_2
 
--include $(RIOTCPU)/stm32f1/Makefile.features
+include $(RIOTCPU)/stm32f1/Makefile.features

--- a/boards/common/wsn430/Makefile.features
+++ b/boards/common/wsn430/Makefile.features
@@ -7,4 +7,4 @@ FEATURES_PROVIDED += periph_uart
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = msp430
 
--include $(RIOTCPU)/msp430fxyz/Makefile.features
+include $(RIOTCPU)/msp430fxyz/Makefile.features

--- a/boards/ek-lm4f120xl/Makefile.features
+++ b/boards/ek-lm4f120xl/Makefile.features
@@ -8,4 +8,4 @@ FEATURES_PROVIDED += periph_uart
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m4_1
 
--include $(RIOTCPU)/lm4f120/Makefile.features
+include $(RIOTCPU)/lm4f120/Makefile.features

--- a/boards/f4vi1/Makefile.features
+++ b/boards/f4vi1/Makefile.features
@@ -6,4 +6,4 @@ FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m4_1
 
--include $(RIOTCPU)/stm32f4/Makefile.features
+include $(RIOTCPU)/stm32f4/Makefile.features

--- a/boards/feather-m0/Makefile.features
+++ b/boards/feather-m0/Makefile.features
@@ -12,4 +12,4 @@ FEATURES_PROVIDED += periph_uart
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m0_2
 
--include $(RIOTCPU)/samd21/Makefile.features
+include $(RIOTCPU)/samd21/Makefile.features

--- a/boards/fox/Makefile.features
+++ b/boards/fox/Makefile.features
@@ -9,4 +9,4 @@ FEATURES_PROVIDED += periph_uart
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m3_1
 
--include $(RIOTCPU)/stm32f1/Makefile.features
+include $(RIOTCPU)/stm32f1/Makefile.features

--- a/boards/ikea-tradfri/Makefile.features
+++ b/boards/ikea-tradfri/Makefile.features
@@ -9,4 +9,4 @@ FEATURES_PROVIDED += periph_uart
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m4_2
 
--include $(RIOTCPU)/efm32/Makefile.features
+include $(RIOTCPU)/efm32/Makefile.features

--- a/boards/iotlab-a8-m3/Makefile.features
+++ b/boards/iotlab-a8-m3/Makefile.features
@@ -1,3 +1,3 @@
 include $(RIOTBOARD)/common/iotlab/Makefile.features
 
--include $(RIOTCPU)/stm32f1/Makefile.features
+include $(RIOTCPU)/stm32f1/Makefile.features

--- a/boards/iotlab-m3/Makefile.features
+++ b/boards/iotlab-m3/Makefile.features
@@ -1,3 +1,3 @@
 include $(RIOTBOARD)/common/iotlab/Makefile.features
 
--include $(RIOTCPU)/stm32f1/Makefile.features
+include $(RIOTCPU)/stm32f1/Makefile.features

--- a/boards/jiminy-mega256rfr2/Makefile.features
+++ b/boards/jiminy-mega256rfr2/Makefile.features
@@ -7,4 +7,4 @@ include $(RIOTBOARD)/common/arduino-atmega/Makefile.features
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = avr6
 
--include $(RIOTCPU)/atmega256rfr2/Makefile.features
+include $(RIOTCPU)/atmega256rfr2/Makefile.features

--- a/boards/limifrog-v1/Makefile.features
+++ b/boards/limifrog-v1/Makefile.features
@@ -8,4 +8,4 @@ FEATURES_PROVIDED += periph_uart
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m3_2
 
--include $(RIOTCPU)/stm32l1/Makefile.features
+include $(RIOTCPU)/stm32l1/Makefile.features

--- a/boards/lobaro-lorabox/Makefile.features
+++ b/boards/lobaro-lorabox/Makefile.features
@@ -6,4 +6,4 @@ FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 
--include $(RIOTCPU)/stm32l1/Makefile.features
+include $(RIOTCPU)/stm32l1/Makefile.features

--- a/boards/maple-mini/Makefile.features
+++ b/boards/maple-mini/Makefile.features
@@ -8,4 +8,4 @@ FEATURES_PROVIDED += periph_uart
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m3_1
 
--include $(RIOTCPU)/stm32f1/Makefile.features
+include $(RIOTCPU)/stm32f1/Makefile.features

--- a/boards/mbed_lpc1768/Makefile.features
+++ b/boards/mbed_lpc1768/Makefile.features
@@ -6,4 +6,4 @@ FEATURES_PROVIDED += periph_uart
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m3_1
 
--include $(RIOTCPU)/lpc1768/Makefile.features
+include $(RIOTCPU)/lpc1768/Makefile.features

--- a/boards/mega-xplained/Makefile.features
+++ b/boards/mega-xplained/Makefile.features
@@ -11,4 +11,4 @@ FEATURES_PROVIDED += periph_uart
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = avr8
 
--include $(RIOTCPU)/atmega1284p/Makefile.features
+include $(RIOTCPU)/atmega1284p/Makefile.features

--- a/boards/microbit/Makefile.features
+++ b/boards/microbit/Makefile.features
@@ -10,4 +10,4 @@ FEATURES_PROVIDED += periph_uart
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m0_1
 
--include $(RIOTCPU)/nrf51/Makefile.features
+include $(RIOTCPU)/nrf51/Makefile.features

--- a/boards/mips-malta/Makefile.features
+++ b/boards/mips-malta/Makefile.features
@@ -4,4 +4,4 @@ FEATURES_PROVIDED += periph_timer
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = mips32r2
 
--include $(RIOTCPU)/mips32r2_generic/Makefile.features
+include $(RIOTCPU)/mips32r2_generic/Makefile.features

--- a/boards/msb-430/Makefile.features
+++ b/boards/msb-430/Makefile.features
@@ -9,4 +9,4 @@ FEATURES_PROVIDED += periph_uart
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = msp430
 
--include $(RIOTCPU)/msp430fxyz/Makefile.features
+include $(RIOTCPU)/msp430fxyz/Makefile.features

--- a/boards/msb-430h/Makefile.features
+++ b/boards/msb-430h/Makefile.features
@@ -7,4 +7,4 @@ FEATURES_PROVIDED += periph_uart
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = msp430
 
--include $(RIOTCPU)/msp430fxyz/Makefile.features
+include $(RIOTCPU)/msp430fxyz/Makefile.features

--- a/boards/msba2/Makefile.features
+++ b/boards/msba2/Makefile.features
@@ -9,4 +9,4 @@ FEATURES_PROVIDED += periph_uart
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = arm7
 
--include $(RIOTCPU)/lpc2387/Makefile.features
+include $(RIOTCPU)/lpc2387/Makefile.features

--- a/boards/msbiot/Makefile.features
+++ b/boards/msbiot/Makefile.features
@@ -11,4 +11,4 @@ FEATURES_PROVIDED += periph_uart
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m4_1
 
--include $(RIOTCPU)/stm32f4/Makefile.features
+include $(RIOTCPU)/stm32f4/Makefile.features

--- a/boards/native/Makefile.features
+++ b/boards/native/Makefile.features
@@ -11,4 +11,4 @@ FEATURES_PROVIDED += ethernet
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = x86
 
--include $(RIOTCPU)/native/Makefile.features
+include $(RIOTCPU)/native/Makefile.features

--- a/boards/nrf51dongle/Makefile.features
+++ b/boards/nrf51dongle/Makefile.features
@@ -9,4 +9,4 @@ FEATURES_PROVIDED += periph_uart
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m0_1
 
--include $(RIOTCPU)/nrf51/Makefile.features
+include $(RIOTCPU)/nrf51/Makefile.features

--- a/boards/nrf6310/Makefile.features
+++ b/boards/nrf6310/Makefile.features
@@ -10,4 +10,4 @@ FEATURES_PROVIDED += periph_uart
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m0_2
 
--include $(RIOTCPU)/nrf51/Makefile.features
+include $(RIOTCPU)/nrf51/Makefile.features

--- a/boards/nucleo-f030r8/Makefile.features
+++ b/boards/nucleo-f030r8/Makefile.features
@@ -12,4 +12,4 @@ include $(RIOTBOARD)/common/nucleo64/Makefile.features
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m0_1
 
--include $(RIOTCPU)/stm32f0/Makefile.features
+include $(RIOTCPU)/stm32f0/Makefile.features

--- a/boards/nucleo-f031k6/Makefile.features
+++ b/boards/nucleo-f031k6/Makefile.features
@@ -13,4 +13,4 @@ include $(RIOTBOARD)/common/nucleo32/Makefile.features
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m0_1
 
--include $(RIOTCPU)/stm32f0/Makefile.features
+include $(RIOTCPU)/stm32f0/Makefile.features

--- a/boards/nucleo-f042k6/Makefile.features
+++ b/boards/nucleo-f042k6/Makefile.features
@@ -13,4 +13,4 @@ include $(RIOTBOARD)/common/nucleo32/Makefile.features
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m0_1
 
--include $(RIOTCPU)/stm32f0/Makefile.features
+include $(RIOTCPU)/stm32f0/Makefile.features

--- a/boards/nucleo-f070rb/Makefile.features
+++ b/boards/nucleo-f070rb/Makefile.features
@@ -13,4 +13,4 @@ include $(RIOTBOARD)/common/nucleo64/Makefile.features
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m0_1
 
--include $(RIOTCPU)/stm32f0/Makefile.features
+include $(RIOTCPU)/stm32f0/Makefile.features

--- a/boards/nucleo-f072rb/Makefile.features
+++ b/boards/nucleo-f072rb/Makefile.features
@@ -13,4 +13,4 @@ include $(RIOTBOARD)/common/nucleo64/Makefile.features
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m0_1
 
--include $(RIOTCPU)/stm32f0/Makefile.features
+include $(RIOTCPU)/stm32f0/Makefile.features

--- a/boards/nucleo-f091rc/Makefile.features
+++ b/boards/nucleo-f091rc/Makefile.features
@@ -14,4 +14,4 @@ include $(RIOTBOARD)/common/nucleo64/Makefile.features
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m0_1
 
--include $(RIOTCPU)/stm32f0/Makefile.features
+include $(RIOTCPU)/stm32f0/Makefile.features

--- a/boards/nucleo-f103rb/Makefile.features
+++ b/boards/nucleo-f103rb/Makefile.features
@@ -12,4 +12,4 @@ include $(RIOTBOARD)/common/nucleo64/Makefile.features
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m3_1
 
--include $(RIOTCPU)/stm32f1/Makefile.features
+include $(RIOTCPU)/stm32f1/Makefile.features

--- a/boards/nucleo-f207zg/Makefile.features
+++ b/boards/nucleo-f207zg/Makefile.features
@@ -13,4 +13,4 @@ include $(RIOTBOARD)/common/nucleo144/Makefile.features
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m3_2
 
--include $(RIOTCPU)/stm32f2/Makefile.features
+include $(RIOTCPU)/stm32f2/Makefile.features

--- a/boards/nucleo-f302r8/Makefile.features
+++ b/boards/nucleo-f302r8/Makefile.features
@@ -13,4 +13,4 @@ include $(RIOTBOARD)/common/nucleo64/Makefile.features
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m4_2
 
--include $(RIOTCPU)/stm32f3/Makefile.features
+include $(RIOTCPU)/stm32f3/Makefile.features

--- a/boards/nucleo-f303k8/Makefile.features
+++ b/boards/nucleo-f303k8/Makefile.features
@@ -12,4 +12,4 @@ include $(RIOTBOARD)/common/nucleo32/Makefile.features
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m4_2
 
--include $(RIOTCPU)/stm32f3/Makefile.features
+include $(RIOTCPU)/stm32f3/Makefile.features

--- a/boards/nucleo-f303re/Makefile.features
+++ b/boards/nucleo-f303re/Makefile.features
@@ -13,4 +13,4 @@ include $(RIOTBOARD)/common/nucleo64/Makefile.features
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m4_2
 
--include $(RIOTCPU)/stm32f3/Makefile.features
+include $(RIOTCPU)/stm32f3/Makefile.features

--- a/boards/nucleo-f303ze/Makefile.features
+++ b/boards/nucleo-f303ze/Makefile.features
@@ -12,4 +12,4 @@ include $(RIOTBOARD)/common/nucleo144/Makefile.features
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m4_3
 
--include $(RIOTCPU)/stm32f3/Makefile.features
+include $(RIOTCPU)/stm32f3/Makefile.features

--- a/boards/nucleo-f334r8/Makefile.features
+++ b/boards/nucleo-f334r8/Makefile.features
@@ -12,4 +12,4 @@ include $(RIOTBOARD)/common/nucleo64/Makefile.features
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m4_2
 
--include $(RIOTCPU)/stm32f3/Makefile.features
+include $(RIOTCPU)/stm32f3/Makefile.features

--- a/boards/nucleo-f401re/Makefile.features
+++ b/boards/nucleo-f401re/Makefile.features
@@ -15,4 +15,4 @@ include $(RIOTBOARD)/common/nucleo64/Makefile.features
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m4_3
 
--include $(RIOTCPU)/stm32f4/Makefile.features
+include $(RIOTCPU)/stm32f4/Makefile.features

--- a/boards/nucleo-f410rb/Makefile.features
+++ b/boards/nucleo-f410rb/Makefile.features
@@ -10,4 +10,4 @@ FEATURES_PROVIDED += periph_uart
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m4_3
 
--include $(RIOTCPU)/stm32f4/Makefile.features
+include $(RIOTCPU)/stm32f4/Makefile.features

--- a/boards/nucleo-f411re/Makefile.features
+++ b/boards/nucleo-f411re/Makefile.features
@@ -11,4 +11,4 @@ FEATURES_PROVIDED += periph_uart
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m4_3
 
--include $(RIOTCPU)/stm32f4/Makefile.features
+include $(RIOTCPU)/stm32f4/Makefile.features

--- a/boards/nucleo-f412zg/Makefile.features
+++ b/boards/nucleo-f412zg/Makefile.features
@@ -14,4 +14,4 @@ include $(RIOTBOARD)/common/nucleo144/Makefile.features
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m4_3
 
--include $(RIOTCPU)/stm32f4/Makefile.features
+include $(RIOTCPU)/stm32f4/Makefile.features

--- a/boards/nucleo-f413zh/Makefile.features
+++ b/boards/nucleo-f413zh/Makefile.features
@@ -16,4 +16,4 @@ include $(RIOTBOARD)/common/nucleo144/Makefile.features
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m4_3
 
--include $(RIOTCPU)/stm32f4/Makefile.features
+include $(RIOTCPU)/stm32f4/Makefile.features

--- a/boards/nucleo-f429zi/Makefile.features
+++ b/boards/nucleo-f429zi/Makefile.features
@@ -14,4 +14,4 @@ include $(RIOTBOARD)/common/nucleo144/Makefile.features
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m4_3
 
--include $(RIOTCPU)/stm32f4/Makefile.features
+include $(RIOTCPU)/stm32f4/Makefile.features

--- a/boards/nucleo-f446re/Makefile.features
+++ b/boards/nucleo-f446re/Makefile.features
@@ -15,4 +15,4 @@ include $(RIOTBOARD)/common/nucleo64/Makefile.features
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m4_3
 
--include $(RIOTCPU)/stm32f4/Makefile.features
+include $(RIOTCPU)/stm32f4/Makefile.features

--- a/boards/nucleo-f446ze/Makefile.features
+++ b/boards/nucleo-f446ze/Makefile.features
@@ -13,4 +13,4 @@ include $(RIOTBOARD)/common/nucleo144/Makefile.features
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m4_3
 
--include $(RIOTCPU)/stm32f4/Makefile.features
+include $(RIOTCPU)/stm32f4/Makefile.features

--- a/boards/nucleo-f722ze/Makefile.features
+++ b/boards/nucleo-f722ze/Makefile.features
@@ -11,4 +11,4 @@ include $(RIOTBOARD)/common/nucleo144/Makefile.features
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m7
 
--include $(RIOTCPU)/stm32f7/Makefile.features
+include $(RIOTCPU)/stm32f7/Makefile.features

--- a/boards/nucleo-f746zg/Makefile.features
+++ b/boards/nucleo-f746zg/Makefile.features
@@ -10,4 +10,4 @@ include $(RIOTBOARD)/common/nucleo144/Makefile.features
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m7
 
--include $(RIOTCPU)/stm32f7/Makefile.features
+include $(RIOTCPU)/stm32f7/Makefile.features

--- a/boards/nucleo-f767zi/Makefile.features
+++ b/boards/nucleo-f767zi/Makefile.features
@@ -10,4 +10,4 @@ include $(RIOTBOARD)/common/nucleo144/Makefile.features
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m7
 
--include $(RIOTCPU)/stm32f7/Makefile.features
+include $(RIOTCPU)/stm32f7/Makefile.features

--- a/boards/nucleo-l031k6/Makefile.features
+++ b/boards/nucleo-l031k6/Makefile.features
@@ -13,4 +13,4 @@ include $(RIOTBOARD)/common/nucleo32/Makefile.features
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m0_1
 
--include $(RIOTCPU)/stm32l0/Makefile.features
+include $(RIOTCPU)/stm32l0/Makefile.features

--- a/boards/nucleo-l053r8/Makefile.features
+++ b/boards/nucleo-l053r8/Makefile.features
@@ -12,4 +12,4 @@ include $(RIOTBOARD)/common/nucleo64/Makefile.features
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m0_1
 
--include $(RIOTCPU)/stm32l0/Makefile.features
+include $(RIOTCPU)/stm32l0/Makefile.features

--- a/boards/nucleo-l073rz/Makefile.features
+++ b/boards/nucleo-l073rz/Makefile.features
@@ -14,4 +14,4 @@ include $(RIOTBOARD)/common/nucleo64/Makefile.features
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m0_1
 
--include $(RIOTCPU)/stm32l0/Makefile.features
+include $(RIOTCPU)/stm32l0/Makefile.features

--- a/boards/nucleo-l152re/Makefile.features
+++ b/boards/nucleo-l152re/Makefile.features
@@ -15,4 +15,4 @@ include $(RIOTBOARD)/common/nucleo64/Makefile.features
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m3_2
 
--include $(RIOTCPU)/stm32l1/Makefile.features
+include $(RIOTCPU)/stm32l1/Makefile.features

--- a/boards/nucleo-l432kc/Makefile.features
+++ b/boards/nucleo-l432kc/Makefile.features
@@ -12,4 +12,4 @@ include $(RIOTBOARD)/common/nucleo32/Makefile.features
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m4_1
 
--include $(RIOTCPU)/stm32l4/Makefile.features
+include $(RIOTCPU)/stm32l4/Makefile.features

--- a/boards/nucleo-l433rc/Makefile.features
+++ b/boards/nucleo-l433rc/Makefile.features
@@ -13,4 +13,4 @@ include $(RIOTBOARD)/common/nucleo64/Makefile.features
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m4_2
 
--include $(RIOTCPU)/stm32l4/Makefile.features
+include $(RIOTCPU)/stm32l4/Makefile.features

--- a/boards/nucleo-l452re/Makefile.features
+++ b/boards/nucleo-l452re/Makefile.features
@@ -13,4 +13,4 @@ include $(RIOTBOARD)/common/nucleo64/Makefile.features
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m4_2
 
--include $(RIOTCPU)/stm32l4/Makefile.features
+include $(RIOTCPU)/stm32l4/Makefile.features

--- a/boards/nucleo-l476rg/Makefile.features
+++ b/boards/nucleo-l476rg/Makefile.features
@@ -14,4 +14,4 @@ include $(RIOTBOARD)/common/nucleo64/Makefile.features
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m4_2
 
--include $(RIOTCPU)/stm32l4/Makefile.features
+include $(RIOTCPU)/stm32l4/Makefile.features

--- a/boards/nucleo-l496zg/Makefile.features
+++ b/boards/nucleo-l496zg/Makefile.features
@@ -13,4 +13,4 @@ include $(RIOTBOARD)/common/nucleo144/Makefile.features
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m4_3
 
--include $(RIOTCPU)/stm32l4/Makefile.features
+include $(RIOTCPU)/stm32l4/Makefile.features

--- a/boards/nz32-sc151/Makefile.features
+++ b/boards/nz32-sc151/Makefile.features
@@ -12,4 +12,4 @@ FEATURES_PROVIDED += periph_uart
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m3_2
 
--include $(RIOTCPU)/stm32l1/Makefile.features
+include $(RIOTCPU)/stm32l1/Makefile.features

--- a/boards/opencm904/Makefile.features
+++ b/boards/opencm904/Makefile.features
@@ -6,4 +6,4 @@ FEATURES_PROVIDED += periph_uart
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m3_1
 
--include $(RIOTCPU)/stm32f1/Makefile.features
+include $(RIOTCPU)/stm32f1/Makefile.features

--- a/boards/openmote-b/Makefile.features
+++ b/boards/openmote-b/Makefile.features
@@ -9,4 +9,4 @@ FEATURES_PROVIDED += periph_uart
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m3_2
 
--include $(RIOTCPU)/cc2538/Makefile.features
+include $(RIOTCPU)/cc2538/Makefile.features

--- a/boards/openmote-cc2538/Makefile.features
+++ b/boards/openmote-cc2538/Makefile.features
@@ -9,4 +9,4 @@ FEATURES_PROVIDED += periph_adc
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m3_2
 
--include $(RIOTCPU)/cc2538/Makefile.features
+include $(RIOTCPU)/cc2538/Makefile.features

--- a/boards/pic32-clicker/Makefile.features
+++ b/boards/pic32-clicker/Makefile.features
@@ -6,4 +6,4 @@ FEATURES_PROVIDED += periph_uart
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = mips32r2
 
--include $(RIOTCPU)/mips_pic32mx/Makefile.features
+include $(RIOTCPU)/mips_pic32mx/Makefile.features

--- a/boards/pic32-wifire/Makefile.features
+++ b/boards/pic32-wifire/Makefile.features
@@ -6,4 +6,4 @@ FEATURES_PROVIDED += periph_uart
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = mips32r2
 
--include $(RIOTCPU)/mips_pic32mz/Makefile.features
+include $(RIOTCPU)/mips_pic32mz/Makefile.features

--- a/boards/remote-pa/Makefile.features
+++ b/boards/remote-pa/Makefile.features
@@ -9,4 +9,4 @@ FEATURES_PROVIDED += periph_adc
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m3_2
 
--include $(RIOTCPU)/cc2538/Makefile.features
+include $(RIOTCPU)/cc2538/Makefile.features

--- a/boards/remote-reva/Makefile.features
+++ b/boards/remote-reva/Makefile.features
@@ -9,4 +9,4 @@ FEATURES_PROVIDED += periph_adc
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m3_2
 
--include $(RIOTCPU)/cc2538/Makefile.features
+include $(RIOTCPU)/cc2538/Makefile.features

--- a/boards/remote-revb/Makefile.features
+++ b/boards/remote-revb/Makefile.features
@@ -9,4 +9,4 @@ FEATURES_PROVIDED += periph_adc
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m3_2
 
--include $(RIOTCPU)/cc2538/Makefile.features
+include $(RIOTCPU)/cc2538/Makefile.features

--- a/boards/ruuvitag/Makefile.features
+++ b/boards/ruuvitag/Makefile.features
@@ -10,4 +10,4 @@ FEATURES_PROVIDED += periph_uart
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m4_3
 
--include $(RIOTCPU)/nrf52/Makefile.features
+include $(RIOTCPU)/nrf52/Makefile.features

--- a/boards/samd21-xpro/Makefile.features
+++ b/boards/samd21-xpro/Makefile.features
@@ -12,4 +12,4 @@ FEATURES_PROVIDED += periph_uart
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m0_2
 
--include $(RIOTCPU)/samd21/Makefile.features
+include $(RIOTCPU)/samd21/Makefile.features

--- a/boards/saml21-xpro/Makefile.features
+++ b/boards/saml21-xpro/Makefile.features
@@ -11,4 +11,4 @@ FEATURES_PROVIDED += periph_uart
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m0_2
 
--include $(RIOTCPU)/saml21/Makefile.features
+include $(RIOTCPU)/saml21/Makefile.features

--- a/boards/samr21-xpro/Makefile.features
+++ b/boards/samr21-xpro/Makefile.features
@@ -12,4 +12,4 @@ FEATURES_PROVIDED += periph_uart
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m0_2
 
--include $(RIOTCPU)/samd21/Makefile.features
+include $(RIOTCPU)/samd21/Makefile.features

--- a/boards/samr30-xpro/Makefile.features
+++ b/boards/samr30-xpro/Makefile.features
@@ -12,4 +12,4 @@ FEATURES_PROVIDED += periph_uart
 FEATURES_MCU_GROUP = cortex_m0_2
 
 # samr30 is a specific flavor of saml21
--include $(RIOTCPU)/saml21/Makefile.features
+include $(RIOTCPU)/saml21/Makefile.features

--- a/boards/seeeduino_arch-pro/Makefile.features
+++ b/boards/seeeduino_arch-pro/Makefile.features
@@ -6,4 +6,4 @@ FEATURES_PROVIDED += periph_uart
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m3_1
 
--include $(RIOTCPU)/lpc1768/Makefile.features
+include $(RIOTCPU)/lpc1768/Makefile.features

--- a/boards/sensebox_samd21/Makefile.features
+++ b/boards/sensebox_samd21/Makefile.features
@@ -10,4 +10,4 @@ FEATURES_PROVIDED += periph_uart
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m0_2
 
--include $(RIOTCPU)/samd21/Makefile.features
+include $(RIOTCPU)/samd21/Makefile.features

--- a/boards/slstk3401a/Makefile.features
+++ b/boards/slstk3401a/Makefile.features
@@ -11,4 +11,4 @@ FEATURES_PROVIDED += periph_uart
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m4_2
 
--include $(RIOTCPU)/efm32/Makefile.features
+include $(RIOTCPU)/efm32/Makefile.features

--- a/boards/slstk3402a/Makefile.features
+++ b/boards/slstk3402a/Makefile.features
@@ -11,4 +11,4 @@ FEATURES_PROVIDED += periph_uart
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m4_2
 
--include $(RIOTCPU)/efm32/Makefile.features
+include $(RIOTCPU)/efm32/Makefile.features

--- a/boards/sltb001a/Makefile.features
+++ b/boards/sltb001a/Makefile.features
@@ -11,4 +11,4 @@ FEATURES_PROVIDED += periph_uart
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m4_2
 
--include $(RIOTCPU)/efm32/Makefile.features
+include $(RIOTCPU)/efm32/Makefile.features

--- a/boards/slwstk6000b/Makefile.features
+++ b/boards/slwstk6000b/Makefile.features
@@ -11,4 +11,4 @@ FEATURES_PROVIDED += periph_uart
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m4_2
 
--include $(RIOTCPU)/efm32/Makefile.features
+include $(RIOTCPU)/efm32/Makefile.features

--- a/boards/slwstk6220a/Makefile.features
+++ b/boards/slwstk6220a/Makefile.features
@@ -6,4 +6,4 @@ FEATURES_PROVIDED += periph_uart
 # The board MCU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m4_1
 
--include $(RIOTCPU)/ezr32wg/Makefile.features
+include $(RIOTCPU)/ezr32wg/Makefile.features

--- a/boards/sodaq-autonomo/Makefile.features
+++ b/boards/sodaq-autonomo/Makefile.features
@@ -11,4 +11,4 @@ FEATURES_PROVIDED += periph_uart
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m0_2
 
--include $(RIOTCPU)/samd21/Makefile.features
+include $(RIOTCPU)/samd21/Makefile.features

--- a/boards/sodaq-explorer/Makefile.features
+++ b/boards/sodaq-explorer/Makefile.features
@@ -11,4 +11,4 @@ FEATURES_PROVIDED += periph_uart
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m0_2
 
--include $(RIOTCPU)/samd21/Makefile.features
+include $(RIOTCPU)/samd21/Makefile.features

--- a/boards/sodaq-one/Makefile.features
+++ b/boards/sodaq-one/Makefile.features
@@ -11,4 +11,4 @@ FEATURES_PROVIDED += periph_uart
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m0_2
 
--include $(RIOTCPU)/samd21/Makefile.features
+include $(RIOTCPU)/samd21/Makefile.features

--- a/boards/spark-core/Makefile.features
+++ b/boards/spark-core/Makefile.features
@@ -7,4 +7,4 @@ FEATURES_PROVIDED += periph_uart
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m3_2
 
--include $(RIOTCPU)/stm32f1/Makefile.features
+include $(RIOTCPU)/stm32f1/Makefile.features

--- a/boards/stk3600/Makefile.features
+++ b/boards/stk3600/Makefile.features
@@ -13,4 +13,4 @@ FEATURES_PROVIDED += periph_uart
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m3_2
 
--include $(RIOTCPU)/efm32/Makefile.features
+include $(RIOTCPU)/efm32/Makefile.features

--- a/boards/stk3700/Makefile.features
+++ b/boards/stk3700/Makefile.features
@@ -13,4 +13,4 @@ FEATURES_PROVIDED += periph_uart
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m3_2
 
--include $(RIOTCPU)/efm32/Makefile.features
+include $(RIOTCPU)/efm32/Makefile.features

--- a/boards/stm32f0discovery/Makefile.features
+++ b/boards/stm32f0discovery/Makefile.features
@@ -9,4 +9,4 @@ FEATURES_PROVIDED += periph_uart
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m0_1
 
--include $(RIOTCPU)/stm32f0/Makefile.features
+include $(RIOTCPU)/stm32f0/Makefile.features

--- a/boards/stm32f3discovery/Makefile.features
+++ b/boards/stm32f3discovery/Makefile.features
@@ -11,4 +11,4 @@ FEATURES_PROVIDED += periph_uart
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m4_3
 
--include $(RIOTCPU)/stm32f3/Makefile.features
+include $(RIOTCPU)/stm32f3/Makefile.features

--- a/boards/stm32f429i-disc1/Makefile.features
+++ b/boards/stm32f429i-disc1/Makefile.features
@@ -7,4 +7,4 @@ FEATURES_PROVIDED += periph_uart
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m4_2
 
--include $(RIOTCPU)/stm32f4/Makefile.features
+include $(RIOTCPU)/stm32f4/Makefile.features

--- a/boards/stm32f4discovery/Makefile.features
+++ b/boards/stm32f4discovery/Makefile.features
@@ -19,4 +19,4 @@ FEATURES_MCU_GROUP = cortex_m4_2
 FEATURES_CONFLICT += periph_spi:periph_dac
 FEATURES_CONFLICT_MSG += "On stm32f4discovery boards there are the same pins for the DAC and/or SPI_0."
 
--include $(RIOTCPU)/stm32f4/Makefile.features
+include $(RIOTCPU)/stm32f4/Makefile.features

--- a/boards/stm32f769i-disco/Makefile.features
+++ b/boards/stm32f769i-disco/Makefile.features
@@ -7,4 +7,4 @@ FEATURES_PROVIDED += periph_uart
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m7
 
--include $(RIOTCPU)/stm32f7/Makefile.features
+include $(RIOTCPU)/stm32f7/Makefile.features

--- a/boards/stm32l476g-disco/Makefile.features
+++ b/boards/stm32l476g-disco/Makefile.features
@@ -6,4 +6,4 @@ FEATURES_PROVIDED += periph_uart
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m4_2
 
--include $(RIOTCPU)/stm32l4/Makefile.features
+include $(RIOTCPU)/stm32l4/Makefile.features

--- a/boards/telosb/Makefile.features
+++ b/boards/telosb/Makefile.features
@@ -9,4 +9,4 @@ FEATURES_PROVIDED += periph_uart
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = msp430
 
--include $(RIOTCPU)/msp430fxyz/Makefile.features
+include $(RIOTCPU)/msp430fxyz/Makefile.features

--- a/boards/thingy52/Makefile.features
+++ b/boards/thingy52/Makefile.features
@@ -9,4 +9,4 @@ FEATURES_PROVIDED += periph_uart
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m4_3
 
--include $(RIOTCPU)/nrf52/Makefile.features
+include $(RIOTCPU)/nrf52/Makefile.features

--- a/boards/ublox-c030-u201/Makefile.features
+++ b/boards/ublox-c030-u201/Makefile.features
@@ -10,4 +10,4 @@ FEATURES_PROVIDED += periph_uart
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m4_3
 
--include $(RIOTCPU)/stm32f4/Makefile.features
+include $(RIOTCPU)/stm32f4/Makefile.features

--- a/boards/waspmote-pro/Makefile.features
+++ b/boards/waspmote-pro/Makefile.features
@@ -11,4 +11,4 @@ FEATURES_PROVIDED += periph_uart
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = avr8
 
--include $(RIOTCPU)/atmega1281/Makefile.features
+include $(RIOTCPU)/atmega1281/Makefile.features

--- a/boards/yunjia-nrf51822/Makefile.features
+++ b/boards/yunjia-nrf51822/Makefile.features
@@ -12,4 +12,4 @@ FEATURES_PROVIDED += periph_uart
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m0_2
 
--include $(RIOTCPU)/nrf51/Makefile.features
+include $(RIOTCPU)/nrf51/Makefile.features

--- a/boards/z1/Makefile.features
+++ b/boards/z1/Makefile.features
@@ -9,4 +9,4 @@ FEATURES_PROVIDED += periph_uart
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = msp430
 
--include $(RIOTCPU)/msp430fxyz/Makefile.features
+include $(RIOTCPU)/msp430fxyz/Makefile.features


### PR DESCRIPTION
### Contribution description

This adds a sanity check that CPU/Makefile.features is always used and replace the optional '-include' from boards as CPU Makefile.features always exist (done with `sed`).


### Testing procedure

Verify that murdock correctly builds 128 times (== all boards) for `examples/hello-world`.

### Issues/PRs references

~Waiting for: https://github.com/RIOT-OS/RIOT/pull/10064 and https://github.com/RIOT-OS/RIOT/pull/10063~

Part of working on https://github.com/RIOT-OS/RIOT/issues/9913
