### PR TITLE
drivers/gsm: add a (generic) gsm driver, with support for UBlox and Quectel.

### DIFF
--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -172,6 +172,11 @@ ifneq (,$(filter gsm_quectel,$(USEMODULE)))
   FEATURES_REQUIRED += periph_gpio_irq
 endif
 
+ifneq (,$(filter gsm_ublox,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_gpio
+  FEATURES_REQUIRED += periph_gpio_irq
+endif
+
 ifneq (,$(filter hd44780,$(USEMODULE)))
   FEATURES_REQUIRED += periph_gpio
   USEMODULE += xtimer

--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -167,6 +167,11 @@ ifneq (,$(filter gsm_gprs,$(USEMODULE)))
   USEMODULE += ipv4_addr
 endif
 
+ifneq (,$(filter gsm_quectel,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_gpio
+  FEATURES_REQUIRED += periph_gpio_irq
+endif
+
 ifneq (,$(filter hd44780,$(USEMODULE)))
   FEATURES_REQUIRED += periph_gpio
   USEMODULE += xtimer

--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -156,6 +156,17 @@ ifneq (,$(filter grove_ledbar,$(USEMODULE)))
   USEMODULE += my9221
 endif
 
+ifneq (,$(filter gsm,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_uart
+  USEMODULE += at
+  USEMODULE += fmt
+  USEMODULE += xtimer
+endif
+
+ifneq (,$(filter gsm_gprs,$(USEMODULE)))
+  USEMODULE += ipv4_addr
+endif
+
 ifneq (,$(filter hd44780,$(USEMODULE)))
   FEATURES_REQUIRED += periph_gpio
   USEMODULE += xtimer

--- a/drivers/Makefile.include
+++ b/drivers/Makefile.include
@@ -82,6 +82,10 @@ ifneq (,$(filter fxos8700,$(USEMODULE)))
   USEMODULE_INCLUDES += $(RIOTBASE)/drivers/fxos8700/include
 endif
 
+ifneq (,$(filter gsm_%,$(USEMODULE)))
+  USEMODULE_INCLUDES += $(RIOTBASE)/drivers/gsm/include
+endif
+
 ifneq (,$(filter grove_ledbar,$(USEMODULE)))
   USEMODULE_INCLUDES += $(RIOTBASE)/drivers/grove_ledbar/include
 endif

--- a/drivers/gsm/Makefile
+++ b/drivers/gsm/Makefile
@@ -1,0 +1,10 @@
+# exclude submodule sources from *.c wildcard source selection
+SRC := gsm.c
+
+# enable submodules
+SUBMODULES := 1
+
+# name base module
+BASE_MODULE := gsm
+
+include $(RIOTBASE)/Makefile.base

--- a/drivers/gsm/call.c
+++ b/drivers/gsm/call.c
@@ -1,0 +1,147 @@
+/*
+ * Copyright (C) 2018 Max van Kessel
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+#include <string.h>
+#include <assert.h>
+#include <errno.h>
+
+#include "periph/uart.h"
+#include "fmt.h"
+#include "log.h"
+
+#include "byteorder.h"
+
+#include "gsm/call.h"
+#include "include/gsm_internal.h"
+
+/**
+ * @ingroup     drivers_gsm
+ * @{
+ *
+ * @file
+ * @brief       gsm call implementation.
+ *
+ * @author      Max van Kessel
+ *
+ * @}
+ */
+#define MODULE  "gsm_call: "
+
+int gsm_call_dial_up(gsm_t *dev, const char * number, bool is_voice_call)
+{
+    int result = -EINVAL;
+
+    if (dev && number) {
+        char buf[GSM_AT_LINEBUFFER_SIZE];
+        char *pos = buf;
+
+        pos += fmt_str(pos, "ATD");
+        pos += fmt_str(pos, number);
+
+        if (is_voice_call) {
+            pos += fmt_str(pos, ";");
+        }
+        *pos = '\0';
+
+        gsm_lock(dev);
+
+        result = at_send_cmd_get_resp(&dev->at_dev, buf, buf, sizeof(buf), GSM_SERIAL_TIMEOUT_US * 5);
+
+        if (result > 0) {
+            if (strncmp(buf, "CONNECT", 7) == 0) {
+                result = 0;
+
+                if(!is_voice_call){
+                    at_drain(&dev->at_dev);
+
+                    /* switch to data mode requires another buffer */
+                    dev->state = GSM_CALL;
+                }
+            }
+            else {
+                LOG_INFO(MODULE"unexpected response: %s\n", buf);
+                result = -1;
+            }
+        }
+
+        gsm_unlock(dev);
+    }
+
+    return result;
+}
+
+void gsm_call_dial_down(gsm_t *dev)
+{
+    if (dev) {
+        at_drain(&dev->at_dev);
+
+        /* switch to data mode requires another buffer */
+        dev->state = GSM_ON;
+    }
+}
+
+int __attribute__((weak)) gsm_call_switch_to_command_mode(gsm_t *dev)
+{
+    int err = -EINVAL;
+
+    if (dev) {
+        if (dev->state == GSM_CALL) {
+
+            dev->state = GSM_ON;
+
+            gsm_lock(dev);
+
+            err = at_send_cmd_wait_ok(&dev->at_dev, "+++", GSM_SERIAL_TIMEOUT_US);
+
+            gsm_unlock(dev);
+
+            if (err != 0) {
+                dev->state = GSM_CALL;
+            }
+        }
+        else {
+            err = 0;
+        }
+    }
+
+    return err;
+}
+
+int __attribute__((weak)) gsm_call_switch_to_data_mode(gsm_t *dev)
+{
+    int err = -EINVAL;
+
+    if (dev) {
+        if (dev->state == GSM_ON) {
+            char buf[GSM_AT_LINEBUFFER_SIZE];
+
+            gsm_lock(dev);
+
+            err = at_send_cmd_get_resp(&dev->at_dev, "ATO", buf,
+                            GSM_AT_LINEBUFFER_SIZE, GSM_SERIAL_TIMEOUT_US);
+
+            gsm_unlock(dev);
+
+            if (err > 0) {
+                if (strncmp(buf, "CONNECT", 7) == 0) {
+                    err = 0;
+
+                    dev->state = GSM_CALL;
+                }
+                else {
+                    err = -1;
+                }
+            }
+        }
+        else {
+            err = 0;
+        }
+    }
+
+    return err;
+}

--- a/drivers/gsm/generic.c
+++ b/drivers/gsm/generic.c
@@ -1,0 +1,61 @@
+/*
+ * Copyright (C) 2018 Max van Kessel
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+#include <assert.h>
+#include <errno.h>
+#include <stdint.h>
+
+#include "log.h"
+#include "xtimer.h"
+
+#include "gsm/generic.h"
+
+#include "include/gsm_internal.h"
+
+/**
+ * @ingroup     drivers_gsm
+ * @{
+ *
+ * @file
+ * @brief       Generic gsm implementation.
+ *
+ * @author      Max van Kessel
+ *
+ * @}
+ */
+
+#define MODULE  "gsm_generic: "
+
+int generic_init(gsm_generic_t *dev)
+{
+    int err = -EINVAL;
+
+    if (dev) {
+        /* generic modem should be on by default */
+
+        /* send AT to see if it's alive */
+        bool alive = gsm_is_alive(dev, 3);
+
+        if (!alive) {
+            LOG_INFO(MODULE"no response on AT\n");
+
+            /* TODO no response on AT check if device is in command mode */
+            err = -1;
+        }
+        else {
+            dev->state = GSM_ON;
+            err = 0;
+        }
+
+    }
+    return err;
+}
+
+const gsm_driver_t gsm_generic_driver = {
+    .init_base = generic_init,
+};

--- a/drivers/gsm/gprs.c
+++ b/drivers/gsm/gprs.c
@@ -1,0 +1,220 @@
+/*
+ * Copyright (C) 2018 Max van Kessel
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+#include <assert.h>
+#include <errno.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "fmt.h"
+#include "log.h"
+#include "net/ipv4/addr.h"
+
+#include "gsm/gprs.h"
+#include "include/gsm_internal.h"
+
+/**
+ * @ingroup     drivers_gsm
+ * @{
+ *
+ * @file
+ * @brief       gsm gprs implementation.
+ *
+ * @author      Max van Kessel
+ *
+ * @}
+ */
+
+#define MODULE  "gsm_gprs: "
+
+static const char * gsm_context_types[GSM_CONTEXT_COUNT] = {"IP", "PPP", "IPV6",
+        "IP4V6"};
+
+int gsm_grps_attach(gsm_t *dev)
+{
+    int err = -EINVAL;
+
+    if (dev) {
+        gsm_lock(dev);
+
+        err = at_send_cmd_wait_ok(&dev->at_dev, "AT+CGATT=1",
+                                    GSM_SERIAL_TIMEOUT_US);
+
+        gsm_unlock(dev);
+    }
+
+    return err;
+}
+
+int gsm_grps_detach(gsm_t *dev)
+{
+    int err = -EINVAL;
+
+    if (dev) {
+        gsm_lock(dev);
+
+        err = at_send_cmd_wait_ok(&dev->at_dev, "AT+CGATT=0",
+                                    GSM_SERIAL_TIMEOUT_US);
+
+        gsm_unlock(dev);
+    }
+
+    return err;
+}
+
+int gsm_gprs_setup_pdp_context(gsm_t *dev, uint8_t ctx, gsm_context_t type,
+                        const char * apn, const char * user, const char * pass)
+{
+    int err = -EINVAL;
+
+    if ((dev) && (type < GSM_CONTEXT_COUNT)) {
+        char buf[128] = { 0 };
+        char *pos = buf;
+
+        pos += fmt_str(pos, "AT+CGDCONT=");
+        pos += fmt_u32_dec(pos, ctx);
+        pos += fmt_str(pos, ",\"");
+        pos += fmt_str(pos, gsm_context_types[type]);
+        pos += fmt_str(pos, "\",\"");
+        pos += fmt_str(pos, apn);
+
+        if (user) {
+            pos += fmt_str(pos, "\",\"");
+            pos += fmt_str(pos, user);
+
+            if(pass) {
+                pos += fmt_str(pos, "\",\"");
+                pos += fmt_str(pos, pass);
+            }
+        }
+        pos += fmt_str(pos, "\"\0");
+
+        gsm_lock(dev);
+
+         /* AT+CGDCONT=<ctx>,"<type>","<apn>",["<user>",["<pass>"]] */
+        err = at_send_cmd_wait_ok(&dev->at_dev, buf, GSM_SERIAL_TIMEOUT_US);
+
+        gsm_unlock(dev);
+    }
+
+    return err;
+}
+
+int gsm_grps_activate_context(gsm_t *dev, uint8_t ctx)
+{
+    int err = -EINVAL;
+
+    if (dev) {
+       char buf [GSM_AT_LINEBUFFER_SIZE_SMALL];
+       char *pos = buf;
+
+       assert(dev);
+
+       pos += fmt_str(pos, "AT+CGACT=1,");
+       pos += fmt_u32_dec(pos, ctx);
+       *pos = '\0';
+
+        gsm_lock(dev);
+
+        err = at_send_cmd_wait_ok(&dev->at_dev, buf, GSM_SERIAL_TIMEOUT_US);
+
+        gsm_unlock(dev);
+    }
+
+    return err;
+}
+
+int gsm_grps_deactivate_context(gsm_t *dev, uint8_t ctx)
+{
+    int err = -EINVAL;
+
+    if (dev) {
+        char buf[GSM_AT_LINEBUFFER_SIZE_SMALL];
+        char *pos = buf;
+
+        pos += fmt_str(pos, "AT+CGACT=0,");
+        pos += fmt_u32_dec(pos, ctx);
+        *pos = '\0';
+
+        gsm_lock(dev);
+
+        err = at_send_cmd_get_resp(&dev->at_dev, buf, buf,
+                           GSM_AT_LINEBUFFER_SIZE_SMALL, GSM_SERIAL_TIMEOUT_US);
+
+        if (err > 0) {
+            if (strcmp(buf, "OK") == 0) {
+                err = 0;
+            }
+            else if (strncmp(buf, "NO CARRIER", 10) == 0) {
+                err = 0;
+            }
+            else {
+                err = -1;
+            }
+        }
+
+        gsm_unlock(dev);
+    }
+    return err;
+}
+
+uint32_t gsm_gprs_get_address(gsm_t *dev, uint8_t ctx)
+{
+    uint32_t ip = 0;
+
+    if (dev) {
+        int res;
+        char buf[GSM_AT_LINEBUFFER_SIZE];
+        char *pos = buf;
+
+        pos += fmt_str(pos, "AT+CGPADDR=");
+        pos += fmt_u32_dec(pos, ctx);
+        *pos = '\0';
+
+        gsm_lock(dev);
+
+        res = at_send_cmd_get_resp(&dev->at_dev, buf, buf,
+                sizeof(buf), GSM_SERIAL_TIMEOUT_US);
+
+        if ((res > 13) && strncmp(buf, "+CGPADDR:", 9) == 0) {
+            buf[res] = '\0';
+            pos = strchr(buf, '"');
+            if (pos != NULL) {
+                char * end = strrchr(buf, '"');
+                *end = '\0';
+                ipv4_addr_from_str((ipv4_addr_t *)&ip, ++pos);
+            }
+        }
+
+        gsm_unlock(dev);
+    }
+    return ip;
+}
+
+
+int gsm_gprs_get_registration(gsm_t *dev)
+{
+    int res;
+    char buf[GSM_AT_LINEBUFFER_SIZE_SMALL];
+
+    gsm_lock(dev);
+
+    res = at_send_cmd_get_resp(&dev->at_dev, "AT+CGREG?", buf,
+            GSM_AT_LINEBUFFER_SIZE_SMALL, GSM_SERIAL_TIMEOUT_US);
+
+    gsm_unlock(dev);
+
+    if ((res > 0) && (strncmp(buf, "+CGREG:", 6) == 0)) {
+        res = atoi(buf + 9);
+    }
+    else {
+        res = -1;
+    }
+
+    return res;
+}

--- a/drivers/gsm/gsm.c
+++ b/drivers/gsm/gsm.c
@@ -1,0 +1,850 @@
+/*
+ * Copyright (C) 2016 Kaspar Schleiser <kaspar@schleiser.de>
+ * Copyright (C) 2018 OTA keys S.A.
+ * Copyright (C) 2018 Max van Kessel
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+#include <ctype.h>
+#include <stdint.h>
+#include <string.h>
+#include <stdlib.h>
+#include <errno.h>
+
+#include "log.h"
+#include "fmt.h"
+#include "xtimer.h"
+
+#include "periph/gpio.h"
+
+#include "gsm.h"
+
+#include "include/gsm_internal.h"
+
+/**
+ * @ingroup     drivers_gsm
+ * @{
+ *
+ * @file
+ * @brief       Generic gsm implementation.
+ *
+ * @author
+ *
+ * @}
+ */
+
+#define MODULE  "gsm: "
+
+#ifdef MODULE_AT_URC
+#define GSM_HAS_THREAD
+#endif
+
+#ifdef MODULE_AT_URC
+static void * idle_thread(void *arg);
+#endif
+
+#ifdef MODULE_AT_URC
+static void creg_cb(void *arg, const char *buf);
+#endif
+
+#ifdef MODULE_PERIPH_GPIO_IRQ
+static void ring_cb(void *arg);
+#endif
+
+int gsm_init(gsm_t *dev, const gsm_params_t *params, const gsm_driver_t *driver)
+{
+    int err = -EINVAL;
+
+    if(dev){
+        /* initialize and lock device */
+        rmutex_init(&dev->mutex);
+        rmutex_lock(&dev->mutex);
+
+        /* store provided parameters in device */
+        dev->params = params;
+        dev->driver = driver;
+
+        /* initialize AT device */
+        err = at_dev_init(&dev->at_dev, params->uart, params->baudrate,
+                            dev->buffer, GSM_UART_BUFSIZE);
+
+        if(err) {
+            LOG_WARNING(MODULE"failed to initialize at parser with %d\n", err);
+            goto out;
+        }
+
+        if((dev->driver) && (dev->driver->init_base)) {
+            err = dev->driver->init_base(dev);
+
+            if(err) {
+                LOG_WARNING(MODULE"failed to initialize base with %d\n", err);
+                goto out;
+            }
+        }
+
+#ifdef MODULE_PERIPH_GPIO_IRQ
+        if(dev->params->ri_pin != GPIO_UNDEF) {
+            gpio_init_int(dev->params->ri_pin, GPIO_IN, GPIO_FALLING, ring_cb, dev);
+        }
+#endif
+
+#ifdef GSM_HAS_THREAD
+        dev->pid = thread_create(dev->stack, GSM_THREAD_STACKSIZE, GSM_THREAD_PRIO,
+                THREAD_CREATE_STACKTEST, idle_thread, dev, "gsm");
+#endif
+
+out:
+        gsm_unlock(dev);
+    }
+
+    return err;
+}
+
+void gsm_lock(gsm_t *dev)
+{
+    rmutex_lock(&dev->mutex);
+}
+
+void gsm_unlock(gsm_t *dev)
+{
+    rmutex_unlock(&dev->mutex);
+}
+
+int gsm_poweron(gsm_t *dev)
+{
+    int err = -EINVAL;
+
+    if (dev) {
+        gsm_lock(dev);
+
+        dev->state = GSM_BOOT;
+
+        if ((dev->driver) && (dev->driver->power_on)) {
+            err = dev->driver->power_on(dev);
+
+            if (err < 0) {
+                LOG_WARNING(MODULE"failed to power on\n");
+
+                dev->state = GSM_OFF;
+            }
+            else {
+                dev->state = GSM_ON;
+            }
+        }
+
+        if (dev->state == GSM_ON) {
+            at_dev_poweron(&dev->at_dev);
+
+            /* enable network registration unsolicited result code */
+            err = at_send_cmd_wait_ok(&dev->at_dev, "AT+CREG="GSM_URC_CREG, GSM_SERIAL_TIMEOUT_US);
+            if (err < 0) {
+                LOG_INFO(MODULE"failed to enable unsolicited result for CREG\n");
+            }
+
+            /* set error result codes to numeric values */
+            err = at_send_cmd_wait_ok(&dev->at_dev, "AT+CMEE=1", GSM_SERIAL_TIMEOUT_US);
+            if (err < 0) {
+                LOG_INFO(MODULE"failed to enable extended error notification CMEE\n");
+            }
+        }
+
+        gsm_unlock(dev);
+    }
+
+    return err;
+}
+
+void gsm_poweroff(gsm_t *dev)
+{
+    if (dev) {
+        int err = -EINVAL;
+        gsm_lock(dev);
+
+        err = at_send_cmd_wait_ok(&dev->at_dev, "AT+CFUN=0", GSM_SERIAL_TIMEOUT_US * 3);
+
+        if ((dev->driver) && (dev->driver->power_off)) {
+            err = dev->driver->power_off(dev);
+
+            if (err < 0) {
+                LOG_WARNING(MODULE"failed to power off\n");
+            }
+            else {
+                at_dev_poweroff(&dev->at_dev);
+
+                dev->state = GSM_OFF;
+            }
+        }
+        gsm_unlock(dev);
+    }
+}
+
+int gsm_wake_up(gsm_t *dev)
+{
+    int err = -EINVAL;
+    if (dev) {
+
+        gsm_lock(dev);
+
+        if ((dev->driver) && (dev->driver->wake_up)) {
+            err = dev->driver->wake_up(dev);
+
+            if (err < 0) {
+                LOG_WARNING(MODULE"failed to wake\n");
+            }
+            else {
+                dev->state = GSM_UNDEFINED;
+                err = -1;
+            }
+        }
+        gsm_unlock(dev);
+    }
+
+    return err;
+}
+
+void gsm_sleep(gsm_t *dev)
+{
+    if (dev) {
+        gsm_lock(dev);
+
+        if ((dev->driver) && (dev->driver->sleep)) {
+            dev->driver->sleep(dev);
+
+            dev->state = GSM_SLEEP;
+        }
+        gsm_unlock(dev);
+    }
+}
+
+int gsm_enable_radio(gsm_t *dev)
+{
+    int err = -EINVAL;
+
+    if (dev) {
+        gsm_lock(dev);
+
+        err = at_send_cmd_wait_ok(&dev->at_dev, "AT+CFUN=1",
+        GSM_SERIAL_TIMEOUT_US * 30);
+
+        gsm_unlock(dev);
+    }
+
+    return err;
+}
+
+int gsm_disable_radio(gsm_t *dev)
+{
+    int err = -EINVAL;
+
+    if (dev) {
+        gsm_lock(dev);
+
+        err = at_send_cmd_wait_ok(&dev->at_dev, "AT+CFUN=0",
+                                    GSM_SERIAL_TIMEOUT_US * 30);
+
+        gsm_unlock(dev);
+    }
+
+    return err;
+}
+
+bool __attribute__((weak)) gsm_is_alive(gsm_t *dev, uint8_t retries)
+{
+    bool alive = false;
+    if (dev) {
+        int err;
+        /* send AT to see if it's alive */
+        do {
+            err = at_send_cmd_wait_ok(&dev->at_dev, "AT",
+                                        GSM_SERIAL_TIMEOUT_US);
+
+            xtimer_usleep(GSM_SERIAL_TIMEOUT_US);
+        } while (err != 0 && (retries--));
+
+        if (err == 0) {
+            alive = true;
+        }
+    }
+    return alive;
+}
+
+int gsm_set_puk(gsm_t *dev, const char *puk, const char *pin)
+{
+    int res = -EINVAL;
+
+    if ((strlen(pin) == 4)) {
+        char buf[GSM_AT_LINEBUFFER_SIZE_SMALL];
+        char *pos = buf;
+        bool quotes = false;
+
+        pos += fmt_str(pos, "AT+CPIN=");
+        if (strlen(puk) == 8) {
+            pos += fmt_str(pos, "\"");
+            pos += fmt_str(pos, puk);
+            pos += fmt_str(pos, "\",\"");
+
+            quotes = true;
+        }
+        pos += fmt_str(pos, pin);
+        if (quotes) {
+            pos += fmt_str(pos, "\"");
+        }
+        *pos = '\0';
+
+        gsm_lock(dev);
+
+        res = at_send_cmd_get_resp(&dev->at_dev, buf, buf,
+                        GSM_AT_LINEBUFFER_SIZE_SMALL, GSM_SERIAL_TIMEOUT_US);
+
+        gsm_unlock(dev);
+
+        if (res > 0) {
+            /* if one matches (equals 0), return 0 */
+            res = strncmp(buf, "OK", 2) && strncmp(buf, "+CPIN: READY", 12);
+
+            if (res > 0) {
+                LOG_INFO(MODULE"unexpected response: %s\n", buf);
+            }
+        }
+    }
+
+    return res;
+}
+
+int gsm_set_pin(gsm_t *dev, const char *pin)
+{
+    return gsm_set_puk(dev, NULL, pin);
+}
+
+
+int gsm_check_pin(gsm_t *dev)
+{
+    int res;
+    char linebuf[GSM_AT_LINEBUFFER_SIZE_SMALL];
+
+    gsm_lock(dev);
+
+    res = at_send_cmd_get_resp(&dev->at_dev, "AT+CPIN?", linebuf,
+            GSM_AT_LINEBUFFER_SIZE_SMALL, GSM_SERIAL_TIMEOUT_US);
+
+    gsm_unlock(dev);
+
+    if (res > 0) {
+        if (!strncmp(linebuf, "OK", res)) {
+            res = 0;
+        }
+        else if (!strcmp(linebuf, "+CPIN: READY")) {
+            /* sim is ready */
+            res = 0;
+        }
+        else if (!strcmp(linebuf, "+CPIN: SIM PIN")) {
+            /* sim needs pin */
+            res = 1;
+        }
+        else {
+            LOG_INFO(MODULE"unexpected response: %s\n", linebuf);
+            res = -1;
+        }
+    }
+
+    return res;
+}
+
+int gsm_check_operator(gsm_t *dev)
+{
+    char buf[GSM_AT_LINEBUFFER_SIZE];
+
+    gsm_lock(dev);
+
+    int res = at_send_cmd_get_resp(&dev->at_dev, "AT+COPS?", buf, sizeof(buf),
+                                    GSM_SERIAL_TIMEOUT_US);
+    if ((res > 0) && (strncmp(buf, "+COPS:", 6) == 0)) {
+        res = 0;
+    }
+    else {
+        res = -1;
+    }
+
+    gsm_unlock(dev);
+
+    return res;
+}
+
+size_t gsm_get_operator(gsm_t *dev, char *outbuf, size_t len, uint8_t * tech)
+{
+    char buf[GSM_AT_LINEBUFFER_SIZE];
+    char *pos = buf;
+
+    gsm_lock(dev);
+
+    int res = at_send_cmd_get_resp(&dev->at_dev, "AT+COPS?", buf, sizeof(buf),
+                                    GSM_SERIAL_TIMEOUT_US);
+
+    gsm_unlock(dev);
+
+    if (res > 0) {
+        /* +COPS: 1,0,"NL KPN KPN",8 */
+        if (strncmp(pos, "+COPS:", 6) == 0) {
+            size_t outlen = 0;
+            if (res < 10) {
+                /* not registered yet */
+                res = -1;
+            }
+            else {
+                /* skip '+COPS: [0-3],[0-3],"' */
+                pos = strchr(buf, '"');
+                while ((*(++pos) != '"') && (len--)) {
+                    *outbuf++ = *pos;
+                    outlen++;
+                }
+                if (len) {
+                    *outbuf = '\0';
+                    res = outlen;
+                }
+                else {
+                    res = -ENOSPC;
+                }
+
+                if (tech) {
+                    if (*(++pos) == ',') {
+                        *tech = (uint8_t)scn_u32_dec(++pos, 1);
+                    }
+                }
+            }
+        }
+        else {
+            res = -1;
+            LOG_INFO(MODULE"unexpected response: %s\n", buf);
+        }
+    }
+
+    return res;
+}
+
+ssize_t gsm_get_imei(gsm_t *dev, char *buf, size_t len)
+{
+    gsm_lock(dev);
+
+    int res = at_send_cmd_get_resp(&dev->at_dev, "AT+GSN", buf, len,
+                                    GSM_SERIAL_TIMEOUT_US);
+    if (res > 0) {
+        buf[res] = '\0';
+    }
+    else {
+        res = -1;
+    }
+
+    gsm_unlock(dev);
+
+    return res;
+}
+
+ssize_t gsm_get_imsi(gsm_t *dev, char *buf, size_t len)
+{
+    gsm_lock(dev);
+
+    int res = at_send_cmd_get_resp(&dev->at_dev, "AT+CIMI", buf, len,
+            GSM_SERIAL_TIMEOUT_US);
+
+    if (res > 0) {
+        if ((strncmp(buf, "+CME ERROR:", 10) == 0)
+                        || (strncmp(buf, "ERROR:", 6) == 0)) {
+            res = -1;
+            LOG_INFO(MODULE"unexpected response: %s\n", buf);
+        }
+    }
+    else {
+        res = -1;
+    }
+
+    gsm_unlock(dev);
+
+    return res;
+}
+
+ssize_t gsm_get_simcard_identification(gsm_t *dev, char *outbuf, size_t len)
+{
+    int err = -EINVAL;
+
+    if(dev) {
+        char buf[GSM_AT_LINEBUFFER_SIZE];
+        char *pos = buf;
+
+
+        gsm_lock(dev);
+
+        err = at_send_cmd_get_resp(&dev->at_dev, "AT+CCID", buf, len,
+                                    GSM_SERIAL_TIMEOUT_US);
+
+        gsm_unlock(dev);
+
+        if (err <= 0) {
+            if (err == 0) {
+                err = -1;
+            }
+            goto out;
+        }
+
+        if (strncmp(buf, "+CCID:", 6) == 0) {
+            pos = strchr(buf, ':');
+            if (pos) {
+                size_t outlen = 0;
+                while ((!isalnum((uint8_t )(*(++pos))))
+                                && ((buf + GSM_AT_LINEBUFFER_SIZE) > pos)) {
+                }
+
+                while ((isalnum((uint8_t )*pos)) && (len--)) {
+                    *outbuf++ = *pos++;
+                    outlen++;
+                }
+                if (len) {
+                    *outbuf = '\0';
+                    err = outlen;
+                }
+                else {
+                    err = -ENOSPC;
+                }
+            }
+        }
+        else {
+            err = -1;
+        }
+    }
+out:
+    return err;
+}
+
+ssize_t gsm_get_identification(gsm_t *dev, char *buf, size_t len)
+{
+    ssize_t res = -1;
+    if(dev && buf){
+
+        gsm_lock(dev);
+
+        res = at_send_cmd_get_lines(&dev->at_dev, "ATI", buf, len, false,
+                GSM_SERIAL_TIMEOUT_US);
+
+        gsm_unlock(dev);
+
+        if (res >= 0) {
+            char * pos = &buf[res -1]; /* will provide the pointer to index of the terminator */
+
+            /* OK is still in the buffer, so find final character */
+            if (strncmp(pos - 2, "OK", 2) == 0) {
+                pos -= 2;
+
+                while (--pos != buf) {
+                    if (isalnum((uint8_t)*pos)) {
+                        break;
+                    }
+                }
+
+                *(++pos) = '\0';
+                res = pos - buf;
+            }
+        }
+    }
+
+    return res;
+}
+
+int __attribute__((weak)) gsm_signal_to_rssi(unsigned rssi)
+{
+    return (int)rssi;
+}
+
+int gsm_get_signal(gsm_t *dev, int *rssi, unsigned *ber)
+{
+    char buf[32];
+    char *pos = buf;
+
+    gsm_lock(dev);
+
+    int res = at_send_cmd_get_resp(&dev->at_dev, "AT+CSQ", buf, sizeof(buf),
+            GSM_SERIAL_TIMEOUT_US);
+    if ((res > 2) && strncmp(buf, "+CSQ: ", 6) == 0) {
+        pos += 6; /* skip "+CSQ: " */
+        *rssi = gsm_signal_to_rssi(scn_u32_dec(pos, 2));
+        pos += 2 + (*rssi > 9); /* skip rssi value ( n, or nn,) */
+        *ber = scn_u32_dec(pos, 2);
+        res = 0;
+    }
+    else {
+        res = -1;
+    }
+
+    gsm_unlock(dev);
+
+    return res;
+}
+
+int gsm_get_registration(gsm_t *dev, uint16_t * location_id, uint32_t * cell_id)
+{
+    int res = -EINVAL;
+
+    if(dev) {
+        char buf[GSM_AT_LINEBUFFER_SIZE];
+
+        gsm_lock(dev);
+
+        res = at_send_cmd_get_resp(&dev->at_dev, "AT+CREG?", buf, sizeof(buf),
+                                    GSM_SERIAL_TIMEOUT_US);
+        gsm_unlock(dev);
+
+        if ((res > 0) && (strncmp(buf, "+CREG:", 6) == 0)) {
+            char * pos = strtok(buf, ",");
+            if (pos) {
+                int registration;
+                /* skip first token */
+                pos = strtok(NULL, ",");
+
+                registration = atoi(pos);
+
+                pos = strtok(NULL, ",");
+
+                /* creg extension: +CREG: 2,1,"008E","CE87" */
+                if ((pos != NULL) && (location_id)) {
+                    char loc[5] = { 0 };
+                    char * loc_ptr = &loc[0];
+                    unsigned int len = res - (++pos - buf);
+                    while ((*(pos) != '"') && (len--)) {
+                        *loc_ptr++ = *pos++;
+                    }
+
+                    *location_id = strtol(loc, NULL, 16);
+                }
+
+                pos = strtok(NULL, ",");
+
+                if ((pos != NULL) && (cell_id)) {
+                    char cell[9] = { 0 };
+                    char * cell_ptr = &cell[0];
+                    unsigned int len = res - (++pos - buf);
+                    while ((*(pos) != '"') && (len--)) {
+                        *cell_ptr++ = *pos++;
+                    }
+
+                    *cell_id = strtol(cell, NULL, 16);
+                }
+
+                res = registration;
+            }
+            else {
+                res = -1;
+            }
+        }
+        else {
+            res = -1;
+        }
+    }
+
+    return res;
+}
+
+ssize_t __attribute__((weak)) gsm_get_local_time(gsm_t *dev, char * outbuf, size_t len)
+{
+    ssize_t res = -1;
+    if(dev && outbuf) {
+        char buf[GSM_AT_LINEBUFFER_SIZE];
+
+        gsm_lock(dev);
+
+        res = at_send_cmd_get_lines(&dev->at_dev, "AT+CCLK?", buf,
+                GSM_AT_LINEBUFFER_SIZE, false, GSM_SERIAL_TIMEOUT_US);
+
+        gsm_unlock(dev);
+
+        if (res > 0) {
+            if (strncmp(buf, "+CCLK:", 6) == 0) {
+                char * pos = strchr(buf, '"');
+                if (pos) {
+                    size_t outlen = 0;
+                    while ((*(++pos) != '"') && (len--)) {
+                        *outbuf++ = *pos;
+                        outlen++;
+                    }
+                    if (len) {
+                        *outbuf = '\0';
+                        res = outlen;
+                    }
+                    else {
+                        res = -ENOSPC;
+                    }
+                }
+                else {
+                    res = -1;
+                }
+            }
+        }
+    }
+
+    return res;
+}
+
+
+ssize_t gsm_cmd(gsm_t *dev, const char *cmd, uint8_t *buf, size_t len, unsigned timeout)
+{
+    gsm_lock(dev);
+
+    ssize_t res = at_send_cmd_get_lines(&dev->at_dev, cmd, (char *)buf, len,
+                                        true, (uint32_t)US_PER_SEC * timeout);
+
+    gsm_unlock(dev);
+
+    return res;
+}
+
+
+void gsm_print_status(gsm_t *dev)
+{
+    char buf[GSM_AT_LINEBUFFER_SIZE];
+    uint16_t loc;
+    uint32_t cell;
+
+    int res = gsm_get_identification(dev, buf, GSM_AT_LINEBUFFER_SIZE);
+
+    if (res >= 2) {
+        printf("device type %s\n", buf);
+    }
+    else {
+        printf("error reading device type!\n");
+    }
+
+    res = gsm_get_imei(dev, buf, GSM_AT_LINEBUFFER_SIZE);
+    if (res >= 0) {
+        printf("IMEI: \"%s\"\n", buf);
+    }
+    else {
+        printf("error getting IMEI\n");
+    }
+
+    res = gsm_get_simcard_identification(dev, buf, GSM_AT_LINEBUFFER_SIZE);
+    if (res >= 0) {
+        printf("ICCID: \"%s\"\n", buf);
+    }
+    else {
+        printf("error getting ICCID\n");
+    }
+
+    res = gsm_get_imsi(dev, buf, GSM_AT_LINEBUFFER_SIZE);
+    if (res >= 0) {
+        printf("IMSI: \"%s\"\n", buf);
+    }
+    else {
+        printf("error getting IMSI\n");
+    }
+
+    res = gsm_get_registration(dev, &loc, &cell);
+    if (res > 0) {
+        uint8_t tech = -1;
+        printf("registration code: %d\n", res);
+        printf("location id: %X\n", loc);
+        printf("cell id: %X\n", cell);
+
+        res = gsm_get_operator(dev, buf, GSM_AT_LINEBUFFER_SIZE, &tech);
+        if (res >= 0) {
+            if ((char)tech != -1) {
+                printf("registered to \"%s\" (%u)\n", buf, tech);
+            }
+            else {
+                printf("registered to \"%s\"\n", buf);
+            }
+        }
+        else {
+            printf("no operator\n");
+        }
+    }
+    else {
+        printf("not registered\n");
+    }
+
+    int rssi;
+    unsigned ber;
+    res = gsm_get_signal(dev, &rssi, &ber);
+    if (res == 0) {
+        printf(MODULE"RSSI= %ddBm ber=%u%%\n", rssi, ber);
+    }
+    else {
+        printf(MODULE"error getting signal strength\n");
+    }
+}
+
+#ifdef MODULE_AT_URC
+void gsm_register_urc_callback(gsm_t *dev, at_urc_t *urc)
+{
+    if(dev) {
+        gsm_lock(dev);
+
+        at_add_urc(&dev->at_dev, urc);
+
+        gsm_unlock(dev);
+    }
+}
+
+#endif
+
+#ifdef GSM_HAS_THREAD
+static void * idle_thread(void *arg)
+{
+    gsm_t *dev = arg;
+    assert(dev);
+
+#ifdef MODULE_AT_URC
+    unsigned i;
+    at_urc_t urc[] = {
+        {
+            .code = "+CREG",
+            .cb = creg_cb,
+            .arg = dev,
+        },
+    };
+
+    gsm_lock(dev);
+
+    /* register all unsolicited result codes */
+    for (i = 0; i < sizeof(urc) / sizeof(urc[0]); i++) {
+        at_add_urc(&dev->at_dev, &urc[i]);
+    }
+
+    gsm_unlock(dev);
+#endif
+
+    while(1) {
+        if (dev->state >= GSM_ON) {
+#ifdef MODULE_AT_URC
+            gsm_lock(dev);
+            at_process_urc(&dev->at_dev, 1000 * US_PER_MS);
+            gsm_unlock(dev);
+#endif
+        }
+        thread_sleep();
+    }
+
+    return NULL;
+}
+#endif
+
+#ifdef MODULE_AT_URC
+static void creg_cb(void *arg, const char *buf)
+{
+    (void)arg;
+    LOG_DEBUG(MODULE"CREG received: %s\n", buf);
+}
+#endif
+
+#ifdef MODULE_PERIPH_GPIO_IRQ
+static void ring_cb(void *arg)
+{
+#ifdef GSM_HAS_THREAD
+    if (arg) {
+        thread_wakeup(((gsm_t *)arg)->pid);
+    }
+#else
+    (void)arg;
+#endif
+    LOG_DEBUG(MODULE"ring!");
+}
+#endif

--- a/drivers/gsm/gsm.c
+++ b/drivers/gsm/gsm.c
@@ -163,7 +163,7 @@ void gsm_poweroff(gsm_t *dev)
         int err = -EINVAL;
         gsm_lock(dev);
 
-        err = at_send_cmd_wait_ok(&dev->at_dev, "AT+CFUN=0", GSM_SERIAL_TIMEOUT_US * 3);
+        at_send_cmd_wait_ok(&dev->at_dev, "AT+CFUN=0", GSM_SERIAL_TIMEOUT_US * 3);
 
         if ((dev->driver) && (dev->driver->power_off)) {
             err = dev->driver->power_off(dev);

--- a/drivers/gsm/include/gsm_internal.h
+++ b/drivers/gsm/include/gsm_internal.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2018 Max van Kessel
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     drivers_gsm
+ * @brief
+ *
+ * @{
+ *
+ * @file
+ * @brief
+ *
+ * @author  Max van Kessel
+ */
+#ifndef GSM_INTERNAL_H
+#define GSM_INTERNAL_H
+
+#include <stdint.h>
+
+#include "gsm.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief locks the gsm with a mutal exclusion
+ *
+ * @param dev   gsm device to lock
+ */
+void gsm_lock(gsm_t *dev);
+
+/**
+ * @brief unlocks the gsm
+ *
+ * @param dev   gsm device to unlock
+ */
+void gsm_unlock(gsm_t *dev);
+
+/**
+ * @brief Calculates signal value to rssi value in dBm
+ *
+ * @param signal    signal to convert
+ *
+ * @return  RSSI value in dBm
+ */
+int gsm_signal_to_rssi(unsigned signal);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GSM_INTERNAL_H */

--- a/drivers/gsm/include/gsm_internal.h
+++ b/drivers/gsm/include/gsm_internal.h
@@ -56,3 +56,4 @@ int gsm_signal_to_rssi(unsigned signal);
 #endif
 
 #endif /* GSM_INTERNAL_H */
+/** @} */

--- a/drivers/gsm/quectel.c
+++ b/drivers/gsm/quectel.c
@@ -317,4 +317,3 @@ int gsm_signal_to_rssi(unsigned signal)
 
     return rssi;
 }
-

--- a/drivers/gsm/quectel.c
+++ b/drivers/gsm/quectel.c
@@ -1,0 +1,320 @@
+/*
+ * Copyright (C) 2018 Max van Kessel
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+#include <assert.h>
+#include <errno.h>
+
+#include "log.h"
+#include "xtimer.h"
+#include "quectel.h"
+
+#include "gsm/call.h"
+
+#include "include/gsm_internal.h"
+
+/**
+ * @ingroup     drivers_gsm_quectel
+ * @{
+ *
+ * @file
+ * @brief       Generic Quectel implementation.
+ *
+ * @author      Max van Kessel
+ *
+ * @}
+ */
+
+#define MODULE  "quectel: "
+
+static inline int configure_interface_control(gsm_t *dev);
+
+int quectel_init(gsm_t *dev)
+{
+    int err = -EINVAL;
+
+    if (dev) {
+        quectel_params_t *params = (quectel_params_t *)dev->params;
+
+        assert(params->power_pin != GPIO_UNDEF);
+
+        gsm_lock(dev);
+
+        /* make sure reset pin at modem is (high) idle */
+        if (params->reset_pin != GPIO_UNDEF) {
+            gpio_write(params->reset_pin, params->invert_reset_pin ? 1 : 0);
+        }
+
+        if (params->status_pin != GPIO_UNDEF) {
+            bool status = gpio_read(params->status_pin);
+            if (params->invert_status_pin) {
+                status = !status;
+            }
+
+            if (status) {
+                err = configure_interface_control(dev);
+
+                LOG_DEBUG(MODULE"device already on\n");
+
+                dev->state = GSM_ON;
+            }
+        }
+
+        err = 0;
+
+        gsm_unlock(dev);
+    }
+    return err;
+}
+
+int quectel_power_on(gsm_t *dev)
+{
+    int err = -EINVAL;
+
+    if ((dev) && (dev->params)) {
+        bool status = false;
+        quectel_params_t * params = (quectel_params_t *)dev->params;
+
+        gsm_lock(dev);
+
+        if (params->status_pin != GPIO_UNDEF) {
+            status = gpio_read(params->status_pin);
+            if (params->invert_status_pin) {
+                status = !status;
+            }
+        }
+
+        if (!status) {
+            if (params->reset_pin != GPIO_UNDEF) {
+                gpio_write(params->reset_pin, params->invert_reset_pin ? 1 : 0);
+            }
+
+            gpio_write(params->power_pin, params->invert_power_pin ? 1 : 0);
+            xtimer_usleep(QUECTEL_POWER_KEY_ON_TIME_US);
+            gpio_write(params->power_pin, params->invert_power_pin ? 0 : 1);
+
+            if (params->status_pin != GPIO_UNDEF) {
+                uint32_t timeout = QUECTEL_STATUS_DETECT_TIMEOUT_US;
+                while ((!status) && (timeout--)) {
+                    xtimer_usleep(1);
+
+                    status = gpio_read(params->status_pin);
+                    if (params->invert_status_pin) {
+                        status = !status;
+                    }
+                }
+
+                /* give modem some more time to boot */
+                xtimer_usleep(US_PER_SEC);
+            }
+            else {
+                status = gsm_is_alive(dev, 5);
+            }
+        }
+        else {
+            LOG_DEBUG(MODULE"device already on\n");
+        }
+
+        if (status) {
+            (void)configure_interface_control(dev);
+        }
+
+        err = status ? 0 : -1;
+
+        gsm_unlock(dev);
+    }
+
+    return err;
+}
+
+int quectel_power_off(gsm_t *dev)
+{
+    int err = -EINVAL;
+
+    if ((dev) && (dev->params)) {
+        bool status = true;
+        quectel_params_t * params = (quectel_params_t *)dev->params;
+
+       gsm_lock(dev);
+
+        if (params->status_pin != GPIO_UNDEF) {
+            status = gpio_read(params->status_pin);
+            if (params->invert_status_pin) {
+                status = !status;
+            }
+        }
+
+        if (status) {
+            gpio_write(params->power_pin, params->invert_power_pin ? 1 : 0);
+            xtimer_usleep(QUECTEL_POWER_KEY_OFF_TIME_US);
+            gpio_write(params->power_pin, params->invert_power_pin ? 0 : 1);
+
+            if (params->status_pin != GPIO_UNDEF) {
+                uint32_t timeout = QUECTEL_STATUS_DETECT_TIMEOUT_US;
+                while ((status) && (timeout--)) {
+                    xtimer_usleep(1);
+
+                    status = gpio_read(params->status_pin);
+                    if (params->invert_status_pin) {
+                        status = !status;
+                    }
+                }
+            }
+            else {
+                status = false;
+            }
+        }
+        else {
+            LOG_DEBUG(MODULE"device already off\n");
+        }
+
+        err = (!status) ? 0 : -1;
+
+        gsm_unlock(dev);
+    }
+
+    return err;
+}
+
+bool gsm_is_alive(gsm_t *dev, uint8_t retries)
+{
+    bool alive = false;
+    if (dev) {
+        int err;
+        quectel_params_t * params = (quectel_params_t *)dev->params;
+
+        if (params->status_pin != GPIO_UNDEF) {
+            alive = gpio_read(params->status_pin);
+            if (params->invert_status_pin) {
+                alive = !alive;
+            }
+        }
+        else {
+            /* send AT to see if it's alive */
+            do {
+                err = at_send_cmd_wait_ok(&dev->at_dev, "AT", GSM_SERIAL_TIMEOUT_US);
+
+                xtimer_usleep(GSM_SERIAL_TIMEOUT_US);
+            } while (err != 0 && (retries--));
+
+            if (err == 0) {
+                alive = true;
+            }
+        }
+    }
+    return alive;
+}
+
+void quectel_sleep(gsm_t *dev)
+{
+    (void)dev;
+}
+
+void quectel_reset(gsm_t *dev)
+{
+    if (dev) {
+        quectel_params_t * params = (quectel_params_t *)dev->params;
+
+        /* make sure reset pin at modem is (high) idle */
+        if (params->reset_pin != GPIO_UNDEF) {
+
+            gpio_write(params->reset_pin, params->invert_reset_pin ? 0 : 1);
+            xtimer_usleep(QUECTEL_RESET_TIME_US);
+            gpio_write(params->reset_pin, params->invert_reset_pin ? 0 : 1);
+        }
+    }
+}
+
+static inline int configure_interface_control(gsm_t *dev)
+{
+    int err = 0;
+    quectel_params_t *params = (quectel_params_t *)dev->params;
+
+    if (params->dtr_pin != GPIO_UNDEF) {
+        gpio_clear(params->dtr_pin);
+
+        /* set DTR pin: change to command mode while connected call is active*/
+        err = at_send_cmd_wait_ok(&dev->at_dev, "AT&D1", GSM_SERIAL_TIMEOUT_US);
+    }
+
+    if (params->dcd_pin != GPIO_UNDEF) {
+        /* set DCD pin: function is ON only in presence of data carrier */
+        err = at_send_cmd_wait_ok(&dev->at_dev, "AT&C1", GSM_SERIAL_TIMEOUT_US);
+    }
+
+    return err;
+}
+
+
+const gsm_driver_t quectel_driver = {
+    .init_base  = quectel_init,
+    .power_on   = quectel_power_on,
+    .power_off  = quectel_power_off,
+    .sleep      = quectel_sleep,
+    .reset      = quectel_reset,
+};
+
+int gsm_call_switch_to_command_mode(gsm_t *dev)
+{
+    int err = -EINVAL;
+
+    if (dev) {
+        if (dev->state == GSM_PPP) {
+
+            quectel_params_t *params = (quectel_params_t *)dev->params;
+
+            dev->state = GSM_ON;
+
+            gsm_lock(dev);
+
+            if (params->dtr_pin != GPIO_UNDEF) {
+                gpio_set(params->dtr_pin);
+
+                xtimer_usleep(100 * US_PER_MS);
+
+                gpio_clear(params->dtr_pin);
+
+                /* verify command mode */
+                err = at_send_cmd_wait_ok(&dev->at_dev, "AT", GSM_SERIAL_TIMEOUT_US);
+            }
+            else {
+                err = at_send_cmd_wait_ok(&dev->at_dev, "+++", GSM_SERIAL_TIMEOUT_US);
+            }
+
+            gsm_unlock(dev);
+
+            if (err != 0) {
+                dev->state = GSM_PPP;
+            }
+        }
+        else {
+            err = 0;
+        }
+    }
+
+    return err;
+}
+
+int gsm_signal_to_rssi(unsigned signal)
+{
+    int rssi = 0;
+
+    if ((signal != 99) && (signal != 199)) {
+        if (signal == 0) {
+            rssi = -113;
+        }
+        else if ((signal >= 1) && (signal <= 31)) {
+            rssi = (int)(2 * signal) - 113;
+        }
+        else if ((signal >= 100) && (signal <= 191)) {
+            rssi = (int)(signal) - 216;
+        }
+    }
+
+    return rssi;
+}
+

--- a/drivers/gsm/sms.c
+++ b/drivers/gsm/sms.c
@@ -1,0 +1,259 @@
+/*
+ * Copyright (C) 2018 OTA keys S.A.
+ * Copyright (C) 2018 Max van Kessel
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+#include <assert.h>
+#include <errno.h>
+#include <stdbool.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "fmt.h"
+#include "log.h"
+
+#include "gsm/sms.h"
+
+/**
+ * @ingroup     drivers_gsm
+ * @{
+ *
+ * @file
+ * @brief       gsm sms implementation.
+ *
+ * @author      Vincent Dupont <vincent@otakeys.com>
+ * @author      Max van Kessel
+ *
+ * @}
+ */
+
+#define MODULE  "gsm_sms: "
+
+#define GSM_SMS_FIELD_NUMOF     (11)
+#define GSM_SMS_FIELD_SENDER_ID (1)
+#define GSM_SMS_FIELD_DATE_ID   (3)
+#define GSM_SMS_FIELD_LEN_ID    (GSM_SMS_FIELD_NUMOF - 1)
+
+static void sms_callback(void *arg, const char *buf);
+
+int gsm_sms_init(gsm_sms_t *sms, gsm_t *dev)
+{
+    int err = -EINVAL;
+
+    assert(dev);
+    assert(sms);
+
+    sms->base = dev;
+
+    return err;
+}
+
+int gsm_sms_set_format(gsm_sms_t * sms, gsm_sms_message_format_t format)
+{
+    int err = -EINVAL;
+
+    if (sms) {
+        gsm_t *dev = sms->base;
+        char buf[GSM_AT_LINEBUFFER_SIZE_SMALL];
+        char *pos = buf;
+
+        assert(dev);
+
+        pos += fmt_str(pos, "AT+CMGF=");
+        pos += fmt_u32_dec(pos, format);
+        *pos = '\0';
+
+        gsm_lock(dev);
+
+        err = at_send_cmd_wait_ok(&dev->at_dev, buf, GSM_SERIAL_TIMEOUT_US);
+
+        gsm_unlock(dev);
+    }
+    return err;
+}
+
+int gsm_sms_set_characters(gsm_sms_t * sms, const char * set)
+{
+    int err = -EINVAL;
+
+    if (sms) {
+        gsm_t *dev = sms->base;
+        char buf[GSM_AT_LINEBUFFER_SIZE_SMALL];
+        char *pos = buf;
+
+        assert(dev);
+
+        pos += fmt_str(pos, "AT+CSCS=");
+
+        if (set) {
+            pos += fmt_str(pos, set);
+        }
+        else {
+            pos += fmt_str(pos, GSM_SMS_DEFAULT_CHARACTER_SET);
+        }
+        *pos = '\0';
+
+        gsm_lock(dev);
+
+        err = at_send_cmd_wait_ok(&dev->at_dev, buf, GSM_SERIAL_TIMEOUT_US);
+
+        gsm_unlock(dev);
+    }
+
+    return err;
+}
+
+int gsm_sms_enable_reception(gsm_sms_t * sms, gsm_sms_cb_t cb, void *arg)
+{
+    int err = -EINVAL;
+
+    if (sms) {
+        gsm_t *dev = sms->base;
+        char buf[GSM_AT_LINEBUFFER_SIZE_SMALL];
+
+        gsm_lock(dev);
+
+        sms->callback = cb;
+        sms->callback_args = arg;
+
+        /* new message indications */
+        err = at_send_cmd_wait_ok(&dev->at_dev, "AT+CNMI=1,1", GSM_SERIAL_TIMEOUT_US);
+
+        if (err < 0) {
+            goto out;
+        }
+
+        /* set header info */
+        err = at_send_cmd_wait_ok(&dev->at_dev, "AT+CSDH=1", GSM_SERIAL_TIMEOUT_US);
+
+        if (err < 0) {
+            goto out;
+        }
+
+        /* set default storage, stores sms into modem */
+        err = at_send_cmd_get_lines(&dev->at_dev,
+                "AT+CPMS=\"ME\",\"ME\",\"ME\"", buf,
+                GSM_AT_LINEBUFFER_SIZE_SMALL, false, GSM_SERIAL_TIMEOUT_US);
+
+        if (err < 0) {
+            goto out;
+        }
+
+        /* delete all messages */
+        err = at_send_cmd_wait_ok(&dev->at_dev, "AT+CMGD=0,4", GSM_SERIAL_TIMEOUT_US);
+
+#ifdef MODULE_AT_URC
+        static at_urc_t urc = {
+            .code = "+CMTI",
+            .cb = sms_callback,
+            .arg = sms,
+        };
+
+        gsm_register_urc_callback(dev, &urc);
+#endif
+out:
+        gsm_unlock(dev);
+    }
+
+    return err;
+}
+
+#ifdef MODULE_AT_URC
+static void sms_callback(void *arg, const char *buf)
+{
+    if (strncmp(buf, "+CMTI:", 6) == 0) {
+        gsm_sms_t * sms_dev = (gsm_sms_t *)arg;
+
+        if ((sms_dev) && (sms_dev->callback)) {
+            gsm_t * dev = sms_dev->base;
+
+            char resp_buf[64];
+            char sms_buf[256];
+            char req_buf[32];
+            char *sms = NULL;
+            char *sender = NULL;
+            char *date = NULL;
+            unsigned long len = 0;
+            unsigned i = 0;
+
+            LOG_DEBUG("SMS received\n");
+
+            gsm_lock(dev);
+            /* Decode */
+
+            unsigned long index = strtoul(buf + 12, NULL, 10);
+            char *pos = req_buf;
+
+            pos += fmt_str(pos, "AT+CMGR=");
+            pos += fmt_u32_dec(pos, index);
+            *pos = '\0';
+
+            int res = at_send_cmd_get_lines(&dev->at_dev, req_buf,
+                                            sms_buf, sizeof(sms_buf), false,
+                                            GSM_SERIAL_TIMEOUT_US);
+            if (res < 0) {
+                goto out;
+            }
+
+            char *cur = sms_buf;
+            do {
+                if (i == GSM_SMS_FIELD_SENDER_ID) {
+                    sender = cur + 1; /* remove leading '"' */
+                }
+                if (i == GSM_SMS_FIELD_DATE_ID) {
+                    date = cur + 1; /* remove leading '"' */
+                    if (*cur == '\"') {
+                        while (*cur != ',') {
+                            cur++;
+                        }
+                        cur++;
+                    }
+                }
+                if (i == GSM_SMS_FIELD_LEN_ID) {
+                    len = strtoul(cur, NULL, 0);
+                }
+                while (*cur != ',' && *cur != '\n') {
+                    cur++;
+                }
+                *cur = '\0';
+                cur++;
+                i++;
+            } while (i < GSM_SMS_FIELD_NUMOF);
+
+            if (sender) {
+                sender[strlen(sender) - 1] = '\0'; /* remove trailing '"' */
+            }
+            if (date) {
+                date[strlen(date) - 1] = '\0'; /* remove trailing '"' */
+            }
+
+            pos = req_buf;
+            pos += fmt_str(pos, "AT+CMGD=");
+            pos += fmt_u32_dec(pos, index);
+            *pos = '\0';
+
+            res = at_send_cmd_get_lines(&dev->at_dev, req_buf, resp_buf,
+                    sizeof(resp_buf), true, GSM_SERIAL_TIMEOUT_US);
+
+            if (res < 0) {
+                goto out;
+            }
+
+            if (len) {
+                while ((*cur == '\r' || *cur == '\n') && (*cur != '\0')) {
+                    cur++;
+                }
+                sms = cur;
+                sms[len] = '\0';
+            }
+            out:
+            gsm_unlock(dev);
+            sms_dev->callback(sms_dev->callback_args, sms, sender, date);
+        }
+    }
+}
+#endif

--- a/drivers/gsm/ublox.c
+++ b/drivers/gsm/ublox.c
@@ -1,0 +1,261 @@
+/*
+ * Copyright (C) 2018 OTA keys S.A.
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+#include <assert.h>
+#include <errno.h>
+
+#include "fmt.h"
+#include "log.h"
+#include "xtimer.h"
+#include "ublox.h"
+
+/**
+ * @ingroup drivers_gsm_ublox
+ * @{
+ *
+ * @file
+ * @brief   Generic Ublox implementation.
+ *
+ * @author  Vincent Dupont <vincent@otakeys.com>
+ * @}
+ */
+
+#define LOG_HEADER  "ublox: "
+
+static void ublox_reset(gsm_t *dev)
+{
+    ublox_params_t *params = (ublox_params_t *)dev->params;
+
+    if (params->pwr_on_pin != GPIO_UNDEF) {
+        gpio_set(params->pwr_on_pin);
+    }
+
+    if (params->reset_pin != GPIO_UNDEF) {
+        gpio_set(params->reset_pin);
+        xtimer_usleep(51 * US_PER_MS);
+        gpio_clear(params->reset_pin);
+    }
+
+    if (params->pwr_on_pin != GPIO_UNDEF) {
+        xtimer_usleep(150 * US_PER_MS);
+        gpio_clear(params->pwr_on_pin);
+        xtimer_sleep(5);
+    }
+}
+
+
+static int change_baudrate(gsm_t *dev, uint32_t baudrate)
+{
+    char buf[64];
+    char *pos = buf;
+
+    pos += fmt_str(pos, "AT+IPR=");
+    pos += fmt_u32_dec(pos, baudrate);
+    *pos = '\0';
+
+    return at_send_cmd_wait_ok(&dev->at_dev, buf, GSM_SERIAL_TIMEOUT_US);
+}
+
+
+static int ublox_init(gsm_t *dev)
+{
+    int err = -EINVAL;
+
+    if(dev) {
+        ublox_params_t *params = (ublox_params_t *)dev->params;
+        char buf[128];
+        char *pos;
+
+        assert(params->pwr_on_pin != GPIO_UNDEF);
+
+        gsm_lock(dev);
+
+        /* make sure reset pin at modem is (high) idle */
+        if(params->reset_pin != GPIO_UNDEF) {
+            gpio_write(params->reset_pin, 1);
+        }
+
+        if(params->dtr_pin != GPIO_UNDEF) {
+            gpio_clear(params->dtr_pin);
+            xtimer_usleep(100);
+            err = at_send_cmd_wait_ok(&dev->at_dev, "AT+UPSV=3",
+            GSM_SERIAL_TIMEOUT_US);
+        } else {
+            err = at_send_cmd_wait_ok(&dev->at_dev, "AT+UPSV=1",
+            GSM_SERIAL_TIMEOUT_US);
+        }
+
+        /* Error messages */
+        at_send_cmd_wait_ok(&dev->at_dev, "AT+CMEE=1", GSM_SERIAL_TIMEOUT_US);
+        /* Auto answer */
+        at_send_cmd_wait_ok(&dev->at_dev, "ATS0=1", GSM_SERIAL_TIMEOUT_US);
+
+        if(dev->params->baudrate != params->change_over_baudrate) {
+            if(change_baudrate(dev, params->change_over_baudrate) != 0) {
+                LOG_ERROR(LOG_HEADER"failed to change baudrate to %lu", params->change_over_baudrate);
+            }
+        }
+
+        /* GPIO1 */
+        if(params->gpio1_mode != UBLOX_GPIO_MODE_DEFAULT) {
+            pos = buf;
+            pos += fmt_str(pos, "AT+UGPIOC=");
+            pos += fmt_u16_dec(pos, UBLOX_GPIO1);
+            pos += fmt_str(pos, ",");
+            pos += fmt_u16_dec(pos,
+                    params->gpio1_mode & UBLOX_GPIO_MODE_DISABLED);
+            if(params->gpio1_mode == UBLOX_GPIO_MODE_OUTPUT) {
+                pos += fmt_str(pos, ",");
+                if(params->gpio1_mode & UBLOX_GPIO_OUTPUT_HIGH) {
+                    pos += fmt_u16_dec(pos, 1);
+                } else {
+                    pos += fmt_u16_dec(pos, 0);
+                }
+            }
+            *pos = '\0';
+            at_send_cmd_wait_ok(&dev->at_dev, buf, GSM_SERIAL_TIMEOUT_US);
+        }
+        /* GPIO2 */
+        if(params->gpio2_mode != UBLOX_GPIO_MODE_DEFAULT) {
+            pos = buf;
+            pos += fmt_str(pos, "AT+UGPIOC=");
+            pos += fmt_u16_dec(pos, UBLOX_GPIO2);
+            pos += fmt_str(pos, ",");
+            pos += fmt_u16_dec(pos,
+                    params->gpio1_mode & UBLOX_GPIO_MODE_DISABLED);
+            if(params->gpio2_mode == UBLOX_GPIO_MODE_OUTPUT) {
+                pos += fmt_str(pos, ",");
+                if(params->gpio2_mode & UBLOX_GPIO_OUTPUT_HIGH) {
+                    pos += fmt_u16_dec(pos, 1);
+                } else {
+                    pos += fmt_u16_dec(pos, 0);
+                }
+            }
+            *pos = '\0';
+            at_send_cmd_wait_ok(&dev->at_dev, buf, GSM_SERIAL_TIMEOUT_US);
+        }
+        /* GPIO3 */
+        if(params->gpio3_mode != UBLOX_GPIO_MODE_DEFAULT) {
+            pos = buf;
+            pos += fmt_str(pos, "AT+UGPIOC=");
+            pos += fmt_u16_dec(pos, UBLOX_GPIO3);
+            pos += fmt_str(pos, ",");
+            pos += fmt_u16_dec(pos,
+                    params->gpio3_mode & UBLOX_GPIO_MODE_DISABLED);
+            if(params->gpio3_mode == UBLOX_GPIO_MODE_OUTPUT) {
+                pos += fmt_str(pos, ",");
+                if(params->gpio3_mode & UBLOX_GPIO_OUTPUT_HIGH) {
+                    pos += fmt_u16_dec(pos, 1);
+                } else {
+                    pos += fmt_u16_dec(pos, 0);
+                }
+            }
+            *pos = '\0';
+            at_send_cmd_wait_ok(&dev->at_dev, buf, GSM_SERIAL_TIMEOUT_US);
+        }
+        /* GPIO4 */
+        if(params->gpio4_mode != UBLOX_GPIO_MODE_DEFAULT) {
+            pos = buf;
+            pos += fmt_str(pos, "AT+UGPIOC=");
+            pos += fmt_u16_dec(pos, UBLOX_GPIO4);
+            pos += fmt_str(pos, ",");
+            pos += fmt_u16_dec(pos,
+                    params->gpio4_mode & UBLOX_GPIO_MODE_DISABLED);
+            if(params->gpio4_mode == UBLOX_GPIO_MODE_OUTPUT) {
+                pos += fmt_str(pos, ",");
+                if(params->gpio4_mode & UBLOX_GPIO_OUTPUT_HIGH) {
+                    pos += fmt_u16_dec(pos, 1);
+                } else {
+                    pos += fmt_u16_dec(pos, 0);
+                }
+            }
+            *pos = '\0';
+            at_send_cmd_wait_ok(&dev->at_dev, buf, GSM_SERIAL_TIMEOUT_US);
+        }
+
+        if(params->gps_connected) {
+            if(params->gps_pm_exti) {
+                /* Turn on GPS */
+                at_send_cmd_wait_ok(&dev->at_dev, "AT+UGPS=1,0",
+                GSM_SERIAL_TIMEOUT_US);
+
+                /* configure UBX-CFG-PM2 to use EXTI */
+                at_send_cmd_get_lines(&dev->at_dev,
+                        "AT+UGUBX=\"B5 62 06 3B 30 00 02 06 00 00 60 14 43 01 E8 03 00 00 10 "
+                                "27 00 00 00 00 00 00 00 00 00 00 2C 01 00 00 4F C1 03 00 86 02 00 00 "
+                                "FE 00 00 00 64 40 01 00 00 00 00 00 BE 58\"",
+                        buf, sizeof(buf), false, GSM_SERIAL_TIMEOUT_US);
+
+                /* Turn off GPS */
+                at_send_cmd_wait_ok(&dev->at_dev, "AT+UGPS=0",
+                GSM_SERIAL_TIMEOUT_US);
+            }
+
+            /* setup A-GPS */
+            if(params->agps_token) {
+                pos = buf;
+                pos += fmt_str(pos, "AT+UGSRV=\"");
+                pos += fmt_str(pos, params->agps_server);
+                pos += fmt_str(pos, "\",\"");
+                pos += fmt_str(pos, params->agps_server2);
+                pos += fmt_str(pos, "\",\"");
+                pos += fmt_str(pos, params->agps_token);
+                pos += fmt_str(pos, "\"");
+                *pos = '\0';
+                at_send_cmd_wait_ok(&dev->at_dev, buf, GSM_SERIAL_TIMEOUT_US);
+            }
+
+            at_send_cmd_wait_ok(&dev->at_dev, "AT+UGRMC=1",
+            GSM_SERIAL_TIMEOUT_US);
+            at_send_cmd_wait_ok(&dev->at_dev, "AT+UGGSV=1",
+            GSM_SERIAL_TIMEOUT_US);
+            at_send_cmd_wait_ok(&dev->at_dev, "AT+UGGGA=1",
+            GSM_SERIAL_TIMEOUT_US);
+            at_send_cmd_wait_ok(&dev->at_dev, "AT+UGGSA=1",
+            GSM_SERIAL_TIMEOUT_US);
+        }
+
+        dev->state = GSM_ON;
+    }
+
+    gsm_unlock(dev);
+
+    return err;
+}
+
+static void ublox_sleep(gsm_t *dev)
+{
+    ublox_params_t *params = (ublox_params_t *)dev->params;
+
+    if (params->dtr_pin != GPIO_UNDEF) {
+        gpio_set(params->dtr_pin);
+    }
+}
+
+static int ublox_wake_up(gsm_t *dev)
+{
+    ublox_params_t *params = (ublox_params_t *)dev->params;
+
+    if (params->dtr_pin != GPIO_UNDEF) {
+        gpio_clear(params->dtr_pin);
+        xtimer_usleep(100);
+        return 0;
+    }
+
+    return -1;
+}
+
+
+const gsm_driver_t ublox_driver = {
+    .init_base  = ublox_init,
+    .power_on   = NULL,
+    .power_off  = NULL,
+    .sleep      = ublox_sleep,
+    .reset      = ublox_reset,
+    .wake_up    = ublox_wake_up,
+};

--- a/drivers/include/gsm.h
+++ b/drivers/include/gsm.h
@@ -123,6 +123,9 @@ typedef struct gsm_params {
     gpio_t      ri_pin;     /**< ring indicator */
 } gsm_params_t;
 
+/**
+ * @brief   gsm device context
+ */
 typedef struct gsm {
     const gsm_driver_t  *driver;                    /**< gsm driver */
     const gsm_params_t  *params;                    /**< gsm parameters */
@@ -138,6 +141,9 @@ typedef struct gsm {
     char            buffer[GSM_UART_BUFSIZE];       /**< at buffer */
 } gsm_t;
 
+/**
+ * @brief gsm api
+ */
 struct gsm_driver {
 
     /**
@@ -370,7 +376,9 @@ ssize_t gsm_get_simcard_identification(gsm_t *dev, char *outbuf, size_t len);
 /**
  * @brief   Gets modem identification
  *
- * @param[in] dev   Device to write to
+ * @param[in]  dev  Device to write to
+ * @param[out] buf  Buffer to write identication in
+ * @param[in]  len  Maximum length of @p buf
  *
  * @return  Length of data written into @p buf.
  * @return  < 0 for failure
@@ -451,3 +459,4 @@ void gsm_register_urc_callback(gsm_t *dev, at_urc_t *urc);
 #endif
 
 #endif /* GSM_H */
+/** @} */

--- a/drivers/include/gsm.h
+++ b/drivers/include/gsm.h
@@ -1,0 +1,453 @@
+/*
+ * Copyright (C) 2016 Kaspar Schleiser <kaspar@schleiser.de>
+ * Copyright (C) 2018 OTA keys S.A.
+ * Copyright (C) 2018 Max van Kessel
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @defgroup    drivers_gsm     GSM
+ * @ingroup     drivers
+ * @brief       A generic implementation of the GSM API
+ *
+ * @{
+ *
+ * @file
+ * @brief   GSM-independent driver
+ *
+ * @author  Kaspar Schleiser <kaspar@schleiser.de>
+ * @author  Vincent Dupont <vincent@otakeys.com>
+ * @author  Max van Kessel
+ */
+#ifndef GSM_H
+#define GSM_H
+
+#include <stdint.h>
+
+#include "rmutex.h"
+#include "thread.h"
+
+#include "periph/gpio.h"
+#include "periph/uart.h"
+
+#include "at.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   gsm thread stack size
+ */
+#ifndef GSM_THREAD_STACKSIZE
+#define GSM_THREAD_STACKSIZE            (THREAD_STACKSIZE_DEFAULT)
+#endif
+
+/**
+ * @brief   gsm thread priority
+ */
+#ifndef GSM_THREAD_PRIO
+#define GSM_THREAD_PRIO                 (THREAD_PRIORITY_MAIN - 1)
+#endif
+
+/**
+ * @brief   at device buffer size
+ */
+#ifndef GSM_UART_BUFSIZE
+#define GSM_UART_BUFSIZE                (128U)
+#endif
+
+/**
+ * @brief   at device default timeout in micro seconds
+ */
+#ifndef GSM_SERIAL_TIMEOUT_US
+#define GSM_SERIAL_TIMEOUT_US           (1000000U)
+#endif
+
+/**
+ * @brief   small line buffer size
+ */
+#ifndef GSM_AT_LINEBUFFER_SIZE_SMALL
+#define GSM_AT_LINEBUFFER_SIZE_SMALL    (32)
+#endif
+
+/**
+ * @brief   normal linebuffer size
+ */
+#ifndef GSM_AT_LINEBUFFER_SIZE
+#define GSM_AT_LINEBUFFER_SIZE          (64)
+#endif
+
+/**
+ * @brief   CREG unsolicited result code registration
+ */
+#ifndef GSM_URC_CREG
+#define GSM_URC_CREG                    "2"
+#endif
+
+/**
+ * @brief   indication if a thread must be initialized
+ */
+#ifdef MODULE_AT_URC
+#define GSM_HAS_THREAD
+#endif
+
+/**
+ * @brief   States of gsm modem
+ */
+enum {
+    GSM_UNDEFINED = 0,  /**< GSM_UNDEFINED */
+    GSM_OFF,            /**< GSM_OFF */
+    GSM_BOOT,           /**< GSM_BOOT */
+    GSM_ON,             /**< GSM_ON */
+    GSM_CALL,           /**< GSM_CALL */
+    GSM_SLEEP,          /**< GSM_SLEEP */
+};
+
+/**
+ * @brief   Default gsm_driver_t type definition
+ */
+typedef struct gsm_driver gsm_driver_t;
+
+/**
+ * @brief   gsm device parameters
+ *
+ * Common GSM parameters.
+ */
+typedef struct gsm_params {
+    uart_t      uart;       /**< communication interface of modem */
+    uint32_t    baudrate;   /**< initial baudrate */
+    gpio_t      ri_pin;     /**< ring indicator */
+} gsm_params_t;
+
+typedef struct gsm {
+    const gsm_driver_t  *driver;                    /**< gsm driver */
+    const gsm_params_t  *params;                    /**< gsm parameters */
+
+    rmutex_t        mutex;                          /**< lock */
+#if defined(GSM_HAS_THREAD) || defined(DOXYGEN)
+    kernel_pid_t    pid;                            /**< thread pid */
+    char            stack[GSM_THREAD_STACKSIZE];    /**< stack */
+#endif
+    int             state;                          /**< gsm state */
+
+    at_dev_t        at_dev;                         /**< at parser */
+    char            buffer[GSM_UART_BUFSIZE];       /**< at buffer */
+} gsm_t;
+
+struct gsm_driver {
+
+    /**
+     * @brief   Initialize the device driver
+     *
+     * @param[in]   dev     device driver to initialize
+     *
+     * @return 0 on success
+     */
+    int (*init_base)(gsm_t *dev);
+
+    /**
+     * @brief   Power on the module
+     *
+     * @param[in]   dev     device to act on
+     *
+     * @return 0 on success
+     */
+    int (*power_on)(gsm_t *dev);
+
+    /**
+     * @brief   Power off the module
+     *
+     * @param[in]   dev     device to act on
+     *
+     * @return 0 on success
+     */
+    int (*power_off)(gsm_t *dev);
+
+    /**
+     * @brief   Set module to sleep
+     *
+     * @param[in]   dev     device to act on
+     *
+     */
+    void (*sleep)(gsm_t *dev);
+
+    /**
+     * @brief   Wake module
+     *
+     * @param[in]   dev     device to act on
+     *
+     * @return 0 for succes
+     */
+    int (*wake_up)(gsm_t *dev);
+
+    /**
+     * @brief   Reset module
+     *
+     * @param[in]   dev     device to act on
+     *
+     */
+    void (*reset)(gsm_t *dev);
+};
+
+/**
+ * @brief   Initialize gsm module and base module.
+ *
+ * @param[in] dev       Device to initialize
+ * @param[in] params
+ * @param[in] driver
+ *
+ * @return    0 for success
+ * @return  < 0 for failure
+ */
+int gsm_init(gsm_t *dev, const gsm_params_t *params, const gsm_driver_t *driver);
+
+/**
+ * @brief   Powers the gsm module.
+ *
+ * @param[in] dev   Device to operate on
+ *
+ * @return    0 for success
+ * @return  < 0 for failure
+ */
+int gsm_poweron(gsm_t *dev);
+
+/**
+ * @brief   Turns the gsm module off.
+ *
+ * @param[in] dev  Device to operate on
+ *
+ * @return  none
+ */
+void gsm_poweroff(gsm_t *dev);
+
+/**
+ * @brief   Wakes the gsm module.
+ *
+ * @param[in] dev   Device to operate on
+ *
+ * @return    0 for success
+ * @return  < 0 for failure
+ */
+int gsm_wake_up(gsm_t *dev);
+
+/**
+ * @brief   Lets the gsm module sleep.
+ *
+ * @param[in] dev  Device to operate on
+ *
+ * @return  none
+ */
+void gsm_sleep(gsm_t *dev);
+
+/**
+ * @brief   Enables the gsm radio.
+ *
+ * @param[in] dev   Device to enable
+ *
+ * @return    0 for success
+ * @return  < 0 for failure
+ */
+int gsm_enable_radio(gsm_t *dev);
+
+/**
+ * @brief   Disable the gsm radio.
+ *
+ * @param[in] dev   Device to disable
+ *
+ * @return    0 for success
+ * @return  < 0 for failure
+ */
+int gsm_disable_radio(gsm_t *dev);
+
+/**
+ * @brief   Checks if gsm is alive
+ * @note    Time between retries is GSM_SERIAL_TIMEOUT_US
+ *
+ * @param[in] dev       Device to operate on
+ * @param[in] retries   Number of retries
+ *
+ * @return    true for success, otherwise false
+ */
+bool gsm_is_alive(gsm_t *dev, uint8_t retries);
+
+/**
+ * @brief   Set sim puk into modem and pin
+ *
+ * @param[in] dev   Device to write to
+ * @param[in] puk   Puk to set
+ * @param[in] pin   Set new pin
+ *
+ * @return    0 for success
+ * @return  < 0 for failure
+ */
+int gsm_set_puk(gsm_t *dev, const char *puk, const char *pin);
+
+/**
+ * @brief   Set sim pin into modem
+ *
+ * @param[in] dev   Device to write to
+ * @param[in] pin   Pin to set
+ *
+ * @return    0 for success
+ * @return  < 0 for failure
+ */
+int gsm_set_pin(gsm_t *dev, const char *pin);
+
+/**
+ * @brief   Checks if modem is already unlocked or needs unlocking
+ *
+ * @param[in] dev   Device to write to
+ *
+ * @return  > 0 for pin required
+ * @return    0 for unlocked
+ * @return  < 0 for failure
+ */
+int gsm_check_pin(gsm_t *dev);
+
+/**
+ * @brief   Checks if an operator is available
+ *
+ * @param[in] dev   Device to operate on
+ *
+ * @return    0 for success
+ * @return  < 0 for failure
+ */
+int gsm_check_operator(gsm_t *dev);
+
+/**
+ * @brief   Gets a list of operators
+ *
+ * @param[in]   dev     Device to operate on
+ * @param[out]  outbuf  Buffer to store operator data in
+ * @param[in]   len     Length of buffer
+ * @param[out]  tech    Access technology (may be NULL)
+ *
+ * @return  Length of data written into @p outbuf.
+ * @return  < 0 for failure
+ */
+size_t gsm_get_operator(gsm_t *dev, char *outbuf, size_t len, uint8_t * tech);
+
+/**
+ * @brief   gets International Mobile Equipment Identity (IMEI)
+ *
+ * @param[in]   dev    Device to write to
+ * @param[out]  buf    Buffer to store imei data in
+ * @param[in]   len    Length of buffer
+ *
+ * @return  Length of data written into @p buf.
+ * @return  < 0 for failure
+ */
+ssize_t gsm_get_imei(gsm_t *dev, char *buf, size_t len);
+
+/**
+ * @brief   Gets International Mobile Subscriber Identity (IMSI)
+ *
+ * @param[in]   dev    Device to write to
+ * @param[out]  buf    Buffer to store imsi data in
+ * @param[in]   len    Length of buffer
+ *
+ * @return  Length of data written into @p buf.
+ * @return  < 0 for failure
+ */
+ssize_t gsm_get_imsi(gsm_t *dev, char *buf, size_t len);
+
+/**
+ * @brief   Gets simcard identification
+ *
+ * @param[in]   dev    Device to write to
+ * @param[out]  outbuf Buffer to store ccid data in
+ * @param[in]   len    Length of buffer
+ *
+ * @return  Length of data written into @p outbuf.
+ * @return  < 0 for failure
+ */
+ssize_t gsm_get_simcard_identification(gsm_t *dev, char *outbuf, size_t len);
+
+/**
+ * @brief   Gets modem identification
+ *
+ * @param[in] dev   Device to write to
+ *
+ * @return  Length of data written into @p buf.
+ * @return  < 0 for failure
+ */
+ssize_t gsm_get_identification(gsm_t *dev, char *buf, size_t len);
+
+/**
+ * @brief   Gets modem signal quality
+ *
+ * @param[in]   dev     Device to write to
+ * @param[out]  rssi    RSSI value [dBm]
+ * @param[out]  ber     Bearer value
+ *
+ * @return    0 for success
+ * @return  < 0 for failure
+ */
+int gsm_get_signal(gsm_t *dev, int *rssi, unsigned *ber);
+
+/**
+ * @brief   Get registration value
+ *
+ * @param[in]   dev         device to operate on
+ * @param[out]  location_id location identifier
+ * @param[out]  cell_id     cellular tower identifier
+ *
+ * @return  positive CREG value on success
+ * @return  < 0 on error
+ */
+int gsm_get_registration(gsm_t *dev, uint16_t * location_id, uint32_t * cell_id);
+
+/**
+ * @brief   Gets modem local time
+ *
+ * @param[in]   dev    Device to write to
+ * @param[out]  outbuf Buffer to store time in
+ * @param[in]   len    Length of buffer
+ *
+ * @return  Length of data written into @p outbuf.
+ * @return  < 0 for failure
+ */
+ssize_t gsm_get_local_time(gsm_t *dev, char * outbuf, size_t len);
+
+
+/**
+ * @brief   Send a 'raw' command to the modem and get the result
+ *
+ * @param[in]   dev         device to operate on
+ * @param[in]   cmd         command to send
+ * @param[out]  buf         response buffer
+ * @param[in]   len         length of @p buf
+ * @param[in]   timeout_sec command timeout in seconds
+ *
+ * @return  the length of the response on success
+ * @return  < 0 on error
+ */
+ssize_t gsm_cmd(gsm_t *dev, const char *cmd, uint8_t *buf, size_t len,
+                    unsigned timeout_sec);
+
+/**
+ * @brief   Print modem status on stdout
+ *
+ * @param[in]   dev  device to operate on
+ */
+void gsm_print_status(gsm_t *dev);
+
+#if defined(MODULE_AT_URC) || DOXYGEN
+/**
+ * @brief Register a unsolicited result code
+ *
+ * @param[in] dev   device to operate on
+ * @param[in] urc   urc information
+ */
+void gsm_register_urc_callback(gsm_t *dev, at_urc_t *urc);
+#endif
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GSM_H */

--- a/drivers/include/gsm/call.h
+++ b/drivers/include/gsm/call.h
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2018 Max van Kessel
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     drivers_gsm
+ * @brief       A generic implementation of the GSM Call API
+ *
+ * @{
+ *
+ * @file
+ * @brief   GSM-independent Call driver
+ *
+ * @author  Max van Kessel
+ */
+
+#ifndef GSM_CALL_H
+#define GSM_CALL_H
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#include "gsm.h"
+
+/**
+ * @brief   GSM default PPP number
+ */
+#ifndef GSM_PPP_NUMBER
+#define GSM_PPP_NUMBER         "*99#"
+#endif
+
+/**
+ * @brief Start dialing
+ *
+ * @param[in]   dev             device to operate on
+ * @param[in]   number          the number to call
+ * @param[in]   is_voice_call   set to true for a voice call, false for data call
+ *
+ * @return  0 on success
+ * @return  < 0 on error
+ */
+int gsm_call_dial_up(gsm_t *dev, const char * number, bool is_voice_call);
+
+/**
+ * @brief Stop calling
+ *
+ * @param[in] dev   device to operate on
+ */
+void gsm_call_dial_down(gsm_t *dev);
+/**
+ * @brief Switch from data mode to command mode
+ *
+ * @param[in]   dev             device to operate on
+ *
+ * @return  0 on success
+ * @return  < 0 on error
+ */
+int gsm_call_switch_to_command_mode(gsm_t *dev);
+
+/**
+ * @brief Switch from command mode to data mode
+ *
+ * @param[in]   dev             device to operate on
+ *
+ * @return  0 on success
+ * @return  < 0 on error
+ */
+int gsm_call_switch_to_data_mode(gsm_t *dev);
+
+#endif /* GSM_CALL_H */

--- a/drivers/include/gsm/call.h
+++ b/drivers/include/gsm/call.h
@@ -26,6 +26,11 @@
 
 #include "gsm.h"
 
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
 /**
  * @brief   GSM default PPP number
  */
@@ -71,4 +76,9 @@ int gsm_call_switch_to_command_mode(gsm_t *dev);
  */
 int gsm_call_switch_to_data_mode(gsm_t *dev);
 
+#ifdef __cplusplus
+}
+#endif
+
 #endif /* GSM_CALL_H */
+/** @} */

--- a/drivers/include/gsm/generic.h
+++ b/drivers/include/gsm/generic.h
@@ -1,0 +1,39 @@
+/*
+ * Copyright (C) 2018 Max van Kessel
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     drivers_gsm
+ * @brief       A generic implementation of the GSM driver
+ *
+ * @{
+ *
+ * @file
+ * @brief   GSM-independent driver
+ *
+ * @author  Max van Kessel
+ */
+#ifndef GSM_GENERIC_H
+#define GSM_GENERIC_H
+
+#include "gsm.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef struct gsm gsm_generic_t;
+
+typedef struct gsm_driver gsm_generic_driver_t;
+
+extern const gsm_generic_driver_t gsm_generic_driver;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GSM_GENERIC_H */

--- a/drivers/include/gsm/generic.h
+++ b/drivers/include/gsm/generic.h
@@ -37,3 +37,4 @@ extern const gsm_generic_driver_t gsm_generic_driver;
 #endif
 
 #endif /* GSM_GENERIC_H */
+/** @} */

--- a/drivers/include/gsm/gprs.h
+++ b/drivers/include/gsm/gprs.h
@@ -99,6 +99,7 @@ int gsm_grps_deactivate_context(gsm_t *dev, uint8_t ctx);
  * @brief   Gets device address
  *
  * @param[in] dev   Device to operate on
+ * @param[in] ctx   Context of the requested IP address
  *
  * @return  ipv4 address
  */
@@ -119,3 +120,4 @@ int gsm_gprs_get_registration(gsm_t *dev);
 #endif
 
 #endif /* GSM_GPRS_H */
+/** @} */

--- a/drivers/include/gsm/gprs.h
+++ b/drivers/include/gsm/gprs.h
@@ -1,0 +1,121 @@
+/*
+ * Copyright (C) 2018 Max van Kessel
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     drivers_gsm
+ * @brief       A generic implementation of the GSM GPRS API
+ *
+ * @{
+ *
+ * @file
+ * @brief   GSM-independent GPRS message driver
+ *
+ * @author  Max van Kessel
+ */
+#ifndef GSM_GPRS_H
+#define GSM_GPRS_H
+
+#include <stdint.h>
+
+#include "gsm.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+    GSM_CONTEXT_IP = 0,
+    GSM_CONTEXT_PPP,
+    GSM_CONTEXT_IPV6,
+    GSM_CONTEXT_IP4V6,
+    GSM_CONTEXT_COUNT,
+} gsm_context_t;
+
+/**
+ * @brief   Attach to GPRS service
+ *
+ * @param[in]   dev     device to operate on
+ *
+ * @return  0 on success
+ * @return  < 0 on error
+ */
+int gsm_grps_attach(gsm_t *dev);
+
+/**
+ * @brief   Detach from GPRS service
+ *
+ * @param[in]   dev     device to operate on
+ *
+ * @return  0 on success
+ * @return  < 0 on error
+ */
+int gsm_grps_detach(gsm_t *dev);
+
+/**
+ * @brief Setup gprs pdp context
+ *
+ * @param[in]   dev     device to operate on
+ * @param[in]   ctx     context to setup
+ * @param[in]   type    pdp type
+ * @param[in]   apn     access point name
+ * @param[in]   user    user identifier (optional)
+ * @param[in]   pass    password        (optional)
+ *
+ * @return  0 on success
+ * @return  < 0 on error
+ */
+int gsm_gprs_setup_pdp_context(gsm_t *dev, uint8_t ctx, gsm_context_t type,
+                const char * apn, const char * user, const char * pass);
+
+
+/**
+ * @brief   Activate PDP context
+ *
+ * @param[in]   dev     device to operate on
+ * @param[in]   ctx     context to activate
+ *
+ * @return  0 on success
+ * @return  < 0 on error
+ */
+int gsm_grps_activate_context(gsm_t *dev, uint8_t ctx);
+
+/**
+ * @brief   Deactivate PDP context
+ *
+ * @param[in]   dev     device to operate on
+ * @param[in]   ctx     context to deactivate
+ *
+ * @return  0 on success
+ * @return  < 0 on error
+ */
+int gsm_grps_deactivate_context(gsm_t *dev, uint8_t ctx);
+
+/**
+ * @brief   Gets device address
+ *
+ * @param[in] dev   Device to operate on
+ *
+ * @return  ipv4 address
+ */
+uint32_t gsm_gprs_get_address(gsm_t *dev, uint8_t ctx);
+
+/**
+ * @brief   Gets device network registration
+ *
+ * @param[in] dev   Device to operate on
+ *
+ * @return  registration value
+ * @return  < 0 for failure
+ */
+int gsm_gprs_get_registration(gsm_t *dev);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GSM_GPRS_H */

--- a/drivers/include/gsm/quectel.h
+++ b/drivers/include/gsm/quectel.h
@@ -1,0 +1,85 @@
+/*
+ * Copyright (C) 2018 Max van Kessel
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @defgroup    drivers_gsm_quectel Quectel
+ * @ingroup     drivers_gsm
+ * @brief       A generic implementation for the Quectel gsm modules
+ *
+ * @{
+ *
+ * @file
+ * @brief   Quectel GSM driver
+ *
+ * @author  Max van Kessel
+ */
+
+#ifndef GSM_QUECTEL_H
+#define GSM_QUECTEL_H
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#include "periph/gpio.h"
+#include "gsm.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Specifies the default on time the power key needs for action
+ */
+#ifndef QUECTEL_POWER_KEY_ON_TIME_US
+#define QUECTEL_POWER_KEY_ON_TIME_US            (1000 * US_PER_MS)
+#endif
+
+/**
+ * @brief Specifies the default off time the power key needs for action
+ */
+#ifndef QUECTEL_POWER_KEY_OFF_TIME_US
+#define QUECTEL_POWER_KEY_OFF_TIME_US           (1000 * US_PER_MS)
+#endif
+
+/**
+ * @brief Specifies the default time of action on the status line
+ */
+#ifndef QUECTEL_STATUS_DETECT_TIMEOUT_US
+#define QUECTEL_STATUS_DETECT_TIMEOUT_US        (5000 * US_PER_MS)
+#endif
+
+/**
+ * @brief Specifies the default time on the reset pin
+ */
+#ifndef QUECTEL_RESET_TIME_US
+#define QUECTEL_RESET_TIME_US                   (500 * US_PER_MS)
+#endif
+
+typedef struct gsm_quectel_params {
+    gsm_params_t base;              /**< gsm base parameters */
+    gpio_t      power_pin;          /**< quectel power pin*/
+    bool        invert_power_pin;   /**< select inversion of power pin */
+    gpio_t      status_pin;         /**< quectel status pin (modem output) */
+    bool        invert_status_pin;  /**< select inversion of status pin */
+    gpio_t      reset_pin;          /**< quectel reset pin*/
+    bool        invert_reset_pin;   /**< select inversion of reset pin*/
+    gpio_t      dtr_pin;            /**< quectel dtr pin (modem intput) */
+    gpio_t      dcd_pin;            /**< quectel dcd pin (modem output) */
+} quectel_params_t;
+
+typedef struct quectel {
+    gsm_t base;                     /**< gsm base driver */
+} quectel_t;
+
+extern const gsm_driver_t quectel_driver;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GSM_QUECTEL_H */

--- a/drivers/include/gsm/quectel.h
+++ b/drivers/include/gsm/quectel.h
@@ -60,6 +60,9 @@ extern "C" {
 #define QUECTEL_RESET_TIME_US                   (500 * US_PER_MS)
 #endif
 
+/**
+ * @brief Quectel gsm device parameters
+ */
 typedef struct gsm_quectel_params {
     gsm_params_t base;              /**< gsm base parameters */
     gpio_t      power_pin;          /**< quectel power pin*/
@@ -72,10 +75,16 @@ typedef struct gsm_quectel_params {
     gpio_t      dcd_pin;            /**< quectel dcd pin (modem output) */
 } quectel_params_t;
 
+/**
+ * @brief Quectel gsm device context
+ */
 typedef struct quectel {
     gsm_t base;                     /**< gsm base driver */
 } quectel_t;
 
+/**
+ * @brief exported gsm api for the Quectel device
+ */
 extern const gsm_driver_t quectel_driver;
 
 #ifdef __cplusplus
@@ -83,3 +92,4 @@ extern const gsm_driver_t quectel_driver;
 #endif
 
 #endif /* GSM_QUECTEL_H */
+/** @} */

--- a/drivers/include/gsm/sms.h
+++ b/drivers/include/gsm/sms.h
@@ -54,8 +54,8 @@ typedef void (*gsm_sms_cb_t)(void *arg, char *sms, char *sender, char *date);
  */
 typedef struct gsm_sms {
     gsm_t *base;            /**< Pointer to the base driver */
-    gsm_sms_cb_t callback;  /**< */
-    void *callback_args;    /**< */
+    gsm_sms_cb_t callback;  /**< SMS callback */
+    void *callback_args;    /**< SMS callback arguments */
 } gsm_sms_t;
 
 /**
@@ -109,3 +109,4 @@ int gsm_sms_enable_reception(gsm_sms_t * sms, gsm_sms_cb_t cb, void *arg);
 #endif
 
 #endif /* GSM_SMS_H */
+/** @} */

--- a/drivers/include/gsm/sms.h
+++ b/drivers/include/gsm/sms.h
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2018 OTA keys S.A.
+ * Copyright (C) 2018 Max van Kessel
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     drivers_gsm
+ * @brief       A generic implementation of the GSM SMS API
+ *
+ * @{
+ *
+ * @file
+ * @brief   GSM-independent SMS message driver
+ *
+ * @author  Max van Kessel
+ * @author  Vincent Dupont <vincent@otakeys.com>
+ */
+#ifndef GSM_SMS_H
+#define GSM_SMS_H
+
+#include <stdint.h>
+
+#include "gsm.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+* @brief   Default sms message character set
+*/
+#ifndef GSM_SMS_DEFAULT_CHARACTER_SET
+#define GSM_SMS_DEFAULT_CHARACTER_SET       "GSM"
+#endif
+
+/**
+* @brief   GSM SMS message format enumeration
+*/
+#ifndef HAVE_GSM_SMS_MESSAGE_FORMAT_T
+typedef enum {
+    GSM_SMS_MESSAGE_FORMAT_PDU = 0,
+    GSM_SMS_MESSAGE_FORMAT_TEXT,
+} gsm_sms_message_format_t;
+#endif
+
+typedef void (*gsm_sms_cb_t)(void *arg, char *sms, char *sender, char *date);
+
+/**
+ * @brief GSM SMS device structure
+ */
+typedef struct gsm_sms {
+    gsm_t *base;            /**< Pointer to the base driver */
+    gsm_sms_cb_t callback;  /**< */
+    void *callback_args;    /**< */
+} gsm_sms_t;
+
+/**
+ * @brief   Initialize gsm sms module
+ *
+ * @param[in]   sms     Sms device
+ * @param[in]   dev     Device to operate on
+ *
+ * @return    0 for success
+ * @return  < 0 for failure
+ */
+int gsm_sms_init(gsm_sms_t *sms, gsm_t *dev);
+
+/**
+ * @brief   Sets character format of sms message
+ *
+ * @param[in]   sms     Device to operate on
+ * @param[in]   format  Character format of sms message
+ *
+ * @return    0 for success
+ * @return  < 0 for failure
+ */
+int gsm_sms_set_format(gsm_sms_t * sms, gsm_sms_message_format_t format);
+
+/**
+ * @brief   Sets character set of sms message
+ * @note    if set equals to null, default message set is loaded
+ *
+ * @param[in]   sms     Device to operate on
+ * @param[in]   set     Character set of sms message
+ *
+ * @return    0 for success
+ * @return  < 0 for failure
+ */
+int gsm_sms_set_characters(gsm_sms_t * sms, const char * set);
+
+/**
+ * @brief   Enable sms message reception
+ *
+ * @param[in]   sms     Device to operate on
+ * @param[in]   cb      sms message callback
+ * @param[in]   arg     sms message callback argument
+ *
+ * @return    0 for success
+ * @return  < 0 for failure
+ */
+int gsm_sms_enable_reception(gsm_sms_t * sms, gsm_sms_cb_t cb, void *arg);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GSM_SMS_H */

--- a/drivers/include/gsm/ublox.h
+++ b/drivers/include/gsm/ublox.h
@@ -1,0 +1,97 @@
+/*
+ * Copyright (C) 2018 OTA keys S.A.
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @defgroup    drivers_gsm_ublox Ublox
+ * @ingroup     drivers_gsm
+ * @brief       A generic implementation for the Ublox gsm modules
+ *
+ * @{
+ *
+ * @file
+ * @brief   U-Blox GSM driver
+ *
+ * @author  Vincent Dupont <vincent@otakeys.com>
+ */
+
+#ifndef GSM_UBLOX_H
+#define GSM_UBLOX_H
+
+#include <stdint.h>
+#include <stdbool.h>
+
+#include "periph/gpio.h"
+#include "gsm.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+typedef enum {
+    UBLOX_GPIO1 = 16,
+    UBLOX_GPIO2 = 23,
+    UBLOX_GPIO3 = 24,
+    UBLOX_GPIO4 = 25,
+} ublox_gpio_t;
+
+typedef enum {
+    UBLOX_GPIO_MODE_OUTPUT = 0,
+    UBLOX_GPIO_MODE_INPUT,
+    UBLOX_GPIO_MODE_NET_STATUS,
+    UBLOX_GPIO_MODE_GNSS_SUPPLY_EN,
+    UBLOX_GPIO_MODE_GNSS_DATA_RDY,
+    UBLOX_GPIO_MODE_GNSS_RTC_SHARING,
+    UBLOX_GPIO_MODE_SIM_CARD_DET,
+    UBLOX_GPIO_MODE_HEADSET_DET,
+    UBLOX_GPIO_MODE_TX_BURST_IND,
+    UBLOX_GPIO_MODE_OP_STATUS_IND,
+    UBLOX_GPIO_MODE_FN_STATUS_IND,
+    UBLOX_GPIO_MODE_I2S,
+    UBLOX_GPIO_MODE_SPI,
+    UBLOX_GPIO_MODE_MASTER_CLK,
+    UBLOX_GPIO_MODE_UART,
+    UBLOX_GPIO_MODE_WIFI_EN,
+    UBLOX_GPIO_MODE_RI = 18,
+    UBLOX_GPIO_MODE_LAST_GAP_EN,
+    UBLOX_GPIO_MODE_DISABLED = 255,
+    /* Do not change mode */
+    UBLOX_GPIO_MODE_DEFAULT,
+} ublox_gpio_mode_t;
+
+#define UBLOX_GPIO_OUTPUT_HIGH  (1 << 9)
+#define UBLOX_GPIO_OUTPUT_LOW   (0)
+
+typedef struct ublox_params {
+    gsm_params_t base;                  /**< gsm base parameters */
+    uint32_t    change_over_baudrate;   /**< initial baudrate */
+    gpio_t      pwr_on_pin;             /**< ublox power pin*/
+    gpio_t      reset_pin;              /**< ublox reset pin*/
+    gpio_t      dtr_pin;                /**< ublox dtr pin (modem intput) */
+    uint32_t gpio1_mode;                /**< GPIO1 mode */
+    uint32_t gpio2_mode;                /**< GPIO2 mode */
+    uint32_t gpio3_mode;                /**< GPIO3 mode */
+    uint32_t gpio4_mode;                /**< GPIO4 mode */
+    /** A GPS module is connected on the I2C interface */
+    bool gps_connected;
+    bool gps_pm_exti;
+    char *agps_server;      /**< A-GPS server URL */
+    char *agps_server2;     /**< A-GPS server URL */
+    char *agps_token;       /**< A-GPS token */
+} ublox_params_t;
+
+typedef struct ublox_gsm {
+    gsm_t base;             /**< gsm base driver */
+} ublox_t;
+
+extern const gsm_driver_t ublox_driver;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GSM_UBLOX_H */

--- a/drivers/include/gsm/ublox.h
+++ b/drivers/include/gsm/ublox.h
@@ -95,3 +95,4 @@ extern const gsm_driver_t ublox_driver;
 #endif
 
 #endif /* GSM_UBLOX_H */
+/** @} */

--- a/examples/gsm/Makefile
+++ b/examples/gsm/Makefile
@@ -1,0 +1,39 @@
+# name of your application
+APPLICATION = gsm
+
+# If no BOARD is found in the environment, use this default:
+BOARD ?= native
+
+# This has to be the absolute path to the RIOT base directory:
+RIOTBASE ?= $(CURDIR)/../..
+
+# Comment this out to disable code in RIOT that does safety checking
+# which is not needed in a production environment but helps in the
+# development process:
+DEVELHELP ?= 1
+
+# Change this to 0 show compiler invocation lines by default:
+QUIET ?= 1
+
+USEMODULE += shell
+USEMODULE += shell_commands
+USEMODULE += ps
+
+USEMODULE += at_urc
+
+USEMODULE += gsm
+USEMODULE += gsm_generic
+USEMODULE += gsm_gprs
+USEMODULE += gsm_call
+
+AT_PRINT_INCOMING ?= 1
+
+MODEM_UART     ?= "UART_NUMOF-1"
+MODEM_BAUDRATE ?= 115200
+
+# export modem parameters
+CFLAGS += -DMODEM_UART="UART_DEV($(MODEM_UART))"
+CFLAGS += -DMODEM_BAUDRATE=$(MODEM_BAUDRATE)
+CFLAGS += -DLOG_LEVEL=LOG_DEBUG
+
+include $(RIOTBASE)/Makefile.include

--- a/examples/gsm/main.c
+++ b/examples/gsm/main.c
@@ -1,0 +1,365 @@
+#include <ctype.h>
+#include <string.h>
+#include <stdlib.h>
+#include <errno.h>
+
+#include "at.h"
+#include "fmt.h"
+#include "board.h"
+#include "shell.h"
+#include "xtimer.h"
+
+#include "gsm/generic.h"
+#include "gsm/gprs.h"
+#include "gsm/call.h"
+
+#include "net/ipv4/addr.h"
+
+#ifndef MODEM_RI_PIN
+#define MODEM_RI_PIN    GPIO_UNDEF
+#endif
+
+#define MAX_CMD_LEN     (256)
+
+static const gsm_params_t params = {
+    .uart            = MODEM_UART,
+    .baudrate        = MODEM_BAUDRATE,
+    .ri_pin          = MODEM_RI_PIN,
+};
+
+static gsm_generic_t _modem;
+
+int _at_send_handler(int argc, char **argv)
+{
+    if (argc < 2) {
+        printf("Usage: %s <command>, [timeout]\n", argv[0]);
+        return 1;
+    }
+
+    uint8_t timeout = 20;
+
+    if (argc > 2) {
+        timeout = (uint8_t)atoi(argv[2]);
+    }
+
+    uint8_t resp[MAX_CMD_LEN + 1];
+    resp[MAX_CMD_LEN] = '\0';
+
+    gsm_cmd((gsm_t *)&_modem, argv[1], resp, MAX_CMD_LEN, timeout);
+    puts((char *)resp);
+
+    return 0;
+}
+
+int _modem_status_handler(int argc, char **argv)
+{
+    (void)argc;
+    (void)argv;
+
+    gsm_print_status((gsm_t *)&_modem);
+    return 0;
+}
+
+int _modem_init_pdp_handler(int argc, char **argv)
+{
+    (void)argc;
+    (void)argv;
+
+    if (argc < 2) {
+        printf("Usage: %s <context> <apn> [user [pass]]\n", argv[0]);
+        return 1;
+    }
+
+    gsm_gprs_setup_pdp_context((gsm_t *)&_modem, (uint8_t)atoi(argv[1]),
+                    GSM_CONTEXT_IP, argv[2], (argv[3]) ? argv[3] : NULL,
+                    (argv[4]) ? argv[4] : NULL);
+    return 0;
+}
+
+int _modem_sim_status_handler(int argc, char **argv)
+{
+    int result;
+    (void)argc;
+    (void)argv;
+
+    result = gsm_check_pin((gsm_t *)&_modem);
+    if (result == 0) {
+        printf("Simcard unlocked.\n");
+    }
+    else if (result == 1) {
+        printf("Simcard present, needs unlocking.\n");
+    }
+    else {
+        printf("Failed to check simcard status.\n");
+    }
+
+    return 0;
+}
+
+int _modem_cpin_handler(int argc, char **argv)
+{
+    int result;
+
+    if (argc < 2) {
+        printf("Usage: %s <pin> [puk]\n", argv[0]);
+        return 1;
+    }
+
+    result = gsm_set_puk((gsm_t *)&_modem, argv[2], argv[1]);
+    if (result == 0) {
+        printf("Simcard unlocked\n");
+    }
+    else {
+        printf("Error %d", result);
+    }
+
+    return 0;
+}
+
+int _modem_sim_handler(int argc, char **argv)
+{
+    if (argc < 2) {
+        printf("Usage: %s <status|pin>\n", argv[0]);
+    }
+    else {
+        if (strcmp(argv[1], "status") == 0) {
+            return _modem_sim_status_handler(argc - 1, &argv[1]);
+        }
+        else if (strcmp(argv[1], "pin") == 0) {
+            return _modem_cpin_handler(argc - 1, &argv[1]);
+        }
+    }
+    return 0;
+}
+
+int _modem_power_handler(int argc, char **argv)
+{
+    if (argc < 2) {
+        printf("Usage: %s <on(1)/off(0)>\n", argv[0]);
+        return 1;
+    }
+
+    if (strncmp(argv[1], "1", 1) == 0) {
+        int result = gsm_poweron((gsm_t *)&_modem);
+
+        if (result == 0) {
+            printf("Device powered on\n");
+        }
+        else {
+            printf("Error %d", result);
+        }
+    }
+    else {
+        gsm_poweroff((gsm_t *)&_modem);
+    }
+
+    return 0;
+}
+
+int _modem_radio_handler(int argc, char **argv)
+{
+    if (argc < 2) {
+        printf("Usage: %s <on(1)/off(0)>\n", argv[0]);
+        return 1;
+    }
+
+    if (strncmp(argv[1], "1", 1) == 0) {
+        int result = gsm_enable_radio((gsm_t *)&_modem);
+
+        if (result == 0) {
+            printf("Device radio on\n");
+        }
+        else {
+            printf("Error %d", result);
+        }
+    }
+    else {
+        gsm_disable_radio((gsm_t *)&_modem);
+    }
+
+    return 0;
+}
+
+int _modem_gprs_attach(int argc, char **argv)
+{
+    if (argc < 2) {
+        printf("Usage: %s <attach(1)/detach(0)>\n", argv[0]);
+        return 1;
+    }
+
+    if (strncmp(argv[1], "1", 1) == 0) {
+        int result = gsm_grps_attach((gsm_t *)&_modem);
+
+        if (result == 0) {
+            printf("Attached\n");
+        }
+        else {
+            printf("Error %d", result);
+        }
+    }
+    else {
+        gsm_grps_detach((gsm_t *)&_modem);
+    }
+
+    return 0;
+}
+
+int _modem_gprs_activate(int argc, char **argv)
+{
+    if (argc < 2) {
+        printf("Usage: %s <activate(1)/deactivate(0)>\n", argv[0]);
+        return 1;
+    }
+
+    if (strncmp(argv[1], "1", 1) == 0) {
+        int result = gsm_grps_activate_context((gsm_t *)&_modem, (uint8_t)atoi(argv[2]));
+
+        if (result == 0) {
+            printf("Activated\n");
+        }
+        else {
+            printf("Error %d\n", result);
+        }
+    }
+    else {
+        gsm_grps_deactivate_context((gsm_t *)&_modem, (uint8_t)atoi(argv[2]));
+    }
+
+    return 0;
+}
+
+
+int _modem_datamode_handler(int argc, char **argv)
+{
+    (void)argc;
+    (void)argv;
+
+    if (gsm_call_switch_to_data_mode((gsm_t *)&_modem) != 0) {
+        printf("Failed to switch to data mode\n");
+    }
+
+    return 0;
+}
+
+int _modem_cmdmode_handler(int argc, char **argv)
+{
+    (void)argc;
+    (void)argv;
+
+    if (gsm_call_switch_to_command_mode((gsm_t *)&_modem) != 0) {
+        printf("Failed to switch to command mode\n");
+    }
+
+    return 0;
+}
+
+int _modem_ip_handler(int argc, char **argv)
+{
+    char buf[IPV4_ADDR_MAX_STR_LEN];
+
+    if (argc < 2) {
+        printf("Usage: %s <context>\n", argv[0]);
+        return 1;
+    }
+
+    uint32_t ip = gsm_gprs_get_address((gsm_t *)&_modem,
+                    (uint8_t)atoi(argv[1]));
+
+    printf("Address (ipv4) %s\n",
+                    ipv4_addr_to_str(buf, (ipv4_addr_t *)&ip,
+                                    IPV4_ADDR_MAX_STR_LEN));
+
+    return 0;
+}
+
+int _modem_rssi_handler(int argc, char **argv)
+{
+    (void)argc;
+    (void)argv;
+
+    int rssi;
+    unsigned ber;
+
+    if (gsm_get_signal((gsm_t *)&_modem, &rssi, &ber) == 0) {
+        printf("RSSI= %ddBm ber=%u%%\n", rssi, ber);
+    }
+    else {
+        puts("Failed to get signal strength");
+    }
+
+    return 0;
+}
+
+int _modem_time_handler(int argc, char **argv)
+{
+    (void)argc;
+    (void)argv;
+
+    char buf[32];
+
+    if (gsm_get_local_time((gsm_t *)&_modem, buf, 32) >= 0) {
+        printf("%s\n", buf);
+    }
+    else {
+        puts("Failed to get time");
+    }
+
+    return 0;
+}
+
+int _modem_gprs_handler(int argc, char **argv)
+{
+    if (argc < 2) {
+        printf("Usage: %s <attach|activate|setup|ip>\n", argv[0]);
+    }
+    else {
+
+        if (strcmp(argv[1], "attach") == 0) {
+            return _modem_gprs_attach(argc - 1, &argv[1]);
+        }
+        else if (strcmp(argv[1], "setup") == 0) {
+            return _modem_init_pdp_handler(argc - 1, &argv[1]);
+        }
+        else if (strcmp(argv[1], "activate") == 0) {
+            return _modem_gprs_activate(argc - 1, &argv[1]);
+        }
+        else if (strcmp(argv[1], "ip") == 0) {
+            return _modem_ip_handler(argc - 1, &argv[1]);
+        }
+    }
+    return 0;
+}
+
+
+static const shell_command_t commands[] = {
+    {"atcmd",        "Sends an AT cmd",     _at_send_handler},
+    {"status",       "Print Modem status",  _modem_status_handler},
+    {"gprs",         "GPRS operations",    _modem_gprs_handler},
+    {"sim",          "Sim operations",      _modem_sim_handler},
+    {"power",        "Power (On/Off)",      _modem_power_handler},
+    {"radio",        "Radio (On/Off)",      _modem_radio_handler},
+    {"datamode",     "Switch to datamode",  _modem_datamode_handler },
+    {"cmdmode",      "Switch to commandmode",_modem_cmdmode_handler },
+    {"rssi",         "Get rssi",             _modem_rssi_handler },
+    {"time",         "Get time",            _modem_time_handler },
+    {NULL, NULL, NULL}
+};
+
+int main(void)
+{
+    char line_buf[SHELL_DEFAULT_BUFSIZE];
+
+    int err = gsm_init((gsm_t *)&_modem, (gsm_params_t *)&params, &gsm_generic_driver);
+
+    if (err < 0) {
+        printf("Failed to initialize gsm driver with error %d\n", err);
+        return -1;
+    }
+
+    /* start the shell */
+    puts("Initialization OK, starting shell now");
+
+    shell_run(commands, line_buf, SHELL_DEFAULT_BUFSIZE);
+
+    return 0;
+}

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -30,6 +30,7 @@ PSEUDOMODULES += gnrc_sixlowpan_router
 PSEUDOMODULES += gnrc_sixlowpan_router_default
 PSEUDOMODULES += gnrc_sock_check_reuse
 PSEUDOMODULES += gnrc_txtsnd
+PSEUDOMODULES += gsm_%
 PSEUDOMODULES += l2filter_blacklist
 PSEUDOMODULES += l2filter_whitelist
 PSEUDOMODULES += lis2dh12_spi


### PR DESCRIPTION
### Contribution description

I've extended the PR #8602 "gsm" driver from @vincent-d. 
Features of the PR (which incorporates functionality from other PR's):
- Generic modem commands, e.g. IMEI, IMSI, SIM PIN & PUK.
- GPRS commands, e.g. activating contexts, getting IP addresses of contexts.
- Basic call interface, which needs to be extended.
- SMS functionality.
- Basic API for modem specific commands, e.g. poweron, poweroff, sleep.
- Specific implementation for Quectel and UBlox devices.

### Testing procedure

Example is included in the example directory. It holds numerous shell commands for communicating with the modem.

The example uses the generic gsm module for communicating with the modem. And due to the generic nature, it doesn't know how to power up the modem (which is also specific for different modems). So it has to be powered manually. Specific implementations hold these power up sequences.

### Issues/PRs references

#8943 