### PR TITLE
drivers/adxl345: fix ADXL345 driver

### DIFF
--- a/drivers/adxl345/adxl345.c
+++ b/drivers/adxl345/adxl345.c
@@ -23,6 +23,7 @@
 
 #include "assert.h"
 #include "periph/i2c.h"
+#include "byteorder.h"
 #include "adxl345.h"
 #include "adxl345_regs.h"
 #include "adxl345_params.h"
@@ -83,9 +84,11 @@ void adxl345_read(const adxl345_t *dev, adxl345_data_t *data)
     i2c_read_regs(ADXL345_BUS, ADXL345_ADDR, ADXL345_DATA_X0, (void *)result, 6, 0);
     i2c_release(ADXL345_BUS);
 
-#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+    /* ADXL345 returns value in little endian, so swap is needed on big endian
+     * platforms. See Analog Devices ADXL345 datasheet page 27. */
+#if __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
     for (int i = 0; i < 3; i++) {
-        result[i] = ((result[i] & 0xFF) << 8 | (result[i] >> 8));
+        result[i] = byteorder_swaps((uint16_t)result[i]);
     }
 #endif
 

--- a/drivers/adxl345/adxl345.c
+++ b/drivers/adxl345/adxl345.c
@@ -42,7 +42,7 @@ int adxl345_init(adxl345_t *dev, const adxl345_params_t* params)
     dev->params = (adxl345_params_t*)params;
 
     /* get scale_factor from full_res and range parameters */
-    dev->scale_factor = (dev->params->full_res ? 4 : (dev->params->range * 4));
+    dev->scale_factor = (dev->params->full_res ? 4 : (4 << dev->params->range));
 
     /* Acquire exclusive access */
     i2c_acquire(BUS);

--- a/drivers/adxl345/adxl345.c
+++ b/drivers/adxl345/adxl345.c
@@ -34,6 +34,8 @@
 #define ADXL345_BUS                 (dev->params->i2c)
 #define ADXL345_ADDR                (dev->params->addr)
 
+#define ADXL345_PARAM_SCALE_FACTOR  (4)
+
 int adxl345_init(adxl345_t *dev, const adxl345_params_t* params)
 {
     uint8_t reg;

--- a/drivers/adxl345/adxl345.c
+++ b/drivers/adxl345/adxl345.c
@@ -25,12 +25,13 @@
 #include "periph/i2c.h"
 #include "adxl345.h"
 #include "adxl345_regs.h"
+#include "adxl345_params.h"
 
 #define ENABLE_DEBUG        (0)
 #include "debug.h"
 
-#define BUS                 (dev->params->i2c)
-#define ADDR                (dev->params->addr)
+#define ADXL345_BUS                 (dev->params->i2c)
+#define ADXL345_ADDR                (dev->params->addr)
 
 int adxl345_init(adxl345_t *dev, const adxl345_params_t* params)
 {
@@ -42,29 +43,30 @@ int adxl345_init(adxl345_t *dev, const adxl345_params_t* params)
     dev->params = (adxl345_params_t*)params;
 
     /* get scale_factor from full_res and range parameters */
-    dev->scale_factor = (dev->params->full_res ? 4 : (4 << dev->params->range));
+    dev->scale_factor = (dev->params->full_res ? ADXL345_PARAM_SCALE_FACTOR : (4 << dev->params->range));
 
     /* Acquire exclusive access */
-    i2c_acquire(BUS);
+    i2c_acquire(ADXL345_BUS);
 
     /* test if the target device responds */
-    i2c_read_reg(BUS, ADDR, ACCEL_ADXL345_CHIP_ID_REG, &reg, 0);
-    if (reg != ACCEL_ADXL345_CHIP_ID) {
-        i2c_release(BUS);
+    i2c_read_reg(ADXL345_BUS, ADXL345_ADDR, ADXL345_CHIP_ID_REG, &reg, 0);
+    if (reg != ADXL345_CHIP_ID) {
+        i2c_release(ADXL345_BUS);
         DEBUG("[adxl345] init - error: invalid id value [0x%02x]\n", (int)reg);
         return ADXL345_NODEV;
     }
     /* configure the user offset */
-    i2c_write_regs(BUS, ADDR, ACCEL_ADXL345_OFFSET_X, dev->params->offset, 3, 0);
+    i2c_write_regs(ADXL345_BUS, ADXL345_ADDR, ADXL345_OFFSET_X, dev->params->offset, 3, 0);
     /* Basic device setup */
-    reg = (dev->params->full_res | dev->params->range);
-    i2c_write_reg(BUS, ADDR, ACCEL_ADXL345_DATA_FORMAT, reg, 0);
-    i2c_write_reg(BUS, ADDR, ACCEL_ADXL345_BW_RATE, dev->params->rate, 0);
+    reg = (dev->params->full_res ? ADXL345_FULL_RES : 0);
+    reg |= dev->params->range;
+    i2c_write_reg(ADXL345_BUS, ADXL345_ADDR, ADXL345_DATA_FORMAT, reg, 0);
+    i2c_write_reg(ADXL345_BUS, ADXL345_ADDR, ADXL345_BW_RATE, dev->params->rate, 0);
     /* Put device in measure mode */
-    i2c_write_reg(BUS, ADDR, ACCEL_ADXL345_POWER_CTL, MEASURE_BIT, 0);
+    i2c_write_reg(ADXL345_BUS, ADXL345_ADDR, ADXL345_POWER_CTL, ADXL345_MEASURE_BIT, 0);
 
     /* Release the bus */
-    i2c_release(BUS);
+    i2c_release(ADXL345_BUS);
 
     DEBUG("[adxl345] init: successful\n");
 
@@ -77,9 +79,9 @@ void adxl345_read(const adxl345_t *dev, adxl345_data_t *data)
 
     assert(dev && data);
 
-    i2c_acquire(BUS);
-    i2c_read_regs(BUS, ADDR, ACCEL_ADXL345_DATA_X0, (void *)result, 6, 0);
-    i2c_release(BUS);
+    i2c_acquire(ADXL345_BUS);
+    i2c_read_regs(ADXL345_BUS, ADXL345_ADDR, ADXL345_DATA_X0, (void *)result, 6, 0);
+    i2c_release(ADXL345_BUS);
 
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
     for (int i = 0; i < 3; i++) {
@@ -98,38 +100,38 @@ void adxl345_set_interrupt(const adxl345_t *dev)
 
     DEBUG("[adxl345] Update interruptions configuration\n");
 
-    i2c_acquire(BUS);
+    i2c_acquire(ADXL345_BUS);
     /* Set threshold */
-    i2c_write_reg(BUS, ADDR, ACCEL_ADXL345_THRESH_TAP, dev->interrupt.thres_tap, 0);
+    i2c_write_reg(ADXL345_BUS, ADXL345_ADDR, ADXL345_THRESH_TAP, dev->interrupt.thres_tap, 0);
     /* Set Map */
-    i2c_write_reg(BUS, ADDR, ACCEL_ADXL345_INT_MAP, dev->interrupt.map, 0);
+    i2c_write_reg(ADXL345_BUS, ADXL345_ADDR, ADXL345_INT_MAP, dev->interrupt.map, 0);
     /* Set Duration */
-    i2c_write_reg(BUS, ADDR, ACCEL_ADXL345_TAP_DUR, dev->interrupt.thres_dur, 0);
+    i2c_write_reg(ADXL345_BUS, ADXL345_ADDR, ADXL345_TAP_DUR, dev->interrupt.thres_dur, 0);
     /* Enable axes */
-    i2c_write_reg(BUS, ADDR, ACCEL_ADXL345_TAP_AXES, dev->interrupt.tap_axes, 0);
+    i2c_write_reg(ADXL345_BUS, ADXL345_ADDR, ADXL345_TAP_AXES, dev->interrupt.tap_axes, 0);
     /* Set source */
-    i2c_write_reg(BUS, ADDR, ACCEL_ADXL345_INT_SOURCE, dev->interrupt.source, 0);
+    i2c_write_reg(ADXL345_BUS, ADXL345_ADDR, ADXL345_INT_SOURCE, dev->interrupt.source, 0);
     /* Set latent threshold */
-    i2c_write_reg(BUS, ADDR, ACCEL_ADXL345_TAP_LAT, dev->interrupt.thres_latent, 0);
+    i2c_write_reg(ADXL345_BUS, ADXL345_ADDR, ADXL345_TAP_LAT, dev->interrupt.thres_latent, 0);
     /* Set window threshold */
-    i2c_write_reg(BUS, ADDR, ACCEL_ADXL345_TAP_WIN, dev->interrupt.thres_window, 0);
+    i2c_write_reg(ADXL345_BUS, ADXL345_ADDR, ADXL345_TAP_WIN, dev->interrupt.thres_window, 0);
     /* Set activity threshold */
-    i2c_write_reg(BUS, ADDR, ACCEL_ADXL345_THRESH_ACT, dev->interrupt.thres_act, 0);
+    i2c_write_reg(ADXL345_BUS, ADXL345_ADDR, ADXL345_THRESH_ACT, dev->interrupt.thres_act, 0);
     /* Set inactivity threshold */
-    i2c_write_reg(BUS, ADDR, ACCEL_ADXL345_THRESH_INACT, dev->interrupt.thres_inact, 0);
+    i2c_write_reg(ADXL345_BUS, ADXL345_ADDR, ADXL345_THRESH_INACT, dev->interrupt.thres_inact, 0);
     /* Set inactivity time */
-    i2c_write_reg(BUS, ADDR, ACCEL_ADXL345_TIME_INACT, dev->interrupt.time_inact, 0);
+    i2c_write_reg(ADXL345_BUS, ADXL345_ADDR, ADXL345_TIME_INACT, dev->interrupt.time_inact, 0);
     /* Set free-fall threshold */
-    i2c_write_reg(BUS, ADDR, ACCEL_ADXL345_THRESH_FF, dev->interrupt.thres_ff, 0);
+    i2c_write_reg(ADXL345_BUS, ADXL345_ADDR, ADXL345_THRESH_FF, dev->interrupt.thres_ff, 0);
     /* Set free-fall time */
-    i2c_write_reg(BUS, ADDR, ACCEL_ADXL345_TIME_FF, dev->interrupt.time_ff, 0);
+    i2c_write_reg(ADXL345_BUS, ADXL345_ADDR, ADXL345_TIME_FF, dev->interrupt.time_ff, 0);
     /* Set axis control */
-    i2c_write_reg(BUS, ADDR, ACCEL_ADXL345_ACT_INACT_CTL, dev->interrupt.act_inact, 0);
+    i2c_write_reg(ADXL345_BUS, ADXL345_ADDR, ADXL345_ACT_INACT_CTL, dev->interrupt.act_inact, 0);
     /* Enable interrupt */
-    i2c_write_reg(BUS, ADDR, ACCEL_ADXL345_INT_ENABLE, dev->interrupt.enable, 0);
+    i2c_write_reg(ADXL345_BUS, ADXL345_ADDR, ADXL345_INT_ENABLE, dev->interrupt.enable, 0);
 
     /* Release the bus */
-    i2c_release(BUS);
+    i2c_release(ADXL345_BUS);
 }
 
 void adxl345_set_measure(const adxl345_t *dev)
@@ -140,11 +142,11 @@ void adxl345_set_measure(const adxl345_t *dev)
 
     DEBUG("[adxl345] set device to measure mode\n");
 
-    i2c_acquire(BUS);
-    i2c_read_reg(BUS, ADDR, ACCEL_ADXL345_POWER_CTL, &reg, 0);
-    reg |= MEASURE_BIT;
-    i2c_write_reg(BUS, ADDR, ACCEL_ADXL345_POWER_CTL, reg, 0);
-    i2c_release(BUS);
+    i2c_acquire(ADXL345_BUS);
+    i2c_read_reg(ADXL345_BUS, ADXL345_ADDR, ADXL345_POWER_CTL, &reg, 0);
+    reg |= ADXL345_MEASURE_BIT;
+    i2c_write_reg(ADXL345_BUS, ADXL345_ADDR, ADXL345_POWER_CTL, reg, 0);
+    i2c_release(ADXL345_BUS);
 }
 
 void adxl345_set_standby(const adxl345_t *dev)
@@ -155,11 +157,11 @@ void adxl345_set_standby(const adxl345_t *dev)
 
     DEBUG("[adxl345] set device to standby mode\n");
 
-    i2c_acquire(BUS);
-    i2c_read_reg(BUS, ADDR, ACCEL_ADXL345_POWER_CTL, &reg, 0);
-    reg &= ~MEASURE_BIT;
-    i2c_write_reg(BUS, ADDR, ACCEL_ADXL345_POWER_CTL, reg, 0);
-    i2c_release(BUS);
+    i2c_acquire(ADXL345_BUS);
+    i2c_read_reg(ADXL345_BUS, ADXL345_ADDR, ADXL345_POWER_CTL, &reg, 0);
+    reg &= ~ADXL345_MEASURE_BIT;
+    i2c_write_reg(ADXL345_BUS, ADXL345_ADDR, ADXL345_POWER_CTL, reg, 0);
+    i2c_release(ADXL345_BUS);
 }
 
 void adxl345_set_sleep(const adxl345_t *dev)
@@ -170,11 +172,11 @@ void adxl345_set_sleep(const adxl345_t *dev)
 
     DEBUG("[adxl345] set device to sleep mode\n");
 
-    i2c_acquire(BUS);
-    i2c_read_reg(BUS, ADDR, ACCEL_ADXL345_POWER_CTL, &reg, 0);
-    reg |= SLEEP_BIT;
-    i2c_write_reg(BUS, ADDR, ACCEL_ADXL345_POWER_CTL, reg, 0);
-    i2c_release(BUS);
+    i2c_acquire(ADXL345_BUS);
+    i2c_read_reg(ADXL345_BUS, ADXL345_ADDR, ADXL345_POWER_CTL, &reg, 0);
+    reg |= ADXL345_SLEEP_BIT;
+    i2c_write_reg(ADXL345_BUS, ADXL345_ADDR, ADXL345_POWER_CTL, reg, 0);
+    i2c_release(ADXL345_BUS);
 }
 
 void adxl345_set_autosleep(const adxl345_t *dev)
@@ -185,11 +187,11 @@ void adxl345_set_autosleep(const adxl345_t *dev)
 
     DEBUG("[adxl345] set device to autosleep mode\n");
 
-    i2c_acquire(BUS);
-    i2c_read_reg(BUS, ADDR, ACCEL_ADXL345_POWER_CTL, &reg, 0);
-    reg |= AUTOSLEEP_BIT;
-    i2c_write_reg(BUS, ADDR, ACCEL_ADXL345_POWER_CTL, reg, 0);
-    i2c_release(BUS);
+    i2c_acquire(ADXL345_BUS);
+    i2c_read_reg(ADXL345_BUS, ADXL345_ADDR, ADXL345_POWER_CTL, &reg, 0);
+    reg |= ADXL345_AUTOSLEEP_BIT;
+    i2c_write_reg(ADXL345_BUS, ADXL345_ADDR, ADXL345_POWER_CTL, reg, 0);
+    i2c_release(ADXL345_BUS);
 }
 
 void adxl345_set_bandwidth_rate(const adxl345_t *dev, uint8_t bw_rate)
@@ -200,11 +202,11 @@ void adxl345_set_bandwidth_rate(const adxl345_t *dev, uint8_t bw_rate)
 
     DEBUG("[adxl345] set device rate to %d Hz\n", (int)bw_rate);
 
-    i2c_acquire(BUS);
-    i2c_read_reg(BUS, ADDR, ACCEL_ADXL345_BW_RATE, &reg, 0);
+    i2c_acquire(ADXL345_BUS);
+    i2c_read_reg(ADXL345_BUS, ADXL345_ADDR, ADXL345_BW_RATE, &reg, 0);
     reg |= bw_rate;
-    i2c_write_reg(BUS, ADDR, ACCEL_ADXL345_BW_RATE, reg, 0);
-    i2c_release(BUS);
+    i2c_write_reg(ADXL345_BUS, ADXL345_ADDR, ADXL345_BW_RATE, reg, 0);
+    i2c_release(ADXL345_BUS);
 }
 
 void adxl345_set_fifo_mode(const adxl345_t *dev, uint8_t mode,
@@ -217,8 +219,8 @@ void adxl345_set_fifo_mode(const adxl345_t *dev, uint8_t mode,
     DEBUG("[adxl345] set fifo mode to %d, output trigger to %d and trigger "
           "value to :%d\n", (int)mode, (int)output, (int)value);
 
-    i2c_acquire(BUS);
-    reg = ((mode << FIFO_MODE_POS) | (output << FIFO_TRIGGER_POS) | value);
-    i2c_write_reg(BUS, ADDR, ACCEL_ADXL345_FIFO_CTL, reg, 0);
-    i2c_release(BUS);
+    i2c_acquire(ADXL345_BUS);
+    reg = ((mode << ADXL345_FIFO_MODE_POS) | (output << ADXL345_FIFO_TRIGGER_POS) | value);
+    i2c_write_reg(ADXL345_BUS, ADXL345_ADDR, ADXL345_FIFO_CTL, reg, 0);
+    i2c_release(ADXL345_BUS);
 }

--- a/drivers/adxl345/include/adxl345_params.h
+++ b/drivers/adxl345/include/adxl345_params.h
@@ -48,14 +48,14 @@ extern "C" {
                                      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0F}
 #endif
 #ifndef ADXL345_PARAM_FULL_RES
-#define ADXL345_PARAM_FULL_RES      (1)
+#define ADXL345_PARAM_FULL_RES      (1 << 3)
 #endif
 #ifndef ADXL345_PARAM_OFFSET
 #define ADXL345_PARAM_OFFSET        { 0, 0, 0 }
 #endif
-#ifndef ADXL345_PARAM_SCALE_FACTOR
-#define ADXL345_PARAM_SCALE_FACTOR  (3.9)
-#endif
+
+#define ADXL345_PARAM_SCALE_FACTOR  (4)
+
 #ifndef ADXL345_PARAMS
 #define ADXL345_PARAMS              { .i2c    = ADXL345_PARAM_I2C,       \
                                       .addr   = ADXL345_PARAM_ADDR,      \

--- a/drivers/adxl345/include/adxl345_params.h
+++ b/drivers/adxl345/include/adxl345_params.h
@@ -54,8 +54,6 @@ extern "C" {
 #define ADXL345_PARAM_OFFSET        { 0, 0, 0 }
 #endif
 
-#define ADXL345_PARAM_SCALE_FACTOR  (4)
-
 #ifndef ADXL345_PARAMS
 #define ADXL345_PARAMS              { .i2c    = ADXL345_PARAM_I2C,       \
                                       .addr   = ADXL345_PARAM_ADDR,      \

--- a/drivers/adxl345/include/adxl345_params.h
+++ b/drivers/adxl345/include/adxl345_params.h
@@ -48,7 +48,7 @@ extern "C" {
                                      0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x0F}
 #endif
 #ifndef ADXL345_PARAM_FULL_RES
-#define ADXL345_PARAM_FULL_RES      (1 << 3)
+#define ADXL345_PARAM_FULL_RES      (1)
 #endif
 #ifndef ADXL345_PARAM_OFFSET
 #define ADXL345_PARAM_OFFSET        { 0, 0, 0 }

--- a/drivers/adxl345/include/adxl345_regs.h
+++ b/drivers/adxl345/include/adxl345_regs.h
@@ -27,113 +27,115 @@
  * @name    Register addresses
  * @{
  */
-#define ACCEL_ADXL345_CHIP_ID_REG    (0x00) /**< Device ID */
-#define ACCEL_ADXL345_THRESH_TAP     (0x1D) /**< Tap threshold */
-#define ACCEL_ADXL345_OFFSET_X       (0x1E) /**< X-axis offset */
-#define ACCEL_ADXL345_OFFSET_Y       (0x1F) /**< Y-axis offset */
-#define ACCEL_ADXL345_OFFSET_Z       (0x20) /**< Z-axis offset */
-#define ACCEL_ADXL345_TAP_DUR        (0x21) /**< Tap duration */
-#define ACCEL_ADXL345_TAP_LAT        (0x22) /**< Tap latency */
-#define ACCEL_ADXL345_TAP_WIN        (0x23) /**< Tap window */
-#define ACCEL_ADXL345_THRESH_ACT     (0x24) /**< Activity threshold */
-#define ACCEL_ADXL345_THRESH_INACT   (0x25) /**< Inactivity threshold */
-#define ACCEL_ADXL345_TIME_INACT     (0x26) /**< Inactivity time */
-#define ACCEL_ADXL345_ACT_INACT_CTL  (0x27) /**< Axis enable control for activity and inactivity detection */
-#define ACCEL_ADXL345_THRESH_FF      (0x28) /**< Free-fall threshold */
-#define ACCEL_ADXL345_TIME_FF        (0x29) /**< Free-fall time */
-#define ACCEL_ADXL345_TAP_AXES       (0x2A) /**< Axis control for single tap/double tap */
-#define ACCEL_ADXL345_ACT_TAP_STATUS (0x2B) /**< Source of single tap/double tap */
-#define ACCEL_ADXL345_BW_RATE        (0x2C) /**< Data rate and power mode control */
-#define ACCEL_ADXL345_POWER_CTL      (0x2D) /**< Power-saving features control */
-#define ACCEL_ADXL345_INT_ENABLE     (0x2E) /**< Interrupt enable control */
-#define ACCEL_ADXL345_INT_MAP        (0x2F) /**< Interrupt mapping control */
-#define ACCEL_ADXL345_INT_SOURCE     (0x30) /**< Source of interrupts */
-#define ACCEL_ADXL345_DATA_FORMAT    (0x31) /**< Data format control */
-#define ACCEL_ADXL345_DATA_X0        (0x32) /**< X-Axis Data 0 */
-#define ACCEL_ADXL345_DATA_X1        (0x33) /**< X-Axis Data 1 */
-#define ACCEL_ADXL345_DATA_Y0        (0x34) /**< Y-Axis Data 0 */
-#define ACCEL_ADXL345_DATA_Y1        (0x35) /**< Y-Axis Data 1 */
-#define ACCEL_ADXL345_DATA_Z0        (0x36) /**< Z-Axis Data 0 */
-#define ACCEL_ADXL345_DATA_Z1        (0x37) /**< Z-Axis Data 1 */
-#define ACCEL_ADXL345_FIFO_CTL       (0x38) /**< FIFO control */
-#define ACCEL_ADXL345_FIFO_STATUS    (0x39) /**< FIFO status */
+#define ADXL345_CHIP_ID_REG    (0x00) /**< Device ID */
+#define ADXL345_THRESH_TAP     (0x1D) /**< Tap threshold */
+#define ADXL345_OFFSET_X       (0x1E) /**< X-axis offset */
+#define ADXL345_OFFSET_Y       (0x1F) /**< Y-axis offset */
+#define ADXL345_OFFSET_Z       (0x20) /**< Z-axis offset */
+#define ADXL345_TAP_DUR        (0x21) /**< Tap duration */
+#define ADXL345_TAP_LAT        (0x22) /**< Tap latency */
+#define ADXL345_TAP_WIN        (0x23) /**< Tap window */
+#define ADXL345_THRESH_ACT     (0x24) /**< Activity threshold */
+#define ADXL345_THRESH_INACT   (0x25) /**< Inactivity threshold */
+#define ADXL345_TIME_INACT     (0x26) /**< Inactivity time */
+#define ADXL345_ACT_INACT_CTL  (0x27) /**< Axis enable control for activity and inactivity detection */
+#define ADXL345_THRESH_FF      (0x28) /**< Free-fall threshold */
+#define ADXL345_TIME_FF        (0x29) /**< Free-fall time */
+#define ADXL345_TAP_AXES       (0x2A) /**< Axis control for single tap/double tap */
+#define ADXL345_ACT_TAP_STATUS (0x2B) /**< Source of single tap/double tap */
+#define ADXL345_BW_RATE        (0x2C) /**< Data rate and power mode control */
+#define ADXL345_POWER_CTL      (0x2D) /**< Power-saving features control */
+#define ADXL345_INT_ENABLE     (0x2E) /**< Interrupt enable control */
+#define ADXL345_INT_MAP        (0x2F) /**< Interrupt mapping control */
+#define ADXL345_INT_SOURCE     (0x30) /**< Source of interrupts */
+#define ADXL345_DATA_FORMAT    (0x31) /**< Data format control */
+#define ADXL345_DATA_X0        (0x32) /**< X-Axis Data 0 */
+#define ADXL345_DATA_X1        (0x33) /**< X-Axis Data 1 */
+#define ADXL345_DATA_Y0        (0x34) /**< Y-Axis Data 0 */
+#define ADXL345_DATA_Y1        (0x35) /**< Y-Axis Data 1 */
+#define ADXL345_DATA_Z0        (0x36) /**< Z-Axis Data 0 */
+#define ADXL345_DATA_Z1        (0x37) /**< Z-Axis Data 1 */
+#define ADXL345_FIFO_CTL       (0x38) /**< FIFO control */
+#define ADXL345_FIFO_STATUS    (0x39) /**< FIFO status */
 /** @} */
 
 /**
  * @name    Device ID for ADXL345
  * @{
  */
-#define ACCEL_ADXL345_CHIP_ID        (0xE5)
+#define ADXL345_CHIP_ID        (0xE5)
 /** @} */
 
 /**
  * @name    Resolution masks for output data
  * @{
  */
-#define RES_10_BITS       (0x03FF)
-#define RES_11_BITS       (0x07FF)
-#define RES_12_BITS       (0x0FFF)
-#define RES_13_BITS       (0x1FFF)
+#define ADXL345_RES_10_BITS       (0x03FF)
+#define ADXL345_RES_11_BITS       (0x07FF)
+#define ADXL345_RES_12_BITS       (0x0FFF)
+#define ADXL345_RES_13_BITS       (0x1FFF)
 /** @} */
 
 /**
  * @name    bits definitions for ACT_INACT_CTL register
  * @{
  */
-#define INACT_Z_ENABLE    (1 << 0)
-#define INACT_Y_ENABLE    (1 << 1)
-#define INACT_X_ENABLE    (1 << 2)
-#define INACT_ACDC        (1 << 3)
-#define ACT_Z_ENABLE      (1 << 4)
-#define ACT_Y_ENABLE      (1 << 5)
-#define ACT_X_ENABLE      (1 << 6)
-#define ACT_ACDC          (1 << 7)
+#define ADXL345_INACT_Z_ENABLE    (1 << 0)
+#define ADXL345_INACT_Y_ENABLE    (1 << 1)
+#define ADXL345_INACT_X_ENABLE    (1 << 2)
+#define ADXL345_INACT_ACDC        (1 << 3)
+#define ADXL345_ACT_Z_ENABLE      (1 << 4)
+#define ADXL345_ACT_Y_ENABLE      (1 << 5)
+#define ADXL345_ACT_X_ENABLE      (1 << 6)
+#define ADXL345_ACT_ACDC          (1 << 7)
 /** @} */
 
 /**
  * @name    bits definitions for TAP_AXES register
  * @{
  */
-#define TAP_Z_ENABLE      (1 << 0)
-#define TAP_Y_ENABLE      (1 << 1)
-#define TAP_X_ENABLE      (1 << 2)
-#define SUPPRESS          (1 << 3)
-#define TAP_ALL_ENABLE    (TAP_Z_ENABLE|TAP_Y_ENABLE|TAP_X_ENABLE)
+#define ADXL345_TAP_Z_ENABLE      (1 << 0)
+#define ADXL345_TAP_Y_ENABLE      (1 << 1)
+#define ADXL345_TAP_X_ENABLE      (1 << 2)
+#define ADXL345_SUPPRESS          (1 << 3)
+#define ADXL345_TAP_ALL_ENABLE    (ADXL345_TAP_Z_ENABLE | \
+                                   ADXL345_TAP_Y_ENABLE | \
+                                   ADXL345_TAP_X_ENABLE)
 /** @} */
 
 /**
  * @name    bits definitions for ACT_TAP_STATUS register
  * @{
  */
-#define TAP_Z_SRC         (1 << 0)
-#define TAP_Y_SRC         (1 << 1)
-#define TAP_X_SRC         (1 << 2)
-#define ASLEEP            (1 << 3)
-#define ACT_Z_SRC         (1 << 4)
-#define ACT_Y_SRC         (1 << 5)
-#define ACT_X_SRC         (1 << 6)
+#define ADXL345_TAP_Z_SRC         (1 << 0)
+#define ADXL345_TAP_Y_SRC         (1 << 1)
+#define ADXL345_TAP_X_SRC         (1 << 2)
+#define ADXL345_ASLEEP            (1 << 3)
+#define ADXL345_ACT_Z_SRC         (1 << 4)
+#define ADXL345_ACT_Y_SRC         (1 << 5)
+#define ADXL345_ACT_X_SRC         (1 << 6)
 /** @} */
 
 /**
  * @name    bits definitions for BW_RATE register
  * @{
  */
-#define RATE_MASK         (0x0F)
-#define LOWPOWER          (1 << 4)
+#define ADXL345_RATE_MASK         (0x0F)
+#define ADXL345_LOWPOWER          (1 << 4)
 /** @} */
 
 /**
  * @name    bits definitions for PWR_CTL register
  * @{
  */
-#define WAKEUP_8HZ        (0x00)
-#define WAKEUP_4HZ        (0x01)
-#define WAKEUP_2HZ        (0x02)
-#define WAKEUP_1HZ        (0x03)
-#define SLEEP_BIT         (1 << 2)
-#define MEASURE_BIT       (1 << 3)
-#define AUTOSLEEP_BIT     (1 << 4)
-#define LINK_BIT          (1 << 5)
+#define ADXL345_WAKEUP_8HZ        (0x00)
+#define ADXL345_WAKEUP_4HZ        (0x01)
+#define ADXL345_WAKEUP_2HZ        (0x02)
+#define ADXL345_WAKEUP_1HZ        (0x03)
+#define ADXL345_SLEEP_BIT         (1 << 2)
+#define ADXL345_MEASURE_BIT       (1 << 3)
+#define ADXL345_AUTOSLEEP_BIT     (1 << 4)
+#define ADXL345_LINK_BIT          (1 << 5)
 /** @} */
 
 /**
@@ -141,45 +143,45 @@
  * registers
  * @{
  */
-#define OVERRUN          (1 << 0)
-#define WATERMARK        (1 << 1)
-#define FREEFALL         (1 << 2)
-#define INACTIVITY       (1 << 3)
-#define ACTIVITY         (1 << 4)
-#define DOUBLE_TAP       (1 << 5)
-#define SINGLE_TAP       (1 << 6)
-#define DATA_READY       (1 << 7)
+#define ADXL345_OVERRUN          (1 << 0)
+#define ADXL345_WATERMARK        (1 << 1)
+#define ADXL345_FREEFALL         (1 << 2)
+#define ADXL345_INACTIVITY       (1 << 3)
+#define ADXL345_ACTIVITY         (1 << 4)
+#define ADXL345_DOUBLE_TAP       (1 << 5)
+#define ADXL345_SINGLE_TAP       (1 << 6)
+#define ADXL345_DATA_READY       (1 << 7)
 /** @} */
 
 /**
  * @name    bits definitions for DATA_FORMAT register
  * @{
  */
-#define RANGE_MASK        (0x03)
-#define JUSTIFY           (1 << 2)
-#define FULL_RES          (1 << 3)
-#define INT_INVERT        (1 << 5)
-#define SPI_BIT           (1 << 6)
-#define SELF_TEST         (1 << 7)
+#define ADXL345_RANGE_MASK        (0x03)
+#define ADXL345_JUSTIFY           (1 << 2)
+#define ADXL345_FULL_RES          (1 << 3)
+#define ADXL345_INT_INVERT        (1 << 5)
+#define ADXL345_SPI_BIT           (1 << 6)
+#define ADXL345_SELF_TEST         (1 << 7)
 /** @} */
 
 /**
  * @name    bits definitions for FIFO_CTL register
  * @{
  */
-#define SAMPLES_MASK      (0x0F)
-#define FIFO_TRIGGER_POS  (4)
-#define FIFO_TRIGGER      (1 << FIFO_TRIGGER_POS)
-#define FIFO_MODE_POS     (6)
-#define FIFO_MODE_MASK    (0xC0)
+#define ADXL345_SAMPLES_MASK      (0x0F)
+#define ADXL345_FIFO_TRIGGER_POS  (4)
+#define ADXL345_FIFO_TRIGGER      (1 << ADXL345_FIFO_TRIGGER_POS)
+#define ADXL345_FIFO_MODE_POS     (6)
+#define ADXL345_FIFO_MODE_MASK    (0xC0)
 /** @} */
 
 /**
  * @name    bits definitions for FIFO_STATUS register
  * @{
  */
-#define FIFO_ENTRIES_MASK (0x3F)
-#define FIFO_TRIG         (1 << 7)
+#define ADXL345_FIFO_ENTRIES_MASK (0x3F)
+#define ADXL345_FIFO_TRIG         (1 << 7)
 /** @} */
 
 #ifdef __cplusplus

--- a/drivers/include/adxl345.h
+++ b/drivers/include/adxl345.h
@@ -53,10 +53,10 @@ enum {
  * @brief   Define ADXL345 sensitivity
  */
 enum {
-    ADXL345_RANGE_2G    = 1,     /**< +/- 2 g Full Scale Range */
-    ADXL345_RANGE_4G    = 2,     /**< +/- 4 g Full Scale Range */
-    ADXL345_RANGE_8G    = 4,     /**< +/- 8 g Full Scale Range */
-    ADXL345_RANGE_16G   = 8      /**< +/- 16 g Full Scale Range */
+    ADXL345_RANGE_2G    = 0,     /**< +/- 2 g Full Scale Range */
+    ADXL345_RANGE_4G    = 1,     /**< +/- 4 g Full Scale Range */
+    ADXL345_RANGE_8G    = 2,     /**< +/- 8 g Full Scale Range */
+    ADXL345_RANGE_16G   = 3      /**< +/- 16 g Full Scale Range */
 };
 
 /**

--- a/drivers/include/adxl345.h
+++ b/drivers/include/adxl345.h
@@ -159,7 +159,7 @@ typedef struct {
 typedef struct {
     adxl345_params_t *params;       /**< Device configuration */
     adxl345_interrupt_t interrupt;  /**< Interrupts configuration  */
-    float scale_factor;             /**< Scale factor for converting value to mg */
+    int16_t scale_factor;           /**< Scale factor for converting value to mg */
 } adxl345_t;
 
 /**


### PR DESCRIPTION
### Contribution description

Fixes the broken ADXL345 driver.

1) Scale factor can be 4, not 3.9. 3.9 came from "typical scale factor is 3.9" from datasheets' Table 1, but accelerometer accuracy is never so good to really demand floating-point precision (adding hundreds bytes to firmware footprint on FPU-less controllers). Even datasheet itself states "maintaining 4 mg/LSB scale factor in all g ranges".

2) There's no need to change scale factor. It's always 4.

3) Byte reordering was never supposed to be done with arithmetic +

4) Byte reordering is not needed on BE platforms (BTW, __BYTE_ORDER__ macros used in RIOT is not exactly portable, are we ok with this?)

EDIT: more fixes
* full_res settings fixed

EDIT 2:
* scale calculation for 10-bit mode fixed
* bloody mess with variously named #defines fixed 

## Testing

Will test the driver on an actual devices later this week.

**The main question is: how this driver, being completely broken and unnecessary bloated, got into OS release?**