### PR TITLE
drivers/periph_eeprom: refactor implementation and test application

### DIFF
--- a/drivers/include/periph/eeprom.h
+++ b/drivers/include/periph/eeprom.h
@@ -46,6 +46,9 @@ uint8_t eeprom_read_byte(uint32_t pos);
 /**
  * @brief   Read @p len bytes from the given position
  *
+ * This function must be implemented by each CPU that provides an internal
+ * EEPROM.
+ *
  * @param[in]  pos      start position in eeprom
  * @param[out] data     output byte array to write to
  * @param[in]  len      the number of bytes to read
@@ -64,6 +67,9 @@ void eeprom_write_byte(uint32_t pos, uint8_t data);
 
 /**
  * @brief   Write @p len bytes at the given position
+ *
+ * This function must be implemented by each CPU that provides an internal
+ * EEPROM.
  *
  * @param[in] pos       start position in eeprom
  * @param[in] data      input byte array to read into

--- a/drivers/periph_common/eeprom.c
+++ b/drivers/periph_common/eeprom.c
@@ -28,26 +28,16 @@
 
 #include "periph/eeprom.h"
 
-size_t eeprom_read(uint32_t pos, uint8_t *data, size_t len)
+uint8_t eeprom_read_byte(uint32_t pos)
 {
-    assert(pos + len < EEPROM_SIZE);
-
-    for (size_t i = 0; i < len; i++) {
-        data[i] = eeprom_read_byte(pos++);
-    }
-
-    return len;
+    uint8_t byte;
+    eeprom_read(pos, &byte, 1);
+    return byte;
 }
 
-size_t eeprom_write(uint32_t pos, const uint8_t *data, size_t len)
+void eeprom_write_byte(uint32_t pos, uint8_t byte)
 {
-    assert(pos + len < EEPROM_SIZE);
-
-    for (size_t i = 0; i < len; i++) {
-        eeprom_write_byte(pos++, data[i]);
-    }
-
-    return len;
+    eeprom_write(pos, &byte, 1);
 }
 
 #endif

--- a/tests/periph_eeprom/tests/01-run.py
+++ b/tests/periph_eeprom/tests/01-run.py
@@ -1,0 +1,19 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2018 Inria
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import sys
+from testrunner import run
+
+
+def testfunc(child):
+    child.sendline('test')
+    child.expect('SUCCESS')
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc))


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR follows discussions in #10026 and #10056 and refactor the architecture specific implementation:
Before, each CPU architecture with an internal had to implement eeprom_read_byte/eeprom_write_byte functions and eeprom_read/eeprom_write were just wrappers on top of the former (basically looping on each byte).
This PR changes this to the opposite: each CPU now provides a specific implementation of eeprom_read and eeprom_write and eeprom_read_byte/eeprom_write_byte are special case of them. The API is kept unchanged.

This will allow architecture specific implementations to provide optimization (like what's proposed in #10026) without having to change the API.

In the meantime, I refactor slightly the test application:
- added 2 new commands for manipulating eeprom_read_byte/eeprom_write_byte functions
- added a new test command that performs different calls to the different API functions and that checks everything is correctly written/read
- added an automatic python script that calls this test function

Thus, this PR should be merged before the 2 other related PRs #10026 and #10056 (since it provides an automatic testing procedure and other fixes).

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Grab a board with a CPU providing internal EEPROM: arduino-mega2560, nucleo-l073rz, nucleo-l152re
- Run the following command:
```
$ make BOARD=<your board> -C tests/periph_eeprom flash test
```

It should run without error.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Following the discussion in #10056 and should be helpful for #10026.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
