### PR TITLE
tests/periph_flashpage: add automated test for flash peripheral

### DIFF
--- a/tests/periph_flashpage/main.c
+++ b/tests/periph_flashpage/main.c
@@ -319,6 +319,29 @@ static int cmd_test_last(int argc, char **argv)
     return 0;
 }
 
+#ifdef MODULE_PERIPH_FLASHPAGE_RAW
+/**
+ * @brief   Does a short raw write on last page available
+ *
+ * @note    Since every hardware can have different flash layouts for
+ *          automated testing we always write to the last page available
+ *          so we are independent of the size or layout
+ */
+static int cmd_test_last_raw(int argc, char **argv)
+{
+    (void) argc;
+    (void) argv;
+
+    /* try to align */
+    memcpy(raw_buf, "test12344321tset", 16);
+
+    flashpage_write_raw((void*) ((int)CPU_FLASH_BASE + (int)FLASHPAGE_SIZE * ((int)FLASHPAGE_NUMOF - 2)), raw_buf, strlen(raw_buf));
+
+    puts("wrote raw short buffer to last flash page");
+    return 0;
+}
+#endif
+
 static const shell_command_t shell_commands[] = {
     { "info", "Show information about pages", cmd_info },
     { "dump", "Dump the selected page to STDOUT", cmd_dump },
@@ -332,6 +355,9 @@ static const shell_command_t shell_commands[] = {
     { "edit", "Write bytes to the local page buffer", cmd_edit },
     { "test", "Write and verify test pattern", cmd_test },
     { "test_last", "Write and verify test pattern on last page available", cmd_test_last },
+#ifdef MODULE_PERIPH_FLASHPAGE_RAW
+    { "test_last_raw", "Write and verify raw short write on last page available", cmd_test_last_raw },
+#endif
     { NULL, NULL, NULL }
 };
 

--- a/tests/periph_flashpage/main.c
+++ b/tests/periph_flashpage/main.c
@@ -290,6 +290,35 @@ static int cmd_test(int argc, char **argv)
     return 0;
 }
 
+/**
+ * @brief   Does a write and verify test on last page available
+ *
+ * @note    Since every hardware can have different flash layouts for
+ *          automated testing we always write to the last page available
+ *          so we are independent of the size or layout
+ */
+static int cmd_test_last(int argc, char **argv)
+{
+    (void) argc;
+    (void) argv;
+    char fill = 'a';
+
+    for (unsigned i = 0; i < sizeof(page_mem); i++) {
+        page_mem[i] = (uint8_t)fill++;
+        if (fill > 'z') {
+            fill = 'a';
+        }
+    }
+
+    if (flashpage_write_and_verify((int)FLASHPAGE_NUMOF - 2, page_mem) != FLASHPAGE_OK) {
+        puts("error verifying the content of last page");
+        return 1;
+    }
+
+    puts("wrote local page buffer to last flash page");
+    return 0;
+}
+
 static const shell_command_t shell_commands[] = {
     { "info", "Show information about pages", cmd_info },
     { "dump", "Dump the selected page to STDOUT", cmd_dump },
@@ -302,6 +331,7 @@ static const shell_command_t shell_commands[] = {
     { "erase", "Erase the given page buffer", cmd_erase },
     { "edit", "Write bytes to the local page buffer", cmd_edit },
     { "test", "Write and verify test pattern", cmd_test },
+    { "test_last", "Write and verify test pattern on last page available", cmd_test_last },
     { NULL, NULL, NULL }
 };
 

--- a/tests/periph_flashpage/tests/01-run.py
+++ b/tests/periph_flashpage/tests/01-run.py
@@ -1,0 +1,20 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2018 Federico Pellegrin <fede@evolware.org>
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import sys
+from testrunner import run
+
+
+def testfunc(child):
+    # writes and verifies the last page of the flash
+    child.sendline("test_last")
+    child.expect_exact('wrote local page buffer to last flash page')
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc))

--- a/tests/periph_flashpage/tests/01-run.py
+++ b/tests/periph_flashpage/tests/01-run.py
@@ -14,6 +14,16 @@ def testfunc(child):
     # writes and verifies the last page of the flash
     child.sendline("test_last")
     child.expect_exact('wrote local page buffer to last flash page')
+    child.expect('>')
+
+    # check if board has raw write capability and if so test that as well
+    # capability is deduced from help contents
+    child.sendline("help")
+    index = child.expect(['test_last_raw', '>'])
+    if index == 0:
+        child.sendline("test_last_raw")
+        child.expect_exact('wrote raw short buffer to last flash page')
+        child.expect('>')
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
### Contribution description
Add a simple automatic test for flash peripheral as discussed in #10069. The test will do an erase/write/read/compare cycle using the flashpage_write_and_verify() function on the last page of the flash available. The last page is used to try to be hardware independant.

### Testing procedure
Execute:

`make flash test`

in tests/periph_flashpage

### Issues/PRs references
As discussed in #10069 to test the proposed PR.
