### PR TITLE
coap: Replace `COAP_CT_` with `COAP_FORMAT_`

### DIFF
--- a/sys/include/net/coap.h
+++ b/sys/include/net/coap.h
@@ -123,6 +123,8 @@ extern "C" {
 
 /**
  * @name    Content types
+ * @deprecated  Deprecated in favour of [COAP_FORMAT_](@ref net_coap_format)
+ *              style defines
  * @{
  */
 #define COAP_CT_LINK_FORMAT     (40)
@@ -134,11 +136,14 @@ extern "C" {
 
 /**
  * @name    Content-Format option codes
+ * @anchor  net_coap_format
  * @{
  */
 #define COAP_FORMAT_TEXT         (0)
 #define COAP_FORMAT_LINK        (40)
+#define COAP_FORMAT_XML         (41)
 #define COAP_FORMAT_OCTET       (42)
+#define COAP_FORMAT_EXI         (47)
 #define COAP_FORMAT_JSON        (50)
 #define COAP_FORMAT_CBOR        (60)
 /** @} */

--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -981,7 +981,7 @@ uint8_t gcoap_op_state(void)
 int gcoap_get_resource_list(void *buf, size_t maxlen, uint8_t cf)
 {
     (void)cf; /* only used in the assert below. */
-    assert(cf == COAP_CT_LINK_FORMAT);
+    assert(cf == COAP_FORMAT_LINK);
 
     /* skip the first listener, gcoap itself (we skip /.well-known/core) */
     gcoap_listener_t *listener = _coap_state.listeners->next;

--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -842,7 +842,7 @@ ssize_t coap_well_known_core_default_handler(coap_pkt_t *pkt, uint8_t *buf, \
     coap_block2_init(pkt, &slicer);
     uint8_t *payload = buf + coap_get_total_hdr_len(pkt);
     uint8_t *bufpos = payload;
-    bufpos += coap_put_option_ct(bufpos, 0, COAP_CT_LINK_FORMAT);
+    bufpos += coap_put_option_ct(bufpos, 0, COAP_FORMAT_LINK);
     bufpos += coap_opt_put_block2(bufpos, COAP_OPT_CONTENT_FORMAT, &slicer, 1);
 
     *bufpos++ = 0xff;

--- a/tests/unittests/tests-gcoap/tests-gcoap.c
+++ b/tests/unittests/tests-gcoap/tests-gcoap.c
@@ -264,15 +264,15 @@ static void test_gcoap__server_get_resource_list(void)
     gcoap_register_listener(&listener);
     gcoap_register_listener(&listener_second);
 
-    size = gcoap_get_resource_list(NULL, 0, COAP_CT_LINK_FORMAT);
+    size = gcoap_get_resource_list(NULL, 0, COAP_FORMAT_LINK);
     TEST_ASSERT_EQUAL_INT(strlen(resource_list_str), size);
 
     res[0] = 'A';
-    size = gcoap_get_resource_list(res, 0, COAP_CT_LINK_FORMAT);
+    size = gcoap_get_resource_list(res, 0, COAP_FORMAT_LINK);
     TEST_ASSERT_EQUAL_INT(0, size);
     TEST_ASSERT_EQUAL_INT((int)'A', (int)res[0]);
 
-    size = gcoap_get_resource_list(res, 127, COAP_CT_LINK_FORMAT);
+    size = gcoap_get_resource_list(res, 127, COAP_FORMAT_LINK);
     res[size] = '\0';
     TEST_ASSERT_EQUAL_INT(strlen(resource_list_str), size);
     TEST_ASSERT_EQUAL_STRING(resource_list_str, (char *)res);


### PR DESCRIPTION
### Contribution description

According to the IANA defines, there is only CoAP content-formats. and no CoAP content types. This PR merges the list of content types into the list of content formats and replaces all `COAP_CT_.*`occurences in our code with `COAP_FORMAT_.*`. I merged into the `COAP_FORMAT_` options because those were more often used than the `COAP_CT_` defines.

Not sure whether to call this an API_CHANGE, but all example code uses `COAP_FORMAT_`, so the old defines "should" not have been used outside our implementations, but if somebody wants to call this an api change I'm fine with it.

### Testing procedure

A small test to verify that the `.well-known/core` still has content number 40 should be enough here.

### Issues/PRs references

None
