### PR TITLE
drivers: htu21d relative humidity and temperature sensor driver

### DIFF
--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -175,6 +175,10 @@ ifneq (,$(filter hts221,$(USEMODULE)))
   FEATURES_REQUIRED += periph_i2c
 endif
 
+ifneq (,$(filter htu21d,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_i2c
+endif
+
 ifneq (,$(filter ina220,$(USEMODULE)))
   FEATURES_REQUIRED += periph_i2c
 endif

--- a/drivers/Makefile.include
+++ b/drivers/Makefile.include
@@ -98,6 +98,10 @@ ifneq (,$(filter hts221,$(USEMODULE)))
   USEMODULE_INCLUDES += $(RIOTBASE)/drivers/hts221/include
 endif
 
+ifneq (,$(filter htu21d,$(USEMODULE)))
+  USEMODULE_INCLUDES += $(RIOTBASE)/drivers/htu21d/include
+endif
+
 ifneq (,$(filter ina220,$(USEMODULE)))
   USEMODULE_INCLUDES += $(RIOTBASE)/drivers/ina220/include
 endif

--- a/drivers/htu21d/Makefile
+++ b/drivers/htu21d/Makefile
@@ -1,0 +1,3 @@
+MODULE = htu21d
+
+include $(RIOTBASE)/Makefile.base

--- a/drivers/htu21d/htu21d.c
+++ b/drivers/htu21d/htu21d.c
@@ -1,0 +1,381 @@
+/*
+ * Copyright (C) 2018 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_htu21d
+ * @brief       Device driver for the HTU21D humidity and temperature sensor
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ * @file
+ * @{
+ */
+
+#include <errno.h>
+#include <string.h>
+#include <stdlib.h>
+
+#include "htu21d_regs.h"
+#include "htu21d.h"
+
+#include "log.h"
+#include "xtimer.h"
+
+#define ENABLE_DEBUG    (0)
+#include "debug.h"
+
+#if ENABLE_DEBUG
+
+#define ASSERT_PARAM(cond) \
+    if (!(cond)) { \
+        DEBUG("[htu21d] %s: %s\n", \
+              __func__, "parameter condition (" # cond ") not fulfilled"); \
+        assert(cond); \
+    }
+
+#define DEBUG_DEV(f, d, ...) \
+        DEBUG("[htu21d] %s i2c dev=%d addr=%02x: " f "\n", \
+              __func__, d->params.dev, d->params.addr, ## __VA_ARGS__);
+
+#else /* ENABLE_DEBUG */
+
+#define ASSERT_PARAM(cond) assert(cond);
+#define DEBUG_DEV(f, d, ...)
+
+#endif /* ENABLE_DEBUG */
+
+#define ERROR_DEV(f, d, ...) \
+        LOG_ERROR("[htu21d] %s i2c dev=%d addr=%02x: " f "\n", \
+                  __func__, d->params.dev, d->params.addr, ## __VA_ARGS__);
+
+#define EXEC_RET(f) { \
+    int _r; \
+    if ((_r = f) != HTU21D_OK) { \
+        DEBUG("[htu21d] %s: error code %d\n", __func__, _r); \
+        return _r; \
+    } \
+}
+
+#define EXEC_RET_CODE(f, c) { \
+    int _r; \
+    if ((_r = f) != HTU21D_OK) { \
+        DEBUG("[htu21d] %s: error code %d\n", __func__, _r); \
+        return c; \
+    } \
+}
+
+/** Forward declaration of functions for internal use */
+
+static int _user_reg_write(const htu21d_t *dev, uint8_t data);
+static int _user_reg_read(const htu21d_t *dev, uint8_t *data);
+static int _send_command(const htu21d_t *dev, uint8_t cmd);
+static int _read_bytes(const htu21d_t* dev, uint8_t *data, uint8_t len);
+static int _fetch_raw (htu21d_t *dev, int16_t *raw);
+static uint8_t _crc8 (uint8_t data[], int len);
+
+int htu21d_init(htu21d_t *dev, const htu21d_params_t *params)
+{
+    ASSERT_PARAM(dev != NULL);
+    ASSERT_PARAM(params != NULL);
+    DEBUG_DEV("params=%p", dev, params);
+
+    /* init sensor data structure */
+    dev->params = *params;
+    dev->measure_tmp = false;
+    dev->measure_hum = false;
+
+    /* reset the sensor and wait the start-up time*/
+    EXEC_RET(_send_command(dev, HTU21D_SOFT_RESET));
+    xtimer_usleep (15 * US_PER_MS);
+
+    /* read user register */
+    htu21d_user_reg_t user_reg;
+    EXEC_RET(_user_reg_read(dev, (uint8_t *)&user_reg));
+
+    switch (params->res) {
+        case HTU21D_RES_RH12_T14:
+                user_reg.resolution_1 = 0;
+                user_reg.resolution_0 = 0;
+                break;
+        case HTU21D_RES_RH11_T11:
+                user_reg.resolution_1 = 1;
+                user_reg.resolution_0 = 1;
+                break;
+        case HTU21D_RES_RH10_T13:
+                user_reg.resolution_1 = 1;
+                user_reg.resolution_0 = 0;
+                break;
+        case HTU21D_RES_RH8_T12:
+                user_reg.resolution_1 = 0;
+                user_reg.resolution_0 = 1;
+                break;
+    }
+    EXEC_RET(_user_reg_write(dev, user_reg.val));
+
+    return HTU21D_OK;
+}
+
+static const uint8_t _times_tmp[] = { 85, 22, 43, 11 };
+static const uint8_t _times_hum[] = { 29, 4, 9, 15 };
+
+int htu21d_measure_tmp(htu21d_t *dev)
+{
+    ASSERT_PARAM(dev != NULL);
+    DEBUG_DEV("", dev);
+
+    if (dev->measure_tmp || dev->measure_hum) {
+        /* measurement can't be started if sensor is already measuring */
+        return -HTU21D_ERROR_MEASURING;
+    }
+
+    EXEC_RET(_send_command(dev, HTU21D_TMP_MEAS));
+    dev->measure_tmp = true;
+    return _times_tmp[dev->params.res];
+}
+
+int htu21d_measure_hum(htu21d_t *dev)
+{
+    ASSERT_PARAM(dev != NULL);
+    DEBUG_DEV("", dev);
+
+    if (dev->measure_tmp || dev->measure_hum) {
+        /* measurement can't be started if sensor is already measuring */
+        return -HTU21D_ERROR_MEASURING;
+    }
+
+    EXEC_RET(_send_command(dev, HTU21D_HUM_MEAS));
+    dev->measure_hum = true;
+    return _times_hum[dev->params.res];
+}
+
+int htu21d_fetch_tmp(htu21d_t *dev, int16_t* tmp, int16_t *raw_tmp)
+{
+    ASSERT_PARAM(dev != NULL);
+    DEBUG_DEV("tmp=%p raw_tmp=%p", dev, tmp, raw_tmp);
+
+    if (!dev->measure_tmp) {
+        return -HTU21D_ERROR_NOT_MEASURING;
+    }
+
+    int16_t raw;
+    EXEC_RET(_fetch_raw(dev, &raw));
+
+    if (raw_tmp) {
+        *raw_tmp = raw;
+    }
+
+    if (tmp) {
+        *tmp =((17572 * raw) / 65536) - 4685;
+    }
+
+    return HTU21D_OK;
+}
+
+int htu21d_fetch_hum(htu21d_t *dev, int16_t* hum, int16_t *raw_hum)
+{
+    ASSERT_PARAM(dev != NULL);
+    DEBUG_DEV("hum=%p raw_hum=%p", dev, hum, raw_hum);
+
+    if (!dev->measure_hum) {
+        return -HTU21D_ERROR_NOT_MEASURING;
+    }
+
+    int16_t raw;
+    EXEC_RET(_fetch_raw(dev, &raw));
+
+    if (raw_hum) {
+        *raw_hum = raw;
+    }
+
+    if (hum) {
+        *hum = ((12500 * raw) / 65536) - 600;
+    }
+
+    return HTU21D_OK;
+}
+
+int htu21d_read (htu21d_t *dev,
+                 int16_t *tmp, int16_t *hum,
+                 int16_t *raw_tmp, int16_t *raw_hum)
+{
+    ASSERT_PARAM(dev != NULL);
+    DEBUG_DEV("tmp=%p hum=%p tmp_raw=%p raw_hum=%p",
+              dev, tmp, hum, raw_tmp, raw_hum);
+
+    int res;
+
+    if (tmp || raw_tmp) {
+        /* start temperature measurement */
+        if ((res = htu21d_measure_tmp(dev)) <= 0) {
+            DEBUG_DEV("could not start temperature measurement", dev);
+            return res;
+        }
+        /* wait for results and fetch them */
+        do {
+            /* wait for results */
+            xtimer_usleep(5 * US_PER_MS);
+            /* try to fetch data, returns with error if still not available */
+            res = htu21d_fetch_tmp(dev, tmp, raw_tmp);
+            /* return if error code is not HTU21D_ERROR_MEASURING */
+            if (res != HTU21D_OK && res != -HTU21D_ERROR_MEASURING) {
+                return res;
+            }
+        } while (res != HTU21D_OK);
+    }
+    if (hum || raw_hum) {
+        /* start humidity measurement */
+        if ((res = htu21d_measure_hum(dev)) <= 0) {
+            DEBUG_DEV("could not start humidity measurement", dev);
+            return res;
+        }
+        do {
+            /* wait for results */
+            xtimer_usleep(5 * US_PER_MS);
+            /* try to fetch data, returns with error if still not available */
+            res = htu21d_fetch_hum(dev, hum, raw_hum);
+            /* return if error code is not HTU21D_ERROR_MEASURING */
+            if (res != HTU21D_OK && res != -HTU21D_ERROR_MEASURING) {
+                return res;
+            }
+        } while (res != HTU21D_OK);
+    }
+
+    return HTU21D_OK;
+}
+
+/** Functions for internal use only */
+
+int _fetch_raw(htu21d_t *dev, int16_t *raw)
+{
+    ASSERT_PARAM(dev != NULL);
+    ASSERT_PARAM(raw != NULL);
+    DEBUG_DEV("raw=%p", dev, raw);
+
+    if (!dev->measure_tmp && !dev->measure_hum) {
+        return -HTU21D_ERROR_NOT_MEASURING;
+    }
+
+    uint8_t data[3];
+    int res = _read_bytes(dev, data, 3);
+
+    if (res == HTU21D_OK) {
+        /* data MSB @ lower address */
+        *raw = (data[0] << 8) | data[1];
+        dev->measure_tmp = false;
+        dev->measure_hum = false;
+        /* check crc */
+        if (_crc8(data,2) != data[2]) {
+            DEBUG_DEV("CRC check for data failed", dev);
+            return -HTU21D_ERROR_CRC;
+        }
+    }
+    else if (res == -HTU21D_ERROR_I2C_NO_ACK) {
+        return -HTU21D_ERROR_MEASURING;
+    }
+
+    return res;
+}
+
+static int _write_byte(const htu21d_t* dev, uint8_t data, uint8_t flags)
+{
+    int res = HTU21D_OK;
+
+    DEBUG_DEV("send byte 0x%02x", dev, data);
+
+    if (i2c_acquire(dev->params.dev) != HTU21D_OK) {
+        DEBUG_DEV ("could not aquire I2C bus", dev);
+        return -HTU21D_ERROR_I2C;
+    }
+
+    res = i2c_write_byte(dev->params.dev, dev->params.addr, data, flags);
+    i2c_release(dev->params.dev);
+
+    if (res != HTU21D_OK) {
+        DEBUG_DEV("could not write byte 0x%02x to sensor, reason=%d",
+                  dev, data, res);
+        return -HTU21D_ERROR_I2C;
+    }
+
+    return res;
+}
+
+static int _read_bytes(const htu21d_t* dev, uint8_t *data, uint8_t len)
+{
+    int res = HTU21D_OK;
+
+    if (i2c_acquire(dev->params.dev) != HTU21D_OK) {
+        DEBUG_DEV ("could not aquire I2C bus", dev);
+        return -HTU21D_ERROR_I2C;
+    }
+
+    res = i2c_read_bytes(dev->params.dev, dev->params.addr, (void*)data, len, 0);
+    i2c_release(dev->params.dev);
+
+    if (res == HTU21D_OK) {
+        if (ENABLE_DEBUG) {
+            printf("[htu21d] %s bus=%d addr=%02x: read following bytes: ",
+                   __func__, dev->params.dev, dev->params.addr);
+            for (int i=0; i < len; i++)
+                printf("%02x ", data[i]);
+            printf("\n");
+        }
+        return HTU21D_OK;
+    }
+    else if (res == -EIO) {
+        DEBUG_DEV("no ack from sensor", dev);
+        return -HTU21D_ERROR_I2C_NO_ACK;
+    }
+    else {
+        DEBUG_DEV("could not read %d bytes from sensor, reason %d (%s)",
+                  dev, len, res, strerror(res * -1));
+        return -HTU21D_ERROR_I2C;
+    }
+}
+
+static int _send_command(const htu21d_t *dev, uint8_t cmd)
+{
+    ASSERT_PARAM(dev != NULL);
+    DEBUG_DEV("send command 0x%02x", dev, cmd);
+
+    return _write_byte(dev, cmd, 0);
+}
+
+static int _user_reg_read(const htu21d_t *dev, uint8_t *data)
+{
+    EXEC_RET(_write_byte(dev, HTU21D_READ_USER_REG, I2C_NOSTOP));
+    EXEC_RET(_read_bytes(dev, data, 1));
+    return HTU21D_OK;
+}
+
+static int _user_reg_write(const htu21d_t *dev, uint8_t data)
+{
+    EXEC_RET(_write_byte(dev, HTU21D_WRITE_USER_REG, I2C_NOSTOP));
+    EXEC_RET(_write_byte(dev, data, I2C_NOSTART));
+    return HTU21D_OK;
+}
+
+static const uint8_t g_polynom = 0x31;
+
+static uint8_t _crc8 (uint8_t data[], int len)
+{
+    /* initialization value */
+    uint8_t crc = 0;
+
+    /* iterate over all bytes */
+    for (int i=0; i < len; i++)
+    {
+        crc ^= data[i];
+
+        for (int i = 0; i < 8; i++)
+        {
+            bool xor = crc & 0x80;
+            crc = crc << 1;
+            crc = xor ? crc ^ g_polynom : crc;
+        }
+    }
+
+    return crc;
+}

--- a/drivers/htu21d/htu21d_saul.c
+++ b/drivers/htu21d/htu21d_saul.c
@@ -1,0 +1,53 @@
+/*
+ * Copyright (C) 2018 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_htu21d
+ * @brief       HTU21D adaption to the RIOT actuator/sensor interface
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ * @file
+ */
+
+#include <string.h>
+
+#include "saul.h"
+#include "htu21d.h"
+
+static int read_hum(const void *dev, phydat_t *res)
+{
+    int ret = htu21d_read((htu21d_t *)dev, 0, res->val, 0, 0);
+    if (ret < 0) {
+        return -ECANCELED;
+    }
+    res->unit = UNIT_PERCENT;
+    res->scale = -2;
+    return 1;
+}
+
+static int read_tmp(const void *dev, phydat_t *res)
+{
+    int ret = htu21d_read((htu21d_t *)dev, res->val, 0, 0, 0);
+    if (ret < 0) {
+        return -ECANCELED;
+    }
+    res->unit = UNIT_TEMP_C;
+    res->scale = -2;
+    return 1;
+}
+
+const saul_driver_t htu21d_saul_hum_driver = {
+    .read = read_hum,
+    .write = saul_notsup,
+    .type = SAUL_SENSE_HUM,
+};
+
+const saul_driver_t htu21d_saul_tmp_driver = {
+    .read = read_tmp,
+    .write = saul_notsup,
+    .type = SAUL_SENSE_TEMP,
+};

--- a/drivers/htu21d/include/htu21d_params.h
+++ b/drivers/htu21d/include/htu21d_params.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2018 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_htu21d
+ * @brief       Default configuration for HTU21D humidity and temperature sensor
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ * @file
+ * @{
+ */
+
+#ifndef HTU21D_PARAMS_H
+#define HTU21D_PARAMS_H
+
+#include "board.h"
+#include "htu21d.h"
+#include "saul_reg.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Set default configuration parameters
+ * @{
+ */
+#ifndef HTU21D_PARAM_DEV
+#define HTU21D_PARAM_DEV          I2C_DEV(0)
+#endif
+#ifndef HTU21D_PARAM_ADDR
+#define HTU21D_PARAM_ADDR         (HTU21D_I2C_ADDRESS)
+#endif
+#ifndef HTU21D_PARAM_RES
+#define HTU21D_PARAM_RES          (HTU21D_RES_RH12_T14)
+#endif
+
+#ifndef HTU21D_PARAMS
+#define HTU21D_PARAMS             { \
+                                     .dev  = HTU21D_PARAM_DEV,  \
+                                     .addr = HTU21D_PARAM_ADDR, \
+                                     .res  = HTU21D_PARAM_RES, \
+                                   }
+#endif
+
+#ifndef HTU21D_SAUL_INFO
+#define HTU21D_SAUL_INFO          { .name = "htu21d" }
+#endif
+/**@}*/
+
+/**
+ * @brief   Allocate some memory to store the actual configuration
+ */
+static const htu21d_params_t htu21d_params[] =
+{
+    HTU21D_PARAMS
+};
+
+/**
+ * @brief   Additional meta information to keep in the SAUL registry
+ */
+static const saul_reg_info_t htu21d_saul_info[] =
+{
+    HTU21D_SAUL_INFO
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* HTU21D_PARAMS_H */
+/** @} */

--- a/drivers/htu21d/include/htu21d_regs.h
+++ b/drivers/htu21d/include/htu21d_regs.h
@@ -1,0 +1,55 @@
+/*
+ * Copyright (C) 2018 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_htu21d
+ * @brief       Definitions for HTU21D humidity and temperature sensor
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ * @file
+ * @{
+ */
+
+#ifndef HTU21D_REGS_H
+#define HTU21D_REGS_H
+
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/**
+ * @name    Commands
+ */
+#define HTU21D_TMP_MEAS_WH    0xe3  /**< trigger temperature measurement with hold */
+#define HTU21D_HUM_MEAS_WH    0xe5  /**< trigger humidity measurement with hold */
+#define HTU21D_TMP_MEAS       0xf3  /**< trigger temperature measurement */
+#define HTU21D_HUM_MEAS       0xf5  /**< trigger humidity measurement */
+#define HTU21D_WRITE_USER_REG 0xe6  /**< write user register */
+#define HTU21D_READ_USER_REG  0xe7  /**< read user register */
+#define HTU21D_SOFT_RESET     0xfe  /**< soft reset */
+
+/** User register structure */
+typedef union {
+    struct {
+        uint8_t resolution_0: 1;    /**< measurement resolution bit 0 */
+        uint8_t disable_otp : 1;    /**< disable opt_reload */
+        uint8_t enable_heat : 1;    /**< enable heater */
+        uint8_t reserved    : 3;    /**< reserved */
+        uint8_t battery_stat: 1;    /**< status end of battery */
+        uint8_t resolution_1: 1;    /**< measurement resolution bit 0 */
+    };
+    uint8_t val;                    /**< register as 8 bit value */
+} htu21d_user_reg_t;
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* HTU21D_REGS_H */

--- a/drivers/include/htu21d.h
+++ b/drivers/include/htu21d.h
@@ -1,0 +1,302 @@
+/*
+ * Copyright (C) 2018 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    drivers_htu21d HTU21D humidity and temperature
+ * @ingroup     drivers_sensors
+ * @ingroup     drivers_saul
+ * @brief       Device driver for HTU21D humidity and temperature sensor
+ *
+ * The driver works also with Sensirion SHT21.
+ *
+ * The sensor only supports single measurements and polling. Therefore,
+ * the measurement process includes the following steps:
+ *
+ * 1. Trigger the sensor to measure either temperature or relative humidity.
+ *    This is done by #htu21d_measure_tmp or #htu21d_measure_hum.
+ * 2. Wait the time the sensor requires to complete the measurement.
+ *    The maximum time in ms the sensor might require is returned by
+ *    #htu21d_measure_tmp and #htu21d_measure_hum. The measurement
+ *    time depends on the configured resolution, see #htu21d_res_t.
+ * 3. Fetch the results for either temperature or relative humidity
+ *    with #htu21d_fetch_tmp or #htu21d_fetch_hum.
+ *
+ * @note
+ * These steps can be performed either for temperature or humidity only,
+ * but not for both at the same time. That is, the measurements can not
+ * be mixed:
+ * - After triggering a temperature measurement with
+ *   the #htu21d_measure_tmp function, the #htu21d_fetch_tmp function
+ *   must be used to retrieve the results.
+ * - After triggering a humidity measurement with
+ *   the #htu21d_measure_hum function, the #htu21d_fetch_hum function
+ *   must be used to retrieve the results.
+ * Otherwise, incorrect results will be retrieved.
+ *
+ * Example:
+ * ```
+ * while (1) {
+ *     ...
+ *     int res;
+ *     int16_t tmp;
+ *     int16_t raw;
+ *
+ *     res = htu21d_measure_tmp(&dev);
+ *     if (res > 0) {
+ *         xtimer_usleep(res * US_PER_MS);
+ *     }
+ *     res = htu21d_fetch_tmp (&dev, &tmp, &raw);
+ *       ...
+ * }
+ * ```
+ *
+ * The #htu21d_fetch_tmp and #htu21d_fetch_hum return the raw sensor data
+ * as 16-bit 2's complement and the sensor data converted to temperature
+ * or humidity.
+ *
+ * If any data are not needed, the corresponding parameter can be set to
+ * NULL, for example
+ *
+ * ```
+ *     res = htu21d_fetch_tmp (&dev, NULL, &raw);
+ * ```
+ * to fetch only raw sensor data for the temperature.
+ *
+ * For convenience, the #htu21d_read function carries out all measurement
+ * steps for temperature and/or humidity as one blocking function call. Using
+ * As with other fetch functions, the parameters can be set to NULL for
+ * data that are not needed.
+ *
+ * @note Using this function can be faster because #htu21d_measure_tmp and
+ * #htu21d_measure_hum return the maximum time the sensor needs according to
+ * the datasheet. This maximum time can be up to 85 ms. The # htu21d_read
+ * functoin checks the availability of the results every 5 ms and may
+ * be faster if the sensor does not need the maximum time.
+ *
+ * Example:
+ * ```
+ * while (1) {
+ *     ...
+ *     int res;
+ *     int16_t tmp;
+ *     int16_t hum_raw;
+ *
+ *     res = htu21d_read(&dev, &tmp, NULL, NULL, &hum_raw);
+ *     ...
+ * }
+ * ```
+ *
+ * Although the sensor supports a so-called hold-master mode that uses
+ * clock stretching to keep the master waiting when a measurement is
+ * triggered until the results are avialablae, this hold-master mode
+ * is not used by the driver
+ *
+ * - to prevent the master from being blocked,
+ * - to avoid blocking the I2C bus, and
+ * - not all I2C implementations support clock stretching.
+ *
+ * This driver provides @ref drivers_saul capabilities.
+ *
+ * @{
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ * @file
+ */
+
+#ifndef HTU21D_H
+#define HTU21D_H
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "periph/gpio.h"
+#include "periph/i2c.h"
+
+/** HTU21D I2C address */
+#define HTU21D_I2C_ADDRESS  (0x40)
+
+/** Definition of error codes */
+typedef enum {
+    HTU21D_OK,                   /**< success */
+    HTU21D_ERROR_I2C,            /**< I2C communication error */
+    HTU21D_ERROR_I2C_NO_ACK,     /**< I2C no ack from slave */
+    HTU21D_ERROR_CRC,            /**< data CRC error */
+    HTU21D_ERROR_MEASURING,      /**< measurement in progress */
+    HTU21D_ERROR_NOT_MEASURING,  /**< measurement not started  */
+} htu21d_error_codes_t;
+
+/**
+ * @brief   Resolutions
+ *
+ * The resolution determines the maximum time needed by the sensor for
+ * one measurement.
+ *
+ * Resolution | RH [ms] | T [ms]
+ * ---------- | ------- | ------
+ * 14 bit     |         | 85
+ * 13 bit     |         | 43
+ * 12 bit     | 29      | 22
+ * 11 bit     | 15      | 11
+ * 10 bit     |  9      ||
+ *  8 bit     |  4      ||
+ */
+typedef enum {
+    HTU21D_RES_RH12_T14 = 0,    /**< RH with 12 bit, Temperature with 14 */
+    HTU21D_RES_RH8_T12,         /**< RH with  8 bit, Temperature with 12 */
+    HTU21D_RES_RH10_T13,        /**< RH with 13 bit, Temperature with 13 */
+    HTU21D_RES_RH11_T11,        /**< RH with 11 bit, Temperature with 11 */
+} htu21d_res_t;
+
+/**
+ * @brief   HTU21D device initialization parameters
+ */
+typedef struct {
+    unsigned  dev;   /**< I2C device (default I2C_DEV(0)) */
+    uint8_t   addr;  /**< I2C slave address (default #HTU21D_I2C_ADDRESS) */
+    htu21d_res_t res; /**< measurement resolution (default #HTU21D_RES_RH12_T14) */
+} htu21d_params_t;
+
+/**
+ * @brief   HTU21D sensor device data structure type
+ */
+typedef struct {
+    bool measure_tmp;          /**< measurement of temperature started */
+    bool measure_hum;          /**< measurement of humidity started */
+    htu21d_params_t params;    /**< device initialization parameters */
+
+} htu21d_t;
+
+/**
+ * @brief	Initialize the HTU21D sensor device
+ *
+ * This function resets the sensor and initializes the sensor according to
+ * given intialization parameters. All registers are reset to default values.
+ *
+ * @param[in]   dev     device descriptor of HTU21D sensor to be initialized
+ * @param[in]   params  HTU21D initialization parameters
+ *
+ * @retval  HTU21D_OK      on success
+ * @retval  HTU21D_ERROR_* a negative error code on error,
+ *                         see #htu21d_error_codes_t
+ */
+int htu21d_init(htu21d_t *dev, const htu21d_params_t *params);
+
+/**
+ * @brief   Trigger a single measurement of temperature
+ *
+ * Triggers a single measurement of the temperature and returns the time
+ * in ms needed by the sensor to finish the measurement. Temperature can be
+ * fetched after this time using function #htu21d_fetch_tmp.
+ *
+ * @param[in]   dev     device descriptor of HTU21D sensor
+ *
+ * @return   time needed by the sensor on success, or
+ *           a negative error code on error, see #htu21d_error_codes_t
+ */
+int htu21d_measure_tmp (htu21d_t *dev);
+
+/**
+ * @brief   Trigger a single measurement of relative humidity
+ *
+ * Triggers a single measurement of the relative humidity and returns the
+ * time in ms needed by the sensor to finish the measurement. Relative
+ * humidity Temperature can be fetched after this time using
+ * function #htu21d_fetch_tmp.
+ *
+ * @param[in]   dev     device descriptor of HTU21D sensor
+ *
+ * @return   time needed by the sensor on success, or
+ *           a negative error code on error, see #htu21d_error_codes_t
+ */
+int htu21d_measure_hum (htu21d_t *dev);
+
+/**
+ * @brief   Fetch the temperature in hundredths of a degree Celsius
+ *
+ * The function reads the raw sensor data from the measurement previously
+ * started with #htu21d_measure_tmp and converts them to the temperature in
+ * hundredths of a degree Celsius. If the measurement has not been finished
+ * when it is called, it fails with the error code #HTU21D_ERROR_MEASURING.
+ * The error code can be used for polling.
+ *
+ * @note The \p tmp and \p raw parameter can be NULL if values are not
+ * of interest.
+ *
+ * @param[in]   dev     device descriptor of HTU21D sensor
+ * @param[out]  tmp     temperature in hundredths of a degree Celsius
+ * @param[out]  raw     raw temperature sensor data as 16 bit two's complement
+ *
+ * @retval  HTU21D_OK                   on success
+ * @retval  HTU21D_ERROR_MEASURING      measurement still in progress
+ * @retval  HTU21D_ERROR_NOT_MEASURING  measurement not started
+ * @retval  HTU21D_ERROR_*              a negative error code on error,
+ *                                      see #htu21d_error_codes_t
+ */
+int htu21d_fetch_tmp (htu21d_t *dev, int16_t *tmp, int16_t *raw);
+
+/**
+ * @brief   Fetch the relative humidity in hundredths of a degree Celsius
+ *
+ * The function reads raw sensor data from the measurement previously
+ * started with #htu21d_measure_hum and converts them to the relative
+ * humidity hundredths of a percent. If the measurement has not been finished
+ * when it is called, it fails with the error code #HTU21D_ERROR_MEASURING.
+ * The error code can be used for polling.
+ *
+ * @param[in]   dev     device descriptor of HTU21D sensor
+ * @param[out]  hum     relative humidity in hundredths of a percent
+ * @param[out]  raw     raw humidity sensor data as 16 bit two's complement
+ *
+ * @note The \p hum and \p raw parameter can be NULL if values are not
+ * of interest.
+ *
+ * @retval  HTU21D_OK                   on success
+ * @retval  HTU21D_ERROR_MEASURING      measurement still in progress
+ * @retval  HTU21D_ERROR_NOT_MEASURING  measurement not started
+ * @retval  HTU21D_ERROR_*              a negative error code on error,
+ *                                      see #htu21d_error_codes_t
+ */
+int htu21d_fetch_hum (htu21d_t *dev, int16_t *hum, int16_t *raw);
+
+/**
+ * @brief   Convenience function to trigger a measurement and fetcht the results
+ *
+ * The function triggers a single measurement of temperature and/or relative
+ * humidity and returns the converted measurement results.
+ *
+ * Output parameters can be NULL if values are not of interest.
+ *
+ * @note This function waits for measurement results and returns once these
+ * results are available. Depending on the resolution, it can take from some
+ * ms up to 85 ms.
+ *
+ * @param[in]   dev     device descriptor of HTU21D sensor
+ * @param[out]  tmp     temperature in hundredths of a degree Celsius
+ * @param[out]  hum     relative humidity in hundredths of a percent
+ * @param[out]  raw_tmp raw temperature sensor data as 16 bit two's complement
+ * @param[out]  raw_hum raw humidity sensor data as 16 bit two's complement
+ *
+ * @retval  HTU21D_OK       on success
+ * @retval  HTU21D_ERROR_*  a negative error code on error,
+ *                          see #htu21d_error_codes_t
+ */
+int htu21d_read (htu21d_t *dev,
+                 int16_t *tmp, int16_t *hum,
+                 int16_t *raw_tmp, int16_t *raw_hum);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* HTU21D_H */
+/** @} */

--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -380,6 +380,10 @@ auto_init_mpu9150();
     extern void auto_init_hts221(void);
     auto_init_hts221();
 #endif
+#ifdef MODULE_HTU21D
+    extern void auto_init_htu21d(void);
+    auto_init_htu21d();
+#endif
 #ifdef MODULE_DHT
     extern void auto_init_dht(void);
     auto_init_dht();

--- a/sys/auto_init/saul/auto_init_htu21d.c
+++ b/sys/auto_init/saul/auto_init_htu21d.c
@@ -1,0 +1,78 @@
+/*
+ * Copyright (C) 2018 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     sys_auto_init_saul
+ * @ingroup     drivers_htu21d
+ * @brief       Auto initialization for HTU21D humidity and temperature sensor
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ * @file
+ */
+
+#ifdef MODULE_HTU21D
+
+#include "assert.h"
+#include "log.h"
+#include "saul_reg.h"
+#include "htu21d_params.h"
+#include "htu21d.h"
+
+/**
+ * @brief   Define the number of configured sensors
+ */
+#define HTU21D_NUM     (sizeof(htu21d_params) / sizeof(htu21d_params[0]))
+
+/**
+ * @brief   Allocate memory for the device descriptors
+ */
+static htu21d_t htu21d_devs[HTU21D_NUM];
+
+/**
+ * @brief   Memory for the SAUL registry entries
+ */
+static saul_reg_t saul_entries[HTU21D_NUM * 2];
+
+/**
+ * @brief   Define the number of saul info
+ */
+#define HTU21D_INFO_NUM (sizeof(htu21d_saul_info) / sizeof(htu21d_saul_info[0]))
+
+/**
+ * @name    Import SAUL endpoints
+ * @{
+ */
+extern const saul_driver_t htu21d_saul_tmp_driver;
+extern const saul_driver_t htu21d_saul_hum_driver;
+/** @} */
+
+void auto_init_htu21d(void)
+{
+    assert(HTU21D_INFO_NUM == HTU21D_NUM);
+
+    for (unsigned int i = 0; i < HTU21D_NUM; i++) {
+        LOG_DEBUG("[auto_init_saul] initializing htu21d #%u\n", i);
+
+        if (htu21d_init(&htu21d_devs[i], &htu21d_params[i]) != HTU21D_OK) {
+            LOG_ERROR("[auto_init_saul] error initializing htu21d #%u\n", i);
+            continue;
+        }
+
+        saul_entries[(i * 2)].dev = &(htu21d_devs[i]);
+        saul_entries[(i * 2)].name = htu21d_saul_info[i].name;
+        saul_entries[(i * 2)].driver = &htu21d_saul_tmp_driver;
+        saul_entries[(i * 2) + 1].dev = &(htu21d_devs[i]);
+        saul_entries[(i * 2) + 1].name = htu21d_saul_info[i].name;
+        saul_entries[(i * 2) + 1].driver = &htu21d_saul_hum_driver;
+        saul_reg_add(&(saul_entries[(i * 2)]));
+        saul_reg_add(&(saul_entries[(i * 2) + 1]));
+    }
+}
+
+#else
+typedef int dont_be_pedantic;
+#endif /* MODULE_HTU21D */

--- a/tests/driver_htu21d/Makefile
+++ b/tests/driver_htu21d/Makefile
@@ -1,0 +1,6 @@
+include ../Makefile.tests_common
+
+USEMODULE += htu21d
+USEMODULE += xtimer
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/driver_htu21d/main.c
+++ b/tests/driver_htu21d/main.c
@@ -1,0 +1,91 @@
+/*
+ * Copyright (C) 2018 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @brief       Test application for HTU21D humidity and temperature sensor
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ * @file
+ *
+ * The test application demonstrates the use of the HTU21D. Either
+ * single measurement steps or the blocking function #htu21d_read
+ * can be used. Blocking function is activated by defining
+ * USE_HTU21D_BLOCKING.
+ * ```
+ * CFLAGS="-DUSE_HTU21D_BLOCKING" make -C tests/driver_htu21d/ BOARD=...
+ * ```
+ */
+
+#include <stdio.h>
+#include <stdlib.h>
+
+#include "thread.h"
+#include "xtimer.h"
+
+#include "htu21d.h"
+#include "htu21d_params.h"
+
+#define SLEEP   (100 * US_PER_MS)
+
+int main(void)
+{
+    htu21d_t dev;
+
+    puts("HTU21D driver test application\n");
+    puts("Initializing HTU21D sensor");
+
+    /* initialize the sensor with default configuration parameters */
+    if (htu21d_init(&dev, &htu21d_params[0]) == HTU21D_OK) {
+        puts("[OK]\n");
+    }
+    else {
+        puts("[Failed]");
+        return 1;
+    }
+
+    while (1) {
+        int16_t tmp;
+        int16_t hum;
+        int res;
+
+        /* wait between measuremens or do something else */
+        xtimer_usleep(SLEEP);
+
+#ifdef USE_HTU21D_BLOCKING
+        /* read and print data with single blocking function */
+        res = htu21d_read(&dev, &tmp, &hum, 0, 0);
+#else
+        /* trigger temperature management */
+        res = htu21d_measure_tmp(&dev);
+        if (res > 0) {
+            /* wait the returned measurement time or do something else */
+            xtimer_usleep(res * US_PER_MS);
+            /* fetch the data */
+            res = htu21d_fetch_tmp (&dev, &tmp, NULL);
+        }
+        /* trigger relative humidity management */
+        res = htu21d_measure_hum(&dev);
+        if (res > 0) {
+            /* wait the returned measurement time or do something else */
+            xtimer_usleep(res * US_PER_MS);
+            /* fetch the data */
+            res = htu21d_fetch_hum (&dev, &hum, NULL);
+        }
+#endif
+        if (res == HTU21D_OK) {
+            /* print resulting floats as integers */
+            int16_t tmp_abs = abs(tmp);
+            printf("temp [°C/100]: %c%d.%02d, ", (tmp < 0) ? '-' : '+',
+                   tmp_abs/100, tmp_abs - (tmp_abs / 100) * 100);
+            printf("hum [%%/100]: +%d.%02d\n",
+                   hum/100, hum - (hum / 100) * 100);
+        }
+    }
+
+    return 0;
+}


### PR DESCRIPTION
### Contribution description

This PR adds a driver for the TE Connectivity HTU21D humidity and temperature sensor. The driver could also be used with Sensirion SHT21 and with SI7021.

The sensor only supports single measurements and polling. This driver provides ```drivers/saul``` capabilities.

**Please note:**
Even though the HTU21D driver also works with SI7021 sensor for which ```drivers/si70xx``` already exists, there the following differences:

- ```drivers/si70xx``` checks some registers during intialization that do no exist in HTU21D sensor (heater control register and revision registers).
- ```drivers/si70xx``` uses clock stretching which blocks the bus and the master during  the measurement which can take up to 85 ms. ```drivers/htu21d``` does not use clock stretching to avoid this blocking.
- ```drivers/si70xx``` does not implement the CRC check while ```drivers/htu21d``` implement and use it.

As an alternative, I could provide a PR that
- defines a pseudomodule for HTU21D,
- modifies ```drivers/si70xx``` so that it would also work also with HTU21D,
- includes wrapper files ```drivers/include/htu21d.h``` and ```drivers/htu21d/include/htu21d_params.h which just redefine symbols with prefix ```htu21d_```, and
- includes a ```tests/driver_htu21d``` as test application.

I have it already realized it also in that way and could provide it. The same could be done for SHT21.
But please keep in mind that a pseudo/wrapper module would use  ```drivers/si70xx``` which blocks the bus and the master while waiting for measurement results.

### Testing procedure

USEMODULE=htu21d make flash -C tests/saul BOARD=...