### PR TITLE
Add script for auto-formatting and validating board lists in Makefiles

### DIFF
--- a/dist/tools/format-board-list/format-board-list.py
+++ b/dist/tools/format-board-list/format-board-list.py
@@ -7,30 +7,41 @@ from pprint import pprint
 from tempfile import NamedTemporaryFile
 import shutil
 
-TARGET_VARIABLES = ['BOARD_INSUFFICIENT_MEMORY', 'BOARD_BLACKLIST', 'BOARD_WHITELIST']
+
+MAKEFILE_LAST_LINE = 'include $(RIOTBASE)/Makefile.include'
 
 def chdir_to_riot_root():
 	SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 	RIOT_DIR = os.path.realpath(SCRIPT_DIR + "/../../..")
 	os.chdir(RIOT_DIR)
 
+class BoardListVariable:
+	def __init__(self, name):
+		self.name = name
+		self.regex = re.compile('%s\\s*([\\+:]?=)(.+)' % (self.name))
+
+	def match(self, line):
+		return self.regex.match(line)
+
+TARGET_VARIABLES = [
+	BoardListVariable('BOARD_INSUFFICIENT_MEMORY'),
+	BoardListVariable('BOARD_BLACKLIST'),
+	BoardListVariable('BOARD_WHITELIST')
+]
 
 class BoardList:
-	def __init__(self, first_line_of_board_list):
+	def __init__(self, matched_variable, first_line_of_board_list):
 		self.boards = []
-		self.target_variable = None
+		self.matched_variable = matched_variable
 		self.variable_operation = None
-		self.regex = re.compile('([A-Z_]+)\\s*([\\+:]?=)(.+)')
 		self.parse_first_line(first_line_of_board_list)
 
 	def parse_first_line(self, line):
-		m = self.regex.match(line)
+		m = self.matched_variable.match(line)
 		assert m is not None, "Regex should match '%s'" % (line)
-		assert m.group(1) in TARGET_VARIABLES, "Match '%s' should be in TARGET_VARIABLES" % (m.group(1))
 
-		self.target_variable = m.group(1)
-		self.variable_operation = m.group(2)
-		self.add_boards_from_line(m.group(3))
+		self.variable_operation = m.group(1)
+		self.add_boards_from_line(m.group(2))
 
 	def add_boards_from_line(self, line):
 		boards = self._extract_boards(line)
@@ -45,14 +56,14 @@ class BoardList:
 
 	def __str__(self):
 		self.boards.sort()
-		prefix = "%s %s " % (self.target_variable, self.variable_operation)
+		prefix = "%s %s " % (self.matched_variable.name, self.variable_operation)
 		spacing = len(prefix) * ' '
 		return prefix + (" \\\n" + spacing).join(self.boards)
 
 
 def get_affected_filenames(target_variable):
 	try:
-		output = subprocess.check_output(["git", "grep", target_variable]).decode("utf-8").strip()
+		output = subprocess.check_output(["git", "grep", target_variable.name]).decode("utf-8").strip()
 	except subprocess.CalledProcessError as e:
 		print("broke:\n", e.output) # TODO
 
@@ -66,22 +77,50 @@ def has_more_boards(line):
 	return line.rstrip().endswith('\\')
 
 def consume_until_board_list(source_file, target_file):
-	# Write to the temp file unmodified until we reach a board list or EOF
-	current_line = source_file.readline()
-	while current_line is not '':
-		if any(target_variable in current_line for target_variable in TARGET_VARIABLES):
-			return BoardList(current_line), current_line
+	current_line = 'x'
+	previous_line = ''
 
-		target_file.write(current_line)
+	# When we're moving things around within the Makefile, such as a board list
+	# or the base Makefile include, we need to skip newlines afterwards, since
+	# otherwise we'd have several newlines in a row, e.g.
+	#
+	# newline
+	# line that is moved to the end of the file
+	# newline
+	#
+	skip_newlines = True
+
+	# Write to the target_file unmodified until we reach a board list or EOF
+	while current_line is not '':
+		previous_line = current_line
 		current_line = source_file.readline()
 
-	return None, current_line
+		if skip_newlines and current_line.strip() is '':
+			continue
+
+		skip_newlines = False
+
+		if current_line.strip() == MAKEFILE_LAST_LINE:
+			current_line = '\n'
+			skip_newlines = True
+			continue
+
+		for target_variable in TARGET_VARIABLES:
+			if target_variable.match(current_line) is not None:
+				return BoardList(target_variable, current_line), current_line, previous_line
+
+		target_file.write(current_line)
+
+	return None, current_line, previous_line
 
 def format_makefile_board_lists(source_file, target_file):
+	board_lists = []
 
+	previous_line = ''
 	while True:
-		board_list, current_line = consume_until_board_list(source_file, target_file)
+		board_list, current_line, previous_line = consume_until_board_list(source_file, target_file)
 
+		# If consume_until_board_list returns None we've reached the end of the file
 		if board_list is None:
 			break
 
@@ -89,10 +128,19 @@ def format_makefile_board_lists(source_file, target_file):
 			current_line = source_file.readline()
 			board_list.add_boards_from_line(current_line)
 
-		# Write the board list to formatted file
-		target_file.write(str(board_list))
+		board_lists.append(board_list)
+		previous_line = current_line
+
+	if previous_line.strip() != '':
 		target_file.write('\n')
 
+	# Write the board list to formatted file
+	for board_list in board_lists:
+		target_file.write(str(board_list))
+		target_file.write('\n\n')
+
+	target_file.write(MAKEFILE_LAST_LINE)
+	target_file.write('\n')
 	target_file.flush()
 
 

--- a/dist/tools/format-board-list/format-board-list.py
+++ b/dist/tools/format-board-list/format-board-list.py
@@ -18,7 +18,7 @@ def chdir_to_riot_root():
 class BoardListVariable:
 	def __init__(self, name):
 		self.name = name
-		self.regex = re.compile('%s\\s*(:=)(.+)' % (self.name))
+		self.regex = re.compile('%s\\s*([\\+:]=)(.+)' % (self.name))
 
 	def match(self, line):
 		return self.regex.match(line)

--- a/dist/tools/format-board-list/format-board-list.py
+++ b/dist/tools/format-board-list/format-board-list.py
@@ -2,20 +2,35 @@
 import os
 import sys
 import subprocess
+import re
 from pprint import pprint
 from tempfile import NamedTemporaryFile
 import shutil
+
+TARGET_VARIABLES = ['BOARD_INSUFFICIENT_MEMORY', 'BOARD_BLACKLIST', 'BOARD_WHITELIST']
 
 def chdir_to_riot_root():
 	SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
 	RIOT_DIR = os.path.realpath(SCRIPT_DIR + "/../../..")
 	os.chdir(RIOT_DIR)
 
-TARGET_VARIABLE = 'BOARD_INSUFFICIENT_MEMORY := '
 
 class BoardList:
-	def __init__(self):
+	def __init__(self, first_line_of_board_list):
 		self.boards = []
+		self.target_variable = None
+		self.variable_operation = None
+		self.regex = re.compile('([A-Z_]+)\\s*([\\+:]?=)(.+)')
+		self.parse_first_line(first_line_of_board_list)
+
+	def parse_first_line(self, line):
+		m = self.regex.match(line)
+		assert m is not None, "Regex should match '%s'" % (line)
+		assert m.group(1) in TARGET_VARIABLES, "Match '%s' should be in TARGET_VARIABLES" % (m.group(1))
+
+		self.target_variable = m.group(1)
+		self.variable_operation = m.group(2)
+		self.add_boards_from_line(m.group(3))
 
 	def add_boards_from_line(self, line):
 		boards = self._extract_boards(line)
@@ -29,13 +44,14 @@ class BoardList:
 		return boards
 
 	def __str__(self):
-		spacing = len(TARGET_VARIABLE) * ' '
-		return TARGET_VARIABLE + (" \\\n" + spacing).join(self.boards)
+		prefix = "%s %s " % (self.target_variable, self.variable_operation)
+		spacing = len(prefix) * ' '
+		return prefix + (" \\\n" + spacing).join(self.boards)
 
 
-def get_affected_filenames():
+def get_affected_filenames(target_variable):
 	try:
-		output = subprocess.check_output(["git", "grep", TARGET_VARIABLE]).decode("utf-8").strip()
+		output = subprocess.check_output(["git", "grep", target_variable]).decode("utf-8").strip()
 	except subprocess.CalledProcessError as e:
 		print("broke:\n", e.output) # TODO
 
@@ -44,40 +60,39 @@ def get_affected_filenames():
 	filenames = list(filter(lambda filename: os.path.basename(filename) == 'Makefile', filenames))
 	return filenames
 
+
 def has_more_boards(line):
 	return line.rstrip().endswith('\\')
 
-def format_makefile_board_list(source_file, target_file):
-	board_list = BoardList()
-
-	# Write to the temp file unmodified until we reach the board list
-	while True:
-		current_line = source_file.readline()
-		if TARGET_VARIABLE in current_line:
-			break;
-		target_file.write(current_line)
-
-	# Extract the board list
-	current_line = current_line[len(TARGET_VARIABLE):]
-	board_list.add_boards_from_line(current_line)
-
-	while has_more_boards(current_line):
-		current_line = source_file.readline()
-		board_list.add_boards_from_line(current_line)
-
-	# Write the board list to formatted file
-	target_file.write(str(board_list))
-	target_file.write('\n')
-
-	# Write the rest of the file unmodified
+def consume_until_board_list(source_file, target_file):
+	# Write to the temp file unmodified until we reach a board list or EOF
 	current_line = source_file.readline()
 	while current_line is not '':
+		if any(target_variable in current_line for target_variable in TARGET_VARIABLES):
+			return BoardList(current_line), current_line
+
 		target_file.write(current_line)
 		current_line = source_file.readline()
 
-	target_file.flush()
-	return board_list
+	return None, current_line
 
+def format_makefile_board_lists(source_file, target_file):
+
+	while True:
+		board_list, current_line = consume_until_board_list(source_file, target_file)
+
+		if board_list is None:
+			break
+
+		while has_more_boards(current_line):
+			current_line = source_file.readline()
+			board_list.add_boards_from_line(current_line)
+
+		# Write the board list to formatted file
+		target_file.write(str(board_list))
+		target_file.write('\n')
+
+	target_file.flush()
 
 
 if len(sys.argv) != 2 or sys.argv[1] not in ['validate', 'format']:
@@ -90,12 +105,22 @@ if len(sys.argv) != 2 or sys.argv[1] not in ['validate', 'format']:
 
 mode = sys.argv[1]
 chdir_to_riot_root()
-filenames = get_affected_filenames()
+
+filenames = []
+for target_variable in TARGET_VARIABLES:
+	filenames.extend(get_affected_filenames(target_variable))
+filenames = set(filenames)
+
 formatting_errors = False
 for filename in filenames:
 	source_file = open(filename, 'r', encoding="utf-8")
 	temp_file = NamedTemporaryFile(mode='w+', prefix='formatted-makefile-', encoding="utf-8")
-	format_makefile_board_list(source_file, temp_file)
+
+	try:
+		format_makefile_board_lists(source_file, temp_file)
+	except AssertionError as e:
+		print("Error in file %s: %s" % (source_file, e))
+		sys.exit(1)
 
 	if mode == 'validate':
 		diff = subprocess.Popen(['diff', '-u', filename, temp_file.name], stdout=subprocess.PIPE)

--- a/dist/tools/format-board-list/format-board-list.py
+++ b/dist/tools/format-board-list/format-board-list.py
@@ -44,6 +44,7 @@ class BoardList:
 		return boards
 
 	def __str__(self):
+		self.boards.sort()
 		prefix = "%s %s " % (self.target_variable, self.variable_operation)
 		spacing = len(prefix) * ' '
 		return prefix + (" \\\n" + spacing).join(self.boards)

--- a/dist/tools/format-board-list/format-board-list.py
+++ b/dist/tools/format-board-list/format-board-list.py
@@ -18,7 +18,7 @@ def chdir_to_riot_root():
 class BoardListVariable:
 	def __init__(self, name):
 		self.name = name
-		self.regex = re.compile('%s\\s*([\\+:]?=)(.+)' % (self.name))
+		self.regex = re.compile('%s\\s*(:=)(.+)' % (self.name))
 
 	def match(self, line):
 		return self.regex.match(line)

--- a/dist/tools/format-board-list/format-board-list.py
+++ b/dist/tools/format-board-list/format-board-list.py
@@ -1,0 +1,110 @@
+#!/usr/bin/env python3
+import os
+import sys
+import subprocess
+from pprint import pprint
+from tempfile import NamedTemporaryFile
+import shutil
+
+def chdir_to_riot_root():
+	SCRIPT_DIR = os.path.dirname(os.path.realpath(__file__))
+	RIOT_DIR = os.path.realpath(SCRIPT_DIR + "/../../..")
+	os.chdir(RIOT_DIR)
+
+TARGET_VARIABLE = 'BOARD_INSUFFICIENT_MEMORY := '
+
+class BoardList:
+	def __init__(self):
+		self.boards = []
+
+	def add_boards_from_line(self, line):
+		boards = self._extract_boards(line)
+		self.boards.extend(boards)
+
+	def _extract_boards(self, line):
+		cleaned_line = line.strip().rstrip('\\').rstrip()
+		boards = cleaned_line.split(' ')
+		boards = list(map(lambda board: board.strip(), boards))
+		boards = list(filter(lambda board: len(board) > 0, boards))
+		return boards
+
+	def __str__(self):
+		spacing = len(TARGET_VARIABLE) * ' '
+		return TARGET_VARIABLE + (" \\\n" + spacing).join(self.boards)
+
+
+def get_affected_filenames():
+	try:
+		output = subprocess.check_output(["git", "grep", TARGET_VARIABLE]).decode("utf-8").strip()
+	except subprocess.CalledProcessError as e:
+		print("broke:\n", e.output) # TODO
+
+	# git-grep returns a 'filename:occurrence' list of results, one per line
+	filenames = [line.split(":", maxsplit=1)[0] for line in output.split("\n")]
+	filenames = list(filter(lambda filename: os.path.basename(filename) == 'Makefile', filenames))
+	return filenames
+
+def has_more_boards(line):
+	return line.rstrip().endswith('\\')
+
+def format_makefile_board_list(source_file, target_file):
+	board_list = BoardList()
+
+	# Write to the temp file unmodified until we reach the board list
+	while True:
+		current_line = source_file.readline()
+		if TARGET_VARIABLE in current_line:
+			break;
+		target_file.write(current_line)
+
+	# Extract the board list
+	current_line = current_line[len(TARGET_VARIABLE):]
+	board_list.add_boards_from_line(current_line)
+
+	while has_more_boards(current_line):
+		current_line = source_file.readline()
+		board_list.add_boards_from_line(current_line)
+
+	# Write the board list to formatted file
+	target_file.write(str(board_list))
+	target_file.write('\n')
+
+	# Write the rest of the file unmodified
+	current_line = source_file.readline()
+	while current_line is not '':
+		target_file.write(current_line)
+		current_line = source_file.readline()
+
+	target_file.flush()
+	return board_list
+
+
+
+if len(sys.argv) != 2 or sys.argv[1] not in ['validate', 'format']:
+	print("Usage: format-board-list.py [validate | format]")
+	print("  In validation mode, the script will return a non-zero")
+	print("  exit code if any file is not correctly formatted. In")
+	print("  format mode, it will only return a non-zero exit code if")
+	print("  the script fails to perform its job.")
+	sys.exit(1)
+
+mode = sys.argv[1]
+chdir_to_riot_root()
+filenames = get_affected_filenames()
+formatting_errors = False
+for filename in filenames:
+	source_file = open(filename, 'r', encoding="utf-8")
+	temp_file = NamedTemporaryFile(mode='w+', prefix='formatted-makefile-', encoding="utf-8")
+	format_makefile_board_list(source_file, temp_file)
+
+	if mode == 'validate':
+		diff = subprocess.Popen(['diff', '-u', filename, temp_file.name], stdout=subprocess.PIPE)
+		return_code = diff.wait()
+		if return_code != 0:
+			formatting_errors = True
+			print(diff.stdout.read().decode(encoding='utf-8'))
+	elif mode == 'format':
+		shutil.copyfile(temp_file.name, source_file.name)
+
+if formatting_errors:
+	sys.exit(1)

--- a/dist/tools/format-board-list/lexer.py
+++ b/dist/tools/format-board-list/lexer.py
@@ -1,0 +1,90 @@
+MAKEFILE_LAST_LINE = 'include $(RIOTBASE)/Makefile.include'
+
+class Token:
+	counter = 0
+
+	def __init__(self, name):
+		self.name = name
+		self.id = Token.counter
+		Token.counter += 1
+
+	def __str__(self):
+		return self.name
+
+	def __eq__(self, other):
+		if not isinstance(other, Token):
+			return False
+
+		return self.id == other.id
+
+Token.OTHER = Token('OTHER')
+Token.EOF = Token('EOF')
+Token.EMPTY_LINE = Token('EMPTY_LINE')
+Token.FINAL_INCLUDE = Token('FINAL_INCLUDE')
+Token.BOARD_LIST = Token('BOARD_LIST')
+Token.COMMENT = Token('COMMENT')
+
+
+class Lexeme:
+	"""A lexeme is an instance of a parsed token with the associated content"""
+	def __init__(self, type, content, **kwargs):
+		self.type = type 
+		self.content = content
+		self.metadata = kwargs
+
+	def __str__(self):
+		return self.type.name
+
+	def __repr__(self):
+		return self.__str__()
+
+
+def lex(source_file, target_variables):
+	lexemes = []
+	while True:
+		lexeme = scan_next(source_file, target_variables)
+		lexemes.append(lexeme)
+		if lexeme.type == Token.EOF:
+			break
+
+	return lexemes
+
+
+def scan_next(source_file, target_variables):
+	orig_line = source_file.readline()
+
+	if orig_line is '':
+		return Lexeme(Token.EOF, '')
+
+	line = orig_line.strip()
+	orig_line = orig_line.strip('\n')
+
+	if line == '':
+		return Lexeme(Token.EMPTY_LINE, '')
+
+	if line == MAKEFILE_LAST_LINE:
+		return Lexeme(Token.FINAL_INCLUDE, line)
+
+	if line.startswith('#'):
+		return Lexeme(Token.COMMENT, orig_line)
+
+	for target_variable in target_variables:
+		if target_variable.match(line) is not None:
+			return scan_board_list(source_file, line, target_variable)
+
+	return Lexeme(Token.OTHER, orig_line)
+
+
+def has_more_boards(line):
+	return line.rstrip().endswith('\\')
+
+
+def scan_board_list(source_file, first_line, matched_variable):
+	content = [first_line]
+	current_line = first_line
+
+	while has_more_boards(current_line):
+			current_line = source_file.readline().rstrip('\n')
+			content.append(current_line)
+
+	return Lexeme(Token.BOARD_LIST, '\n'.join(content), variable=matched_variable)

--- a/dist/tools/format-board-list/writer.py
+++ b/dist/tools/format-board-list/writer.py
@@ -1,0 +1,124 @@
+from lexer import Token, Lexeme
+import sys
+import itertools
+
+def handle_comment_potentially_belonging_to_board_list(lexemes, idx, new_lexemes, board_lists):
+	same, diff = consume_until_different_token(lexemes, idx, Token.COMMENT)
+
+	if diff.type == Token.BOARD_LIST:
+		board_lists.extend(same)
+		board_lists.append(diff)
+		board_lists.append(Lexeme(Token.EMPTY_LINE, ''))
+
+		# Skip empty line following board list to avoid two
+		# subsequent empty lines
+		if lexemes[idx + len(same) + 1].type == Token.EMPTY_LINE:
+			idx += 1
+
+		return idx + len(same) + 1
+
+	new_lexemes.extend(same)
+	return idx + len(same)
+
+
+def consume_until_different_token(lexemes, idx, token):
+	"""Consumes lexemes of type 'token' until a different token type is found."""
+	same_type = []
+	while lexemes[idx].type == token:
+		same_type.append(lexemes[idx])
+		idx += 1
+
+	return same_type, lexemes[idx]
+
+
+def move_board_lists_to_end(lexemes):
+	new_lexemes = [] # The re-ordered list of lexemes
+	board_lists = []
+	final_include = None
+
+	idx = 0
+	while lexemes[idx].type != Token.EOF:
+
+		# Comment, potentially belonging to a board list
+		if lexemes[idx].type == Token.COMMENT:
+			idx = handle_comment_potentially_belonging_to_board_list(lexemes, idx, new_lexemes, board_lists)
+			continue
+
+		# Board list without preceding comment
+		if lexemes[idx].type == Token.BOARD_LIST:
+			board_lists.append(lexemes[idx])
+			idx += avoid_subsequent_newlines(lexemes, idx)
+
+		elif lexemes[idx].type == Token.FINAL_INCLUDE:
+			final_include = lexemes[idx]
+			idx += avoid_subsequent_newlines(lexemes, idx)
+
+		else:
+			new_lexemes.append(lexemes[idx])
+
+		idx += 1
+
+	board_lists = format_boardlists(board_lists)
+	append_board_lists(new_lexemes, board_lists)
+
+	assure_preceding_newline(new_lexemes)
+	if final_include is not None:
+		new_lexemes.append(final_include)
+
+	new_lexemes.append(lexemes[idx]) # EOF
+	return new_lexemes
+
+def append_board_lists(new_lexemes, board_lists):
+	"""Append boards lists, making sure that each is preceded by a newline"""
+
+	assure_newline = True
+	for lexeme in board_lists:
+		if assure_newline and lexeme.type != Token.EMPTY_LINE:
+			assure_preceding_newline(new_lexemes)
+			assure_newline = False
+
+		new_lexemes.append(lexeme)
+		if lexeme.type == Token.BOARD_LIST:
+			assure_newline = True
+
+def avoid_subsequent_newlines(lexemes, idx):
+	if lexemes[idx-1].type == Token.EMPTY_LINE and lexemes[idx+1].type == Token.EMPTY_LINE:
+		return 1
+
+	return 0
+
+
+def assure_preceding_newline(lexemes):
+	if lexemes[len(lexemes)-1].type != Token.EMPTY_LINE:
+		lexemes.append(Lexeme(Token.EMPTY_LINE, ''))
+
+
+def format_boardlists(board_lists):
+	return [format_boardlist(board_list) for board_list in board_lists]
+
+def format_boardlist(board_list):
+	if board_list.type != Token.BOARD_LIST:
+		return board_list
+
+	operator = board_list.metadata['variable'].match(board_list.content)[1]
+	variable, boards = board_list.content.split(operator)
+
+	variable = variable.strip()
+	boards = [x.rstrip('\\').strip().split(' ') for x in boards.split('\n')]
+	boards = list(itertools.chain.from_iterable(boards))
+	boards = [x.strip() for x in boards if x != '' and x != '#']
+	boards.sort()
+	boards = " \\\n  ".join(boards)
+
+	content = variable + " := \\\n  " + boards + " \\\n  #"
+	return Lexeme(Token.BOARD_LIST, content)
+
+
+def write(lexemes, target_file):
+	lexemes = move_board_lists_to_end(lexemes)
+	for lexeme in lexemes:
+		target_file.write(lexeme.content)
+		if lexeme.type is not Token.EOF:
+			target_file.write('\n')
+
+	target_file.flush()

--- a/dist/tools/format-board-list/writer.py
+++ b/dist/tools/format-board-list/writer.py
@@ -101,6 +101,9 @@ def format_boardlist(board_list):
 		return board_list
 
 	operator = board_list.metadata['variable'].match(board_list.content)[1]
+	if operator == '+=':
+		return board_list
+
 	variable, boards = board_list.content.split(operator)
 
 	variable = variable.strip()


### PR DESCRIPTION
### Contribution description

Add script for auto-formatting `BOARD_INSUFFICIENT_MEMORY` lists, as proposed in #9965. I'll add the finishing touches to this once there is a consensus that this is the desired format. A follow-up PR could then format all boards and add a check to Murdock.

I did not end up using @vincent-d's solution proposed in #6818 because I'm terrified of awk scripts :sweat_smile:

### Testing procedure

Run the script with either `validate` or `format` as parameter.

### Todo

- [x] BOARD_INSUFFICIENT_MEMORY
- [x] BOARD_BLACKLIST
- [x] BOARD_WHITELIST
- [ ] How to handle special cases?

### Issues/PRs references

Fixes #9965
Fixes #6818
Related to #9983 