### PR TITLE
pkg/lwip: provide socket_zep support

### DIFF
--- a/pkg/lwip/contrib/lwip.c
+++ b/pkg/lwip/contrib/lwip.c
@@ -33,6 +33,11 @@
 #include "mrf24j40_params.h"
 #endif
 
+#ifdef MODULE_SOCKET_ZEP
+#include "socket_zep.h"
+#include "socket_zep_params.h"
+#endif
+
 #include "lwip.h"
 
 #define ENABLE_DEBUG    (0)
@@ -50,6 +55,10 @@
 #define LWIP_NETIF_NUMOF        (sizeof(mrf24j40_params) / sizeof(mrf24j40_params[0]))
 #endif
 
+#ifdef MODULE_SOCKET_ZEP   /* is mutual exclusive with above ifdef */
+#define LWIP_NETIF_NUMOF        (sizeof(socket_zep_params) / sizeof(socket_zep_params[0]))
+#endif
+
 #ifdef LWIP_NETIF_NUMOF
 static struct netif netif[LWIP_NETIF_NUMOF];
 #endif
@@ -64,6 +73,10 @@ static at86rf2xx_t at86rf2xx_devs[LWIP_NETIF_NUMOF];
 
 #ifdef MODULE_MRF24J40
 static mrf24j40_t mrf24j40_devs[LWIP_NETIF_NUMOF];
+#endif
+
+#ifdef MODULE_SOCKET_ZEP
+static socket_zep_t socket_zep_devs[LWIP_NETIF_NUMOF];
 #endif
 
 void lwip_bootstrap(void)
@@ -94,6 +107,15 @@ void lwip_bootstrap(void)
         if (netif_add(&netif[i], &at86rf2xx_devs[i], lwip_netdev_init,
                       tcpip_6lowpan_input) == NULL) {
             DEBUG("Could not add at86rf2xx device\n");
+            return;
+        }
+    }
+#elif defined(MODULE_SOCKET_ZEP)
+    for (unsigned i = 0; i < LWIP_NETIF_NUMOF; i++) {
+        socket_zep_setup(&socket_zep_devs[i], &socket_zep_params[i]);
+        if (netif_add(&netif[i], &socket_zep_devs[i], lwip_netdev_init,
+                      tcpip_6lowpan_input) == NULL) {
+            DEBUG("Could not add socket_zep device\n");
             return;
         }
     }


### PR DESCRIPTION
### Contribution description
This brings 802.15.4 support for native to lwIP. I used this to find [this bug][1] and thought it might also be useful upstream. Downside: There is no automated test for it yet.

[1]: https://savannah.nongnu.org/bugs/?54749

### Testing procedure
Apply the following patch to `tests/lwip/Makefile`:

```diff
diff --git a/tests/lwip/Makefile b/tests/lwip/Makefile
index b38903853..5ff5916f5 100644
--- a/tests/lwip/Makefile
+++ b/tests/lwip/Makefile
@@ -19,11 +19,7 @@ USEMODULE += shell
 USEMODULE += shell_commands
 USEMODULE += ps
 USEMODULE += od
-USEMODULE += netdev_default
-
-ifeq ($(BOARD),native)
-  USEMODULE += lwip_ethernet
-endif
+USEMODULE += socket_zep
 
 # Test only implemented for native
 ifneq ($(BOARD),native)
```

The test should still be able to compile and work with `TERMFLAGS='-z [::]:17754,[::1]:17755'` on one node and `TERMFLAGS='-z [::]:17755,[::1]:17754'` on another.

### Issues/PRs references
Used to debug an issue in #10059 but indepentent (I never tested without #10059, so if the test doesn't work, #10059 needs to be merged first ;-)).