### PR TITLE
tools/pr_check: adapt for label categorization

### DIFF
--- a/dist/tools/pr_check/pr_check.sh
+++ b/dist/tools/pr_check/pr_check.sh
@@ -39,12 +39,12 @@ if [ -n "${SQUASH_COMMITS}" ]; then
 fi
 
 if [ -n "$TRAVIS_PULL_REQUEST" -o -n "$CI_PULL_NR" ]; then
-    if check_gh_label "NEEDS SQUASHING"; then
+    if check_gh_label "CI: needs squashing"; then
         echo -e "${CERROR}Pull request needs squashing according to its labels set on GitHub${CRESET}"
         EXIT_CODE=1
     fi
 
-    if check_gh_label "Waiting For Other PR"; then
+    if check_gh_label "State: waiting for other PR"; then
         echo -e "${CERROR}Pull request is waiting for another pull request according to its labels set on GitHub${CRESET}"
         EXIT_CODE=1
     fi


### PR DESCRIPTION
### Contribution description
In #10030 it was decided to rename all labels to reflect their respective category. The labels "NEEDS SQUASHING" and "Waiting For Other PR" are used in the `dist/tools/pr_check/pr_check.sh` script however, so that script needs to be adapted.

### Testing procedure
I've set the respective triggering labels for this PR. Just check the Travis and Murdock output ;-).

### Issues/PRs references
Final adaption of CI for #10030