### PR TITLE
tests/sx127x: set b-l072z-lrwan1 as default board

### DIFF
--- a/tests/driver_sx127x/Makefile
+++ b/tests/driver_sx127x/Makefile
@@ -1,8 +1,8 @@
+BOARD ?= b-l072z-lrwan1
+
 include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno nucleo-f031k6
-
-BOARD ?= nucleo-l152re
 
 USEMODULE += od
 USEMODULE += shell


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

While trying to build the `tests/driver_sx127x` (LoRa PHY) application for my preferred LoRa board (b-l072z-lrwan1), I noticed 2 things:
- by default (when setting no BOARD from the command line), the application is built for samr21-xpro, whereas the default should be (from the Makefile) nucleo-l152re
- the default is nucleo-l152re whereas this board doesn't provide a LoRa radio par default (you need an external shield)

This PR fixes the 2 points. Now the default is set to be b-l072z-lrwan1 and when no BOARD is set, it's this one that is used.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

make -C tests/driver_sx127x

The board should be b-l072z-lrwan1

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
