### PR TITLE
tests: fix including Makefile.tests_common

### DIFF
--- a/tests/bench_msg_pingpong/Makefile
+++ b/tests/bench_msg_pingpong/Makefile
@@ -1,9 +1,8 @@
-include ../Makefile.tests_common
-
 BOARD_INSUFFICIENT_MEMORY := nucleo-f031k6
 
 USEMODULE += xtimer
 
 TEST_ON_CI_WHITELIST += all
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/bench_mutex_pingpong/Makefile
+++ b/tests/bench_mutex_pingpong/Makefile
@@ -1,9 +1,8 @@
-include ../Makefile.tests_common
-
 BOARD_INSUFFICIENT_MEMORY := nucleo-f031k6
 
 USEMODULE += xtimer
 
 TEST_ON_CI_WHITELIST += all
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/bench_runtime_coreapis/Makefile
+++ b/tests/bench_runtime_coreapis/Makefile
@@ -1,9 +1,8 @@
-include ../Makefile.tests_common
-
 # we use thread flags in this benchmark by default, disable on demand
 USEMODULE += core_thread_flags
 USEMODULE += benchmark
 
 TEST_ON_CI_WHITELIST += all
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/bench_sched_nop/Makefile
+++ b/tests/bench_sched_nop/Makefile
@@ -1,7 +1,6 @@
-include ../Makefile.tests_common
-
 USEMODULE += xtimer
 
 TEST_ON_CI_WHITELIST += all
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/bench_sizeof_coretypes/Makefile
+++ b/tests/bench_sizeof_coretypes/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 # Modules that will have an impact on the size of the TCB (thread_t):
 #
 # disabled by default, enable on demand:
@@ -14,4 +12,5 @@ endif
 
 TEST_ON_CI_WHITELIST += all
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/bench_thread_flags_pingpong/Makefile
+++ b/tests/bench_thread_flags_pingpong/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 BOARD_INSUFFICIENT_MEMORY := nucleo-f031k6
 
 USEMODULE += core_thread_flags
@@ -7,4 +5,5 @@ USEMODULE += xtimer
 
 TEST_ON_CI_WHITELIST += all
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/bench_thread_yield_pingpong/Makefile
+++ b/tests/bench_thread_yield_pingpong/Makefile
@@ -1,9 +1,8 @@
-include ../Makefile.tests_common
-
 BOARD_INSUFFICIENT_MEMORY := nucleo-f031k6
 
 USEMODULE += xtimer
 
 TEST_ON_CI_WHITELIST += all
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/bench_timers/Makefile
+++ b/tests/bench_timers/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno
 
 # These boards only have a single timer in their periph_conf.h, needs special
@@ -53,4 +51,5 @@ test-kinetis-lptmr: all
 # Reset the default goal.
 .DEFAULT_GOAL :=
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/bitarithm_timings/Makefile
+++ b/tests/bitarithm_timings/Makefile
@@ -1,7 +1,6 @@
-include ../Makefile.tests_common
-
 USEMODULE += xtimer
 
 TEST_ON_CI_WHITELIST += all
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/bloom_bytes/Makefile
+++ b/tests/bloom_bytes/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno chronos \
                              msb-430 msb-430h telosb wsn430-v1_3b wsn430-v1_4 z1
 
@@ -12,4 +10,5 @@ DISABLE_MODULE += auto_init
 
 TEST_ON_CI_WHITELIST += all
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/board_calliope-mini/Makefile
+++ b/tests/board_calliope-mini/Makefile
@@ -1,5 +1,4 @@
 BOARD ?= calliope-mini
-include ../Makefile.tests_common
 
 # This test application is for the Calliope mini only
 BOARD_WHITELIST := calliope-mini
@@ -7,4 +6,5 @@ BOARD_WHITELIST := calliope-mini
 # We want to test the Calliope mini support module
 USEMODULE += mini
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/board_microbit/Makefile
+++ b/tests/board_microbit/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 BOARD = microbit
 
 # This test application is for the BBC micro:bit only
@@ -8,4 +6,5 @@ BOARD_WHITELIST := microbit
 # We want to test the microbit support module
 USEMODULE += microbit
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/buttons/Makefile
+++ b/tests/buttons/Makefile
@@ -1,8 +1,7 @@
-include ../Makefile.tests_common
-
 FEATURES_REQUIRED += periph_gpio_irq
 USEMODULE += xtimer
 
 TEST_ON_CI_WHITELIST += all
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/can_trx/Makefile
+++ b/tests/can_trx/Makefile
@@ -1,5 +1,4 @@
 export APPLICATION = can_trx
-include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno
 
@@ -15,4 +14,5 @@ ifneq (,$(filter tja1042,$(TRX_TO_BUILD)))
     USEMODULE += tja1042
 endif
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/cb_mux/Makefile
+++ b/tests/cb_mux/Makefile
@@ -1,7 +1,6 @@
-include ../Makefile.tests_common
-
 USEMODULE += cb_mux
 
 TEST_ON_CI_WHITELIST += all
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/cb_mux_bench/Makefile
+++ b/tests/cb_mux_bench/Makefile
@@ -1,8 +1,7 @@
-include ../Makefile.tests_common
-
 USEMODULE += cb_mux \
              xtimer
 
 TEST_ON_CI_WHITELIST += all
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/conn_can/Makefile
+++ b/tests/conn_can/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-mega2560 arduino-uno \
                              chronos hifive1 msb-430 msb-430h nucleo-f031k6 \
                              nucleo-f042k6 nucleo-f303k8 nucleo-l031k6 \
@@ -20,4 +18,5 @@ USEMODULE += conn_can_isotp_multi
 USEMODULE += can_pm
 USEMODULE += can_trx
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/cortexm_common_ldscript/Makefile
+++ b/tests/cortexm_common_ldscript/Makefile
@@ -1,5 +1,4 @@
 BOARD ?= samr21-xpro
-include ../Makefile.tests_common
 
 
 # Normally all boards using `cortexm_common/ldscripts/cortexm.ld` linkerscript
@@ -17,6 +16,7 @@ BOARD_WHITELIST += feather-m0
 BOARD_WHITELIST += opencm904
 BOARD_WHITELIST += spark-core
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include
 
 

--- a/tests/cpp11_condition_variable/Makefile
+++ b/tests/cpp11_condition_variable/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 # ROM is overflowing for these boards when using
 # gcc-arm-none-eabi-4.9.3.2015q2-1trusty1 from ppa:terry.guo/gcc-arm-embedded
 # (Travis is using this PPA currently, 2015-06-23)
@@ -18,4 +16,5 @@ USEMODULE += timex
 
 TEST_ON_CI_WHITELIST += all
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/cpp11_mutex/Makefile
+++ b/tests/cpp11_mutex/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 # ROM is overflowing for these boards when using
 # gcc-arm-none-eabi-4.9.3.2015q2-1trusty1 from ppa:terry.guo/gcc-arm-embedded
 # (Travis is using this PPA currently, 2015-06-23)
@@ -17,4 +15,5 @@ USEMODULE += xtimer
 
 TEST_ON_CI_WHITELIST += all
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/cpp11_thread/Makefile
+++ b/tests/cpp11_thread/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 # ROM is overflowing for these boards when using
 # gcc-arm-none-eabi-4.9.3.2015q2-1trusty1 from ppa:terry.guo/gcc-arm-embedded
 # (Travis is using this PPA currently, 2015-06-23)
@@ -18,4 +16,5 @@ USEMODULE += timex
 
 TEST_ON_CI_WHITELIST += all
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/cpu_efm32_features/Makefile
+++ b/tests/cpu_efm32_features/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 BOARD = sltb001a
 
 BOARD_WHITELIST := ikea-tradfri \
@@ -13,4 +11,5 @@ BOARD_WHITELIST := ikea-tradfri \
 # see cpu/efm32/efm32-features.mk for the supported flags
 EFM32_UART_MODES = 1
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_adcxx1c/Makefile
+++ b/tests/driver_adcxx1c/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 USEMODULE += adc081c
 USEMODULE += xtimer
 
@@ -15,4 +13,5 @@ CFLAGS += -DADCXX1C_PARAM_HIGH_LIMIT=$(TEST_ADCXX1C_HIGH_LIMIT)
 CFLAGS += -DADCXX1C_PARAM_HYSTERESIS=$(TEST_ADCXX1C_HYSTERESIS)
 CFLAGS += -DADCXX1C_PARAM_CYCLES=$(TEST_ADCXX1C_CYCLE_TIME)
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_ads101x/Makefile
+++ b/tests/driver_ads101x/Makefile
@@ -1,5 +1,4 @@
-include ../Makefile.tests_common
-
 USEMODULE += ads101x
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_adt7310/Makefile
+++ b/tests/driver_adt7310/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 BOARD_INSUFFICIENT_MEMORY := arduino-mega2560 \
                              mega-xplained \
                              waspmote-pro
@@ -15,4 +13,5 @@ TEST_ADT7310_CS  ?= GPIO_PIN\(0,0\)
 CFLAGS += -DTEST_ADT7310_SPI=$(TEST_ADT7310_SPI)
 CFLAGS += -DTEST_ADT7310_CS=$(TEST_ADT7310_CS)
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_adxl345/Makefile
+++ b/tests/driver_adxl345/Makefile
@@ -1,6 +1,5 @@
-include ../Makefile.tests_common
-
 USEMODULE += xtimer
 USEMODULE += adxl345
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_apa102/Makefile
+++ b/tests/driver_apa102/Makefile
@@ -1,7 +1,6 @@
-include ../Makefile.tests_common
-
 USEMODULE += apa102
 USEMODULE += color
 USEMODULE += xtimer
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_at/Makefile
+++ b/tests/driver_at/Makefile
@@ -1,9 +1,8 @@
-include ../Makefile.tests_common
-
 BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno nucleo-f031k6
 
 USEMODULE += shell
 USEMODULE += at
 USEMODULE += at_urc
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_at30tse75x/Makefile
+++ b/tests/driver_at30tse75x/Makefile
@@ -1,9 +1,8 @@
-include ../Makefile.tests_common
-
 BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno
 
 USEMODULE += at30tse75x
 USEMODULE += shell
 USEMODULE += shell_commands
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_at86rf2xx/Makefile
+++ b/tests/driver_at86rf2xx/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 # exclude boards with insufficient memory
 BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno nucleo-f031k6
 
@@ -27,4 +25,5 @@ DRIVER ?= at86rf231
 # include the selected driver
 USEMODULE += $(DRIVER)
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_ata8520e/Makefile
+++ b/tests/driver_ata8520e/Makefile
@@ -1,9 +1,8 @@
-include ../Makefile.tests_common
-
 BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno
 
 USEMODULE += ata8520e
 USEMODULE += shell
 USEMODULE += shell_commands
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_bh1750/Makefile
+++ b/tests/driver_bh1750/Makefile
@@ -1,6 +1,5 @@
-include ../Makefile.tests_common
-
 USEMODULE += xtimer
 USEMODULE += bh1750fvi
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_bmp180/Makefile
+++ b/tests/driver_bmp180/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 USEMODULE += bmp180
 USEMODULE += xtimer
 USEMODULE += printf_float
@@ -10,4 +8,5 @@ TEST_ALTITUDE ?= 158 # altitude in Polytechnique School campus
 # export altitude parameter
 CFLAGS += -DTEST_ALTITUDE=$(TEST_ALTITUDE)
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_bmx055/Makefile
+++ b/tests/driver_bmx055/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 # include and auto-initialize all available sensors
 USEMODULE += saul_default
 # include driver for bmx055 sensor
@@ -7,4 +5,5 @@ USEMODULE += bmx055
 # include xtimer for polling
 USEMODULE += xtimer
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_bmx280/Makefile
+++ b/tests/driver_bmx280/Makefile
@@ -1,8 +1,7 @@
-include ../Makefile.tests_common
-
 DRIVER ?= bme280
 
 USEMODULE += $(DRIVER)
 USEMODULE += xtimer
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_dht/Makefile
+++ b/tests/driver_dht/Makefile
@@ -1,7 +1,6 @@
-include ../Makefile.tests_common
-
 USEMODULE += dht
 USEMODULE += fmt
 USEMODULE += xtimer
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_ds1307/Makefile
+++ b/tests/driver_ds1307/Makefile
@@ -1,7 +1,6 @@
-include ../Makefile.tests_common
-
 USEMODULE += ds1307
 USEMODULE += embunit
 USEMODULE += xtimer
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_dsp0401/Makefile
+++ b/tests/driver_dsp0401/Makefile
@@ -1,8 +1,7 @@
-include ../Makefile.tests_common
-
 USEMODULE += dsp0401
 
 LOOPS ?= 3
 CFLAGS += -DLOOPS=$(LOOPS)
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_dynamixel/Makefile
+++ b/tests/driver_dynamixel/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno
 
 # chronos : USART_1 undeclared
@@ -11,4 +9,5 @@ BOARD_BLACKLIST += mips-malta
 USEMODULE += dynamixel
 USEMODULE += shell
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_enc28j60/Makefile
+++ b/tests/driver_enc28j60/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-mega2560 arduino-uno \
                              msb-430 msb-430h nucleo-f334r8 nucleo-l053r8 \
                              nucleo-f031k6 nucleo-f042k6 nucleo-f303k8 \
@@ -36,4 +34,5 @@ CFLAGS += -DENC28J60_PARAM_RESET=$(ENC_RST)
 # make sure we read the local enc28j60 params file
 CFLAGS += -I$(CURDIR)
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_encx24j600/Makefile
+++ b/tests/driver_encx24j600/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-mega2560 arduino-uno \
                              msb-430 msb-430h \
                              nucleo-l053r8 nucleo-f031k6 nucleo-f042k6 \
@@ -38,4 +36,5 @@ CFLAGS += -DENCX24J600_INT=$(ENC_INT)
 # make sure we read the local encx24j600 params file
 CFLAGS += -I$(CURDIR)
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_feetech/Makefile
+++ b/tests/driver_feetech/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno
 
 # chronos : USART_1 undeclared
@@ -11,4 +9,5 @@ BOARD_BLACKLIST += mips-malta
 USEMODULE += feetech
 USEMODULE += shell
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_fxos8700/Makefile
+++ b/tests/driver_fxos8700/Makefile
@@ -1,5 +1,4 @@
-include ../Makefile.tests_common
-
 USEMODULE += fxos8700
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_grove_ledbar/Makefile
+++ b/tests/driver_grove_ledbar/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 USEMODULE += grove_ledbar
 
 # set default device parameters in case they are undefined
@@ -13,4 +11,5 @@ CFLAGS += -DGROVE_LEDBAR_CLK=$(TEST_GROVE_LEDBAR_CLK)
 CFLAGS += -DGROVE_LEDBAR_DAT=$(TEST_GROVE_LEDBAR_DAT)
 CFLAGS += -DGROVE_LEDBAR_DIR=$(TEST_GROVE_LEDBAR_DIR)
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_hd44780/Makefile
+++ b/tests/driver_hd44780/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 # the stm32f4discovery does not have the arduino pinout
 BOARD_BLACKLIST := stm32f4discovery jiminy-mega256rfr2
 
@@ -8,4 +6,5 @@ FEATURES_REQUIRED += arduino
 
 USEMODULE += hd44780
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_hdc1000/Makefile
+++ b/tests/driver_hdc1000/Makefile
@@ -1,7 +1,6 @@
-include ../Makefile.tests_common
-
 USEMODULE += hdc1000
 USEMODULE += xtimer
 USEMODULE += fmt
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_hih6130/Makefile
+++ b/tests/driver_hih6130/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 USEMODULE += hih6130
 USEMODULE += xtimer
 
@@ -11,4 +9,5 @@ TEST_HIH6130_ADDR ?= 0x27
 CFLAGS += -DTEST_HIH6130_I2C=$(TEST_HIH6130_I2C)
 CFLAGS += -DTEST_HIH6130_ADDR=$(TEST_HIH6130_ADDR)
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_hts221/Makefile
+++ b/tests/driver_hts221/Makefile
@@ -1,6 +1,5 @@
-include ../Makefile.tests_common
-
 USEMODULE += hts221
 USEMODULE += xtimer
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_ina220/Makefile
+++ b/tests/driver_ina220/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 USEMODULE += ina220
 USEMODULE += xtimer
 
@@ -11,4 +9,5 @@ TEST_INA220_ADDR ?= 0x40
 CFLAGS += -DTEST_INA220_I2C=$(TEST_INA220_I2C)
 CFLAGS += -DTEST_INA220_ADDR=$(TEST_INA220_ADDR)
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_io1_xplained/Makefile
+++ b/tests/driver_io1_xplained/Makefile
@@ -1,7 +1,6 @@
-include ../Makefile.tests_common
-
 USEMODULE += io1_xplained
 USEMODULE += xtimer
 USEMODULE += printf_float
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_isl29020/Makefile
+++ b/tests/driver_isl29020/Makefile
@@ -1,6 +1,5 @@
-include ../Makefile.tests_common
-
 USEMODULE += isl29020
 USEMODULE += xtimer
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_isl29125/Makefile
+++ b/tests/driver_isl29125/Makefile
@@ -1,9 +1,9 @@
 # If no BOARD is found in the environment, use this default:
 BOARD ?= samr21-xpro
 
-include ../Makefile.tests_common
 
 USEMODULE += isl29125
 USEMODULE += xtimer
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_jc42/Makefile
+++ b/tests/driver_jc42/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 USEMODULE += jc42
 USEMODULE += xtimer
 
@@ -13,4 +11,5 @@ CFLAGS += -DTEST_I2C=$(TEST_I2C)
 CFLAGS += -DTEST_I2C_ADDR=$(TEST_I2C_ADDR)
 CFLAGS += -DTEST_I2C_SPEED=$(TEST_I2C_SPEED)
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_kw2xrf/Makefile
+++ b/tests/driver_kw2xrf/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-mega2560 arduino-uno \
                              nucleo-f031k6 nucleo-f042k6 nucleo-l031k6 \
                              nucleo-f334r8 nucleo-l053r8 stm32f0discovery \
@@ -16,4 +14,5 @@ DRIVER ?= kw2xrf
 # finally include the actual chosen driver
 USEMODULE += $(DRIVER)
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_l3g4200d/Makefile
+++ b/tests/driver_l3g4200d/Makefile
@@ -1,6 +1,5 @@
-include ../Makefile.tests_common
-
 USEMODULE += l3g4200d
 USEMODULE += xtimer
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_lc709203f/Makefile
+++ b/tests/driver_lc709203f/Makefile
@@ -1,7 +1,6 @@
-include ../Makefile.tests_common
-
 USEMODULE += lc709203f
 USEMODULE += xtimer
 CFLAGS += -DDEVELHELP
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_lis2dh12/Makefile
+++ b/tests/driver_lis2dh12/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 # as default we use the SPI mode for now, as the I2C mode is not supported, yet
 DRIVER ?= lis2dh12_spi
 
@@ -7,4 +5,5 @@ USEMODULE += fmt
 USEMODULE += xtimer
 USEMODULE += $(DRIVER)
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_lis3dh/Makefile
+++ b/tests/driver_lis3dh/Makefile
@@ -1,7 +1,6 @@
-include ../Makefile.tests_common
-
 FEATURES_REQUIRED += periph_gpio_irq
 USEMODULE += lis3dh
 USEMODULE += xtimer
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_lis3mdl/Makefile
+++ b/tests/driver_lis3mdl/Makefile
@@ -1,7 +1,7 @@
 BOARD ?= limifrog-v1
-include ../Makefile.tests_common
 
 USEMODULE += lis3mdl
 USEMODULE += xtimer
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_lpd8808/Makefile
+++ b/tests/driver_lpd8808/Makefile
@@ -1,6 +1,5 @@
-include ../Makefile.tests_common
-
 USEMODULE += lpd8808
 USEMODULE += xtimer
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_lps331ap/Makefile
+++ b/tests/driver_lps331ap/Makefile
@@ -1,6 +1,5 @@
-include ../Makefile.tests_common
-
 USEMODULE += lps331ap
 USEMODULE += xtimer
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_lsm303dlhc/Makefile
+++ b/tests/driver_lsm303dlhc/Makefile
@@ -1,6 +1,5 @@
-include ../Makefile.tests_common
-
 USEMODULE += lsm303dlhc
 USEMODULE += xtimer
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_lsm6dsl/Makefile
+++ b/tests/driver_lsm6dsl/Makefile
@@ -1,6 +1,5 @@
-include ../Makefile.tests_common
-
 USEMODULE += lsm6dsl
 USEMODULE += xtimer
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_mag3110/Makefile
+++ b/tests/driver_mag3110/Makefile
@@ -1,6 +1,5 @@
-include ../Makefile.tests_common
-
 USEMODULE += mag3110
 USEMODULE += xtimer
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_mma7660/Makefile
+++ b/tests/driver_mma7660/Makefile
@@ -1,6 +1,5 @@
-include ../Makefile.tests_common
-
 USEMODULE += mma7660
 USEMODULE += xtimer
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_mma8x5x/Makefile
+++ b/tests/driver_mma8x5x/Makefile
@@ -1,6 +1,5 @@
-include ../Makefile.tests_common
-
 USEMODULE += mma8x5x
 USEMODULE += xtimer
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_mpl3115a2/Makefile
+++ b/tests/driver_mpl3115a2/Makefile
@@ -1,6 +1,5 @@
-include ../Makefile.tests_common
-
 USEMODULE += mpl3115a2
 USEMODULE += xtimer
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_mpu9150/Makefile
+++ b/tests/driver_mpu9150/Makefile
@@ -1,6 +1,5 @@
-include ../Makefile.tests_common
-
 USEMODULE += mpu9150
 USEMODULE += xtimer
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_mq3/Makefile
+++ b/tests/driver_mq3/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 USEMODULE += mq3
 USEMODULE += xtimer
 
@@ -9,4 +7,5 @@ MQ3_ADC_LINE  ?= ADC_LINE\(0\)
 # export parameters
 CFLAGS += -DMQ3_ADC_LINE=$(MQ3_ADC_LINE)
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_my9221/Makefile
+++ b/tests/driver_my9221/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 USEMODULE += my9221
 
 # set default device parameters in case they are undefined
@@ -15,4 +13,5 @@ CFLAGS += -DTEST_MY9221_DAT=$(TEST_MY9221_DAT)
 CFLAGS += -DTEST_MY9221_DIR=$(TEST_MY9221_DIR)
 CFLAGS += -DTEST_MY9221_NUM=$(TEST_MY9221_NUM)
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_nrf24l01p_lowlevel/Makefile
+++ b/tests/driver_nrf24l01p_lowlevel/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 # exclude boards with insufficient memory
 BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno nucleo-f031k6
 
@@ -21,4 +19,5 @@ CFLAGS += -DCE_PIN=$(CE_PIN)
 CFLAGS += -DCS_PIN=$(CS_PIN)
 CFLAGS += -DIRQ_PIN=$(IRQ_PIN)
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_nvram_spi/Makefile
+++ b/tests/driver_nvram_spi/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 USEMODULE += nvram_spi
 USEMODULE += xtimer
 
@@ -15,4 +13,5 @@ CFLAGS += -DTEST_NVRAM_SPI_CS=$(TEST_NVRAM_SPI_CS)
 CFLAGS += -DTEST_NVRAM_SPI_SIZE=$(TEST_NVRAM_SPI_SIZE)
 CFLAGS += -DTEST_NVRAM_SPI_ADDRESS_COUNT=$(TEST_NVRAM_SPI_ADDRESS_COUNT)
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_pcd8544/Makefile
+++ b/tests/driver_pcd8544/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno
 
 USEMODULE += shell
@@ -17,4 +15,5 @@ CFLAGS += -DTEST_PCD8544_CS=$(TEST_PCD8544_CS)
 CFLAGS += -DTEST_PCD8544_RESET=$(TEST_PCD8544_RESET)
 CFLAGS += -DTEST_PCD8544_MODE=$(TEST_PCD8544_MODE)
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_pir/Makefile
+++ b/tests/driver_pir/Makefile
@@ -1,9 +1,8 @@
-include ../Makefile.tests_common
-
 BOARD_INSUFFICIENT_MEMORY := nucleo-f031k6
 
 USEMODULE += pir
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include
 
 all-polling: CFLAGS += -DTEST_PIR_POLLING

--- a/tests/driver_pn532/Makefile
+++ b/tests/driver_pn532/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 FEATURES_REQUIRED = periph_i2c periph_gpio
 
 USEMODULE += xtimer
@@ -33,4 +31,5 @@ endif
 
 CFLAGS += -I$(CURDIR)
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_pulse_counter/Makefile
+++ b/tests/driver_pulse_counter/Makefile
@@ -1,7 +1,6 @@
-include ../Makefile.tests_common
-
 BOARD_BLACKLIST := msb-430 msb-430h telosb wsn430-v1_3b wsn430-v1_4 z1
 
 USEMODULE += pulse_counter
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_rn2xx3/Makefile
+++ b/tests/driver_rn2xx3/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno
 
 DRIVER ?= rn2483
@@ -8,4 +6,5 @@ USEMODULE += $(DRIVER)
 USEMODULE += shell
 USEMODULE += shell_commands
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_sdcard_spi/Makefile
+++ b/tests/driver_sdcard_spi/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 # exclude boards with insufficient memory
 BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno nucleo-f031k6
 
@@ -8,4 +6,5 @@ USEMODULE += auto_init_storage
 USEMODULE += fmt
 USEMODULE += shell
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_servo/Makefile
+++ b/tests/driver_servo/Makefile
@@ -1,6 +1,5 @@
-include ../Makefile.tests_common
-
 USEMODULE += xtimer
 USEMODULE += servo
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_sht1x/Makefile
+++ b/tests/driver_sht1x/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno
 
 DRIVER ?= sht11
@@ -11,4 +9,5 @@ USEMODULE += saul_default
 USEMODULE += shell_commands
 USEMODULE += ps
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_si114x/Makefile
+++ b/tests/driver_si114x/Makefile
@@ -1,6 +1,5 @@
-include ../Makefile.tests_common
-
 # This test should also work with Si1146 and Si1147 variants.
 USEMODULE += si1145
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_si70xx/Makefile
+++ b/tests/driver_si70xx/Makefile
@@ -1,6 +1,5 @@
-include ../Makefile.tests_common
-
 # This test should also work with Si7006, Si7013 and Si7020 variants.
 USEMODULE += si7021
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_soft_spi/Makefile
+++ b/tests/driver_soft_spi/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 BOARD ?= native
 
 USEMODULE += soft_spi
@@ -12,4 +10,5 @@ TEST_CS_PIN ?= GPIO_PIN\(0,2\)
 CFLAGS += -DTEST_SOFT_SPI_DEV=$(TEST_SOFT_SPI_DEV)
 CFLAGS += -DTEST_CS_PIN=$(TEST_CS_PIN)
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_srf02/Makefile
+++ b/tests/driver_srf02/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno
 
 USEMODULE += xtimer
@@ -14,4 +12,5 @@ TEST_MODE      ?= SRF02_MODE_REAL_CM
 CFLAGS += -DTEST_SRF02_I2C=$(TEST_SRF02_I2C)
 CFLAGS += -DTEST_MODE=$(TEST_MODE)
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_srf04/Makefile
+++ b/tests/driver_srf04/Makefile
@@ -1,9 +1,8 @@
-include ../Makefile.tests_common
-
 BOARD ?= nrf52dk
 
 RIOTBASE ?= $(CURDIR)/../..
 
 USEMODULE += srf04
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_srf08/Makefile
+++ b/tests/driver_srf08/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 USEMODULE += xtimer
 USEMODULE += srf08
 
@@ -15,4 +13,5 @@ CFLAGS += -DTEST_SRF08_SPEED=$(TEST_SRF08_SPEED)
 CFLAGS += -DTEST_MODE=$(TEST_MODE)
 CFLAGS += -DTEST_NUM_ECHOS=$(TEST_NUM_ECHOS)
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_sx127x/Makefile
+++ b/tests/driver_sx127x/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno nucleo-f031k6
 
 BOARD ?= nucleo-l152re
@@ -15,4 +13,5 @@ DRIVER ?= sx1276
 # use SX1276 by default
 USEMODULE += $(DRIVER)
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_tcs37727/Makefile
+++ b/tests/driver_tcs37727/Makefile
@@ -1,6 +1,5 @@
-include ../Makefile.tests_common
-
 USEMODULE += tcs37727
 USEMODULE += xtimer
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_tmp006/Makefile
+++ b/tests/driver_tmp006/Makefile
@@ -1,6 +1,5 @@
-include ../Makefile.tests_common
-
 USEMODULE += tmp006
 USEMODULE += xtimer
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_tsl2561/Makefile
+++ b/tests/driver_tsl2561/Makefile
@@ -1,6 +1,5 @@
-include ../Makefile.tests_common
-
 USEMODULE += tsl2561
 USEMODULE += xtimer
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_veml6070/Makefile
+++ b/tests/driver_veml6070/Makefile
@@ -1,6 +1,5 @@
-include ../Makefile.tests_common
-
 USEMODULE += veml6070
 USEMODULE += xtimer
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_xbee/Makefile
+++ b/tests/driver_xbee/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno nucleo-f031k6 \
                              nucleo-f042k6 nucleo-f030r8 nucleo-f334r8 \
                              stm32f0discovery
@@ -19,4 +17,5 @@ CFLAGS += -DGNRC_PKTBUF_SIZE=512
 # That way xbee_params.h get's included and auto configuration can pick it up.
 CFLAGS += -I$(CURDIR)
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/emb6/Makefile
+++ b/tests/emb6/Makefile
@@ -1,6 +1,5 @@
 # overwrite board, do not set native as default
 BOARD ?= samr21-xpro
-include ../Makefile.tests_common
 
 # MSP-430 doesn't support C11's atomic functionality yet
 BOARD_BLACKLIST := msb-430 msb-430h pic32-clicker pic32-wifire \
@@ -41,4 +40,5 @@ USEMODULE += $(DRIVER)
 CFLAGS += -Wno-unused-parameter -Wno-unused-function -Wno-type-limits
 CFLAGS += -Wno-sign-compare -Wno-missing-field-initializers
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/events/Makefile
+++ b/tests/events/Makefile
@@ -1,9 +1,8 @@
-include ../Makefile.tests_common
-
 FORCE_ASSERTS = 1
 USEMODULE += event_callback
 USEMODULE += event_timeout
 
 TEST_ON_CI_WHITELIST += all
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/evtimer_msg/Makefile
+++ b/tests/evtimer_msg/Makefile
@@ -1,9 +1,8 @@
-include ../Makefile.tests_common
-
 BOARD_INSUFFICIENT_MEMORY := nucleo-f031k6 nucleo-f042k6
 
 USEMODULE += evtimer
 
 TEST_ON_CI_WHITELIST += all
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/evtimer_underflow/Makefile
+++ b/tests/evtimer_underflow/Makefile
@@ -1,9 +1,8 @@
-include ../Makefile.tests_common
-
 BOARD_INSUFFICIENT_MEMORY := nucleo-f031k6 nucleo-f042k6
 
 USEMODULE += evtimer
 
 TEST_ON_CI_WHITELIST += all
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/fault_handler/Makefile
+++ b/tests/fault_handler/Makefile
@@ -1,5 +1,4 @@
 # name of your application
-include ../Makefile.tests_common
 
 ifeq ($(shell uname),Darwin)
 CFLAGS += -Wno-language-extension-token
@@ -7,4 +6,5 @@ endif
 
 USEMODULE += xtimer
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/float/Makefile
+++ b/tests/float/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 DISABLE_MODULE += auto_init
 
 # for native we can go do a couple of more operations in reasonable time...
@@ -9,4 +7,5 @@ endif
 
 TEST_ON_CI_WHITELIST += all
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/fmt_print/Makefile
+++ b/tests/fmt_print/Makefile
@@ -1,7 +1,6 @@
-include ../Makefile.tests_common
-
 USEMODULE += fmt
 
 TEST_ON_CI_WHITELIST += all
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/gnrc_ipv6_ext/Makefile
+++ b/tests/gnrc_ipv6_ext/Makefile
@@ -1,5 +1,4 @@
 # name of your application
-include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-mega2560 arduino-uno \
                              chronos msb-430 msb-430h nucleo-f030r8 \
@@ -27,4 +26,5 @@ TEST_ON_CI_WHITELIST += all
 
 # Note: The test can check more things with ENABLE_DEBUG set to 1 in gnrc_ipv6.c
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/gnrc_ipv6_nib/Makefile
+++ b/tests/gnrc_ipv6_nib/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno \
                              chronos nucleo-f031k6 nucleo-f042k6 nucleo-l031k6 \
                              telosb wsn430-v1_3b wsn430-v1_4
@@ -17,4 +15,5 @@ CFLAGS += -DTEST_SUITES
 
 TEST_ON_CI_WHITELIST += all
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/gnrc_ipv6_nib_6ln/Makefile
+++ b/tests/gnrc_ipv6_nib_6ln/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-mega2560 arduino-uno \
                              chronos nucleo-f030r8 nucleo-l053r8 nucleo-f031k6 \
                              nucleo-l031k6 nucleo-f042k6 stm32f0discovery \
@@ -20,4 +18,5 @@ CFLAGS += -DTEST_SUITES
 
 TEST_ON_CI_WHITELIST += all
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/gnrc_ndp/Makefile
+++ b/tests/gnrc_ndp/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-mega2560 arduino-uno \
                              chronos nucleo-f031k6 nucleo-f042k6 nucleo-l031k6 \
                              telosb waspmote-pro wsn430-v1_3b wsn430-v1_4
@@ -16,4 +14,5 @@ CFLAGS += -DTEST_SUITES
 
 TEST_ON_CI_WHITELIST += all
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/gnrc_netif/Makefile
+++ b/tests/gnrc_netif/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 BOARD_INSUFFICIENT_MEMORY := airfy-beacon arduino-duemilanove arduino-mega2560 \
                              arduino-uno b-l072z-lrwan1 blackpill bluepill calliope-mini \
                              cc2650-launchpad cc2650stk chronos hifive1 \
@@ -36,4 +34,5 @@ CFLAGS += -DTEST_SUITES
 
 TEST_ON_CI_WHITELIST += all
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/gnrc_sixlowpan/Makefile
+++ b/tests/gnrc_sixlowpan/Makefile
@@ -1,5 +1,4 @@
 # name of your application
-include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-mega2560 arduino-uno \
                              chronos hifive1 msb-430 msb-430h nucleo-f030r8 \
@@ -21,4 +20,5 @@ USEMODULE += gnrc_pktdump
 
 TEST_ON_CI_WHITELIST += all
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/gnrc_sock_dns/Makefile
+++ b/tests/gnrc_sock_dns/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 RIOTBASE ?= $(CURDIR)/../..
 
 BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-mega2560 arduino-uno \
@@ -26,4 +24,5 @@ ifeq ($(BOARD),$(filter $(BOARD),$(LOW_MEMORY_BOARDS)))
               -DNRC_IPV6_NIB_OFFL_NUMOF=1
 endif
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/gnrc_sock_ip/Makefile
+++ b/tests/gnrc_sock_ip/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno \
                              chronos nucleo-f031k6 nucleo-f042k6 nucleo-l031k6
 
@@ -12,4 +10,5 @@ CFLAGS += -DTEST_SUITES
 
 TEST_ON_CI_WHITELIST += all
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/gnrc_sock_udp/Makefile
+++ b/tests/gnrc_sock_udp/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno \
                              chronos nucleo-f031k6 nucleo-f042k6 nucleo-l031k6
 
@@ -13,4 +11,5 @@ CFLAGS += -DTEST_SUITES
 
 TEST_ON_CI_WHITELIST += all
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/gnrc_tcp_client/Makefile
+++ b/tests/gnrc_tcp_client/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 # If no BOARD is found in the environment, use this default:
 BOARD ?= native
 PORT ?= tap1
@@ -29,4 +27,5 @@ USEMODULE += auto_init_gnrc_netif
 USEMODULE += gnrc_ipv6_default
 USEMODULE += gnrc_tcp
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/gnrc_tcp_server/Makefile
+++ b/tests/gnrc_tcp_server/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 # If no BOARD is found in the environment, use this default:
 BOARD ?= native
 PORT ?= tap0
@@ -35,4 +33,5 @@ USEMODULE += gnrc_tcp
 # include this for IP address manipulation
 USEMODULE += shell_commands
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/gnrc_udp/Makefile
+++ b/tests/gnrc_udp/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-mega2560 arduino-uno \
                              calliope-mini chronos hifive1 mega-xplained \
                              microbit msb-430 msb-430h \
@@ -22,6 +20,7 @@ USEMODULE += ps
 USEMODULE += netstats_l2
 USEMODULE += netstats_ipv6
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include
 
 # Set a custom channel if needed

--- a/tests/irq/Makefile
+++ b/tests/irq/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 BOARD_INSUFFICIENT_MEMORY := nucleo-f031k6
 
 USEMODULE += auto_init
@@ -7,4 +5,5 @@ USEMODULE += xtimer
 
 TEST_ON_CI_WHITELIST += all
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/isr_yield_higher/Makefile
+++ b/tests/isr_yield_higher/Makefile
@@ -1,5 +1,4 @@
 APPLICATION = isr_yield_higher
-include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_MEMORY := nucleo-f031k6
 
@@ -7,4 +6,5 @@ USEMODULE += xtimer
 
 TEST_ON_CI_WHITELIST += all
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/leds/Makefile
+++ b/tests/leds/Makefile
@@ -1,3 +1,2 @@
 include ../Makefile.tests_common
-
 include $(RIOTBASE)/Makefile.include

--- a/tests/libc_newlib/Makefile
+++ b/tests/libc_newlib/Makefile
@@ -1,8 +1,7 @@
-include ../Makefile.tests_common
-
 TEST_ON_CI_WHITELIST += all
 USEMODULE += embunit
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include
 
 # Compile time tests

--- a/tests/libfixmath/Makefile
+++ b/tests/libfixmath/Makefile
@@ -1,8 +1,7 @@
-include ../Makefile.tests_common
-
 USEPKG += libfixmath
 USEMODULE += libfixmath
 
 TEST_ON_CI_WHITELIST += native
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/libfixmath_unittests/Makefile
+++ b/tests/libfixmath_unittests/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 BOARD_BLACKLIST := arduino-mega2560 waspmote-pro arduino-uno arduino-duemilanove \
                    jiminy-mega256rfr2 mega-xplained
 # arduino-mega2560: builds locally but breaks travis (possibly because of
@@ -19,4 +17,5 @@ USEMODULE += printf_float
 
 TEST_ON_CI_WHITELIST += native
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/lwip/Makefile
+++ b/tests/lwip/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 # lwIP's memory management doesn't seem to work on non 32-bit platforms at the
 # moment.
 BOARD_BLACKLIST := arduino-uno arduino-duemilanove arduino-mega2560 chronos \
@@ -30,4 +28,5 @@ ifneq ($(BOARD),native)
   TESTS=
 endif
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/lwip_sock_ip/Makefile
+++ b/tests/lwip_sock_ip/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 # lwIP's memory management doesn't seem to work on non 32-bit platforms at the
 # moment.
 BOARD_BLACKLIST := arduino-uno arduino-duemilanove arduino-mega2560 chronos \
@@ -40,4 +38,5 @@ CFLAGS += -DLWIP_SO_RCVTIMEO
 
 TEST_ON_CI_WHITELIST += all
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/lwip_sock_tcp/Makefile
+++ b/tests/lwip_sock_tcp/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 # lwIP's memory management doesn't seem to work on non 32-bit platforms at the
 # moment.
 BOARD_BLACKLIST := arduino-uno arduino-duemilanove arduino-mega2560 chronos \
@@ -41,4 +39,5 @@ CFLAGS += -DLWIP_SOCK_TCP_ACCEPT_TIMEOUT=500
 CFLAGS += -DLWIP_NETIF_LOOPBACK=1
 CFLAGS += -DLWIP_HAVE_LOOPIF=1
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/lwip_sock_udp/Makefile
+++ b/tests/lwip_sock_udp/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 # lwIP's memory management doesn't seem to work on non 32-bit platforms at the
 # moment.
 BOARD_BLACKLIST := arduino-uno arduino-duemilanove arduino-mega2560 chronos \
@@ -38,4 +36,5 @@ DISABLE_MODULE += auto_init
 CFLAGS += -DSO_REUSE
 CFLAGS += -DLWIP_SO_RCVTIMEO
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/malloc/Makefile
+++ b/tests/malloc/Makefile
@@ -1,3 +1,2 @@
 include ../Makefile.tests_common
-
 include $(RIOTBASE)/Makefile.include

--- a/tests/mcuboot/Makefile
+++ b/tests/mcuboot/Makefile
@@ -1,6 +1,5 @@
 BOARD ?= nrf52dk
 
-include ../Makefile.tests_common
 
 BOARD_WHITELIST := nrf52dk
 
@@ -9,4 +8,5 @@ export IMAGE_VERSION = 1.1.1+1
 # this test is supposed to always build the mcuboot image
 all: mcuboot
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/memarray/Makefile
+++ b/tests/memarray/Makefile
@@ -1,8 +1,8 @@
-include ../Makefile.tests_common
 USEMODULE += memarray
 
 # Used for invoking _ps_handler
 USEMODULE += shell_commands
 USEMODULE += ps
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/minimal/Makefile
+++ b/tests/minimal/Makefile
@@ -1,8 +1,8 @@
 DEVELHELP ?= 0
-include ../Makefile.tests_common
 
 CFLAGS += -DNDEBUG -DLOG_LEVEL=LOG_NONE
 
 DISABLE_MODULE += auto_init
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/mpu_stack_guard/Makefile
+++ b/tests/mpu_stack_guard/Makefile
@@ -1,5 +1,4 @@
 BOARD ?= samr21-xpro
-include ../Makefile.tests_common
 
 BOARD_WHITELIST += arduino-due      # cortex-m3
 BOARD_WHITELIST += arduino-zero     # cortex-m0plus
@@ -41,6 +40,7 @@ BOARD_WHITELIST += udoo             # cortex-m3
 
 USEMODULE += mpu_stack_guard
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include
 
 ifeq (llvm,$(TOOLCHAIN))

--- a/tests/msg_avail/Makefile
+++ b/tests/msg_avail/Makefile
@@ -1,7 +1,6 @@
-include ../Makefile.tests_common
-
 DISABLE_MODULE += auto_init
 
 TEST_ON_CI_WHITELIST += all
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/msg_send_receive/Makefile
+++ b/tests/msg_send_receive/Makefile
@@ -1,7 +1,6 @@
-include ../Makefile.tests_common
-
 BOARD_INSUFFICIENT_MEMORY := nucleo-f031k6
 
 TEST_ON_CI_WHITELIST += all
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/msg_try_receive/Makefile
+++ b/tests/msg_try_receive/Makefile
@@ -1,7 +1,6 @@
-include ../Makefile.tests_common
-
 BOARD_INSUFFICIENT_MEMORY := nucleo-f031k6
 
 TEST_ON_CI_WHITELIST += all
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/mutex_order/Makefile
+++ b/tests/mutex_order/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno \
                              nucleo-f031k6 nucleo-f042k6 nucleo-l031k6 \
                              nucleo-f030r8 nucleo-l053r8 stm32f0discovery
@@ -7,4 +5,5 @@ BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno \
 # list of boards to run CI tests on
 TEST_ON_CI_WHITELIST += all
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/mutex_unlock_and_sleep/Makefile
+++ b/tests/mutex_unlock_and_sleep/Makefile
@@ -1,7 +1,6 @@
-include ../Makefile.tests_common
-
 DISABLE_MODULE += auto_init
 
 TEST_ON_CI_WHITELIST += all
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/netdev_test/Makefile
+++ b/tests/netdev_test/Makefile
@@ -2,7 +2,6 @@
 # testing this netdev simulating framework, so I it's better if the assert is
 # ignored.
 CFLAGS += -DNDEBUG
-include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno nucleo-f031k6
 
@@ -19,4 +18,5 @@ CFLAGS += -DGNRC_PKTBUF_SIZE=200
 
 TEST_ON_CI_WHITELIST += all
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/netstats_l2/Makefile
+++ b/tests/netstats_l2/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 BOARD_PROVIDES_NETIF := airfy-beacon fox iotlab-m3 mulle native nrf51dongle \
 	nrf6310 pba-d-01-kw2x samd21-xpro saml21-xpro samr21-xpro spark-core \
 	yunjia-nrf51822
@@ -15,4 +13,5 @@ USEMODULE += gnrc_netdev_default
 USEMODULE += auto_init_gnrc_netif
 USEMODULE += netstats_l2
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/nhdp/Makefile
+++ b/tests/nhdp/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 BOARD_BLACKLIST := arduino-mega2560 chronos msb-430 msb-430h telosb \
                    wsn430-v1_3b wsn430-v1_4 z1 waspmote-pro arduino-uno \
                    arduino-duemilanove jiminy-mega256rfr2 mega-xplained
@@ -13,4 +11,5 @@ USEMODULE += nhdp
 
 TEST_ON_CI_WHITELIST += all
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/od/Makefile
+++ b/tests/od/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 USEMODULE += od
 # USEMODULE += od_string
 
@@ -11,4 +9,5 @@ else
   TESTS=$(APPDIR)/tests/02-run.py
 endif
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/periph_adc/Makefile
+++ b/tests/periph_adc/Makefile
@@ -1,7 +1,7 @@
 BOARD ?= pba-d-01-kw2x
-include ../Makefile.tests_common
 
 FEATURES_REQUIRED = periph_adc
 USEMODULE += xtimer
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/periph_cpuid/Makefile
+++ b/tests/periph_cpuid/Makefile
@@ -1,5 +1,4 @@
-include ../Makefile.tests_common
-
 FEATURES_REQUIRED = periph_cpuid
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/periph_dac/Makefile
+++ b/tests/periph_dac/Makefile
@@ -1,7 +1,7 @@
 BOARD ?= stm32f4discovery
-include ../Makefile.tests_common
 
 FEATURES_REQUIRED = periph_dac
 USEMODULE += xtimer
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/periph_dma/Makefile
+++ b/tests/periph_dma/Makefile
@@ -1,5 +1,4 @@
-include ../Makefile.tests_common
-
 FEATURES_REQUIRED = periph_dma
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/periph_eeprom/Makefile
+++ b/tests/periph_eeprom/Makefile
@@ -1,9 +1,9 @@
 BOARD ?= b-l072z-lrwan1
-include ../Makefile.tests_common
 
 FEATURES_REQUIRED += periph_eeprom
 
 USEMODULE += shell
 USEMODULE += shell_commands  # provides reboot command
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/periph_flashpage/Makefile
+++ b/tests/periph_flashpage/Makefile
@@ -1,9 +1,9 @@
 BOARD ?= iotlab-m3
-include ../Makefile.tests_common
 
 FEATURES_REQUIRED += periph_flashpage
 FEATURES_OPTIONAL += periph_flashpage_raw
 
 USEMODULE += shell
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/periph_gpio/Makefile
+++ b/tests/periph_gpio/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno
 
 FEATURES_REQUIRED = periph_gpio
@@ -8,6 +6,7 @@ FEATURES_OPTIONAL = periph_gpio_irq
 USEMODULE += shell
 USEMODULE += benchmark
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include
 
 bench:

--- a/tests/periph_hwrng/Makefile
+++ b/tests/periph_hwrng/Makefile
@@ -1,7 +1,6 @@
-include ../Makefile.tests_common
-
 FEATURES_REQUIRED = periph_hwrng
 
 USEMODULE += xtimer
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/periph_i2c/Makefile
+++ b/tests/periph_i2c/Makefile
@@ -1,5 +1,4 @@
 BOARD ?= samr21-xpro
-include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno
 
@@ -7,4 +6,5 @@ FEATURES_REQUIRED = periph_i2c
 
 USEMODULE += shell
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/periph_pm/Makefile
+++ b/tests/periph_pm/Makefile
@@ -1,5 +1,4 @@
 BOARD ?= slstk3401a
-include ../Makefile.tests_common
 
 # method `fflush()` is not defined for MSP-430 (#6445 will fix this)
 BOARD_BLACKLIST := chronos msb-430h msb-430 telosb wsn430-v1_3b wsn430-v1_4 z1
@@ -8,4 +7,5 @@ FEATURES_OPTIONAL += periph_rtc
 
 USEMODULE += shell
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/periph_pwm/Makefile
+++ b/tests/periph_pwm/Makefile
@@ -1,9 +1,9 @@
 BOARD ?= samr21-xpro
-include ../Makefile.tests_common
 
 FEATURES_REQUIRED = periph_pwm
 
 USEMODULE += xtimer
 USEMODULE += shell
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/periph_qdec/Makefile
+++ b/tests/periph_qdec/Makefile
@@ -1,8 +1,8 @@
 BOARD ?= nucleo-f401re
-include ../Makefile.tests_common
 
 FEATURES_REQUIRED = periph_qdec
 
 USEMODULE += xtimer
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/periph_rtc/Makefile
+++ b/tests/periph_rtc/Makefile
@@ -1,7 +1,6 @@
-include ../Makefile.tests_common
-
 FEATURES_REQUIRED = periph_rtc
 
 USEMODULE += xtimer
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/periph_rtt/Makefile
+++ b/tests/periph_rtt/Makefile
@@ -1,8 +1,8 @@
 BOARD ?= samr21-xpro
-include ../Makefile.tests_common
 
 FEATURES_REQUIRED = periph_rtt
 
 DISABLE_MODULE += auto_init
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/periph_spi/Makefile
+++ b/tests/periph_spi/Makefile
@@ -1,5 +1,4 @@
 BOARD ?= samr21-xpro
-include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno
 
@@ -9,4 +8,5 @@ USEMODULE += xtimer
 USEMODULE += shell
 USEMODULE += shell_commands
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/periph_timer/Makefile
+++ b/tests/periph_timer/Makefile
@@ -1,9 +1,8 @@
-include ../Makefile.tests_common
-
 BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno
 
 FEATURES_REQUIRED = periph_timer
 
 TEST_ON_CI_WHITELIST += all
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/periph_uart/Makefile
+++ b/tests/periph_uart/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno nucleo-f031k6
 
 FEATURES_REQUIRED = periph_uart
@@ -7,4 +5,5 @@ FEATURES_REQUIRED = periph_uart
 USEMODULE += shell
 USEMODULE += xtimer
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/pipe/Makefile
+++ b/tests/pipe/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 #malloc.h not found
 BOARD_BLACKLIST := jiminy-mega256rfr2 mega-xplained
 BOARD_INSUFFICIENT_MEMORY := nucleo-f031k6
@@ -8,4 +6,5 @@ USEMODULE += pipe
 
 TEST_ON_CI_WHITELIST += all
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/pkg_cayenne-lpp/Makefile
+++ b/tests/pkg_cayenne-lpp/Makefile
@@ -1,7 +1,6 @@
-include ../Makefile.tests_common
-
 USEPKG += cayenne-lpp
 
 TEST_ON_CI_WHITELIST += all
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/pkg_cmsis-dsp/Makefile
+++ b/tests/pkg_cmsis-dsp/Makefile
@@ -1,5 +1,4 @@
 BOARD ?= samr21-xpro
-include ../Makefile.tests_common
 
 USEPKG += cmsis-dsp
 
@@ -34,4 +33,5 @@ BOARD_WHITELIST := \
   nrf6310 \
   #
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/pkg_fatfs/Makefile
+++ b/tests/pkg_fatfs/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 BOARD ?= native
 
 BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno
@@ -50,4 +48,5 @@ image:
 compressed-image:
 	@./create_fat_image_file.sh $(FATFS_IMAGE_FILE_SIZE_MIB)
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/pkg_fatfs_vfs/Makefile
+++ b/tests/pkg_fatfs_vfs/Makefile
@@ -1,5 +1,4 @@
 APPLICATION = pkg_fatfs_vfs
-include ../Makefile.tests_common
 
 USEMODULE += fatfs_vfs
 FEATURES_OPTIONAL += periph_rtc
@@ -49,6 +48,7 @@ BOARD_WHITELIST := airfy-beacon arduino-due arduino-duemilanove arduino-mega2560
 
 TEST_DEPS += image
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include
 
 image:

--- a/tests/pkg_jsmn/Makefile
+++ b/tests/pkg_jsmn/Makefile
@@ -1,7 +1,6 @@
-include ../Makefile.tests_common
-
 USEPKG += jsmn
 
 TEST_ON_CI_WHITELIST += all
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/pkg_libcoap/Makefile
+++ b/tests/pkg_libcoap/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 # msp430 and avr have problems with int width and libcoaps usage of :x notation in structs
 BOARD_BLACKLIST := arduino-mega2560 chronos msb-430 msb-430h telosb wsn430-v1_3b \
                    wsn430-v1_4 z1 waspmote-pro arduino-uno arduino-duemilanove \
@@ -16,4 +14,5 @@ USEPKG += libcoap
 
 TEST_ON_CI_WHITELIST += all
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/pkg_libhydrogen/Makefile
+++ b/tests/pkg_libhydrogen/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 # AVR boards: require avr-gcc >= 7.0 (https://gcc.gnu.org/bugzilla/show_bug.cgi?id=60040)
 # MSP430 boards: invalid alignment of 'hydro_random_context'
 BOARD_BLACKLIST := arduino-duemilanove arduino-mega2560 arduino-uno \
@@ -11,4 +9,5 @@ TEST_ON_CI_WHITELIST += all
 USEPKG += libhydrogen
 USEMODULE += embunit
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/pkg_lora-serialization/Makefile
+++ b/tests/pkg_lora-serialization/Makefile
@@ -1,8 +1,7 @@
-include ../Makefile.tests_common
-
 USEPKG += lora-serialization
 
 TEST_ON_CI_WHITELIST += all
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include
 
 test:

--- a/tests/pkg_micro-ecc-with-hwrng/Makefile
+++ b/tests/pkg_micro-ecc-with-hwrng/Makefile
@@ -1,9 +1,8 @@
-include ../Makefile.tests_common
-
 FEATURES_REQUIRED = periph_hwrng
 
 USEPKG += micro-ecc
 
 TEST_ON_CI_WHITELIST += all
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/pkg_micro-ecc/Makefile
+++ b/tests/pkg_micro-ecc/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno
 
 USEMODULE += hashes
@@ -7,4 +5,5 @@ USEPKG += micro-ecc
 
 TEST_ON_CI_WHITELIST += all
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/pkg_microcoap/Makefile
+++ b/tests/pkg_microcoap/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-mega2560 arduino-uno \
                              chronos msb-430 msb-430h nucleo-f031k6 \
                              nucleo-f042k6 nucleo-f303k8 nucleo-l031k6 \
@@ -36,4 +34,5 @@ ifneq (,$(filter $(BOARD),$(LOW_MEMORY_BOARDS)))
   USEMODULE += prng_minstd
 endif
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/pkg_minmea/Makefile
+++ b/tests/pkg_minmea/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 USEPKG += minmea
 
 # The MSP-430 toolchain lacks mktime and NAN
@@ -15,4 +13,5 @@ BOARD_BLACKLIST += arduino-duemilanove \
 
 TEST_ON_CI_WHITELIST += all
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/pkg_monocypher/Makefile
+++ b/tests/pkg_monocypher/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 # No 8 bit and 16 bit support
 BOARD_BLACKLIST := arduino-duemilanove arduino-mega2560 arduino-uno chronos \
         jiminy-mega256rfr2 mega-xplained msb-430 msb-430h telosb \
@@ -15,4 +13,5 @@ USEMODULE += random
 USEPKG += monocypher
 
 TEST_ON_CI_WHITELIST += all
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/pkg_oonf_api/Makefile
+++ b/tests/pkg_oonf_api/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 BOARD_WHITELIST := native
 
 USEMODULE += gnrc_ipv6
@@ -8,4 +6,5 @@ USEMODULE += oonf_common
 USEMODULE += oonf_rfc5444
 USEPKG += oonf_api
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/pkg_semtech-loramac/Makefile
+++ b/tests/pkg_semtech-loramac/Makefile
@@ -1,6 +1,5 @@
 BOARD ?= b-l072z-lrwan1
 
-include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno \
                              nucleo-f031k6 nucleo-f042k6 nucleo-l031k6
@@ -21,4 +20,5 @@ USEMODULE += fmt
 CFLAGS += -DREGION_$(LORA_REGION)
 CFLAGS += -DLORAMAC_ACTIVE_REGION=LORAMAC_REGION_$(LORA_REGION)
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/pkg_tiny-asn1/Makefile
+++ b/tests/pkg_tiny-asn1/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno
 
 BOARD_BLACKLIST := wsn430-v1_3b wsn430-v1_4
@@ -8,4 +6,5 @@ USEPKG += tiny-asn1
 
 TEST_ON_CI_WHITELIST += all
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/pkg_tinycbor/Makefile
+++ b/tests/pkg_tinycbor/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 # No 8 bit and 16 bit support yet
 BOARD_BLACKLIST := arduino-duemilanove arduino-mega2560 arduino-uno chronos \
 	jiminy-mega256rfr2 mega-xplained msb-430 msb-430h telosb \
@@ -12,4 +10,5 @@ USEPKG += tinycbor
 USEMODULE += tinycbor_float
 
 TEST_ON_CI_WHITELIST += all
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/pkg_tinycrypt/Makefile
+++ b/tests/pkg_tinycrypt/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 # tinycrypt works for 32-bit architectures only. The nrf52dk is chosen as a
 # placeholder for all Cortex-M4 boards.
 BOARD_WHITELIST += native nrf52dk
@@ -9,4 +7,5 @@ TEST_ON_CI_WHITELIST += all
 USEPKG += tinycrypt
 USEMODULE = fmt
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/pkg_u8g2/Makefile
+++ b/tests/pkg_u8g2/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno \
                              chronos msb-430 msb-430h nucleo-f031k6 telosb \
                              wsn430-v1_3b wsn430-v1_4 z1
@@ -59,4 +57,5 @@ CFLAGS += -DTEST_PIN_RESET=$(TEST_PIN_RESET)
 
 CFLAGS += -DTEST_DISPLAY=$(TEST_DISPLAY)
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/pkg_ucglib/Makefile
+++ b/tests/pkg_ucglib/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-mega2560 arduino-uno \
                              waspmote-pro
 
@@ -42,4 +40,5 @@ CFLAGS += -DTEST_PIN_RESET=$(TEST_PIN_RESET)
 CFLAGS += -DTEST_DISPLAY=$(TEST_DISPLAY)
 CFLAGS += -DTEST_DISPLAY_EXT=$(TEST_DISPLAY_EXT)
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/pkg_umorse/Makefile
+++ b/tests/pkg_umorse/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 USEMODULE += xtimer
 
 USEPKG += umorse
@@ -9,4 +7,5 @@ CFLAGS += -DUMORSE_DELAY_DIT=$(UMORSE_DELAY_DIT)
 
 TEST_ON_CI_WHITELIST += all
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/posix_semaphore/Makefile
+++ b/tests/posix_semaphore/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno \
                              chronos mbed_lpc1768 msb-430 msb-430h nrf6310 \
                              nucleo-f031k6 nucleo-f042k6 nucleo-l031k6 \
@@ -14,4 +12,5 @@ DISABLE_MODULE += auto_init
 
 TEST_ON_CI_WHITELIST += all
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/posix_time/Makefile
+++ b/tests/posix_time/Makefile
@@ -1,7 +1,6 @@
-include ../Makefile.tests_common
-
 USEMODULE += posix_time
 
 TEST_ON_CI_WHITELIST += all
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/ps_schedstatistics/Makefile
+++ b/tests/ps_schedstatistics/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno \
                              chronos msb-430 msb-430h nucleo-f030r8 \
                              nucleo-l053r8 nucleo-f031k6 nucleo-f042k6 \
@@ -14,4 +12,5 @@ USEMODULE += printf_float
 
 TEST_ON_CI_WHITELIST += all
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/pthread/Makefile
+++ b/tests/pthread/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 BOARD_BLACKLIST := arduino-mega2560 waspmote-pro arduino-uno arduino-duemilanove \
                    jiminy-mega256rfr2 mega-xplained
 # arduino mega2560 uno duemilanove : unknown type name: clockid_t
@@ -11,4 +9,5 @@ USEMODULE += pthread
 
 TEST_ON_CI_WHITELIST += all
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/pthread_barrier/Makefile
+++ b/tests/pthread_barrier/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 BOARD_BLACKLIST := arduino-mega2560 waspmote-pro arduino-uno arduino-duemilanove \
                    jiminy-mega256rfr2 mega-xplained
 # arduino mega2560 uno duemilanove : unknown type name: clockid_t
@@ -16,4 +14,5 @@ USEMODULE += xtimer
 
 TEST_ON_CI_WHITELIST += all
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/pthread_cleanup/Makefile
+++ b/tests/pthread_cleanup/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 BOARD_BLACKLIST := arduino-mega2560 waspmote-pro arduino-uno arduino-duemilanove \
                    jiminy-mega256rfr2 mega-xplained
 # arduino mega2560 uno duemilanove : unknown type name: clockid_t
@@ -10,4 +8,5 @@ USEMODULE += pthread
 
 TEST_ON_CI_WHITELIST += all
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/pthread_condition_variable/Makefile
+++ b/tests/pthread_condition_variable/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 BOARD_BLACKLIST := arduino-mega2560 waspmote-pro arduino-uno arduino-duemilanove \
                    jiminy-mega256rfr2 mega-xplained
 # arduino mega2560 uno duemilanove : unknown type name: clockid_t
@@ -16,4 +14,5 @@ CFLAGS += -DNATIVE_AUTO_EXIT
 
 TEST_ON_CI_WHITELIST += all
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/pthread_cooperation/Makefile
+++ b/tests/pthread_cooperation/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 BOARD_BLACKLIST := arduino-mega2560 waspmote-pro arduino-uno arduino-duemilanove \
                    jiminy-mega256rfr2 mega-xplained
 # arduino mega2560 uno duemilanove : unknown type name: clockid_t
@@ -13,4 +11,5 @@ USEMODULE += pthread
 
 TEST_ON_CI_WHITELIST += all
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/pthread_rwlock/Makefile
+++ b/tests/pthread_rwlock/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 BOARD_BLACKLIST := arduino-mega2560 waspmote-pro arduino-uno arduino-duemilanove \
                    jiminy-mega256rfr2 mega-xplained
 # arduino mega2560 uno duemilanove : unknown type name: clockid_t
@@ -15,4 +13,5 @@ BOARD_INSUFFICIENT_MEMORY += chronos msb-430 msb-430h nucleo-f031k6 \
                              nucleo-f303k8 nucleo-f334r8 nucleo-l053r8 \
                              stm32f0discovery
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/pthread_tls/Makefile
+++ b/tests/pthread_tls/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 BOARD_BLACKLIST := arduino-mega2560 waspmote-pro arduino-uno arduino-duemilanove \
                    jiminy-mega256rfr2 mega-xplained
 # arduino mega2560 uno duemilanove : unknown type name: clockid_t
@@ -11,4 +9,5 @@ USEMODULE += pthread
 
 TEST_ON_CI_WHITELIST += all
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/puf_sram/Makefile
+++ b/tests/puf_sram/Makefile
@@ -1,7 +1,7 @@
 BOARD ?= nucleo-f411re
 
-include ../Makefile.tests_common
 
 USEMODULE += puf_sram
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/rmutex/Makefile
+++ b/tests/rmutex/Makefile
@@ -1,9 +1,8 @@
-include ../Makefile.tests_common
-
 BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno \
                              nucleo-f031k6 nucleo-f042k6 nucleo-l031k6 \
                              nucleo-f030r8 nucleo-l053r8 stm32f0discovery
 
 TEST_ON_CI_WHITELIST += all
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/rng/Makefile
+++ b/tests/rng/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 # some boards have not enough rom and/or ram
 BOARD_BLACKLIST += nucleo-f031k6 nucleo-f042k6 nucleo-l031k6 pic32-clicker
 BOARD_INSUFFICIENT_MEMORY += arduino-duemilanove arduino-uno
@@ -17,4 +15,5 @@ FEATURES_OPTIONAL += periph_hwrng
 
 TEST_ON_CI_WHITELIST += native
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/saul/Makefile
+++ b/tests/saul/Makefile
@@ -1,8 +1,7 @@
-include ../Makefile.tests_common
-
 # include and auto-initialize all available sensors
 USEMODULE += saul_default
 
 USEMODULE += xtimer
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/sched_testing/Makefile
+++ b/tests/sched_testing/Makefile
@@ -1,7 +1,6 @@
-include ../Makefile.tests_common
-
 BOARD_INSUFFICIENT_MEMORY := nucleo-f031k6
 
 TEST_ON_CI_WHITELIST += all
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/shell/Makefile
+++ b/tests/shell/Makefile
@@ -1,5 +1,4 @@
 DEVELHELP=0
-include ../Makefile.tests_common
 
 USEMODULE += shell
 USEMODULE += shell_commands
@@ -12,4 +11,5 @@ BOARD_BLACKLIST += chronos
 
 TEST_ON_CI_WHITELIST += all
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/slip/Makefile
+++ b/tests/slip/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-mega2560 arduino-uno \
                              msb-430 msb-430h nucleo-f031k6 nucleo-f042k6 \
                              nucleo-l031k6 nucleo-f030r8 nucleo-f303k8 \
@@ -29,4 +27,5 @@ CFLAGS += -DSLIP_BAUDRATE=$(SLIP_BAUDRATE)
 # That way slip_params.h get's included and auto configuration can pick it up.
 CFLAGS += -I$(CURDIR)
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/sntp/Makefile
+++ b/tests/sntp/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-mega2560 arduino-uno \
                              chronos msb-430 msb-430h nucleo-f031k6 \
                              nucleo-f042k6 nucleo-l031k6 nucleo-f030r8 \
@@ -15,4 +13,5 @@ USEMODULE += gnrc_netdev_default
 USEMODULE += shell
 USEMODULE += shell_commands
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/socket_zep/Makefile
+++ b/tests/socket_zep/Makefile
@@ -1,5 +1,4 @@
 APPLICATION = socket_zep
-include ../Makefile.tests_common
 
 BOARD_WHITELIST = native    # socket_zep is only available on native
 
@@ -12,4 +11,5 @@ CFLAGS += -DDEVELHELP
 
 TERMFLAGS ?= -z [::1]:17754
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/ssp/Makefile
+++ b/tests/ssp/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 # avr8, msp430, esp8266 and mips don't support ssp (yet)
 BOARD_BLACKLIST := arduino-mega2560 waspmote-pro arduino-uno arduino-duemilanove \
                    chronos msb-430 msb-430h telosb wsn430-v1_3b wsn430-v1_4 z1 \
@@ -10,4 +8,5 @@ USEMODULE += ssp
 
 TEST_ON_CI_WHITELIST += all
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/struct_tm_utility/Makefile
+++ b/tests/struct_tm_utility/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 DISABLE_MODULE += auto_init
 
 USEMODULE += shell
@@ -10,4 +8,5 @@ BOARD_BLACKLIST := chronos msb-430 msb-430h telosb wsn430-v1_3b wsn430-v1_4 z1
 
 TEST_ON_CI_WHITELIST += all
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/thread_basic/Makefile
+++ b/tests/thread_basic/Makefile
@@ -1,9 +1,8 @@
-include ../Makefile.tests_common
-
 BOARD_INSUFFICIENT_MEMORY := nucleo-f031k6
 
 DISABLE_MODULE += auto_init
 
 TEST_ON_CI_WHITELIST += all
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/thread_cooperation/Makefile
+++ b/tests/thread_cooperation/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno \
                              chronos msb-430 msb-430h nucleo-f031k6 \
                              nucleo-f303k8
@@ -22,4 +20,5 @@ CFLAGS += -DPROBLEM=$(PROBLEM)
 
 TEST_ON_CI_WHITELIST += all
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/thread_exit/Makefile
+++ b/tests/thread_exit/Makefile
@@ -1,9 +1,8 @@
-include ../Makefile.tests_common
-
 BOARD_INSUFFICIENT_MEMORY := nucleo-f031k6
 
 DISABLE_MODULE += auto_init
 
 TEST_ON_CI_WHITELIST += all
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/thread_flags/Makefile
+++ b/tests/thread_flags/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 BOARD_INSUFFICIENT_MEMORY := nucleo-f031k6
 
 USEMODULE += core_thread_flags
@@ -7,4 +5,5 @@ USEMODULE += xtimer
 
 TEST_ON_CI_WHITELIST += all
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/thread_flags_xtimer/Makefile
+++ b/tests/thread_flags_xtimer/Makefile
@@ -1,8 +1,7 @@
-include ../Makefile.tests_common
-
 USEMODULE += core_thread_flags
 USEMODULE += xtimer
 
 TEST_ON_CI_WHITELIST += all
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/thread_flood/Makefile
+++ b/tests/thread_flood/Makefile
@@ -1,7 +1,6 @@
-include ../Makefile.tests_common
-
 DISABLE_MODULE += auto_init
 
 TEST_ON_CI_WHITELIST += all
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/thread_msg/Makefile
+++ b/tests/thread_msg/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno \
                              nucleo-f031k6 nucleo-f042k6
 
@@ -7,4 +5,5 @@ DISABLE_MODULE += auto_init
 
 TEST_ON_CI_WHITELIST += all
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/thread_msg_block_w_queue/Makefile
+++ b/tests/thread_msg_block_w_queue/Makefile
@@ -1,9 +1,8 @@
-include ../Makefile.tests_common
-
 BOARD_INSUFFICIENT_MEMORY := nucleo-f031k6
 
 DISABLE_MODULE += auto_init
 
 TEST_ON_CI_WHITELIST += all
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/thread_msg_block_wo_queue/Makefile
+++ b/tests/thread_msg_block_wo_queue/Makefile
@@ -1,9 +1,8 @@
-include ../Makefile.tests_common
-
 BOARD_INSUFFICIENT_MEMORY := nucleo-f031k6
 
 DISABLE_MODULE += auto_init
 
 TEST_ON_CI_WHITELIST += all
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/thread_msg_seq/Makefile
+++ b/tests/thread_msg_seq/Makefile
@@ -1,8 +1,7 @@
-include ../Makefile.tests_common
-
 BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno \
                              nucleo-f031k6 nucleo-f042k6
 
 DISABLE_MODULE += auto_init
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/thread_priority_inversion/Makefile
+++ b/tests/thread_priority_inversion/Makefile
@@ -1,8 +1,7 @@
-include ../Makefile.tests_common
-
 
 USEMODULE += xtimer
 
 BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno nucleo-f031k6
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/thread_race/Makefile
+++ b/tests/thread_race/Makefile
@@ -1,7 +1,6 @@
-include ../Makefile.tests_common
-
 DISABLE_MODULE += auto_init
 
 TEST_ON_CI_WHITELIST += all
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/trace/Makefile
+++ b/tests/trace/Makefile
@@ -1,6 +1,5 @@
 # name of your application
 APPLICATION = trace
-include ../Makefile.tests_common
 
 USEMODULE += trace
 
@@ -8,4 +7,5 @@ BOARD_WHITELIST := native
 
 TEST_ON_CI_WHITELIST += all
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/trickle/Makefile
+++ b/tests/trickle/Makefile
@@ -1,7 +1,6 @@
-include ../Makefile.tests_common
-
 USEMODULE += trickle
 
 TEST_ON_CI_WHITELIST += all
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/unittests/Makefile
+++ b/tests/unittests/Makefile
@@ -1,5 +1,4 @@
 DEVELHELP ?= 0
-include ../Makefile.tests_common
 
 BOARD_INSUFFICIENT_MEMORY := airfy-beacon \
                              arduino-duemilanove \
@@ -253,6 +252,7 @@ INCLUDES += -I$(RIOTBASE)/tests/unittests/common
 # list of boards to run CI tests on
 TEST_ON_CI_WHITELIST += all
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include
 
 .PHONY: $(UNIT_TESTS)

--- a/tests/warn_conflict/Makefile
+++ b/tests/warn_conflict/Makefile
@@ -1,5 +1,4 @@
 BOARD ?= stm32f4discovery
-include ../Makefile.tests_common
 
 # The stm32f4discovery is the only board that provides known conflicting features,
 # so using this compile test on other boards will not provide the expected warning.
@@ -12,4 +11,5 @@ FEATURES_REQUIRED = periph_dac periph_spi
 
 TEST_ON_CI_WHITELIST += all
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/xtimer_drift/Makefile
+++ b/tests/xtimer_drift/Makefile
@@ -1,8 +1,7 @@
-include ../Makefile.tests_common
-
 BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno \
                              nucleo-f031k6 nucleo-f042k6
 
 USEMODULE += xtimer
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/xtimer_hang/Makefile
+++ b/tests/xtimer_hang/Makefile
@@ -1,9 +1,8 @@
-include ../Makefile.tests_common
-
 BOARD_INSUFFICIENT_MEMORY := nucleo-f031k6
 
 USEMODULE += xtimer
 
 TEST_ON_CI_WHITELIST += all
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/xtimer_longterm/Makefile
+++ b/tests/xtimer_longterm/Makefile
@@ -1,8 +1,7 @@
-include ../Makefile.tests_common
-
 BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno \
                              nucleo-f031k6 nucleo-f042k6
 
 USEMODULE += xtimer
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/xtimer_msg/Makefile
+++ b/tests/xtimer_msg/Makefile
@@ -1,9 +1,8 @@
-include ../Makefile.tests_common
-
 BOARD_INSUFFICIENT_MEMORY := nucleo-f031k6
 
 USEMODULE += xtimer
 
 TEST_ON_CI_WHITELIST += all
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/xtimer_msg_receive_timeout/Makefile
+++ b/tests/xtimer_msg_receive_timeout/Makefile
@@ -1,7 +1,6 @@
-include ../Makefile.tests_common
-
 USEMODULE += xtimer
 
 TEST_ON_CI_WHITELIST += all
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/xtimer_now64_continuity/Makefile
+++ b/tests/xtimer_now64_continuity/Makefile
@@ -1,8 +1,7 @@
-include ../Makefile.tests_common
-
 USEMODULE += fmt
 USEMODULE += xtimer
 
 TEST_ON_CI_WHITELIST += all
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/xtimer_periodic_wakeup/Makefile
+++ b/tests/xtimer_periodic_wakeup/Makefile
@@ -1,9 +1,8 @@
-include ../Makefile.tests_common
-
 BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove arduino-uno chronos
 
 USEMODULE += xtimer
 
 TEST_ON_CI_WHITELIST += all
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/xtimer_remove/Makefile
+++ b/tests/xtimer_remove/Makefile
@@ -1,7 +1,6 @@
-include ../Makefile.tests_common
-
 USEMODULE += xtimer
 
 TEST_ON_CI_WHITELIST += all
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/xtimer_reset/Makefile
+++ b/tests/xtimer_reset/Makefile
@@ -1,7 +1,6 @@
-include ../Makefile.tests_common
-
 USEMODULE += xtimer
 
 TEST_ON_CI_WHITELIST += all
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/xtimer_usleep/Makefile
+++ b/tests/xtimer_usleep/Makefile
@@ -1,5 +1,3 @@
-include ../Makefile.tests_common
-
 USEMODULE += xtimer
 
 TEST_ON_CI_WHITELIST += all
@@ -10,4 +8,5 @@ TEST_ON_CI_WHITELIST += all
 #CFLAGS += -DSLEEP_PIN=7
 #CFLAGS += -DSLEEP_PORT=PORT_F
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include

--- a/tests/xtimer_usleep_short/Makefile
+++ b/tests/xtimer_usleep_short/Makefile
@@ -1,7 +1,6 @@
-include ../Makefile.tests_common
-
 USEMODULE += xtimer
 
 TEST_ON_CI_WHITELIST += all
 
+include ../Makefile.tests_common
 include $(RIOTBASE)/Makefile.include


### PR DESCRIPTION
### Contribution description

Fixes `include ../Makefile.tests_common` in Makefiles — it should be placed at the end of the file, before the final `include $(RIOTBASE)/Makefile.include`, otherwise it can interfere with other variables.

E.g. `BOARD ?= something` does nothing as BOARD already defined in Makefile.tests_common

### Issues/PRs references

#10118