### PR TITLE
pkg/semtech-loramac: switch to RIOT AES

### DIFF
--- a/pkg/semtech-loramac/Makefile.include
+++ b/pkg/semtech-loramac/Makefile.include
@@ -1,3 +1,5 @@
+USEMODULE += crypto
+
 INCLUDES += -I$(RIOTBASE)/pkg/semtech-loramac/include
 
 DIRS += $(RIOTBASE)/pkg/semtech-loramac/contrib

--- a/pkg/semtech-loramac/patches/0004-switch-to-riot-aes.patch
+++ b/pkg/semtech-loramac/patches/0004-switch-to-riot-aes.patch
@@ -1,0 +1,206 @@
+From fa275bbb8259fd3ddc9960f85e94bd444e1034d3 Mon Sep 17 00:00:00 2001
+From: Oleg Artamonov <oleg@unwds.com>
+Date: Sun, 7 Oct 2018 21:37:45 +0300
+Subject: [PATCH] Switch to RIOT AES implementation
+
+---
+ src/mac/LoRaMacCrypto.c  | 25 ++++++++++---------------
+ src/system/crypto/cmac.c | 26 +++++++++-----------------
+ src/system/crypto/cmac.h |  5 +++--
+ 3 files changed, 22 insertions(+), 34 deletions(-)
+
+diff --git a/src/mac/LoRaMacCrypto.c b/src/mac/LoRaMacCrypto.c
+index c6837c2..bcf31c2 100644
+--- a/src/mac/LoRaMacCrypto.c
++++ b/src/mac/LoRaMacCrypto.c
+@@ -29,8 +29,6 @@
+  * \author    Daniel Jaeckle ( STACKFORCE )
+  */
+ #include "utilities.h"
+-
+-#include "aes.h"
+ #include "cmac.h"
+ 
+ #include "LoRaMacCrypto.h"
+@@ -67,7 +65,7 @@ static uint8_t sBlock[] = { 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
+ /*!
+  * AES computation context variable
+  */
+-static aes_context AesContext;
++static cipher_context_t AesContext;
+ 
+ /*!
+  * CMAC computation context variable
+@@ -120,8 +118,7 @@ void LoRaMacPayloadEncrypt( const uint8_t *buffer, uint16_t size, const uint8_t
+     uint8_t bufferIndex = 0;
+     uint16_t ctr = 1;
+ 
+-    memset1( AesContext.ksch, '\0', 240 );
+-    aes_set_key( key, 16, &AesContext );
++    aes_init(&AesContext, key, 16);
+ 
+     aBlock[5] = dir;
+ 
+@@ -139,7 +136,7 @@ void LoRaMacPayloadEncrypt( const uint8_t *buffer, uint16_t size, const uint8_t
+     {
+         aBlock[15] = ( ( ctr ) & 0xFF );
+         ctr++;
+-        aes_encrypt( aBlock, sBlock, &AesContext );
++        aes_encrypt(&AesContext, aBlock, sBlock);
+         for( i = 0; i < 16; i++ )
+         {
+             encBuffer[bufferIndex + i] = buffer[bufferIndex + i] ^ sBlock[i];
+@@ -151,7 +148,7 @@ void LoRaMacPayloadEncrypt( const uint8_t *buffer, uint16_t size, const uint8_t
+     if( size > 0 )
+     {
+         aBlock[15] = ( ( ctr ) & 0xFF );
+-        aes_encrypt( aBlock, sBlock, &AesContext );
++        aes_encrypt(&AesContext, aBlock, sBlock);
+         for( i = 0; i < size; i++ )
+         {
+             encBuffer[bufferIndex + i] = buffer[bufferIndex + i] ^ sBlock[i];
+@@ -179,13 +176,12 @@ void LoRaMacJoinComputeMic( const uint8_t *buffer, uint16_t size, const uint8_t
+ 
+ void LoRaMacJoinDecrypt( const uint8_t *buffer, uint16_t size, const uint8_t *key, uint8_t *decBuffer )
+ {
+-    memset1( AesContext.ksch, '\0', 240 );
+-    aes_set_key( key, 16, &AesContext );
+-    aes_encrypt( buffer, decBuffer, &AesContext );
++    aes_init(&AesContext, key, 16);
++    aes_encrypt(&AesContext, buffer, decBuffer);
+     // Check if optional CFList is included
+     if( size >= 16 )
+     {
+-        aes_encrypt( buffer + 16, decBuffer + 16, &AesContext );
++        aes_encrypt(&AesContext, buffer + 16, decBuffer + 16);
+     }
+ }
+ 
+@@ -194,18 +190,17 @@ void LoRaMacJoinComputeSKeys( const uint8_t *key, const uint8_t *appNonce, uint1
+     uint8_t nonce[16];
+     uint8_t *pDevNonce = ( uint8_t * )&devNonce;
+     
+-    memset1( AesContext.ksch, '\0', 240 );
+-    aes_set_key( key, 16, &AesContext );
++    aes_init(&AesContext, key, 16);
+ 
+     memset1( nonce, 0, sizeof( nonce ) );
+     nonce[0] = 0x01;
+     memcpy1( nonce + 1, appNonce, 6 );
+     memcpy1( nonce + 7, pDevNonce, 2 );
+-    aes_encrypt( nonce, nwkSKey, &AesContext );
++    aes_encrypt(&AesContext, nonce, nwkSKey);
+ 
+     memset1( nonce, 0, sizeof( nonce ) );
+     nonce[0] = 0x02;
+     memcpy1( nonce + 1, appNonce, 6 );
+     memcpy1( nonce + 7, pDevNonce, 2 );
+-    aes_encrypt( nonce, appSKey, &AesContext );
++    aes_encrypt(&AesContext, nonce, appSKey);
+ }
+diff --git a/src/system/crypto/cmac.c b/src/system/crypto/cmac.c
+index c7a52cf..4a05849 100644
+--- a/src/system/crypto/cmac.c
++++ b/src/system/crypto/cmac.c
+@@ -35,9 +35,8 @@ DEALINGS WITH THE SOFTWARE
+ //#include <sys/param.h>
+ //#include <sys/systm.h> 
+ #include <stdint.h>
+-#include "aes.h"
+ #include "cmac.h"
+ #include "utilities.h"
+ 
+ #define LSHIFT(v, r) do {                                       \
+   int32_t i;                                                  \
+@@ -59,19 +58,18 @@ void AES_CMAC_Init(AES_CMAC_CTX *ctx)
+ {
+             memset1(ctx->X, 0, sizeof ctx->X);
+             ctx->M_n = 0;
+-        memset1(ctx->rijndael.ksch, '\0', 240);
++        //memset1(ctx->rijndael.ksch, '\0', 240);
+ }
+     
+ void AES_CMAC_SetKey(AES_CMAC_CTX *ctx, const uint8_t key[AES_CMAC_KEY_LENGTH])
+ {
+-           //rijndael_set_key_enc_only(&ctx->rijndael, key, 128);
+-       aes_set_key( key, AES_CMAC_KEY_LENGTH, &ctx->rijndael);
++       aes_init(&ctx->rijndael, key, AES_CMAC_KEY_LENGTH);
+ }
+     
+ void AES_CMAC_Update(AES_CMAC_CTX *ctx, const uint8_t *data, uint32_t len)
+ {
+             uint32_t mlen;
+-        uint8_t in[16];
++            uint8_t in[16];
+     
+             if (ctx->M_n > 0) {
+                   mlen = MIN(16 - ctx->M_n, len);
+@@ -80,18 +78,16 @@ void AES_CMAC_Update(AES_CMAC_CTX *ctx, const uint8_t *data, uint32_t len)
+                     if (ctx->M_n < 16 || len == mlen)
+                             return;
+                    XOR(ctx->M_last, ctx->X);
+-                    //rijndael_encrypt(&ctx->rijndael, ctx->X, ctx->X);
+-            aes_encrypt( ctx->X, ctx->X, &ctx->rijndael);
++                    aes_encrypt(&ctx->rijndael, ctx->X, ctx->X);
+                     data += mlen;
+                     len -= mlen;
+             }
+             while (len > 16) {      /* not last block */
+ 
+                     XOR(data, ctx->X);
+-                    //rijndael_encrypt(&ctx->rijndael, ctx->X, ctx->X);
+ 
+                     memcpy1(in, &ctx->X[0], 16); //Bestela ez du ondo iten
+-            aes_encrypt( in, in, &ctx->rijndael);
++                    aes_encrypt(&ctx->rijndael, in, in);
+                     memcpy1(&ctx->X[0], in, 16);
+ 
+                     data += 16;
+@@ -109,9 +105,7 @@ void AES_CMAC_Final(uint8_t digest[AES_CMAC_DIGEST_LENGTH], AES_CMAC_CTX *ctx)
+             /* generate subkey K1 */
+             memset1(K, '\0', 16);
+ 
+-            //rijndael_encrypt(&ctx->rijndael, K, K);
+-
+-            aes_encrypt( K, K, &ctx->rijndael);
++            aes_encrypt(&ctx->rijndael, K, K);
+ 
+             if (K[0] & 0x80) {
+                     LSHIFT(K, K);
+@@ -143,10 +137,8 @@ void AES_CMAC_Final(uint8_t digest[AES_CMAC_DIGEST_LENGTH], AES_CMAC_CTX *ctx)
+            }
+            XOR(ctx->M_last, ctx->X);
+ 
+-           //rijndael_encrypt(&ctx->rijndael, ctx->X, digest);
+-
+-       memcpy1(in, &ctx->X[0], 16); //Bestela ez du ondo iten
+-       aes_encrypt(in, digest, &ctx->rijndael);
++           memcpy1(in, &ctx->X[0], 16); //Bestela ez du ondo iten
++           aes_encrypt(&ctx->rijndael, in, digest);
+            memset1(K, 0, sizeof K);
+ 
+ }
+diff --git a/src/system/crypto/cmac.h b/src/system/crypto/cmac.h
+index c12e970..7f14e0d 100644
+--- a/src/system/crypto/cmac.h
++++ b/src/system/crypto/cmac.h
+@@ -36,13 +36,14 @@ DEALINGS WITH THE SOFTWARE
+ #ifndef _CMAC_H_
+ #define _CMAC_H_
+ 
+-#include "aes.h" 
++#include "crypto/aes.h"
++#include "crypto/ciphers.h"
+   
+ #define AES_CMAC_KEY_LENGTH     16
+ #define AES_CMAC_DIGEST_LENGTH  16
+  
+ typedef struct _AES_CMAC_CTX {
+-            aes_context    rijndael;
++            cipher_context_t    rijndael;
+             uint8_t        X[16];
+             uint8_t        M_last[16];
+             uint32_t       M_n;
+-- 
+2.17.1
+


### PR DESCRIPTION
### Contribution description

Patch to adapt LoRaMAC 4.4.1 to RIOT AES implementation.

1) Code size: RIOT AES significantly bigger without #10037, ~1KB bigger with #10037, about the same size as LoRaMAC AES with #10037 and aes_decrypt disabled (LoRaWAN doesn't need it)

2) Performance: generally, RIOT AES is significantly (over 2 times) faster, especially on Cortex-M3 and above. On Cortex-M0, decryption is about the same speed, encryption is almost 2 times faster with RIOT AES.

Such difference is to be expected, as RIOT uses faster T-tables implementation while LoRaMAC uses S-boxes.

3) Compatibility: LoRaMAC AES and RIOT AES can't be used simultaneously because of the same function names aes_encrypt() and aes_decrypt(). So, **porting LoRaMAC to RIOT AES is a must if one needs AES for any other function, not just LoRaWAN**.

### Testing procedure

Build examples/lorawan, flash, connect.

Tested on custom STM32L0/SX1276 hardware and Er-Telecom/Actility network. Works fine. Test was done on a slightly different semtech-loramac code and patches, not exactly from the RIOT repo, but this should be of no significance.