### PR TITLE
cpu/esp8266: cpu frequency settings feature added

### DIFF
--- a/cpu/esp8266/include/user_config.h
+++ b/cpu/esp8266/include/user_config.h
@@ -5,6 +5,13 @@
  * General Public License v2.1. See the file LICENSE in the top level
  * directory for more details.
  */
+/**
+ * @ingroup     cpu_esp8266
+ * @brief       Default configurations required by the SDK
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ * @file
+ * @{
+ */
 
 #ifndef USER_CONFIG_H
 #define USER_CONFIG_H
@@ -13,10 +20,17 @@
 extern "C" {
 #endif
 
-/* This file is just to satisfy SDK */
+/**
+ * @brief   Default CPU frequency in MHz.
+ * Possible values are 80 and 160.
+ */
+#ifndef ESP8266_CPU_FREQUENCY
+#define ESP8266_CPU_FREQUENCY   80
+#endif
 
 #ifdef __cplusplus
 }
 #endif
 
 #endif /* USER_CONFIG_H */
+/** @} */

--- a/cpu/esp8266/sdk/main.c
+++ b/cpu/esp8266/sdk/main.c
@@ -129,6 +129,19 @@ void system_restart(void)
     __asm__ volatile (" call0 0x40000080 ");
 }
 
+extern bool system_update_cpu_freq(uint8 freq)
+{
+    if (freq == 160) {
+        DPORT.CPU_CLOCK |= DPORT_CPU_CLOCK_X2;
+        ets_update_cpu_frequency(160);
+    }
+    else {
+        DPORT.CPU_CLOCK &= ~DPORT_CPU_CLOCK_X2;
+        ets_update_cpu_frequency(80);
+    }
+    return true;
+}
+
 /**
  * Following code is completly or at least partially from
  * https://github.com/pvvx/esp8266web

--- a/cpu/esp8266/sdk/main.h
+++ b/cpu/esp8266/sdk/main.h
@@ -42,13 +42,13 @@ extern "C" {
 #define system_get_time       phy_get_mactime
 #define system_get_chip_id()  (((DPORT.OTP_MAC1 & 0xffff) << 8) + ((DPORT.OTP_MAC0 >> 24) & 0xff))
 #define system_get_cpu_freq   ets_get_cpu_frequency
-/* TODO #define system_update_cpu_freq  ets_update_cpu_frequency */
 
 extern int      os_printf_plus (const char* format, ...);
 
 extern void     system_deep_sleep (uint32_t time_in_us);
 extern uint8_t  system_get_checksum(uint8_t *ptr, uint32_t len);
 extern void     system_restart (void);
+extern bool     system_update_cpu_freq(uint8 freq);
 
 extern bool     system_rtc_mem_read(uint32_t src_addr, void *des_addr, uint32_t save_size);
 extern bool     system_rtc_mem_write(uint32_t src_addr, void *des_addr, uint32_t save_size);

--- a/cpu/esp8266/startup.c
+++ b/cpu/esp8266/startup.c
@@ -170,8 +170,8 @@ void IRAM user_init (void)
     syscalls_init ();
     thread_isr_stack_init ();
 
-    /* run system in high performance mode */
-    system_update_cpu_freq(160);
+    /* set system frequency */
+    system_update_cpu_freq(ESP8266_CPU_FREQUENCY);
 
     /* reinit system timer as microsecond timer */
     system_timer_reinit ();
@@ -191,6 +191,7 @@ void IRAM user_init (void)
 #include "esp/dport_regs.h"
 #include "esp/phy_info.h"
 #include "esp/spiflash.h"
+#include "user_config.h"
 
 /**
  * @brief   Defines the structure of the file header in SPI flash
@@ -661,8 +662,8 @@ void __attribute__((noreturn)) IRAM cpu_user_start (void)
 
     /** }@ */
 
-    /* run system in high performance mode */
-    /* TODO system_update_cpu_freq(160); */
+    /* set system frequency */
+    system_update_cpu_freq(ESP8266_CPU_FREQUENCY);
 
     /* PHASE 3: start RIOT-OS kernel */
 


### PR DESCRIPTION
### Contribution description

With this PR it becomes possible to set the default CPU frequency for the non-SDK and the SDK-Version as well. For that purpose,

- the define ```ESP8266_CPU_FREQUENCY``` is introduced, and
- the function ```system_update_cpu_freq``` is implemented in non-SDK version.

Using ```-DESP8266_CPU_FREQENCY=<freq>``` in CFLAGS where ```<freq>``` can be 80 or 160 is used to define the CPU frequency to be 80 MHz or 160 MHz. If ```ESP8266_CPU_FREQENCY``` is not defined, ```ESP8266_CPU_FREQUENCY_DEFAULT``` is used which is defined to be 80 MHz.

### Testing procedure

Using
```
make flash BOARD=esp8266-esp-12x -C tests/bench_thread_yield_pingpong
```
compiles and flashes the benchmark test with the default CPU frequency of 80 MHz. Using command
```
CFLAGS="-DESP8266_CPU_FREQUENCY=160" make flash BOARD=esp8266-esp-12x -C tests/bench_thread_yield_pingpong
```
compiles and flashes the benchmark test with a CPU frequency of 160 MHz. The result of the benchmark test should be the double.
