### PR TITLE
sys/ubjson: Unconditionally include <sys/types.h>

### DIFF
--- a/sys/include/ubjson.h
+++ b/sys/include/ubjson.h
@@ -36,11 +36,7 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-#if defined(MODULE_MSP430_COMMON)
-#   include "msp430_types.h"
-#elif !defined(__linux__)
-#   include <sys/types.h>
-#endif
+#include <sys/types.h>
 
 #ifdef __cplusplus
 extern "C" {


### PR DESCRIPTION
### Contribution description

msp430_types.h is included implicitly if needed by sys/types.h
native Linux also needs sys/types.h for ssize_t, no idea why it was excluded originally..
This PR is necessary in order to build on native without `-std=gnu99`

### Testing procedure

Run unit tests (tests-ubjson)


### Issues/PRs references

