### PR TITLE
tests/openthread: remove useless dependency handling

### DIFF
--- a/tests/openthread/Makefile
+++ b/tests/openthread/Makefile
@@ -25,11 +25,6 @@ ifneq (,$(filter iotlab-m3 fox iotlab-a8-m3,$(BOARD)))
   DRIVER := at86rf231
 endif
 
-ifneq (,$(filter at86rf2%,$(DRIVER)))
-  FEATURES_REQUIRED += periph_spi
-  FEATURES_REQUIRED += periph_gpio
-endif
-
 USEMODULE += $(DRIVER)
 
 USEMODULE += random


### PR DESCRIPTION
### Contribution description

The features requirement declaration in the application is useless.
It is already handled by `drivers/Makefile.dep`.

### Testing procedure

The result is unchanged with this commit:

    make BOARD=samr21-xpro info-debug-variable-FEATURES_REQUIRED | tail -n 1 | \
        tr ' ' '\n' | sort -u
    make BOARD=iotlab-m3 info-debug-variable-FEATURES_REQUIRED | tail -n 1 | \
        tr ' ' '\n' | sort -u

```
cpp
periph_gpio
periph_gpio_irq
periph_spi
periph_timer
periph_uart
```

### Issues/PRs references

Found while reviewing https://github.com/RIOT-OS/RIOT/pull/10119
Will also need to be propagated in https://github.com/RIOT-OS/RIOT/pull/9336
