### PR TITLE
cpu, periph_gpio: mark closing #endif for MODULE_PERIPH_GPIO_IRQ

### DIFF
--- a/cpu/atmega_common/periph/gpio.c
+++ b/cpu/atmega_common/periph/gpio.c
@@ -59,7 +59,7 @@
 #endif
 
 static gpio_isr_ctx_t config[GPIO_EXT_INT_NUMOF];
-#endif
+#endif /* MODULE_PERIPH_GPIO_IRQ */
 
 /**
  * @brief     Extract the pin number of the given pin
@@ -306,4 +306,4 @@ ISR(INT7_vect, ISR_BLOCK)
 }
 #endif
 
-#endif
+#endif /* MODULE_PERIPH_GPIO_IRQ */

--- a/cpu/cc2538/periph/gpio.c
+++ b/cpu/cc2538/periph/gpio.c
@@ -33,7 +33,7 @@
 
 #ifdef MODULE_PERIPH_GPIO_IRQ
 static gpio_isr_ctx_t isr_ctx[4][8];
-#endif
+#endif /* MODULE_PERIPH_GPIO_IRQ */
 
 /**
  * @brief Access GPIO low-level device
@@ -245,7 +245,7 @@ void isr_gpiod(void)
 {
     handle_isr(3);
 }
-#endif
+#endif /* MODULE_PERIPH_GPIO_IRQ */
 
 /* CC2538 specific add-on GPIO functions */
 

--- a/cpu/cc26x0/periph/gpio.c
+++ b/cpu/cc26x0/periph/gpio.c
@@ -31,7 +31,7 @@
  * @brief   static callback memory
  */
 static gpio_isr_ctx_t gpio_chan[GPIO_ISR_CHAN_NUMOF];
-#endif
+#endif /* MODULE_PERIPH_GPIO_IRQ */
 
 int gpio_init(gpio_t pin, gpio_mode_t mode)
 {
@@ -131,4 +131,4 @@ void isr_edge(void)
     }
     cortexm_isr_end();
 }
-#endif
+#endif /* MODULE_PERIPH_GPIO_IRQ */

--- a/cpu/efm32/periph/gpio.c
+++ b/cpu/efm32/periph/gpio.c
@@ -37,7 +37,7 @@
  * @brief   Hold one interrupt context per interrupt line
  */
 static gpio_isr_ctx_t isr_ctx[NUMOF_IRQS];
-#endif
+#endif /* MODULE_PERIPH_GPIO_IRQ */
 
 static inline GPIO_Port_TypeDef _port_num(gpio_t pin)
 {
@@ -173,4 +173,4 @@ void isr_gpio_odd(void)
 {
     gpio_irq();
 }
-#endif
+#endif /* MODULE_PERIPH_GPIO_IRQ */

--- a/cpu/esp8266/periph/gpio.c
+++ b/cpu/esp8266/periph/gpio.c
@@ -226,7 +226,7 @@ void gpio_irq_disable (gpio_t pin)
 
     gpio_int_enabled_table [pin] = false;
 }
-#endif
+#endif /* MODULE_PERIPH_GPIO_IRQ */
 
 int gpio_read (gpio_t pin)
 {

--- a/cpu/ezr32wg/periph/gpio.c
+++ b/cpu/ezr32wg/periph/gpio.c
@@ -35,7 +35,7 @@
  * @brief   Hold one interrupt context per interrupt line
  */
 static gpio_isr_ctx_t isr_ctx[NUMOF_IRQS];
-#endif
+#endif /* MODULE_PERIPH_GPIO_IRQ */
 
 static inline int _port_num(gpio_t pin)
 {
@@ -164,4 +164,4 @@ void isr_gpio_even(void)
     cortexm_isr_end();
 }
 
-#endif
+#endif /* MODULE_PERIPH_GPIO_IRQ */

--- a/cpu/fe310/periph/gpio.c
+++ b/cpu/fe310/periph/gpio.c
@@ -35,7 +35,7 @@
 #ifdef MODULE_PERIPH_GPIO_IRQ
 static gpio_flank_t isr_flank[GPIO_NUMOF];
 static gpio_isr_ctx_t isr_ctx[GPIO_NUMOF];
-#endif
+#endif /* MODULE_PERIPH_GPIO_IRQ */
 
 int gpio_init(gpio_t pin, gpio_mode_t mode)
 {
@@ -215,4 +215,4 @@ void gpio_irq_disable(gpio_t pin)
             break;
     }
 }
-#endif
+#endif /* MODULE_PERIPH_GPIO_IRQ */

--- a/cpu/kinetis/periph/gpio.c
+++ b/cpu/kinetis/periph/gpio.c
@@ -115,7 +115,7 @@ static isr_ctx_t isr_ctx[CTX_NUMOF];
 static uint32_t isr_map[ISR_MAP_SIZE];
 
 static const uint8_t port_irqs[] = PORT_IRQS;
-#endif
+#endif /* MODULE_PERIPH_GPIO_IRQ */
 
 static inline PORT_Type *port(gpio_t pin)
 {
@@ -176,7 +176,7 @@ static void ctx_clear(int port, int pin)
     int ctx = get_ctx(port, pin);
     write_map(port, pin, ctx);
 }
-#endif
+#endif /* MODULE_PERIPH_GPIO_IRQ */
 
 static inline void clk_en(gpio_t pin)
 {
@@ -211,7 +211,7 @@ void gpio_init_port(gpio_t pin, uint32_t pcr)
      * need to free its interrupt context. We to this only after we
      * re-configured the pin in case an event is happening just in between... */
     uint32_t isr_state = port(pin)->PCR[pin_num(pin)];
-#endif
+#endif /* MODULE_PERIPH_GPIO_IRQ */
 
     /* set new PCR value */
     port(pin)->PCR[pin_num(pin)] = pcr;
@@ -221,7 +221,7 @@ void gpio_init_port(gpio_t pin, uint32_t pcr)
     if (isr_state & PORT_PCR_IRQC_MASK) {
         ctx_clear(port_num(pin), pin_num(pin));
     }
-#endif
+#endif /* MODULE_PERIPH_GPIO_IRQ */
 }
 
 int gpio_read(gpio_t pin)

--- a/cpu/lm4f120/periph/gpio.c
+++ b/cpu/lm4f120/periph/gpio.c
@@ -93,7 +93,7 @@ typedef struct {
 } gpio_state_t;
 
 static gpio_state_t gpio_config[NUM_OF_PORT][NUM_OF_PINS];
-#endif
+#endif /* MODULE_PERIPH_GPIO_IRQ */
 
 
 int gpio_init(gpio_t pin, gpio_mode_t mode)
@@ -275,4 +275,4 @@ void gpio_irq_disable(gpio_t pin)
 
     HWREG(im_reg_addr) &= ~(pin_bit);
 }
-#endif
+#endif /* MODULE_PERIPH_GPIO_IRQ */

--- a/cpu/lpc1768/periph/gpio.c
+++ b/cpu/lpc1768/periph/gpio.c
@@ -33,7 +33,7 @@
 static gpio_isr_ctx_t isr_ctx[NUMOF_IRQS];
 
 static gpio_flank_t isr_state[2][32];
-#endif
+#endif /* MODULE_PERIPH_GPIO_IRQ */
 
 #define PIN_MASK        (0x1f)
 #define PORT_SHIFT      (5U)
@@ -241,4 +241,4 @@ void isr_eint3(void)
 
     cortexm_isr_end();
 }
-#endif
+#endif /* MODULE_PERIPH_GPIO_IRQ */

--- a/cpu/lpc2387/periph/gpio.c
+++ b/cpu/lpc2387/periph/gpio.c
@@ -58,13 +58,13 @@ static int _isr_map_entry(gpio_t pin) {
 
     return _pin;
 }
-#endif
+#endif /* MODULE_PERIPH_GPIO_IRQ */
 
 void gpio_init_ports(void) {
     SCS |= 0x1; /* set GPIO ports 0 and 1 to FIO mode (3.7.2) */
 #ifdef MODULE_PERIPH_GPIO_IRQ
     memset(&_gpio_isr_map[0], 0xff, 64);
-#endif
+#endif /* MODULE_PERIPH_GPIO_IRQ */
 }
 
 int gpio_init(gpio_t pin, gpio_mode_t mode)
@@ -312,4 +312,4 @@ void GPIO_IRQHandler(void)
 
     VICVectAddr = 0;                                /* Acknowledge Interrupt */
 }
-#endif
+#endif /* MODULE_PERIPH_GPIO_IRQ */

--- a/cpu/nrf5x_common/periph/gpio.c
+++ b/cpu/nrf5x_common/periph/gpio.c
@@ -39,7 +39,7 @@
  * @brief   Place to store the interrupt context
  */
 static gpio_isr_ctx_t exti_chan;
-#endif
+#endif /* MODULE_PERIPH_GPIO_IRQ */
 
 /**
  * @brief   Get the port's base address
@@ -153,4 +153,4 @@ void isr_gpiote(void)
     }
     cortexm_isr_end();
 }
-#endif
+#endif /* MODULE_PERIPH_GPIO_IRQ */

--- a/cpu/sam0_common/periph/gpio.c
+++ b/cpu/sam0_common/periph/gpio.c
@@ -43,7 +43,7 @@
 #define NUMOF_IRQS                  (16U)
 
 static gpio_isr_ctx_t gpio_config[NUMOF_IRQS];
-#endif
+#endif /* MODULE_PERIPH_GPIO_IRQ */
 
 static inline PortGroup *_port(gpio_t pin)
 {
@@ -233,4 +233,4 @@ void isr_eic(void)
     }
     cortexm_isr_end();
 }
-#endif
+#endif /* MODULE_PERIPH_GPIO_IRQ */

--- a/cpu/sam3/periph/gpio.c
+++ b/cpu/sam3/periph/gpio.c
@@ -107,7 +107,7 @@ static void _ctx_clear(int port, int pin)
         _write_map(port, pin, CTX_NUMOF);
     }
 }
-#endif
+#endif /* MODULE_PERIPH_GPIO_IRQ */
 
 /**
  * @brief Extract the pin's port base address from the given pin identifier
@@ -165,7 +165,7 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
     port->PIO_IDR = (1 << pin_num);
 #ifdef MODULE_PERIPH_GPIO_IRQ
     _ctx_clear(port_num, pin_num);
-#endif
+#endif /* MODULE_PERIPH_GPIO_IRQ */
 
      /* give the PIO module the power over the corresponding pin */
     port->PIO_PER = (1 << pin_num);
@@ -341,4 +341,4 @@ void isr_piod(void)
 {
     isr_handler(PIOD, PD);
 }
-#endif
+#endif /* MODULE_PERIPH_GPIO_IRQ */

--- a/cpu/stm32_common/periph/gpio.c
+++ b/cpu/stm32_common/periph/gpio.c
@@ -44,7 +44,7 @@
  * @brief   Allocate memory for one callback and argument per EXTI channel
  */
 static gpio_isr_ctx_t isr_ctx[EXTI_NUMOF];
-#endif
+#endif /* MODULE_PERIPH_GPIO_IRQ */
 
 /**
  * @brief   Extract the port base address from the given pin identifier
@@ -248,7 +248,7 @@ void isr_exti(void)
     }
     cortexm_isr_end();
 }
-#endif
+#endif /* MODULE_PERIPH_GPIO_IRQ */
 
 #else
 typedef int dont_be_pedantic;

--- a/cpu/stm32f1/periph/gpio.c
+++ b/cpu/stm32f1/periph/gpio.c
@@ -45,7 +45,7 @@
  * @brief   Allocate memory for one callback and argument per EXTI channel
  */
 static gpio_isr_ctx_t exti_ctx[GPIO_ISR_CHAN_NUMOF];
-#endif
+#endif /* MODULE_PERIPH_GPIO_IRQ */
 
 /**
  * @brief   Extract the pin's port base address from the given pin identifier
@@ -230,4 +230,4 @@ void isr_exti(void)
     }
     cortexm_isr_end();
 }
-#endif
+#endif /* MODULE_PERIPH_GPIO_IRQ */

--- a/drivers/include/periph/gpio.h
+++ b/drivers/include/periph/gpio.h
@@ -192,7 +192,7 @@ void gpio_irq_enable(gpio_t pin);
  */
 void gpio_irq_disable(gpio_t pin);
 
-#endif /* MODULE_PERIPH_GPIO_IRQ */
+#endif /* defined(MODULE_PERIPH_GPIO_IRQ) || defined(DOXYGEN) */
 
 /**
  * @brief   Get the current value of the given pin


### PR DESCRIPTION
### Contribution description
While reviewing all the PRs related to #9992 I noticed at some point, that the `#endif`s were not always commented properly with the opening `#ifdef`/`#if`. Since I already were in the middle of it and it was to me a too minor detail to block all those PRs for it, I decided to just go on with it and fix it myself later. So here we go.

### Testing procedure
Look at the code, check if the `#endif` matches with the commented `#ifdef` / `#if`. As an entry point I also checked the balance of `#ifdef MODULE_PERIPH_GPIO_IRQ` vs `#endif /* MODULE_PERIPH_GPIO_IRQ */` within `cpu/` and `drivers/`:

```sh
git grep "#ifn\?def\s\+MODULE_PERIPH_GPIO_IRQ" -- cpu/ drivers/ | wc -l
git grep --name-only "#ifn\?def\s\+MODULE_PERIPH_GPIO_IRQ" -- cpu/ drivers/ | xargs grep "#endif\s\+/\*\s\+MODULE_PERIPH_GPIO_IRQ\s\+\*/" | awk -F: '{print $1}' | wc -l
```

### Issues/PRs references
Follow-up to #9992 and its dependencies.