### PR TITLE
core/byteorder: Extend swap macros to adapt from LE data

### DIFF
--- a/core/include/byteorder.h
+++ b/core/include/byteorder.h
@@ -367,47 +367,60 @@ static inline le_uint64_t byteorder_btolll(be_uint64_t v)
 }
 
 /**
- * @brief Swaps the byteorder according to the endianess
+ * @brief Adapts a big endian value to the endianess of the platform
+ * by swapping the bytes, if needed.
  */
 #if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
-#   define _byteorder_swap(V, T) (byteorder_swap##T((V)))
+#   define byteorder_from_be(V, T) (byteorder_swap##T((V)))
 #elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
-#   define _byteorder_swap(V, T) (V)
+#   define byteorder_from_be(V, T) (V)
+#else
+#   error "Byte order is neither little nor big!"
+#endif
+
+/**
+ * @brief Adapts a little endian value to the endianess of the platform by
+ * swapping the bytes, if needed.
+ */
+#if __BYTE_ORDER__ == __ORDER_LITTLE_ENDIAN__
+#   define byteorder_from_le(V, T) (V)
+#elif __BYTE_ORDER__ == __ORDER_BIG_ENDIAN__
+#   define byteorder_from_le(V, T) (byteorder_swap##T((V)))
 #else
 #   error "Byte order is neither little nor big!"
 #endif
 
 static inline network_uint16_t byteorder_htons(uint16_t v)
 {
-    network_uint16_t result = { _byteorder_swap(v, s) };
+    network_uint16_t result = { byteorder_from_be(v, s) };
     return result;
 }
 
 static inline network_uint32_t byteorder_htonl(uint32_t v)
 {
-    network_uint32_t result = { _byteorder_swap(v, l) };
+    network_uint32_t result = { byteorder_from_be(v, l) };
     return result;
 }
 
 static inline network_uint64_t byteorder_htonll(uint64_t v)
 {
-    network_uint64_t result = { _byteorder_swap(v, ll) };
+    network_uint64_t result = { byteorder_from_be(v, ll) };
     return result;
 }
 
 static inline uint16_t byteorder_ntohs(network_uint16_t v)
 {
-    return _byteorder_swap(v.u16, s);
+    return byteorder_from_be(v.u16, s);
 }
 
 static inline uint32_t byteorder_ntohl(network_uint32_t v)
 {
-    return _byteorder_swap(v.u32, l);
+    return byteorder_from_be(v.u32, l);
 }
 
 static inline uint64_t byteorder_ntohll(network_uint64_t v)
 {
-    return _byteorder_swap(v.u64, ll);
+    return byteorder_from_be(v.u64, ll);
 }
 
 static inline uint16_t htons(uint16_t v)

--- a/tests/unittests/tests-core/tests-core-byteorder.c
+++ b/tests/unittests/tests-core/tests-core-byteorder.c
@@ -14,6 +14,22 @@
 
 #include "tests-core.h"
 
+static void test_byteorder_adapt_le(void)
+{
+    le_uint16_t data = { .u8 = { 0x34, 0x12 } };
+    static const uint16_t host = 0x1234;
+
+    TEST_ASSERT_EQUAL_INT(host, byteorder_from_le(data.u16, s));
+}
+
+static void test_byteorder_adapt_be(void)
+{
+    be_uint16_t data = { .u8 = { 0x12, 0x34 } };
+    static const uint16_t host = 0x1234;
+
+    TEST_ASSERT_EQUAL_INT(host, byteorder_from_be(data.u16, s));
+}
+
 static void test_byteorder_little_to_big_16(void)
 {
     le_uint16_t little = { .u8 = { 0x12, 0x34 } };
@@ -103,6 +119,8 @@ static void test_byteorder_htobebufs(void)
 Test *tests_core_byteorder_tests(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
+        new_TestFixture(test_byteorder_adapt_le),
+        new_TestFixture(test_byteorder_adapt_be),
         new_TestFixture(test_byteorder_little_to_big_16),
         new_TestFixture(test_byteorder_big_to_little_16),
         new_TestFixture(test_byteorder_little_to_big_32),


### PR DESCRIPTION
### Contribution description
Currently in ```byteorder.h``` there is only one macro defined to swap the order of bytes for multiple int types (```_byteorder_swap```). This macro has a misleading name and description: *Swaps the byteorder according to the endianess*; this does not say that he macro actually assumes that the value is in big endian. So if the platform is little endian it swaps the bytes.

This PR proposes a change of name (```byteorder_from_be```) and documentation for that macro, as well as a second one to adapt a little endian value to the endianess of the platform (```byteorder_from_le```).

This way by knowing the byte order of the value the macro handles if the bytes should be swapped or not depending on the platform.

### Testing procedure
Run the unit tests, which contains a byte order test (specially `test_byteorder_adapt_le` and `test_byteorder_adapt_be`). 

### Issues/PRs references
Could be used for #10088 data swapping.