### PR TITLE
net/rdcli_simple: do not send CF opt in POST msg

### DIFF
--- a/sys/net/application_layer/rdcli_simple/rdcli_simple.c
+++ b/sys/net/application_layer/rdcli_simple/rdcli_simple.c
@@ -60,7 +60,7 @@ int rdcli_simple_register(void)
         return RDCLI_SIMPLE_ERROR;
     }
     /* finish, we don't have any payload */
-    ssize_t len = gcoap_finish(&pkt, 0, COAP_FORMAT_LINK);
+    ssize_t len = gcoap_finish(&pkt, 0, COAP_FORMAT_NONE);
     if (gcoap_req_send2(buf, len, &remote, NULL) == 0) {
         return RDCLI_SIMPLE_ERROR;
     }


### PR DESCRIPTION
### Contribution description
Through the resource directory interop today @chrysn discovered a bug in the simple registration endpoint implementation: For the initial `POST` message, the content format option should not be set. This PR fixes that.

### Testing procedure
Run the `examples/rdcli_simple` example and observe the traffic in wireshark. Without this PR, the content format option in the initial `POST` message is set. With this PR, this option is not set anymore.

### Issues/PRs references
none
