### PR TITLE
boards/remote-revb: Update broken link in readme

### DIFF
--- a/boards/remote-revb/README.md
+++ b/boards/remote-revb/README.md
@@ -111,7 +111,7 @@ More Reading
 2. [CC2538 System-on-Chip Solution for 2.4-GHz IEEE 802.15.4 and ZigBee applications (SWRU319B)][cc2538]
 3. [CC1200 sub-1GHz RF transceiver][cc1200]
 
-[remote-site]: http://www.zolertia.io/products "Zolertia RE-Mote"
+[remote-site]: https://zolertia.io/product/re-mote-suite/ "Zolertia RE-Mote"
 [zolertia-wiki]: https://github.com/Zolertia/Resources/wiki
 [cc1200]: http://www.ti.com/product/cc1200     "CC1200"
 [cc2538]: http://www.ti.com/product/cc2538     "CC2538"


### PR DESCRIPTION
The README.md has a broken link (https://zolertia.io/products) link, change it to https://zolertia.io/product/re-mote-suite/