### PR TITLE
dist/tools/commit-msg/check.sh: Enhance reporting

### DIFF
--- a/dist/tools/commit-msg/check.sh
+++ b/dist/tools/commit-msg/check.sh
@@ -35,11 +35,15 @@ ERROR="$(git log \
         msg_length=$(echo "${msg}" | awk '{print length($0)}')
 
         if [ ${msg_length} -gt ${MSG_MAX_LENGTH} ]; then
-            echo "Commit message is longer than ${MSG_MAX_LENGTH} characters:" >&2
-            echo "    \"${msg}\"" >&2
             if [ ${msg_length} -gt ${MSG_STRETCH_LENGTH} ]; then
+                MSG="Error: Commit message is longer than ${MSG_STRETCH_LENGTH} characters:"
                 echo "error"
+            else
+                MSG="Warning: Commit message is longer than ${MSG_MAX_LENGTH}"
+                MSG="${MSG} (but < ${MSG_STRETCH_LENGTH}) characters:"
             fi
+            echo "${MSG}" >&2
+            echo "    \"${msg}\"" >&2
         fi
     done)"
 


### PR DESCRIPTION
### Contribution description

Enhance the way `dist/tools/commit-msg/check.sh` reports overlong commit messages.  With messages longer than 50 but less than 72, gives a _Warning:_.  With ones longer than 72, gives an _Error:_

### Testing procedure

Run `dist/tools/commit-msg/check.sh` and visually inspect the results.

Should not change anything else (I hope).

### Issues/PRs references

https://lists.riot-os.org/pipermail/devel/2018-October/005989.html