### PR TITLE
misc: use correct hauke.petersen@fu email address

### DIFF
--- a/cpu/efm32/periph/gpio.c
+++ b/cpu/efm32/periph/gpio.c
@@ -14,7 +14,7 @@
  * @file
  * @brief       Low-level GPIO driver implementation
  *
- * @author      Hauke Petersen <mail@haukepetersen.de>
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  * @author      Ryan Kurte <ryankurte@gmail.com>
  * @author      Bas Stottelaar <basstottelaar@gmail.com>
  *

--- a/cpu/stm32_common/periph/gpio.c
+++ b/cpu/stm32_common/periph/gpio.c
@@ -17,7 +17,7 @@
  * @file
  * @brief       Low-level GPIO driver implementation
  *
- * @author      Hauke Petersen <mail@haukepetersen.de>
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  * @author      Fabian Nack <nack@inf.fu-berlin.de>
  * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
  * @author      Katja Kirstein <katja.kirstein@haw-hamburg.de>

--- a/drivers/lpd8808/lpd8808.c
+++ b/drivers/lpd8808/lpd8808.c
@@ -13,7 +13,7 @@
  * @file
  * @brief       LPD8808 based LED strip driver implementation
  *
- * @author      Hauke Petersen <mail@haukepetersen.de>
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  *
  * @}
  */


### PR DESCRIPTION
### Contribution description
I found some leftover @author tags with an incorrect email address of mine, all of those occurances should use my FU mail address. This PR fixes that.

I am however a little unsure of also removing the entry from the `.mailmap` file, could someone confirm (or reject) that change?! Thanks.

### Testing procedure
n/a

### Issues/PRs references
none