### PR TITLE
drivers/hd44780: fix compilation errors

### DIFF
--- a/drivers/hd44780/hd44780.c
+++ b/drivers/hd44780/hd44780.c
@@ -32,7 +32,7 @@
 
 static inline void _command(const hd44780_t *dev, uint8_t value);
 static void _pulse(const hd44780_t *dev);
-static void _send(const hd44780_t *dev, uint8_t value, uint8_t mode);
+static void _send(const hd44780_t *dev, uint8_t value, hd44780_state_t state);
 static void _write_bits(const hd44780_t *dev, uint8_t bits, uint8_t value);
 
 /**


### PR DESCRIPTION
### Contribution description

This PR fixes a compilation problem because of conflicting types I had on platform ESP32:
```
drivers/hd44780/hd44780.c:71:13: error: conflicting types for '_send'
 static void _send(const hd44780_t *dev, uint8_t value, hd44780_state_t state)
             ^
drivers/hd44780/hd44780.c:35:13: note: previous declaration of '_send' was here
 static void _send(const hd44780_t *dev, uint8_t value, uint8_t mode);
```

### Testing procedure

```
make BOARD=arduino-uno -C tests/driver_hd44780/
```