### PR TITLE
cpu/stm32_common: correctly pull periph_flash_common dependency

### DIFF
--- a/cpu/stm32_common/Makefile.dep
+++ b/cpu/stm32_common/Makefile.dep
@@ -5,3 +5,9 @@ ifneq (,$(filter periph_i2c,$(USEMODULE)))
     USEMODULE += periph_i2c_2
   endif
 endif
+
+# flashpage and eeprom periph implementations share flash lock/unlock functions
+# in periph_flash_common
+ifneq (,$(filter periph_flashpage periph_eeprom,$(FEATURES_REQUIRED)))
+  USEMODULE += periph_flash_common
+endif

--- a/cpu/stm32_common/Makefile.include
+++ b/cpu/stm32_common/Makefile.include
@@ -8,12 +8,6 @@ USEMODULE += periph_common
 # include stm32 common functions and stm32 common periph drivers
 USEMODULE += stm32_common stm32_common_periph
 
-# flashpage and eeprom periph implementations share flash lock/unlock functions
-# in periph_flash_common
-ifneq (,$(filter periph_flashpage periph_eeprom,$(FEATURES_REQUIRED)))
-  FEATURES_REQUIRED += periph_flash_common
-endif
-
 # For stm32 cpu's we use the stm32_common.ld linker script
 export LINKFLAGS += -L$(RIOTCPU)/stm32_common/ldscripts
 LINKER_SCRIPT ?= stm32_common.ld


### PR DESCRIPTION
### Contribution description

While working on #8774 it popped up that stm32 `periph_flashpage` feature did not pull `periph_flashpage_common` dependency correctly in some cases.

### Testing procedure

Add `FEATURES_REQUIRED += periph_flashpage` in drivers or sys `Makefile.dep`. Without this PR, `periph_flashpage_common` is not built.

### Issues/PRs references

#8774 