### PR TITLE
sys/arduino: add docs for analog map (strictly needed to build)

### DIFF
--- a/sys/arduino/doc.txt
+++ b/sys/arduino/doc.txt
@@ -105,6 +105,16 @@
  *  };
  * @endcode
  *
+ * - a mapping of ADC lines to Arduino analogs pins named `arduino_analog_map`, e.g.
+ * @code{c}
+ *  static const adc_t arduino_analog_map[] = {
+ *      ADC_LINE(3),
+ *      ADC_LINE(2),
+ *      ADC_LINE(1),
+ *      ...
+ *  };
+ * @endcode
+ *
  * - a define `ARDUINO_LED` that is mapped to an Arduino pin number connected to
  *   any on-board LED, or to pin 0 in case no LED is defined:
  * @code{c}


### PR DESCRIPTION
### Contribution description
Add to the arduino module documentation a reference to the analog map that is strictly needed for the module to work. If this is missing in the board specific header file, the application will not work, therefore I believe it is useful to have it documented here.

### Testing procedure
Just documentation, no testing needed.

