### PR TITLE
sys/arduino: add arduino time functions micros() and delayMicroseconds()

### DIFF
--- a/sys/arduino/base.cpp
+++ b/sys/arduino/base.cpp
@@ -62,6 +62,16 @@ void delay(unsigned long msec)
     xtimer_usleep(1000 * msec);
 }
 
+void delayMicroseconds(unsigned long usec)
+{
+    xtimer_usleep(usec);
+}
+
+unsigned int micros()
+{
+    return xtimer_now_usec();
+}
+
 /*
  * Bitfield for the state of the ADC-channels.
  * 0: Not initialized

--- a/sys/arduino/base.cpp
+++ b/sys/arduino/base.cpp
@@ -67,7 +67,7 @@ void delayMicroseconds(unsigned long usec)
     xtimer_usleep(usec);
 }
 
-unsigned int micros()
+unsigned long micros()
 {
     return xtimer_now_usec();
 }

--- a/sys/arduino/include/arduino.hpp
+++ b/sys/arduino/include/arduino.hpp
@@ -83,6 +83,20 @@ int digitalRead(int pin);
 void delay(unsigned long msec);
 
 /**
+ * @brief   Sleep for a given amount of time [microseconds]
+ *
+ * @param[in] usec      number of microseconds to sleep
+ */
+void delayMicroseconds(unsigned long usec);
+
+/**
+ * @brief   Returns the number of microseconds since start
+ *
+ * @return value of microseconds since start
+ */
+unsigned long micros();
+
+/**
  * @brief   Read the current value of the given analog pin
  *
  * @param[in] pin       pin to read


### PR DESCRIPTION
### Contribution description
This PR adds two standard time related functions in the Arduino module, making it more complete and therefore making it easier to use Arduino unmodified sketches on top of RIOT.
The added functions are:

- micros(): https://www.arduino.cc/reference/en/language/functions/time/micros/
- delayMicroseconds(): https://www.arduino.cc/reference/en/language/functions/time/delaymicroseconds/

### Testing procedure
There is no automatic tests for the Arduino module. To test manually you can call the two new functions in your Arduino sketch.
