### PR TITLE
cpu: change adc_sample return to int32_t

### DIFF
--- a/cpu/atmega_common/periph/adc.c
+++ b/cpu/atmega_common/periph/adc.c
@@ -99,9 +99,9 @@ int adc_init(adc_t line)
     return 0;
 }
 
-int adc_sample(adc_t line, adc_res_t res)
+int32_t adc_sample(adc_t line, adc_res_t res)
 {
-    int sample = 0;
+    int32_t sample = 0;
 
     /* check if resolution is applicable */
     if (res != ADC_RES_10BIT) {

--- a/cpu/cc2538/include/periph_cpu.h
+++ b/cpu/cc2538/include/periph_cpu.h
@@ -249,14 +249,18 @@ typedef struct {
  */
 #define HAVE_ADC_RES_T
 typedef enum {
-    ADC_RES_6BIT  =             (0xa00),    /**< not supported by hardware */
+    ADC_RES_6BIT  =             (0x0a00),    /**< not supported by hardware */
     ADC_RES_7BIT  =             (0 << 4),   /**< ADC resolution: 7 bit */
-    ADC_RES_8BIT  =             (0xb00),    /**< not supported by hardware */
+    ADC_RES_8BIT  =             (0x0b00),    /**< not supported by hardware */
     ADC_RES_9BIT  =             (1 << 4),   /**< ADC resolution: 9 bit */
     ADC_RES_10BIT =             (2 << 4),   /**< ADC resolution: 10 bit */
     ADC_RES_12BIT =             (3 << 4),   /**< ADC resolution: 12 bit */
-    ADC_RES_14BIT =             (0xc00),    /**< not supported by hardware */
-    ADC_RES_16BIT =             (0xd00),    /**< not supported by hardware */
+    ADC_RES_14BIT =             (0x0c00),    /**< not supported by hardware */
+    ADC_RES_16BIT =             (0x0d00),    /**< not supported by hardware */
+    ADC_RES_18BIT =             (0x0e00),    /**< not supported by hardware */
+    ADC_RES_20BIT =             (0x0f00),    /**< not supported by hardware */
+    ADC_RES_22BIT =             (0x1000),    /**< not supported by hardware */
+    ADC_RES_24BIT =             (0x1100),    /**< not supported by hardware */
 } adc_res_t;
 /** @} */
 

--- a/cpu/cc2538/periph/adc.c
+++ b/cpu/cc2538/periph/adc.c
@@ -51,7 +51,7 @@ int adc_init(adc_t line)
     return 0;
 }
 
-int adc_sample(adc_t line, adc_res_t res)
+int32_t adc_sample(adc_t line, adc_res_t res)
 {
     /* check if adc line valid */
     if (line >= ADC_NUMOF) {
@@ -112,5 +112,5 @@ int adc_sample(adc_t line, adc_res_t res)
         sample = 0;
     }
 
-    return (int)sample;
+    return sample;
 }

--- a/cpu/efm32/include/periph_cpu.h
+++ b/cpu/efm32/include/periph_cpu.h
@@ -71,6 +71,10 @@ typedef enum {
     ADC_RES_12BIT = ADC_MODE(adcRes12Bit, 0),   /**< ADC resolution: 12 bit */
     ADC_RES_14BIT = ADC_MODE_UNDEF(0),          /**< ADC resolution: 14 bit (unsupported) */
     ADC_RES_16BIT = ADC_MODE_UNDEF(1),          /**< ADC resolution: 16 bit (unsupported) */
+    ADC_RES_18BIT = ADC_MODE_UNDEF(2),          /**< ADC resolution: 18 bit (unsupported) */
+    ADC_RES_20BIT = ADC_MODE_UNDEF(3),          /**< ADC resolution: 20 bit (unsupported) */
+    ADC_RES_22BIT = ADC_MODE_UNDEF(4),          /**< ADC resolution: 22 bit (unsupported) */
+    ADC_RES_24BIT = ADC_MODE_UNDEF(5),          /**< ADC resolution: 24 bit (unsupported) */
 } adc_res_t;
 /** @} */
 #endif /* ndef DOXYGEN */

--- a/cpu/efm32/periph/adc.c
+++ b/cpu/efm32/periph/adc.c
@@ -59,7 +59,7 @@ int adc_init(adc_t line)
     return 0;
 }
 
-int adc_sample(adc_t line, adc_res_t res)
+int32_t adc_sample(adc_t line, adc_res_t res)
 {
     /* resolutions larger than 12 bits are not supported */
     if (res >= ADC_MODE_UNDEF(0)) {
@@ -90,7 +90,7 @@ int adc_sample(adc_t line, adc_res_t res)
 
     while (adc_config[dev].dev->STATUS & ADC_STATUS_SINGLEACT);
 
-    int result = ADC_DataSingleGet(adc_config[dev].dev);
+    int32_t result = ADC_DataSingleGet(adc_config[dev].dev);
 
     /* for resolutions that are not really supported, shift the result (for
        instance, 10 bit resolution is achieved by shifting a 12 bit sample). */

--- a/cpu/esp8266/periph/adc.c
+++ b/cpu/esp8266/periph/adc.c
@@ -42,7 +42,7 @@ int adc_init(adc_t line)
 }
 
 
-int adc_sample(adc_t line, adc_res_t res)
+int32_t adc_sample(adc_t line, adc_res_t res)
 {
     CHECK_PARAM_RET (line < ADC_NUMOF, -1)
     CHECK_PARAM_RET (res == ADC_RES_10BIT, -1)

--- a/cpu/kinetis/include/periph_cpu.h
+++ b/cpu/kinetis/include/periph_cpu.h
@@ -208,7 +208,11 @@ typedef enum {
     ADC_RES_10BIT = ADC_CFG1_MODE(2),   /**< ADC resolution: 10 bit */
     ADC_RES_12BIT = ADC_CFG1_MODE(1),   /**< ADC resolution: 12 bit */
     ADC_RES_14BIT = (0xff),             /**< ADC resolution: 14 bit */
-    ADC_RES_16BIT = ADC_CFG1_MODE(3)    /**< ADC resolution: 16 bit */
+    ADC_RES_16BIT = ADC_CFG1_MODE(3),   /**< ADC resolution: 16 bit */
+    ADC_RES_18BIT = (0xff),             /**< not supported */
+    ADC_RES_20BIT = (0xff),             /**< not supported */
+    ADC_RES_22BIT = (0xff),             /**< not supported */
+    ADC_RES_24BIT = (0xff),             /**< not supported */
 } adc_res_t;
 /** @} */
 

--- a/cpu/kinetis/periph/adc.c
+++ b/cpu/kinetis/periph/adc.c
@@ -207,9 +207,9 @@ int adc_init(adc_t line)
     return res;
 }
 
-int adc_sample(adc_t line, adc_res_t res)
+int32_t adc_sample(adc_t line, adc_res_t res)
 {
-    int sample;
+    int32_t sample;
 
     /* check if resolution is applicable */
     if (res > 0xf0) {
@@ -229,7 +229,7 @@ int adc_sample(adc_t line, adc_res_t res)
     /* wait until conversion is complete */
     while (!(dev(line)->SC1[0] & ADC_SC1_COCO_MASK)) {}
     /* read and return result */
-    sample = (int)dev(line)->R[0];
+    sample = (int32_t)dev(line)->R[0];
 
     /* power off and unlock the device */
     done(line);

--- a/cpu/lm4f120/include/periph_cpu.h
+++ b/cpu/lm4f120/include/periph_cpu.h
@@ -97,12 +97,16 @@ enum {
 #ifndef DOXYGEN
 #define HAVE_ADC_RES_T
 typedef enum {
-    ADC_RES_6BIT  = 0xa00,            /**< not supported by hardware */
-    ADC_RES_8BIT  = 0xb00,            /**< not supported by hardware */
+    ADC_RES_6BIT  = 0x0a00,           /**< not supported by hardware */
+    ADC_RES_8BIT  = 0x0b00,           /**< not supported by hardware */
     ADC_RES_10BIT = ADC_RES_10BIT_S,  /**< ADC resolution: 10 bit */
     ADC_RES_12BIT = ADC_RES_12BIT_S,  /**< ADC resolution: 12 bit */
-    ADC_RES_14BIT = 0xc00,            /**< not supported by hardware */
-    ADC_RES_16BIT = 0xd00,            /**< not supported by hardware */
+    ADC_RES_14BIT = 0x0c00,           /**< not supported by hardware */
+    ADC_RES_16BIT = 0x0d00,           /**< not supported by hardware */
+    ADC_RES_18BIT = 0x0e00,           /**< not supported by hardware */
+    ADC_RES_20BIT = 0x0f00,           /**< not supported by hardware */
+    ADC_RES_22BIT = 0x1000,           /**< not supported by hardware */
+    ADC_RES_24BIT = 0x1100,           /**< not supported by hardware */
 } adc_res_t;
 #endif /* ndef DOXYGEN */
 

--- a/cpu/lm4f120/periph/adc.c
+++ b/cpu/lm4f120/periph/adc.c
@@ -100,9 +100,9 @@ int adc_init(adc_t line)
     return 0;
 }
 
-int adc_sample(adc_t line, adc_res_t res)
+int32_t adc_sample(adc_t line, adc_res_t res)
 {
-    int value[2];
+    int32_t value[2];
 
     if ((res != ADC_RES_10BIT) && (res != ADC_RES_12BIT)) {
         return -1;
@@ -114,7 +114,7 @@ int adc_sample(adc_t line, adc_res_t res)
     ROM_ADCSequenceConfigure(ADC0_BASE, SEQ, ADC_TRIGGER_PROCESSOR, 0);
     ROM_ADCSequenceStepConfigure(ADC0_BASE, SEQ, 0, line | ADC_CTL_IE | ADC_CTL_END);
     /* set resolution */
-    ROM_ADCResolutionSet(ADC0_BASE, (unsigned long)res);
+    ROM_ADCResolutionSet(ADC0_BASE, (uint32_t)res);
 
     /* start conversion and wait for results */
     ROM_ADCSequenceEnable(ADC0_BASE, SEQ);
@@ -123,7 +123,7 @@ int adc_sample(adc_t line, adc_res_t res)
     while (!ROM_ADCIntStatus(ADC0_BASE, SEQ, false)) {}
 
     /* get results */
-    ROM_ADCSequenceDataGet(ADC0_BASE, SEQ, (unsigned long *) value);
+    ROM_ADCSequenceDataGet(ADC0_BASE, SEQ, (uint32_t *) value);
 
     /* disable device again */
     ROM_ADCSequenceDisable(ADC0_BASE, SEQ);

--- a/cpu/nrf51/include/periph_cpu.h
+++ b/cpu/nrf51/include/periph_cpu.h
@@ -75,7 +75,11 @@ typedef enum {
     ADC_RES_10BIT = 0x02,   /**< ADC resolution: 10 bit */
     ADC_RES_12BIT = 0xf1,   /**< ADC resolution: 12 bit (not supported) */
     ADC_RES_14BIT = 0xf2,   /**< ADC resolution: 14 bit (not supported) */
-    ADC_RES_16BIT = 0xf3    /**< ADC resolution: 16 bit (not supported) */
+    ADC_RES_16BIT = 0xf3,   /**< ADC resolution: 16 bit (not supported) */
+    ADC_RES_18BIT = 0xf4,   /**< ADC resolution: 18 bit (not supported) */
+    ADC_RES_20BIT = 0xf5,   /**< ADC resolution: 20 bit (not supported) */
+    ADC_RES_22BIT = 0xf6,   /**< ADC resolution: 22 bit (not supported) */
+    ADC_RES_24BIT = 0xf7,   /**< ADC resolution: 24 bit (not supported) */
 } adc_res_t;
 /** @} */
 

--- a/cpu/nrf51/periph/adc.c
+++ b/cpu/nrf51/periph/adc.c
@@ -55,9 +55,9 @@ int adc_init(adc_t line)
     return 0;
 }
 
-int adc_sample(adc_t line, adc_res_t res)
+int32_t adc_sample(adc_t line, adc_res_t res)
 {
-    int val;
+    int32_t val;
 
     /* check if resolution is valid */
     if (res > 2) {
@@ -77,7 +77,7 @@ int adc_sample(adc_t line, adc_res_t res)
     /* wait for conversion to be complete */
     while (NRF_ADC->BUSY == 1) {}
     /* get result */
-    val = (int)NRF_ADC->RESULT;
+    val = (int32_t)NRF_ADC->RESULT;
 
     /* free device */
     done();

--- a/cpu/nrf52/include/periph_cpu.h
+++ b/cpu/nrf52/include/periph_cpu.h
@@ -76,7 +76,11 @@ typedef enum {
     ADC_RES_10BIT = 0x01,   /**< ADC resolution: 10 bit */
     ADC_RES_12BIT = 0x02,   /**< ADC resolution: 12 bit */
     ADC_RES_14BIT = 0xf1,   /**< supported with oversampling, not implemented */
-    ADC_RES_16BIT = 0xf2    /**< not supported by hardware */
+    ADC_RES_16BIT = 0xf2,   /**< not supported by hardware */
+    ADC_RES_18BIT = 0xf3,   /**< not supported by hardware */
+    ADC_RES_20BIT = 0xf4,   /**< not supported by hardware */
+    ADC_RES_22BIT = 0xf5,   /**< not supported by hardware */
+    ADC_RES_24BIT = 0xf6,   /**< not supported by hardware */
 } adc_res_t;
 /** @} */
 

--- a/cpu/nrf52/periph/adc.c
+++ b/cpu/nrf52/periph/adc.c
@@ -103,7 +103,7 @@ int adc_init(adc_t line)
     return 0;
 }
 
-int adc_sample(adc_t line, adc_res_t res)
+int32_t adc_sample(adc_t line, adc_res_t res)
 {
     assert(line < ADC_NUMOF);
 
@@ -142,5 +142,5 @@ int adc_sample(adc_t line, adc_res_t res)
      * connected via jumper wire a the board's GND pin. There seems to be a
      * slight difference between the internal CPU GND and the board's GND
      * voltage levels?! (observed on nrf52dk and nrf52840dk) */
-    return (result < 0) ? 0 : (int)result;
+    return (result < 0) ? 0 : (int32_t)result;
 }

--- a/cpu/sam0_common/periph/adc.c
+++ b/cpu/sam0_common/periph/adc.c
@@ -159,7 +159,7 @@ int adc_init(adc_t line)
     return 0;
 }
 
-int adc_sample(adc_t line, adc_res_t res)
+int32_t adc_sample(adc_t line, adc_res_t res)
 {
     if (line >= ADC_NUMOF) {
         DEBUG("adc: line arg not applicable\n");
@@ -182,7 +182,7 @@ int adc_sample(adc_t line, adc_res_t res)
     ADC_0_DEV->SWTRIG.reg = ADC_SWTRIG_START;
     /* Wait for the result */
     while (!(ADC_0_DEV->INTFLAG.reg & ADC_INTFLAG_RESRDY)) {}
-    int result = ADC_0_DEV->RESULT.reg;
+    int32_t result = ADC_0_DEV->RESULT.reg;
     _adc_poweroff();
     _done();
     return result;

--- a/cpu/sam3/include/periph_cpu.h
+++ b/cpu/sam3/include/periph_cpu.h
@@ -187,7 +187,11 @@ typedef enum {
     ADC_RES_10BIT = ADC_MR_LOWRES_BITS_10,  /**< ADC resolution: 10 bit */
     ADC_RES_12BIT = ADC_MR_LOWRES_BITS_12,  /**< ADC resolution: 12 bit */
     ADC_RES_14BIT = 0x4,                    /**< not applicable */
-    ADC_RES_16BIT = 0x8                     /**< not applicable */
+    ADC_RES_16BIT = 0x8,                    /**< not applicable */
+    ADC_RES_18BIT = 0x9,                    /**< not applicable */
+    ADC_RES_20BIT = 0xa,                    /**< not applicable */
+    ADC_RES_22BIT = 0xb,                    /**< not applicable */
+    ADC_RES_24BIT = 0xc,                    /**< not applicable */
 } adc_res_t;
 /** @} */
 

--- a/cpu/sam3/periph/adc.c
+++ b/cpu/sam3/periph/adc.c
@@ -68,7 +68,7 @@ int adc_init(adc_t line)
     return 0;
 }
 
-int adc_sample(adc_t line, adc_res_t res)
+int32_t adc_sample(adc_t line, adc_res_t res)
 {
     assert(line < ADC_NUMOF);
 
@@ -89,7 +89,7 @@ int adc_sample(adc_t line, adc_res_t res)
     /* wait for result */
     while (!(ADC->ADC_ISR & ADC_ISR_DRDY)) {}
     /* read result */
-    int sample = (int)(ADC->ADC_LCDR & ADC_LCDR_LDATA_Msk);
+    int32_t sample = (int32_t)(ADC->ADC_LCDR & ADC_LCDR_LDATA_Msk);
 
     /* disable channel */
     ADC->ADC_CHDR = (1 << line);

--- a/cpu/samd21/include/periph_cpu.h
+++ b/cpu/samd21/include/periph_cpu.h
@@ -99,12 +99,16 @@ static inline int _sercom_id(SercomUsart *sercom)
  */
 #define HAVE_ADC_RES_T
 typedef enum {
-    ADC_RES_6BIT  = 0xff,                       /**< not supported */
+    ADC_RES_6BIT  = 0x0f,                       /**< not supported */
     ADC_RES_8BIT  = ADC_CTRLB_RESSEL_8BIT,      /**< ADC resolution: 8 bit */
     ADC_RES_10BIT = ADC_CTRLB_RESSEL_10BIT,     /**< ADC resolution: 10 bit */
     ADC_RES_12BIT = ADC_CTRLB_RESSEL_12BIT,     /**< ADC resolution: 12 bit */
-    ADC_RES_14BIT = 0xfe,                       /**< not supported */
-    ADC_RES_16BIT = 0xfd                        /**< not supported */
+    ADC_RES_14BIT = 0x09,                       /**< not supported */
+    ADC_RES_16BIT = 0x0a,                       /**< not supported */
+    ADC_RES_18BIT = 0x0b,                       /**< not supported */
+    ADC_RES_20BIT = 0x0c,                       /**< not supported */
+    ADC_RES_22BIT = 0x0d,                       /**< not supported */
+    ADC_RES_24BIT = 0x0e,                       /**< not supported */
 } adc_res_t;
 /** @} */
 #ifdef __cplusplus

--- a/cpu/saml21/include/periph_cpu.h
+++ b/cpu/saml21/include/periph_cpu.h
@@ -38,12 +38,16 @@ static const int8_t exti_config[2][32] = {
 
 #define HAVE_ADC_RES_T
 typedef enum {
-    ADC_RES_6BIT  = 0xff,                       /**< not supported */
+    ADC_RES_6BIT  = 0x0f,                       /**< not supported */
     ADC_RES_8BIT  = ADC_CTRLC_RESSEL_8BIT,      /**< ADC resolution: 8 bit */
     ADC_RES_10BIT = ADC_CTRLC_RESSEL_10BIT,     /**< ADC resolution: 10 bit */
     ADC_RES_12BIT = ADC_CTRLC_RESSEL_12BIT,     /**< ADC resolution: 12 bit */
-    ADC_RES_14BIT = 0xfe,                       /**< not supported */
-    ADC_RES_16BIT = 0xfd                        /**< not supported */
+    ADC_RES_14BIT = 0x09,                       /**< not supported */
+    ADC_RES_16BIT = 0x0a,                       /**< not supported */
+    ADC_RES_18BIT = 0x0b,                       /**< not supported */
+    ADC_RES_20BIT = 0x0c,                       /**< not supported */
+    ADC_RES_22BIT = 0x0d,                       /**< not supported */
+    ADC_RES_24BIT = 0x0e,                       /**< not supported */
 } adc_res_t;
 /** @} */
 #ifdef __cplusplus

--- a/cpu/stm32f0/include/periph_cpu.h
+++ b/cpu/stm32f0/include/periph_cpu.h
@@ -53,8 +53,12 @@ typedef enum {
     ADC_RES_8BIT  = (0x2 << 3),     /**< ADC resolution: 8 bit */
     ADC_RES_10BIT = (0x1 << 3),     /**< ADC resolution: 10 bit */
     ADC_RES_12BIT = (0x0 << 3),     /**< ADC resolution: 12 bit */
-    ADC_RES_14BIT = (0xfe),         /**< not applicable */
-    ADC_RES_16BIT = (0xff)          /**< not applicable */
+    ADC_RES_14BIT = (0x01),         /**< not applicable */
+    ADC_RES_16BIT = (0x02),         /**< not applicable */
+    ADC_RES_18BIT = (0x03),         /**< not applicable */
+    ADC_RES_20BIT = (0x04),         /**< not applicable */
+    ADC_RES_22BIT = (0x05),         /**< not applicable */
+    ADC_RES_24BIT = (0x06),         /**< not applicable */
 } adc_res_t;
 /** @} */
 #endif /* ndef DOXYGEN */

--- a/cpu/stm32f0/periph/adc.c
+++ b/cpu/stm32f0/periph/adc.c
@@ -75,9 +75,9 @@ int adc_init(adc_t line)
     return 0;
 }
 
-int adc_sample(adc_t line,  adc_res_t res)
+int32_t adc_sample(adc_t line,  adc_res_t res)
 {
-    int sample;
+    int32_t sample;
 
     /* check if resolution is applicable */
     if (res > 0xf0) {
@@ -94,7 +94,7 @@ int adc_sample(adc_t line,  adc_res_t res)
     ADC1->CR |= ADC_CR_ADSTART;
     while (!(ADC1->ISR & ADC_ISR_EOC)) {}
     /* read result */
-    sample = (int)ADC1->DR;
+    sample = (int32_t)ADC1->DR;
 
     /* unlock and power off device again */
     done();

--- a/cpu/stm32f1/periph/adc.c
+++ b/cpu/stm32f1/periph/adc.c
@@ -125,9 +125,9 @@ int adc_init(adc_t line)
     return 0;
 }
 
-int adc_sample(adc_t line, adc_res_t res)
+int32_t adc_sample(adc_t line, adc_res_t res)
 {
-    int sample;
+    int32_t sample;
 
     /* check if the linenel is valid */
     if (line >= ADC_NUMOF) {
@@ -148,7 +148,7 @@ int adc_sample(adc_t line, adc_res_t res)
     dev(line)->CR2 |= ADC_CR2_SWSTART;
     while (!(dev(line)->SR & ADC_SR_EOC)) {}
     /* finally read sample and reset the STRT bit in the status register */
-    sample = (int)dev(line)->DR;
+    sample = (int32_t)dev(line)->DR;
 
     /* power off and unlock device again */
     done(line);

--- a/cpu/stm32f2/include/periph_cpu.h
+++ b/cpu/stm32f2/include/periph_cpu.h
@@ -72,7 +72,11 @@ typedef enum {
     ADC_RES_10BIT = 0x01000000,  /**< ADC resolution: 10 bit */
     ADC_RES_12BIT = 0x00000000,  /**< ADC resolution: 12 bit */
     ADC_RES_14BIT = 1,           /**< ADC resolution: 14 bit (not supported) */
-    ADC_RES_16BIT = 2            /**< ADC resolution: 16 bit (not supported)*/
+    ADC_RES_16BIT = 2            /**< ADC resolution: 16 bit (not supported) */
+    ADC_RES_18BIT = 3,           /**< ADC resolution: 18 bit (not supported) */
+    ADC_RES_20BIT = 4,           /**< ADC resolution: 20 bit (not supported) */
+    ADC_RES_22BIT = 5,           /**< ADC resolution: 22 bit (not supported) */
+    ADC_RES_24BIT = 6,           /**< ADC resolution: 24 bit (not supported) */
 } adc_res_t;
 /** @} */
 

--- a/cpu/stm32f2/periph/adc.c
+++ b/cpu/stm32f2/periph/adc.c
@@ -111,9 +111,9 @@ int adc_init(adc_t line)
     return 0;
 }
 
-int adc_sample(adc_t line, adc_res_t res)
+int32_t adc_sample(adc_t line, adc_res_t res)
 {
-    int sample;
+    int32_t sample;
 
     /* check if resolution is applicable */
     if (res < 0xff) {
@@ -130,7 +130,7 @@ int adc_sample(adc_t line, adc_res_t res)
     dev(line)->CR2 |= ADC_CR2_SWSTART;
     while (!(dev(line)->SR & ADC_SR_EOC)) {}
     /* finally read sample and reset the STRT bit in the status register */
-    sample = (int)dev(line)->DR;
+    sample = (int32_t)dev(line)->DR;
 
     /* power off and unlock device again */
     done(line);

--- a/cpu/stm32f4/include/periph_cpu.h
+++ b/cpu/stm32f4/include/periph_cpu.h
@@ -71,6 +71,10 @@ typedef enum {
     ADC_RES_12BIT = 0x00000000,     /**< ADC resolution: 12 bit */
     ADC_RES_14BIT = 1,              /**< ADC resolution: 14 bit (not supported) */
     ADC_RES_16BIT = 2               /**< ADC resolution: 16 bit (not supported)*/
+    ADC_RES_18BIT = 3,              /**< ADC resolution: 18 bit (not supported) */
+    ADC_RES_20BIT = 4,              /**< ADC resolution: 20 bit (not supported) */
+    ADC_RES_22BIT = 5,              /**< ADC resolution: 22 bit (not supported) */
+    ADC_RES_24BIT = 6,              /**< ADC resolution: 24 bit (not supported) */
 } adc_res_t;
 /** @} */
 #endif /* ndef DOXYGEN */

--- a/cpu/stm32f4/periph/adc.c
+++ b/cpu/stm32f4/periph/adc.c
@@ -94,9 +94,9 @@ int adc_init(adc_t line)
     return 0;
 }
 
-int adc_sample(adc_t line, adc_res_t res)
+int32_t adc_sample(adc_t line, adc_res_t res)
 {
-    int sample;
+    int32_t sample;
 
     /* check if resolution is applicable */
     if (res & 0xff) {
@@ -113,7 +113,7 @@ int adc_sample(adc_t line, adc_res_t res)
     dev(line)->CR2 |= ADC_CR2_SWSTART;
     while (!(dev(line)->SR & ADC_SR_EOC)) {}
     /* finally read sample and reset the STRT bit in the status register */
-    sample = (int)dev(line)->DR;
+    sample = (int32_t)dev(line)->DR;
 
     /* power off and unlock device again */
     done(line);

--- a/cpu/stm32l0/include/periph_cpu.h
+++ b/cpu/stm32l0/include/periph_cpu.h
@@ -56,8 +56,12 @@ typedef enum {
     ADC_RES_8BIT  = (0x2 << 3),     /**< ADC resolution: 8 bit */
     ADC_RES_10BIT = (0x1 << 3),     /**< ADC resolution: 10 bit */
     ADC_RES_12BIT = (0x0 << 3),     /**< ADC resolution: 12 bit */
-    ADC_RES_14BIT = (0xfe),         /**< not applicable */
-    ADC_RES_16BIT = (0xff)          /**< not applicable */
+    ADC_RES_14BIT = (0x01),         /**< not applicable */
+    ADC_RES_16BIT = (0x02),         /**< not applicable */
+    ADC_RES_18BIT = (0x03),         /**< not applicable */
+    ADC_RES_20BIT = (0x04),         /**< not applicable */
+    ADC_RES_22BIT = (0x05),         /**< not applicable */
+    ADC_RES_24BIT = (0x06),         /**< not applicable */
 } adc_res_t;
 /** @} */
 #endif /* ndef DOXYGEN */

--- a/cpu/stm32l0/periph/adc.c
+++ b/cpu/stm32l0/periph/adc.c
@@ -123,9 +123,9 @@ int adc_init(adc_t line)
     return 0;
 }
 
-int adc_sample(adc_t line,  adc_res_t res)
+int32_t adc_sample(adc_t line,  adc_res_t res)
 {
-    int sample;
+    int32_t sample;
 
     /* check if resolution is applicable */
     if ( (res != ADC_RES_6BIT) &&
@@ -164,7 +164,7 @@ int adc_sample(adc_t line,  adc_res_t res)
     while (!(ADC1->ISR & ADC_ISR_EOC)) {}
 
     /* read result */
-    sample = (int)ADC1->DR;
+    sample = (int32_t)ADC1->DR;
 
     /* Disable ADC */
     _disable_adc();

--- a/cpu/stm32l1/include/periph_cpu.h
+++ b/cpu/stm32l1/include/periph_cpu.h
@@ -68,8 +68,12 @@ typedef enum {
     ADC_RES_8BIT  = (ADC_CR1_RES_1),                    /**< ADC resolution: 8 bit */
     ADC_RES_10BIT = (ADC_CR1_RES_0),                    /**< ADC resolution: 10 bit */
     ADC_RES_12BIT = (0x00),                             /**< ADC resolution: 12 bit */
-    ADC_RES_14BIT = (0xfe),                             /**< not applicable */
-    ADC_RES_16BIT = (0xff)                              /**< not applicable */
+    ADC_RES_14BIT = (0x01),                             /**< not applicable */
+    ADC_RES_16BIT = (0x02),                             /**< not applicable */
+    ADC_RES_18BIT = (0x03),                             /**< not applicable */
+    ADC_RES_20BIT = (0x04),                             /**< not applicable */
+    ADC_RES_22BIT = (0x05),                             /**< not applicable */
+    ADC_RES_24BIT = (0x06),                             /**< not applicable */
 } adc_res_t;
 /** @} */
 

--- a/cpu/stm32l1/periph/adc.c
+++ b/cpu/stm32l1/periph/adc.c
@@ -152,9 +152,9 @@ int adc_init(adc_t line)
     return 0;
 }
 
-int adc_sample(adc_t line, adc_res_t res)
+int32_t adc_sample(adc_t line, adc_res_t res)
 {
-    int sample;
+    int32_t sample;
 
     /* check if resolution is applicable */
     if ( (res != ADC_RES_6BIT) &&
@@ -178,7 +178,7 @@ int adc_sample(adc_t line, adc_res_t res)
     ADC1->CR2 |= ADC_CR2_SWSTART;
     while (!(ADC1->SR & ADC_SR_EOC)) {}
     /* finally read sample and reset the STRT bit in the status register */
-    sample = (int)ADC1->DR;
+    sample = (int32_t)ADC1->DR;
     ADC1 -> SR &= ~ADC_SR_STRT;
 
     /* power off and unlock device again */

--- a/cpu/stm32l4/include/periph_cpu.h
+++ b/cpu/stm32l4/include/periph_cpu.h
@@ -73,8 +73,12 @@ typedef enum {
     ADC_RES_8BIT  = (ADC_CFGR_RES_1), /**< ADC resolution: 8 bit */
     ADC_RES_10BIT = (ADC_CFGR_RES_0), /**< ADC resolution: 10 bit */
     ADC_RES_12BIT = (0x0),            /**< ADC resolution: 12 bit */
-    ADC_RES_14BIT = (0x1),            /**< not applicable */
-    ADC_RES_16BIT = (0x2)             /**< not applicable */
+    ADC_RES_14BIT = (0x01),           /**< not applicable */
+    ADC_RES_16BIT = (0x02),           /**< not applicable */
+    ADC_RES_18BIT = (0x03),           /**< not applicable */
+    ADC_RES_20BIT = (0x04),           /**< not applicable */
+    ADC_RES_22BIT = (0x05),           /**< not applicable */
+    ADC_RES_24BIT = (0x06),           /**< not applicable */
 } adc_res_t;
 /** @} */
 #endif /* ndef DOXYGEN */

--- a/cpu/stm32l4/periph/adc.c
+++ b/cpu/stm32l4/periph/adc.c
@@ -179,9 +179,9 @@ int adc_init(adc_t line)
     return 0;
 }
 
-int adc_sample(adc_t line, adc_res_t res)
+int32_t adc_sample(adc_t line, adc_res_t res)
 {
-    int sample;
+    int32_t sample;
 
     /* check if resolution is applicable */
     if (res & 0x3) {
@@ -205,7 +205,7 @@ int adc_sample(adc_t line, adc_res_t res)
     while (!(dev(line)->ISR & ADC_ISR_EOC)) {}
 
     /* read the sample */
-    sample = (int)dev(line)->DR;
+    sample = (int32_t)dev(line)->DR;
 
     /* free the device again */
     done(line);

--- a/drivers/include/mq3.h
+++ b/drivers/include/mq3.h
@@ -62,7 +62,7 @@ int mq3_init(mq3_t *dev, adc_t adc_line);
  *
  * @return              the raw sensor value, between 0 and MQ3_MAX_RAW_VALUE
  */
-int mq3_read_raw(const mq3_t *dev);
+int32_t mq3_read_raw(const mq3_t *dev);
 
 /**
  * @brief   Read the scaled sensor value of PPM of alcohol

--- a/drivers/include/periph/adc.h
+++ b/drivers/include/periph/adc.h
@@ -113,7 +113,7 @@ int adc_init(adc_t line);
  * @return                  the sampled value on success
  * @return                  -1 if resolution is not applicable
  */
-int adc_sample(adc_t line, adc_res_t res);
+int32_t adc_sample(adc_t line, adc_res_t res);
 
 #ifdef __cplusplus
 }

--- a/drivers/include/periph/adc.h
+++ b/drivers/include/periph/adc.h
@@ -84,6 +84,10 @@ typedef enum {
     ADC_RES_12BIT,          /**< ADC resolution: 12 bit */
     ADC_RES_14BIT,          /**< ADC resolution: 14 bit */
     ADC_RES_16BIT,          /**< ADC resolution: 16 bit */
+    ADC_RES_18BIT,          /**< ADC resolution: 18 bit */
+    ADC_RES_20BIT,          /**< ADC resolution: 20 bit */
+    ADC_RES_22BIT,          /**< ADC resolution: 22 bit */
+    ADC_RES_24BIT,          /**< ADC resolution: 24 bit */
 } adc_res_t;
 #endif
 

--- a/drivers/io1_xplained/io1_xplained.c
+++ b/drivers/io1_xplained/io1_xplained.c
@@ -99,7 +99,7 @@ int io1_xplained_init(io1_xplained_t *dev, const io1_xplained_params_t *params)
 
 int io1_xplained_read_light_level(uint16_t *light)
 {
-    int sample = adc_sample(IO1_LIGHT_ADC_LINE, IO1_LIGHT_ADC_RES);
+    int32_t sample = adc_sample(IO1_LIGHT_ADC_LINE, IO1_LIGHT_ADC_RES);
 
     if (sample < 0) {
         DEBUG("[io1_xplained] Light sensor read failed\n");

--- a/drivers/mq3/mq3.c
+++ b/drivers/mq3/mq3.c
@@ -30,7 +30,7 @@ int mq3_init(mq3_t *dev, adc_t adc_line)
     return adc_init(dev->adc_line);
 }
 
-int mq3_read_raw(const mq3_t *dev)
+int32_t mq3_read_raw(const mq3_t *dev)
 {
     return adc_sample(dev->adc_line, PRECISION);
 }

--- a/drivers/saul/adc_saul.c
+++ b/drivers/saul/adc_saul.c
@@ -29,6 +29,11 @@
 static int read_adc(const void *dev, phydat_t *res)
 {
     const saul_adc_params_t *params = *((const saul_adc_params_t **)dev);
+
+    /* SAUL supports 16 bit only */
+    assert((params->res != ADC_RES_18BIT) && (params->res != ADC_RES_20BIT) &&
+           (params->res != ADC_RES_22BIT) && (params->res != ADC_RES_24BIT))
+
     res->val[0] = adc_sample(params->line, params->res);
     memset(&(res->val[1]), 0, 2 * sizeof(res->val[1]));
     /* Raw ADC reading has no unit */

--- a/sys/arduino/base.cpp
+++ b/sys/arduino/base.cpp
@@ -86,7 +86,7 @@ int analogRead(int arduino_pin)
     }
 
     /* Read the ADC channel */
-    adc_value = adc_sample(arduino_analog_map[arduino_pin], ADC_RES_10BIT);
+    adc_value = (int)adc_sample(arduino_analog_map[arduino_pin], ADC_RES_10BIT);
 
     return adc_value;
 }

--- a/tests/periph_adc/main.c
+++ b/tests/periph_adc/main.c
@@ -32,7 +32,7 @@
 int main(void)
 {
     xtimer_ticks32_t last = xtimer_now();
-    int sample = 0;
+    int32_t sample = 0;
 
     puts("\nRIOT ADC peripheral driver test\n");
     puts("This test will sample all available ADC lines once every 100ms with\n"
@@ -54,7 +54,7 @@ int main(void)
             if (sample < 0) {
                 printf("ADC_LINE(%u): 10-bit resolution not applicable\n", i);
             } else {
-                printf("ADC_LINE(%u): %i\n", i, sample);
+                printf("ADC_LINE(%u): %" PRIi32 "\n", i, sample);
             }
         }
         xtimer_periodic_wakeup(&last, DELAY);


### PR DESCRIPTION
### Contribution description

adc_sample return value type changed from `int` to `int32_t`

1) There are 16-bit CPUs on the market with 18-bit or even 24-bit ADCs (e.g. some MSP430s)
2) MISRA-C:2004 rule 6.3 recommends to avoid using types without explicitly specified size and signedness

### Testing procedure

Build tests/periph_adc for the board of your choice.