### PR TITLE
doccheck: exclude dist/tools directory from group check

### DIFF
--- a/dist/tools/doccheck/check.sh
+++ b/dist/tools/doccheck/check.sh
@@ -32,7 +32,7 @@ then
 fi
 
 exclude_filter() {
-    grep -v -e vendor -e examples -e tests
+    grep -v -e vendor -e examples -e tests -e "\<dist/tools\>"
 }
 
 # Check all groups are defined


### PR DESCRIPTION
### Contribution description
Removes doc group checks from `dist/tools`. Doxygen is not supposed to build that so checking it doesn't make sense.


### Testing procedure
Take e.g. #10072 and run this fix on it. In current state (0ca02de0a2f52097e43b20fce6d5b425aac73f99 & 19d0da08f99db03f5c4499b2a569cf5d35b672be) it should fail in current master. It is fixed with this PR.

### Issues/PRs references
See https://github.com/RIOT-OS/RIOT/pull/10072#issuecomment-428946313