### PR TITLE
cpu/stm32_common: fix source selection declared as module dependencies (broken)

### DIFF
--- a/cpu/stm32_common/Makefile.dep
+++ b/cpu/stm32_common/Makefile.dep
@@ -1,7 +1,0 @@
-ifneq (,$(filter periph_i2c,$(USEMODULE)))
-  ifneq (,$(filter $(CPU),stm32f0 stm32f3 stm32f7 stm32l0 stm32l4))
-    USEMODULE += periph_i2c_1
-  else # stm32f1/f2/f4/l1
-    USEMODULE += periph_i2c_2
-  endif
-endif

--- a/cpu/stm32_common/Makefile.include
+++ b/cpu/stm32_common/Makefile.include
@@ -8,12 +8,6 @@ USEMODULE += periph_common
 # include stm32 common functions and stm32 common periph drivers
 USEMODULE += stm32_common stm32_common_periph
 
-# flashpage and eeprom periph implementations share flash lock/unlock functions
-# in periph_flash_common
-ifneq (,$(filter periph_flashpage periph_eeprom,$(FEATURES_REQUIRED)))
-  FEATURES_REQUIRED += periph_flash_common
-endif
-
 # For stm32 cpu's we use the stm32_common.ld linker script
 export LINKFLAGS += -L$(RIOTCPU)/stm32_common/ldscripts
 LINKER_SCRIPT ?= stm32_common.ld

--- a/cpu/stm32_common/periph/Makefile
+++ b/cpu/stm32_common/periph/Makefile
@@ -9,4 +9,10 @@ ifneq (,$(filter periph_i2c,$(USEMODULE)))
   endif
 endif
 
+# flashpage and eeprom periph implementations share flash lock/unlock functions
+# defined in flash_common.c
+ifneq (,$(filter periph_flashpage periph_eeprom,$(USEMODULE)))
+  SRC += flash_common.c
+endif
+
 include $(RIOTMAKE)/periph.mk

--- a/cpu/stm32_common/periph/Makefile
+++ b/cpu/stm32_common/periph/Makefile
@@ -1,5 +1,12 @@
 MODULE = stm32_common_periph
 
-include $(RIOTCPU)/stm32_common/Makefile.dep
+# Select the specific implementation for `periph_i2c`
+ifneq (,$(filter periph_i2c,$(USEMODULE)))
+  ifneq (,$(filter $(CPU),stm32f0 stm32f3 stm32f7 stm32l0 stm32l4))
+    SRC += i2c_1.c
+  else # stm32f1/f2/f4/l1
+    SRC += i2c_2.c
+  endif
+endif
 
 include $(RIOTMAKE)/periph.mk

--- a/cpu/stm32f0/Makefile.features
+++ b/cpu/stm32f0/Makefile.features
@@ -1,5 +1,4 @@
 ifeq (,$(filter nucleo-f031k6,$(BOARD)))
-  FEATURES_PROVIDED += periph_flash_common
   FEATURES_PROVIDED += periph_flashpage
   FEATURES_PROVIDED += periph_flashpage_raw
 endif

--- a/cpu/stm32f1/Makefile.features
+++ b/cpu/stm32f1/Makefile.features
@@ -1,4 +1,3 @@
-FEATURES_PROVIDED += periph_flash_common
 FEATURES_PROVIDED += periph_flashpage
 FEATURES_PROVIDED += periph_flashpage_raw
 

--- a/cpu/stm32l0/Makefile.features
+++ b/cpu/stm32l0/Makefile.features
@@ -1,5 +1,4 @@
 FEATURES_PROVIDED += periph_eeprom
-FEATURES_PROVIDED += periph_flash_common
 FEATURES_PROVIDED += periph_flashpage
 FEATURES_PROVIDED += periph_flashpage_raw
 FEATURES_PROVIDED += periph_hwrng

--- a/cpu/stm32l1/Makefile.features
+++ b/cpu/stm32l1/Makefile.features
@@ -1,5 +1,4 @@
 FEATURES_PROVIDED += periph_eeprom
-FEATURES_PROVIDED += periph_flash_common
 FEATURES_PROVIDED += periph_flashpage
 FEATURES_PROVIDED += periph_flashpage_raw
 

--- a/cpu/stm32l4/Makefile.features
+++ b/cpu/stm32l4/Makefile.features
@@ -1,4 +1,3 @@
-FEATURES_PROVIDED += periph_flash_common
 FEATURES_PROVIDED += periph_flashpage
 FEATURES_PROVIDED += periph_flashpage_raw
 FEATURES_PROVIDED += periph_hwrng


### PR DESCRIPTION
### Contribution description

This fixes the handling of `periph_flashpage` for `stm32_common`. If a module would have required  `periph_flashpage` it would not have worked and if an application would have said declared an optional feature it would not have worked either.

The does not fix the global handling of CPU dependencies but replaces using modules/periphs to declare module internal only selection of source files to only source file inclusion.
The fact that they are described as `module` is never used in the code.

This also fixes the `i2c` handling the same way.

More description in the commit messages.


### Testing procedure

Not used that they are declared as modules:

There is no output for
```
git grep -e MODULE_PERIPH_I2C_1 -e MODULE_PERIPH_I2C_2 -e MODULE_PERIPH_FLASH_COMMON
```
 
#### Flashpage handling

##### Flashpage uses `flash_common`

This does not break master handling for `periph_flashpage`:

Both with master and this PR, `flash_common` is used

```
cd tests/periph_flashpage
make BOARD=iotlab-m3 clean all &>/dev/null && test -f bin/iotlab-m3/stm32_common_periph/flash_common.o && echo flash_common_compiled || echo ERROR_no_flash_common
flash_common_compiled
```

##### Handling dependency in `Makefile.dep`

With this diff applied, as if a module depended on it in `Makefile.dep`, it now works with this PR.

``` diff
diff --git a/Makefile.dep b/Makefile.dep
index 4c55e2e27..92b939f42 100644
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -788,6 +788,8 @@ ifneq (,$(filter periph_gpio_irq,$(USEMODULE)))
   FEATURES_REQUIRED += periph_gpio
 endif

+FEATURES_REQUIRED += periph_flashpage
+
 # always select gpio (until explicit dependencies are sorted out)
 FEATURES_OPTIONAL += periph_gpio

```
Compiling in `examples/hello-world` with the same test command it succeeds with this PR.
With master we get `ERROR_no_flash_common`

##### Flashpage works with FEATURES_OPTIONAL

With this PR, it also works with `FEATURES_OPTIONAL += periph_flashpage` in an application:
```
cd examples/hello-world
FEATURES_OPTIONAL=periph_flashpage make BOARD=iotlab-m3 clean all &>/dev/null && test -f bin/iotlab-m3/stm32_common_periph/flash_common.o && echo flash_common_compiled || echo ERROR_no_flash_common
flash_common_compiled
```
With master we get `ERROR_no_flash_common`

#### eeprom handling

The same tests can be run by using `periph_eeprom` feature, BOARD `b-l072z-lrwan1` and `tests/periph_eeprom`.


#### i2c handling

The same `i2c` implementation is still used with this PR as with master.

```
cd tests/periph_i2c
make BOARD=nucleo-f091rc clean all &>/dev/null; ls bin/nucleo-f091rc/stm32_common_periph/i2c_1.o
bin/nucleo-f091rc/stm32_common_periph/i2c_1.o
make BOARD=iotlab-m3 clean all &>/dev/null; ls bin/iotlab-m3/stm32_common_periph/i2c_2.o
bin/iotlab-m3/stm32_common_periph/i2c_2.o
```

### Issues/PRs references

Previous attempt to fix it:

https://github.com/RIOT-OS/RIOT/pull/9892
https://github.com/RIOT-OS/RIOT/issues/9913 (by fixing dependency handling globally)
https://github.com/RIOT-OS/RIOT/pull/10146

Required for PRs

https://github.com/RIOT-OS/RIOT/pull/9969
https://github.com/RIOT-OS/RIOT/pull/8774