### PR TITLE
sys/arduino: add possibility to customize Arduino serial port at compile time

### DIFF
--- a/sys/arduino/doc.txt
+++ b/sys/arduino/doc.txt
@@ -112,6 +112,12 @@
  * @endcode
  *   This links to the third entry in the `arduino_pinmap` array.
  *
+ * - a define `ARDUINO_UART_DEV` that defines the UART to use as the Arduino
+ *   primary serial port (default UART_DEV(0)):
+ * @code{c}
+ *  #define ARDUINO_UART_DEV         (UART_DEV(3))
+ * @endcode
+ *
  * In addition, you have to add the 'arduino' feature to the board. For this,
  * just add `FEATURES_PROVIDED += arduino` to the 'other features' section in
  * your board's `Makefile.features'.

--- a/sys/arduino/include/arduino.hpp
+++ b/sys/arduino/include/arduino.hpp
@@ -45,10 +45,17 @@ enum {
     HIGH = 1            /**< pin is set */
 };
 
+#ifndef ARDUINO_UART_DEV
 /**
- * @brief   Primary serial port (mapped to UART_DEV(0))
+ * @brief UART device to use for Arduino serial
  */
-static SerialPort Serial(UART_DEV(0));
+#define ARDUINO_UART_DEV        UART_DEV(0)
+#endif
+
+/**
+ * @brief   Primary serial port (mapped to ARDUINO_UART_DEV)
+ */
+static SerialPort Serial(ARDUINO_UART_DEV);
 
 /**
  * @brief   Configure a pin as either input or output


### PR DESCRIPTION
### Contribution description
This PR gives the possibility to easily customize the serial port used by the Arduino module that was previously hardcoded to be UART0 in the Arduino module source code. With this PR the UART used can be customized in the usual board specific arduino_board.h header file. The default has been kept as UART0 for backwards compatibility. 

### Testing procedure
Manual procedure: use a board setup with the arduino module with more than one serial. Change the ARDUINO_UART_DEV, rebuild and see the different serial being used.
