### PR TITLE
drivers: add VCNL40X0 proximity and ambient light sensors

### DIFF
--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -452,6 +452,15 @@ ifneq (,$(filter uart_half_duplex,$(USEMODULE)))
   USEMODULE += xtimer
 endif
 
+ifneq (,$(filter vcnl40x0,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_i2c
+endif
+
+ifneq (,$(filter vcnl40x0_full,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_gpio_irq
+  USEMODULE += vcnl40x0
+endif
+
 ifneq (,$(filter veml6070,$(USEMODULE)))
   FEATURES_REQUIRED += periph_i2c
 endif

--- a/drivers/Makefile.include
+++ b/drivers/Makefile.include
@@ -250,6 +250,10 @@ ifneq (,$(filter veml6070,$(USEMODULE)))
   USEMODULE_INCLUDES += $(RIOTBASE)/drivers/veml6070/include
 endif
 
+ifneq (,$(filter vcnl40x0,$(USEMODULE)))
+  USEMODULE_INCLUDES += $(RIOTBASE)/drivers/vcnl40x0/include
+endif
+
 ifneq (,$(filter w5100,$(USEMODULE)))
   USEMODULE_INCLUDES += $(RIOTBASE)/drivers/w5100/include
 endif

--- a/drivers/include/vcnl40x0.h
+++ b/drivers/include/vcnl40x0.h
@@ -1,0 +1,416 @@
+/*
+ * Copyright (C) 2018 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    drivers_vcnl40x0 VCNL40X0 proximity and ambient light sensors
+ * @ingroup     drivers_sensors
+ * @ingroup     drivers_saul
+ * @brief       Device driver for Vishay VCNL40X0 proximity and ambient light sensors
+ *
+ * The driver can be used with Vishay VCNL4010, VCNL4020, and VCNL3020.
+ *
+ * The driver is divided into two parts
+ *
+ * - a basic driver ```vcnl40x0```, and
+ * - a fully functional driver ```vcnl40x0_full```.
+ *
+ * The base driver ```vcnl40x0``` only supports a basic set of functions and
+ * therefore has a small size. The procedure for retrieving new data is simply
+ * polling. Ambient light and distance measurements are supported.
+ *
+ * The fully functional driver `` `vcnl40x0_full``` supports all the features
+ * supported by the base driver, as well as all other sensor features,
+ * including interrupts and their configuration. The approach to retrieving
+ * data is to use data-ready interrupts. In addition, threshold interrupts
+ * can be used and configured. 
+ *
+ * For using interrupts, the according GPIO to which the sensor's
+ * **INT** output pin is connected has to be defined by the application in
+ * configuration parameters.
+ *
+ * This driver provides @ref drivers_saul capabilities.
+ *
+ * @{
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ * @file
+ */
+
+#ifndef VCNL40X0_H
+#define VCNL40X0_H
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+#include <stdbool.h>
+#include <stdint.h>
+
+#include "periph/gpio.h"
+#include "periph/i2c.h"
+
+/**< VCNL40X0 I2C addresses */
+#define VCNL40X0_I2C_ADDRESS    (0x13)
+
+/** VCNL40X0 Produc Revision ID */
+#define VCNL40X0_ID             (0x21)
+
+/** Definition of error codes */
+typedef enum {
+    VCNL40X0_OK,                /**< success */
+    VCNL40X0_ERROR_I2C,         /**< I2C communication error */
+    VCNL40X0_ERROR_WRONG_ID,    /**< wrong id read */
+    VCNL40X0_ERROR_NO_DATA,     /**< no data are available */
+    VCNL40X0_ERROR_RAW_DATA,    /**< reading raw data failed */
+    VCNL40X0_ERROR_INV_RATE,    /**< invalid measurement rate */
+    VCNL40X0_ERROR_INV_MODE,    /**< invalid measurement mode */
+} vcnl40x0_error_codes_t;
+
+/**
+ * @brief   Ambient light sensor (ALS) measurement rate
+ *
+ * Defines the measurement rate for Ambient light sensor (ALS) measurements.
+ *
+ * @note If a different ambient light measurement rate than
+ * #VCNL40X0_ALS_RATE_NONE is used, periodic selftimed measurements
+ * are activated. In this case, on-demand measurements are not possible
+ * for proximity and for ambient light.
+ */
+typedef enum {
+    VCNL40X0_ALS_RATE_1 = 0,    /**<  1 sample per second */
+    VCNL40X0_ALS_RATE_2,        /**<  2 samples per second (default) */
+    VCNL40X0_ALS_RATE_3,        /**<  3 samples per second */
+    VCNL40X0_ALS_RATE_4,        /**<  4 samples per second */
+    VCNL40X0_ALS_RATE_5,        /**<  5 samples per second */
+    VCNL40X0_ALS_RATE_6,        /**<  6 samples per second */
+    VCNL40X0_ALS_RATE_8,        /**<  8 samples per second */
+    VCNL40X0_ALS_RATE_10,       /**< 10 samples per second */
+    VCNL40X0_ALS_RATE_NONE      /**< not enabled, on-demand measurements only */
+} vcnl40x0_als_rate_t;
+
+/**
+ * @brief   Averaging function for ambient light measurements
+ *
+ * Defines the number of conversions during one measurement cycle.
+ */
+typedef enum {
+    VCNL40X0_ALS_AVG_NONE = 0,  /**< no averaging */
+    VCNL40X0_ALS_AVG_2,         /**< averaging uses   2 conversions */
+    VCNL40X0_ALS_AVG_4,         /**< averaging uses   4 conversions */
+    VCNL40X0_ALS_AVG_8,         /**< averaging uses   8 conversions */
+    VCNL40X0_ALS_AVG_16,        /**< averaging uses  16 conversions */
+    VCNL40X0_ALS_AVG_32,        /**< averaging uses  32 conversions (default) */
+    VCNL40X0_ALS_AVG_64,        /**< averaging uses  64 conversions */
+    VCNL40X0_ALS_AVG_128,       /**< averaging uses 128 conversions */
+} vcnl40x0_als_avg_t;
+
+/**
+ * @brief   Proximity (PRX) measurement rate
+ *
+ * Defines the measurement rate for proximity measurements.
+ *
+ * @note If a different proximity measurement rate than
+ * #VCNL40X0_PRX_RATE_NONE is used, periodic selftimed measurements
+ * are activated. In this case, on-demand measurements are not possible
+ * for proximity and for ambient light.
+ */
+typedef enum {
+    VCNL40X0_PRX_RATE_1_95 = 0, /**< 1.95    measurements per second (default) */
+    VCNL40X0_PRX_RATE_3_90625,  /**< 3.90625 measurements per second */
+    VCNL40X0_PRX_RATE_7_8125,   /**< 7.8125  measurements per second */
+    VCNL40X0_PRX_RATE_16_625,   /**< 16.625  measurements per second */
+    VCNL40X0_PRX_RATE_31_25,    /**< 31.25   measurements per second */
+    VCNL40X0_PRX_RATE_62_5,     /**< 62.5    measurements per second */
+    VCNL40X0_PRX_RATE_125,      /**< 125     measurements per second */
+    VCNL40X0_PRX_RATE_250,      /**< 250     measurements per second */
+    VCNL40X0_PRX_RATE_NONE      /**< not enabled, on-demand measurements only */
+} vcnl40x0_prx_rate_t;
+
+/**
+ * @brief   Proximity (PRX) IR test signal frequency
+ */
+typedef enum {
+    VCNL40X0_PRX_FREQ_390_K_625 = 0, /**< 390.625 kHz IR test signal */
+    VCNL40X0_PRX_FREQ_780_K_25,      /**< 780.25 kHz  IR test signal */
+    VCNL40X0_PRX_FREQ_1_M_5625,      /**< 1.5625 MHz  IR test signal */
+    VCNL40X0_PRX_FREQ_3_M_125,       /**< 3.125  MHz  IR test signal */
+} vcnl40x0_prx_freq_t;
+
+/**
+ * @brief   VCNL40X0 device initialization parameters
+ */
+typedef struct {
+
+    unsigned  dev;      /**< I2C device (default I2C_DEV(0)) */
+
+    vcnl40x0_als_rate_t als_rate;  /**< Ambient light measurement (ALS) rate */
+    vcnl40x0_als_avg_t  als_avg;   /**< Averaging function for ALS */
+
+    vcnl40x0_prx_rate_t prx_rate;  /**< Proximity measurementrate */
+    uint8_t prx_ir_led;            /**< IR LED current for proximity measurements
+                                        range is 0 ... 200 mA in steps of 10 mA */
+
+    gpio_t  int_pin;    /**< interrupt pin: #GPIO_UNDEF if not used */
+
+} vcnl40x0_params_t;
+
+#if MODULE_VCNL40X0_FULL || DOXYGEN
+
+/**
+ * @brief   Interrupt types
+ */
+typedef enum {
+    VCNL40X0_INT_ALS_DRDY,  /**< ambient light data ready interrupt */
+    VCNL40X0_INT_PRX_DRDY,  /**< proximity data ready interrupt */
+    VCNL40X0_INT_THS_LO,    /**< low threshold exceeded interrupt */
+    VCNL40X0_INT_THS_HI,    /**< high threshold exceeded interrupt */
+} vcnl40x0_int_t;
+
+/**
+ * @brief   Threshold interrupt types
+ */
+typedef enum {
+    VCNL40X0_INT_THS_PRX = 0,   /**< threshold applied to proximity measurements */
+    VCNL40X0_INT_THS_ALS,       /**< threshold applied to ambient light measurements */
+} vcnl40x0_int_ths_t;
+
+/**
+ * @brief   Threshold interrupt counts, the number of consecutive measurements
+ *          needed above/below the threshold
+ */
+typedef enum {
+    VCNL40X0_INT_THS_1 = 0,     /**<   1 count (default) */
+    VCNL40X0_INT_THS_2,         /**<   2 counts */
+    VCNL40X0_INT_THS_4,         /**<   4 counts */
+    VCNL40X0_INT_THS_8,         /**<   8 counts */
+    VCNL40X0_INT_THS_16,        /**<  16 counts */
+    VCNL40X0_INT_THS_32,        /**<  32 counts */
+    VCNL40X0_INT_THS_64,        /**<  64 counts */
+    VCNL40X0_INT_THS_128,       /**< 128 counts */
+} vcnl40x0_int_ths_cnt_t;
+
+/**
+ * @brief   Interrupt service routine function prototype
+ */
+typedef void (*vcnl40x0_isr_t)(void *arg);
+
+/**
+ * @brief   Interrupt context
+ */
+typedef struct {
+    vcnl40x0_isr_t isr;     /**< interrupt service routine */
+    void* arg;              /**< interrupt service routine argument */
+} vcnl40x0_int_ctx_t;
+
+#endif /* MODULE_VCNL40X0_FULL */
+
+/**
+ * @brief   VCNL40X0 sensor device data structure type
+ */
+typedef struct {
+
+    vcnl40x0_params_t params;          /**< device initialization parameters */
+
+#if MODULE_VCNL40X0_FULL || DOXYGEN
+    vcnl40x0_int_ctx_t isr_als_drdy;   /**< ambient light data ready ISR */
+    vcnl40x0_int_ctx_t isr_prx_drdy;   /**< proximity data ready ISR */
+    vcnl40x0_int_ctx_t isr_ths_lo;     /**< low threshold exceeded ISR */
+    vcnl40x0_int_ctx_t isr_ths_hi;     /**< high threshold exceeded ISR */
+
+    bool gpio_init;                    /**< GPIO already initialized */
+#endif /* MODULE_VCNL40X0_FULL */
+
+} vcnl40x0_t;
+
+/**
+ * @brief	Initialize the VCNL40X0 sensor device
+ *
+ * This function resets the sensor and initializes the sensor according to
+ * given intialization parameters. All registers are reset to default values.
+ *
+ * @param[in]   dev     device descriptor of VCNL40X0 sensor to be initialized
+ * @param[in]   params  configuration parameters, see #vcnl40x0_params_t
+ *
+ * @retval  VCNL40X0_OK      on success
+ * @retval  VCNL40X0_ERROR_* a negative error code on error,
+ *                           see #vcnl40x0_error_codes_t
+ */
+int vcnl40x0_init(vcnl40x0_t *dev, const vcnl40x0_params_t *params);
+
+/**
+ * @brief   Read one sample of ambient light measurement (ALS)
+ *          in quarters of a Lux
+ *
+ * Ambient light data are given in quarters of a Lux in the range
+ * 0.25 lx to 16,383.00 lx. The resolution is 0.25 lx
+ *
+ * If an ALS rate different from #VCNL40X0_ALS_RATE_NONE is used as
+ * parameter #vcnl40x0_params_t::als_rate, the last available data sample
+ * is returned.
+ *
+ * If #VCNL40X0_ALS_RATE_NONE is used as parameter
+ * #vcnl40x0_params_t::als_rate, a single on-demand measurement is started
+ * in continuous conversion mode. In this case, the function waits for
+ * available data. Depending on #vcnl40x0_params_t::als_avg this can take
+ * from 23 ms when averaging is disabled (#VCNL40X0_ALS_AVG_NONE) up to
+ * 90 ms for averaging over 128 conversions (#VCNL40X0_ALS_AVG_128).
+ *
+ * @param[in]   dev     device descriptor of VCNL40X0 sensor to be initialized
+ * @param[out]  als     ambient light measurement data
+ *
+ * @retval  VCNL40X0_OK      on success
+ * @retval  VCNL40X0_ERROR_* a negative error code on error,
+ *                           see #vcnl40x0_error_codes_t
+ */
+int vcnl40x0_read_als(const vcnl40x0_t *dev, uint16_t *als);
+
+/**
+ * @brief   Read one data sample of proximity measurement (PRX)
+ *
+ * Proximity data samples are given as a 16-bit values. The range of these
+ * values depends on the IR LED current used for measurement.
+ *
+ * @note A number of disturbing effects such as DC noise, sensor coverage,
+ * or surrounding objects cause an offset in the measured proximity values.
+ * The application should remove this offset, for example, by finding the
+ * minimum value ever measured and subtracting it from the current reading.
+ * The minimum value is then assumed to be 0 (no proximity).
+ *
+ * @param[in]   dev     device descriptor of VCNL40X0 sensor to be initialized
+ * @param[out]  prx     proximity measurement data
+ *
+ * @retval  VCNL40X0_OK      on success
+ * @retval  VCNL40X0_ERROR_* a negative error code on error,
+ *                           see #vcnl40x0_error_codes_t
+ */
+int vcnl40x0_read_prox(vcnl40x0_t *dev, uint16_t *prx);
+
+/**
+ * @brief   Ambient light measurement (ALS) data-ready status function
+ *
+ * The function checks the ASL data ready flag and returns. It can be
+ * used for polling new ambient light measurement data.
+ *
+ * @param[in]   dev     device descriptor of VCNL40X0 sensor
+ *
+ * @retval  VCNL40X0_OK             new data available
+ * @retval  VCNL40X0_ERROR_NO_DATA  no new data available
+ * @retval  VCNL40X0_ERROR_*        negative error code,
+ *                                  see #vcnl40x0_error_codes_t
+ */
+int vcnl40x0_als_data_ready (const vcnl40x0_t *dev);
+
+/**
+ * @brief   Proximity data-ready status function
+ *
+ * The function checks the proximity data ready flag and returns. It can be
+ * used for polling new proximity data.
+ *
+ * @param[in]   dev     device descriptor of VCNL40X0 sensor
+ *
+ * @retval  VCNL40X0_OK             new data available
+ * @retval  VCNL40X0_ERROR_NO_DATA  no new data available
+ * @retval  VCNL40X0_ERROR_*        negative error code,
+ *                                  see #vcnl40x0_error_codes_t
+ */
+int vcnl40x0_prx_data_ready (const vcnl40x0_t *dev);
+
+#if MODULE_VCNL40X0_FULL || DOXYGEN
+
+/**
+ * @brief   Enable an interrupt
+ *
+ * If required, this function initializes the GPIO defined by
+ * #vcnl40x0_params_t::int_pin and activates the interrupt of type
+ * #vcnl40x0_int_t specified by the @p intr parameter. The interrupt
+ * service routine specified by the @p isr parameter is attached
+ * to this interrupt.
+ *
+ * @note The interrupt service routine specified by parameter @p isr is called
+ * in the interrupt context and shouldn't block or do anything time consuming.
+ *
+ * @note  Unlike other sensor drivers, the GPIO used as the interrupt signal
+ * pin is initialized by the driver as soon as an interrupt is activated.
+ * The driver intercepts all interrupts and calls the user function registered
+ * by the parameter @p isr for the interrupt.
+ *
+ * @param[in]   dev     device descriptor of VCNL40X0 sensor
+ * @param[in]   intr    interrupt to be enabled, see #vcnl40x0_int_t
+ * @param[in]   isr     interrupt service routine called for the interrupt
+ * @param[in]   isr_arg interrupt service routine argument
+ *
+ * @retval  VCNL40X0_OK         on success
+ * @retval  VCNL40X0_ERROR_*    negative error code on error,
+ *                              see #vcnl40x0_error_codes_t
+ */
+int vcnl40x0_enable_int(vcnl40x0_t *dev, vcnl40x0_int_t intr,
+                        vcnl40x0_isr_t isr, void *isr_arg);
+
+/**
+ * @brief   Disable an interrupt
+ *
+ * @param[in]   dev     device descriptor of VCNL40X0 sensor
+ * @param[in]   intr    interrupt to be disabled, see #vcnl40x0_int_t
+ *
+ * @retval  VCNL40X0_OK         on success
+ * @retval  VCNL40X0_ERROR_*    negative error code on error,
+ *                              see #vcnl40x0_error_codes_t
+ */
+int vcnl40x0_disable_int(vcnl40x0_t *dev, vcnl40x0_int_t intr);
+
+/**
+ * @brief   Config threshold interrupt
+ *
+ * This function configures the thresholds that are used for the generation
+ * of threshold interrupts (#VCNL40X0_INT_THS_LO or #VCNL40X0_INT_THS_HI).
+ *
+ * @param[in]   dev     device descriptor of VCNL40X0 sensor
+ * @param[in]   sel     selects to which measurements thresholds are applied,
+ *                      see #vcnl40x0_int_ths_t
+ * @param[in]   low     low threshold
+ * @param[in]   high    high threshold
+ * @param[in]   count   number of consecutive measurements needed above/below
+ *                      the threshold
+ */
+int vcnl40x0_set_int_thresh(vcnl40x0_t *dev, vcnl40x0_int_ths_t sel,
+                            uint16_t low, uint16_t high,
+                            vcnl40x0_int_ths_t count);
+
+/**
+ * @brief   Config the modulator timings for proximity measurements
+ *
+ * When proximity measurements are enabled, a number of parameters define
+ * the timing of the IR LED test signal. These are the frequency (default
+ * #VCNL40X0_PRX_FREQ_390_K_625), the modulation delay time (default 0),
+ * and the modulation dead time (default 1). Normally, the values are
+ * determined by the sensor so that it is normally not needed to call
+ * this function.
+ *
+ * @param[in]   dev      device descriptor of VCNL40X0 sensor
+ * @param[in]   freq     IR LED test signal frequency, see #vcnl40x0_prx_freq_t
+ * @param[in]   t_delay  time between the IR LED signal and the IR input signal
+ *                       evaluation [0...7]
+ * @param[in]   t_dead   dead time in evaluation of IR signal at the IR signal
+ *                       slopes [0...7]
+ *
+ * @retval  VCNL40X0_OK         on success
+ * @retval  VCNL40X0_ERROR_*    negative error code on error,
+ *                              see #vcnl40x0_error_codes_t
+ */
+int vcnl40x0_set_prx_mod (vcnl40x0_t *dev, vcnl40x0_prx_freq_t freq,
+                          uint8_t t_delay, uint8_t t_dead);
+
+#endif /* MODULE_VCNL40X0_FULL */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* VCNL40X0_H */
+/** @} */

--- a/drivers/vcnl40x0/Makefile
+++ b/drivers/vcnl40x0/Makefile
@@ -1,0 +1,3 @@
+MODULE = vcnl40x0
+
+include $(RIOTBASE)/Makefile.base

--- a/drivers/vcnl40x0/include/vcnl40x0_params.h
+++ b/drivers/vcnl40x0/include/vcnl40x0_params.h
@@ -1,0 +1,99 @@
+/*
+ * Copyright (C) 2018 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_vcnl40x0
+ * @brief       Default configuration for Vishay VCNL40X0 proximity and ambient light sensor
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ * @file
+ * @{
+ */
+
+#ifndef VCNL40X0_PARAMS_H
+#define VCNL40X0_PARAMS_H
+
+#include "board.h"
+#include "vcnl40x0.h"
+#include "saul_reg.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Set default configuration parameters
+ * @{
+ */
+#ifndef VCNL40X0_PARAM_DEV
+/** default device is I2C_DEV(0) */
+#define VCNL40X0_PARAM_DEV          I2C_DEV(0)
+#endif
+
+#ifndef VCNL40X0_PARAM_ALS_RATE
+/** default ambient light measurement rate is 2 measurements per second */
+#define VCNL40X0_PARAM_ALS_RATE     (VCNL40X0_ALS_RATE_2)
+#endif
+
+#ifndef VCNL40X0_PARAM_ALS_AVG
+/** default number of conversions used during one measurement cycle is 32 */
+#define VCNL40X0_PARAM_ALS_AVG      (VCNL40X0_ALS_AVG_32)
+#endif
+
+#ifndef VCNL40X0_PARAM_PRX_RATE
+/** default proximity measurement rate is 1.95 measurements per second */
+#define VCNL40X0_PARAM_PRX_RATE     (VCNL40X0_PRX_RATE_1_95)
+#endif
+
+#ifndef VCNL40X0_PARAM_PRX_IR_LED
+/** default IR LED current used for proximity measurement rate is 20 mA */
+#define VCNL40X0_PARAM_PRX_IR_LED   (20)
+#endif
+
+#ifndef VCNL40X0_PARAM_INT_PIN
+/** default interrupt pin */
+#define VCNL40X0_PARAM_INT_PIN      (GPIO_PIN(0, 0))
+#endif
+
+#ifndef VCNL40X0_PARAMS
+#define VCNL40X0_PARAMS             { \
+                                        .dev  = VCNL40X0_PARAM_DEV,  \
+                                        .als_rate = VCNL40X0_PARAM_ALS_RATE, \
+                                        .als_avg = VCNL40X0_PARAM_ALS_AVG, \
+                                        .prx_rate = VCNL40X0_PARAM_PRX_RATE, \
+                                        .prx_ir_led = VCNL40X0_PARAM_PRX_IR_LED, \
+                                        .int_pin = VCNL40X0_PARAM_INT_PIN, \
+                                    }
+#endif
+
+#ifndef VCNL40X0_SAUL_INFO
+#define VCNL40X0_SAUL_INFO          { .name = "vcnl40x0" }
+#endif
+/**@}*/
+
+/**
+ * @brief   Allocate some memory to store the actual configuration
+ */
+static const vcnl40x0_params_t vcnl40x0_params[] =
+{
+    VCNL40X0_PARAMS
+};
+
+/**
+ * @brief   Additional meta information to keep in the SAUL registry
+ */
+static const saul_reg_info_t vcnl40x0_saul_info[] =
+{
+    VCNL40X0_SAUL_INFO
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* VCNL40X0_PARAMS_H */
+/** @} */

--- a/drivers/vcnl40x0/include/vcnl40x0_regs.h
+++ b/drivers/vcnl40x0/include/vcnl40x0_regs.h
@@ -1,0 +1,111 @@
+/*
+ * Copyright (C) 2018 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_vcnl40x0
+ * @brief       Register definitions for Vishay VCNL40X0 proximity and ambient light sensor
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ * @file
+ * @{
+ */
+
+#ifndef VCNL40X0_REGS_H
+#define VCNL40X0_REGS_H
+
+#ifdef __cplusplus
+extern "C"
+{
+#endif
+
+/**
+ * @name    Register addresses
+ * @{
+ */
+#define VCNL40X0_REG_COMMAND          (0x80) /**< Command */
+#define VCNL40X0_REG_PROD_REV_ID      (0x81) /**< Product and Revision ID */
+#define VCNL40X0_REG_PRX_RATE         (0x82) /**< Rate of Proximity Measurement */
+#define VCNL40X0_REG_IR_LED_CURR      (0x83) /**< LED Current Setting for Proximity Mode */
+#define VCNL40X0_REG_ALS_PARAM        (0x84) /**< Ambient Light Parameter */
+#define VCNL40X0_REG_ALS_RES_H        (0x85) /**< Ambient Light Result */
+#define VCNL40X0_REG_ALS_RES_L        (0x86) /**< Ambient Light Result low byte */
+#define VCNL40X0_REG_PRX_RES_H        (0x87) /**< Proximity Measurement Result */
+#define VCNL40X0_REG_PRX_RES_L        (0x88) /**< Proximity Measurement Result */
+#define VCNL40X0_REG_INT_CTRL         (0x89) /**< Interrupt Control */
+#define VCNL40X0_REG_LOW_THRESH_H     (0x8a) /**< Low Threshold */
+#define VCNL40X0_REG_LOW_THRESH_L     (0x8b) /**< Low Threshold */
+#define VCNL40X0_REG_HIGH_THRESH_H    (0x8c) /**< High Threshold */
+#define VCNL40X0_REG_HIGH_THRESH_L    (0x8d) /**< High Threshold */
+#define VCNL40X0_REG_INT_STATUS       (0x8e) /**< Interrupt Status */
+#define VCNL40X0_REG_PRX_MOD_ADJ      (0x8f) /**< Proximity Modulator Timing Adjustment */
+/** @} */
+
+/**
+ * @name    Register structure definitions
+ * @{
+ */
+
+/* Command Register (VCNL40X0_REG_COMMAND) */
+#define VCNL40X0_REG_CFG_LOCK       (0x80)  /**< config lock */
+#define VCNL40X0_REG_ALS_DATA_RDY   (0x40)  /**< ambient light measurement data available */
+#define VCNL40X0_REG_PRX_DATA_RDY   (0x20)  /**< proximity measurement data available */
+#define VCNL40X0_REG_ALS_OD         (0x10)  /**< on-demand ambient light measurement */
+#define VCNL40X0_REG_PRX_OD         (0x08)  /**< on-demand proximity measurement */
+#define VCNL40X0_REG_ALS_EN         (0x04)  /**< periodic ambient light measurement */
+#define VCNL40X0_REG_PRX_EN         (0x02)  /**< periodic proximity measurement */
+#define VCNL40X0_REG_SELFTIMED_EN   (0x01)  /**< selftimed measurement */
+
+/* Product and Revision ID (VCNL40X0_REG_PROD_REV_ID) */
+#define VCNL40X0_REG_PROD_ID        (0xf0)  /**< Product ID */
+#define VCNL40X0_REG_REV            (0x0f)  /**< Revision ID */
+
+/* Proximity Rate Register (VCNL40X0_REG_PRX_RATE) */
+#define VCNL40X0_REG_PRX_RATE_M     (0x07)  /**< Rate of Proximity */
+
+/* Ambient Light Parameter Register (VCNL40X0_REG_ALS_PARAM) */
+#define VCNL40X0_REG_CONT_CONV      (0x80)  /**< Continuous conversion mode */
+#define VCNL40X0_REG_ALS_RATE       (0x70)  /**< Ambient light measurement rate */
+#define VCNL40X0_REG_AUTO_OFFSET    (0x08)  /**< Automatic offset compensation */
+#define VCNL40X0_REG_AVG_FUNC       (0x07)  /**< Averaging function */
+
+/* LED Current Setting for Proximity Mode Register (VCNL40X0_REG_IR_LED_CURR) */
+#define VCNL40X0_REG_IR_LED_CURR_M  (0x3f)  /**< IR LED current value */
+
+/* Proximity Modulator Timing Adjustment Register (VCNL40X0_REG_PRX_MOD_ADJ) */
+#define VCNL40X0_REG_MOD_DELAY      (0xe0)  /**< Modulation delay time */
+#define VCNL40X0_REG_PRX_FREQ       (0x18)  /**< Proximity frequency */
+#define VCNL40X0_REG_MOD_DEAD       (0x07)  /**< Modulation dead time */
+
+/* Interrupt Control Register (VCNL40X0_REG_INT_CTRL) */
+#define VCNL40X0_REG_INT_CNT_EXC    (0xe0)  /**< Int count exceed */
+#define VCNL40X0_REG_INT_PRX_DRDY_E (0x08)  /**< Proximity data ready enabled */
+#define VCNL40X0_REG_INT_ALS_DRDY_E (0x04)  /**< Ambient light data ready enabled */
+#define VCNL40X0_REG_INT_THS_E      (0x02)  /**< threshold exceeded enabled*/
+#define VCNL40X0_REG_INT_THS_SEL    (0x01)  /**< threshold selection */
+
+/* Interrupt Status Register (VCNL40X0_REG_INT_STATUS) */
+#define VCNL40X0_REG_INT_PRX_DRDY   (0x08)  /**< Proximity data ready */
+#define VCNL40X0_REG_INT_ALS_DRDY   (0x04)  /**< Ambient light data ready */
+#define VCNL40X0_REG_INT_THS_LO     (0x02)  /**< Low threshold exceeded */
+#define VCNL40X0_REG_INT_THS_HI     (0x01)  /**< High threshold exceeded */
+#define VCNL40X0_REG_INT_ALL        (VCNL40X0_REG_INT_PRX_DRDY | \
+                                     VCNL40X0_REG_INT_ALS_DRDY | \
+                                     VCNL40X0_REG_INT_THS_LO | \
+                                     VCNL40X0_REG_INT_THS_HI) \
+
+/* Proximity Modulator Timing Adjustment Register (VCNL40X0_REG_PRX_MOD_ADJ) */
+#define VCNL40X0_REG_PRX_DELAY      (0xe0)  /**< Modulation delay time */
+#define VCNL40X0_REG_PRX_FREQ       (0x18)  /**< Proximity frequency */
+#define VCNL40X0_REG_PRX_DEAD       (0x07)  /**< Modulation dead time */
+
+/** @} */
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* VCNL40X0_REGS_H */
+/** @} */

--- a/drivers/vcnl40x0/vcnl40x0.c
+++ b/drivers/vcnl40x0/vcnl40x0.c
@@ -1,0 +1,571 @@
+/*
+ * Copyright (C) 2018 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_vcnl40x0
+ * @brief       Device driver for the Vishay VCNL40X0 proximity and ambient light sensor
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ * @file
+ * @{
+ */
+
+#include <string.h>
+#include <stdlib.h>
+
+#include "vcnl40x0_regs.h"
+#include "vcnl40x0.h"
+
+#include "irq.h"
+#include "log.h"
+#include "xtimer.h"
+
+#define ENABLE_DEBUG    (0)
+#include "debug.h"
+
+#if ENABLE_DEBUG
+
+#define ASSERT_PARAM(cond) \
+    if (!(cond)) { \
+        DEBUG("[vcnl40x0] %s: %s\n", \
+              __func__, "parameter condition (" # cond ") not fulfilled"); \
+        assert(cond); \
+    }
+
+#define DEBUG_DEV(f, d, ...) \
+        DEBUG("[vcnl40x0] %s i2c dev=%d addr=%02x: " f "\n", \
+              __func__, d->params.dev, VCNL40X0_I2C_ADDRESS, ## __VA_ARGS__);
+
+#else /* ENABLE_DEBUG */
+
+#define ASSERT_PARAM(cond) assert(cond);
+#define DEBUG_DEV(f, d, ...)
+
+#endif /* ENABLE_DEBUG */
+
+#define ERROR_DEV(f, d, ...) \
+        LOG_ERROR("[vcnl40x0] %s i2c dev=%d addr=%02x: " f "\n", \
+                  __func__, d->params.dev, VCNL40X0_I2C_ADDRESS, ## __VA_ARGS__);
+
+#define EXEC_RET(f) { \
+    int _r; \
+    if ((_r = f) != VCNL40X0_OK) { \
+        DEBUG("[vcnl40x0] %s: error code %d\n", __func__, _r); \
+        return _r; \
+    } \
+}
+
+#define EXEC_RET_CODE(f, c) { \
+    int _r; \
+    if ((_r = f) != VCNL40X0_OK) { \
+        DEBUG("[vcnl40x0] %s: error code %d\n", __func__, _r); \
+        return c; \
+    } \
+}
+
+#define EXEC(f) { \
+    int _r; \
+    if ((_r = f) != VCNL40X0_OK) { \
+        DEBUG("[vcnl40x0] %s: error code %d\n", __func__, _r); \
+        return; \
+    } \
+}
+
+/** Forward declaration of functions for internal use */
+
+static int _is_available(const vcnl40x0_t *dev);
+static void _set_reg_bit(uint8_t *byte, uint8_t mask, uint8_t bit);
+static int _reg_read(const vcnl40x0_t *dev, uint8_t reg, uint8_t *data, uint16_t len);
+static int _reg_write(const vcnl40x0_t *dev, uint8_t reg, uint8_t *data, uint16_t len);
+static int _update_reg(const vcnl40x0_t *dev, uint8_t reg, uint8_t mask, uint8_t val);
+
+int vcnl40x0_init(vcnl40x0_t *dev, const vcnl40x0_params_t *params)
+{
+    ASSERT_PARAM(dev != NULL);
+    ASSERT_PARAM(params != NULL);
+    DEBUG_DEV("params=%p", dev, params);
+
+    /* init sensor data structure */
+    dev->params = *params;
+
+#if MODULE_VCNL40X0_FULL
+    dev->gpio_init = false;
+#endif
+
+    /* check availability of the sensor */
+    EXEC_RET(_is_available(dev));
+
+    uint8_t cmd = 0;
+    uint8_t als = 0;
+    uint8_t prx = 0;
+    uint8_t adj = 1; /* freq = 390.625 kHz, t_dead = 1, t_delay = 0 */
+
+    /* disable all activities to change configuration */
+    EXEC_RET(_reg_write(dev, VCNL40X0_REG_COMMAND, &cmd, 1));
+
+    /* disable all interrupts */
+    EXEC_RET(_reg_write(dev, VCNL40X0_REG_INT_CTRL, &cmd, 1));
+
+    /* set default ALS measurement parameters */
+    _set_reg_bit(&als, VCNL40X0_REG_AUTO_OFFSET, 1);
+    _set_reg_bit(&als, VCNL40X0_REG_AVG_FUNC, dev->params.als_avg);
+    _set_reg_bit(&als, VCNL40X0_REG_ALS_RATE, VCNL40X0_ALS_RATE_2);
+
+    /* configure measurement modes */
+    if (dev->params.prx_rate != VCNL40X0_PRX_RATE_NONE) {
+        /* periodic selftimed measurement mode */
+        _set_reg_bit(&cmd, VCNL40X0_REG_SELFTIMED_EN, 1);
+        _set_reg_bit(&cmd, VCNL40X0_REG_PRX_EN, 1);
+        _set_reg_bit(&prx, VCNL40X0_REG_PRX_RATE_M, dev->params.prx_rate);
+    }
+    if (dev->params.als_rate != VCNL40X0_ALS_RATE_NONE) {
+        /* periodic selftimed measurement mode */
+        _set_reg_bit(&cmd, VCNL40X0_REG_SELFTIMED_EN, 1);
+        _set_reg_bit(&cmd, VCNL40X0_REG_ALS_EN, 1);
+        _set_reg_bit(&als, VCNL40X0_REG_ALS_RATE, dev->params.als_rate);
+    }
+    else {
+        /* on-demand measurement mode, enable continuous conversion */
+        _set_reg_bit(&als, VCNL40X0_REG_CONT_CONV, 1);
+    }
+
+    /* write registers */
+    EXEC_RET(_reg_write(dev, VCNL40X0_REG_PRX_MOD_ADJ, &adj, 1));
+    EXEC_RET(_reg_write(dev, VCNL40X0_REG_PRX_RATE, &prx, 1));
+    EXEC_RET(_reg_write(dev, VCNL40X0_REG_ALS_PARAM, &als, 1));
+    EXEC_RET(_reg_write(dev, VCNL40X0_REG_COMMAND, &cmd, 1));
+
+    /* set LED IR current */
+    EXEC_RET(_update_reg(dev, VCNL40X0_REG_IR_LED_CURR,
+                              VCNL40X0_REG_IR_LED_CURR_M,
+                              dev->params.prx_ir_led / 10));
+
+    return VCNL40X0_OK;
+}
+
+int vcnl40x0_als_data_ready (const vcnl40x0_t *dev)
+{
+    ASSERT_PARAM(dev != NULL);
+    DEBUG_DEV("", dev);
+
+    uint8_t reg;
+    _reg_read(dev, VCNL40X0_REG_COMMAND, &reg, 1);
+
+    return (reg & VCNL40X0_REG_ALS_DATA_RDY) ? VCNL40X0_OK
+                                             : VCNL40X0_ERROR_NO_DATA;
+}
+
+int vcnl40x0_prx_data_ready (const vcnl40x0_t *dev)
+{
+    ASSERT_PARAM(dev != NULL);
+    DEBUG_DEV("", dev);
+
+    uint8_t reg;
+    _reg_read(dev, VCNL40X0_REG_COMMAND, &reg, 1);
+
+    return (reg & VCNL40X0_REG_PRX_DATA_RDY) ? VCNL40X0_OK
+                                              : VCNL40X0_ERROR_NO_DATA;
+}
+
+int vcnl40x0_read_als(const vcnl40x0_t *dev, uint16_t *als)
+{
+    ASSERT_PARAM(dev != NULL);
+    ASSERT_PARAM(als != NULL);
+    DEBUG_DEV("als=%p", dev, als);
+
+    uint8_t data[2];
+    uint8_t reg;
+
+    if (dev->params.als_rate == VCNL40X0_ALS_RATE_NONE) {
+        /* check whether on-demand ALS measurement is possible */
+        if (dev->params.prx_rate != VCNL40X0_PRX_RATE_NONE) {
+            DEBUG_DEV("periodic selftimed proximity measurement activated, "
+                      "on-demand measurement not possible", dev);
+            return -VCNL40X0_ERROR_INV_MODE;
+        }
+        /* enable ALS on-demand measurement */
+        reg = 0;
+        _set_reg_bit(&reg, VCNL40X0_REG_ALS_OD, 1);
+        _set_reg_bit(&reg, VCNL40X0_REG_ALS_EN, 1);
+        EXEC_RET(_reg_write(dev, VCNL40X0_REG_COMMAND, &reg, 1));
+        /* wait for data */
+        while (vcnl40x0_als_data_ready(dev) == VCNL40X0_ERROR_NO_DATA) {
+            xtimer_usleep(1000);
+        }
+        /* read the data sample */
+        EXEC_RET_CODE(_reg_read(dev, VCNL40X0_REG_ALS_RES_H, data, 2),
+                      -VCNL40X0_ERROR_RAW_DATA);
+    }
+    else {
+        /*
+         * in selftimed periodic measurement measurement mode, simply
+         * the last available data sample is read
+         */
+        EXEC_RET_CODE(_reg_read(dev, VCNL40X0_REG_ALS_RES_H, data, 2),
+                      -VCNL40X0_ERROR_RAW_DATA);
+    }
+
+    /* data MSB @ lower address */
+    *als = (data[0] << 8) | data[1];
+
+    return VCNL40X0_OK;
+}
+
+int vcnl40x0_read_prox(vcnl40x0_t *dev, uint16_t *prox)
+{
+    ASSERT_PARAM(dev != NULL);
+    ASSERT_PARAM(prox != NULL);
+    DEBUG_DEV("prox=%p", dev, prox);
+
+    uint8_t data[2];
+    uint8_t reg;
+
+    if (dev->params.prx_rate == VCNL40X0_PRX_RATE_NONE) {
+        /* check whether on-demand ALS measurement is possible */
+        if (dev->params.als_rate != VCNL40X0_ALS_RATE_NONE) {
+            DEBUG_DEV("periodic selftimed proximity measurement activated, "
+                      "on-demand measurement not possible", dev);
+            return -VCNL40X0_ERROR_INV_MODE;
+        }
+        /* enable proximity on-demand measurement */
+        reg = 0;
+        _set_reg_bit(&reg, VCNL40X0_REG_PRX_OD, 1);
+        _set_reg_bit(&reg, VCNL40X0_REG_PRX_EN, 1);
+        EXEC_RET(_reg_write(dev, VCNL40X0_REG_COMMAND, &reg, 1));
+        /* wait for data */
+        while (vcnl40x0_prx_data_ready(dev) == VCNL40X0_ERROR_NO_DATA) {
+            xtimer_usleep(1000);
+        }
+        /* read the data sample */
+        EXEC_RET_CODE(_reg_read(dev, VCNL40X0_REG_PRX_RES_H, data, 2),
+                      -VCNL40X0_ERROR_RAW_DATA);
+    }
+    else {
+        /*
+         * in selftimed periodic measurement mode, read and return
+         * the last available data sample
+         */
+        EXEC_RET_CODE(_reg_read(dev, VCNL40X0_REG_PRX_RES_H, data, 2),
+                      -VCNL40X0_ERROR_RAW_DATA);
+    }
+
+    /* data MSB @ lower address */
+    *prox = (data[0] << 8) | data[1];
+
+
+     return VCNL40X0_OK;
+}
+
+#if MODULE_VCNL40X0_FULL
+
+void _vcnl40x0_isr(void *arg)
+{
+    unsigned state = irq_disable();
+
+    vcnl40x0_t* dev =  (vcnl40x0_t*)arg;
+    uint8_t reg;
+
+    DEBUG_DEV("", dev);
+
+    /* get interrupt status */
+    _reg_read(dev, VCNL40X0_REG_INT_STATUS, &reg, 1);
+
+    /* call registered interrupt service routines */
+    if ((reg & VCNL40X0_REG_INT_ALS_DRDY) && dev->isr_als_drdy.isr) {
+        dev->isr_als_drdy.isr(dev->isr_als_drdy.arg);
+    }
+    if ((reg & VCNL40X0_REG_INT_PRX_DRDY) && dev->isr_prx_drdy.isr) {
+        dev->isr_prx_drdy.isr(dev->isr_prx_drdy.arg);
+    }
+    if ((reg & VCNL40X0_REG_INT_THS_LO) && dev->isr_ths_lo.isr) {
+        dev->isr_ths_lo.isr(dev->isr_ths_lo.arg);
+    }
+    if ((reg & VCNL40X0_REG_INT_THS_HI) && dev->isr_ths_hi.isr) {
+        dev->isr_ths_hi.isr(dev->isr_ths_hi.arg);
+    }
+
+    /* clear interrupt status with value of status register */
+    _reg_write(dev, VCNL40X0_REG_INT_STATUS, &reg, 1);
+
+    irq_restore (state);
+}
+
+int vcnl40x0_enable_int(vcnl40x0_t *dev, vcnl40x0_int_t intr,
+                        vcnl40x0_isr_t isr, void *isr_arg)
+{
+    ASSERT_PARAM(dev != NULL);
+    ASSERT_PARAM(isr != NULL);
+    ASSERT_PARAM(dev->params.int_pin != GPIO_UNDEF);
+    DEBUG_DEV("", dev);
+
+    if (!dev->gpio_init) {
+        dev->gpio_init = true;
+        gpio_init_int(dev->params.int_pin, GPIO_IN_PU, GPIO_FALLING,
+                      _vcnl40x0_isr, dev);
+    }
+
+    switch (intr) {
+
+        case VCNL40X0_INT_ALS_DRDY:
+                 dev->isr_als_drdy.isr = isr;
+                 dev->isr_als_drdy.arg = isr_arg;
+                 EXEC_RET(_update_reg(dev, VCNL40X0_REG_INT_CTRL,
+                                           VCNL40X0_REG_INT_ALS_DRDY_E, 1));
+                 break;
+
+        case VCNL40X0_INT_PRX_DRDY:
+                 dev->isr_prx_drdy.isr = isr;
+                 dev->isr_prx_drdy.arg = isr_arg;
+                 EXEC_RET(_update_reg(dev, VCNL40X0_REG_INT_CTRL,
+                                           VCNL40X0_REG_INT_PRX_DRDY_E, 1));
+                 break;
+
+        case VCNL40X0_INT_THS_LO:
+                 dev->isr_ths_lo.isr = isr;
+                 dev->isr_ths_lo.arg = isr_arg;
+                 EXEC_RET(_update_reg(dev, VCNL40X0_REG_INT_CTRL,
+                                           VCNL40X0_REG_INT_THS_E, 1));
+                 break;
+
+        case VCNL40X0_INT_THS_HI:
+                 dev->isr_ths_hi.isr = isr;
+                 dev->isr_ths_hi.arg = isr_arg;
+                 EXEC_RET(_update_reg(dev, VCNL40X0_REG_INT_CTRL,
+                                           VCNL40X0_REG_INT_THS_E, 1));
+                 break;
+
+        default: break;
+    }
+
+    return VCNL40X0_OK;
+}
+
+int vcnl40x0_disable_int(vcnl40x0_t *dev, vcnl40x0_int_t intr)
+{
+    ASSERT_PARAM(dev != NULL);
+    DEBUG_DEV("", dev);
+
+    switch (intr) {
+
+        case VCNL40X0_INT_ALS_DRDY:
+                 dev->isr_als_drdy.isr = NULL;
+                 dev->isr_als_drdy.arg = NULL;
+                 EXEC_RET(_update_reg(dev, VCNL40X0_REG_INT_CTRL,
+                                           VCNL40X0_REG_INT_ALS_DRDY_E, 0));
+                 break;
+
+        case VCNL40X0_INT_PRX_DRDY:
+                 dev->isr_prx_drdy.isr = NULL;
+                 dev->isr_prx_drdy.arg = NULL;
+                 EXEC_RET(_update_reg(dev, VCNL40X0_REG_INT_CTRL,
+                                           VCNL40X0_REG_INT_PRX_DRDY_E, 0));
+                 break;
+
+        case VCNL40X0_INT_THS_LO:
+                 dev->isr_ths_lo.isr = NULL;
+                 dev->isr_ths_lo.arg = NULL;
+                 if (dev->isr_ths_hi.isr) {
+                     /* disable intr if dev->isr_ths_hi.isr is also NULL */
+                     EXEC_RET(_update_reg(dev, VCNL40X0_REG_INT_CTRL,
+                                               VCNL40X0_REG_INT_THS_E, 0));
+                 }
+                 break;
+
+        case VCNL40X0_INT_THS_HI:
+                 dev->isr_ths_hi.isr = NULL;
+                 dev->isr_ths_hi.arg = NULL;
+                 if (dev->isr_ths_lo.isr) {
+                     /* disable intr if dev->isr_ths_lo.isr is also NULL */
+                     EXEC_RET(_update_reg(dev, VCNL40X0_REG_INT_CTRL,
+                                               VCNL40X0_REG_INT_THS_E, 0));
+                 }
+                 break;
+
+        default: break;
+    }
+
+    return VCNL40X0_OK;
+}
+
+int vcnl40x0_set_int_thresh(vcnl40x0_t *dev, vcnl40x0_int_ths_t sel,
+                            uint16_t low, uint16_t high,
+                            vcnl40x0_int_ths_t count)
+{
+    ASSERT_PARAM(dev != NULL);
+    DEBUG_DEV("", dev);
+
+    uint8_t data[2];
+
+    data[0] = low >> 8;
+    data[1] = low & 0xff;
+    EXEC_RET(_reg_write(dev, VCNL40X0_REG_LOW_THRESH_H, data, 2));
+
+    data[0] = high >> 8;
+    data[1] = high & 0xff;
+    EXEC_RET(_reg_write(dev, VCNL40X0_REG_HIGH_THRESH_H, data, 2));
+
+    EXEC_RET(_update_reg(dev, VCNL40X0_REG_INT_CTRL,
+                              VCNL40X0_REG_INT_THS_SEL, sel));
+    EXEC_RET(_update_reg(dev, VCNL40X0_REG_INT_CTRL,
+                              VCNL40X0_REG_INT_CNT_EXC, count));
+    return VCNL40X0_OK;
+}
+
+int vcnl40x0_set_prx_mod (vcnl40x0_t *dev, vcnl40x0_prx_freq_t freq,
+                          uint8_t t_delay, uint8_t t_dead)
+{
+    ASSERT_PARAM(dev != NULL);
+    ASSERT_PARAM(t_delay < 8);
+    ASSERT_PARAM(t_dead < 8);
+
+    uint8_t reg = 0;
+    _set_reg_bit(&reg, VCNL40X0_REG_PRX_FREQ, freq);
+    _set_reg_bit(&reg, VCNL40X0_REG_PRX_DELAY, t_delay);
+    _set_reg_bit(&reg, VCNL40X0_REG_PRX_DEAD, t_dead);
+    EXEC_RET(_reg_write(dev, VCNL40X0_REG_PRX_MOD_ADJ, &reg, 1));
+
+    return VCNL40X0_OK;
+}
+
+#endif /* MODULE_VCNL40X0_FULL */
+
+/** Functions for internal use only */
+
+/**
+ * @brief   Check the chip ID to test whether sensor is available
+ */
+static int _is_available(const vcnl40x0_t *dev)
+{
+    DEBUG_DEV("", dev);
+
+    uint8_t reg;
+
+    /* read the chip id from VCNL40X0_REG_ID_X */
+    EXEC_RET(_reg_read(dev, VCNL40X0_REG_PROD_REV_ID, &reg,1));
+
+    if (reg != VCNL40X0_ID) {
+        DEBUG_DEV("sensor is not available, wrong product/revision id %02x, "
+                  "should be %02x", dev, reg, VCNL40X0_ID);
+        return -VCNL40X0_ERROR_WRONG_ID;
+    }
+
+    return VCNL40X0_OK;
+}
+
+static void _set_reg_bit(uint8_t *byte, uint8_t mask, uint8_t bit)
+{
+    ASSERT_PARAM(byte != NULL);
+
+    uint8_t shift = 0;
+    while (!((mask >> shift) & 0x01)) {
+        shift++;
+    }
+    *byte = ((*byte & ~mask) | ((bit << shift) & mask));
+}
+
+static int _update_reg(const vcnl40x0_t *dev, uint8_t reg, uint8_t mask, uint8_t val)
+{
+    DEBUG_DEV("reg=%02x mask=%02x val=%02x", dev, reg, mask, val);
+
+    uint8_t reg_val;
+    uint8_t shift = 0;
+
+    while (!((mask >> shift) & 0x01)) {
+        shift++;
+    }
+
+    /* read current register value */
+    EXEC_RET(_reg_read(dev, reg, &reg_val, 1));
+
+    /* set masked bits to the given value  */
+    reg_val = (reg_val & ~mask) | ((val << shift) & mask);
+
+    /* write back new register value */
+    EXEC_RET(_reg_write(dev, reg, &reg_val, 1));
+
+    return VCNL40X0_OK;
+}
+
+static int _reg_read(const vcnl40x0_t *dev, uint8_t reg, uint8_t *data, uint16_t len)
+{
+    ASSERT_PARAM(dev != NULL);
+    ASSERT_PARAM(data != NULL);
+    ASSERT_PARAM(len != 0);
+
+    DEBUG_DEV("read %d byte from sensor registers starting at addr 0x%02x",
+              dev, len, reg);
+
+    if (i2c_acquire(dev->params.dev)) {
+        DEBUG_DEV("could not aquire I2C bus", dev);
+        return -VCNL40X0_ERROR_I2C;
+    }
+
+    int res = i2c_read_regs(dev->params.dev, VCNL40X0_I2C_ADDRESS, reg, data, len, 0);
+    i2c_release(dev->params.dev);
+
+    if (res == VCNL40X0_OK) {
+        if (ENABLE_DEBUG) {
+            printf("[vcnl40x0] %s i2c dev=%d addr=%02x: read following bytes: ",
+                   __func__, dev->params.dev, VCNL40X0_I2C_ADDRESS);
+            for (int i = 0; i < len; i++) {
+                printf("%02x ", data[i]);
+            }
+            printf("\n");
+        }
+    }
+    else {
+        DEBUG_DEV("could not read %d bytes from sensor registers "
+                  "starting at addr %02x, reason %d (%s)",
+                  dev, len, reg, res, strerror(res * -1));
+        return -VCNL40X0_ERROR_I2C;
+    }
+
+    return res;
+}
+
+static int _reg_write(const vcnl40x0_t *dev, uint8_t reg, uint8_t *data, uint16_t len)
+{
+    ASSERT_PARAM(dev != NULL);
+    ASSERT_PARAM(data != NULL);
+    ASSERT_PARAM(len != 0);
+
+    DEBUG_DEV("write %d bytes to sensor registers starting at addr 0x%02x",
+              dev, len, reg);
+
+    if (ENABLE_DEBUG) {
+        printf("[vcnl40x0] %s i2c dev=%d addr=%02x: write following bytes: ",
+               __func__, dev->params.dev, VCNL40X0_I2C_ADDRESS);
+        for (int i = 0; i < len; i++) {
+            printf("%02x ", data[i]);
+        }
+        printf("\n");
+    }
+
+    if (i2c_acquire(dev->params.dev)) {
+        DEBUG_DEV("could not aquire I2C bus", dev);
+        return -VCNL40X0_ERROR_I2C;
+    }
+
+    int res;
+
+    if (!data || !len) {
+        res = i2c_write_byte(dev->params.dev, VCNL40X0_I2C_ADDRESS, reg, 0);
+    }
+    else {
+        res = i2c_write_regs(dev->params.dev, VCNL40X0_I2C_ADDRESS, reg, data, len, 0);
+    }
+    i2c_release(dev->params.dev);
+
+    if (res != VCNL40X0_OK) {
+        DEBUG_DEV("could not write %d bytes to sensor registers "
+                  "starting at addr 0x%02x, reason %d (%s)",
+                  dev, len, reg, res, strerror(res * -1));
+        return -VCNL40X0_ERROR_I2C;
+    }
+
+    return res;
+}

--- a/drivers/vcnl40x0/vcnl40x0_saul.c
+++ b/drivers/vcnl40x0/vcnl40x0_saul.c
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2018 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_vcnl40x0
+ * @brief       VCNL40X0 adaption to the RIOT actuator/sensor interface
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ * @file
+ */
+
+#include <string.h>
+
+#include "saul.h"
+#include "vcnl40x0.h"
+
+static int read_als(const void *dev, phydat_t *res)
+{
+    uint16_t data;
+    int ret = vcnl40x0_read_als((const vcnl40x0_t *)dev, &data);
+    if (ret < 0) {
+        return -ECANCELED;
+    }
+    res->val[0] = data / 4;
+    res->unit = UNIT_LUX;
+    res->scale = 0;
+    return 1;
+}
+
+const saul_driver_t vcnl40x0_saul_als_driver = {
+    .read = read_als,
+    .write = saul_notsup,
+    .type = SAUL_SENSE_LIGHT,
+};

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -111,6 +111,9 @@ PSEUDOMODULES += si7013
 PSEUDOMODULES += si7020
 PSEUDOMODULES += si7021
 
+# include variants of VCNL40x0 drivers as pseudo modules
+PSEUDOMODULES += vcnl40x0_full
+
 # include variants of RN2XX3 drivers as pseudo modules
 PSEUDOMODULES += rn2483
 PSEUDOMODULES += rn2903

--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -428,6 +428,10 @@ void auto_init(void)
     extern void auto_init_tsl2561(void);
     auto_init_tsl2561();
 #endif
+#ifdef MODULE_VCNL4010
+    extern void auto_init_vcnl40x0(void);
+    auto_init_vcnl40x0();
+#endif
 #ifdef MODULE_VEML6070
     extern void auto_init_veml6070(void);
     auto_init_veml6070();

--- a/sys/auto_init/saul/auto_init_vcnl40x0.c
+++ b/sys/auto_init/saul/auto_init_vcnl40x0.c
@@ -1,0 +1,74 @@
+/*
+ * Copyright (C) 2018 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_vcnl40x0
+ * @ingroup     sys_auto_init_saul
+ * @brief       Auto initialization of Vishay VCNL40X0 proximity and ambient light sensor
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ * @file
+ * @{
+ */
+
+#ifdef MODULE_VCNL40X0
+
+#include "assert.h"
+#include "log.h"
+#include "saul_reg.h"
+#include "vcnl40x0.h"
+#include "vcnl40x0_params.h"
+
+/**
+ * @brief   Define the number of configured sensors
+ */
+#define VCNL40X0_NUM    (sizeof(vcnl40x0_params) / sizeof(vcnl40x0_params[0]))
+
+/**
+ * @brief   Allocate memory for the device descriptors
+ */
+static vcnl40x0_t vcnl40x0_devs[VCNL40X0_NUM];
+
+/**
+ * @brief   Memory for the SAUL registry entries
+ */
+static saul_reg_t saul_entries[VCNL40X0_NUM];
+
+/**
+ * @brief   Define the number of saul info
+ */
+#define VCNL40X0_INFO_NUM    (sizeof(vcnl40x0_saul_info) / sizeof(vcnl40x0_saul_info[0]))
+
+/**
+ * @name    Reference the driver structs
+ * @{
+ */
+extern saul_driver_t vcnl40x0_saul_als_driver;
+/** @} */
+
+void auto_init_vcnl40x0(void)
+{
+    assert(VCNL40X0_NUM == VCNL40X0_INFO_NUM);
+
+    for (unsigned int i = 0; i < VCNL40X0_NUM; i++) {
+        LOG_DEBUG("[auto_init_saul] initializing vcnl40x0 #%u\n", i);
+
+        if (vcnl40x0_init(&vcnl40x0_devs[i], &vcnl40x0_params[i]) < 0) {
+            LOG_ERROR("[auto_init_saul] error initializing vcnl40x0 #%u\n", i);
+            continue;
+        }
+
+        saul_entries[i].dev = &(vcnl40x0_devs[i]);
+        saul_entries[i].name = vcnl40x0_saul_info[i].name;
+        saul_entries[i].driver = &vcnl40x0_saul_als_driver;
+        saul_reg_add(&(saul_entries[i]));
+    }
+}
+
+#else
+typedef int dont_be_pedantic;
+#endif /* MODULE_VCNL40X0 */

--- a/tests/driver_vcnl40x0/Makefile
+++ b/tests/driver_vcnl40x0/Makefile
@@ -1,0 +1,6 @@
+include ../Makefile.tests_common
+
+USEMODULE += vcnl40x0
+USEMODULE += xtimer
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/driver_vcnl40x0/README.md
+++ b/tests/driver_vcnl40x0/README.md
@@ -1,0 +1,20 @@
+# About
+
+This is a manual test application for the Vishay VCNL4010 proximity and
+ambient light sensor driver.
+
+# Usage
+
+The test application demonstrates the use of the VCNL40X0 driver. It uses a
+VCNL4010, VCNL4020, or VCNL3020 sensor connected to I2C_DEV(0) with
+following configuration parameters:
+
+- Ambient light measurement with
+     - a rate of 10 per second (#VCNL40X0_ALS_RATE_10) and
+     - averaging over 32 conversions (#VCNL40X0_ALS_AVG_32)
+
+- Proximity measurement with
+     - a rate of 31.25 per seconds (#VCNL40X0_PRX_RATE_31_25) and
+     - an IR LED current of 20 mA.
+
+The application fetches data periodically every 100 ms.

--- a/tests/driver_vcnl40x0/main.c
+++ b/tests/driver_vcnl40x0/main.c
@@ -1,0 +1,96 @@
+/*
+ * Copyright (C) 2018 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @brief       Test application for Vishay VCNL40X0 proximity and ambient light sensor
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ * @file
+ *
+ * The test application demonstrates the use of the VCNL40X0 driver. It uses a
+ * VCNL4010, VCNL4020, or VCNL3020 sensor connected to I2C_DEV(0) with
+ * following configuration parameters:
+ *
+ * - Ambient light measurement with
+ *      - a rate of 10 per second (#VCNL40X0_ALS_RATE_10) and
+ *      - averaging over 32 conversions (#VCNL40X0_ALS_AVG_32)
+ *
+ * - Proximity measurement with
+ *      - a rate of 31.25 per seconds (#VCNL40X0_PRX_RATE_31_25) and
+ *      - an IR LED current of 20 mA.
+ *
+ * The application fetches data periodically every 100 ms.
+ */
+
+#ifndef VCNL40X0_PARAM_ALS_RATE
+#define VCNL40X0_PARAM_ALS_RATE     (VCNL40X0_ALS_RATE_10)
+#endif
+#ifndef VCNL40X0_PARAM_PRX_RATE
+#define VCNL40X0_PARAM_PRX_RATE     (VCNL40X0_PRX_RATE_31_25)
+#endif
+
+#include <stdio.h>
+
+#include "thread.h"
+#include "xtimer.h"
+
+#include "vcnl40x0.h"
+#include "vcnl40x0_params.h"
+
+#define SLEEP   (100 * US_PER_MS)
+
+int main(void)
+{
+    vcnl40x0_t dev;
+
+    puts("VCNL40X0 proximity and ambient light sensor driver test application\n");
+    puts("Initializing VCNL40X0 sensor");
+
+    /* initialize the sensor with default configuration parameters */
+    if (vcnl40x0_init(&dev, &vcnl40x0_params[0]) == VCNL40X0_OK) {
+        puts("[OK]\n");
+    }
+    else {
+        puts("[Failed]");
+        return 1;
+    }
+
+    uint16_t min_prox =  UINT16_MAX;    /* proximity offset value */
+
+    while (1) {
+        uint16_t prox;
+        uint16_t als;
+
+        /* wait longer than period of VCNL40X0 DOR */
+        xtimer_usleep(SLEEP);
+
+        /* read and print data */
+        if (vcnl40x0_read_prox(&dev, &prox) == VCNL40X0_OK) {
+
+            /*
+             * Simple proximity offset correction:
+             * A number of disturbing effects such as DC noise, sensor
+             * coverage, or surrounding objects cause an offset in the
+             * measured proximity values. Find the minimum value ever
+             * measured and subtract it from the current reading. The
+             * minimum value is assumed to be 0 (no proximity).
+             */
+            min_prox = (prox < min_prox) ? prox : min_prox;
+            prox -= min_prox;
+
+            printf("Proximity [cnts]: %5" PRIu16 ",  ", prox);
+        }
+
+        if (vcnl40x0_read_als(&dev, &als) == VCNL40X0_OK) {
+            printf("ALS [lux] %5" PRIu16 ".%02" PRIu16, als/4, (als % 4) * 25);
+        }
+
+        printf("\n");
+    }
+    return 0;
+}

--- a/tests/driver_vcnl40x0_full/Makefile
+++ b/tests/driver_vcnl40x0_full/Makefile
@@ -1,0 +1,7 @@
+include ../Makefile.tests_common
+
+USEMODULE += vcnl40x0_full
+USEMODULE += core_mbox
+USEMODULE += xtimer
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/driver_vcnl40x0_full/README.md
+++ b/tests/driver_vcnl40x0_full/README.md
@@ -1,0 +1,22 @@
+# About
+
+This is a manual test application for the Vishay VCNL4010 proximity and
+ambient light sensor driver.
+
+# Usage
+
+The test application demonstrates the use of the VCNL40X0 driver. It uses a
+VCNL4010, VCNL4020, or VCNL3020 sensor connected to I2C_DEV(0) with
+following configuration parameters:
+
+- Ambient light measurement with
+     - a rate of 4 per second (#VCNL40X0_ALS_RATE_4) and
+     - averaging over 32 conversions (#VCNL40X0_ALS_AVG_32)
+
+- Proximity measurement with
+     - a rate of 1.95 per seconds (#VCNL40X0_PRX_RATE_1_95) and
+     - an IR LED current of 20 mA.
+
+The application uses data ready interrupts to fetch the data. Furthermore,
+it configures and enables threshold interrupts that are triggered when
+ambient light exceed the thresholds.

--- a/tests/driver_vcnl40x0_full/main.c
+++ b/tests/driver_vcnl40x0_full/main.c
@@ -1,0 +1,135 @@
+/*
+ * Copyright (C) 2018 Gunar Schorcht
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @brief       Test application for Vishay VCNL40X0 proximity and ambient light sensor
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ * @file
+ *
+ * The test application demonstrates the use of the VCNL40X0 driver. It uses a
+ * VCNL4010, VCNL4020, or VCNL3020 sensor connected to I2C_DEV(0) with
+ * following configuration parameters:
+ *
+ * - Ambient light measurement with
+ *      - a rate of 4 per second (#VCNL40X0_ALS_RATE_4) and
+ *      - averaging over 32 conversions (#VCNL40X0_ALS_AVG_32)
+ *
+ * - Proximity measurement with
+ *      - a rate of 1.95 per seconds (#VCNL40X0_PRX_RATE_1_95) and
+ *      - an IR LED current of 20 mA.
+ *
+ * The application uses data ready interrupts to fetch the data. Furthermore,
+ * it configures and enables threshold interrupts that are triggered when
+ * ambient light exceed the thresholds.
+ */
+
+#ifndef VCNL40X0_PARAM_ALS_RATE
+#define VCNL40X0_PARAM_ALS_RATE     (VCNL40X0_ALS_RATE_10)
+#endif
+#ifndef VCNL40X0_PARAM_PRX_RATE
+#define VCNL40X0_PARAM_PRX_RATE     (VCNL40X0_PRX_RATE_1_95)
+#endif
+
+#include <stdio.h>
+
+#include "mbox.h"
+#include "thread.h"
+#include "xtimer.h"
+
+#include "vcnl40x0.h"
+#include "vcnl40x0_params.h"
+
+#define SLEEP   (100 * US_PER_MS)
+
+kernel_pid_t p_main;
+
+static msg_t  ie_queue[4]; /* message queue for up to 4 interrupt envents */
+static mbox_t ie_mbox;     /* mail box for interrupt events */
+
+/*
+ * Interrupt service routine that handles all interrupts and informs the main
+ * thread about the type of interrupt.
+ */
+static void vcnl40x0_isr (void *arg)
+{
+    /* send a message to trigger main thread to handle the interrupt */
+    msg_t ie = { .type = (vcnl40x0_int_t)arg };
+    mbox_try_put(&ie_mbox, &ie);
+}
+
+int main(void)
+{
+    vcnl40x0_t dev;
+
+    p_main = sched_active_pid;
+    mbox_init (&ie_mbox, ie_queue, sizeof(ie_queue) / sizeof(ie_queue[0]));
+
+    puts("VCNL40X0 proximity and ambient light sensor driver test application\n");
+    puts("Initializing VCNL40X0 sensor");
+
+    /* initialize the sensor with default configuration parameters */
+    if (vcnl40x0_init(&dev, &vcnl40x0_params[0]) == VCNL40X0_OK) {
+        puts("[OK]\n");
+    }
+    else {
+        puts("[Failed]");
+        return 1;
+    }
+
+    /* enable the the DRDY interrupts */
+    vcnl40x0_enable_int(&dev, VCNL40X0_INT_ALS_DRDY, vcnl40x0_isr, (void*)VCNL40X0_INT_ALS_DRDY);
+    vcnl40x0_enable_int(&dev, VCNL40X0_INT_PRX_DRDY, vcnl40x0_isr, (void*)VCNL40X0_INT_PRX_DRDY);
+
+    /* configure and enable threshold interrupts */
+    vcnl40x0_set_int_thresh(&dev, VCNL40X0_INT_THS_ALS, 100, 500, VCNL40X0_INT_THS_4);
+    vcnl40x0_enable_int(&dev, VCNL40X0_INT_THS_LO, vcnl40x0_isr, (void*)VCNL40X0_INT_THS_LO);
+    vcnl40x0_enable_int(&dev, VCNL40X0_INT_THS_HI, vcnl40x0_isr, (void*)VCNL40X0_INT_THS_HI);
+
+    uint16_t min_prox =  UINT16_MAX;    /* proximity offset value */
+
+    while (1) {
+        uint16_t prox;
+        uint16_t als;
+
+        /* wait for any interrupt event */
+        msg_t ie;
+        mbox_get (&ie_mbox, &ie);
+
+        /* in case of any data ready interrupts fetch and print the data */
+        if (ie.type == VCNL40X0_INT_PRX_DRDY &&
+            vcnl40x0_read_prox(&dev, &prox) == VCNL40X0_OK) {
+
+            /*
+             * Simple proximity offset correction:
+             * A number of disturbing effects such as DC noise, sensor
+             * coverage, or surrounding objects cause an offset in the
+             * measured proximity values. Find the minimum value ever
+             * measured and subtract it from the current reading. The
+             * minimum value is assumed to be 0 (no proximity).
+             */
+            min_prox = (prox < min_prox) ? prox : min_prox;
+            prox -= min_prox;
+
+            printf("Proximity [cnts]: %5" PRIu16 "\n", prox);
+        }
+        if (ie.type == VCNL40X0_INT_ALS_DRDY &&
+            vcnl40x0_read_als(&dev, &als) == VCNL40X0_OK) {
+            printf("ALS [lux] %5" PRIu16 ".%02" PRIu16 "\n", als/4, (als % 4) * 25);
+        }
+
+        /* in case of any data threshold interrupts */
+        if (ie.type == VCNL40X0_INT_THS_LO) {
+            printf("ALS low threshold exceeded\n");
+        }
+        if (ie.type == VCNL40X0_INT_THS_HI) {
+            printf("ALS high threshold exceeded\n");
+        }
+    }
+    return 0;
+}


### PR DESCRIPTION
### Contribution description

This PR adds a driver for Vishay VCNL40X0 proximity and ambient light sensors. It works with Vishay VCNL4010, VCNL4020, and VCNL3020.

The driver is divided into two parts

 - a basic driver ```vcnl40x0```, and
 - a fully functional driver ```vcnl40x0_full```, defined as psuedomodule.

The base driver ```vcnl40x0``` only supports a basic set of functions and therefore has a small size. The procedure for retrieving new data is simply polling. Ambient light and distance measurements are supported.

The fully functional driver ```vcnl40x0_full``` supports all the features supported by the base driver, as well as all other sensor features, including interrupts and their configuration. The approach to retrieving data is to use data-ready interrupts. In addition, threshold interrupts can be used and configured. 

The driver provides ```drivers/saul``` capabilities.

### Testing procedure

There is a separate test application for each part of the driver:
```
make -c tests/drivers_vcnl40x0 BOARD=...
```
```
make -c tests/drivers_vcnl40x0_full BOARD=...
```
For the latter case, the GPIO used for the interrupt signal must be configured accordingly.