### PR TITLE
 nrf5x_common: gpio: fix port 1 functionality 

### DIFF
--- a/cpu/nrf5x_common/periph/gpio.c
+++ b/cpu/nrf5x_common/periph/gpio.c
@@ -57,6 +57,18 @@ static inline NRF_GPIO_Type* port(gpio_t pin)
 #endif
 }
 
+/**
+ * @brief   Get a pin's offset
+ */
+static inline int pin_num(gpio_t pin)
+{
+#ifdef CPU_MODEL_NRF52840XXAA
+    return (pin & PIN_MASK);
+#else
+    return (int)pin;
+#endif
+}
+
 int gpio_init(gpio_t pin, gpio_mode_t mode)
 {
     switch (mode) {

--- a/cpu/nrf5x_common/periph/gpio.c
+++ b/cpu/nrf5x_common/periph/gpio.c
@@ -44,7 +44,7 @@ static gpio_isr_ctx_t exti_chan;
 /**
  * @brief   Get the port's base address
  */
-static inline NRF_GPIO_Type* port(gpio_t pin)
+static inline NRF_GPIO_Type *port(gpio_t pin)
 {
 #if (CPU_FAM_NRF51)
     (void) pin;
@@ -77,7 +77,7 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
         case GPIO_IN_PU:
         case GPIO_OUT:
             /* configure pin direction, input buffer and pull resistor state */
-            port(pin)->PIN_CNF[pin] = mode;
+            port(pin)->PIN_CNF[pin_num(pin)] = mode;
             break;
         default:
             return -1;
@@ -88,35 +88,36 @@ int gpio_init(gpio_t pin, gpio_mode_t mode)
 
 int gpio_read(gpio_t pin)
 {
-    if (port(pin)->DIR & (1 << pin)) {
-        return (port(pin)->OUT & (1 << pin)) ? 1 : 0;
+    if (port(pin)->DIR & (1 << pin_num(pin))) {
+        return (port(pin)->OUT & (1 << pin_num(pin))) ? 1 : 0;
     }
     else {
-        return (port(pin)->IN & (1 << pin)) ? 1 : 0;
+        return (port(pin)->IN & (1 << pin_num(pin))) ? 1 : 0;
     }
 }
 
 void gpio_set(gpio_t pin)
 {
-    port(pin)->OUTSET = (1 << pin);
+    port(pin)->OUTSET = (1 << pin_num(pin));
 }
 
 void gpio_clear(gpio_t pin)
 {
-    port(pin)->OUTCLR = (1 << pin);
+    port(pin)->OUTCLR = (1 << pin_num(pin));
 }
 
 void gpio_toggle(gpio_t pin)
 {
-    port(pin)->OUT ^= (1 << pin);
+    port(pin)->OUT ^= (1 << pin_num(pin));
 }
 
 void gpio_write(gpio_t pin, int value)
 {
     if (value) {
-        port(pin)->OUTSET = (1 << pin);
-    } else {
-        port(pin)->OUTCLR = (1 << pin);
+        port(pin)->OUTSET = (1 << pin_num(pin));
+    }
+    else {
+        port(pin)->OUTCLR = (1 << pin_num(pin));
     }
 }
 
@@ -135,7 +136,7 @@ int gpio_init_int(gpio_t pin, gpio_mode_t mode, gpio_flank_t flank,
     NVIC_EnableIRQ(GPIOTE_IRQn);
     /* configure the GPIOTE channel: set even mode, pin and active flank */
     NRF_GPIOTE->CONFIG[0] = (GPIOTE_CONFIG_MODE_Event |
-                             (pin << GPIOTE_CONFIG_PSEL_Pos) |
+                             (pin_num(pin) << GPIOTE_CONFIG_PSEL_Pos) |
 #ifdef CPU_MODEL_NRF52840XXAA
                              ((pin & PORT_BIT) << 8) |
 #endif


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

This PR fixes the functionality of the port 1 GPIO pins on the NRF5 platforms (mainly the nRF52840).
There used to be an unused function for this, which was removed in #9699.
This PR reverts that change, and makes use of the function to ensure functionality of port 1.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

With this PR the `gpio`-functions work with pins on port 1.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->

Reverts #9699
