### PR TITLE
openocd.sh: fix binfile on osx

### DIFF
--- a/dist/tools/openocd/openocd.sh
+++ b/dist/tools/openocd/openocd.sh
@@ -172,9 +172,12 @@ _split_banks() {
 
     # The following command needs specific osx handling (non gnu):
     # * Same commands for a pattern should be on different lines
+    # * Cannot use '\n' in the replacement string
+    local sed_escaped_newline=\\$'\n'
+
     sed -n '
     /^{.*}$/ {
-        s/\} /\}\n/g
+        s/\} /\}'"${sed_escaped_newline}"'/g
         s/[{}]//g
         p
     }'

--- a/dist/tools/openocd/openocd.sh
+++ b/dist/tools/openocd/openocd.sh
@@ -159,6 +159,20 @@ _is_binfile() {
         [[ -z "${firmware_type}" ]] && _has_bin_extension "${firmware}"; }
 }
 
+# Split bank info on different lines without the '{}'
+_split_banks() {
+    # Input:
+    #   ...
+    #   {name nrf51 base 0 size 0 bus_width 1 chip_width 1} {name nrf51 base 268439552 size 0 bus_width 1 chip_width 1}
+    #   ...
+    #
+    # Output:
+    #   name nrf51 base 0 size 0 bus_width 1 chip_width 1
+    #   name nrf51 base 268439552 size 0 bus_width 1 chip_width 1
+
+    sed -n '/^{.*}$/ {s/\} /\}\n/g;s/[{}]//g;p}'
+}
+
 # Outputs bank info on different lines without the '{}'
 _flash_list() {
     # Openocd output for 'flash list' is
@@ -169,7 +183,7 @@ _flash_list() {
             ${OPENOCD_ADAPTER_INIT} \
             -f '${OPENOCD_CONFIG}' \
             -c 'flash list' \
-            -c 'shutdown'" 2>&1 | sed -n '/^{.*}$/ {s/\} /\}\n/g;s/[{}]//g;p}'
+            -c 'shutdown'" 2>&1 | _split_banks
 }
 
 # Print flash address for 'bank_num' num defaults to 1

--- a/dist/tools/openocd/openocd.sh
+++ b/dist/tools/openocd/openocd.sh
@@ -170,7 +170,14 @@ _split_banks() {
     #   name nrf51 base 0 size 0 bus_width 1 chip_width 1
     #   name nrf51 base 268439552 size 0 bus_width 1 chip_width 1
 
-    sed -n '/^{.*}$/ {s/\} /\}\n/g;s/[{}]//g;p}'
+    # The following command needs specific osx handling (non gnu):
+    # * Same commands for a pattern should be on different lines
+    sed -n '
+    /^{.*}$/ {
+        s/\} /\}\n/g
+        s/[{}]//g
+        p
+    }'
 }
 
 # Outputs bank info on different lines without the '{}'


### PR DESCRIPTION
### Contribution description

OSx default sed does not have the 'gnu' extensions and fails in 'openocd.sh' when flashing a binfile.

It fixes usage of:
 * multiple commands in one line
 * '\n' in replacement string

### Testing procedure

`iotlab-m3` flash base address should work:

```
make -C examples/hello-world/ BOARD=iotlab-m3 binfile flash 'IMAGE_FILE=$(BINFILE)' 2>/dev/null | grep 'Binfile detected, adding ROM base address: 0x08000000' 
Binfile detected, adding ROM base address: 0x08000000
```

And there is currently a debug commit to see if it works with multiple lines.

`_flash_list` should correctly print two lines for `yunjia-nrf51822` board.

```
make -C examples/hello-world/ BOARD=yunjia-nrf51822 binfile flash 'IMAGE_FILE=$(BINFILE)' 2>&1 >/dev/null  | head -n 4
DEBUG
name nrf51 base 0 size 0 bus_width 1 chip_width 1
name nrf51 base 268439552 size 0 bus_width 1 chip_width 1
DEBUG
```

It would be great to also try if all commits are necessary by removing the last one.

### Issues/PRs references

https://github.com/RIOT-OS/RIOT/pull/10065#issuecomment-429820176