### PR TITLE
Fix LESS compilation errors when running `make doc` on macOS

### DIFF
--- a/doc/doxygen/Makefile
+++ b/doc/doxygen/Makefile
@@ -1,4 +1,5 @@
 RIOTBASE=$(shell git rev-parse --show-toplevel)
+
 # Generate list of quoted absolute include paths. Evaluated in riot.doxyfile.
 export STRIP_FROM_INC_PATH_LIST=$(shell \
     git ls-tree -dr --full-tree --name-only HEAD core drivers sys |\
@@ -7,7 +8,29 @@ export STRIP_FROM_INC_PATH_LIST=$(shell \
 
 # use lessc (http://lesscss.org/#using-less) for compiling CSS
 # It can also be installed in ubuntu with the `node-less` package
-LESSC ?= $(shell command -v lessc 2>/dev/null)
+ifeq (,$(LESSC))
+  ifneq (,$(shell command -v lessc 2>/dev/null))
+    LESSC=lessc
+  else ifneq (,$(shell command -v lesscpy 2>/dev/null))
+    LESSC=lesscpy
+  else
+    $(warning Did not find a LESS compiler, so I cannot build the CSS file in case you modified \
+              the LESS file.)
+  endif
+endif
+
+SED=sed
+ifneq (,$(LESSC))
+    UNAME := $(shell uname -s)
+    ifeq ($(UNAME),Darwin)
+        ifneq (,$(shell command -v gsed 2>/dev/null))
+            SED=gsed
+        else
+            $(warning The version of sed that ships with macOS is very old, so you need gnu-sed. \
+                      Please run 'brew install gnu-sed' and run 'make doc' again.)
+       endif
+    endif
+endif
 
 .PHONY: doc
 doc: html
@@ -26,7 +49,7 @@ src/css/riot.css: src/css/riot.less src/css/variables.less
 	@$(LESSC) $< $@
 
 src/css/variables.less: src/config.json
-	@grep "^\s*\"@" $< | sed -e 's/^\s*"//g' -e 's/":\s*"/: /g' \
+	@grep "^\s*\"@" $< | $(SED) -e 's/^\s*"//g' -e 's/":\s*"/: /g' \
 	  -e 's/",\?$$/;/g' -e 's/\\"/"/g' > $@
 endif
 


### PR DESCRIPTION
### Contribution description

When having a LESS compiler (lessc) installed and running
`make doc` on macOS, the documentation generation failed
because the `sed` regular expressions in the docs Makefile
are not compatible with the ancient version of `sed` that
comes with macOS.

I've added a check for this case and we're now throwing
a more helpful error in this scenario.

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->



<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

* On macOS
    1. Install nodejs
    2. Install less
    3. Run make doc

~~~
"/Applications/Xcode.app/Contents/Developer/usr/bin/make" -BC doc/doxygen
ParseError: Unrecognised input in /Users/ljenss/_dev/RIOT/doc/doxygen/src/css/variables.less on line 1, column 5:
1     "@gray-base": "rgb(0, 0, 0)",
2     "@gray-darker": "lighten(@gray-base, 13.5%)",

make[1]: *** [src/css/riot.css] Error 1
make: *** [doc] Error 2
~~~

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->




<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
