### PR TITLE
tests/arduino: add automatic test for arduino module

### DIFF
--- a/tests/sys_arduino/Makefile
+++ b/tests/sys_arduino/Makefile
@@ -1,0 +1,5 @@
+include ../Makefile.tests_common
+
+USEMODULE += arduino
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/sys_arduino/arduino-test.sketch
+++ b/tests/sys_arduino/arduino-test.sketch
@@ -1,0 +1,100 @@
+/*
+ * Copyright (C) 2018 Federico Pellegrin <fede@evolware.org>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Test application for arduino module
+ *
+ * @author      Federico Pellegrin <fede@evolware.org>
+ *
+ * @}
+ */
+
+#include <stdlib.h>
+#include <string.h>
+
+#ifdef STDIO_UART_BAUDRATE
+#define SERIAL_BAUDRATE STDIO_UART_BAUDRATE
+#else
+#define SERIAL_BAUDRATE 115200
+#endif
+
+/* Input buffer for receiving chars on the serial port */
+char buf[64];
+
+/* Counter of received chars in currently receiving line */
+int count = 0;
+
+void setup(void)
+{
+    Serial.begin(SERIAL_BAUDRATE);
+    Serial.println("Hello Arduino!");
+}
+
+void loop(void)
+{
+    /* Read chars if available and seek for CR or LF */
+    while (Serial.available() > 0) {
+        int tmp = Serial.read();
+        if (tmp == '\n' || tmp == '\r') {
+           buf[count] = 0;
+
+           if (count > 1) {
+                if (strncmp(buf, "echo", 4) == 0) {
+                    /* echo command just echoes back the input string */
+                    Serial.write("ECHO:");
+                    for (int i = 4; i < count; i++) {
+                        Serial.write(buf[i]);
+                    }
+                } else if (strncmp(buf, "numb", 4) == 0) {
+                    /* numb command prints input number in various formats */
+                    int numb=atoi(buf + 5);
+                    Serial.print(numb);
+                    Serial.print(" ");
+                    Serial.print(numb, DEC);
+                    Serial.print(" ");
+                    Serial.print(numb, HEX);
+                    Serial.print(" ");
+                    Serial.print(numb, OCT);
+                } else if (strncmp(buf, "time", 4) == 0) {
+                    /* time command tests printing time and sleeps  */
+                    unsigned long curtime = micros();
+                    unsigned long curtime2, curtime3;
+
+                    Serial.print((int) curtime);
+                    delay(36);
+                    Serial.print(" ");
+                    curtime2=micros();
+                    Serial.print((int) curtime2);
+                    delayMicroseconds(36000);
+                    Serial.print(" ");
+                    curtime3=micros();
+                    Serial.print((int) curtime3);
+
+                    /* test also that time is actually running */
+                    if ((curtime3 > curtime2) && (curtime2 > curtime)) {
+                        Serial.print(" OK END");
+                    } else {
+                        Serial.print(" ERR END");
+                    }
+                } else {
+                    Serial.write("UNK");
+                }
+                Serial.println("");
+            }
+            count = 0;
+        }
+        else {
+            buf[count++] = tmp;
+        }
+    }
+    delay(500);
+}

--- a/tests/sys_arduino/tests/01-run.py
+++ b/tests/sys_arduino/tests/01-run.py
@@ -1,0 +1,32 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2018 Federico Pellegrin <fede@evolware.org>
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import sys
+from testrunner import run
+
+
+def testfunc(child):
+    # 1 Basic read+write test on serial with error command
+    child.sendline("wrang")
+    child.expect_exact("UNK")
+
+    # 2 Test serial echo
+    child.sendline("echo quite long string echoing on arduino module test")
+    child.expect("ECHO: quite long string echoing on arduino module test")
+
+    # 3 Test on various print base conversions
+    child.sendline("numb 4242")
+    child.expect_exact("4242 4242 1092 10222")
+
+    # 4 Test if time is running and being printed
+    child.sendline("time")
+    child.expect("OK END")
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc))


### PR DESCRIPTION
### Contribution description
This PR adds an automatic test for the arduino module using the standard RIOT testing facilities. 
The goal is to provide an easier way to test the module when we apply changes and maybe even integrate it into the CI system.
The current code will test:
- if code is built correctly (sketch conversion)
- basic serial read/write functionality
- serial printing routines for various formats conversion (dec,hex,oct)
- time printing routines and sleep verification

I tested this on my saml21-xpro.

### Testing procedure
A board with arduino support is needed (arduino_board.h present), then in the tests/sys_arduino:

`BOARD=<board name> make all flash test`

This will build the test, flash it and execute the test.

