### PR TITLE
tests/lwip_sock_{i,ud}p: correctly get array address

### DIFF
--- a/tests/lwip_sock_ip/stack.c
+++ b/tests/lwip_sock_ip/stack.c
@@ -197,9 +197,16 @@ void _net_init(void)
     netif_add(&netif, &netdev, lwip_netdev_init, tcpip_input);
 #endif
 #if LWIP_IPV6
-    static const uint8_t local6[] = _TEST_ADDR6_LOCAL;
+    static const uint8_t local6_a[] = _TEST_ADDR6_LOCAL;
+    /* XXX need to copy into a stack variable. Otherwise, when just using
+     * `local6_a` this leads to weird alignment problems on some platforms with
+     * netif_add_ip6_address() below */
+    ip6_addr_t local6;
     s8_t idx;
-    netif_add_ip6_address(&netif, (ip6_addr_t *)&local6, &idx);
+
+    memcpy(&local6.addr, local6_a, sizeof(local6));
+    ip6_addr_clear_zone(&local6);
+    netif_add_ip6_address(&netif, &local6, &idx);
     for (int i = 0; i <= idx; i++) {
         netif.ip6_addr_state[i] |= IP6_ADDR_VALID;
     }

--- a/tests/lwip_sock_udp/stack.c
+++ b/tests/lwip_sock_udp/stack.c
@@ -199,9 +199,16 @@ void _net_init(void)
     netif_add(&netif, &netdev, lwip_netdev_init, tcpip_input);
 #endif
 #if LWIP_IPV6
-    static const uint8_t local6[] = _TEST_ADDR6_LOCAL;
+    static const uint8_t local6_a[] = _TEST_ADDR6_LOCAL;
+    /* XXX need to copy into a stack variable. Otherwise, when just using
+     * `local6_a` this leads to weird alignment problems on some platforms with
+     * netif_add_ip6_address() below */
+    ip6_addr_t local6;
     s8_t idx;
-    netif_add_ip6_address(&netif, (ip6_addr_t *)&local6, &idx);
+
+    memcpy(&local6.addr, local6_a, sizeof(local6));
+    ip6_addr_clear_zone(&local6);
+    netif_add_ip6_address(&netif, &local6, &idx);
     for (int i = 0; i <= idx; i++) {
         netif.ip6_addr_state[i] |= IP6_ADDR_VALID;
     }


### PR DESCRIPTION
### Contribution description
We want the address of the start of the array.

### Testing procedure
Flash `samr21-xpro` with either `tests/lwip_sock_ip` or `tests/lwip_sock_udp`. Without this PR the test will crash, with it it won't.

### Issues/PRs references
The test might hang without #10059 and #10107 merged but it won't crash at least ;-).
