### PR TITLE
lorabox: add port to flasher parameters

### DIFF
--- a/boards/lobaro-lorabox/Makefile.include
+++ b/boards/lobaro-lorabox/Makefile.include
@@ -21,6 +21,6 @@ HEXFILE = $(BINFILE)
 # -u: use sector by sector erase
 # -S: swap RTS and DTR
 # -l 0x1ff: amount of sectors to erase
-FFLAGS += -e -u -S -l 0x1ff -w $(BINFILE)
+FFLAGS += -p $(PORT) -e -u -S -l 0x1ff -w $(BINFILE)
 
 TERMFLAGS +=  --set-rts 0


### PR DESCRIPTION
### Contribution description

This adds the port parameter to the stm32loader flash script. This was
necessary to allow flashing on macOS X where the default port is not
autodetected correctly and needs to be specified, e.g. by running:

    BOARD=lobaro-lorabox PORT=/dev/tty.SLAB_USBtoUART \
    make -C examples/lorawan flash term`

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->



<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Try to flash `lobaro-lorabox` on macOS X, which will fail on master.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->