### PR TITLE
dist/tools: add build system sanity check script

### DIFF
--- a/dist/tools/buildsystem_sanity_check/check.sh
+++ b/dist/tools/buildsystem_sanity_check/check.sh
@@ -1,0 +1,62 @@
+#!/usr/bin/env bash
+#
+# Copyright (C) 2018 Gaëtan Harter <gaetan.harter@fu-berlin.de>
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+#
+
+#
+# Central test script to have sanity checks for the build system
+# It is run unconditionally on all files.
+#
+#
+
+: "${RIOTBASE:="$(cd "$(dirname "$0")/../../../" || exit; pwd)"}"
+
+SCRIPT_PATH=dist/tools/buildsystem_sanity_check/check.sh
+
+# Modules should not check the content of FEATURES_PROVIDED/_REQUIRED/OPTIONAL
+# Handling specific behaviors/dependencies should by checking the content of:
+# * `USEMODULE`
+# * maybe `FEATURES_USED` if it is not a module (== not a periph_)
+check_not_parsing_features() {
+    local patterns=()
+    local pathspec=()
+
+    patterns+=(-e 'if.*filter.*FEATURES_PROVIDED')
+    patterns+=(-e 'if.*filter.*FEATURES_REQUIRED')
+    patterns+=(-e 'if.*filter.*FEATURES_OPTIONAL')
+
+    # Pathspec with exclude should start by an inclusive pathspec in git 2.7.4
+    pathspec+=('*')
+
+    # Ignore this file when matching as it self matches
+    pathspec+=(":!${SCRIPT_PATH}")
+
+    # These two files contain sanity checks using FEATURES_ so are allowed
+    pathspec+=(':!Makefile.include' ':!makefiles/info-global.inc.mk')
+
+    git -C "${RIOTBASE}" grep "${patterns[@]}" -- "${pathspec[@]}"
+}
+
+
+main() {
+    local errors=''
+
+    errors+="$(check_not_parsing_features)"
+
+    if [ -n "${errors}" ]
+    then
+        printf 'Invalid build system patterns found by %s:\n' "${0}"
+        printf '%s\n' "${errors}"
+        exit 1
+    fi
+    exit 0
+}
+
+
+if [[ "${BASH_SOURCE[0]}" == "${0}" ]]; then
+    main
+fi


### PR DESCRIPTION
### Contribution description

Split from https://github.com/RIOT-OS/RIOT/pull/10060

Add a script to execute sanity checks on build system files.
It should prevent bad patterns to re-appear after being cleaned.

Currently adds a check for using the content of `FEATURES` instead of
`USEMODULE`.

Modules should not check the content of FEATURES_PROVIDED/_REQUIRED/OPTIONAL
Handling specific behaviors/dependencies should by checking the content of:
 * `USEMODULE`
 * maybe `FEATURES_USED` if it is not a module (== not a periph_)


The script cannot currently be enabled by default as there are some fixes that are not included:
https://github.com/RIOT-OS/RIOT/pull/10060

### Testing procedure

The script correctly passes `shellcheck` without errors.

You can list the current errors by running:

```
./dist/tools/buildsystem_sanity_check/check.sh
```

It finds the current violations on using `FEATURES_PROVIDED`, `FEATURES_OPTIONAL` and `FEATURES_REQUIRED` to configure specific behavior.

```
./dist/tools/buildsystem_sanity_check/check.sh 
Invalid build system patterns found by dist/tools/buildsystem_sanity_check/check.sh:
boards/hifive1/Makefile.features:ifneq (,$(filter periph_rtc,$(FEATURES_REQUIRED)))
pkg/fatfs/Makefile.dep:ifneq (, $(filter periph_rtc, $(FEATURES_PROVIDED)))
sys/shell/commands/Makefile:ifneq (,$(filter periph_rtc,$(FEATURES_PROVIDED)))
```

With the fixes to these, it runs silently without errors as done in https://github.com/RIOT-OS/RIOT/pull/10060

### Issues/PRs references

Split from https://github.com/RIOT-OS/RIOT/pull/10060 and is part of working on https://github.com/RIOT-OS/RIOT/issues/9913