### PR TITLE
pkg/semtech-loramac: Reduce timeout in timer

### DIFF
--- a/pkg/semtech-loramac/contrib/semtech_loramac_timer.c
+++ b/pkg/semtech-loramac/contrib/semtech_loramac_timer.c
@@ -62,9 +62,10 @@ void TimerSetValue(TimerEvent_t *obj, uint32_t value)
 
     /* According to the lorawan specifications, the data sent from the gateway
        could arrive with a short shift in time of +/- 20ms. Here the timeout is
-       triggered 22ms in advance to make sure the radio switches to RX mode on
-       time and doesn't miss any downlink messages. */
-    obj->timeout = (value - 22) * US_PER_MS;
+       triggered 50ms in advance to make sure the radio switches to RX mode on
+       time and doesn't miss any downlink messages, taking in consideration
+       possible xtimer inaccuracies. */
+    obj->timeout = (value - 50) * US_PER_MS;
 }
 
 TimerTime_t TimerGetCurrentTime(void)


### PR DESCRIPTION
### Contribution description
This modifies the time in which the timeout is triggered in advance in the semtech-loramac timer module.
This value has been reduced for the latest version update of semtech_loramac package (#8864), but for datarates above 2 the downlink messages in the join process are missed (see #10103).

### Testing procedure
1- Run the `lorawan` example with the current master. As it uses DR 5 it should fail to join.
2- Apply the patch and the join should succeed.

### Issues/PRs references
Fixes #10103
#8864
