### PR TITLE
pkg/nimble: use STACKTEST flag for controller thread

### DIFF
--- a/pkg/nimble/contrib/controller_init.c
+++ b/pkg/nimble/contrib/controller_init.c
@@ -39,7 +39,8 @@ void nimble_riot_controller_init(void)
      * Create task where NimBLE LL will run. This one is required as LL has its
      * own event queue and should have highest priority.
      */
-    thread_create(stack, sizeof(stack), NIMBLE_CONTROLLER_PRIO, 0,
-                  (thread_task_func_t)nimble_port_ll_task_func,
-                  NULL, "nimble_ctrl");
+    thread_create(stack, sizeof(stack), NIMBLE_CONTROLLER_PRIO,
+                  THREAD_CREATE_STACKTEST,
+                  (thread_task_func_t)nimble_port_ll_task_func, NULL,
+                  "nimble_ctrl");
 }


### PR DESCRIPTION
### Contribution description
Just debugged some hard-fault in nimble and suspected a stack overflow, until I noticed that `ps` did not show the actual values due to the missing `STACKTEST` flag... So this PR enables the THREAD_CREATE_STACKTEST flag when creating the controller thread in case DEVELHELP is enabled.

### Testing procedure
build with and without DEVELHELP should suffice.

### Issues/PRs references
none