### PR TITLE
cpu/cc2538/i2c: correctly initialize and use mutex locks

### DIFF
--- a/cpu/cc2538/periph/i2c.c
+++ b/cpu/cc2538/periph/i2c.c
@@ -67,7 +67,7 @@
 
 #define INVALID_SPEED_MASK  (0x0f)
 
-static mutex_t lock = MUTEX_INIT;
+static mutex_t lock[I2C_NUMOF];
 
 void isr_i2c(void)
 {
@@ -217,6 +217,10 @@ void i2c_init(i2c_t dev)
 {
     DEBUG("%s (%i)\n", __FUNCTION__, (int)dev);
     assert(dev < I2C_NUMOF);
+
+    /* initialize lock */
+    mutex_init(&lock[dev]);
+
     /* enable i2c clock */
     _i2c_clock_enable(true);
     /* reset i2c periph */
@@ -235,7 +239,7 @@ int i2c_acquire(i2c_t dev)
 {
     DEBUG("%s\n", __FUNCTION__);
     if (dev < I2C_NUMOF) {
-        mutex_lock(&lock);
+        mutex_lock(&lock[dev]);
         return 0;
     }
     return -1;
@@ -245,7 +249,7 @@ int i2c_release(i2c_t dev)
 {
     DEBUG("%s\n", __FUNCTION__);
     if (dev < I2C_NUMOF) {
-        mutex_unlock(&lock);
+        mutex_unlock(&lock[dev]);
         return 0;
     }
     return -1;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

I started to check if #8446 could be closed and noticed that CC2538 mutex lock might be badly initialized/used in the I2C peripheral driver.
Regarding the code change, I couldn't find any reference to MUTEX_INIT in CC2538 cpus or board config. So I think it uses the default null value, and thus no mutex.

I could not test it yet.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Build and run an application using I2C feature on a cc2538dk, remote or firefly board.
- Check the output, it should work as expected

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

#8446

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
