### PR TITLE
tests/cn-cbor: move from unittests to regular test

### DIFF
--- a/tests/pkg_cn-cbor/Makefile
+++ b/tests/pkg_cn-cbor/Makefile
@@ -1,0 +1,32 @@
+include ../Makefile.tests_common
+
+BOARD_BLACKLIST :=  arduino-duemilanove \
+                    arduino-mega2560 \
+                    arduino-uno \
+                    chronos \
+                    jiminy-mega256rfr2 \
+                    mega-xplained \
+                    msb-430 \
+                    msb-430h \
+                    telosb \
+                    waspmote-pro \
+                    wsn430-v1_3b \
+                    wsn430-v1_4 \
+                    z1 \
+                    #
+
+USEPKG += cn-cbor
+USEMODULE += embunit
+USEMODULE += fmt
+USEMODULE += memarray
+
+# Tests will fail on platforms <64 bit if not set.
+# Workaround for missing overflow detection in cn-cbor.
+CFLAGS += -DCBOR_NO_LL
+
+# Skips test cases for floating point data types.
+# CFLAGS += -DCBOR_NO_FLOAT
+
+TEST_ON_CI_WHITELIST += all
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/pkg_cn-cbor/main.c
+++ b/tests/pkg_cn-cbor/main.c
@@ -197,7 +197,9 @@ TestRef test_cn_cbor(void)
     return (TestRef) & tests_cn_cbor;
 }
 
-void tests_cn_cbor(void)
+int main(void)
 {
+    TESTS_START();
     TESTS_RUN(test_cn_cbor());
+    TESTS_END();
 }

--- a/tests/pkg_cn-cbor/tests/01-run.py
+++ b/tests/pkg_cn-cbor/tests/01-run.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2017 Freie Universität Berlin
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import sys
+from testrunner import run
+
+
+def testfunc(child):
+    child.expect(r'OK \(\d+ tests\)')
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc))

--- a/tests/unittests/tests-cn_cbor/Makefile
+++ b/tests/unittests/tests-cn_cbor/Makefile
@@ -1,8 +1,0 @@
-include $(RIOTBASE)/Makefile.base
-
-# Tests will fail on platforms <64 bit if not set.
-# Workaround for missing overflow detection in cn-cbor.
-CFLAGS += -DCBOR_NO_LL
-
-# Skips test cases for floating point data types.
-# CFLAGS += -DCBOR_NO_FLOAT

--- a/tests/unittests/tests-cn_cbor/Makefile.include
+++ b/tests/unittests/tests-cn_cbor/Makefile.include
@@ -1,3 +1,0 @@
-USEPKG += cn-cbor
-USEMODULE += fmt
-USEMODULE += memarray


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This moves tests for the cn-cbor package from unittests to a regular
test, which should help to decrease binary size of unittests.


### Testing procedure

run the tests, i.e. `BOARD=<your-favourite> make -C tests/pkg_cn-cbor flash test`


### Issues/PRs references

- issue #10187
- similar PRs: #10183, #10184, #10185 
