### PR TITLE
tests/relic: move from unittests to regular test

### DIFF
--- a/pkg/relic/Makefile.include
+++ b/pkg/relic/Makefile.include
@@ -1,1 +1,8 @@
 INCLUDES += -I$(PKGDIRBASE)/relic/include
+
+ifneq (,$(filter cortex-m%,$(CPU_ARCH)))
+  # relic package package is not using system includes right now, so
+  # many newlib headers (not even stdio.h) are not found.
+  # Fixed in #9821 for jerryscript, should be applicable here too.
+  TOOLCHAINS_BLACKLIST += llvm
+endif

--- a/tests/pkg_relic/Makefile
+++ b/tests/pkg_relic/Makefile
@@ -1,0 +1,45 @@
+include ../Makefile.tests_common
+
+# The following boards are known to fail or have not been tested.
+BOARD_BLACKLIST :=  arduino-duemilanove \
+                    arduino-mega2560 \
+                    arduino-uno \
+                    chronos \
+                    f4vi1 \
+                    jiminy-mega256rfr2 \
+                    mega-xplained \
+                    msb-430 \
+                    msb-430h \
+                    msbiot \
+                    redbee-econotag \
+                    stm32f0discovery \
+                    stm32f3discovery \
+                    telosb \
+                    waspmote-pro \
+                    wsn430-v1_3b \
+                    wsn430-v1_4 \
+                    z1 \
+                    #
+
+BOARD_INSUFFICIENT_MEMORY :=    nucleo-f030r8 \
+                                nucleo-f031k6 \
+                                nucleo-f042k6 \
+                                nucleo-l031k6 \
+                                nucleo-l053r8 \
+                                #
+
+CFLAGS += -DTHREAD_STACKSIZE_MAIN=\(5*THREAD_STACKSIZE_DEFAULT\)
+
+USEPKG += relic
+USEMODULE += embunit
+
+# -DWORD=32 : 	Specifies the word width of the target system. This is
+#  				currently not automatically detected so adjusted to your target
+#  				platform.
+
+# The rest of the parameters are configuration parameters for RELIC described in its documentation.
+export RELIC_CONFIG_FLAGS=-DARCH=NONE -DOPSYS=NONE -DQUIET=off -DWORD=32 -DFP_PRIME=255 -DWITH="BN;MD;DV;FP;EP;CP;BC;EC" -DSEED=ZERO
+
+TEST_ON_CI_WHITELIST += all
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/pkg_relic/main.c
+++ b/tests/pkg_relic/main.c
@@ -130,7 +130,7 @@ static void tests_relic_ecdh(void)
 
 }
 
-TestRef tests_relic_all(void)
+TestRef tests_relic(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
         new_TestFixture(tests_relic_ecdh)
@@ -140,7 +140,11 @@ TestRef tests_relic_all(void)
     return (TestRef)&RELICTest;
 }
 
-void tests_relic(void)
+int main(void)
 {
-    TESTS_RUN(tests_relic_all());
+    TESTS_START();
+    TESTS_RUN(tests_relic());
+    TESTS_END();
+
+    return 0;
 }

--- a/tests/pkg_relic/tests/01-run.py
+++ b/tests/pkg_relic/tests/01-run.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2017 Freie Universität Berlin
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import sys
+from testrunner import run
+
+
+def testfunc(child):
+    child.expect(r'OK \(\d+ tests\)', timeout=120)
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc))

--- a/tests/unittests/Makefile
+++ b/tests/unittests/Makefile
@@ -93,7 +93,7 @@ endif
 ARM7_BOARDS := avsextrem \
                msba2 \
                #
-DISABLE_TEST_FOR_ARM7 := tests-relic tests-cpp_%
+DISABLE_TEST_FOR_ARM7 := tests-cpp_%
 
 ARM_CORTEX_M_BOARDS := airfy-beacon \
                        arduino-due \
@@ -190,14 +190,14 @@ ARM_CORTEX_M_BOARDS := airfy-beacon \
                        udoo \
                        yunjia-nrf51822 \
                        #
-DISABLE_TEST_FOR_ARM_CORTEX_M := tests-relic
+DISABLE_TEST_FOR_ARM_CORTEX_M :=
 
 AVR_BOARDS := arduino-duemilanove \
               arduino-mega2560 \
               arduino-uno \
               waspmote-pro \
               #
-DISABLE_TEST_FOR_AVR := tests-relic tests-cpp_%
+DISABLE_TEST_FOR_AVR := tests-cpp_%
 
 MSP430_BOARDS := chronos \
                  msb-430 \
@@ -207,7 +207,7 @@ MSP430_BOARDS := chronos \
                  wsn430-v1_4 \
                  z1 \
                  #
-DISABLE_TEST_FOR_MSP430 := tests-relic tests-spiffs tests-cpp_%
+DISABLE_TEST_FOR_MSP430 := tests-spiffs tests-cpp_%
 
 ifneq (, $(filter $(ARM7_BOARDS), $(BOARD)))
   UNIT_TESTS := $(filter-out $(DISABLE_TEST_FOR_ARM7), $(UNIT_TESTS))

--- a/tests/unittests/tests-relic/Makefile
+++ b/tests/unittests/tests-relic/Makefile
@@ -1,9 +1,0 @@
-MODULE = tests-relic
-
-# The following boards are known to fail or have not been tested.
-BOARD_BLACKLIST := arduino-mega2560 chronos f4vi1 mega-xplained msb-430 \
-                   msb-430h msbiot redbee-econotag stm32f0discovery \
-                   stm32f3discovery telosb wsn430-v1_3b wsn430-v1_4 z1 \
-                   waspmote-pro
-
-include $(RIOTBASE)/Makefile.base

--- a/tests/unittests/tests-relic/Makefile.include
+++ b/tests/unittests/tests-relic/Makefile.include
@@ -1,8 +1,0 @@
-USEPKG += relic
-
-# -DWORD=32 : 	Specifies the word width of the target system. This is
-#  				currently not automatically detected so adjusted to your target
-#  				platform.
-
-# The rest of the parameters are configuration parameters for RELIC described in its documentation.
-export RELIC_CONFIG_FLAGS=-DARCH=NONE -DOPSYS=NONE -DQUIET=off -DWORD=32 -DFP_PRIME=255 -DWITH="BN;MD;DV;FP;EP;CP;BC;EC" -DSEED=ZERO


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This moves tests for the relic package from unittests to a regular
test, which should help to decrease binary size of unittests.


### Testing procedure

run the tests, i.e. `BOARD=<your-favourite> make -C tests/pkg_relic flash test`


### Issues/PRs references

- issue #10187
- similar PRs: #10183, #10184, #10185, #10188 
