### PR TITLE
pkg/lua: Fix warnings on discarded qualifiers.

### DIFF
--- a/pkg/lua/Makefile.lua
+++ b/pkg/lua/Makefile.lua
@@ -6,6 +6,11 @@ endif
 
 CFLAGS += -DLUA_MAXCAPTURES=16 -DL_MAXLENNUM=50
 
+# Upstream has several of these warnings which will not be fixed: because it
+# would require a big refactor and because the lua developers do not accept
+# patches.
+CFLAGS += -Wno-cast-qual
+
 #    Enable these options to debug stack usage
 #          -Wstack-usage=128 -Wno-error=stack-usage=128
 

--- a/pkg/lua/contrib/binsearch.h
+++ b/pkg/lua/contrib/binsearch.h
@@ -60,14 +60,14 @@ extern "C" {
  * UNSAFE MACRO: Difference in bytes between the addresses of two consecutive
  * array elements.
  */
-#define _ARRAY_STRIDE(arr) ((size_t)((uint8_t *)((arr) + 1) - (uint8_t *)(arr)))
+#define _ARRAY_STRIDE(arr) ((size_t)((const uint8_t *)((arr) + 1) - (const uint8_t *)(arr)))
 
 /**
  * UNSAFE MACRO: Offset in bytes from the start of the array to member "member"
  * of the first element.
  */
 #define _ARRAY_MEMBER_OFFS(arr, member) \
-    ((size_t)((uint8_t *)(&((arr)->member)) - (uint8_t *)(arr)))
+    ((size_t)((const uint8_t *)(&((arr)->member)) - (const uint8_t *)(arr)))
 
 /**
  * Find the index of the array element that contains "str" in


### PR DESCRIPTION
### Contribution description

#### Suppress warnings on the upstream code

Upstream lua has many instances of discarding cont qualifiers throughexplicit casting. This disables the warnigns for the package so that they don't show up when one enables -Wcast-qual globally, as I aspire to do in https://github.com/RIOT-OS/RIOT/issues/10177

####  Fix warning on my own code

There was a cast in a macro that calculated offsets. Since it was only doing a pointer difference, the cast was inocuous, but I fix it anyways.

### Testing procedure

Compile `examples/lua_REPL` with `WERROR=0 CFLAGS=-Wcast-qual make`

After these patches, lua and lua-contrib should report no more warnings of that type.

### Issues/PRs references

Small fix towards #10177 .
