### PR TITLE
drivers/at: add function to read raw data bytes from modem

### DIFF
--- a/drivers/at/at.c
+++ b/drivers/at/at.c
@@ -58,6 +58,24 @@ void at_send_bytes(at_dev_t *dev, const char *bytes, size_t len)
     uart_write(dev->uart, (const uint8_t *)bytes, len);
 }
 
+ssize_t at_recv_bytes(at_dev_t *dev, char *bytes, size_t len, uint32_t timeout)
+{
+    char *resp_pos = bytes;
+
+    while (len) {
+        int read_res;
+        if ((read_res = isrpipe_read_timeout(&dev->isrpipe, resp_pos, 1, timeout)) == 1) {
+            resp_pos += read_res;
+            len -= read_res;
+        }
+        else if (read_res == -ETIMEDOUT) {
+            break;
+        }
+    }
+
+    return (resp_pos - bytes);
+}
+
 int at_send_cmd(at_dev_t *dev, const char *command, uint32_t timeout)
 {
     size_t cmdlen = strlen(command);

--- a/drivers/include/at.h
+++ b/drivers/include/at.h
@@ -221,6 +221,18 @@ int at_expect_bytes(at_dev_t *dev, const char *bytes, uint32_t timeout);
 void at_send_bytes(at_dev_t *dev, const char *bytes, size_t len);
 
 /**
+ * @brief   Receive raw bytes from a device
+ *
+ * @param[in]   dev     device to operate on
+ * @param[in]   bytes   buffer where store received bytes
+ * @param[in]   len     maximum number of bytes to receive
+ * @param[in]   timeout timeout (in usec) of inactivity to finish read
+ *
+ * @returns     Number of bytes read, eventually zero if no bytes available
+ */
+ssize_t at_recv_bytes(at_dev_t *dev, char *bytes, size_t len, uint32_t timeout);
+
+/**
  * @brief   Send command to device
  *
  * @param[in]   dev     device to operate on

--- a/tests/driver_at/main.c
+++ b/tests/driver_at/main.c
@@ -105,6 +105,25 @@ static int send_lines(int argc, char **argv)
     return 0;
 }
 
+static int send_recv_bytes(int argc, char **argv)
+{
+    char buffer[64];
+
+    if (argc < 3) {
+        printf("Usage: %s <command> <number of bytes>\n", argv[0]);
+        return 1;
+    }
+
+    sprintf(buffer, "%s%s", argv[1], AT_SEND_EOL);
+    at_send_bytes(&at_dev, buffer, strlen(buffer));
+
+    ssize_t len = at_recv_bytes(&at_dev, buffer, atoi(argv[2]), 10 * US_PER_SEC);
+
+    printf("Response (len=%d): %s\n", (int)len, buffer);
+
+    return 0;
+}
+
 static int drain(int argc, char **argv)
 {
     (void)argc;
@@ -228,6 +247,7 @@ static const shell_command_t shell_commands[] = {
     { "send", "Send a command and wait response", send },
     { "send_ok", "Send a command and wait OK", send_ok },
     { "send_lines", "Send a command and wait lines", send_lines },
+    { "send_recv_bytes", "Send a command and wait response as raw bytes", send_recv_bytes },
     { "drain", "Drain AT device", drain },
     { "power_on", "Power on AT device", power_on },
     { "power_off", "Power off AT device", power_off },


### PR DESCRIPTION
### Contribution description
This PR adds a function to read raw data bytes from the modem device. All previous functions work on a line basis and are not suitable for some operations like raw data bytes transfer.
My use case for example is transfering via GPRS an image file to flash remotely the device. To do this I start the firmware image transfer by first issuing AT commands and then having to read the raw data bytes and flashing on the device (following concepts from #9342 ).

### Testing procedure
The manual test under tests/drivers_at was augmented to call also this function. With a device with a modem connected use on the test shell for example:
`send_recv_bytes AT+CGMM 31`
The function will send the AT+CGMM and then try to read 31 bytes. If less are found it will wait for the timeout to expire, otherwise return immediately with the 31 bytes.

