### PR TITLE
coap: Update list of defines for "PATCH and FETCH Methods" and SenML

### DIFF
--- a/sys/include/net/coap.h
+++ b/sys/include/net/coap.h
@@ -65,6 +65,9 @@ extern "C" {
 #define COAP_METHOD_POST        (2)
 #define COAP_METHOD_PUT         (3)
 #define COAP_METHOD_DELETE      (4)
+#define COAP_METHOD_FETCH       (5)
+#define COAP_METHOD_PATCH       (6)
+#define COAP_METHOD_IPATCH      (7)
 /** @} */
 
 /**
@@ -104,9 +107,11 @@ extern "C" {
 #define COAP_CODE_METHOD_NOT_ALLOWED         ((4 << 5) | 5)
 #define COAP_CODE_NOT_ACCEPTABLE             ((4 << 5) | 6)
 #define COAP_CODE_REQUEST_ENTITY_INCOMPLETE  ((4 << 5) | 8)
+#define COAP_CODE_CONFLICT                   ((4 << 5) | 9)
 #define COAP_CODE_PRECONDITION_FAILED        ((4 << 5) | 12)
 #define COAP_CODE_REQUEST_ENTITY_TOO_LARGE   ((4 << 5) | 13)
 #define COAP_CODE_UNSUPPORTED_CONTENT_FORMAT ((4 << 5) | 15)
+#define COAP_CODE_UNPROCESSABLE_ENTITY       ((4 << 5) | 22)
 /** @} */
 
 /**

--- a/sys/include/net/coap.h
+++ b/sys/include/net/coap.h
@@ -145,13 +145,23 @@ extern "C" {
  * @anchor  net_coap_format
  * @{
  */
-#define COAP_FORMAT_TEXT         (0)
-#define COAP_FORMAT_LINK        (40)
-#define COAP_FORMAT_XML         (41)
-#define COAP_FORMAT_OCTET       (42)
-#define COAP_FORMAT_EXI         (47)
-#define COAP_FORMAT_JSON        (50)
-#define COAP_FORMAT_CBOR        (60)
+#define COAP_FORMAT_TEXT                      (0)
+#define COAP_FORMAT_LINK                     (40)
+#define COAP_FORMAT_XML                      (41)
+#define COAP_FORMAT_OCTET                    (42)
+#define COAP_FORMAT_EXI                      (47)
+#define COAP_FORMAT_JSON                     (50)
+#define COAP_FORMAT_JSON_PATCH_JSON          (51)
+#define COAP_FORMAT_MERGE_PATCH_JSON         (52)
+#define COAP_FORMAT_CBOR                     (60)
+#define COAP_FORMAT_SENML_JSON              (110)
+#define COAP_FORMAT_SENSML_JSON             (111)
+#define COAP_FORMAT_SENML_CBOR              (112)
+#define COAP_FORMAT_SENSML_CBOR             (113)
+#define COAP_FORMAT_SENML_EXI               (114)
+#define COAP_FORMAT_SENSML_EXI              (115)
+#define COAP_FORMAT_SENML_XML               (310)
+#define COAP_FORMAT_SENSML_XML              (311)
 /** @} */
 
 /**

--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -101,10 +101,13 @@ extern "C" {
  * @name    Nanocoap specific CoAP method flags used in coap_handlers array
  * @{
  */
-#define COAP_GET                (0x1)
-#define COAP_POST               (0x2)
-#define COAP_PUT                (0x4)
-#define COAP_DELETE             (0x8)
+#define COAP_GET                (0x01)
+#define COAP_POST               (0x02)
+#define COAP_PUT                (0x04)
+#define COAP_DELETE             (0x08)
+#define COAP_FETCH              (0x10)
+#define COAP_PATCH              (0x20)
+#define COAP_IPATCH             (0x40)
 #define COAP_MATCH_SUBTREE      (0x8000) /**< Path is considered as a prefix
                                               when matching */
 /** @} */


### PR DESCRIPTION
### Contribution description

Updated our list of defines with the ones from rfc8132 (Fetch, patch and ipatch) and accompanying response codes. I decided to rewrite the existing hexadecimal response codes to decimal to better match the formatting of the [IANA response code list](https://www.iana.org/assignments/core-parameters/core-parameters.xhtml#response-codes)

Also added content types from rfc8428 (senml).

Decided to bundle it in a single PR because it is defines only.

### Testing procedure

Test if nanocoap and/or gcoap still compiles.

### Issues/PRs references

None