### PR TITLE
CORD: enable THREAD_CREATE_STACKTEST for threads

### DIFF
--- a/sys/net/application_layer/cord/ep/cord_ep_standalone.c
+++ b/sys/net/application_layer/cord/ep/cord_ep_standalone.c
@@ -87,7 +87,8 @@ static void *_reg_runner(void *arg)
 
 void cord_ep_standalone_run(void)
 {
-    thread_create(_stack, sizeof(_stack), PRIO, 0, _reg_runner, NULL, TNAME);
+    thread_create(_stack, sizeof(_stack), PRIO, THREAD_CREATE_STACKTEST,
+                  _reg_runner, NULL, TNAME);
 }
 
 void cord_ep_standalone_signal(bool connected)

--- a/sys/net/application_layer/cord/epsim/cord_epsim_standalone.c
+++ b/sys/net/application_layer/cord/epsim/cord_epsim_standalone.c
@@ -53,6 +53,7 @@ static void *reg_runner(void *arg)
 #ifdef MODULE_CORD_EPSIM_STANDALONE
 void cord_epsim_run(void)
 {
-    thread_create(_stack, sizeof(_stack), PRIO, 0, reg_runner, NULL, TNAME);
+    thread_create(_stack, sizeof(_stack), PRIO, THREAD_CREATE_STACKTEST,
+                  reg_runner, NULL, TNAME);
 }
 #endif


### PR DESCRIPTION
### Contribution description

This enables the `THREAD_CREATE_STACKTEST` flag for the standalone CORD threads.

### Testing procedure

Testing if the example applications for both `cord_ep` and `cord_epsim` still work with and without `DEVELHELP` enabled should be enough

### Issues/PRs references

similar to #10181 
