### PR TITLE
Makefile.base: use thin static archives.

### DIFF
--- a/Makefile.base
+++ b/Makefile.base
@@ -67,10 +67,12 @@ $(BINDIR)/$(MODULE)/:
 
 $(BINDIR)/$(MODULE).a $(OBJ): | $(BINDIR)/$(MODULE)/
 
+relpath = $(shell realpath --relative-to=$(abspath .) $(1))
+
 $(BINDIR)/$(MODULE).a: $(OBJ) | $(DIRS:%=ALL--%)
 	@# Recreate archive to cleanup deleted/non selected source files objects
 	$(Q)$(RM) $@
-	$(Q)$(AR) $(ARFLAGS) $@ $^
+	$(Q)$(AR) $(ARFLAGS) $(foreach f,$@ $^,$(call relpath,$f))
 
 CXXFLAGS = $(filter-out $(CXXUWFLAGS), $(CFLAGS)) $(CXXEXFLAGS)
 CCASFLAGS = $(filter-out $(CCASUWFLAGS), $(CFLAGS)) $(CCASEXFLAGS)

--- a/Makefile.include
+++ b/Makefile.include
@@ -498,6 +498,49 @@ print-size: $(ELFFILE)
 
 endif # BUILD_IN_DOCKER
 
+# Rules to check the correctness of thin archives.
+
+relpath = $(shell realpath --relative-to=$(abspath .) $(1))
+
+# Each ARCHECK file contains all the absolute paths found inside the archive.
+BASELIB_ARCHECKS = $(patsubst %.a,%.a-check,$(filter %.a,$(BASELIBS)))
+
+# For each a file, print the absolute paths found inside it
+# If "ar t" is called with an absolute path it will print an abs path regardless
+# of how the archive is internally
+# In case of a malformed archive, ar prints to stderr (and sets an error code).
+# Doing `2>&1` is hacky, the correct thing would be to get the exit code.
+# The `| %.a` is necessary to be able to check file produced in docker.
+%.a-check: %.a
+	$(Q)$(AR) t $(call relpath,$<) 2>&1 | grep '^/' | '$(LAZYSPONGE)' $(LAZYSPONGE_FLAGS) '$@'
+
+# There's no point on keeping files whose content is later copied to another file
+.INTERMEDIATE: $(BASELIB_ARCHECKS)
+
+ARCHIVE_CHECK = $(BINDIR)/$(APPLICATION).archive-check
+
+$(ARCHIVE_CHECK): $(BASELIB_ARCHECKS)
+	$(Q)cat $^ | '$(LAZYSPONGE)' $(LAZYSPONGE_FLAGS) '$@'
+
+# Rule to check if thin archives are correctly produced, that is, with a correct
+# relative path.
+ifeq ($(BUILD_IN_DOCKER),1)
+archive-check: ..in-docker-container
+else
+archive-check: $(ARCHIVE_CHECK) FORCE
+	@if [ -s '$<' ] ; then \
+		$(COLOR_ECHO) '$(COLOR_RED)Found the following absolute paths in archives' ;\
+		cat '$<';\
+		$(COLOR_ECHO) '$(COLOR_RESET)' ;\
+		exit 1;\
+	elif [ -f '$<' ] ; then \
+		$(COLOR_ECHO) '$(COLOR_GREEN)Archives correctly formed$(COLOR_RESET)' ;\
+	else \
+		$(COLOR_ECHO) '$(COLOR_RED)Unexpected error (file not found)$(COLOR_RESET)' ;\
+		exit 1;\
+	fi
+endif # BUILD_IN_DOCKER
+
 # Check given command is available in the path
 #   check_cmd 'command' 'description'
 define check_cmd

--- a/makefiles/cflags.inc.mk
+++ b/makefiles/cflags.inc.mk
@@ -65,5 +65,5 @@ CFLAGS += $(filter-out $(OPTIONAL_CFLAGS_BLACKLIST),$(OPTIONAL_CFLAGS))
 # Default ARFLAGS for platforms which do not specify it.
 # Note: make by default provides ARFLAGS=rv which we want to override
 ifeq ($(origin ARFLAGS),default)
-  ARFLAGS = rcs
+  ARFLAGS = rcTs
 endif

--- a/makefiles/docker.inc.mk
+++ b/makefiles/docker.inc.mk
@@ -9,6 +9,7 @@ export DOCKER_MAKECMDGOALS_POSSIBLE = \
   scan-build \
   scan-build-analyze \
   tests-% \
+  archive-check \
   #
 export DOCKER_MAKECMDGOALS = $(filter $(DOCKER_MAKECMDGOALS_POSSIBLE),$(MAKECMDGOALS))
 

--- a/sys/arduino/Makefile.include
+++ b/sys/arduino/Makefile.include
@@ -2,7 +2,7 @@
 
 # Define application sketches module, it will be generated into $(BINDIR)
 SKETCH_MODULE     ?= arduino_sketches
-SKETCH_MODULE_DIR ?= $(BINDIR)/$(SKETCH_MODULE)
+SKETCH_MODULE_DIR ?= $(BINDIR)/$(SKETCH_MODULE)_src
 SKETCHES           = $(wildcard $(APPDIR)/*.sketch)
 include $(RIOTBASE)/sys/arduino/sketches.inc.mk
 

--- a/sys/arduino/sketches.inc.mk
+++ b/sys/arduino/sketches.inc.mk
@@ -19,7 +19,8 @@ SKETCH_GENERATED_FILES = $(SKETCH_MODULE_DIR)/Makefile $(SKETCH_MODULE_DIR)/$(SK
 # Building the module files
 #   Do not use $^ in receipes as Makefile is also a prerequisite
 $(SKETCH_MODULE_DIR)/Makefile: $(SKETCH_MODULE_DIR)/$(SKETCH_CPP)
-	$(Q)echo 'SRCXX = $(SKETCH_CPP)'               > $@
+	$(Q)echo 'MODULE = $(SKETCH_MODULE)'           > $@
+	$(Q)echo 'SRCXX = $(SKETCH_CPP)'              >> $@
 	$(Q)echo 'include $$(RIOTBASE)/Makefile.base' >> $@
 $(SKETCH_MODULE_DIR)/$(SKETCH_CPP): $(SKETCHES_ALL)
 	@mkdir -p $(@D)


### PR DESCRIPTION
## Contribution description

Normal, or thick archives contain a copy of the object code. Thin archives, on the contrary, are just an index to the .o files.

This patch does two things:

1. Change ARFLAGS to enable the "T" options.
2. Call AR with all relative paths.

The second step is necessary because the build system handles all absolute paths. If the index in the thin archive contains absolute paths, archives created in docker are no usable outside, and moving the objects breaks the archive.

If all arguments to AR are relative, the resulting archive contains filenames *relative to the .a file* and nothing should break as long as the relative location of the .a and .o remains unchanged.

Compilation time is unchanged, but **disc usage** is **reduced** by approximately **2x**:

## Disk space savings

The following numbers were extracted from these branches:

- https://github.com/cladmi/RIOT/tree/wip/du/buildtest (vanilla)
- https://github.com/jcarrano/RIOT/tree/wip/du/buildtest-with-thinarc (the previous branch with this PR on top)

After compiling everything, there will be an output directory containing the sizes of the build artefacts. I used these command lines:

```sh
$ find . -name "*.bin.bindirsize" -type f -exec tail  -n1 '{}' \; | cut -f 1 | awk '{s+=$1} END {printf "%.0f", s}'
$ find . -name "*.pkg.bindirsize" -type f -exec tail  -n1 '{}' \; | cut -f 1 | awk '{s+=$1} END {printf "%.0f", s}'
$ find .  -type f -exec tail  -n1 '{}' \; | cut -f 1 | awk '{s+=$1} END {printf "%.0f", s}'
```

Sizes are broken down into package and non-package files because package data is mostly unaffected by this change. Units is million KiB (sorry for the mixture of 1000 and 1024 base)

| Thin Archive      |  no               |  yes                   | Savings (%) |
| --------------------- | ---------------: | -------------------: | ---------------- |
| pkg (10e6 KiB)   | 1 790          | 905                   | 49%             |
| Non pkg             |       71         |  71                    | 1%               |
| Total                   | 1 812          | 976                   | 46 %            |

## Testing procedure

### Thin archives

One of the issues with thin archives is how paths to object files are stored in .a files. If done incorrectly, there will be absolute paths, which means that docker-generated file won't be usable outside the container and, more generally, that it is not possible to move the bin directory.

I added a new target that checks if the archives have absolute paths. Run:

```
BOARD=<your-board> make archive-check
```

Inside and outside of docker (the command is docker-enabled).

### ~Make functions~

~I added tests for the new make functions, in `tests/build_system_utils`. Just run `make`. I refactored the code and improved the output to make it clearer which tests are being run.~

## Other stuff

- ~The commits following the first one may need some tidying up/reworking.~
- ~I would like to have feedback regarding `utils.inc.mk` (is that the correct place to put the code?).~
- ~I have no idea why disc space savings are so high. I was expecting 50% percent reduction or so, not 90%.~

## Dependencies

~Depends on #11218~
Depends on #12155.