### PR TITLE
pkg/nimble: prepare for building without DEVELHELP

### DIFF
--- a/examples/nimble_gatt/main.c
+++ b/examples/nimble_gatt/main.c
@@ -90,6 +90,7 @@ static void start_advertise(void)
     rc = ble_gap_adv_start(own_addr_type, NULL, BLE_HS_FOREVER,
                            &advp, gap_event_cb, NULL);
     assert(rc == 0);
+    (void)rc;
 }
 
 static void app_ble_sync_cb(void)
@@ -101,6 +102,7 @@ static void app_ble_sync_cb(void)
 
     rc = ble_hs_id_infer_auto(0, &own_addr_type);
     assert(rc == 0);
+    (void)rc;
 
     /* generate the advertising data */
     update_ad();

--- a/pkg/nimble/Makefile
+++ b/pkg/nimble/Makefile
@@ -6,14 +6,17 @@ PKG_LICENSE = Apache-2.0
 TDIR = $(RIOTPKG)/$(PKG_NAME)
 PDIR = $(PKG_BUILDDIR)
 
-# As of now, NimBLE does not build without warnings for -Wextra, so we disable
-# that flag for this package. Will hopefully be fixed some time in the future.
+# NimBLE is not optimized for building with all (extra) warnings enabled. So for
+# now, we disable a number of selected compiler warnings when building NimBLE.
 CFLAGS += -Wno-extra
+ifeq (llvm,$(TOOLCHAIN))
 # the static function `ble_ll_adv_active_chanset_is_sec()` in
 # `nimble/controller/src/ble_ll_adv.c` isn't used in our compilation path, so
 # tell LLVM/clang not to be so pedantic with this.
-ifeq (llvm,$(TOOLCHAIN))
   CFLAGS += -Wno-unused-function
+  CFLAGS += -Wno-sometimes-uninitialized
+else
+  CFLAGS += -Wno-unused-but-set-variable
 endif
 
 .PHONY: all


### PR DESCRIPTION
### Contribution description
As stated found in #10181, `examples/nimble_gatt` does not build with `DEVELHELP=0` currently. This PR is one step in fixing that. This PR does however not go all the way, as there is also code in nimble that needs to be patched (see https://github.com/apache/mynewt-nimble/pull/225).

So this is my proposed way to get there:
- we merge this PR (as it does not break anything that worked before)
- merge the fix to the riot npl layer in nimble
- make RIOT use the latest master of nimble once the fix has been merged

### Testing procedure
In short: verify that the example is still building as before (with `DEVELHELP=1`), so this PR does not break anything that worked before.
In depth: one would need to switch the nimble package to the branch referenced below and verify a succesfull build with `DEVELHELP=0`

### Issues/PRs references
#10181
https://github.com/apache/mynewt-nimble/pull/225