### PR TITLE
boards/wsn430*: fix doxygen grouping

### DIFF
--- a/boards/wsn430-v1_3b/doc.txt
+++ b/boards/wsn430-v1_3b/doc.txt
@@ -1,5 +1,5 @@
 /**
 @defgroup    boards_wsn430-v1_3b WSN430 v1.3b
 @ingroup     boards
-@brief       Support for the WSN430 V1 Rev 3b
+@brief       Support for the Senslab WSN430 V1 Rev 3b
  */

--- a/boards/wsn430-v1_3b/include/board.h
+++ b/boards/wsn430-v1_3b/include/board.h
@@ -7,8 +7,7 @@
  */
 
 /**
- * @defgroup    boards_wsn430-v1_3b WSN430 v1.3b
- * @ingroup     boards
+ * @ingroup     boards_wsn430-v1_3b
  * @brief       Support for the Senslab WSN430 v1.3b board
  *
  * @{

--- a/boards/wsn430-v1_4/doc.txt
+++ b/boards/wsn430-v1_4/doc.txt
@@ -1,5 +1,5 @@
 /**
 @defgroup    boards_wsn430-v1_4 WSN430 v1.4
 @ingroup     boards
-@brief       Support for the WSN430 V1 Rev 4
+@brief       Support for the Senslab WSN430 V1 Rev 4
  */

--- a/boards/wsn430-v1_4/include/board.h
+++ b/boards/wsn430-v1_4/include/board.h
@@ -7,8 +7,7 @@
  */
 
 /**
- * @defgroup    boards_wsn430-v1_4 WSN430 v1.4
- * @ingroup     boards
+ * @ingroup     boards_wsn430-v1_4
  * @brief       Support for the Senslab WSN430 v1.4 board
  *
  * @{


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

While looking at an [IoT-LAB issue](https://github.com/iot-lab/iot-lab/issues/248), I noticed that the wsn430 boards group were defined twice: in doc.txt and board.h.

This PR is fixing that.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Build the doc and read it.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None in RIOT

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
