### PR TITLE
net/nanocoap: rename variable name 'class'

### DIFF
--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -966,14 +966,14 @@ static inline unsigned coap_get_total_hdr_len(coap_pkt_t *pkt)
 /**
  * @brief   Encode given code class and code detail to raw code
  *
- * @param[in]   class   message code class
+ * @param[in]   cls     message code class
  * @param[in]   detail  message code detail
  *
  * @returns     raw message code
  */
-static inline uint8_t coap_code(unsigned class, unsigned detail)
+static inline uint8_t coap_code(unsigned cls, unsigned detail)
 {
-    return (class << 5) | detail;
+    return (cls << 5) | detail;
 }
 
 /**


### PR DESCRIPTION
'class' is keyword in c++ and leads to conflicts

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR partially addresses #8767 by tackling the invalid variable name 'class' in nanocoap.h.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Try any coap example applications, it should work.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

partially addresses #8767

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
