### PR TITLE
pthread: Make pthread_tls into a submodule

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -547,6 +547,10 @@ ifneq (,$(filter pthread,$(USEMODULE)))
   USEMODULE += timex
 endif
 
+ifneq (,$(filter pthread_tls,$(USEMODULE)))
+  USEMODULE += pthread
+endif
+
 ifneq (,$(filter schedstatistics,$(USEMODULE)))
   USEMODULE += xtimer
 endif

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -54,6 +54,7 @@ PSEUDOMODULES += pktqueue
 PSEUDOMODULES += printf_float
 PSEUDOMODULES += prng
 PSEUDOMODULES += prng_%
+PSEUDOMODULES += pthread_tls
 PSEUDOMODULES += saul_adc
 PSEUDOMODULES += saul_default
 PSEUDOMODULES += saul_gpio

--- a/sys/posix/pthread/Makefile
+++ b/sys/posix/pthread/Makefile
@@ -1,1 +1,6 @@
+# exclude pthread_tls if not selected explicitly
+ifeq (,$(filter pthread_tls,$(USEMODULE)))
+  SRC := $(filter-out pthread_tls.c,$(wildcard *.c))
+endif
+
 include $(RIOTBASE)/Makefile.base

--- a/tests/pthread_tls/Makefile
+++ b/tests/pthread_tls/Makefile
@@ -8,6 +8,7 @@ BOARD_BLACKLIST := arduino-mega2560 waspmote-pro arduino-uno arduino-duemilanove
 
 USEMODULE += posix
 USEMODULE += pthread
+USEMODULE += pthread_tls
 
 TEST_ON_CI_WHITELIST += all
 


### PR DESCRIPTION
### Contribution description

The pthread_tls functionality is conditionally linked via a weak symbol hack in pthread.c:

https://github.com/RIOT-OS/RIOT/blob/a8c2de12fa5099e1371e07d9647420d125080c7f/sys/posix/pthread/pthread.c#L194-L198 

This hack does not work when linking intermediates with `ld -r` where the symbol is available always, regardless if the other pthread_tls symbols are used or not. This PR makes the pthread_tls parts depend on a pseudomodule named pthread_tls.


### Testing procedure

build and run tests/pthread_tls test


### Issues/PRs references

split from #8711
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
