### PR TITLE
tests/libfixmath: Add delay at start of test

### DIFF
--- a/tests/libfixmath/Makefile
+++ b/tests/libfixmath/Makefile
@@ -2,7 +2,8 @@ include ../Makefile.tests_common
 
 USEPKG += libfixmath
 USEMODULE += libfixmath
+USEMODULE += xtimer
 
-TEST_ON_CI_WHITELIST += native
+TEST_ON_CI_WHITELIST += all
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/libfixmath/main.c
+++ b/tests/libfixmath/main.c
@@ -30,6 +30,7 @@
 
 #include <stdio.h>
 
+#include "xtimer.h"
 #include "fix16.h"
 
 #ifndef M_PI
@@ -184,6 +185,8 @@ static void unary_ops(void)
 
 int main(void)
 {
+    /* Delay output to prevent flooding of buffer */
+    xtimer_sleep(1);
     puts("Unary.");
     unary_ops();
 


### PR DESCRIPTION

### Contribution description

Add a delay to the start of the test since many boards start outputting before a connection is formed and the input buffer gets flooded.

### Testing procedure

`BOARD=nucleo-f103rb make flash term -C tests/libfixmath`
check the first output, it should be `Unary.`
compare against master.

_I have tested on nucleo but it should be tested on other boards especially with different default clock speeds since it uses a dumb delay_ 
### Issues/PRs references

fixes #9766