### PR TITLE
tests/heatshrink: move from unittests to regular test

### DIFF
--- a/tests/pkg_heatshrink/Makefile
+++ b/tests/pkg_heatshrink/Makefile
@@ -1,0 +1,11 @@
+include ../Makefile.tests_common
+
+BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove \
+                             arduino-uno \
+                             nucleo-f031k6 \
+                             #
+
+USEPKG += heatshrink
+USEMODULE += embunit
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/pkg_heatshrink/main.c
+++ b/tests/pkg_heatshrink/main.c
@@ -7,7 +7,7 @@
  */
 
 /**
- * @ingroup     unittests
+ * @ingroup     tests
  * @{
  * @file
  * @brief       Tests for the heatshrink compression library package
@@ -106,7 +106,7 @@ static void test_heatshrink(void)
     TEST_ASSERT_EQUAL_INT(_comp_uncomp((const uint8_t*)_data, strlen(_data)), 0);
 }
 
-TestRef test_heatshrink_all(void)
+TestRef tests_heatshrink(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
         new_TestFixture(test_heatshrink),
@@ -116,7 +116,11 @@ TestRef test_heatshrink_all(void)
     return (TestRef) & HeatshrinkTest;
 }
 
-void tests_heatshrink(void)
+int main(void)
 {
-    TESTS_RUN(test_heatshrink_all());
+    TESTS_START();
+    TESTS_RUN(tests_heatshrink());
+    TESTS_END();
+
+    return 0;
 }

--- a/tests/pkg_heatshrink/tests/01-run.py
+++ b/tests/pkg_heatshrink/tests/01-run.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2017 Freie Universität Berlin
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import sys
+from testrunner import run
+
+
+def testfunc(child):
+    child.expect('OK \(\d+ tests\)')
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc))

--- a/tests/unittests/tests-heatshrink/Makefile
+++ b/tests/unittests/tests-heatshrink/Makefile
@@ -1,1 +1,0 @@
-include $(RIOTBASE)/Makefile.base

--- a/tests/unittests/tests-heatshrink/Makefile.include
+++ b/tests/unittests/tests-heatshrink/Makefile.include
@@ -1,1 +1,0 @@
-USEPKG += heatshrink


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This moves tests for the heatshrink package from unittests to a regular
test, which should help to decrease binary size of unittests.



### Testing procedure

run the tests, i.e. `BOARD=<your-favourite> make -C tests/pkg_heatshrink flash test`


### Issues/PRs references

- issue #10187
- similar PRs: #10183, #10184, #10185, #10188, #10189
