### PR TITLE
pkg/nimble: bump version to current master

### DIFF
--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -46,6 +46,7 @@ PSEUDOMODULES += netstats
 PSEUDOMODULES += netstats_l2
 PSEUDOMODULES += netstats_ipv6
 PSEUDOMODULES += netstats_rpl
+PSEUDOMODULES += nimble
 PSEUDOMODULES += newlib
 PSEUDOMODULES += newlib_gnu_source
 PSEUDOMODULES += newlib_nano

--- a/pkg/nimble/Makefile
+++ b/pkg/nimble/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME    = nimble
 PKG_URL     = https://github.com/apache/mynewt-nimble.git
-PKG_VERSION = 050a7108cf56546554b4162f0600ab3b2d7e173f
+PKG_VERSION = ef58876024218e488dcbc15c8631db016241ab1f
 PKG_LICENSE = Apache-2.0
 
 TDIR = $(RIOTPKG)/$(PKG_NAME)
@@ -20,7 +20,6 @@ endif
 
 all: git-download
 	"$(MAKE)" -C $(PDIR)/ext/tinycrypt/src/ -f $(TDIR)/ext.tinycrypt.mk
-	"$(MAKE)" -C $(PDIR)/nimble/src -f $(TDIR)/nimble.mk
 	"$(MAKE)" -C $(PDIR)/nimble/host/src/ -f $(TDIR)/nimble.host.mk
 	"$(MAKE)" -C $(PDIR)/nimble/host/services/gap/src/ -f $(TDIR)/service.gap.mk
 	"$(MAKE)" -C $(PDIR)/nimble/host/services/gatt/src/ -f $(TDIR)/service.gatt.mk

--- a/pkg/nimble/nimble.mk
+++ b/pkg/nimble/nimble.mk
@@ -1,5 +1,0 @@
-MODULE = nimble
-
-SRC += hci_common.c
-
-include $(RIOTBASE)/Makefile.base


### PR DESCRIPTION
### Contribution description
Bumping `nimble` to use a recent commit is needed to integrate some fixes in the RIOT npl implementation in Nimble. 

`pkg/nimble/nimble.mk` is no longer needed to to internal restructuring of Nimble

### Testing procedure
Verify that `examples/nimble_gatt` is working as it did before.

### Issues/PRs references
loosely related to #10196
