### PR TITLE
tools: build and use setsid command from external source when not available

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -570,6 +570,16 @@ define check_cmd
 	    exit 1;}
 endef
 
+# Check if setsid command is available on the system for debug target
+# This is not the case on MacOSX, so it must be built on the fly
+ifneq (,$(filter debug, $(MAKECMDGOALS)))
+  ifneq (0,$(shell which setsid 2>&1 > /dev/null ; echo $$?))
+    SETSID = $(RIOTTOOLS)/setsid/setsid
+    $(call target-export-variables,debug,$(SETSID))
+    DEBUGDEPS += $(SETSID)
+  endif
+endif
+
 ..compiler-check:
 	$(call check_cmd,$(CC),Compiler)
 
@@ -643,7 +653,7 @@ list-ttys:
 doc:
 	make -BC $(RIOTBASE) doc
 
-debug:
+debug: $(DEBUGDEPS)
 	$(call check_cmd,$(DEBUGGER),Debug program)
 	$(DEBUGGER) $(DEBUGGER_FLAGS)
 

--- a/boards/common/arduino-atmega/dist/debug.sh
+++ b/boards/common/arduino-atmega/dist/debug.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
+
+# The setsid command is needed so that Ctrl+C in GDB doesn't kill avarice
+: ${SETSID:=setsid}
+
 sleep 2
-setsid -w avarice $1 &
+${SETSID} -w avarice $1 &
 #sleep 2 && $2/avr-gdb-wrapper -ex "target remote localhost:$3" $4
 sleep 3 && avr-gdb -ex "target remote localhost:$3" $4
 

--- a/boards/mega-xplained/dist/debug.sh
+++ b/boards/mega-xplained/dist/debug.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
+
+# The setsid command is needed so that Ctrl+C in GDB doesn't kill avarice
+: ${SETSID:=setsid}
+
 sleep 2
-setsid -w avarice $1 &
+${SETSID} -w avarice $1 &
 #sleep 2 && $2/avr-gdb-wrapper -ex "target remote localhost:$3" $4
 sleep 3 && avr-gdb -ex "target remote localhost:$3" $4
 

--- a/boards/waspmote-pro/dist/debug.sh
+++ b/boards/waspmote-pro/dist/debug.sh
@@ -1,6 +1,10 @@
 #!/usr/bin/env bash
+
+# The setsid command is needed so that Ctrl+C in GDB doesn't kill avarice
+: ${SETSID:=setsid}
+
 sleep 2
-setsid -w avarice $1 &
+${SETSID} -w avarice $1 &
 #sleep 2 && $2/avr-gdb-wrapper -ex "target remote localhost:$3" $4
 sleep 3 && avr-gdb -ex "target remote localhost:$3" $4
 

--- a/dist/tools/setsid/.gitignore
+++ b/dist/tools/setsid/.gitignore
@@ -1,0 +1,2 @@
+setsid
+bin

--- a/dist/tools/setsid/Makefile
+++ b/dist/tools/setsid/Makefile
@@ -1,0 +1,17 @@
+PKG_NAME     = setsid
+PKG_URL      = https://github.com/tzvetkoff/setsid-macosx
+PKG_VERSION  = e5b851df41591021baf5cf88d4e41572baf8e08b
+PKG_LICENSE  = BSD-2-Clause
+PKG_BUILDDIR = $(CURDIR)/bin
+
+.PHONY: all
+
+all: git-download
+	@echo "[INFO] compiling setsid from source now"
+	$(MAKE) BINDIR=$(PKG_BUILDDIR) -C $(PKG_BUILDDIR)
+	@mv $(PKG_BUILDDIR)/setsid $(CURDIR)/setsid
+
+distclean::
+	@rm -f $(CURDIR)/setsid
+
+include $(RIOTBASE)/pkg/pkg.mk

--- a/makefiles/tools/targets.inc.mk
+++ b/makefiles/tools/targets.inc.mk
@@ -29,3 +29,8 @@ $(RIOTTOOLS)/mosquitto_rsmb/mosquitto_rsmb:
 
 mosquitto_rsmb: $(RIOTTOOLS)/mosquitto_rsmb/mosquitto_rsmb
 	@make -C $(RIOTTOOLS)/mosquitto_rsmb run
+
+$(RIOTTOOLS)/setsid/setsid: $(RIOTTOOLS)/setsid/Makefile
+	@echo "[INFO] setsid binary not found - building it from source now"
+	@make -C $(RIOTTOOLS)/setsid
+	@echo "[INFO] setsid binary successfully build!"

--- a/makefiles/vars.inc.mk
+++ b/makefiles/vars.inc.mk
@@ -19,6 +19,7 @@ export USEPKG                # Pkg dependencies (third party modules) of the app
 export DISABLE_MODULE        # Used in the application's Makefile to suppress DEFAULT_MODULEs.
 export APPDEPS               # Files / Makefile targets that need to be created before the application can be build. Set in the application's Makefile.
 # BUILDDEPS                  # Files / Makefile targets that need to be created before starting to build.
+# DEBUGDEPS                  # Files / Makefile targets that need to be created before starting a debug session.
 
 export RIOTBASE              # The root folder of RIOT. The folder where this very file lives in.
 export RIOTCPU               # For third party CPUs this folder is the base of the CPUs.


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PRs tries to fix #8424 by introducing some make logic to fetch, build and use setsid from an external repository. Apparently setsid is not available by default on MacOSX.

The Make logic in dist/tools and makefiles should be ok. I'm not sure whether the changes in Makefile.include could be improved.

Maybe the external repository is not the best one but this can be changed easily.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

1. Start a debug session on Linux (which provides setsid) using the `debug` target. The external setsid should not be used
2. Start a debug session on MacOSX (which doesn't setsid by default). The external setsid should be fetched and built on the fly.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

fixes #8424

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
