### PR TITLE
boards/common: change openocd config file for stm32l1x

### DIFF
--- a/boards/nucleo-l152re/dist/openocd.cfg
+++ b/boards/nucleo-l152re/dist/openocd.cfg
@@ -1,0 +1,3 @@
+source [find target/stm32l1x_dual_bank.cfg]
+reset_config srst_only
+$_TARGETNAME configure -rtos auto


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
The nucleo-l152re is the only stm32l1x supported board, and it hast two flash banks according to openocd config. Thus, adding the right config file makes the whole flash available.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->
Try to flash a very large firmware (more than 256KB) and it fails on current master, since openocd is not able to write on the second bank (256KB). Normally tests/unittests was enough but with all the recent splitting maybe not anymore.

With this PR it should succeed.

### Issues/PRs references
None.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
