### PR TITLE
nanocoap: change method flag type to uint16_t

### DIFF
--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -99,6 +99,7 @@ extern "C" {
 
 /**
  * @name    Nanocoap specific CoAP method flags used in coap_handlers array
+ * @anchor  nanocoap_method_flags
  * @{
  */
 #define COAP_GET                (0x1)
@@ -198,11 +199,18 @@ typedef struct {
 typedef ssize_t (*coap_handler_t)(coap_pkt_t *pkt, uint8_t *buf, size_t len, void *context);
 
 /**
+ * @brief   Method flag type
+ *
+ * Must be large enough to contain all @ref nanocoap_method_flags "CoAP method flags"
+ */
+typedef uint16_t coap_method_flags_t;
+
+/**
  * @brief   Type for CoAP resource entry
  */
 typedef struct {
     const char *path;               /**< URI path of resource               */
-    unsigned methods;               /**< OR'ed methods this resource allows */
+    coap_method_flags_t methods;    /**< OR'ed methods this resource allows */
     coap_handler_t handler;         /**< ptr to resource handler            */
     void *context;                  /**< ptr to user defined context data   */
 } coap_resource_t;
@@ -1153,7 +1161,7 @@ ssize_t coap_handle_req(coap_pkt_t *pkt, uint8_t *resp_buf, unsigned resp_buf_le
  *
  * @returns     bit field corresponding to the given request method
  */
-static inline unsigned coap_method2flag(unsigned code)
+static inline coap_method_flags_t coap_method2flag(unsigned code)
 {
     return (1 << (code - 1));
 }

--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -389,7 +389,7 @@ static int _find_resource(coap_pkt_t *pdu, const coap_resource_t **resource_ptr,
                                             gcoap_listener_t **listener_ptr)
 {
     int ret = GCOAP_RESOURCE_NO_PATH;
-    unsigned method_flag = coap_method2flag(coap_get_code_detail(pdu));
+    coap_method_flags_t method_flag = coap_method2flag(coap_get_code_detail(pdu));
 
     /* Find path for CoAP msg among listener resources and execute callback. */
     gcoap_listener_t *listener = _coap_state.listeners;

--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -336,7 +336,7 @@ ssize_t coap_handle_req(coap_pkt_t *pkt, uint8_t *resp_buf, unsigned resp_buf_le
         return coap_build_reply(pkt, COAP_CODE_EMPTY, resp_buf, resp_buf_len, 0);
     }
 
-    unsigned method_flag = coap_method2flag(coap_get_code_detail(pkt));
+    coap_method_flags_t method_flag = coap_method2flag(coap_get_code_detail(pkt));
 
     uint8_t uri[NANOCOAP_URI_MAX];
     if (coap_get_uri_path(pkt, uri) <= 0) {


### PR DESCRIPTION
### Contribution description

Change the type of the `coap_resource_t::method` member to `uint32_t` from `unsigned`. The `method` is used for storing flags. Using something that doesn't have a strictly defined size in combination with flags is going to cause bugs or compilation issues at some point. Changing it to `uint32_t` should provide us with plenty flags and to something that is always equal or larger than `unsigned` for our supported architectures.

### Testing procedure

Check if everything {nano,g}coap-related still compiles.

### Issues/PRs references

None
