### PR TITLE
[doc] links http -> https

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,14 +69,14 @@ but not limited to:
 
 ## GETTING STARTED
 * You want to start the RIOT? Just follow our
-[quickstart guide](http://doc.riot-os.org/index.html#the-quickest-start) or
+[quickstart guide](https://doc.riot-os.org/index.html#the-quickest-start) or
 try this
 [tutorial](https://github.com/RIOT-OS/Tutorials/blob/master/README.md).
 For specific toolchain installation, follow instructions in the
-[getting started](http://doc.riot-os.org/getting-started.html) page.
+[getting started](https://doc.riot-os.org/getting-started.html) page.
 * The RIOT API itself can be built from the code using doxygen. The latest
   version of the documentation is uploaded daily to
-  [riot-os.org/api](http://riot-os.org/api).
+  [riot-os.org/api](https://riot-os.org/api).
 
 ### USING THE NATIVE PORT WITH NETWORKING
 If you compile RIOT for the native cpu and include the `netdev_tap` module,
@@ -99,14 +99,14 @@ To contribute something to RIOT, please refer to our
 
 ## MAILING LISTS
 * RIOT OS kernel developers list
- * devel@riot-os.org (http://lists.riot-os.org/mailman/listinfo/devel)
+ * devel@riot-os.org (https://lists.riot-os.org/mailman/listinfo/devel)
 * RIOT OS users list
- * users@riot-os.org (http://lists.riot-os.org/mailman/listinfo/users)
+ * users@riot-os.org (https://lists.riot-os.org/mailman/listinfo/users)
 * RIOT commits
- * commits@riot-os.org (http://lists.riot-os.org/mailman/listinfo/commits)
+ * commits@riot-os.org (https://lists.riot-os.org/mailman/listinfo/commits)
 * Github notifications
  * notifications@riot-os.org
-   (http://lists.riot-os.org/mailman/listinfo/notifications)
+   (https://lists.riot-os.org/mailman/listinfo/notifications)
 
 ## LICENSE
 * Most of the code developed by the RIOT community is licensed under the GNU
@@ -119,10 +119,10 @@ All code files contain licensing information.
 
 For more information, see the RIOT website:
 
-http://www.riot-os.org
+https://www.riot-os.org
 
 
 [master-ci-badge]: https://ci.riot-os.org/RIOT-OS/RIOT/master/latest/badge.svg
 [master-ci-link]: https://ci.riot-os.org/nightlies.html#master
 [irc-badge]: https://img.shields.io/badge/IRC-join%20chat%20%E2%86%92-blue.svg
-[irc-link]: http://webchat.freenode.net?channels=%23riot-os
+[irc-link]: https://webchat.freenode.net?channels=%23riot-os


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Just links in readme from http to https


### Testing procedure

klick and check links -> every website supports https

### Issues/PRs references
nope