### PR TITLE
tests/pkg_heatshrink: re-enable CI test

### DIFF
--- a/tests/pkg_heatshrink/Makefile
+++ b/tests/pkg_heatshrink/Makefile
@@ -5,6 +5,8 @@ BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove \
                              nucleo-f031k6 \
                              #
 
+TEST_ON_CI_WHITELIST += all
+
 USEPKG += heatshrink
 USEMODULE += embunit
 


### PR DESCRIPTION
### Contribution description

When moved out of `unittests` running test on CI was not re-enabled.

### Testing procedure

Check that murdock successfully runs this test

### Issues/PRs references

https://github.com/RIOT-OS/RIOT/pull/10202