### PR TITLE
crypto/helper: Change equals arguments to const

### DIFF
--- a/sys/crypto/helper.c
+++ b/sys/crypto/helper.c
@@ -19,7 +19,7 @@ void crypto_block_inc_ctr(uint8_t block[16], int L)
     }
 }
 
-int crypto_equals(uint8_t *a, uint8_t *b, size_t len)
+int crypto_equals(const uint8_t *a, const uint8_t *b, size_t len)
 {
     uint8_t diff = 0;
     for (size_t i = 0; i < len; ++i, ++a, ++b) {

--- a/sys/include/crypto/helper.h
+++ b/sys/include/crypto/helper.h
@@ -47,7 +47,7 @@ void crypto_block_inc_ctr(uint8_t block[16], int L);
  *
  * @returns 0 iff the blocks are non-equal.
  */
-int crypto_equals(uint8_t *a, uint8_t *b, size_t len);
+int crypto_equals(const uint8_t *a, const uint8_t *b, size_t len);
 
 #ifdef __cplusplus
 }


### PR DESCRIPTION
### Contribution description

Small cleanup changing the arguments to the `crypto_equals` function to const.

### Testing procedure

Should all be fine if murdock agrees.

### Issues/PRs references

None