### PR TITLE
crypto/helper: Add secure wipe function

### DIFF
--- a/sys/crypto/helper.c
+++ b/sys/crypto/helper.c
@@ -33,3 +33,12 @@ int crypto_equals(uint8_t *a, uint8_t *b, size_t len)
 
     return diff;
 }
+
+/* Compiler should not be allowed to optimize this */
+void crypto_secure_wipe(void *buf, size_t len)
+{
+    volatile uint8_t *vbuf = (uint8_t*)buf;
+    for (size_t i = 0; i < len; i++) {
+        vbuf[i] = 0;
+    }
+}

--- a/sys/include/crypto/helper.h
+++ b/sys/include/crypto/helper.h
@@ -49,6 +49,21 @@ void crypto_block_inc_ctr(uint8_t block[16], int L);
  */
 int crypto_equals(uint8_t *a, uint8_t *b, size_t len);
 
+/**
+ * @brief   Secure wipe function.
+ *
+ * This wipe function zeros the supplied buffer in a way that the compiler is
+ * not allowed to optimize. This can be used to erase secrets from memory.
+ *
+ * Note that this function on its own could be insufficient against (data
+ * remanence) attacks. It is outside the scope of this function to thoroughly
+ * shred the memory area.
+ *
+ * @param[in]   buf     buffer to wipe
+ * @param[in]   len     size of the buffer in bytes
+ */
+void crypto_secure_wipe(void *buf, size_t len);
+
 #ifdef __cplusplus
 }
 #endif

--- a/tests/unittests/tests-crypto/tests-crypto-helper.c
+++ b/tests/unittests/tests-crypto/tests-crypto-helper.c
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2018 Koen Zandberg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+#include <string.h>
+
+#include "embUnit/embUnit.h"
+#include "crypto/helper.h"
+
+#define VALUE       0xAA
+
+/* Secret to wipe */
+static uint8_t secret[20];
+
+void test_crypto_wipe(void)
+{
+    memset(secret, VALUE, sizeof(secret));
+    /* Wipe everything except the last byte */
+    crypto_secure_wipe(secret, sizeof(secret) - 1);
+    for (size_t i = 0; i < (sizeof(secret) - 1); i++) {
+        TEST_ASSERT_EQUAL_INT(0, secret[i]);
+    }
+    /* Check last byte */
+    TEST_ASSERT_EQUAL_INT(VALUE, secret[19]);
+}
+
+Test *tests_crypto_helper_tests(void)
+{
+    EMB_UNIT_TESTFIXTURES(fixtures) {
+        new_TestFixture(test_crypto_wipe),
+    };
+    EMB_UNIT_TESTCALLER(crypto_helper_tests, NULL, NULL, fixtures);
+    return (Test *) &crypto_helper_tests;
+}

--- a/tests/unittests/tests-crypto/tests-crypto.c
+++ b/tests/unittests/tests-crypto/tests-crypto.c
@@ -11,6 +11,7 @@
 
 void tests_crypto(void)
 {
+    TESTS_RUN(tests_crypto_helper_tests());
     TESTS_RUN(tests_crypto_chacha_tests());
     TESTS_RUN(tests_crypto_aes_tests());
     TESTS_RUN(tests_crypto_cipher_tests());

--- a/tests/unittests/tests-crypto/tests-crypto.h
+++ b/tests/unittests/tests-crypto/tests-crypto.h
@@ -34,6 +34,12 @@ extern "C" {
 void tests_crypto(void);
 
 /**
+ * @brief   Generates tests for helper functions
+ *
+ * @return  embUnit tests
+ */
+Test *tests_crypto_helper_tests(void);
+/**
  * @brief   Generates tests for crypto/chacha.h
  *
  * @return  embUnit tests if successful, NULL if not.


### PR DESCRIPTION
### Contribution description

Adds a cryptographically secure wipe function to wipe structs with
sensitive data. Works by first casting the pointer to a `volatile`
pointer to ensure that the compiler doesn't optimize the "memset" away.

### Testing procedure

For now it is mostly if this compiles and if the source makes sense

### Issues/PRs references

None