### PR TITLE
[RFC] sys/stdio Add ARM Semihosting support for stdio

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -368,7 +368,7 @@ ifneq (,$(filter newlib,$(USEMODULE)))
   ifeq (,$(filter newlib_syscalls_%,$(USEMODULE)))
     USEMODULE += newlib_syscalls_default
   endif
-  ifeq (,$(filter stdio_rtt,$(USEMODULE)))
+  ifeq (,$(filter stdio_,$(USEMODULE)))
     USEMODULE += stdio_uart
   endif
 endif
@@ -381,7 +381,7 @@ ifneq (,$(filter posix_sockets,$(USEMODULE)))
   USEMODULE += xtimer
 endif
 
-ifneq (,$(filter stdio_rtt,$(USEMODULE)))
+ifneq (,$(filter stdio_,$(USEMODULE)))
   USEMODULE += xtimer
 endif
 

--- a/sys/stdio_semihosting/Makefile
+++ b/sys/stdio_semihosting/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/sys/stdio_semihosting/README.md
+++ b/sys/stdio_semihosting/README.md
@@ -1,0 +1,24 @@
+# ARM Semihosting STDIO
+
+This module provides stdio over JTAG/SWD using ARM's semihosting support.
+
+## Usage
+
+Add `USEMODULE += stdio_semihosting` to your application's Makefile
+
+Tell OpenOCD to enable semihosting with `arm semihosting enable`. One way to
+do this is to add the following to your application's Makefile
+
+    export OPENOCD_DBG_START_CMD = -c 'reset halt' -c 'arm semihosting enable'
+
+## Limitations
+
+* Reads and writes block all threads on the processor. This is a limitation of
+  the Semihosting technology
+* It is somewhat slow
+* The image cannot be used without a debugger attached
+
+## Advantages
+
+Provides IO for any ARM device with a JTAG/SWD connection without any extra
+hardware or pins

--- a/sys/stdio_semihosting/stdio_semihosting.c
+++ b/sys/stdio_semihosting/stdio_semihosting.c
@@ -1,0 +1,119 @@
+/*
+ * Copyright (C) 2018 Phil Wise
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+#include <stdio.h>
+
+#include "stdio_uart.h"
+#include "xtimer.h"
+
+
+static uint32_t send_command(int command, void *message);
+
+
+// http://infocenter.arm.com/help/index.jsp?topic=/com.arm.doc.dui0471g/Bgbjjgij.html
+
+#define SYS_OPEN 0x01
+#define SYS_WRITE 0x05
+#define SYS_READ 0x06
+#define SYS_READC 0x07
+#define SYS_ISTTY 0x09
+
+
+struct read_message {
+    uint32_t fd;
+    void* data;
+    uint32_t length;
+};
+
+struct write_message {
+    uint32_t fd;
+    const void* data;
+    uint32_t length;
+};
+
+struct open_message {
+    const char* filename;
+    uint32_t mode;
+    uint32_t filename_length;
+};
+
+/* -1 means invalid */
+int stdout_fd;
+int stdin_fd;
+
+static uint32_t send_command(int command, void *message)
+{
+    uint32_t result;
+   __asm__ __volatile__("mov r0, %[cmd];"
+       "mov r1, %[msg];"
+       "bkpt #0xAB;"
+       "mov %[res], r0"
+         : [res] "=r" (result)
+         : [cmd] "r" (command),
+           [msg] "r" (message)
+         : "r0", "r1", "memory");
+    return result;
+}
+
+void stdio_init(void)
+{
+    struct open_message m;
+    uint32_t stdin_is_tty;
+    m.filename = ":tt";
+    m.filename_length = 3;
+    m.mode = 0; // Read
+    stdin_fd = send_command(SYS_OPEN, &m);
+
+    m.mode = 4; // Write
+    stdout_fd = send_command(SYS_OPEN, &m);
+
+    stdin_is_tty = send_command(SYS_ISTTY, &stdin_fd);
+    if (stdin_is_tty == 0) {
+        stdin_fd = -1;
+        printf("stdin is not a TTY, disabling it\n");
+    }
+}
+
+ssize_t stdio_read(void* buffer, size_t count)
+{
+    int bytes_read;
+    struct read_message m;
+    uint32_t bytes_not_filled;
+
+    if (stdin_fd == -1) {
+        printf("Can't read from closed stdin!\n");
+        while(1) {
+            // We don't have a stdin. No data is coming...
+            xtimer_sleep(10);
+        }
+    }
+
+    m.fd = stdin_fd;
+    m.data = buffer;
+    m.length = count;
+    bytes_not_filled = send_command(SYS_READ, &m);
+
+    bytes_read = count - bytes_not_filled;
+    if (bytes_read == 0) {
+        stdin_fd = -1;  // Mark as closed
+    }
+    return bytes_read;
+}
+
+
+
+ssize_t stdio_write(const void* buffer, size_t len)
+{
+    struct write_message m;
+    m.fd = stdout_fd;
+    m.data = buffer;
+    m.length = len;
+
+    send_command(SYS_WRITE, &m);
+    return len;
+}


### PR DESCRIPTION
It is useful to be able to debug a board with only a JTAG/SWD connection. This
adds a new type of stdio driver that joins stdio_uart and stdio_rtt but instead
talks the ARM Semihosting protocol.

### Contribution description

I still need to find a suitable way to signal 'no more input', but this provides workable stdout and stdin. For stdin to function it is required to use make gdb-server and connect from a second gdb instance.

### Testing procedure

Add `USEMODULE += stdio_semihosting xtimer` to hello-world's Makefile

Then run:

    # make BOARD=bluepill flash debug
    (gdb) monitor arm semihosting enable
    (gdb) c
    ...
    main(): This is RIOT! (Version: 2018.10-devel-1246-gc0fc-pearl-arm-semihosting)
    Hello World!
    You are running RIOT on a(n) bluepill board.
    This board features a(n) stm32f1 MCU.

### Issues/PRs references

None
