### PR TITLE
net/nanocoap: fix string option separator write handling

### DIFF
--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -653,10 +653,15 @@ size_t coap_opt_put_string(uint8_t *buf, uint16_t lastonum, uint16_t optnum,
 
     while (len) {
         size_t part_len;
-        uripos++;
+        if (*uripos == separator) {
+            uripos++;
+        }
         uint8_t *part_start = (uint8_t *)uripos;
 
-        while (len--) {
+        while (len) {
+            /* must decrement separately from while loop test to ensure
+             * the value remains non-negative */
+            len--;
             if ((*uripos == separator) || (*uripos == '\0')) {
                 break;
             }
@@ -710,10 +715,15 @@ ssize_t coap_opt_add_string(coap_pkt_t *pkt, uint16_t optnum, const char *string
 
     while (unread_len) {
         size_t part_len;
-        uripos++;
+        if (*uripos == separator) {
+            uripos++;
+        }
         uint8_t *part_start = (uint8_t *)uripos;
 
-        while (unread_len--) {
+        while (unread_len) {
+            /* must decrement separately from while loop test to ensure
+             * the value remains non-negative */
+            unread_len--;
             if ((*uripos == separator) || (*uripos == '\0')) {
                 break;
             }


### PR DESCRIPTION
### Contribution description
Both the nanocoap `coap_opt_put_string()` and `coap_opt_add_string()` functions assume the first character in the string is a separator, and skip over it when writing the (first) option. This behavior likely resulted from our initial handling of Path strings. For a path we usually send the full concatenated path as a single string, which always starts with a '/', at least for a Uri-Path option.

However, for a Uri-Query we usually send each query individually, for example in the `cord_common_add_qstring()` function, and we don't expect to start the query key with an '&'.

The error is not expressed currently in the cord module because gcoap uses an older mechanism to write a query option. I'm trying to update how gcoap writes options in some other work, and encountered the problem.

### Testing procedure
Probably the easiest way to test is to copy/paste the included unit test, test_nanocoap__get_query() into the tests-nanocoap unit test in master. It tries to add the query string 'ab=cde'. You'll see the test fails because the length of the option is short by one. It neglects to write the first character in the key, so the option contains 'b=cde'.
