### PR TITLE
 gnrc_pktbuf: add gnrc_pktbuf_reverse_snips() helper function

### DIFF
--- a/sys/include/net/gnrc/pktbuf.h
+++ b/sys/include/net/gnrc/pktbuf.h
@@ -226,6 +226,24 @@ gnrc_pktsnip_t *gnrc_pktbuf_remove_snip(gnrc_pktsnip_t *pkt, gnrc_pktsnip_t *sni
 gnrc_pktsnip_t *gnrc_pktbuf_replace_snip(gnrc_pktsnip_t *pkt, gnrc_pktsnip_t *old, gnrc_pktsnip_t *add);
 
 /**
+ * @brief   Reverses snip order of a packet in a write-protected manner.
+ *
+ * This can be used to change the send/receive order of a packet (see
+ * @ref gnrc_pktsnip_t)
+ *
+ * @note    @p pkt is released on failure.
+ *
+ * @param[in] pkt   A packet. When this function fails (due to a full packet
+ *                  packet buffer) @p pkt will be released.
+ *
+ * @return  The reversed version of @p pkt on success
+ * @return  NULL, when there is not enough space in the packet buffer to reverse
+ *          the packet in a write-protected manner. @p pkt is released in that
+ *          case.
+ */
+gnrc_pktsnip_t *gnrc_pktbuf_reverse_snips(gnrc_pktsnip_t *pkt);
+
+/**
  * @brief Duplicates pktsnip chain upto (including) a snip with the given type
  *        as a continuous snip.
  *

--- a/sys/net/gnrc/pktbuf/gnrc_pktbuf.c
+++ b/sys/net/gnrc/pktbuf/gnrc_pktbuf.c
@@ -86,5 +86,28 @@ gnrc_pktsnip_t *gnrc_pktbuf_replace_snip(gnrc_pktsnip_t *pkt,
     return pkt;
 }
 
+gnrc_pktsnip_t *gnrc_pktbuf_reverse_snips(gnrc_pktsnip_t *pkt)
+{
+    gnrc_pktsnip_t *reversed = NULL, *ptr = pkt;
+
+    while (ptr != NULL) {
+        gnrc_pktsnip_t *next;
+
+        /* try to write-protect snip as its next-pointer is changed below */
+        pkt = gnrc_pktbuf_start_write(ptr); /* use pkt as temporary variable */
+        if (pkt == NULL) {
+            gnrc_pktbuf_release(reversed);
+            gnrc_pktbuf_release(ptr);
+            return NULL;
+        }
+        /* switch around pointers */
+        next = pkt->next;
+        pkt->next = reversed;
+        reversed = pkt;
+        ptr = next;
+    }
+    return reversed;
+}
+
 
 /** @} */

--- a/tests/unittests/tests-pktbuf/tests-pktbuf.c
+++ b/tests/unittests/tests-pktbuf/tests-pktbuf.c
@@ -818,6 +818,43 @@ static void test_pktbuf_get_iovec__null(void)
     TEST_ASSERT_EQUAL_INT(0, len);
 }
 
+static void test_pktbuf_reverse_snips__too_full(void)
+{
+    gnrc_pktsnip_t *pkt, *pkt_next, *pkt_huge;
+    const size_t pkt_huge_size = GNRC_PKTBUF_SIZE - (3 * 8) -
+                                 (3 * sizeof(gnrc_pktsnip_t)) - 4;
+
+    pkt_next = gnrc_pktbuf_add(NULL, TEST_STRING8, 8, GNRC_NETTYPE_TEST);
+    TEST_ASSERT_NOT_NULL(pkt_next);
+    /* hold to enforce duplication */
+    gnrc_pktbuf_hold(pkt_next, 1);
+    pkt = gnrc_pktbuf_add(pkt_next, TEST_STRING8, 8, GNRC_NETTYPE_TEST);
+    TEST_ASSERT_NOT_NULL(pkt);
+    /* filling up rest of packet buffer */
+    pkt_huge = gnrc_pktbuf_add(NULL, NULL, pkt_huge_size, GNRC_NETTYPE_UNDEF);
+    TEST_ASSERT_NOT_NULL(pkt_huge);
+    TEST_ASSERT_NULL(gnrc_pktbuf_reverse_snips(pkt));
+    gnrc_pktbuf_release(pkt_huge);
+    /* release because of hold above */
+    gnrc_pktbuf_release(pkt_next);
+    TEST_ASSERT(gnrc_pktbuf_is_empty());
+}
+
+static void test_pktbuf_reverse_snips__success(void)
+{
+    gnrc_pktsnip_t *pkt, *pkt_next, *pkt_reversed;
+
+    pkt_next = gnrc_pktbuf_add(NULL, TEST_STRING8, 8, GNRC_NETTYPE_TEST);
+    TEST_ASSERT_NOT_NULL(pkt_next);
+    pkt = gnrc_pktbuf_add(pkt_next, TEST_STRING8, 8, GNRC_NETTYPE_TEST);
+    TEST_ASSERT_NOT_NULL(pkt);
+    pkt_reversed = gnrc_pktbuf_reverse_snips(pkt);
+    TEST_ASSERT(pkt_reversed == pkt_next);
+    TEST_ASSERT(pkt_reversed->next == pkt);
+    gnrc_pktbuf_release(pkt_reversed);
+    TEST_ASSERT(gnrc_pktbuf_is_empty());
+}
+
 Test *tests_pktbuf_tests(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
@@ -870,6 +907,8 @@ Test *tests_pktbuf_tests(void)
         new_TestFixture(test_pktbuf_get_iovec__1_elem),
         new_TestFixture(test_pktbuf_get_iovec__3_elem),
         new_TestFixture(test_pktbuf_get_iovec__null),
+        new_TestFixture(test_pktbuf_reverse_snips__too_full),
+        new_TestFixture(test_pktbuf_reverse_snips__success),
     };
 
     EMB_UNIT_TESTCALLER(gnrc_pktbuf_tests, set_up, NULL, fixtures);


### PR DESCRIPTION
### Contribution description
This allows for

a) testing the packet reversal properly in unittests
b) use it in other places than `gnrc_ipv6`'s receive function

### Testing procedure
Run the newly provided unittests:

```C
make -C tests/unittests tests-pktbuf test
```

If that succeeds, try to compile `gnrc_networking`. If you really want to be thorough, set up a multihop network with `gnrc_networking` and see if forwarding still works (it should, but I did not test that).

### Issues/PRs references
![PR dependencies](http://page.mi.fu-berlin.de/mlenders/ipv6_rework.svg)