### PR TITLE
gnrc_rpl_srh: cleanup and optimize SRH processing function

### DIFF
--- a/sys/include/net/gnrc/rpl/srh.h
+++ b/sys/include/net/gnrc/rpl/srh.h
@@ -52,6 +52,10 @@ typedef struct __attribute__((packed)) {
 /**
  * @brief   Process the RPL source routing header.
  *
+ * @pre `rh->seq_left > 0`; The 0 case means the destination is reached and
+ *      common among all routing headers, so it should be handled by an
+ *      external routing header handler.
+ *
  * @param[in,out] ipv6  The IPv6 header of the incoming packet.
  * @param[in] rh        A RPL source routing header.
  *

--- a/sys/net/gnrc/routing/rpl/srh/gnrc_rpl_srh.c
+++ b/sys/net/gnrc/routing/rpl/srh/gnrc_rpl_srh.c
@@ -31,7 +31,7 @@ static char addr_str[IPV6_ADDR_MAX_STR_LEN];
 
 int gnrc_rpl_srh_process(ipv6_hdr_t *ipv6, gnrc_rpl_srh_t *rh)
 {
-    ipv6_addr_t addr = ipv6->dst, tmp;
+    ipv6_addr_t addr, tmp;
     uint8_t *addr_vec = (uint8_t *) (rh + 1);
     bool found = false;
     uint8_t n;
@@ -55,6 +55,7 @@ int gnrc_rpl_srh_process(ipv6_hdr_t *ipv6, gnrc_rpl_srh_t *rh)
     pref_elided = rh->seg_left ? GNRC_RPL_SRH_COMPRI(rh->compr) : GNRC_RPL_SRH_COMPRE(rh->compr);
     compri_addr_len = sizeof(ipv6_addr_t) - GNRC_RPL_SRH_COMPRI(rh->compr);
     addr_len = sizeof(ipv6_addr_t) - pref_elided;
+    memcpy(&addr, &ipv6->dst, pref_elided);
     memcpy(&addr.u8[pref_elided], &addr_vec[(i - 1) * compri_addr_len], addr_len);
 
     if (ipv6_addr_is_multicast(&ipv6->dst) || ipv6_addr_is_multicast(&addr)) {
@@ -66,7 +67,7 @@ int gnrc_rpl_srh_process(ipv6_hdr_t *ipv6, gnrc_rpl_srh_t *rh)
     /* check if multiple addresses of my interface exist */
     tmp_pref_elided = GNRC_RPL_SRH_COMPRI(rh->compr);
     tmp_addr_len = sizeof(ipv6_addr_t) - tmp_pref_elided;
-    tmp = ipv6->dst;
+    memcpy(&tmp, &ipv6->dst, tmp_pref_elided);
     for (uint8_t k = 0; k < n; k++) {
         if (k == n - 1) {
             tmp_pref_elided = GNRC_RPL_SRH_COMPRE(rh->compr);
@@ -89,7 +90,7 @@ int gnrc_rpl_srh_process(ipv6_hdr_t *ipv6, gnrc_rpl_srh_t *rh)
     DEBUG("RPL SRH: Next hop: %s at position %d\n",
           ipv6_addr_to_str(addr_str, &addr, sizeof(addr_str)), i);
 
-    ipv6->dst = addr;
+    memcpy(&ipv6->dst, &addr, sizeof(ipv6->dst));
 
     return GNRC_IPV6_EXT_RH_FORWARDED;
 }

--- a/sys/net/gnrc/routing/rpl/srh/gnrc_rpl_srh.c
+++ b/sys/net/gnrc/routing/rpl/srh/gnrc_rpl_srh.c
@@ -37,10 +37,7 @@ int gnrc_rpl_srh_process(ipv6_hdr_t *ipv6, gnrc_rpl_srh_t *rh)
     uint8_t n;
     uint8_t i, pref_elided, tmp_pref_elided, addr_len, compri_addr_len, tmp_addr_len, found_pos = 0;
 
-    if (rh->seg_left == 0) {
-        return GNRC_IPV6_EXT_RH_AT_DST;
-    }
-
+    assert(rh->seg_left > 0);
     n = (((rh->len * 8) - GNRC_RPL_SRH_PADDING(rh->pad_resv) -
         (16 - GNRC_RPL_SRH_COMPRE(rh->compr))) /
         (16 - GNRC_RPL_SRH_COMPRI(rh->compr))) + 1;

--- a/sys/net/gnrc/routing/rpl/srh/gnrc_rpl_srh.c
+++ b/sys/net/gnrc/routing/rpl/srh/gnrc_rpl_srh.c
@@ -69,29 +69,29 @@ int gnrc_rpl_srh_process(ipv6_hdr_t *ipv6, gnrc_rpl_srh_t *rh)
 {
     ipv6_addr_t addr;
     uint8_t *addr_vec = (uint8_t *) (rh + 1);
-    uint8_t n;
-    uint8_t i, pref_elided, addr_len, compri_addr_len;
+    uint8_t num_addr;
+    uint8_t current_pos, pref_elided, addr_len, compri_addr_len;
     const uint8_t new_seg_left = rh->seg_left - 1;
 
     assert(rh->seg_left > 0);
-    n = (((rh->len * 8) - GNRC_RPL_SRH_PADDING(rh->pad_resv) -
-        (16 - GNRC_RPL_SRH_COMPRE(rh->compr))) /
-        (16 - GNRC_RPL_SRH_COMPRI(rh->compr))) + 1;
+    num_addr = (((rh->len * 8) - GNRC_RPL_SRH_PADDING(rh->pad_resv) -
+               (16 - GNRC_RPL_SRH_COMPRE(rh->compr))) /
+               (16 - GNRC_RPL_SRH_COMPRI(rh->compr))) + 1;
 
-    DEBUG("RPL SRH: %u addresses in the routing header\n", (unsigned) n);
+    DEBUG("RPL SRH: %u addresses in the routing header\n", (unsigned) num_addr);
 
-    if (rh->seg_left > n) {
+    if (rh->seg_left > num_addr) {
         DEBUG("RPL SRH: number of segments left > number of addresses - discard\n");
         /* TODO ICMP Parameter Problem - Code 0 */
         return GNRC_IPV6_EXT_RH_ERROR;
     }
 
-    i = n - new_seg_left;
+    current_pos = num_addr - new_seg_left;
     pref_elided = new_seg_left ? GNRC_RPL_SRH_COMPRI(rh->compr) : GNRC_RPL_SRH_COMPRE(rh->compr);
     compri_addr_len = sizeof(ipv6_addr_t) - GNRC_RPL_SRH_COMPRI(rh->compr);
     addr_len = sizeof(ipv6_addr_t) - pref_elided;
     memcpy(&addr, &ipv6->dst, pref_elided);
-    memcpy(&addr.u8[pref_elided], &addr_vec[(i - 1) * compri_addr_len], addr_len);
+    memcpy(&addr.u8[pref_elided], &addr_vec[(current_pos - 1) * compri_addr_len], addr_len);
 
     if (ipv6_addr_is_multicast(&ipv6->dst) || ipv6_addr_is_multicast(&addr)) {
         DEBUG("RPL SRH: found a multicast address - discard\n");
@@ -105,10 +105,10 @@ int gnrc_rpl_srh_process(ipv6_hdr_t *ipv6, gnrc_rpl_srh_t *rh)
         return GNRC_IPV6_EXT_RH_ERROR;
     }
     rh->seg_left = new_seg_left;
-    memcpy(&addr_vec[(i - 1) * compri_addr_len], &ipv6->dst.u8[pref_elided], addr_len);
+    memcpy(&addr_vec[(current_pos - 1) * compri_addr_len], &ipv6->dst.u8[pref_elided], addr_len);
 
     DEBUG("RPL SRH: Next hop: %s at position %d\n",
-          ipv6_addr_to_str(addr_str, &addr, sizeof(addr_str)), i);
+          ipv6_addr_to_str(addr_str, &addr, sizeof(addr_str)), current_pos);
 
     memcpy(&ipv6->dst, &addr, sizeof(ipv6->dst));
 

--- a/sys/net/gnrc/routing/rpl/srh/gnrc_rpl_srh.c
+++ b/sys/net/gnrc/routing/rpl/srh/gnrc_rpl_srh.c
@@ -36,6 +36,7 @@ int gnrc_rpl_srh_process(ipv6_hdr_t *ipv6, gnrc_rpl_srh_t *rh)
     bool found = false;
     uint8_t n;
     uint8_t i, pref_elided, tmp_pref_elided, addr_len, compri_addr_len, tmp_addr_len, found_pos = 0;
+    const uint8_t new_seg_left = rh->seg_left - 1;
 
     assert(rh->seg_left > 0);
     n = (((rh->len * 8) - GNRC_RPL_SRH_PADDING(rh->pad_resv) -
@@ -50,9 +51,8 @@ int gnrc_rpl_srh_process(ipv6_hdr_t *ipv6, gnrc_rpl_srh_t *rh)
         return GNRC_IPV6_EXT_RH_ERROR;
     }
 
-    rh->seg_left--;
-    i = n - rh->seg_left;
-    pref_elided = rh->seg_left ? GNRC_RPL_SRH_COMPRI(rh->compr) : GNRC_RPL_SRH_COMPRE(rh->compr);
+    i = n - new_seg_left;
+    pref_elided = new_seg_left ? GNRC_RPL_SRH_COMPRI(rh->compr) : GNRC_RPL_SRH_COMPRE(rh->compr);
     compri_addr_len = sizeof(ipv6_addr_t) - GNRC_RPL_SRH_COMPRI(rh->compr);
     addr_len = sizeof(ipv6_addr_t) - pref_elided;
     memcpy(&addr, &ipv6->dst, pref_elided);
@@ -84,7 +84,7 @@ int gnrc_rpl_srh_process(ipv6_hdr_t *ipv6, gnrc_rpl_srh_t *rh)
             found = true;
         }
     }
-
+    rh->seg_left = new_seg_left;
     memcpy(&addr_vec[(i - 1) * compri_addr_len], &ipv6->dst.u8[pref_elided], addr_len);
 
     DEBUG("RPL SRH: Next hop: %s at position %d\n",

--- a/sys/net/gnrc/routing/rpl/srh/gnrc_rpl_srh.c
+++ b/sys/net/gnrc/routing/rpl/srh/gnrc_rpl_srh.c
@@ -75,23 +75,28 @@ int gnrc_rpl_srh_process(ipv6_hdr_t *ipv6, gnrc_rpl_srh_t *rh)
 
     assert(rh->seg_left > 0);
     num_addr = (((rh->len * 8) - GNRC_RPL_SRH_PADDING(rh->pad_resv) -
-               (16 - GNRC_RPL_SRH_COMPRE(rh->compr))) /
-               (16 - GNRC_RPL_SRH_COMPRI(rh->compr))) + 1;
+                 (16 - GNRC_RPL_SRH_COMPRE(rh->compr))) /
+                (16 - GNRC_RPL_SRH_COMPRI(rh->compr))) + 1;
 
     DEBUG("RPL SRH: %u addresses in the routing header\n", (unsigned) num_addr);
 
     if (rh->seg_left > num_addr) {
-        DEBUG("RPL SRH: number of segments left > number of addresses - discard\n");
+        DEBUG("RPL SRH: number of segments left > number of addresses - "
+              "discard\n");
         /* TODO ICMP Parameter Problem - Code 0 */
         return GNRC_IPV6_EXT_RH_ERROR;
     }
 
     current_pos = num_addr - new_seg_left;
-    pref_elided = new_seg_left ? GNRC_RPL_SRH_COMPRI(rh->compr) : GNRC_RPL_SRH_COMPRE(rh->compr);
+    pref_elided = (new_seg_left)
+                ? GNRC_RPL_SRH_COMPRI(rh->compr)
+                : GNRC_RPL_SRH_COMPRE(rh->compr);
     compri_addr_len = sizeof(ipv6_addr_t) - GNRC_RPL_SRH_COMPRI(rh->compr);
     addr_len = sizeof(ipv6_addr_t) - pref_elided;
     memcpy(&addr, &ipv6->dst, pref_elided);
-    memcpy(&addr.u8[pref_elided], &addr_vec[(current_pos - 1) * compri_addr_len], addr_len);
+    memcpy(&addr.u8[pref_elided],
+           &addr_vec[(current_pos - 1) * compri_addr_len],
+           addr_len);
 
     if (ipv6_addr_is_multicast(&ipv6->dst) || ipv6_addr_is_multicast(&addr)) {
         DEBUG("RPL SRH: found a multicast address - discard\n");
@@ -105,7 +110,8 @@ int gnrc_rpl_srh_process(ipv6_hdr_t *ipv6, gnrc_rpl_srh_t *rh)
         return GNRC_IPV6_EXT_RH_ERROR;
     }
     rh->seg_left = new_seg_left;
-    memcpy(&addr_vec[(current_pos - 1) * compri_addr_len], &ipv6->dst.u8[pref_elided], addr_len);
+    memcpy(&addr_vec[(current_pos - 1) * compri_addr_len],
+           &ipv6->dst.u8[pref_elided], addr_len);
 
     DEBUG("RPL SRH: Next hop: %s at position %d\n",
           ipv6_addr_to_str(addr_str, &addr, sizeof(addr_str)), current_pos);

--- a/sys/net/gnrc/routing/rpl/srh/gnrc_rpl_srh.c
+++ b/sys/net/gnrc/routing/rpl/srh/gnrc_rpl_srh.c
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2015 Martine Lenders <mlenders@inf.fu-berlin.de>
+ * Copyright (C) 2015 Cenk Gündoğan <cnkgndgn@gmail.com>
+ * Copyright (C) 2018 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -10,6 +11,8 @@
  * @{
  *
  * @file
+ * @author Cenk Gündoğan <cnkgndgn@gmail.com>
+ * @author Martine Lenders <m.lenders@fu-berlin.de>
  */
 
 #include <string.h>
@@ -28,17 +31,19 @@ static char addr_str[IPV6_ADDR_MAX_STR_LEN];
 
 int gnrc_rpl_srh_process(ipv6_hdr_t *ipv6, gnrc_rpl_srh_t *rh)
 {
+    ipv6_addr_t addr = ipv6->dst, tmp;
+    uint8_t *addr_vec = (uint8_t *) (rh + 1);
+    bool found = false;
+    uint8_t n;
+    uint8_t i, pref_elided, tmp_pref_elided, addr_len, compri_addr_len, tmp_addr_len, found_pos = 0;
+
     if (rh->seg_left == 0) {
         return GNRC_IPV6_EXT_RH_AT_DST;
     }
 
-    uint8_t n = (((rh->len * 8) - GNRC_RPL_SRH_PADDING(rh->pad_resv) -
-                 (16 - GNRC_RPL_SRH_COMPRE(rh->compr))) /
-                 (16 - GNRC_RPL_SRH_COMPRI(rh->compr))) + 1;
-    ipv6_addr_t addr = ipv6->dst, tmp;
-    uint8_t i, pref_elided, tmp_pref_elided, addr_len, compri_addr_len, tmp_addr_len, found_pos = 0;
-    uint8_t *addr_vec = (uint8_t *) (rh + 1);
-    bool found = false;
+    n = (((rh->len * 8) - GNRC_RPL_SRH_PADDING(rh->pad_resv) -
+        (16 - GNRC_RPL_SRH_COMPRE(rh->compr))) /
+        (16 - GNRC_RPL_SRH_COMPRI(rh->compr))) + 1;
 
     DEBUG("RPL SRH: %u addresses in the routing header\n", (unsigned) n);
 


### PR DESCRIPTION
### Contribution description
While starting preparations I noticed that the processing function for RPL source routing headers in general needs some polishing. This PR provides that some code cleanup and optimizations.

### Testing procedure
It can be ensured that the function is still doing the same behavior by using the `tests-rpl_srh` unittests. I also ensured with those on `samr21-xpro` with `ps` that the binary size and stack usage indeed goes down:

```diff
diff --git a/tests/unittests/tests-rpl_srh/Makefile.include b/tests/unittests/tests-rpl_srh/Makefile.include
index 4aa358a..7425e14 100644
--- a/tests/unittests/tests-rpl_srh/Makefile.include
+++ b/tests/unittests/tests-rpl_srh/Makefile.include
@@ -1,3 +1,6 @@
 USEMODULE += gnrc_ipv6
 USEMODULE += ipv6_addr
 USEMODULE += gnrc_rpl_srh
+USEMODULE += ps
+
+CFLAGS += -DDEVELHELP
diff --git a/tests/unittests/tests-rpl_srh/tests-rpl_srh.c b/tests/unittests/tests-rpl_srh/tests-rpl_srh.c
index 5bc75a2..f6390c7 100644
--- a/tests/unittests/tests-rpl_srh/tests-rpl_srh.c
+++ b/tests/unittests/tests-rpl_srh/tests-rpl_srh.c
@@ -19,6 +19,7 @@
 #include "net/ipv6/ext.h"
 #include "net/ipv6/hdr.h"
 #include "net/gnrc/rpl/srh.h"
+#include "ps.h"
 
 #include "unittests-constants.h"
 #include "tests-rpl_srh.h"
@@ -120,5 +121,6 @@ Test *tests_rpl_srh_tests(void)
 void tests_rpl_srh(void)
 {
     TESTS_RUN(tests_rpl_srh_tests());
+    ps();
 }
 /** @} */
```

### Issues/PRs references
![PR dependencies](http://page.mi.fu-berlin.de/mlenders/ipv6_rework.svg)