### PR TITLE
drivers/at86rf233: extend doc for smart idle listening feautre

### DIFF
--- a/drivers/include/at86rf2xx.h
+++ b/drivers/include/at86rf2xx.h
@@ -134,7 +134,9 @@ extern "C" {
  * @brief   Smart idle listening feature
  *
  * This feature optimizes radio operation in the listening mode, reducing
- * current consumption by ~50%. It is supported by only at86rf233.
+ * current consumption by ~50%. It is supported by only at86rf233. The reference
+ * manual recommends to disable this feature for RSSI measurements or random number
+ * generation (Section 8.4 and Section 11.2).
  */
 #ifdef MODULE_AT86RF233
 #ifndef AT86RF2XX_SMART_IDLE_LISTENING


### PR DESCRIPTION
### Contribution description

This PR adds a recommendation about the "smart idle listening" feature of the AT86RF233 radio from Atmels reference manual.

### Issues/PRs references
#8971
