### PR TITLE
 gnrc_ipv6_ext: move ipv6_ext_rh (partly) to GNRC

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -245,11 +245,11 @@ ifneq (,$(filter gnrc_icmpv6,$(USEMODULE)))
 endif
 
 ifneq (,$(filter gnrc_rpl_srh,$(USEMODULE)))
-  USEMODULE += ipv6_ext_rh
+  USEMODULE += gnrc_ipv6_ext_rh
 endif
 
-ifneq (,$(filter ipv6_ext_rh,$(USEMODULE)))
-  USEMODULE += ipv6_ext
+ifneq (,$(filter gnrc_ipv6_ext_rh,$(USEMODULE)))
+  USEMODULE += gnrc_ipv6_ext
 endif
 
 ifneq (,$(filter gnrc_ipv6_ext,$(USEMODULE)))

--- a/sys/Makefile
+++ b/sys/Makefile
@@ -46,9 +46,6 @@ endif
 ifneq (,$(filter ipv6_ext_rh,$(USEMODULE)))
   DIRS += net/network_layer/ipv6/ext/rh
 endif
-ifneq (,$(filter ipv6_ext,$(USEMODULE)))
-  DIRS += net/network_layer/ipv6/ext
-endif
 ifneq (,$(filter ipv6_hdr,$(USEMODULE)))
   DIRS += net/network_layer/ipv6/hdr
 endif

--- a/sys/Makefile
+++ b/sys/Makefile
@@ -43,9 +43,6 @@ endif
 ifneq (,$(filter ipv6_addr,$(USEMODULE)))
   DIRS += net/network_layer/ipv6/addr
 endif
-ifneq (,$(filter ipv6_ext_rh,$(USEMODULE)))
-  DIRS += net/network_layer/ipv6/ext/rh
-endif
 ifneq (,$(filter ipv6_hdr,$(USEMODULE)))
   DIRS += net/network_layer/ipv6/hdr
 endif

--- a/sys/include/net/gnrc/ipv6/ext.h
+++ b/sys/include/net/gnrc/ipv6/ext.h
@@ -31,6 +31,10 @@
 #include "net/gnrc/pkt.h"
 #include "net/ipv6/ext.h"
 
+#ifdef MODULE_GNRC_IPV6_EXT_RH
+#include "net/gnrc/ipv6/ext/rh.h"
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/sys/include/net/gnrc/ipv6/ext/rh.h
+++ b/sys/include/net/gnrc/ipv6/ext/rh.h
@@ -37,7 +37,7 @@ enum {
      * @brief   The routing header was successfully processed and this node
      *          is the destination (i.e. ipv6_ext_rh_t::seg_left == 0)
      */
-    GNRC_IPV6_EXT_RH_OK,
+    GNRC_IPV6_EXT_RH_AT_DST,
     /**
      * @brief   The routing header was successfully processed and the packet
      *          was forwarded to another node or should be forwarded to another
@@ -59,7 +59,7 @@ enum {
  * @param[in, out] ipv6     An IPv6 packet.
  * @param[in] ext           A routing header of @p ipv6.
  *
- * @return  @ref GNRC_IPV6_EXT_RH_OK, on success
+ * @return  @ref GNRC_IPV6_EXT_RH_AT_DST, on success
  * @return  @ref GNRC_IPV6_EXT_RH_FORWARDED, when @p pkt was forwarded
  * @return  @ref GNRC_IPV6_EXT_RH_ERROR, on error
  */

--- a/sys/include/net/gnrc/ipv6/ext/rh.h
+++ b/sys/include/net/gnrc/ipv6/ext/rh.h
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2018 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    net_gnrc_ipv6_ext_rh Support for IPv6 routing header extension
+ * @ingroup     net_gnrc_ipv6_ext
+ * @brief       GNRC implementation of IPv6 routing header extension.
+ * @{
+ *
+ * @file
+ * @brief   GNRC routing extension header definitions.
+ *
+ * @author  Martine Lenders <m.lenders@fu-berlin.de>
+ */
+#ifndef NET_GNRC_IPV6_EXT_RH_H
+#define NET_GNRC_IPV6_EXT_RH_H
+
+#include "net/ipv6/hdr.h"
+
+#include "net/ipv6/ext/rh.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+enum {
+    /**
+     * @brief   An error occurred during routing header processing
+     */
+    GNRC_IPV6_EXT_RH_ERROR = 0,
+    /**
+     * @brief   The routing header was successfully processed and this node
+     *          is the destination (i.e. ipv6_ext_rh_t::seg_left == 0)
+     */
+    GNRC_IPV6_EXT_RH_OK,
+    /**
+     * @brief   The routing header was successfully processed and the packet
+     *          was forwarded to another node or should be forwarded to another
+     *          node.
+     *
+     * When @ref gnrc_ipv6_ext_rh_process() returns this value, the packet was
+     * already forwarded to another node. Implementations for specific routing
+     * header types should leave the forwarding to the calling @ref
+     * gnrc_ipv6_ext_rh_process() and should return @ref
+     * GNRC_IPV6_EXT_RH_FORWARDED if they want the packet to be forwarded. They
+     * should however set ipv6_hdr_t::dst accordingly.
+     */
+    GNRC_IPV6_EXT_RH_FORWARDED,
+};
+
+/**
+ * @brief   Process the routing header of an IPv6 packet.
+ *
+ * @param[in, out] ipv6     An IPv6 packet.
+ * @param[in] ext           A routing header of @p ipv6.
+ *
+ * @return  @ref GNRC_IPV6_EXT_RH_OK, on success
+ * @return  @ref GNRC_IPV6_EXT_RH_FORWARDED, when @p pkt was forwarded
+ * @return  @ref GNRC_IPV6_EXT_RH_ERROR, on error
+ */
+int gnrc_ipv6_ext_rh_process(ipv6_hdr_t *ipv6, ipv6_ext_rh_t *ext);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* NET_GNRC_IPV6_EXT_RH_H */
+/** @} */

--- a/sys/include/net/gnrc/rpl/srh.h
+++ b/sys/include/net/gnrc/rpl/srh.h
@@ -60,9 +60,9 @@ typedef struct __attribute__((packed)) {
  * @param[in,out] ipv6  The IPv6 header of the incoming packet.
  * @param[in] rh        A RPL source routing header.
  *
- * @return  EXT_RH_CODE_ERROR
- * @return  EXT_RH_CODE_FORWARD
- * @return  EXT_RH_CODE_OK
+ * @return  @ref GNRC_IPV6_EXT_RH_OK, on success
+ * @return  @ref GNRC_IPV6_EXT_RH_FORWARDED, when @p pkt *should be* forwarded
+ * @return  @ref GNRC_IPV6_EXT_RH_ERROR, on error
  */
 int gnrc_rpl_srh_process(ipv6_hdr_t *ipv6, gnrc_rpl_srh_t *rh);
 

--- a/sys/include/net/gnrc/rpl/srh.h
+++ b/sys/include/net/gnrc/rpl/srh.h
@@ -60,7 +60,7 @@ typedef struct __attribute__((packed)) {
  * @param[in,out] ipv6  The IPv6 header of the incoming packet.
  * @param[in] rh        A RPL source routing header.
  *
- * @return  @ref GNRC_IPV6_EXT_RH_OK, on success
+ * @return  @ref GNRC_IPV6_EXT_RH_AT_DST, on success
  * @return  @ref GNRC_IPV6_EXT_RH_FORWARDED, when @p pkt *should be* forwarded
  * @return  @ref GNRC_IPV6_EXT_RH_ERROR, on error
  */

--- a/sys/include/net/ipv6/ext/rh.h
+++ b/sys/include/net/ipv6/ext/rh.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2015 Martine Lenders <mlenders@inf.fu-berlin.de>
+ * Copyright (C) 2015 Cenk Gündoğan <cnkgndgn@gmail.com>
+ * Copyright (C) 2018 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -9,13 +10,14 @@
 /**
  * @defgroup    net_ipv6_ext_rh IPv6 routing header extension
  * @ingroup     net_ipv6_ext
- * @brief       Implementation of IPv6 routing header extension.
+ * @brief       Definitions for IPv6 routing header extension.
  * @{
  *
  * @file
  * @brief   Routing extension header definitions.
  *
- * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
+ * @author  Cenk Gündoğan <cnkgndgn@gmail.com>
+ * @author  Martine Lenders <m.lenders@fu-berlin.de>
  */
 #ifndef NET_IPV6_EXT_RH_H
 #define NET_IPV6_EXT_RH_H
@@ -31,17 +33,6 @@ extern "C" {
 #endif
 
 /**
- * @name Return codes for routing header processing
- * @{
- */
-#define EXT_RH_CODE_ERROR       (-1)
-#define EXT_RH_CODE_FORWARD     (0)
-#define EXT_RH_CODE_OK          (1)
-/**
- * @}
- */
-
-/**
  * @brief   IPv6 routing extension header.
  *
  * @see [RFC 8200](https://tools.ietf.org/html/rfc8200#section-4.4)
@@ -54,18 +45,6 @@ typedef struct __attribute__((packed)) {
     uint8_t type;       /**< identifier of a particular routing header type */
     uint8_t seg_left;   /**< number of route segments remaining */
 } ipv6_ext_rh_t;
-
-/**
- * @brief   Process the routing header of an IPv6 packet.
- *
- * @param[in, out] ipv6     An IPv6 packet.
- * @param[in] ext           A routing header of @p ipv6.
- *
- * @return  EXT_RH_CODE_ERROR
- * @return  EXT_RH_CODE_FORWARD
- * @return  EXT_RH_CODE_OK
- */
-int ipv6_ext_rh_process(ipv6_hdr_t *ipv6, ipv6_ext_rh_t *ext);
 
 #ifdef __cplusplus
 }

--- a/sys/net/gnrc/Makefile
+++ b/sys/net/gnrc/Makefile
@@ -13,6 +13,9 @@ endif
 ifneq (,$(filter gnrc_ipv6_ext,$(USEMODULE)))
   DIRS += network_layer/ipv6/ext
 endif
+ifneq (,$(filter gnrc_ipv6_ext_rh,$(USEMODULE)))
+  DIRS += network_layer/ipv6/ext/rh
+endif
 ifneq (,$(filter gnrc_ipv6_hdr,$(USEMODULE)))
   DIRS += network_layer/ipv6/hdr
 endif

--- a/sys/net/gnrc/network_layer/ipv6/ext/gnrc_ipv6_ext.c
+++ b/sys/net/gnrc/network_layer/ipv6/ext/gnrc_ipv6_ext.c
@@ -79,7 +79,7 @@ static enum gnrc_ipv6_ext_demux_status _handle_rh(gnrc_pktsnip_t *current, gnrc_
             }
             return GNRC_IPV6_EXT_FORWARDED;
 
-        case GNRC_IPV6_EXT_RH_OK:
+        case GNRC_IPV6_EXT_RH_AT_DST:
             /* this should not happen since we checked seg_left early */
             gnrc_pktbuf_release(pkt);
             return GNRC_IPV6_EXT_ERROR;

--- a/sys/net/gnrc/network_layer/ipv6/ext/rh/Makefile
+++ b/sys/net/gnrc/network_layer/ipv6/ext/rh/Makefile
@@ -1,3 +1,3 @@
-MODULE = ipv6_ext_rh
+MODULE = gnrc_ipv6_ext_rh
 
 include $(RIOTBASE)/Makefile.base

--- a/sys/net/gnrc/network_layer/ipv6/ext/rh/gnrc_ipv6_ext_rh.c
+++ b/sys/net/gnrc/network_layer/ipv6/ext/rh/gnrc_ipv6_ext_rh.c
@@ -16,10 +16,10 @@
 
 #include "net/protnum.h"
 #include "net/ipv6/ext.h"
-#include "net/ipv6/ext/rh.h"
+#include "net/gnrc/ipv6/ext/rh.h"
 #include "net/gnrc/rpl/srh.h"
 
-int ipv6_ext_rh_process(ipv6_hdr_t *hdr, ipv6_ext_rh_t *ext)
+int gnrc_ipv6_ext_rh_process(ipv6_hdr_t *hdr, ipv6_ext_rh_t *ext)
 {
     (void) hdr;
 
@@ -32,7 +32,7 @@ int ipv6_ext_rh_process(ipv6_hdr_t *hdr, ipv6_ext_rh_t *ext)
         default:
             break;
     }
-    return EXT_RH_CODE_ERROR;
+    return GNRC_IPV6_EXT_RH_ERROR;
 }
 
 /** @} */

--- a/sys/net/gnrc/routing/rpl/srh/gnrc_rpl_srh.c
+++ b/sys/net/gnrc/routing/rpl/srh/gnrc_rpl_srh.c
@@ -29,7 +29,7 @@ static char addr_str[IPV6_ADDR_MAX_STR_LEN];
 int gnrc_rpl_srh_process(ipv6_hdr_t *ipv6, gnrc_rpl_srh_t *rh)
 {
     if (rh->seg_left == 0) {
-        return GNRC_IPV6_EXT_RH_OK;
+        return GNRC_IPV6_EXT_RH_AT_DST;
     }
 
     uint8_t n = (((rh->len * 8) - GNRC_RPL_SRH_PADDING(rh->pad_resv) -

--- a/sys/net/gnrc/routing/rpl/srh/gnrc_rpl_srh.c
+++ b/sys/net/gnrc/routing/rpl/srh/gnrc_rpl_srh.c
@@ -14,7 +14,7 @@
 
 #include <string.h>
 #include "net/gnrc/netif/internal.h"
-#include "net/ipv6/ext/rh.h"
+#include "net/gnrc/ipv6/ext/rh.h"
 #include "net/gnrc/rpl/srh.h"
 
 #define ENABLE_DEBUG    (0)
@@ -29,7 +29,7 @@ static char addr_str[IPV6_ADDR_MAX_STR_LEN];
 int gnrc_rpl_srh_process(ipv6_hdr_t *ipv6, gnrc_rpl_srh_t *rh)
 {
     if (rh->seg_left == 0) {
-        return EXT_RH_CODE_OK;
+        return GNRC_IPV6_EXT_RH_OK;
     }
 
     uint8_t n = (((rh->len * 8) - GNRC_RPL_SRH_PADDING(rh->pad_resv) -
@@ -45,7 +45,7 @@ int gnrc_rpl_srh_process(ipv6_hdr_t *ipv6, gnrc_rpl_srh_t *rh)
     if (rh->seg_left > n) {
         DEBUG("RPL SRH: number of segments left > number of addresses - discard\n");
         /* TODO ICMP Parameter Problem - Code 0 */
-        return EXT_RH_CODE_ERROR;
+        return GNRC_IPV6_EXT_RH_ERROR;
     }
 
     rh->seg_left--;
@@ -58,7 +58,7 @@ int gnrc_rpl_srh_process(ipv6_hdr_t *ipv6, gnrc_rpl_srh_t *rh)
     if (ipv6_addr_is_multicast(&ipv6->dst) || ipv6_addr_is_multicast(&addr)) {
         DEBUG("RPL SRH: found a multicast address - discard\n");
         /* TODO discard the packet */
-        return EXT_RH_CODE_ERROR;
+        return GNRC_IPV6_EXT_RH_ERROR;
     }
 
     /* check if multiple addresses of my interface exist */
@@ -75,7 +75,7 @@ int gnrc_rpl_srh_process(ipv6_hdr_t *ipv6, gnrc_rpl_srh_t *rh)
             if (found && ((k - found_pos) > 1)) {
                 DEBUG("RPL SRH: found multiple addresses that belong to me - discard\n");
                 /* TODO send an ICMP Parameter Problem (Code 0) and discard the packet */
-                return EXT_RH_CODE_ERROR;
+                return GNRC_IPV6_EXT_RH_ERROR;
             }
             found_pos = k;
             found = true;
@@ -89,7 +89,7 @@ int gnrc_rpl_srh_process(ipv6_hdr_t *ipv6, gnrc_rpl_srh_t *rh)
 
     ipv6->dst = addr;
 
-    return EXT_RH_CODE_FORWARD;
+    return GNRC_IPV6_EXT_RH_FORWARDED;
 }
 
 /** @} */

--- a/sys/net/network_layer/ipv6/ext/Makefile
+++ b/sys/net/network_layer/ipv6/ext/Makefile
@@ -1,3 +1,0 @@
-MODULE = ipv6_ext
-
-include $(RIOTBASE)/Makefile.base

--- a/tests/unittests/tests-rpl_srh/tests-rpl_srh.c
+++ b/tests/unittests/tests-rpl_srh/tests-rpl_srh.c
@@ -19,6 +19,7 @@
 #include "net/ipv6/ext.h"
 #include "net/ipv6/hdr.h"
 #include "net/gnrc/rpl/srh.h"
+#include "net/gnrc/ipv6/ext/rh.h"
 
 #include "unittests-constants.h"
 #include "tests-rpl_srh.h"
@@ -61,13 +62,13 @@ static void test_rpl_srh_nexthop_no_prefix_elided(void)
 
     /* first hop */
     res = gnrc_rpl_srh_process(&hdr, srh);
-    TEST_ASSERT_EQUAL_INT(res, EXT_RH_CODE_FORWARD);
+    TEST_ASSERT_EQUAL_INT(res, GNRC_IPV6_EXT_RH_FORWARDED);
     TEST_ASSERT_EQUAL_INT(SRH_SEG_LEFT - 1, srh->seg_left);
     TEST_ASSERT(ipv6_addr_equal(&hdr.dst, &expected1));
 
     /* second hop */
     res = gnrc_rpl_srh_process(&hdr, srh);
-    TEST_ASSERT_EQUAL_INT(res, EXT_RH_CODE_FORWARD);
+    TEST_ASSERT_EQUAL_INT(res, GNRC_IPV6_EXT_RH_FORWARDED);
     TEST_ASSERT_EQUAL_INT(SRH_SEG_LEFT - 2, srh->seg_left);
     TEST_ASSERT(ipv6_addr_equal(&hdr.dst, &expected2));
 }
@@ -94,13 +95,13 @@ static void test_rpl_srh_nexthop_prefix_elided(void)
 
     /* first hop */
     res = gnrc_rpl_srh_process(&hdr, srh);
-    TEST_ASSERT_EQUAL_INT(res, EXT_RH_CODE_FORWARD);
+    TEST_ASSERT_EQUAL_INT(res, GNRC_IPV6_EXT_RH_FORWARDED);
     TEST_ASSERT_EQUAL_INT(SRH_SEG_LEFT - 1, srh->seg_left);
     TEST_ASSERT(ipv6_addr_equal(&hdr.dst, &expected1));
 
     /* second hop */
     res = gnrc_rpl_srh_process(&hdr, srh);
-    TEST_ASSERT_EQUAL_INT(res, EXT_RH_CODE_FORWARD);
+    TEST_ASSERT_EQUAL_INT(res, GNRC_IPV6_EXT_RH_FORWARDED);
     TEST_ASSERT_EQUAL_INT(SRH_SEG_LEFT - 2, srh->seg_left);
     TEST_ASSERT(ipv6_addr_equal(&hdr.dst, &expected2));
 }


### PR DESCRIPTION
### Contribution description
This moves all implementation specific parts of the `ipv6_ext_rh` module to `gnrc_ipv6_ext_rh`.

It also removes a module that isn't used after this change and doesn't contain any code (but isn't a pseudo-module for some reason).

### Testing procedure
Try to compile `gnrc_networking` with `USEMODULE = gnrc_rpl_srh`. It should still work.

Also (at least when run without DEBUG) `tests/gnrc_ipv6_ext` should still work without crashing (I will rework them once the integration process progressed).

### Issues/PRs references
Addresses parts of #10133 

![PR dependencies](http://page.mi.fu-berlin.de/mlenders/ipv6_rework.svg)