### PR TITLE
 gnrc_ipv6: assume no preparsed packets

### DIFF
--- a/tests/gnrc_ipv6_ext/main.c
+++ b/tests/gnrc_ipv6_ext/main.c
@@ -161,119 +161,12 @@ static void _send_packet_raw(void)
     assert(pkt->users == 0);
 }
 
-static void _send_packet_parsed(void)
-{
-    gnrc_netif_t *iface = gnrc_netif_iter(NULL);
-
-    gnrc_netif_hdr_t netif_hdr;
-
-    gnrc_netif_hdr_init(&netif_hdr, 8, 8);
-
-    netif_hdr.if_pid = iface->pid;
-
-    uint8_t ipv6_data[] = {
-        /* IPv6 Header */
-        0x60, 0x00, 0x00, 0x00, /* version, traffic class, flow label */
-        0x00, 0x2a,             /* payload length: 42 */
-        0x00,                   /* next header: Hop-by-Hop Option */
-        0x10,                   /* hop limit: 16 */
-        /* source address: fd01::1 */
-        0xfd, 0x01, 0x00, 0x00,
-        0x00, 0x00, 0x00, 0x00,
-        0x00, 0x00, 0x00, 0x00,
-        0x00, 0x00, 0x00, 0x01,
-        /* destination address: fd01::2 */
-        0xfd, 0x01, 0x00, 0x00,
-        0x00, 0x00, 0x00, 0x00,
-        0x00, 0x00, 0x00, 0x00,
-        0x00, 0x00, 0x00, 0x02,
-    };
-
-    uint8_t hop_by_hop_options_data[] = {
-        /* Hop-by-Hop Options Header */
-        /* https://tools.ietf.org/html/rfc6553 */
-        0x2b,       /* next header: IPv6-Route */
-        0x00,       /* hdr ext len: 0 * 8 + 8 = 8 */
-        0x63,       /* option type: RPL Option */
-        0x04,       /* opt data len: 4 */
-        0x80,       /* flags, Down: 1, Rank-Error: 0, Forwarding-Error: 0 */
-        0x00,       /* RPLInstanceID */
-        0x80, 0x00, /* SenderRank */
-    };
-
-    uint8_t rpl_routing_data[] = {
-        /* RPL Routing Header */
-        /* https://tools.ietf.org/html/rfc6554 */
-        0x11,               /* next header: UDP */
-        0x02,               /* hdr ext len: 2 * 8 + 8 = 24 */
-        0x03,               /* routing type: SRH */
-        0x02,               /* segments left: 2 */
-        0xef,               /* ComprI: 14, ComprE: 15 */
-        0xd0, 0x00, 0x00,   /* pad and reserved */
-        /* address: fd01::3, fd01::2 */
-        0x00, 0x03, 0x02, 0x00,
-        0x00, 0x00, 0x00, 0x00,
-        0x00, 0x00, 0x00, 0x00,
-        0x00, 0x00, 0x00, 0x00,
-    };
-
-    uint8_t udp_data[] = {
-        /* UDP (ignored) */
-        0x1f, 0x90, /* source port: 8080 */
-        0x1f, 0x90, /* destination port: 8080 */
-        0x00, 0x0a, /* length: 10 */
-        0xff, 0xff, /* checksum */
-    };
-
-    uint8_t udp_payload[] = {
-        0x00, 0x00,
-    };
-
-    gnrc_pktsnip_t *netif =
-        gnrc_pktbuf_add(NULL,
-                        &netif_hdr,
-                        sizeof(netif_hdr),
-                        GNRC_NETTYPE_NETIF);
-    gnrc_pktsnip_t *ipv6 =
-        gnrc_pktbuf_add(netif,
-                        &ipv6_data,
-                        sizeof(ipv6_data),
-                        GNRC_NETTYPE_IPV6);
-    gnrc_pktsnip_t *hop_by_hop_options =
-        gnrc_pktbuf_add(ipv6,
-                        &hop_by_hop_options_data,
-                        sizeof(hop_by_hop_options_data),
-                        GNRC_NETTYPE_IPV6_EXT);
-    gnrc_pktsnip_t *rpl_routing =
-        gnrc_pktbuf_add(hop_by_hop_options,
-                        &rpl_routing_data,
-                        sizeof(rpl_routing_data),
-                        GNRC_NETTYPE_IPV6_EXT);
-    gnrc_pktsnip_t *udp =
-        gnrc_pktbuf_add(rpl_routing,
-                        udp_data,
-                        sizeof(udp_data),
-                        GNRC_NETTYPE_UDP);
-    gnrc_pktsnip_t *pkt =
-        gnrc_pktbuf_add(udp,
-                        &udp_payload,
-                        sizeof(udp_payload),
-                        GNRC_NETTYPE_UNDEF);
-
-    gnrc_netapi_dispatch_receive(GNRC_NETTYPE_IPV6, GNRC_NETREG_DEMUX_CTX_ALL, pkt);
-
-    printf("pkt->users: %d\n", pkt->users);
-    assert(pkt->users == 0);
-}
-
-
 int main(void)
 {
     puts("RIOT network stack example application");
 
     _init_interface();
     _send_packet_raw();
-    _send_packet_parsed();
 
     /* should be never reached */
     return 0;

--- a/tests/gnrc_ipv6_ext/tests/01-run.py
+++ b/tests/gnrc_ipv6_ext/tests/01-run.py
@@ -12,29 +12,6 @@ from testrunner import run
 
 
 def testfunc(child):
-    index = child.expect_exact([
-        "ipv6: Received (src = fd01::1, dst = fd01::2, next header = 0, length = 42)",
-        "pkt->users: 0"
-    ])
-
-    if index == 1:
-        # debug is disabled
-        child.expect_exact("pkt->users: 0")
-        return
-
-    child.expect_exact("ipv6: handle extension header (nh = 0)")
-    child.expect_exact("ipv6: Received (src = fd01::1, dst = fd01::3, next header = 0, length = 42)")
-    child.expect_exact("ipv6: handle extension header (nh = 0)")
-    child.expect_exact("ipv6: Received (src = fd01::1, dst = fd01::2, next header = 0, length = 42)")
-    child.expect_exact("ipv6: handle extension header (nh = 0)")
-    child.expect_exact("ipv6: forward nh = 17 to other threads")
-    child.expect_exact("pkt->users: 0")
-    child.expect_exact("ipv6: handle extension header (nh = 0)")
-    child.expect_exact("ipv6: Received (src = fd01::1, dst = fd01::3, next header = 0, length = 42)")
-    child.expect_exact("ipv6: handle extension header (nh = 0)")
-    child.expect_exact("ipv6: Received (src = fd01::1, dst = fd01::2, next header = 0, length = 42)")
-    child.expect_exact("ipv6: handle extension header (nh = 0)")
-    child.expect_exact("ipv6: forward nh = 17 to other threads")
     child.expect_exact("pkt->users: 0")
 
 


### PR DESCRIPTION
### Contribution description
As stated in #10229, with #9484 and #10229 we don't have to assume anymore that an IPv6 packet was preparsed before it is handed to IPv6's receive routine. This allows us to remove a whole chunk of code.
Further simplifications not related to finding the IPv6 header in a preparsed packet will follow later.

### Testing procedure
Compile `gnrc_networking` for a IEEE802.15.4-equipped board of your choice and flash. Try to send IPHC-compressed UDP packets and fragmented packets. All should be received and handled correctly. Here is what I did to test (on `iotlab-m3`:

```
m3-9;ping6 fe80::1711:6b10:65f8:a83a
1540324618.692019;m3-9;> ping6 fe80::1711:6b10:65f8:a83a
1540324618.700864;m3-9;12 bytes from fe80::1711:6b10:65f8:a83a: id=83 seq=1 hop limit=64 time = 6.087 ms
1540324619.710639;m3-9;12 bytes from fe80::1711:6b10:65f8:a83a: id=83 seq=2 hop limit=64 time = 7.367 ms
1540324620.716881;m3-9;12 bytes from fe80::1711:6b10:65f8:a83a: id=83 seq=3 hop limit=64 time = 4.820 ms
1540324620.717727;m3-9;--- fe80::1711:6b10:65f8:a83a ping statistics ---
1540324620.718661;m3-9;3 packets transmitted, 3 received, 0% packet loss, time 2.0623902 s
1540324620.719706;m3-9;rtt min/avg/max = 4.820/6.091/7.367 ms
m3-16;udp server start 61616
1540324626.987787;m3-16;> udp server start 61616
1540324626.988009;m3-16;Success: started UDP server on port 61616
m3-9;udp send fe80::1711:6b10:65f8:a83a 61616 "Hello World"                                                                                                                          
1540324643.437245;m3-9;> udp send fe80::1711:6b10:65f8:a83a 61616 "Hello World"
1540324643.439125;m3-9;Success: sent 11 byte(s) to [fe80::1711:6b10:65f8:a83a]:61616
1540324643.443109;m3-16;> PKTDUMP: data received:
1540324643.443296;m3-16;~~ SNIP  0 - size:  11 byte, type: NETTYPE_UNDEF (0)
1540324643.443430;m3-16;00000000  48  65  6C  6C  6F  20  57  6F  72  6C  64
1540324643.444055;m3-16;~~ SNIP  1 - size:   8 byte, type: NETTYPE_UDP (4)
1540324643.444646;m3-16;   src-port: 61616  dst-port: 61616
1540324643.445563;m3-16;   length: 19  cksum: 0xcd02
1540324643.446555;m3-16;~~ SNIP  2 - size:  40 byte, type: NETTYPE_IPV6 (2)
1540324643.447535;m3-16;traffic class: 0x00 (ECN: 0x0, DSCP: 0x00)
1540324643.447722;m3-16;flow label: 0x00000
1540324643.448541;m3-16;length: 19  next header: 17  hop limit: 64
1540324643.449528;m3-16;source address: fe80::1711:6b10:65fb:8a22
1540324643.450545;m3-16;destination address: fe80::1711:6b10:65f8:a83a
1540324643.451547;m3-16;~~ SNIP  3 - size:  24 byte, type: NETTYPE_NETIF (-1)
1540324643.452530;m3-16;if_pid: 7  rssi: -61  lqi: 255
1540324643.453067;m3-16;flags: 0x0
1540324643.453629;m3-16;src_l2addr: 15:11:6B:10:65:FB:8A:22
1540324643.454545;m3-16;dst_l2addr: 15:11:6B:10:65:F8:A8:3A
1540324643.455523;m3-16;~~ PKT    -  4 snips, total size:  83 byte
m3-9;ping6 fe80::1711:6b10:65f8:a83a 512
1540324664.883888;m3-9;> ping6 fe80::1711:6b10:65f8:a83a 512
1540324664.950310;m3-9;520 bytes from fe80::1711:6b10:65f8:a83a: id=84 seq=1 hop limit=64 time = 62.718 ms
1540324666.022960;m3-9;520 bytes from fe80::1711:6b10:65f8:a83a: id=84 seq=2 hop limit=64 time = 71.836 ms
1540324667.093857;m3-9;520 bytes from fe80::1711:6b10:65f8:a83a: id=84 seq=3 hop limit=64 time = 68.880 ms
1540324667.094768;m3-9;--- fe80::1711:6b10:65f8:a83a ping statistics ---
1540324667.095403;m3-9;3 packets transmitted, 3 received, 0% packet loss, time 2.06209628 s
1540324667.096432;m3-9;rtt min/avg/max = 62.718/67.811/71.836 ms
```

Also repeat testing proceedures from #10229.

### Issues/PRs references
Depends on ~~#10229 (and its dependencies)~~ (merged).

![PR dependencies](http://page.mi.fu-berlin.de/mlenders/ipv6_rework.svg)