### PR TITLE
 gnrc_ipv6: move ipv6_ext iteration out of ext_demux()

### DIFF
--- a/sys/include/net/gnrc/ipv6.h
+++ b/sys/include/net/gnrc/ipv6.h
@@ -128,32 +128,6 @@ extern fib_table_t gnrc_ipv6_fib_table;
 kernel_pid_t gnrc_ipv6_init(void);
 
 /**
- * @brief   Demultiplexes a packet according to @p nh.
- *
- * @internal
- *
- * **Do not use outside this module or its submodules!!!**
- * Public access needed for Extension Headers.
- *
- * About `current` and `pkt`:
- *
- *                     current     pkt
- *                     |           |
- *                     v           v
- * IPv6 <- IPv6_EXT <- IPv6_EXT <- UNDEF
- *
- * This situation may happen when the packet has a source routing extension
- * header (RFC 6554), and the packet is forwarded from an interface to another.
- *
- * @param[in] netif     The receiving interface.
- * @param[in] current   A snip to process.
- * @param[in] pkt       A packet.
- * @param[in] nh        A protocol number (see @ref net_protnum) of the current snip.
- */
-void gnrc_ipv6_demux(gnrc_netif_t *netif, gnrc_pktsnip_t *current,
-                     gnrc_pktsnip_t *pkt, uint8_t nh);
-
-/**
  * @brief   Get the IPv6 header from a given list of @ref gnrc_pktsnip_t
  *
  *          This function may be used with e.g. a pointer to a (full) UDP datagram.

--- a/sys/include/net/gnrc/ipv6/ext.h
+++ b/sys/include/net/gnrc/ipv6/ext.h
@@ -27,7 +27,6 @@
 #include <stdint.h>
 #include <stdlib.h>
 
-#include "net/gnrc/netif.h"
 #include "net/gnrc/pkt.h"
 #include "net/ipv6/ext.h"
 
@@ -40,29 +39,17 @@ extern "C" {
 #endif
 
 /**
- * @brief   Demultiplex extension headers according to @p nh.
+ * @brief   Demultiplex an extension header according to @p nh.
  *
- * About `current` and `pkt`:
+ * @param[in] pkt       A packet with the first snip pointing to the extension
+ *                      header to process.
+ * @param[in] nh        Protocol number of @p pkt.
  *
- *                     current     pkt
- *                     |           |
- *                     v           v
- * IPv6 <- IPv6_EXT <- IPv6_EXT <- UNDEF
- *
- * This situation may happen when the packet has a source routing extension
- * header (RFC 6554), and the packet is forwarded from an interface to another.
- *
- * @internal
- *
- * @param[in] netif     The receiving interface.
- * @param[in] current   A snip to process.
- * @param[in] pkt       A packet.
- * @param[in] nh        A protocol number (see @ref net_protnum) of the current snip.
+ * @return  The packet for further processing.
+ * @return  NULL, on error or if packet was consumed (by e.g. forwarding via
+ *          a routing header). @p pkt is released in case of error.
  */
-void gnrc_ipv6_ext_demux(gnrc_netif_t *netif,
-                         gnrc_pktsnip_t *current,
-                         gnrc_pktsnip_t *pkt,
-                         uint8_t nh);
+gnrc_pktsnip_t *gnrc_ipv6_ext_demux(gnrc_pktsnip_t *pkt, unsigned nh);
 
 /**
  * @brief   Builds an extension header for sending.

--- a/sys/include/net/gnrc/pktbuf.h
+++ b/sys/include/net/gnrc/pktbuf.h
@@ -286,8 +286,8 @@ gnrc_pktsnip_t *gnrc_pktbuf_reverse_snips(gnrc_pktsnip_t *pkt);
  *        The original snip is keeped as is except `users` decremented.
  *
  * @deprecated  This function breaks the abstraction of `gnrc_pktbuf` and its
- *              only user within the RIOT code base `gnrc_ipv6_ext` is going to
- *              be reworked so it isn't needed anymore.
+ *              only user within the RIOT code base `gnrc_ipv6_ext` was reworked
+ *              so it isn't needed anymore.
  *              It will be removed after the 2019.04 release.
  *
  * @param[in,out] pkt   The snip to duplicate.

--- a/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
+++ b/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
@@ -93,8 +93,8 @@ kernel_pid_t gnrc_ipv6_init(void)
 static void _dispatch_next_header(gnrc_pktsnip_t *current, gnrc_pktsnip_t *pkt,
                                   uint8_t nh, bool interested);
 
-void gnrc_ipv6_demux(gnrc_netif_t *netif, gnrc_pktsnip_t *current,
-                     gnrc_pktsnip_t *pkt, uint8_t nh)
+static void _demux(gnrc_netif_t *netif, gnrc_pktsnip_t *current,
+                   gnrc_pktsnip_t *pkt, uint8_t nh)
 {
     bool interested;
 
@@ -848,8 +848,7 @@ static void _receive(gnrc_pktsnip_t *pkt)
 #endif /* MODULE_GNRC_IPV6_ROUTER */
     }
 
-    /* IPv6 internal demuxing (ICMPv6, Extension headers etc.) */
-    gnrc_ipv6_demux(netif, pkt, pkt, hdr->nh);
+    _demux(netif, pkt, pkt, hdr->nh);
 }
 
 /** @} */

--- a/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
+++ b/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
@@ -165,12 +165,12 @@ ipv6_hdr_t *gnrc_ipv6_get_header(gnrc_pktsnip_t *pkt)
 static void _dispatch_next_header(gnrc_pktsnip_t *pkt, unsigned nh,
                                   bool interested)
 {
-    const bool should_release = (gnrc_netreg_num(GNRC_NETTYPE_IPV6, nh) == 0) &&
-                                (!interested);
+    const bool has_nh_subs = (gnrc_netreg_num(GNRC_NETTYPE_IPV6, nh) > 0) ||
+                             interested;
 
     DEBUG("ipv6: forward nh = %u to other threads\n", nh);
 
-    if (!should_release) {
+    if (has_nh_subs) {
         gnrc_pktbuf_hold(pkt, 1);   /* don't remove from packet buffer in
                                      * next dispatch */
     }
@@ -179,7 +179,7 @@ static void _dispatch_next_header(gnrc_pktsnip_t *pkt, unsigned nh,
                                      pkt) == 0) {
         gnrc_pktbuf_release(pkt);
     }
-    if (should_release) {
+    if (!has_nh_subs) {
         /* we should exit early. pkt was already released above */
         return;
     }


### PR DESCRIPTION
### Contribution description
Since with #10233 we now assume IPv6 packets always to not be pre-parsed, we can iterate over the extension headers by gradually "eating" them away. This allows us to move the iteration over them out of `gnrc_ipv6_ext_demux()` and into `gnrc_ipv6_demux()`.

By moving the iteration over all extension headers out of `gnrc_ipv6_ext_demux()` we also can

1. simplify the extension header handling a lot, as it now just a loop inside `gnrc_ipv6_demux()`,
2. remove the recursion to `gnrc_ipv6_demux()` within `gnrc_ipv6_ext_demux()`.
3. some cleanup, possible due to all the things above.

I also piggy-backed some follow-up work that are related to demuxing and the fact that they are not pre-parsed:

* since they are not preparsed, we don't haved to specifically write-protect all the extension headers up to the IPv6 packet, as the whole (un-parsed) packet was already write protected when first received.
* since the `gnrc_ipv6_ext` doesn't recurse into `gnrc_ipv6_demux()` anymore, that function can be made private again.

### Testing procedure
I used [`scapy`](https://scapy.net/) to inject packets with and without extension headers into a `native` instance of `gnrc_networking`:

On RIOT:
```
udp server start 1337
````

Within `scapy` (be aware that to send Ethernet frames, root privileges are required, so best start it with `sudo scapy`):

```py
DST_ADDR = "fe80::ac4e:aeff:fec0:caab" # use your RIOT node's address here instead
# first send a simple UDP packet to test if the server is working
sendp(Ether() / 
      IPv6(dst=DST_ADDR) /
      UDP(sport=1339, dport=1337) /
      "\x00\x01", iface="tapbr0")
# now send some extension headers (we assume they all are not parsed)
sendp(Ether() /
      IPv6(dst=DST_ADDR) /
      IPv6ExtHdrDestOpt() /
      UDP(sport=1339, dport=1337) /
      "\x00\x01", iface="tapbr0")
sendp(Ether() /
      IPv6(dst=DST_ADDR) /
      IPv6ExtHdrRouting() /
      UDP(sport=1339, dport=1337) /
      "\x00\x01", iface="tapbr0")
# ...
```

You can find some documentation on IPv6 extension headers in [this document](https://www.idsv6.de/Downloads/IPv6PacketCreationWithScapy.pdf)

You can also just redo the testing procedures in #10229.

### Issues/PRs references
Depends on #10233 (and its dependencies)

![PR dependencies](http://page.mi.fu-berlin.de/mlenders/ipv6_rework.svg)
