### PR TITLE
makefiles/buildtests.inc.mk: fix 'clean-intermediates' not cleaning

### DIFF
--- a/makefiles/buildtests.inc.mk
+++ b/makefiles/buildtests.inc.mk
@@ -20,7 +20,7 @@ buildtest:
 				$(COLOR_ECHO) "$(COLOR_RED)failed!$(COLOR_RESET)" ; \
 				RESULT=false ; \
 			fi ; \
-			$(MAKE) clean-intermediates >/dev/null 2>&1 || true; \
+			BOARD=$${board} $(MAKE) clean-intermediates >/dev/null 2>&1 || true; \
 		fi; \
 	done ; \
 	$${RESULT}


### PR DESCRIPTION
### Contribution description

`clean-intermediates` should be done per board. Without this it only
tries to clean the default board.

This is a split of https://github.com/RIOT-OS/RIOT/pull/9831 as the original problem mentioned there was different than I thought and unrelated to this fix only.


### Testing procedure

Run buildtest in any example without bin at the beginning. Check the bin directory after, only the not intermediates files should be kept:
(it should not be run with variables set from the command line either it triggers another bug!)

```
rm -rf examples/hello-world/bin && \
  BOARDS="iotlab-m3 samr21-xpro" make --no-print-directory -C examples/hello-world/ buildtest && \
  ls examples/hello-world/bin/*
```

With this PR, we only have the `iotlab-m3` and `samr21-xpro` outputs
```
Building for iotlab-m3 ... success.
Building for samr21-xpro ... success.
examples/hello-world/bin/iotlab-m3:
hello-world.elf  hello-world.hex  hello-world.map

examples/hello-world/bin/samr21-xpro:
hello-world.bin  hello-world.elf  hello-world.map
```

With master we have

```
Building for iotlab-m3 ... success.
Building for samr21-xpro ... success.
examples/hello-world/bin/iotlab-m3:
application_hello-world    auto_init.a  boards_common_iotlab    core.a            cortexm_common_periph    cpu.a      hello-world.elf  isrpipe                  newlib_syscalls_default.a  periph_common    pm_layered.a  stdio_uart.a    stm32_common_periph    sys.a
application_hello-world.a  board        boards_common_iotlab.a  cortexm_common    cortexm_common_periph.a  drivers    hello-world.hex  isrpipe.a                periph                     periph_common.a  riotbuild     stm32_common    stm32_common_periph.a  tsrb
auto_init                  board.a      core                    cortexm_common.a  cpu                      drivers.a  hello-world.map  newlib_syscalls_default  periph.a                   pm_layered       stdio_uart    stm32_common.a  sys                    tsrb.a

examples/hello-world/bin/native:

examples/hello-world/bin/samr21-xpro:
application_hello-world    auto_init.a  core            cortexm_common.a         cpu      drivers.a        hello-world.map  newlib_syscalls_default    periph.a         pm_layered    sam0_common         sam0_common_periph.a  sys    tsrb.a
application_hello-world.a  board        core.a          cortexm_common_periph    cpu.a    hello-world.bin  isrpipe          newlib_syscalls_default.a  periph_common    pm_layered.a  sam0_common.a       stdio_uart            sys.a
auto_init                  board.a      cortexm_common  cortexm_common_periph.a  drivers  hello-world.elf  isrpipe.a        periph                     periph_common.a  riotbuild     sam0_common_periph  stdio_uart.a          tsrb
```

### Issues/PRs references

Split out of https://github.com/RIOT-OS/RIOT/pull/9831 and found while working on https://github.com/RIOT-OS/RIOT/issues/9742