### PR TITLE
travis.yml: Use lesscpy from pip.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 dist: trusty
 
 before_install:
-  - sudo apt-get install coreutils realpath doxygen graphviz python-lesscpy cppcheck coccinelle pcregrep python3-pip
-  - sudo pip3 install flake8
+  - sudo apt-get install coreutils realpath doxygen graphviz cppcheck coccinelle pcregrep python3-pip
+  - sudo pip3 install flake8 lesscpy
 
 script:
   - make static-test


### PR DESCRIPTION
### Contribution description

The version of lesscpy in Ubuntu 14 (in travis) is super outdated and causes `make docs` to fail.

lesscpy is used to generate riot.css from riot.less (the rule is only enabled if the tool is found on the system)


### Testing procedure

Use #9819 (it has a test script rebased on top of this PR)
