### PR TITLE
gnrc_ipv6_ext: merge _handle_rh and gnrc_ipv6_ext_rh_process

### DIFF
--- a/sys/include/net/gnrc/ipv6/ext/rh.h
+++ b/sys/include/net/gnrc/ipv6/ext/rh.h
@@ -20,9 +20,7 @@
 #ifndef NET_GNRC_IPV6_EXT_RH_H
 #define NET_GNRC_IPV6_EXT_RH_H
 
-#include "net/ipv6/hdr.h"
-
-#include "net/ipv6/ext/rh.h"
+#include "net/gnrc/pkt.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -56,14 +54,14 @@ enum {
 /**
  * @brief   Process the routing header of an IPv6 packet.
  *
- * @param[in, out] ipv6     An IPv6 packet.
- * @param[in] ext           A routing header of @p ipv6.
+ * @param[in] pkt   An IPv6 packet containing the routing header in the first
+ *                  snip
  *
  * @return  @ref GNRC_IPV6_EXT_RH_AT_DST, on success
  * @return  @ref GNRC_IPV6_EXT_RH_FORWARDED, when @p pkt was forwarded
  * @return  @ref GNRC_IPV6_EXT_RH_ERROR, on error
  */
-int gnrc_ipv6_ext_rh_process(ipv6_hdr_t *ipv6, ipv6_ext_rh_t *ext);
+int gnrc_ipv6_ext_rh_process(gnrc_pktsnip_t *pkt);
 
 #ifdef __cplusplus
 }

--- a/sys/net/gnrc/network_layer/ipv6/ext/rh/gnrc_ipv6_ext_rh.c
+++ b/sys/net/gnrc/network_layer/ipv6/ext/rh/gnrc_ipv6_ext_rh.c
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2015 Martine Lenders <mlenders@inf.fu-berlin.de>
+ * Copyright (C) 2015 Cenk Gündoğan <cenk.guendogan@fu-berlin.de>
+ * Copyright (C) 2018 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -10,29 +11,90 @@
  * @{
  *
  * @file
+ * @author Cenk Gündoğan <cenk.guendogan@fu-berlin.de>
+ * @author Martine Lenders <m.lenders@fu-berlin.de>
  */
 
-#include <stdbool.h>
+#include "net/ipv6/ext/rh.h"
+#include "net/gnrc.h"
 
-#include "net/protnum.h"
-#include "net/ipv6/ext.h"
-#include "net/gnrc/ipv6/ext/rh.h"
+#ifdef MODULE_GNRC_RPL_SRH
 #include "net/gnrc/rpl/srh.h"
+#endif
 
-int gnrc_ipv6_ext_rh_process(ipv6_hdr_t *hdr, ipv6_ext_rh_t *ext)
+#include "net/gnrc/ipv6/ext/rh.h"
+
+#define ENABLE_DEBUG    (0)
+#include "debug.h"
+
+/* unchecked precondition: hdr is gnrc_pktsnip_t::data of the
+ * GNRC_NETTYPE_IPV6 snip within pkt */
+static void _forward_pkt(gnrc_pktsnip_t *pkt, ipv6_hdr_t *hdr)
 {
-    (void) hdr;
+    gnrc_pktsnip_t *netif_snip;
 
+    if (--(hdr->hl) == 0) {
+        DEBUG("ipv6_ext_rh: hop limit reached 0: drop packet\n");
+        gnrc_pktbuf_release(pkt);
+        return;
+    }
+    /* remove L2 headers around IPV6 */
+    netif_snip = gnrc_pktsnip_search_type(pkt, GNRC_NETTYPE_NETIF);
+    if (netif_snip != NULL) {
+        pkt = gnrc_pktbuf_remove_snip(pkt, netif_snip);
+    }
+    /* reverse packet into send order */
+    pkt = gnrc_pktbuf_reverse_snips(pkt);
+    if (pkt == NULL) {
+        DEBUG("ipv6_ext_rh: can't reverse snip order in packet");
+        /* gnrc_pktbuf_reverse_snips() releases pkt on error */
+        return;
+    }
+    /* forward packet */
+    if (!gnrc_netapi_dispatch_send(GNRC_NETTYPE_IPV6,
+                                   GNRC_NETREG_DEMUX_CTX_ALL,
+                                   pkt)) {
+        DEBUG("ipv6_ext_rh: could not dispatch packet to the IPv6 "
+              "thread\n");
+        gnrc_pktbuf_release(pkt);
+    }
+}
+
+int gnrc_ipv6_ext_rh_process(gnrc_pktsnip_t *pkt)
+{
+    gnrc_pktsnip_t *ipv6;
+    ipv6_ext_rh_t *ext = pkt->data;
+    ipv6_hdr_t *hdr;
+    int res = GNRC_IPV6_EXT_RH_AT_DST;
+
+    /* check seg_left early to avoid duplicating the packet */
+    if (ext->seg_left == 0) {
+        return res;
+    }
+    ipv6 = gnrc_pktsnip_search_type(pkt, GNRC_NETTYPE_IPV6);
+    assert(ipv6 != NULL);
+    hdr = ipv6->data;
     switch (ext->type) {
 #ifdef MODULE_GNRC_RPL_SRH
         case IPV6_EXT_RH_TYPE_RPL_SRH:
-            return gnrc_rpl_srh_process(hdr, (gnrc_rpl_srh_t *)ext);
+            res = gnrc_rpl_srh_process(hdr, (gnrc_rpl_srh_t *)ext);
+            break;
 #endif
-
         default:
+            res = GNRC_IPV6_EXT_RH_ERROR;
             break;
     }
-    return GNRC_IPV6_EXT_RH_ERROR;
+    switch (res) {
+        case GNRC_IPV6_EXT_RH_FORWARDED:
+            _forward_pkt(pkt, hdr);
+            break;
+        case GNRC_IPV6_EXT_RH_AT_DST:
+            break;
+        default:
+            gnrc_pktbuf_release(pkt);
+            break;
+    }
+    return res;
 }
 
 /** @} */


### PR DESCRIPTION
### Contribution description
It makes much more sense (and saves us a huge ifdef), when `_handle_rh` and `gnrc_ipv6_ext_rh` are merged into one function.

### Testing procedure
I used scapy again for testing (see testing procedure in #10234).

### Issues/PRs references
Depends on ~~#10231~~ (merged) and ~~#10234 (and its dependencies)~~ (merged).

![PR dependencies](http://page.mi.fu-berlin.de/mlenders/ipv6_rework.svg)
