### PR TITLE
Make lessc mandatory

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,8 @@
 dist: trusty
 
 before_install:
-  - sudo apt-get install coreutils realpath doxygen graphviz python-lesscpy cppcheck coccinelle pcregrep python3-pip
-  - sudo pip3 install flake8
+  - sudo apt-get install coreutils realpath doxygen graphviz cppcheck coccinelle pcregrep python3-pip
+  - sudo pip3 install flake8 lesscpy
 
 script:
   - make static-test

--- a/doc/doxygen/Makefile
+++ b/doc/doxygen/Makefile
@@ -7,13 +7,13 @@ export STRIP_FROM_INC_PATH_LIST=$(shell \
 
 # use lessc (http://lesscss.org/#using-less) for compiling CSS, alternatively
 # fall back to lesscpy (https://github.com/lesscpy/lesscpy)
-ifeq (,$(LESSC))
-  ifneq (,$(shell command -v lessc 2>/dev/null))
-    LESSC=lessc
-  else ifneq (,$(shell command -v lesscpy 2>/dev/null))
-    LESSC=lesscpy
-  endif
+ifneq (,$(shell command -v lessc 2>/dev/null))
+  LESSC_DEFAULT=lessc
+else ifneq (,$(shell command -v lesscpy 2>/dev/null))
+  LESSC_DEFAULT=lesscpy
 endif
+
+LESSC ?= $(LESSC_DEFAULT)
 
 .PHONY: doc
 doc: html
@@ -27,14 +27,12 @@ html: src/css/riot.css src/changelog.md
 man: src/changelog.md
 	( cat riot.doxyfile ; echo "GENERATE_MAN = yes" ) | doxygen -
 
-ifneq (,$(LESSC))
 src/css/riot.css: src/css/riot.less src/css/variables.less
 	@$(LESSC) $< $@
 
 src/css/variables.less: src/config.json
 	@grep "^\s*\"@" $< | sed -e 's/^\s*"//g' -e 's/":\s*"/: /g' \
 	  -e 's/",\?$$/;/g' -e 's/\\"/"/g' > $@
-endif
 
 src/changelog.md: src/changelog.md.tmp ../../release-notes.txt
 	@./generate-changelog.py $+ $@

--- a/doc/doxygen/src/css/riot.css
+++ b/doc/doxygen/src/css/riot.css
@@ -1,9 +1,3 @@
-/*
- * riot.css
- * Copyright (C) 2017 Freie Universität Berlin
- *
- * Distributed under terms of the LGPLv2.1 license (see LICENSE file).
- */
 table,
 div,
 p,
@@ -18,7 +12,7 @@ dl {
 }
 .navbar-inverse {
   border-radius: 0px;
-  border-bottom: 3px #1a1a1a solid;
+  border-bottom: 3px #1a1a1a  solid;
 }
 .nav-tabs-regs {
   margin-top: 1px;
@@ -53,7 +47,7 @@ dl {
 }
 #MSearchField {
   background: #000000;
-  border: #eeeeee solid 1px;
+  border: #eeeeee  solid 1px;
   color: #ffffff;
   display: inline;
   font: 14px "Helvetica Neue", Helvetica, Arial, sans-serif;
@@ -114,8 +108,8 @@ div.toc-sm {
   background-color: #f5f5f5;
   border: 1px solid #e3e3e3;
   border-radius: 4px;
-  -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.05);
-  box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.05);
+  -webkit-box-shadow: inset 0 1px 1px rgba(0,0,0,0.05);
+  box-shadow: inset 0 1px 1px rgba(0,0,0,0.05);
 }
 div.toc {
   padding: 19px;
@@ -157,7 +151,7 @@ h3.glow,
 h4.glow,
 h5.glow,
 h6.glow {
-  text-shadow: 0 0 15px #cce6c7;
+  text-shadow: 0 0 15px #cce6c6;
 }
 h2.groupheader {
   border-color: #eeeeee;
@@ -195,7 +189,7 @@ div.fragment {
   display: block;
   font-family: Menlo, Monaco, Consolas, "Courier New", monospace;
   font-size: 14px;
-  line-height: 1.42857143;
+  line-height: 1.428571429;
   margin: 0 0 10px;
   padding: 10px;
   overflow: visible;
@@ -205,8 +199,8 @@ div.fragment {
 }
 div.line.glow {
   background-color: #d8eed8;
-  box-shadow: 0 0 10px #cce6c7;
-  -webkit-box-shadow: 0 0 15px #cce6c7;
+  box-shadow: 0 0 10px #cce6c6;
+  -webkit-box-shadow: 0 0 15px #cce6c6;
 }
 span.lineno {
   background-color: transparent;
@@ -256,8 +250,8 @@ table.directory {
 .memberdecls td.glow,
 .fieldtable tr.glow {
   background-color: #d8eed8;
-  box-shadow: 0 0 15px #cce6c7;
-  -webkit-box-shadow: 0 0 15px #cce6c7;
+  box-shadow: 0 0 15px #cce6c6;
+  -webkit-box-shadow: 0 0 15px #cce6c6;
 }
 .mdescLeft,
 .mdescRight,
@@ -293,8 +287,8 @@ table.directory {
   border-radius: 4px;
 }
 .memitem.glow {
-  box-shadow: 0 0 15px #cce6c7;
-  -webkit-box-shadow: 0 0 15px #cce6c7;
+  box-shadow: 0 0 15px #cce6c6;
+  -webkit-box-shadow: 0 0 15px #cce6c6;
 }
 .memdoc,
 dl.reflist > dd {
@@ -326,7 +320,6 @@ dl.reflist > dt {
   background: #f5f5f5;
   text-shadow: none;
 }
-/* @group Code Colorization */
 a.code {
   color: #3fa687;
 }
@@ -372,8 +365,8 @@ dl.warning {
   border-left: 0px;
   border: 1px solid transparent;
   border-radius: 4px;
-  -webkit-box-shadow: 0 1px 1px rgba(0, 0, 0, 0.05);
-  box-shadow: 0 1px 1px rgba(0, 0, 0, 0.05);
+  -webkit-box-shadow: 0 1px 1px rgba(0,0,0,0.05);
+  box-shadow: 0 1px 1px rgba(0,0,0,0.05);
 }
 dl.attention > dd,
 dl.deprecated > dd,
@@ -404,7 +397,7 @@ dl.warning > dt {
 }
 dl.attention,
 dl.warning {
-  border-color: #f6ccd6;
+  border-color: #f6ccd7;
 }
 dl.attention > dt,
 dl.warning > dt {
@@ -413,7 +406,7 @@ dl.warning > dt {
   border-color: #bd202c;
 }
 dl.bug {
-  border-color: #fce9db;
+  border-color: #fce7db;
 }
 dl.bug a,
 dl.bug a:visited {
@@ -455,17 +448,17 @@ dl.see > dt {
 dl.post,
 dl.pre,
 dl.invariant {
-  border-color: #cce6c7;
+  border-color: #cce6c6;
 }
 dl.post > dt,
 dl.pre > dt,
 dl.invariant > dt {
   color: #5cb85c;
   background-color: #d8eed8;
-  border-color: #cce6c7;
+  border-color: #cce6c6;
 }
 dl.test {
-  border-color: #d2e2f6;
+  border-color: #d2e1f6;
 }
 dl.test a,
 dl.test a:visited {
@@ -477,10 +470,10 @@ dl.test a:hover {
 dl.test > dt {
   color: #5b7ede;
   background-color: #f0f3fc;
-  border-color: #d2e2f6;
+  border-color: #d2e1f6;
 }
 dl.todo {
-  border-color: #d2f4f6;
+  border-color: #d2f3f6;
 }
 dl.todo a,
 dl.todo a:visited {
@@ -492,7 +485,7 @@ dl.todo a:hover {
 dl.todo > dt {
   color: #5bc0de;
   background-color: #f0f9fc;
-  border-color: #d2f4f6;
+  border-color: #d2f3f6;
 }
 #powerTip div {
   font-family: "Helvetica Neue", Helvetica, Arial, sans-serif;


### PR DESCRIPTION
### Contribution description

The riot.css can be generated by the lessc tool from riot.less, but it is also tracked by git. If the user dows not have the tool, the docs makefile automatically decides not to rebuild it.

The two options to fix this are:

1. Remove the rule to make riot.css, make that step manual.
2. Remove the file and make the step for creating it required.

Since lesscpy (the python version of the tool) is super-easy to install this commit implements (2). This also ensures that everyone always sees the same version of riot.css.

### Testing procedure

Install `lesscpy` from PIP and run `make docs`. The docs should be built fine.

### Issues/PRs references

Depends on #10237 so that travis does not fail.
I don't know if Murdock has lesscpy.

**Replaced by #10249**