### PR TITLE
makefile.iotlab.single.inc.mk: add new IoT-LAB supported nodes

### DIFF
--- a/dist/testbed-support/makefile.iotlab.single.inc.mk
+++ b/dist/testbed-support/makefile.iotlab.single.inc.mk
@@ -67,9 +67,12 @@ IOTLAB_NODE_AUTO_NUM ?= 1
 # board-archi mapping
 IOTLAB_ARCHI_arduino-zero   = arduino-zero:xbee
 IOTLAB_ARCHI_b-l072z-lrwan1 = st-lrwan1:sx1276
+IOTLAB_ARCHI_b-l475e-iot01a = st-iotnode:multi
 IOTLAB_ARCHI_iotlab-a8-m3   = a8:at86rf231
 IOTLAB_ARCHI_iotlab-m3      = m3:at86rf231
+IOTLAB_ARCHI_nrf52dk        = nrf52dk:ble
 IOTLAB_ARCHI_samr21-xpro    = samr21:at86rf233
+IOTLAB_ARCHI_samr30-xpro    = samr30:at86rf215
 IOTLAB_ARCHI_wsn430-v1_3b   = wsn430:cc1101
 IOTLAB_ARCHI_wsn430-v1_4    = wsn430:cc2420
 IOTLAB_ARCHI := $(IOTLAB_ARCHI_$(BOARD))

--- a/dist/testbed-support/makefile.iotlab.single.inc.mk
+++ b/dist/testbed-support/makefile.iotlab.single.inc.mk
@@ -65,13 +65,13 @@ _IOTLAB_EXP_ID := $(if $(IOTLAB_EXP_ID),--id $(IOTLAB_EXP_ID))
 IOTLAB_NODE_AUTO_NUM ?= 1
 
 # board-archi mapping
-IOTLAB_ARCHI_iotlab-m3      = m3:at86rf231
-IOTLAB_ARCHI_iotlab-a8-m3   = a8:at86rf231
-IOTLAB_ARCHI_wsn430-v1_3b   = wsn430:cc1101
-IOTLAB_ARCHI_wsn430-v1_4    = wsn430:cc2420
-IOTLAB_ARCHI_samr21-xpro    = samr21:at86rf233
 IOTLAB_ARCHI_arduino-zero   = arduino-zero:xbee
 IOTLAB_ARCHI_b-l072z-lrwan1 = st-lrwan1:sx1276
+IOTLAB_ARCHI_iotlab-a8-m3   = a8:at86rf231
+IOTLAB_ARCHI_iotlab-m3      = m3:at86rf231
+IOTLAB_ARCHI_samr21-xpro    = samr21:at86rf233
+IOTLAB_ARCHI_wsn430-v1_3b   = wsn430:cc1101
+IOTLAB_ARCHI_wsn430-v1_4    = wsn430:cc2420
 IOTLAB_ARCHI := $(IOTLAB_ARCHI_$(BOARD))
 
 # Try detecting the node automatically


### PR DESCRIPTION
### Contribution description

Support for `nrf52dk` and `samr30-xpro` has been added on saclay site.

I also sorted the definition order.

@aabadie tell me if I should add other architectures here

This should help testing the release if it can be merged before the release

### Testing procedure

Test using `IOTLAB_NODE=auto-ssh` while having an experiment on IoT-LAB with an `nrf52dk` and a `samr30`.

It should automatically find the node of your experiment

```
IOTLAB_NODE=auto-ssh make -C examples/default/ all flash term BOARD=nrf52dk
# flashes and run 'term'
```

(I cannot reflash after flashing `tests/unittests` but that looks like an IoT-LAB issue).

### Issues/PRs references

No reference, just used it to test https://github.com/RIOT-OS/RIOT/pull/10201