### PR TITLE
 gnrc_ipv6_ext_rh: add ICMPv6 error message sending

### DIFF
--- a/sys/include/net/gnrc/rpl/srh.h
+++ b/sys/include/net/gnrc/rpl/srh.h
@@ -56,14 +56,18 @@ typedef struct __attribute__((packed)) {
  *      common among all routing headers, so it should be handled by an
  *      external routing header handler.
  *
- * @param[in,out] ipv6  The IPv6 header of the incoming packet.
+ * @param[in, out] ipv6 The IPv6 header of the incoming packet.
  * @param[in] rh        A RPL source routing header.
+ * @param[out] err_ptr  A pointer to an erroneous octet within @p rh when
+ *                      return value is @ref GNRC_IPV6_EXT_RH_ERROR. For any
+ *                      other return value than @ref GNRC_IPV6_EXT_RH_ERROR the
+ *                      value of `err_ptr` is not defined.
  *
  * @return  @ref GNRC_IPV6_EXT_RH_AT_DST, on success
  * @return  @ref GNRC_IPV6_EXT_RH_FORWARDED, when @p pkt *should be* forwarded
  * @return  @ref GNRC_IPV6_EXT_RH_ERROR, on error
  */
-int gnrc_rpl_srh_process(ipv6_hdr_t *ipv6, gnrc_rpl_srh_t *rh);
+int gnrc_rpl_srh_process(ipv6_hdr_t *ipv6, gnrc_rpl_srh_t *rh, void **err_ptr);
 
 #ifdef __cplusplus
 }

--- a/sys/net/gnrc/routing/rpl/srh/gnrc_rpl_srh.c
+++ b/sys/net/gnrc/routing/rpl/srh/gnrc_rpl_srh.c
@@ -31,10 +31,10 @@ static char addr_str[IPV6_ADDR_MAX_STR_LEN];
 
 /* checks if multiple addresses within the source routing header exist on my
  * interfaces */
-static bool _contains_multiple_of_my_addr(const ipv6_addr_t *dst,
-                                          const gnrc_rpl_srh_t *rh,
-                                          unsigned num_addr,
-                                          unsigned compri_addr_len)
+static void *_contains_multiple_of_my_addr(const ipv6_addr_t *dst,
+                                           const gnrc_rpl_srh_t *rh,
+                                           unsigned num_addr,
+                                           unsigned compri_addr_len)
 {
     ipv6_addr_t addr;
     uint8_t *addr_vec = (uint8_t *) (rh + 1);
@@ -45,30 +45,30 @@ static bool _contains_multiple_of_my_addr(const ipv6_addr_t *dst,
 
     memcpy(&addr, dst, pref_elided);
     for (unsigned i = 0; i < num_addr; i++) {
+        uint8_t *addr_vec_ptr = &addr_vec[i * compri_addr_len];
+
         if (i == num_addr - 1) {
             pref_elided = GNRC_RPL_SRH_COMPRE(rh->compr);
             addr_len = sizeof(ipv6_addr_t) - pref_elided;
         }
-        memcpy(&addr.u8[pref_elided], &addr_vec[i * compri_addr_len], addr_len);
+        memcpy(&addr.u8[pref_elided], addr_vec_ptr, addr_len);
         if (gnrc_netif_get_by_ipv6_addr(&addr) != NULL) {
             if (found && ((i - found_pos) > 1)) {
                 DEBUG("RPL SRH: found multiple addresses that belong to me - "
                       "discard\n");
-                /* TODO send an ICMP Parameter Problem (Code 0) and
-                 * discard the packet */
-                return true;
+                return addr_vec_ptr;
             }
             found_pos = i;
             found = true;
         }
     }
-    return false;
+    return NULL;
 }
 
-int gnrc_rpl_srh_process(ipv6_hdr_t *ipv6, gnrc_rpl_srh_t *rh)
+int gnrc_rpl_srh_process(ipv6_hdr_t *ipv6, gnrc_rpl_srh_t *rh, void **err_ptr)
 {
     ipv6_addr_t addr;
-    uint8_t *addr_vec = (uint8_t *) (rh + 1);
+    uint8_t *addr_vec = (uint8_t *) (rh + 1), *current_address;
     uint8_t num_addr;
     uint8_t current_pos, pref_elided, addr_len, compri_addr_len;
     const uint8_t new_seg_left = rh->seg_left - 1;
@@ -83,7 +83,7 @@ int gnrc_rpl_srh_process(ipv6_hdr_t *ipv6, gnrc_rpl_srh_t *rh)
     if (rh->seg_left > num_addr) {
         DEBUG("RPL SRH: number of segments left > number of addresses - "
               "discard\n");
-        /* TODO ICMP Parameter Problem - Code 0 */
+        *err_ptr = &rh->seg_left;
         return GNRC_IPV6_EXT_RH_ERROR;
     }
 
@@ -94,24 +94,27 @@ int gnrc_rpl_srh_process(ipv6_hdr_t *ipv6, gnrc_rpl_srh_t *rh)
     compri_addr_len = sizeof(ipv6_addr_t) - GNRC_RPL_SRH_COMPRI(rh->compr);
     addr_len = sizeof(ipv6_addr_t) - pref_elided;
     memcpy(&addr, &ipv6->dst, pref_elided);
-    memcpy(&addr.u8[pref_elided],
-           &addr_vec[(current_pos - 1) * compri_addr_len],
-           addr_len);
+    current_address = &addr_vec[(current_pos - 1) * compri_addr_len];
+    memcpy(&addr.u8[pref_elided], current_address, addr_len);
 
-    if (ipv6_addr_is_multicast(&ipv6->dst) || ipv6_addr_is_multicast(&addr)) {
-        DEBUG("RPL SRH: found a multicast address - discard\n");
-        /* TODO discard the packet */
+    if (ipv6_addr_is_multicast(&ipv6->dst)) {
+        DEBUG("RPL SRH: found a multicast destination address - discard\n");
+        *err_ptr = &ipv6->dst;
+        return GNRC_IPV6_EXT_RH_ERROR;
+    }
+    if (ipv6_addr_is_multicast(&addr)) {
+        DEBUG("RPL SRH: found a multicast addres in next address - discard\n");
+        *err_ptr = current_address;
         return GNRC_IPV6_EXT_RH_ERROR;
     }
 
     /* check if multiple addresses of my interface exist */
-    if (_contains_multiple_of_my_addr(&ipv6->dst, rh, num_addr,
-                                      compri_addr_len)) {
+    if ((*err_ptr = _contains_multiple_of_my_addr(&ipv6->dst, rh, num_addr,
+                                                  compri_addr_len))) {
         return GNRC_IPV6_EXT_RH_ERROR;
     }
     rh->seg_left = new_seg_left;
-    memcpy(&addr_vec[(current_pos - 1) * compri_addr_len],
-           &ipv6->dst.u8[pref_elided], addr_len);
+    memcpy(current_address, &ipv6->dst.u8[pref_elided], addr_len);
 
     DEBUG("RPL SRH: Next hop: %s at position %d\n",
           ipv6_addr_to_str(addr_str, &addr, sizeof(addr_str)), current_pos);


### PR DESCRIPTION
### Contribution description
This adds ICMPv6 error messages to the routing header handling of GNRC.

### Testing procedure
Again, I used scapy to inject several broken RPL source routing headers packets (see testing procedure in #10234):

```
sendp(Ether() /
      IPv6(dst=DST_ADDR) /
      IPv6ExtHdrRouting(type=3, segleft=1))
sendp(Ether() /
      IPv6(dst=DST_ADDR) /
      IPv6ExtHdrRouting())
```

### Issues/PRs references
Depends on ~~#8594~~ (merged), ~~#10227, and #10238 (and their dependencies).~~ merged

Accompanies https://github.com/RIOT-OS/RIOT/pull/8594 but isn't dependent on it (though that one fixes a lot of issues in `gnrc_icmpv6_error`.

![PR dependencies](http://page.mi.fu-berlin.de/mlenders/ipv6_rework.svg)