### PR TITLE
 gnrc_ipv6: handle hop-by-hop option before forwarding

### DIFF
--- a/sys/include/net/gnrc/ipv6/ext.h
+++ b/sys/include/net/gnrc/ipv6/ext.h
@@ -66,6 +66,33 @@ gnrc_pktsnip_t *gnrc_ipv6_ext_demux(gnrc_pktsnip_t *pkt, unsigned nh);
 gnrc_pktsnip_t *gnrc_ipv6_ext_build(gnrc_pktsnip_t *ipv6, gnrc_pktsnip_t *next,
                                     uint8_t nh, size_t size);
 
+#if     defined(MODULE_GNRC_IPV6_EXT) || defined(DOXYGEN)
+/**
+ * @brief   Processes a packet's extension headers.
+ *
+ * @param[in] pkt       An IPv6 packet in receive order.
+ * @param[in,out] nh    **In:** The @ref net_protnum of gnrc_pktsnip_t::data of
+ *                      @p pkt (i.e. the first extension header to be
+ *                      processed). <br />
+ *                      **Out:** The @ref net_protnum of header in
+ *                      gnrc_pktsnip_t::data of @p pkt. The extension headers
+ *                      are now marked, so their data can be found in
+ *                      gnrc_pktsnip_t::next of @p pkt and the following. <br />
+ *                      If the return value is NULL, the value of @p nh is
+ *                      undefined.
+ *
+ * @return  @p pkt with all extension headers marked until the first
+ *          non-extension header.
+ * @return  NULL, if packet was consumed by the extension header handling.
+ * @return  NULL, on error. @p pkt is released with EINVAL in that case.
+ */
+gnrc_pktsnip_t *gnrc_ipv6_ext_process_all(gnrc_pktsnip_t *pkt,
+                                          uint8_t *nh);
+#else   /* defined(MODULE_GNRC_IPV6_EXT) || defined(DOXYGEN) */
+/* NOPs to make the usage code more readable */
+#define gnrc_ipv6_ext_process_all(pkt, first_nh)    (pkt);
+#endif  /* defined(MODULE_GNRC_IPV6_EXT) || defined(DOXYGEN) */
+
 #ifdef __cplusplus
 }
 #endif

--- a/sys/include/net/gnrc/ipv6/ext.h
+++ b/sys/include/net/gnrc/ipv6/ext.h
@@ -55,36 +55,38 @@ gnrc_pktsnip_t *gnrc_ipv6_ext_build(gnrc_pktsnip_t *ipv6, gnrc_pktsnip_t *next,
 
 #if     defined(MODULE_GNRC_IPV6_EXT) || defined(DOXYGEN)
 /**
- * @brief   Processes a packet's payload as hop-by-hop option if @p nh is
+ * @brief   Processes a packet's payload as hop-by-hop option if @p protnum is
  *          pointing to a value equal to @ref PROTNUM_IPV6_EXT_HOPOPT.
  *
  * @note    Should be called by @ref net_gnrc_ipv6 before any further processing
  *          (even forwarding-related) is done to @p pkt.
  *
- * @param[in] pkt       An IPv6 packet in receive order. It assumed that
- *                      gnrc_pktsnip_t::data points to a hop-by-hop option when
- *                      @p nh points to value equal to
- *                      @ref PROTNUM_IPV6_EXT_HOPOPT.
- * @param[in,out] nh    **In:** The @ref net_protnum of gnrc_pktsnip_t::data of
- *                      @p pkt. <br />
- *                      **Out:** If @p nh was @ref PROTNUM_IPV6_EXT_HOPOPT on in
- *                      and the return value is not NULL it points to the value
- *                      of the next header field of the processed hop-by-hop
- *                      option header. Since the hop-by-hop option header is now
- *                      marked, gnrc_pktsnip_t::data of @p pkt will then be
- *                      identified by @p nh. <br />
- *                      If @p nh was @ref PROTNUM_IPV6_EXT_HOPOPT on in and the
- *                      return value is NULL the value @p nh is pointing to is
- *                      undefined. <br />
- *                      If @p nh unequal to @ref PROTNUM_IPV6_EXT_HOPOPT on in
- *                      the value @p nh is pointing to remains unchanged.
+ * @param[in] pkt           An IPv6 packet in receive order. It assumed that
+ *                          gnrc_pktsnip_t::data points to a hop-by-hop option
+ *                          when @p protnum points to value equal to
+ *                          @ref PROTNUM_IPV6_EXT_HOPOPT.
+ * @param[in,out] protnum   **In:** The @ref net_protnum of gnrc_pktsnip_t::data
+ *                          of @p pkt. <br />
+ *                          **Out:** If @p protnum was
+ *                          @ref PROTNUM_IPV6_EXT_HOPOPT on in and the return
+ *                          value is not NULL it points to the value of the next
+ *                          header field of the processed hop-by-hop option
+ *                          header. Since the hop-by-hop option header is now
+ *                          marked, gnrc_pktsnip_t::data of @p pkt will then be
+ *                          identified by @p protnum. <br />
+ *                          If @p protnum was @ref PROTNUM_IPV6_EXT_HOPOPT on in
+ *                          and the return value is NULL the value @p protnum is
+ *                          pointing to is undefined. <br />
+ *                          If @p protnum unequal to
+ *                          @ref PROTNUM_IPV6_EXT_HOPOPT on in the value
+ *                          @p protnum is pointing to remains unchanged.
  *
  * @return  @p pkt with the hop-by-hop option marked on success.
  * @return  NULL, if the packet was consumed by the option handling.
  * @return  NULL, on error. @p pkt is released with EINVAL in that case.
  */
 gnrc_pktsnip_t *gnrc_ipv6_ext_process_hopopt(gnrc_pktsnip_t *pkt,
-                                             uint8_t *nh);
+                                             uint8_t *protnum);
 
 /**
  * @brief   Processes a packet's extension headers after a potential initial
@@ -96,16 +98,17 @@ gnrc_pktsnip_t *gnrc_ipv6_ext_process_hopopt(gnrc_pktsnip_t *pkt,
  *          in gnrc_pktsnip_t::data of @p pkt, the function will return an
  *          error.
  *
- * @param[in] pkt       An IPv6 packet in receive order.
- * @param[in,out] nh    **In:** The @ref net_protnum of gnrc_pktsnip_t::data of
- *                      @p pkt (i.e. the first extension header to be
- *                      processed). <br />
- *                      **Out:** The @ref net_protnum of header in
- *                      gnrc_pktsnip_t::data of @p pkt. The extension headers
- *                      are now marked, so their data can be found in
- *                      gnrc_pktsnip_t::next of @p pkt and the following. <br />
- *                      If the return value is NULL, the value of @p nh is
- *                      undefined.
+ * @param[in] pkt           An IPv6 packet in receive order.
+ * @param[in,out] protnum   **In:** The @ref net_protnum of gnrc_pktsnip_t::data
+ *                          of @p pkt (i.e. the first extension header to be
+ *                          processed). <br />
+ *                          **Out:** The @ref net_protnum of header in
+ *                          gnrc_pktsnip_t::data of @p pkt. The extension
+ *                          headers are now marked, so their data can be found
+ *                          in gnrc_pktsnip_t::next of @p pkt and the following.
+ *                          <br />
+ *                          If the return value is NULL, the value of @p protnum
+ *                          is undefined.
  *
  * @return  @p pkt with all extension headers marked until the first
  *          non-extension header.
@@ -114,11 +117,11 @@ gnrc_pktsnip_t *gnrc_ipv6_ext_process_hopopt(gnrc_pktsnip_t *pkt,
  *          hop-by-hop option). @p pkt is released with EINVAL in that case.
  */
 gnrc_pktsnip_t *gnrc_ipv6_ext_process_all(gnrc_pktsnip_t *pkt,
-                                          uint8_t *nh);
+                                          uint8_t *protnum);
 #else   /* defined(MODULE_GNRC_IPV6_EXT) || defined(DOXYGEN) */
 /* NOPs to make the usage code more readable */
-#define gnrc_ipv6_ext_process_hopopt(pkt, nh)   (pkt);
-#define gnrc_ipv6_ext_process_all(pkt, nh)      (pkt);
+#define gnrc_ipv6_ext_process_hopopt(pkt, protnum)  (pkt)
+#define gnrc_ipv6_ext_process_all(pkt, protnum)     (pkt)
 #endif  /* defined(MODULE_GNRC_IPV6_EXT) || defined(DOXYGEN) */
 
 #ifdef __cplusplus

--- a/sys/include/net/gnrc/ipv6/ext.h
+++ b/sys/include/net/gnrc/ipv6/ext.h
@@ -39,22 +39,6 @@ extern "C" {
 #endif
 
 /**
- * @brief   Demultiplex an extension header according to @p nh.
- *
- * This includes dispatching it to interested parties in the
- * @ref net_gnrc_netreg.
- *
- * @param[in] pkt       A packet with the first snip pointing to the extension
- *                      header to process.
- * @param[in] nh        Protocol number of @p pkt.
- *
- * @return  The packet for further processing.
- * @return  NULL, on error or if packet was consumed (by e.g. forwarding via
- *          a routing header). @p pkt is released in case of error.
- */
-gnrc_pktsnip_t *gnrc_ipv6_ext_demux(gnrc_pktsnip_t *pkt, unsigned nh);
-
-/**
  * @brief   Builds an extension header for sending.
  *
  * @param[in] ipv6  The IPv6 header. Can be NULL.

--- a/sys/include/net/gnrc/ipv6/ext.h
+++ b/sys/include/net/gnrc/ipv6/ext.h
@@ -41,6 +41,9 @@ extern "C" {
 /**
  * @brief   Demultiplex an extension header according to @p nh.
  *
+ * This includes dispatching it to interested parties in the
+ * @ref net_gnrc_netreg.
+ *
  * @param[in] pkt       A packet with the first snip pointing to the extension
  *                      header to process.
  * @param[in] nh        Protocol number of @p pkt.

--- a/sys/net/gnrc/network_layer/ipv6/ext/gnrc_ipv6_ext.c
+++ b/sys/net/gnrc/network_layer/ipv6/ext/gnrc_ipv6_ext.c
@@ -150,7 +150,7 @@ static inline bool _has_valid_size(gnrc_pktsnip_t *pkt, uint8_t nh)
 
 gnrc_pktsnip_t *gnrc_ipv6_ext_demux(gnrc_pktsnip_t *pkt, unsigned nh)
 {
-    DEBUG("ipv6_ext: next header = %u", nh);
+    DEBUG("ipv6_ext: next header = %u\n", nh);
     if (!_has_valid_size(pkt, nh)) {
         DEBUG("ipv6_ext: invalid size\n");
         gnrc_pktbuf_release(pkt);

--- a/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
+++ b/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
@@ -732,6 +732,14 @@ static void _receive(gnrc_pktsnip_t *pkt)
           ipv6_addr_to_str(addr_str, &(hdr->dst), sizeof(addr_str)),
           first_nh, byteorder_ntohs(hdr->len));
 
+    if ((pkt = gnrc_ipv6_ext_process_hopopt(pkt, &first_nh)) != NULL) {
+        ipv6 = pkt->next->next;
+    }
+    else {
+        DEBUG("ipv6: packet's extension header was errorneous or packet was "
+              "consumed due to it\n");
+        return;
+    }
     if (_pkt_not_for_me(&netif, hdr)) { /* if packet is not for me */
         DEBUG("ipv6: packet destination not this host\n");
 


### PR DESCRIPTION
### Contribution description
Hop-by-hop options need to be handled separately, as they [are required to be handled hop-by-hop](https://tools.ietf.org/html/rfc7045#section-2.2), as the name implies. Now after weeks of rework, we are now finally able to do this cleanly within `gnrc_ipv6`.


### Testing procedure
Since there is no proper hop-by-hop option support yet, I repeated my tests from #10234, but also tested with duplicate Hop-by-hop header, as this is an error case now, as per [RFC 8200](https://tools.ietf.org/html/rfc8200#section-4.1) and activated DEBUG output to verify that it is indeed handled as an error.

### Issues/PRs references
Depends on ~~#8594~~ (merged) and ~~#10234 (and its dependencies)~~ (merged).

![PR dependencies](http://page.mi.fu-berlin.de/mlenders/ipv6_rework.svg)