### PR TITLE
ipv6_ext_rh: define type numbers at central place

### DIFF
--- a/sys/include/net/gnrc/rpl/srh.h
+++ b/sys/include/net/gnrc/rpl/srh.h
@@ -31,11 +31,6 @@ extern "C" {
 #endif
 
 /**
- * @brief   Type for source routing header.
- */
-#define GNRC_RPL_SRH_TYPE   (3U)
-
-/**
  * @brief   The RPL Source routing header.
  *
  * @see <a href="https://tools.ietf.org/html/rfc6554">

--- a/sys/include/net/ipv6/ext/rh.h
+++ b/sys/include/net/ipv6/ext/rh.h
@@ -33,6 +33,34 @@ extern "C" {
 #endif
 
 /**
+ * @name Routing header types
+ * @see [IANA, IPv6 parameters](https://www.iana.org/assignments/ipv6-parameters/ipv6-parameters.xhtml#ipv6-parameters-3)
+ * @{
+ */
+/**
+ * @brief   Type 0 routing header (deprecated)
+ */
+#define IPV6_EXT_RH_TYPE_0          (0U)
+
+/**
+ * @brief   Nimrod routing header (deprecated)
+ */
+#define IPV6_EXT_RH_TYPE_NIMROD     (1U)
+
+/**
+ * @brief   Type 2 routing header
+ * @see     [RFC 6275, section 6.4](https://tools.ietf.org/html/rfc6275#section-6.4)
+ */
+#define IPV6_EXT_RH_TYPE_2          (2U)
+
+/**
+ * @brief   RPL source routing header
+ * @see     [RFC 6554](https://tools.ietf.org/html/rfc6554)
+ */
+#define IPV6_EXT_RH_TYPE_RPL_SRH    (3U)
+/** @} */
+
+/**
  * @brief   IPv6 routing extension header.
  *
  * @see [RFC 8200](https://tools.ietf.org/html/rfc8200#section-4.4)

--- a/sys/net/gnrc/network_layer/ipv6/ext/rh/gnrc_ipv6_ext_rh.c
+++ b/sys/net/gnrc/network_layer/ipv6/ext/rh/gnrc_ipv6_ext_rh.c
@@ -25,7 +25,7 @@ int gnrc_ipv6_ext_rh_process(ipv6_hdr_t *hdr, ipv6_ext_rh_t *ext)
 
     switch (ext->type) {
 #ifdef MODULE_GNRC_RPL_SRH
-        case GNRC_RPL_SRH_TYPE:
+        case IPV6_EXT_RH_TYPE_RPL_SRH:
             return gnrc_rpl_srh_process(hdr, (gnrc_rpl_srh_t *)ext);
 #endif
 


### PR DESCRIPTION
### Contribution description
This moves the type numbers for routing headers to a central place, as
we did it with other IANA-registered numbers.

### Testing procedure
Compile `gnrc_networking` with `gnrc_rpl_srh` and `gnrc_ipv6_ext` and see if it still compiles.

### Issues/PRs references
None, but related to the IPv6 refactoring project

![PR dependencies](http://page.mi.fu-berlin.de/mlenders/ipv6_rework.svg)
