### PR TITLE
net/nanocoap: make data pointer c++ compliant

### DIFF
--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -211,7 +211,6 @@ typedef struct __attribute__((packed)) {
     uint8_t ver_t_tkl;          /**< version, token, token length           */
     uint8_t code;               /**< CoAP code (e.g.m 205)                  */
     uint16_t id;                /**< Req/resp ID                            */
-    uint8_t data[];             /**< convenience pointer to payload start   */
 } coap_hdr_t;
 
 /**

--- a/sys/include/net/nanocoap.h
+++ b/sys/include/net/nanocoap.h
@@ -952,6 +952,18 @@ static inline unsigned coap_get_id(coap_pkt_t *pkt)
 }
 
 /**
+ * @brief   Get the start of data after the header
+ *
+ * @param[in]   hdr   Header of CoAP packet in contiguous memory
+ *
+ * @returns     pointer to first byte after the header
+ */
+static inline uint8_t *coap_hdr_data_ptr(coap_hdr_t *hdr)
+{
+    return ((uint8_t *)hdr) + sizeof(coap_hdr_t);
+}
+
+/**
  * @brief   Get the total header length (4-byte header + token length)
  *
  * @param[in]   pkt   CoAP packet

--- a/sys/net/application_layer/gcoap/gcoap.c
+++ b/sys/net/application_layer/gcoap/gcoap.c
@@ -476,7 +476,7 @@ static void _find_req_memo(gcoap_request_memo_t **memo_ptr, coap_pkt_t *src_pdu,
         }
 
         if (coap_get_token_len(memo_pdu) == cmplen) {
-            memo_pdu->token = &memo_pdu->hdr->data[0];
+            memo_pdu->token = coap_hdr_data_ptr(memo_pdu->hdr);
             if ((memcmp(src_pdu->token, memo_pdu->token, cmplen) == 0)
                     && sock_udp_ep_equal(&memo->remote_ep, remote)) {
                 *memo_ptr = memo;

--- a/sys/net/application_layer/nanocoap/nanocoap.c
+++ b/sys/net/application_layer/nanocoap/nanocoap.c
@@ -62,7 +62,7 @@ int coap_parse(coap_pkt_t *pkt, uint8_t *buf, size_t len)
     coap_hdr_t *hdr = (coap_hdr_t *)buf;
     pkt->hdr = hdr;
 
-    uint8_t *pkt_pos = hdr->data;
+    uint8_t *pkt_pos = coap_hdr_data_ptr(hdr);
     uint8_t *pkt_end = buf + len;
 
     pkt->payload = NULL;
@@ -402,7 +402,7 @@ ssize_t coap_build_hdr(coap_hdr_t *hdr, unsigned type, uint8_t *token, size_t to
     hdr->id = htons(id);
 
     if (token_len) {
-        memcpy(hdr->data, token, token_len);
+        memcpy(coap_hdr_data_ptr(hdr), token, token_len);
     }
 
     return sizeof(coap_hdr_t) + token_len;


### PR DESCRIPTION
### Contribution description

ISO C++ forbids empty arrays like the struct member `data[]` of nanocoap's `coap_hdr_t`.
`data` is used as a zero-cost convenience pointer to the first data byte of the packet.

To create this behavior (point to data after the header, no memory cost) with C++ also, I defined a macro which manually does the pointer arithmetic previously done by the compiler.

Anything that increases the struct size (like a "real" member to be used the same way as before) would differ from the CoAP message format and could potentially cause problems with packets without payload.

Following the discussion in #8767 I propose this as a possible solution, any comments or improvements are appreciated.

### Testing procedure

Use gcoap with C++ to produce the error (along with others, see #8767 ).


### Issues/PRs references

Partially addresses #8767

*PS: I purposefully did not write a doxygen commdn yet before an agreed solution is found ;)*