### PR TITLE
 doxygen/Makefile: do not rebuild riot.css automatically 

### DIFF
--- a/doc/doxygen/Makefile
+++ b/doc/doxygen/Makefile
@@ -14,21 +14,20 @@ doc: html
 
 # by marking html as phony we force make to re-run Doxygen even if the directory exists.
 .PHONY: html
-html: src/css/riot.css src/changelog.md
+html: src/changelog.md
 	( cat riot.doxyfile ; echo "GENERATE_HTML = yes" ) | doxygen -
 
 .PHONY: man
 man: src/changelog.md
 	( cat riot.doxyfile ; echo "GENERATE_MAN = yes" ) | doxygen -
 
-ifneq (,$(LESSC))
-src/css/riot.css: src/css/riot.less src/css/variables.less
-	@$(LESSC) $< $@
+.PHONY: riot-css
+riot-css: src/css/riot.less src/css/variables.less
+	@$(LESSC) $< src/css/riot.css
 
 src/css/variables.less: src/config.json
 	@grep "^\s*\"@" $< | sed -e 's/^\s*"//g' -e 's/":\s*"/: /g' \
 	  -e 's/",\?$$/;/g' -e 's/\\"/"/g' > $@
-endif
 
 src/changelog.md: src/changelog.md.tmp ../../release-notes.txt
 	@./generate-changelog.py $+ $@

--- a/doc/doxygen/Makefile
+++ b/doc/doxygen/Makefile
@@ -33,7 +33,8 @@ endif
 src/changelog.md: src/changelog.md.tmp ../../release-notes.txt
 	@./generate-changelog.py $+ $@
 
-.PHONY:
+.PHONY: latex clean
+
 latex: src/changelog.md
 	( cat riot.doxyfile ; echo "GENERATE_LATEX= yes" ) | doxygen -
 


### PR DESCRIPTION
### Contribution description

The riot.css can be generated by the lessc tool from riot.less, butit is also tracked by git. If the Makefile detects that the user has the lessc tool, it automatically enables a rule to rebuild it.

This can be annoying to the user if he happens to have the tool in his machine and may also cause the docs built by the CI to differ to what is generated in user's PCs.

This commit removes the rule for generating riot.css and replaces it whith a phony target "riot-css" that must be explicitly called to recompile the stylesheet. Dependencies on that file are removed, since make no longer knows how to remake it.

### Testing procedure

Install lesscpy from PIP and run make docs. The docs should be built fine.

If you `touch doc/doxygen/src/css/riot.less` nothing should get rebuild.

Typing `make riot-css` should unconditionally regenerate `doc/doxygen/src/css/riot.css`.

### Issues/PRs references

I based it off #10237 (the travis commit is from that PR) but that is not strictly necessary.

Replaces #10239.

Fixes #8122 
