### PR TITLE
at86rf2xx: Re-enable ack requests by default

### DIFF
--- a/drivers/at86rf2xx/at86rf2xx.c
+++ b/drivers/at86rf2xx/at86rf2xx.c
@@ -82,6 +82,10 @@ void at86rf2xx_reset(at86rf2xx_t *dev)
     at86rf2xx_set_option(dev, AT86RF2XX_OPT_AUTOACK, true);
     at86rf2xx_set_option(dev, AT86RF2XX_OPT_CSMA, true);
 
+    static const netopt_enable_t enable = NETOPT_ENABLE;
+    netdev_ieee802154_set(&dev->netdev, NETOPT_ACK_REQ,
+                          &enable, sizeof(enable));
+
     /* enable safe mode (protect RX FIFO until reading data starts) */
     at86rf2xx_reg_write(dev, AT86RF2XX_REG__TRX_CTRL_2,
                         AT86RF2XX_TRX_CTRL_2_MASK__RX_SAFE_MODE);


### PR DESCRIPTION
### Contribution description

Properly splitting the flags between netdev_ieee802154 and the at86rf2xx
driver had as side effect that the ACK REQ flag was no longer set by
default. This commit reverts the default settings by enabling it again
on startup. The current code calls the generic netdev setter to set the
flag.

### Testing procedure

Test if ack requests are set on ieee802.15.4 frames for the at86rf2xx driver. Setting up gnrc_networking and pinging a unicast (link local) address and sniffing the frames is probably the easiest way to test this.

### Issues/PRs references

#9957 