### PR TITLE
travis.yml: use the same image as Murdock.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,8 +1,14 @@
-dist: trusty
+sudo: required
+
+language: minimal
+
+services:
+  - docker
 
 before_install:
-  - sudo apt-get install coreutils realpath doxygen graphviz python-lesscpy cppcheck coccinelle pcregrep python3-pip
-  - sudo pip3 install flake8
+  - docker pull riot/riotbuild
 
 script:
-  - make static-test
+  - docker run -a STDIN -a STDOUT -a STDERR --rm -u "$(id -u)"
+      -v "${PWD}:/data/riotbuild" -v /etc/localtime:/etc/localtime:ro
+      riot/riotbuild make static-test


### PR DESCRIPTION
### Contribution description

It does not make sense to do the static tests in a diferent image than the compilation tests.

This commit updates the travis config to use the riotbuild image (the same as murdock). This should fix the issues with old doxygen versions reporting issues that are not, and also simplifies the CI maintenance.

### Testing procedure

The only way to test it is to trigger Travis . Use #9819 (it is rebased on top of this).

### Issues/PRs references

After #9819 everything will start failing the tests because the version of Doxygen in Trusty is from the stone age.

This PR would make #10237 no longer applicable.
