### PR TITLE
tools/ci: correcly report flake8 version. 

### DIFF
--- a/dist/tools/ci/print_toolchain_versions.sh
+++ b/dist/tools/ci/print_toolchain_versions.sh
@@ -5,21 +5,17 @@ get_cmd_version() {
         return
     fi
 
-    local cmd="$1"
-    if command -v "$cmd" 2>&1 >/dev/null; then
-        ver=$("$cmd" --version 2> /dev/null | head -n 1)
-        # some tools (eg. openocd) print version info to stderr
-        if [ -z "$ver" ]; then
-            ver=$("$cmd" --version 2>&1 | head -n 1)
-        fi
-        if [ -z "$ver" ]; then
-            ver="error"
-        fi
-    else
-        ver="missing"
+    VERSION_RAW=$( ($@ --version) 2>&1)
+    ERR=$?
+    VERSION=$(echo "$VERSION_RAW" | head -n 1)
+
+    if [ $ERR -eq 127 ] ; then # 127 means command not found
+        VERSION="missing"
+    elif [ $ERR -ne 0 ] ; then
+        VERSION="error: ${VERSION}"
     fi
 
-    printf "%s" "$ver"
+    printf "%s" "$VERSION"
 }
 
 get_define() {
@@ -123,7 +119,7 @@ for c in \
          python2 \
          python3 \
          ; do
-    printf "%23s: %s\n" "$c" "$(get_cmd_version $c)"
+    printf "%23s: %s\n" "$c" "$(get_cmd_version "${c}")"
 done
 printf "%23s: %s\n" "coccinelle" "$(get_cmd_version spatch)"
 

--- a/dist/tools/ci/print_toolchain_versions.sh
+++ b/dist/tools/ci/print_toolchain_versions.sh
@@ -111,7 +111,6 @@ for c in \
          cmake \
          cppcheck \
          doxygen \
-         flake8 \
          git \
          make \
          openocd \
@@ -121,6 +120,7 @@ for c in \
          ; do
     printf "%23s: %s\n" "$c" "$(get_cmd_version "${c}")"
 done
+printf "%23s: %s\n" "flake8" "$(get_cmd_version "python3 -Wignore -m flake8")"
 printf "%23s: %s\n" "coccinelle" "$(get_cmd_version spatch)"
 
 exit 0


### PR DESCRIPTION
~_This PR is rebased on top if #10251 for easy testing, but it is not required._~

### Contribution description

This PR contains two commits. I can split it if necessary.

**Change the way version detection works**

Detect command line tool versions without using "command". "command" may be a builting in some shells, leading to unportability.

The new version uses the status code to correctly detect a non-existent command. This allows it to differentiate between error in the tool and not-found errors.

It also works with compound commands, for example `python -m callable_module".

**Fix flake8 detection in some systems (for example, riotdocker)**

If the flake8 executable is not found, the static test script reports the tool as missing. It may happen that the flake8 module is installed, but the console entry point is not.

In the flake8 shell script, flake is invoked via `python -m`. The result is a confusing error message where static-test reports the tools as missing, yet the flake8 tests are run.

This patch makes the toolchain version script use the same command as the flake8 script.

### Testing procedure

The easiest way to see the issue is to look at Murdock output from any PR ([example](https://ci.riot-os.org/RIOT-OS/RIOT/10243/cbc72d44a20ca2dbae5d7c10f2bfea070f58425f/output.html)) and see that flake8 is reported as missing, but the test that uses flake8 passes.

~Travis uses a different image that does not show the problem, that's why I rebased on top of #10251. That PR's Travis output has the issue, while this one should not.~

With this PR, the static-tests can detect flake8 without problems.

### Why is this important?

Because if we have tests it is because we want to run them and if the output from the static test is contradictory, how do we know if the tests are running or not?
