### PR TITLE
sys: add riot_hdr module

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -791,6 +791,11 @@ ifneq (,$(filter uuid,$(USEMODULE)))
   USEMODULE += random
 endif
 
+ifneq (,$(filter riotboot_hdr, $(USEMODULE)))
+  USEMODULE += checksum
+  USEMODULE += riotboot
+endif
+
 # Enable periph_gpio when periph_gpio_irq is enabled
 ifneq (,$(filter periph_gpio_irq,$(USEMODULE)))
   FEATURES_REQUIRED += periph_gpio

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -54,6 +54,7 @@ PSEUDOMODULES += pktqueue
 PSEUDOMODULES += printf_float
 PSEUDOMODULES += prng
 PSEUDOMODULES += prng_%
+PSEUDOMODULES += riotboot_%
 PSEUDOMODULES += saul_adc
 PSEUDOMODULES += saul_default
 PSEUDOMODULES += saul_gpio

--- a/sys/Makefile
+++ b/sys/Makefile
@@ -140,7 +140,6 @@ ifneq (,$(filter cord_ep,$(USEMODULE)))
     DIRS += net/application_layer/cord/ep
 endif
 
-
 DIRS += $(dir $(wildcard $(addsuffix /Makefile, $(USEMODULE))))
 
 include $(RIOTBASE)/Makefile.base

--- a/sys/include/riotboot/hdr.h
+++ b/sys/include/riotboot/hdr.h
@@ -1,0 +1,89 @@
+/*
+ * Copyright (C) 2018 Kaspar Schleiser <kaspar@schleiser.de>
+ *                    Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    sys_riotboot_hdr RIOT header helpers and tools
+ * @ingroup     sys
+ * @{
+ *
+ * The header contains
+ *
+ * - "RIOT" as magic number
+ * - the application version
+ * - the address where the RIOT firmware is found
+ * - the checksum of the three previous fields
+ *
+ * @file
+ * @brief       RIOT "partition" header and tools
+ *
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ * @author      Francisco Acosta <francisco.acosta@inria.fr>
+ *
+ * @}
+ */
+
+#ifndef RIOTBOOT_HDR_H
+#define RIOTBOOT_HDR_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#include <stdint.h>
+
+/**
+ * @brief  Magic number for riotboot_hdr
+ *
+ */
+#define RIOTBOOT_MAGIC         0x544f4952 /* "RIOT" */
+
+/**
+ * @brief Structure to store image header - All members are little endian
+ * @{
+ */
+typedef struct {
+    uint32_t magic_number;      /**< Header magic number (always "RIOT")              */
+    uint32_t version;           /**< Integer representing the partition version       */
+    uint32_t start_addr;        /**< Address after the allocated space for the header */
+    uint32_t chksum;            /**< Checksum of riotboot_hdr                         */
+} riotboot_hdr_t;
+/** @} */
+
+/**
+ * @brief  Print formatted riotboot_hdr_t to STDIO
+ *
+ * @param[in] riotboot_hdr  ptr to image header
+ *
+ */
+void riotboot_hdr_print(const riotboot_hdr_t *riotboot_hdr);
+
+/**
+ * @brief  Validate image header
+ *
+ * @param[in] riotboot_hdr  ptr to image header
+ *
+ * @returns 0 if OK
+ * @returns -1 if not OK
+ */
+int riotboot_hdr_validate(const riotboot_hdr_t *riotboot_hdr);
+
+/**
+ * @brief  Calculate header checksum
+ *
+ * @param[in] riotboot_hdr  ptr to image header
+ *
+ * @returns the checksum of the given riotboot_hdr
+ */
+uint32_t riotboot_hdr_checksum(const riotboot_hdr_t *riotboot_hdr);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* RIOTBOOT_HDR_H */

--- a/sys/riotboot/Makefile
+++ b/sys/riotboot/Makefile
@@ -1,0 +1,3 @@
+SUBMODULES := 1
+
+include $(RIOTBASE)/Makefile.base

--- a/sys/riotboot/hdr.c
+++ b/sys/riotboot/hdr.c
@@ -1,0 +1,68 @@
+/*
+ * Copyright (C) 2017 Kaspar Schleiser <kaspar@schleiser.de>
+ *                    Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     sys_riotboot_hdr
+ * @{
+ *
+ * @file
+ * @brief       RIOT header helpers and tools
+ *
+ * @author      Kaspar Schleiser <kaspar@schleiser.de>
+ * @author      Francisco Acosta <francisco.acosta@inria.fr>
+ *
+ * @}
+ */
+
+#include <string.h>
+#include <stddef.h>
+#include <stdio.h>
+
+#ifdef RIOT_VERSION
+#include "log.h"
+#else
+#define LOG_INFO(...) printf(__VA_ARGS__)
+#endif
+
+#include "riotboot/hdr.h"
+#include "checksum/fletcher32.h"
+#include "byteorder.h"
+
+#if __BYTE_ORDER__ != __ORDER_LITTLE_ENDIAN__
+#   error "This code is implementented in a way that it will only work for little-endian systems!"
+#endif
+
+void riotboot_hdr_print(const riotboot_hdr_t *riotboot_hdr)
+{
+    printf("Image magic_number: 0x%08x\n", (unsigned)riotboot_hdr->magic_number);
+    printf("Image Version: 0x%08x\n", (unsigned)riotboot_hdr->version);
+    printf("Image start address: 0x%08x\n", (unsigned)riotboot_hdr->start_addr);
+    printf("Header chksum: 0x%08x\n", (unsigned)riotboot_hdr->chksum);
+    printf("\n");
+}
+
+int riotboot_hdr_validate(const riotboot_hdr_t *riotboot_hdr)
+{
+    if (riotboot_hdr->magic_number != RIOTBOOT_MAGIC) {
+        LOG_INFO("%s: riotboot_hdr magic number invalid\n", __func__);
+        return -1;
+    }
+
+    int res = riotboot_hdr_checksum(riotboot_hdr) == riotboot_hdr->chksum ? 0 : -1;
+    if (res) {
+        LOG_INFO("%s: riotboot_hdr checksum invalid\n", __func__);
+    }
+
+    return res;
+}
+
+uint32_t riotboot_hdr_checksum(const riotboot_hdr_t *riotboot_hdr)
+{
+    return fletcher32((uint16_t *)riotboot_hdr, offsetof(riotboot_hdr_t, chksum) / sizeof(uint16_t));
+}

--- a/tests/riotboot_hdr/Makefile
+++ b/tests/riotboot_hdr/Makefile
@@ -1,0 +1,10 @@
+include ../Makefile.tests_common
+
+USEMODULE += riotboot_hdr
+USEMODULE += embunit
+
+HDR_LOG_LEVEL ?= LOG_NONE
+
+CFLAGS += -DLOG_LEVEL=$(HDR_LOG_LEVEL)
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/riotboot_hdr/main.c
+++ b/tests/riotboot_hdr/main.c
@@ -1,0 +1,93 @@
+/*
+ * Copyright (C) 2018 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup    tests
+ * @{
+ *
+ * @file
+ * @brief      Tests for module riotboot_hdr
+ *
+ * @author     Francisco Acosta <francisco.acosta@inria.fr>
+ */
+
+#include <stdio.h>
+
+#include "riotboot/hdr.h"
+#include "embUnit.h"
+
+const riotboot_hdr_t riotboot_hdr_good = {
+    .magic_number = RIOTBOOT_MAGIC,
+    .version = 0x5bd19bff,
+    .start_addr = 0x00001100,
+    .chksum = 0x02eda672
+};
+
+const riotboot_hdr_t riotboot_hdr_bad_magic = {
+    .magic_number = 0x12345678,
+    .version = 0x5bd19bff,
+    .start_addr = 0x00001100,
+    .chksum = 0x02eda672
+};
+
+const riotboot_hdr_t riotboot_hdr_bad_chksum = {
+    .magic_number = RIOTBOOT_MAGIC,
+    .version = 0x5bd19bff,
+    .start_addr = 0x00001100,
+    .chksum = 0x02000000
+};
+
+static void test_riotboot_hdr_01(void)
+{
+    int ret = riotboot_hdr_validate(&riotboot_hdr_good);
+
+    TEST_ASSERT_EQUAL_INT(0, ret);
+}
+
+static void test_riotboot_hdr_02(void)
+{
+    int ret = riotboot_hdr_validate(&riotboot_hdr_bad_magic);
+
+    TEST_ASSERT_EQUAL_INT(-1, ret);
+}
+
+static void test_riotboot_hdr_03(void)
+{
+    int ret = riotboot_hdr_validate(&riotboot_hdr_bad_chksum);
+
+    TEST_ASSERT_EQUAL_INT(-1, ret);
+}
+
+static void test_riotboot_hdr_04(void)
+{
+    uint32_t chksum = riotboot_hdr_checksum(&riotboot_hdr_good);
+
+    TEST_ASSERT_EQUAL_INT(0x02eda672, chksum);
+}
+
+Test *tests_riotboot_hdr(void)
+{
+    EMB_UNIT_TESTFIXTURES(fixtures) {
+        new_TestFixture(test_riotboot_hdr_01),
+        new_TestFixture(test_riotboot_hdr_02),
+        new_TestFixture(test_riotboot_hdr_03),
+        new_TestFixture(test_riotboot_hdr_04),
+    };
+
+    EMB_UNIT_TESTCALLER(riotboot_hdr_tests, NULL, NULL, fixtures);
+
+    return (Test *)&riotboot_hdr_tests;
+}
+
+int main(void)
+{
+    TESTS_START();
+    TESTS_RUN(tests_riotboot_hdr());
+    TESTS_END();
+    return 0;
+}

--- a/tests/riotboot_hdr/tests/01-run.py
+++ b/tests/riotboot_hdr/tests/01-run.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2018 Francisco Acosta <francisco.acosta@inria.fr>
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import sys
+from testrunner import run
+
+
+def testfunc(child):
+    child.expect(r"OK \(\d+ tests\)")
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc))


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->
This PR adds a module called riot_hdr which is mainly used to identify "partitions" on flash. Sections on flash can be identified by parsing a header.

The header contains
```c
/**
 * @brief Structure to store image header - All members are little endian
 * @{
 */
typedef struct {
    uint32_t magic_number;     /**< header magic_number (always "RIOT")              */
    uint32_t version;          /**< Integer representing the partition version       */
    uint32_t start_addr;       /**< Address after the allocated space for the header */
    uint32_t chksum;           /**< checksum of riot_hdr                             */
} riot_hdr_t;
/** @} */
```

This is a split of #10065, since that PR is too complex to be reviewed as is.

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->
`BOARD=samr21-xpro make -C tests/riot_hdr/ flash test`

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
#10065 