### PR TITLE
README.md: Move netdev_tap instructions to the getting started page

### DIFF
--- a/README.md
+++ b/README.md
@@ -46,7 +46,6 @@ provided by RIOT, e.g. it is possible to link closed-source code with the
 LGPL code.
 
 ## FEATURES
-
 RIOT is based on a microkernel architecture, and provides features including,
 but not limited to:
 
@@ -66,7 +65,6 @@ but not limited to:
 * Sigfox
 * LoRaWAN
 
-
 ## GETTING STARTED
 * You want to start the RIOT? Just follow our
 [quickstart guide](https://doc.riot-os.org/index.html#the-quickest-start) or
@@ -78,22 +76,7 @@ For specific toolchain installation, follow instructions in the
   version of the documentation is uploaded daily to
   [riot-os.org/api](https://riot-os.org/api).
 
-### USING THE NATIVE PORT WITH NETWORKING
-If you compile RIOT for the native cpu and include the `netdev_tap` module,
-you can specify a network interface like this: `PORT=tap0 make term`
-
-#### SETTING UP A TAP NETWORK
-There is a shell script in `RIOT/dist/tools/tapsetup` called `tapsetup` which
-you can use to create a network of tap interfaces.
-
-*USAGE*
-
-To create a bridge and two (or `count` at your option) tap interfaces:
-
-    ./dist/tools/tapsetup/tapsetup [-c [<count>]]
-
 ## CONTRIBUTE
-
 To contribute something to RIOT, please refer to our
 [contributing document](CONTRIBUTING.md).
 

--- a/doc/doxygen/src/getting-started.md
+++ b/doc/doxygen/src/getting-started.md
@@ -91,8 +91,10 @@ complete RIOT stack in a process on your *NIX system. To enable networking
 between multiple native RIOT instances, you need to use tun/tap interfaces.
 
 First, you need to make sure that you're compiling RIOT for the native port
-and add tun/tap support. In the project Makefile, set `BOARD ?= native` and
-include the `netdev_tap` module by adding the line `USEMODULE += netdev_tap`.
+and add tun/tap support. You can do this by compiling your project with the following environment variables:
+
+    BOARD=native USEMODULE+=netdev_tap make
+
 > **Note:** if you're using RIOTs default network stack, you should add
 > `gnrc_netdev_default` and `auto_init_gnrc_netif` instead, which have the
 > `netdev_tap` module included.
@@ -110,7 +112,7 @@ And follow the instructions of the script telling you to start RIOT instances
 on specific tap interfaces. To start a RIOT instance on a specific tap
 interface, run
 
-    PORT=<tap interface name> make term
+    BOARD=native USEMODULE+=netdev_tap PORT=<tap interface name> make term
 
 in the directory of your RIOT application.
 

--- a/doc/doxygen/src/getting-started.md
+++ b/doc/doxygen/src/getting-started.md
@@ -116,8 +116,7 @@ interface, run
 
 in the directory of your RIOT application.
 
-The [gnrc networking example][gnrc_networking] explains how to do all of this
-in more detail.
+The [gnrc_networking] example explains how to do all of this in more detail.
 
 The build system in detail                                  {#the-build-system}
 --------------------------

--- a/doc/doxygen/src/getting-started.md
+++ b/doc/doxygen/src/getting-started.md
@@ -86,10 +86,9 @@ make -C examples/gnrc_networking/ term \
 
 Using the native port with networking  {#using-the-native-port-with-networking}
 -------------------------------------
-RIOT provides a special [native port][native]
-with which you can run the complete RIOT stack in a process on your *NIX
-system. To enable networking between multiple native RIOT instances, you need
-to use tun/tap interfaces.
+RIOT provides a special [native port][native] with which you can run the
+complete RIOT stack in a process on your *NIX system. To enable networking
+between multiple native RIOT instances, you need to use tun/tap interfaces.
 
 First, you need to make sure that you're compiling RIOT for the native port
 and add tun/tap support. In the project Makefile, set `BOARD ?= native` and

--- a/doc/doxygen/src/getting-started.md
+++ b/doc/doxygen/src/getting-started.md
@@ -114,8 +114,8 @@ interface, run
 
 in the directory of your RIOT application.
 
-The [gnrc networking example][gnrc] explains how to do all of this in more
-detail.
+The [gnrc networking example][gnrc_networking] explains how to do all of this
+in more detail.
 
 The build system in detail                                  {#the-build-system}
 --------------------------
@@ -174,5 +174,6 @@ hex file in the `bin` folder of your application directory.
 Learn more about the build system in the
 [Wiki](https://github.com/RIOT-OS/RIOT/wiki/The-Make-Build-System)
 
-[native]: https://github.com/RIOT-OS/RIOT/wiki/Family:-native
-[gnrc]:   https://github.com/RIOT-OS/RIOT/tree/master/examples/gnrc_networking
+[native]:            https://github.com/RIOT-OS/RIOT/wiki/Family:-native
+[gnrc_networking]:
+https://github.com/RIOT-OS/RIOT/tree/master/examples/gnrc_networking

--- a/doc/doxygen/src/getting-started.md
+++ b/doc/doxygen/src/getting-started.md
@@ -32,8 +32,60 @@ information that can help you with your platform:
 * [Atmel ATmega](https://github.com/RIOT-OS/RIOT/wiki/Family%3A-ATmega)
 * [native](https://github.com/RIOT-OS/RIOT/wiki/Family:-native)
 
-The build system                                            {#the-build-system}
-----------------
+Building and executing an example           {#building-and-executing-an-example}
+---------------------------------
+RIOT provides a number of examples in the `examples/` directory. Every example
+has a README that documents its usage and its purpose. You can build them by
+typing
+
+~~~~~~~~ {.sh}
+make BOARD=samr21-xpro
+~~~~~~~~
+
+or
+
+~~~~~~~~ {.sh}
+make all BOARD=samr21-xpro
+~~~~~~~~
+
+into your shell.
+
+To flash the application to a board just type
+
+~~~~~~~~ {.sh}
+make flash BOARD=samr21-xpro
+~~~~~~~~
+
+You can then access the board via the serial interface:
+
+~~~~~~~~ {.sh}
+make term BOARD=samr21-xpro
+~~~~~~~~
+
+If you are using multiple boards you can use the `PORT` macro to specify the
+serial interface:
+
+~~~~~~~~ {.sh}
+make term BOARD=samr21-xpro PORT=/dev/ttyACM1
+~~~~~~~~
+
+Note that the `PORT` macro has a slightly different semantic in `native`. Here
+it is used to provide the name of the TAP interface you want to use for the
+virtualized networking capabilities of RIOT.
+
+We use `pyterm` as the default terminal application. It is shipped with RIOT in
+the `dist/tools/pyterm/` directory. If you choose to use another terminal
+program you can set `TERMPROG` (and if need be the `TERMFLAGS`) macros:
+
+~~~~~~~~ {.sh}
+make -C examples/gnrc_networking/ term \
+    BOARD=samr21-xpro \
+    TERMPROG=gtkterm \
+    TERMFLAGS="-s 115200 -p /dev/ttyACM0 -e"
+~~~~~~~~
+
+The build system in detail                                  {#the-build-system}
+--------------------------
 RIOT uses [GNU make](https://www.gnu.org/software/make/) as build system. The
 simplest way to compile and link an application with RIOT, is to set up a
 Makefile providing at least the following variables:
@@ -88,55 +140,3 @@ hex file in the `bin` folder of your application directory.
 
 Learn more about the build system in the
 [Wiki](https://github.com/RIOT-OS/RIOT/wiki/The-Make-Build-System)
-
-Building and executing an example           {#building-and-executing-an-example}
----------------------------------
-RIOT provides a number of examples in the `examples/` directory. Every example
-has a README that documents its usage and its purpose. You can build them by
-typing
-
-~~~~~~~~ {.sh}
-make BOARD=samr21-xpro
-~~~~~~~~
-
-or
-
-~~~~~~~~ {.sh}
-make all BOARD=samr21-xpro
-~~~~~~~~
-
-into your shell.
-
-To flash the application to a board just type
-
-~~~~~~~~ {.sh}
-make flash BOARD=samr21-xpro
-~~~~~~~~
-
-You can then access the board via the serial interface:
-
-~~~~~~~~ {.sh}
-make term BOARD=samr21-xpro
-~~~~~~~~
-
-If you are using multiple boards you can use the `PORT` macro to specify the
-serial interface:
-
-~~~~~~~~ {.sh}
-make term BOARD=samr21-xpro PORT=/dev/ttyACM1
-~~~~~~~~
-
-Note that the `PORT` macro has a slightly different semantic in `native`. Here
-it is used to provide the name of the TAP interface you want to use for the
-virtualized networking capabilities of RIOT.
-
-We use `pyterm` as the default terminal application. It is shipped with RIOT in
-the `dist/tools/pyterm/` directory. If you choose to use another terminal
-program you can set `TERMPROG` (and if need be the `TERMFLAGS`) macros:
-
-~~~~~~~~ {.sh}
-make -C examples/gnrc_networking/ term \
-    BOARD=samr21-xpro \
-    TERMPROG=gtkterm \
-    TERMFLAGS="-s 115200 -p /dev/ttyACM0 -e"
-~~~~~~~~

--- a/doc/doxygen/src/getting-started.md
+++ b/doc/doxygen/src/getting-started.md
@@ -32,7 +32,7 @@ information that can help you with your platform:
 * [Atmel ATmega](https://github.com/RIOT-OS/RIOT/wiki/Family%3A-ATmega)
 * [native](https://github.com/RIOT-OS/RIOT/wiki/Family:-native)
 
-Building and executing an example           {#building-and-executing-an-example}
+Building and executing an example        {#building-and-executing-an-example}
 ---------------------------------
 RIOT provides a number of examples in the `examples/` directory. Every example
 has a README that documents its usage and its purpose. You can build them by
@@ -101,18 +101,22 @@ include the `netdev_tap` module by adding the line `USEMODULE += netdev_tap`.
 Now, you can connect several native RIOT instances to each other or enable
 communication between a native RIOT instance and its (*NIX) host system.
 
-To connect multiple native RIOT instances to each other, use the shell script called `tapsetup` in `RIOT/dist/tools/tapsetup`.
+To connect multiple native RIOT instances to each other, use the shell script
+called `tapsetup` in `RIOT/dist/tools/tapsetup`.
 First, create a bridge and two (or `count` at your option) tap interfaces:
 
      ./dist/tools/tapsetup/tapsetup [-c [<count>]]
 
-And follow the instructions of the script telling you to start RIOT instances on specific tap interfaces. To start a RIOT instance on a specific tap interface, run
+And follow the instructions of the script telling you to start RIOT instances
+on specific tap interfaces. To start a RIOT instance on a specific tap
+interface, run
 
     PORT=<tap interface name> make term
 
 in the directory of your RIOT application.
 
-The [gnrc networking example][gnrc] explains how to do all of this in more detail.
+The [gnrc networking example][gnrc] explains how to do all of this in more
+detail.
 
 The build system in detail                                  {#the-build-system}
 --------------------------

--- a/doc/doxygen/src/getting-started.md
+++ b/doc/doxygen/src/getting-started.md
@@ -84,6 +84,36 @@ make -C examples/gnrc_networking/ term \
     TERMFLAGS="-s 115200 -p /dev/ttyACM0 -e"
 ~~~~~~~~
 
+Using the native port with networking  {#using-the-native-port-with-networking}
+-------------------------------------
+RIOT provides a special [native port][native]
+with which you can run the complete RIOT stack in a process on your *NIX
+system. To enable networking between multiple native RIOT instances, you need
+to use tun/tap interfaces.
+
+First, you need to make sure that you're compiling RIOT for the native port
+and add tun/tap support. In the project Makefile, set `BOARD ?= native` and
+include the `netdev_tap` module by adding the line `USEMODULE += netdev_tap`.
+> **Note:** if you're using RIOTs default network stack, you should add
+> `gnrc_netdev_default` and `auto_init_gnrc_netif` instead, which have the
+> `netdev_tap` module included.
+
+Now, you can connect several native RIOT instances to each other or enable
+communication between a native RIOT instance and its (*NIX) host system.
+
+To connect multiple native RIOT instances to each other, use the shell script called `tapsetup` in `RIOT/dist/tools/tapsetup`.
+First, create a bridge and two (or `count` at your option) tap interfaces:
+
+     ./dist/tools/tapsetup/tapsetup [-c [<count>]]
+
+And follow the instructions of the script telling you to start RIOT instances on specific tap interfaces. To start a RIOT instance on a specific tap interface, run
+
+    PORT=<tap interface name> make term
+
+in the directory of your RIOT application.
+
+The [gnrc networking example][gnrc] explains how to do all of this in more detail.
+
 The build system in detail                                  {#the-build-system}
 --------------------------
 RIOT uses [GNU make](https://www.gnu.org/software/make/) as build system. The
@@ -140,3 +170,6 @@ hex file in the `bin` folder of your application directory.
 
 Learn more about the build system in the
 [Wiki](https://github.com/RIOT-OS/RIOT/wiki/The-Make-Build-System)
+
+[native]: https://github.com/RIOT-OS/RIOT/wiki/Family:-native
+[gnrc]:   https://github.com/RIOT-OS/RIOT/tree/master/examples/gnrc_networking


### PR DESCRIPTION
### Contribution description
The native port usage instructions seemed a bit out of place in the `RIOT/README.md` to me, since the rest of the document contains more general descriptions of this project (see https://github.com/RIOT-OS/RIOT/issues/10034). This irked me every time I wanted to look something up in said `README`, so I created this PR. To mitigate this situation, I moved parts of the instructions to `doc/doxygen/src/getting-started.md`, i.e. the getting started tutorial that the README links to as well. I didn't want to duplicate too much infromation, though, in case (for example) the tapsetup usage changes and we'll end up with spread-out stale information, so I linked to `examples/gnrc_networking` for usage details.

In `getting-started.md`, I also reordered the sections `The build system` and `Building and executing an example` to avoid newcomers being overwhelmed before learning that there are examples that they can build on and play with.

In `README.md`, I unified the line breaks around section headings (some had an empty line after the heading, some didn't, some had two line breaks before a section, some had only one)

I put these changes into several commits for clarity but I'd also be happy to squash them into one if requested.

### Testing procedure

--

### Issues/PRs references

Resolves https://github.com/RIOT-OS/RIOT/issues/10034 .