### PR TITLE
boards/common/esp32: fix OSX serial port

### DIFF
--- a/boards/common/esp32/Makefile.include
+++ b/boards/common/esp32/Makefile.include
@@ -4,7 +4,7 @@ export CPU_MODEL ?= esp32
 
 # configure the serial interface
 PORT_LINUX ?= /dev/ttyUSB0
-PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial-*)))
 include $(RIOTMAKE)/tools/serial.inc.mk
 
 # reset tool configuration


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->
Fixes the port for OSX machines, which have a pattern of `tty.usbserial-*` instead of `tty.SLAB_USBtoUART*`

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->
`BOARD=esp32-wroom-32 make all flash term` should work on the compatible examples and tests.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
Fixes #10258.