### PR TITLE
sys/ps: Remove unused include xtimer.h

### DIFF
--- a/sys/ps/ps.c
+++ b/sys/ps/ps.c
@@ -22,10 +22,6 @@
 #include "thread.h"
 #include "kernel_types.h"
 
-#ifdef MODULE_SCHEDSTATISTICS
-#include "xtimer.h"
-#endif
-
 #ifdef MODULE_TLSF_MALLOC
 #include "tlsf.h"
 #include "tlsf-malloc.h"


### PR DESCRIPTION
Trivial change. 

### Contribution description

There are no references to xtimer in ps.c. This is probably a left over after some refactoring during the development of the scheduler statistics.


### Testing procedure

ensure that ps still works correctly with USEMODULE += schedstatistics


### Issues/PRs references

