### PR TITLE
core: Rename typedef schedstat -> schedstat_t

### DIFF
--- a/core/include/sched.h
+++ b/core/include/sched.h
@@ -183,12 +183,12 @@ typedef struct {
                                   scheduled to run */
     unsigned int schedules;  /**< How often the thread was scheduled to run */
     uint64_t runtime_ticks;  /**< The total runtime of this thread in ticks */
-} schedstat;
+} schedstat_t;
 
 /**
  *  Thread statistics table
  */
-extern schedstat sched_pidlist[KERNEL_PID_LAST + 1];
+extern schedstat_t sched_pidlist[KERNEL_PID_LAST + 1];
 
 /**
  *  @brief  Register a callback that will be called on every scheduler run

--- a/core/kernel_init.c
+++ b/core/kernel_init.c
@@ -50,8 +50,8 @@ static void *main_trampoline(void *arg)
 #endif
 
 #ifdef MODULE_SCHEDSTATISTICS
-    schedstat *stat = &sched_pidlist[thread_getpid()];
-    stat->laststart = 0;
+    schedstat_t *ss = &sched_pidlist[thread_getpid()];
+    ss->laststart = 0;
 #endif
 
     LOG_INFO("main(): This is RIOT! (Version: " RIOT_VERSION ")\n");

--- a/core/sched.c
+++ b/core/sched.c
@@ -76,7 +76,7 @@ const uint8_t _tcb_name_offset = offsetof(thread_t, name);
 
 #ifdef MODULE_SCHEDSTATISTICS
 static void (*sched_cb) (uint32_t timestamp, uint32_t value) = NULL;
-schedstat sched_pidlist[KERNEL_PID_LAST + 1];
+schedstat_t sched_pidlist[KERNEL_PID_LAST + 1];
 #endif
 
 int __attribute__((used)) sched_run(void)
@@ -116,7 +116,7 @@ int __attribute__((used)) sched_run(void)
 #endif
 
 #ifdef MODULE_SCHEDSTATISTICS
-        schedstat *active_stat = &sched_pidlist[active_thread->pid];
+        schedstat_t *active_stat = &sched_pidlist[active_thread->pid];
         if (active_stat->laststart) {
             active_stat->runtime_ticks += now - active_stat->laststart;
         }
@@ -124,7 +124,7 @@ int __attribute__((used)) sched_run(void)
     }
 
 #ifdef MODULE_SCHEDSTATISTICS
-    schedstat *next_stat = &sched_pidlist[next_thread->pid];
+    schedstat_t *next_stat = &sched_pidlist[next_thread->pid];
     next_stat->laststart = now;
     next_stat->schedules++;
     if (sched_cb) {


### PR DESCRIPTION

### Contribution description

To follow naming conventions, the `schedstat` type should be named `schedstat_t`


### Testing procedure

Compile test should prove that there are no references left to the old name.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
