### PR TITLE
Makefile.include: allow specifying makefiles to be parsed

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -1,6 +1,11 @@
 # 'Makefile.include' directory, must be evaluated before other 'include'
 _riotbase := $(dir $(lastword $(MAKEFILE_LIST)))
 
+# include RIOT_MAKEFILES_GLOBAL_PRE configuration files
+# allows setting user specific system wide configuration parsed before the body
+# of $(RIOTBASE)/Makefile.include
+include $(RIOT_MAKEFILES_GLOBAL_PRE)
+
 # Globally set default goal to `all`
 .DEFAULT_GOAL := all
 
@@ -730,3 +735,8 @@ ifneq ($(_BASELIBS_VALUE_BEFORE_USAGE),$(BASELIBS))
 endif
 
 endif # BOARD=none
+
+# include RIOT_MAKEFILES_GLOBAL_POST configuration files
+# allows setting user specific system wide configuration parsed after the body
+# of $(RIOTBASE)/Makefile.include
+include $(RIOT_MAKEFILES_GLOBAL_POST)

--- a/doc/doxygen/riot.doxyfile
+++ b/doc/doxygen/riot.doxyfile
@@ -765,6 +765,7 @@ INPUT                  = ../../doc.txt \
                          src/creating-modules.md \
                          src/creating-an-application.md \
                          src/getting-started.md \
+                         src/advanced-build-system-tricks.md \
                          src/changelog.md \
                          ../../LOSTANDFOUND.md
 

--- a/doc/doxygen/src/advanced-build-system-tricks.md
+++ b/doc/doxygen/src/advanced-build-system-tricks.md
@@ -1,0 +1,40 @@
+Advanced build system tricks                    {#advanced-build-system-tricks}
+============================
+
+[TOC]
+
+Introduction                                                    {#introduction}
+============
+
+This page describes some build systems tricks that can help developers but are
+not part of the standard workflow.
+
+They are low level commands that should not be taken as part of a stable API
+but better have a documentation than only having a description in the build
+system code.
+
+
+Customize the build system                            {#customize-build-system}
+==========================
+
++ `RIOT_MAKEFILES_GLOBAL_PRE`: files parsed before the body of
+  `$RIOTBASE/Makefile.include`
++ `RIOT_MAKEFILES_GLOBAL_POST`: files parsed after the body of
+  `$RIOTBASE/Makefile.include`
+
+The variables are a list of files that will be included by
+`$RIOTBASE/Makefile.include`.
+They will be handled as relative to the application directory if the path is
+relative.
+
+
+Usage
+-----
+
+You can configure your own files that will be parsed by the build system main
+`Makefile.include` file before or after its main body, examples usages can be:
+
+* Globally overwrite a variable, like `TERMPROG`
+* Specify a hard written `PORT` / `DEBUG_ADAPTER_ID` for some BOARD values
+* Define your custom targets
+* Override default targets

--- a/doc/doxygen/src/mainpage.md
+++ b/doc/doxygen/src/mainpage.md
@@ -235,6 +235,7 @@ Further information                                      {#further-information}
  - @ref getting-started
  - @ref creating-an-application
  - @ref creating-modules
+ - @ref advanced-build-system-tricks
 
 <!--
 Idea for this section: just name each of RIOT's main features/concepts and link


### PR DESCRIPTION
### Contribution description

This allows specifying a list of files that should be parsed by make at
the beginning and at the end of Makefile.include.

It is a generic mechanism to allow specifying system wide configuration:

* Globally overwrite the 'TERMPROG'
* Specify a hard written port / debug_adapter_id for some BOARD values
* Define you own specific targets
* Override default targets

It can include file before and after Makefile.include to allow handling
different configurations.

I cannot use `Makefile.local` for this because it must be in the application directory.

#### TODO

* [ ] Discuss the names, I just put the names for testing but I am bad at naming
 * `RIOT_MAKEFILES_GLOBAL_PRE`
 * `RIOT_MAKEFILES_GLOBAL_POST`
* [ ] Should I document it more somewhere, and if yes, where ?

### Testing procedure

Define files in `RIOT_MAKEFILES_GLOBAL_PRE` and `RIOT_MAKEFILES_GLOBAL_POST` that do print output (`$(info)` or `$(warning)`.

```
echo '$(warning pre config)' > /tmp/pre.mk; echo '$(warning post config)' > /tmp/post.mk; RIOT_MAKEFILES_GLOBAL_PRE="/tmp/pre.mk" RIOT_MAKEFILES_GLOBAL_POST="/tmp/post.mk" make --no-print-directory -C examples/hello-world/ clean
/tmp/pre.mk:1: pre config
/tmp/post.mk:1: post config
```

### Issues/PRs references

Local discussions about managing multiple boards configurations (my board samr21-xpro is on this PORT), providing system wide configuration without putting on the command line. Also defining targets from outside of RIOT for debugging/development reasons.

Now waiting on https://github.com/RIOT-OS/RIOT/pull/10286 for the default `RIOTBASE` value fix.