### PR TITLE
Fix return value of aes_init for keys of incorrect length

### DIFF
--- a/sys/crypto/aes.c
+++ b/sys/crypto/aes.c
@@ -124,7 +124,8 @@ static const u32 Te0[256] = {
     #define Te1(n)  ((Te0[n] >>  8) | (Te0[n] << 24))
     #define Te2(n)  ((Te0[n] >> 16) | (Te0[n] << 16))
     #define Te3(n)  ((Te0[n] >> 24) | (Te0[n] <<  8))
-    #define Te4(n)  (((Te0[n] & 0x00FFFF00) >> 8) | ((Te0[n] & 0x00FFFF00) << 8))
+    #define Te4(n)  (((Te0[n] & 0x00FFFF00) >> 8) | \
+                     ((Te0[n] & 0x00FFFF00) << 8))
 #else /* MODULE_CRYPTO_AES_PRECALCULATED */
     #define Te0(n)  (Te0[n])
     #define Te1(n)  (Te1[n])
@@ -472,11 +473,12 @@ static const u32 Td0[256] = {
     #define Td2(n)  ((Td0[n] >> 16) | (Td0[n] << 16))
     #define Td3(n)  ((Td0[n] >> 24) | (Td0[n] <<  8))
 
-    /* helper to prevent the u8 to be promoted to signed int, which would turn
-     * left shift by 24 into undefined behaviour */
+/* helper to prevent the u8 to be promoted to signed int, which would turn
+ * left shift by 24 into undefined behaviour */
     #define Td4u(n) ((u32)Td4[n])
 
-    #define Td4(n)  (Td4u(n) | (Td4u(n) << 8) | (Td4u(n) << 16) | (Td4u(n)  << 24))
+    #define Td4(n)  (Td4u(n) | (Td4u(n) << 8) | (Td4u(n) << 16) | \
+                     (Td4u(n) << 24))
 
 static const u8 Td4[256] = {
     0x52U, 0x09U, 0x6aU, 0xd5U, 0x30U, 0x36U, 0xa5U, 0x38U,
@@ -800,7 +802,7 @@ int aes_init(cipher_context_t *context, const uint8_t *key, uint8_t keySize)
 
     /* Make sure that context is large enough. If this is not the case,
        you should build with -DAES */
-    if(CIPHER_MAX_CONTEXT_SIZE < AES_KEY_SIZE) {
+    if (CIPHER_MAX_CONTEXT_SIZE < AES_KEY_SIZE) {
         return CIPHER_ERR_BAD_CONTEXT_SIZE;
     }
 
@@ -857,12 +859,12 @@ static int aes_set_encrypt_key(const unsigned char *userKey, const int bits,
 
     if (bits == 128) {
         while (1) {
-            temp  = rk[3];
+            temp = rk[3];
             rk[4] = rk[0] ^
                     (Te4((temp >> 16) & 0xff) & 0xff000000) ^
                     (Te4((temp >>  8) & 0xff) & 0x00ff0000) ^
                     (Te4((temp) & 0xff)       & 0x0000ff00) ^
-                    (Te4((temp >> 24)       ) & 0x000000ff) ^
+                    (Te4((temp >> 24)) & 0x000000ff) ^
                     rcon[i];
             rk[5] = rk[1] ^ rk[4];
             rk[6] = rk[2] ^ rk[5];
@@ -886,7 +888,7 @@ static int aes_set_encrypt_key(const unsigned char *userKey, const int bits,
                      (Te4((temp >> 16) & 0xff) & 0xff000000) ^
                      (Te4((temp >>  8) & 0xff) & 0x00ff0000) ^
                      (Te4((temp) & 0xff)       & 0x0000ff00) ^
-                     (Te4((temp >> 24)       ) & 0x000000ff) ^
+                     (Te4((temp >> 24)) & 0x000000ff) ^
                      rcon[i];
             rk[ 7] = rk[ 1] ^ rk[ 6];
             rk[ 8] = rk[ 2] ^ rk[ 7];
@@ -912,7 +914,7 @@ static int aes_set_encrypt_key(const unsigned char *userKey, const int bits,
                      (Te4((temp >> 16) & 0xff) & 0xff000000) ^
                      (Te4((temp >>  8) & 0xff) & 0x00ff0000) ^
                      (Te4((temp) & 0xff)       & 0x0000ff00) ^
-                     (Te4((temp >> 24)       ) & 0x000000ff) ^
+                     (Te4((temp >> 24)) & 0x000000ff) ^
                      rcon[i];
             rk[ 9] = rk[ 1] ^ rk[ 8];
             rk[10] = rk[ 2] ^ rk[ 9];
@@ -924,7 +926,7 @@ static int aes_set_encrypt_key(const unsigned char *userKey, const int bits,
 
             temp = rk[11];
             rk[12] = rk[ 4] ^
-                     (Te4((temp >> 24)       ) & 0xff000000) ^
+                     (Te4((temp >> 24)) & 0xff000000) ^
                      (Te4((temp >> 16) & 0xff) & 0x00ff0000) ^
                      (Te4((temp >>  8) & 0xff) & 0x0000ff00) ^
                      (Te4((temp) & 0xff)       & 0x000000ff);
@@ -951,6 +953,7 @@ static int aes_set_decrypt_key(const unsigned char *userKey, const int bits,
 
     /* first, start with an encryption schedule */
     int status;
+
     status = aes_set_encrypt_key(userKey, bits, key);
 
     if (status < 0) {
@@ -982,29 +985,29 @@ static int aes_set_decrypt_key(const unsigned char *userKey, const int bits,
         rk += 4;
 #ifdef MODULE_CRYPTO_AES_UNROLL
         rk[0] =
-            Td0(Te4((rk[0] >> 24)       ) & 0xff) ^
+            Td0(Te4((rk[0] >> 24)) & 0xff) ^
             Td1(Te4((rk[0] >> 16) & 0xff) & 0xff) ^
             Td2(Te4((rk[0] >>  8) & 0xff) & 0xff) ^
             Td3(Te4((rk[0]) & 0xff)       & 0xff);
         rk[1] =
-            Td0(Te4((rk[1] >> 24)       ) & 0xff) ^
+            Td0(Te4((rk[1] >> 24)) & 0xff) ^
             Td1(Te4((rk[1] >> 16) & 0xff) & 0xff) ^
             Td2(Te4((rk[1] >>  8) & 0xff) & 0xff) ^
             Td3(Te4((rk[1]) & 0xff)       & 0xff);
         rk[2] =
-            Td0(Te4((rk[2] >> 24)       ) & 0xff) ^
+            Td0(Te4((rk[2] >> 24)) & 0xff) ^
             Td1(Te4((rk[2] >> 16) & 0xff) & 0xff) ^
             Td2(Te4((rk[2] >>  8) & 0xff) & 0xff) ^
             Td3(Te4((rk[2]) & 0xff)       & 0xff);
         rk[3] =
-            Td0(Te4((rk[3] >> 24)       ) & 0xff) ^
+            Td0(Te4((rk[3] >> 24)) & 0xff) ^
             Td1(Te4((rk[3] >> 16) & 0xff) & 0xff) ^
             Td2(Te4((rk[3] >>  8) & 0xff) & 0xff) ^
             Td3(Te4((rk[3]) & 0xff)       & 0xff);
 #else
         for (int k = 0; k < 4; k++) {
             rk[k] =
-                Td0(Te4((rk[k] >> 24)       ) & 0xff) ^
+                Td0(Te4((rk[k] >> 24)) & 0xff) ^
                 Td1(Te4((rk[k] >> 16) & 0xff) & 0xff) ^
                 Td2(Te4((rk[k] >>  8) & 0xff) & 0xff) ^
                 Td3(Te4((rk[k]) & 0xff)       & 0xff);
@@ -1027,8 +1030,9 @@ int aes_encrypt(const cipher_context_t *context, const uint8_t *plainBlock,
     int res;
     AES_KEY aeskey;
     const AES_KEY *key = &aeskey;
+
     res = aes_set_encrypt_key((unsigned char *)context->context,
-                                   AES_KEY_SIZE * 8, &aeskey);
+                              AES_KEY_SIZE * 8, &aeskey);
     if (res < 0) {
         return res;
     }
@@ -1155,22 +1159,30 @@ int aes_encrypt(const cipher_context_t *context, const uint8_t *plainBlock,
         if (key->rounds > 12) {
             /* round 12: */
             s0 = Te0(t0 >> 24) ^ Te1((t1 >> 16) & 0xff) ^ Te2((t2 >>  8) &
-                    0xff) ^ Te3(t3 & 0xff) ^ rk[48];
+                                                              0xff) ^ Te3(
+                t3 & 0xff) ^ rk[48];
             s1 = Te0(t1 >> 24) ^ Te1((t2 >> 16) & 0xff) ^ Te2((t3 >>  8) &
-                    0xff) ^ Te3(t0 & 0xff) ^ rk[49];
+                                                              0xff) ^ Te3(
+                t0 & 0xff) ^ rk[49];
             s2 = Te0(t2 >> 24) ^ Te1((t3 >> 16) & 0xff) ^ Te2((t0 >>  8) &
-                    0xff) ^ Te3(t1 & 0xff) ^ rk[50];
+                                                              0xff) ^ Te3(
+                t1 & 0xff) ^ rk[50];
             s3 = Te0(t3 >> 24) ^ Te1((t0 >> 16) & 0xff) ^ Te2((t1 >>  8) &
-                    0xff) ^ Te3(t2 & 0xff) ^ rk[51];
+                                                              0xff) ^ Te3(
+                t2 & 0xff) ^ rk[51];
             /* round 13: */
             t0 = Te0(s0 >> 24) ^ Te1((s1 >> 16) & 0xff) ^ Te2((s2 >>  8) &
-                    0xff) ^ Te3(s3 & 0xff) ^ rk[52];
+                                                              0xff) ^ Te3(
+                s3 & 0xff) ^ rk[52];
             t1 = Te0(s1 >> 24) ^ Te1((s2 >> 16) & 0xff) ^ Te2((s3 >>  8) &
-                    0xff) ^ Te3(s0 & 0xff) ^ rk[53];
+                                                              0xff) ^ Te3(
+                s0 & 0xff) ^ rk[53];
             t2 = Te0(s2 >> 24) ^ Te1((s3 >> 16) & 0xff) ^ Te2((s0 >>  8) &
-                    0xff) ^ Te3(s1 & 0xff) ^ rk[54];
+                                                              0xff) ^ Te3(
+                s1 & 0xff) ^ rk[54];
             t3 = Te0(s3 >> 24) ^ Te1((s0 >> 16) & 0xff) ^ Te2((s1 >>  8) &
-                    0xff) ^ Te3(s2 & 0xff) ^ rk[55];
+                                                              0xff) ^ Te3(
+                s2 & 0xff) ^ rk[55];
         }
     }
 
@@ -1183,25 +1195,25 @@ int aes_encrypt(const cipher_context_t *context, const uint8_t *plainBlock,
 
     while (1) {
         t0 =
-            Te0((s0 >> 24)       ) ^
+            Te0((s0 >> 24)) ^
             Te1((s1 >> 16) & 0xff) ^
             Te2((s2 >>  8) & 0xff) ^
             Te3((s3)       & 0xff) ^
             rk[4];
         t1 =
-            Te0((s1 >> 24)       ) ^
+            Te0((s1 >> 24)) ^
             Te1((s2 >> 16) & 0xff) ^
             Te2((s3 >>  8) & 0xff) ^
             Te3((s0)       & 0xff) ^
             rk[5];
         t2 =
-            Te0((s2 >> 24)       ) ^
+            Te0((s2 >> 24)) ^
             Te1((s3 >> 16) & 0xff) ^
             Te2((s0 >>  8) & 0xff) ^
             Te3((s1)       & 0xff) ^
             rk[6];
         t3 =
-            Te0((s3 >> 24)       ) ^
+            Te0((s3 >> 24)) ^
             Te1((s0 >> 16) & 0xff) ^
             Te2((s1 >>  8) & 0xff) ^
             Te3((s2)       & 0xff) ^
@@ -1214,25 +1226,25 @@ int aes_encrypt(const cipher_context_t *context, const uint8_t *plainBlock,
         }
 
         s0 =
-            Te0((t0 >> 24)       ) ^
+            Te0((t0 >> 24)) ^
             Te1((t1 >> 16) & 0xff) ^
             Te2((t2 >>  8) & 0xff) ^
             Te3((t3)       & 0xff) ^
             rk[0];
         s1 =
-            Te0((t1 >> 24)       ) ^
+            Te0((t1 >> 24)) ^
             Te1((t2 >> 16) & 0xff) ^
             Te2((t3 >>  8) & 0xff) ^
             Te3((t0)       & 0xff) ^
             rk[1];
         s2 =
-            Te0((t2 >> 24)       ) ^
+            Te0((t2 >> 24)) ^
             Te1((t3 >> 16) & 0xff) ^
             Te2((t0 >>  8) & 0xff) ^
             Te3((t1)       & 0xff) ^
             rk[2];
         s3 =
-            Te0((t3 >> 24)       ) ^
+            Te0((t3 >> 24)) ^
             Te1((t0 >> 16) & 0xff) ^
             Te2((t1 >>  8) & 0xff) ^
             Te3((t2)       & 0xff) ^
@@ -1241,32 +1253,32 @@ int aes_encrypt(const cipher_context_t *context, const uint8_t *plainBlock,
 
 #endif /* ?MODULE_CRYPTO_AES_UNROLL */
     /*
-         * apply last round and
-         * map cipher state to byte array block:
-         */
+     * apply last round and
+     * map cipher state to byte array block:
+     */
     s0 =
-        (Te4((t0 >> 24)       ) & 0xff000000) ^
+        (Te4((t0 >> 24)) & 0xff000000) ^
         (Te4((t1 >> 16) & 0xff) & 0x00ff0000) ^
         (Te4((t2 >>  8) & 0xff) & 0x0000ff00) ^
         (Te4((t3) & 0xff)       & 0x000000ff) ^
         rk[0];
-    PUTU32(cipherBlock     , s0);
+    PUTU32(cipherBlock, s0);
     s1 =
-        (Te4((t1 >> 24)       ) & 0xff000000) ^
+        (Te4((t1 >> 24)) & 0xff000000) ^
         (Te4((t2 >> 16) & 0xff) & 0x00ff0000) ^
         (Te4((t3 >>  8) & 0xff) & 0x0000ff00) ^
         (Te4((t0) & 0xff)       & 0x000000ff) ^
         rk[1];
     PUTU32(cipherBlock +  4, s1);
     s2 =
-        (Te4((t2 >> 24)       ) & 0xff000000) ^
+        (Te4((t2 >> 24)) & 0xff000000) ^
         (Te4((t3 >> 16) & 0xff) & 0x00ff0000) ^
         (Te4((t0 >>  8) & 0xff) & 0x0000ff00) ^
         (Te4((t1) & 0xff)       & 0x000000ff) ^
         rk[2];
     PUTU32(cipherBlock +  8, s2);
     s3 =
-        (Te4((t3 >> 24)       ) & 0xff000000) ^
+        (Te4((t3 >> 24)) & 0xff000000) ^
         (Te4((t0 >> 16) & 0xff) & 0x00ff0000) ^
         (Te4((t1 >>  8) & 0xff) & 0x0000ff00) ^
         (Te4((t2) & 0xff)       & 0x000000ff) ^
@@ -1286,6 +1298,7 @@ int aes_decrypt(const cipher_context_t *context, const uint8_t *cipherBlock,
     int res;
     AES_KEY aeskey;
     const AES_KEY *key = &aeskey;
+
     res = aes_set_decrypt_key((unsigned char *)context->context,
                               AES_KEY_SIZE * 8, &aeskey);
 
@@ -1443,25 +1456,25 @@ int aes_decrypt(const cipher_context_t *context, const uint8_t *cipherBlock,
 
     while (1) {
         t0 =
-            Td0((s0 >> 24)       ) ^
+            Td0((s0 >> 24)) ^
             Td1((s3 >> 16) & 0xff) ^
             Td2((s2 >>  8) & 0xff) ^
             Td3((s1)       & 0xff) ^
             rk[4];
         t1 =
-            Td0((s1 >> 24)       ) ^
+            Td0((s1 >> 24)) ^
             Td1((s0 >> 16) & 0xff) ^
             Td2((s3 >>  8) & 0xff) ^
             Td3((s2)       & 0xff) ^
             rk[5];
         t2 =
-            Td0((s2 >> 24)       ) ^
+            Td0((s2 >> 24)) ^
             Td1((s1 >> 16) & 0xff) ^
             Td2((s0 >>  8) & 0xff) ^
             Td3((s3)       & 0xff) ^
             rk[6];
         t3 =
-            Td0((s3 >> 24)       ) ^
+            Td0((s3 >> 24)) ^
             Td1((s2 >> 16) & 0xff) ^
             Td2((s1 >>  8) & 0xff) ^
             Td3((s0)       & 0xff) ^
@@ -1474,25 +1487,25 @@ int aes_decrypt(const cipher_context_t *context, const uint8_t *cipherBlock,
         }
 
         s0 =
-            Td0((t0 >> 24)       ) ^
+            Td0((t0 >> 24)) ^
             Td1((t3 >> 16) & 0xff) ^
             Td2((t2 >>  8) & 0xff) ^
             Td3((t1)       & 0xff) ^
             rk[0];
         s1 =
-            Td0((t1 >> 24)       ) ^
+            Td0((t1 >> 24)) ^
             Td1((t0 >> 16) & 0xff) ^
             Td2((t3 >>  8) & 0xff) ^
             Td3((t2) & 0xff) ^
             rk[1];
         s2 =
-            Td0((t2 >> 24)       ) ^
+            Td0((t2 >> 24)) ^
             Td1((t1 >> 16) & 0xff) ^
             Td2((t0 >>  8) & 0xff) ^
             Td3((t3)       & 0xff) ^
             rk[2];
         s3 =
-            Td0((t3 >> 24)       ) ^
+            Td0((t3 >> 24)) ^
             Td1((t2 >> 16) & 0xff) ^
             Td2((t1 >>  8) & 0xff) ^
             Td3((t0)       & 0xff) ^
@@ -1501,32 +1514,32 @@ int aes_decrypt(const cipher_context_t *context, const uint8_t *cipherBlock,
 
 #endif /* ?MODULE_CRYPTO_AES_UNROLL */
     /*
-         * apply last round and
-         * map cipher state to byte array block:
-         */
+     * apply last round and
+     * map cipher state to byte array block:
+     */
     s0 =
-        (Td4((t0 >> 24)       ) & 0xff000000) ^
+        (Td4((t0 >> 24)) & 0xff000000) ^
         (Td4((t3 >> 16) & 0xff) & 0x00ff0000) ^
         (Td4((t2 >>  8) & 0xff) & 0x0000ff00) ^
         (Td4((t1) & 0xff)       & 0x000000ff) ^
         rk[0];
-    PUTU32(plainBlock     , s0);
+    PUTU32(plainBlock, s0);
     s1 =
-        (Td4((t1 >> 24)       ) & 0xff000000) ^
+        (Td4((t1 >> 24)) & 0xff000000) ^
         (Td4((t0 >> 16) & 0xff) & 0x00ff0000) ^
         (Td4((t3 >>  8) & 0xff) & 0x0000ff00) ^
         (Td4((t2) & 0xff)       & 0x000000ff) ^
         rk[1];
     PUTU32(plainBlock +  4, s1);
     s2 =
-        (Td4((t2 >> 24)       ) & 0xff000000) ^
+        (Td4((t2 >> 24)) & 0xff000000) ^
         (Td4((t1 >> 16) & 0xff) & 0x00ff0000) ^
         (Td4((t0 >>  8) & 0xff) & 0x0000ff00) ^
         (Td4((t3) & 0xff)       & 0x000000ff) ^
         rk[2];
     PUTU32(plainBlock +  8, s2);
     s3 =
-        (Td4((t3 >> 24)       ) & 0xff000000) ^
+        (Td4((t3 >> 24)) & 0xff000000) ^
         (Td4((t2 >> 16) & 0xff) & 0x00ff0000) ^
         (Td4((t1 >>  8) & 0xff) & 0x0000ff00) ^
         (Td4((t0) & 0xff)       & 0x000000ff) ^

--- a/sys/crypto/aes.c
+++ b/sys/crypto/aes.c
@@ -800,6 +800,11 @@ int aes_init(cipher_context_t *context, const uint8_t *key, uint8_t keySize)
 {
     uint8_t i;
 
+    /* This implementation only supports a single key size (defined in AES_KEY_SIZE) */
+    if (keySize != AES_KEY_SIZE) {
+        return CIPHER_ERR_INVALID_KEY_SIZE;
+    }
+
     /* Make sure that context is large enough. If this is not the case,
        you should build with -DAES */
     if (CIPHER_MAX_CONTEXT_SIZE < AES_KEY_SIZE) {

--- a/sys/include/crypto/aes.h
+++ b/sys/include/crypto/aes.h
@@ -75,6 +75,8 @@ typedef struct {
  * @param       context   the cipher_context_t-struct to save the
  *                        initialization of the cipher in
  * @param       keySize   the size of the key
+ *                        Must be 16, since this implementation does not
+ *                        support key lengths of 24 or 32 bytes
  * @param       key       a pointer to the key
  *
  * @return  CIPHER_INIT_SUCCESS if the initialization was successful.

--- a/tests/unittests/tests-crypto/tests-crypto-aes.c
+++ b/tests/unittests/tests-crypto/tests-crypto-aes.c
@@ -83,14 +83,14 @@ static void test_crypto_aes_decrypt(void)
     TEST_ASSERT_MESSAGE(1 == compare(TEST_1_INP, data, AES_BLOCK_SIZE), "wrong plaintext");
 }
 
-Test* tests_crypto_aes_tests(void)
+Test *tests_crypto_aes_tests(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
         new_TestFixture(test_crypto_aes_encrypt),
-                        new_TestFixture(test_crypto_aes_decrypt),
+        new_TestFixture(test_crypto_aes_decrypt),
     };
 
     EMB_UNIT_TESTCALLER(crypto_aes_tests, NULL, NULL, fixtures);
 
-    return (Test*)&crypto_aes_tests;
+    return (Test *)&crypto_aes_tests;
 }

--- a/tests/unittests/tests-crypto/tests-crypto-aes.c
+++ b/tests/unittests/tests-crypto/tests-crypto-aes.c
@@ -46,14 +46,14 @@ static void test_crypto_aes_encrypt(void)
     int err;
     uint8_t data[AES_BLOCK_SIZE];
 
-    err = aes_init(&ctx, TEST_0_KEY, AES_KEY_SIZE);
+    err = aes_init(&ctx, TEST_0_KEY, sizeof(TEST_0_KEY));
     TEST_ASSERT_EQUAL_INT(1, err);
 
     err = aes_encrypt(&ctx, TEST_0_INP, data);
     TEST_ASSERT_EQUAL_INT(1, err);
     TEST_ASSERT_MESSAGE(1 == compare(TEST_0_ENC, data, AES_BLOCK_SIZE), "wrong ciphertext");
 
-    err = aes_init(&ctx, TEST_1_KEY, AES_KEY_SIZE);
+    err = aes_init(&ctx, TEST_1_KEY, sizeof(TEST_1_KEY));
     TEST_ASSERT_EQUAL_INT(1, err);
 
     err = aes_encrypt(&ctx, TEST_1_INP, data);
@@ -63,19 +63,18 @@ static void test_crypto_aes_encrypt(void)
 
 static void test_crypto_aes_decrypt(void)
 {
-
     cipher_context_t ctx;
     int err;
     uint8_t data[AES_BLOCK_SIZE];
 
-    err = aes_init(&ctx, TEST_0_KEY, AES_KEY_SIZE);
+    err = aes_init(&ctx, TEST_0_KEY, sizeof(TEST_0_KEY));
     TEST_ASSERT_EQUAL_INT(1, err);
 
     err = aes_decrypt(&ctx, TEST_0_ENC, data);
     TEST_ASSERT_EQUAL_INT(1, err);
     TEST_ASSERT_MESSAGE(1 == compare(TEST_0_INP, data, AES_BLOCK_SIZE), "wrong plaintext");
 
-    err = aes_init(&ctx, TEST_1_KEY, AES_KEY_SIZE);
+    err = aes_init(&ctx, TEST_1_KEY, sizeof(TEST_1_KEY));
     TEST_ASSERT_EQUAL_INT(1, err);
 
     err = aes_decrypt(&ctx, TEST_1_ENC, data);

--- a/tests/unittests/tests-crypto/tests-crypto-aes.c
+++ b/tests/unittests/tests-crypto/tests-crypto-aes.c
@@ -82,11 +82,40 @@ static void test_crypto_aes_decrypt(void)
     TEST_ASSERT_MESSAGE(1 == compare(TEST_1_INP, data, AES_BLOCK_SIZE), "wrong plaintext");
 }
 
+static void test_crypto_aes_init_key_length(void)
+{
+    cipher_context_t ctx;
+    int err;
+
+    /* A keylength of 192 bit is not supported by the current implementation */
+    uint8_t unsupported_key_1[24];
+
+    memset(unsupported_key_1, 0, sizeof(unsupported_key_1));
+
+    /* A keylength of 256 bit is not supported by the current implementation */
+    uint8_t unsupported_key_2[32];
+    memset(unsupported_key_2, 0, sizeof(unsupported_key_2));
+
+    /* A keylength of 64 bit is not supported by AES */
+    uint8_t unsupported_key_3[8];
+    memset(unsupported_key_3, 0, sizeof(unsupported_key_3));
+
+    err = aes_init(&ctx, unsupported_key_1, sizeof(unsupported_key_1));
+    TEST_ASSERT_EQUAL_INT(CIPHER_ERR_INVALID_KEY_SIZE, err);
+
+    err = aes_init(&ctx, unsupported_key_2, sizeof(unsupported_key_2));
+    TEST_ASSERT_EQUAL_INT(CIPHER_ERR_INVALID_KEY_SIZE, err);
+
+    err = aes_init(&ctx, unsupported_key_3, sizeof(unsupported_key_3));
+    TEST_ASSERT_EQUAL_INT(CIPHER_ERR_INVALID_KEY_SIZE, err);
+}
+
 Test *tests_crypto_aes_tests(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
         new_TestFixture(test_crypto_aes_encrypt),
         new_TestFixture(test_crypto_aes_decrypt),
+        new_TestFixture(test_crypto_aes_init_key_length),
     };
 
     EMB_UNIT_TESTCALLER(crypto_aes_tests, NULL, NULL, fixtures);

--- a/tests/unittests/tests-crypto/tests-crypto-cipher.c
+++ b/tests/unittests/tests-crypto/tests-crypto-cipher.c
@@ -31,7 +31,7 @@ static void test_crypto_cipher_aes_encrypt(void)
 {
     cipher_t cipher;
     int err, cmp;
-    uint8_t data[16] = {0};
+    uint8_t data[16] = { 0 };
 
     err = cipher_init(&cipher, CIPHER_AES_128, TEST_KEY, 16);
     TEST_ASSERT_EQUAL_INT(1, err);
@@ -40,7 +40,7 @@ static void test_crypto_cipher_aes_encrypt(void)
     TEST_ASSERT_EQUAL_INT(1, err);
 
     cmp = compare(TEST_ENC_AES, data, 16);
-    TEST_ASSERT_MESSAGE(1 == cmp , "wrong ciphertext");
+    TEST_ASSERT_MESSAGE(1 == cmp, "wrong ciphertext");
 }
 
 static void test_crypto_cipher_aes_decrypt(void)
@@ -56,10 +56,10 @@ static void test_crypto_cipher_aes_decrypt(void)
     TEST_ASSERT_EQUAL_INT(1, err);
 
     cmp = compare(TEST_INP, data, 16);
-    TEST_ASSERT_MESSAGE(1 == cmp , "wrong plaintext");
+    TEST_ASSERT_MESSAGE(1 == cmp, "wrong plaintext");
 }
 
-Test* tests_crypto_cipher_tests(void)
+Test *tests_crypto_cipher_tests(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
         new_TestFixture(test_crypto_cipher_aes_encrypt),
@@ -68,5 +68,5 @@ Test* tests_crypto_cipher_tests(void)
 
     EMB_UNIT_TESTCALLER(crypto_cipher_tests, NULL, NULL, fixtures);
 
-    return (Test*)&crypto_cipher_tests;
+    return (Test *)&crypto_cipher_tests;
 }

--- a/tests/unittests/tests-crypto/tests-crypto-cipher.c
+++ b/tests/unittests/tests-crypto/tests-crypto-cipher.c
@@ -7,6 +7,7 @@
  */
 
 #include <limits.h>
+#include <string.h>
 
 #include "embUnit.h"
 #include "crypto/ciphers.h"
@@ -59,11 +60,40 @@ static void test_crypto_cipher_aes_decrypt(void)
     TEST_ASSERT_MESSAGE(1 == cmp, "wrong plaintext");
 }
 
+static void test_crypto_cipher_init_aes_key_length(void)
+{
+    cipher_t cipher;
+    int err;
+
+    /* A keylength of 192 bit is not supported by the current implementation */
+    uint8_t unsupported_key_1[24];
+
+    memset(unsupported_key_1, 0, sizeof(unsupported_key_1));
+
+    /* A keylength of 256 bit is not supported by the current implementation */
+    uint8_t unsupported_key_2[32];
+    memset(unsupported_key_2, 0, sizeof(unsupported_key_2));
+
+    /* A keylength of 64 bit is not supported by AES */
+    uint8_t unsupported_key_3[8];
+    memset(unsupported_key_3, 0, sizeof(unsupported_key_3));
+
+    err = cipher_init(&cipher, CIPHER_AES_128, unsupported_key_1, sizeof(unsupported_key_1));
+    TEST_ASSERT_EQUAL_INT(CIPHER_ERR_INVALID_KEY_SIZE, err);
+
+    err = cipher_init(&cipher, CIPHER_AES_128, unsupported_key_2, sizeof(unsupported_key_2));
+    TEST_ASSERT_EQUAL_INT(CIPHER_ERR_INVALID_KEY_SIZE, err);
+
+    err = cipher_init(&cipher, CIPHER_AES_128, unsupported_key_3, sizeof(unsupported_key_3));
+    TEST_ASSERT_EQUAL_INT(CIPHER_ERR_INVALID_KEY_SIZE, err);
+}
+
 Test *tests_crypto_cipher_tests(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
         new_TestFixture(test_crypto_cipher_aes_encrypt),
-        new_TestFixture(test_crypto_cipher_aes_decrypt)
+        new_TestFixture(test_crypto_cipher_aes_decrypt),
+        new_TestFixture(test_crypto_cipher_init_aes_key_length),
     };
 
     EMB_UNIT_TESTCALLER(crypto_cipher_tests, NULL, NULL, fixtures);


### PR DESCRIPTION
### Contribution description

A proper error code is returned if a key with unsupported (either by the implementation or the AES algorithm) length is passed to `aes_init`.

### Testing procedure

The unit tests in the `tests-crypto` folder have been updated.

### Issues/PRs references

This fixes #10175