### PR TITLE
boards/common/nrf51: add common place for clock configuration

### DIFF
--- a/boards/airfy-beacon/include/periph_conf.h
+++ b/boards/airfy-beacon/include/periph_conf.h
@@ -22,25 +22,11 @@
 
 #include "periph_cpu.h"
 #include "periph_conf_common.h"
+#include "cfg_clock_16_1.h"
 
 #ifdef __cplusplus
  extern "C" {
 #endif
-
-/**
- * @name    Clock configuration
- *
- * @note    The radio will not work with the internal RC oscillator!
- *
- * @{
- */
-#define CLOCK_HFCLK         (16U)           /* set to  0: internal RC oscillator
-                                                      16: 16MHz crystal
-                                                      32: 32MHz crystal */
-#define CLOCK_LFCLK         (1)             /* set to  0: internal RC oscillator
-                                             *         1: 32.768 kHz crystal
-                                             *         2: derived from HFCLK */
-/** @} */
 
 /**
  * @name    UART configuration

--- a/boards/calliope-mini/include/periph_conf.h
+++ b/boards/calliope-mini/include/periph_conf.h
@@ -21,25 +21,11 @@
 #define PERIPH_CONF_H
 
 #include "periph_cpu.h"
+#include "cfg_clock_16_0.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-/**
- * @name    Clock configuration
- *
- * @note    The radio will not work with the internal RC oscillator!
- *
- * @{
- */
-#define CLOCK_HFCLK         (16U)           /* set to  0: internal RC oscillator
-                                                      16: 16MHz crystal
-                                                      32: 32MHz crystal */
-#define CLOCK_LFCLK         (0)             /* set to  0: internal RC oscillator
-                                             *         1: 32.768 kHz crystal
-                                             *         2: derived from HFCLK */
-/** @} */
 
 /**
  * @name    Timer configuration

--- a/boards/common/nrf51/include/cfg_clock_16_0.h
+++ b/boards/common/nrf51/include/cfg_clock_16_0.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2018 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_common_nrf51
+ * @{
+ *
+ * @file
+ * @brief       Common clock configuration for some nrf51 based boards
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ */
+
+#ifndef CFG_CLOCK_16_0_H
+#define CFG_CLOCK_16_0_H
+
+#include "periph_cpu.h"
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/**
+ * @name    Clock configuration
+ *
+ * @note    The radio will not work with the internal RC oscillator!
+ *
+ * @{
+ */
+#define CLOCK_HFCLK         (16U)           /* set to  0: internal RC oscillator
+                                                      16: 16MHz crystal
+                                                      32: 32MHz crystal */
+#define CLOCK_LFCLK         (0)             /* set to  0: internal RC oscillator
+                                             *         1: 32.768 kHz crystal
+                                             *         2: derived from HFCLK */
+/** @} */
+
+#ifdef __cplusplus
+} /* end extern "C" */
+#endif
+
+#endif /* CFG_CLOCK_16_0_H */

--- a/boards/common/nrf51/include/cfg_clock_16_1.h
+++ b/boards/common/nrf51/include/cfg_clock_16_1.h
@@ -1,0 +1,47 @@
+/*
+ * Copyright (C) 2018 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_common_nrf51
+ * @{
+ *
+ * @file
+ * @brief       Common clock configuration for some nrf51 based boards
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ */
+
+#ifndef CFG_CLOCK_16_1_H
+#define CFG_CLOCK_16_1_H
+
+#include "periph_cpu.h"
+
+#ifdef __cplusplus
+ extern "C" {
+#endif
+
+/**
+ * @name    Clock configuration
+ *
+ * @note    The radio will not work with the internal RC oscillator!
+ *
+ * @{
+ */
+#define CLOCK_HFCLK         (16U)           /* set to  0: internal RC oscillator
+                                                      16: 16MHz crystal
+                                                      32: 32MHz crystal */
+#define CLOCK_LFCLK         (1)             /* set to  0: internal RC oscillator
+                                             *         1: 32.768 kHz crystal
+                                             *         2: derived from HFCLK */
+/** @} */
+
+#ifdef __cplusplus
+} /* end extern "C" */
+#endif
+
+#endif /* CFG_CLOCK_16_1_H */

--- a/boards/microbit/include/periph_conf.h
+++ b/boards/microbit/include/periph_conf.h
@@ -20,25 +20,11 @@
 #define PERIPH_CONF_H
 
 #include "periph_cpu.h"
+#include "cfg_clock_16_0.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-/**
- * @name    Clock configuration
- *
- * @note    The radio will not work with the internal RC oscillator!
- *
- * @{
- */
-#define CLOCK_HFCLK         (16U)           /* set to  0: internal RC oscillator
-                                                      16: 16MHz crystal
-                                                      32: 32MHz crystal */
-#define CLOCK_LFCLK         (0)             /* set to  0: internal RC oscillator
-                                             *         1: 32.768 kHz crystal
-                                             *         2: derived from HFCLK */
-/** @} */
 
 /**
  * @name Timer configuration

--- a/boards/nrf51dongle/include/periph_conf.h
+++ b/boards/nrf51dongle/include/periph_conf.h
@@ -21,25 +21,11 @@
 
 #include "periph_cpu.h"
 #include "periph_conf_common.h"
+#include "cfg_clock_16_1.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-/**
- * @name    Clock configuration
- *
- * @note    The radio will not work with the internal RC oscillator!
- *
- * @{
- */
-#define CLOCK_HFCLK         (16U)           /* set to  0: internal RC oscillator
-                                                      16: 16MHz crystal
-                                                      32: 32MHz crystal */
-#define CLOCK_LFCLK         (1)             /* set to  0: internal RC oscillator
-                                             *         1: 32.768 kHz crystal
-                                             *         2: derived from HFCLK */
-/** @} */
 
 /**
  * @name UART configuration

--- a/boards/nrf6310/include/periph_conf.h
+++ b/boards/nrf6310/include/periph_conf.h
@@ -24,25 +24,11 @@
 
 #include "periph_cpu.h"
 #include "periph_conf_common.h"
+#include "cfg_clock_16_1.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-/**
- * @name    Clock configuration
- *
- * @note    The radio will not work with the internal RC oscillator!
- *
- * @{
- */
-#define CLOCK_HFCLK         (16U)           /* set to  0: internal RC oscillator
-                                                      16: 16MHz crystal
-                                                      32: 32MHz crystal */
-#define CLOCK_LFCLK         (1)             /* set to  0: internal RC oscillator
-                                             *         1: 32.768 kHz crystal
-                                             *         2: derived from HFCLK */
-/** @} */
 
 /**
  * @name    UART configuration

--- a/boards/yunjia-nrf51822/include/periph_conf.h
+++ b/boards/yunjia-nrf51822/include/periph_conf.h
@@ -21,25 +21,11 @@
 
 #include "periph_cpu.h"
 #include "periph_conf_common.h"
+#include "cfg_clock_16_0.h"
 
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-/**
- * @name    Clock configuration
- *
- * @note    The radio will not work with the internal RC oscillator!
- *
- * @{
- */
-#define CLOCK_HFCLK         (16U)           /* set to  0: internal RC oscillator
-                                                      16: 16MHz crystal
-                                                      32: 32MHz crystal */
-#define CLOCK_LFCLK         (0)             /* set to  0: internal RC oscillator
-                                             *         1: 32.768 kHz crystal
-                                             *         2: derived from HFCLK */
-/** @} */
 
 /**
  * @name UART configuration


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR follows #10243 by adding a common place for clock configurations.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Building any application for each concerned board (airfy-beacon, calliope-mini, microbit, nrf51dongle, nrf5310, yunjia-nrf51822) should work.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

depends on #10243

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
