### PR TITLE
gnrc_pktbuf: clarify doc of _start_write()

### DIFF
--- a/sys/include/net/gnrc/pktbuf.h
+++ b/sys/include/net/gnrc/pktbuf.h
@@ -172,16 +172,15 @@ static inline void gnrc_pktbuf_release(gnrc_pktsnip_t *pkt)
 }
 
 /**
- * @brief   Must be called once before there is a write operation in a thread.
+ * @brief   Must be called once before there is a write operation on a
+ *          [packet snip](@ref gnrc_pktsnip_t) in a thread.
  *
- * @details This function duplicates a packet in the packet buffer if
+ * @details This function duplicates a packet snip in the packet buffer if
  *          gnrc_pktsnip_t::users of @p pkt > 1.
  *
- * @note    Do *not* call this function in a thread twice on the same packet.
+ * @param[in] pkt   The packet snip you want to write into.
  *
- * @param[in] pkt   The packet you want to write into.
- *
- * @return  The (new) pointer to the pkt.
+ * @return  The (new) pointer to the packet snip.
  * @return  NULL, if gnrc_pktsnip_t::users of @p pkt > 1 and if there is not
  *          enough space in the packet buffer.
  */


### PR DESCRIPTION
### Contribution description
The documentation on `gnrc_pktbuf_start_write()` currently is somewhat misleading:

1. It talks of packets when packet snips are meant.
2. It warns about calling the function twice on the same packet. This is technically true

### Testing procedure
Compile doc with `make doc`, check if `doc/doxygen/html/group__net__gnrc__pktbuf.html#ga640418467294ae3d408c109ab27bd617` is rendered correctly

### Issues/PRs references
Resolves #10261