### PR TITLE
boards/common/silabs: add Arduino API support for SiLabs boards

### DIFF
--- a/boards/common/silabs/Makefile.features
+++ b/boards/common/silabs/Makefile.features
@@ -1,0 +1,2 @@
+# Various other features (if any)
+FEATURES_PROVIDED += arduino

--- a/boards/common/silabs/include/arduino_board.h
+++ b/boards/common/silabs/include/arduino_board.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C)  2018 Federico Pellegrin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_common_silabs
+ * @brief       SiLabs Boards configuration for the Arduino API
+ * @file
+ * @author      Federico Pellegrin <fede@evolware.org>
+ * @{
+ */
+
+#ifndef ARDUINO_BOARD_H
+#define ARDUINO_BOARD_H
+
+#include "arduino_pinmap.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Arduino's digital pins mappings
+ */
+static const gpio_t arduino_pinmap[] = {
+    ARDUINO_PIN_0,
+    ARDUINO_PIN_1,
+    ARDUINO_PIN_2,
+    ARDUINO_PIN_3
+};
+
+/**
+ * @brief   Arduino's analog pins mappings
+ */
+static const adc_t arduino_analog_map[] = {
+    ARDUINO_A0
+};
+
+/**
+ * @brief   On-board LED mapping
+ */
+#define ARDUINO_LED         (0)
+
+/**
+ * @brief   On-board serial port mapping
+ */
+#define ARDUINO_UART_DEV         UART_DEV(0)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ARDUINO_BOARD_H */
+/** @} */

--- a/boards/common/silabs/include/arduino_pinmap.h
+++ b/boards/common/silabs/include/arduino_pinmap.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C)  2018 Federico Pellegrin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_common_silabs
+ * @brief       SiLabs Boards configuration for the Arduino API
+ * @file
+ * @author      Federico Pellegrin <fede@evolware.org>
+ * @{
+ */
+
+#ifndef ARDUINO_PINMAP_H
+#define ARDUINO_PINMAP_H
+
+#include "board.h"
+#include "periph_cpu.h"
+#include "periph/adc.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Arduino's digital pins mappings
+ */
+#define ARDUINO_PIN_0   LED0_PIN
+#define ARDUINO_PIN_1   LED1_PIN
+#define ARDUINO_PIN_2   PB0_PIN
+#define ARDUINO_PIN_3   PB1_PIN
+
+/**
+ * @brief   Arduino's analog pins mappings
+ */
+#define ARDUINO_A0      ADC_LINE(0)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ARDUINO_PINMAP_H */
+/** @} */

--- a/boards/slstk3401a/Makefile.features
+++ b/boards/slstk3401a/Makefile.features
@@ -11,4 +11,6 @@ FEATURES_PROVIDED += periph_uart
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m4_2
 
+include $(RIOTBOARD)/common/silabs/Makefile.features
+
 include $(RIOTCPU)/efm32/Makefile.features

--- a/boards/slstk3402a/Makefile.features
+++ b/boards/slstk3402a/Makefile.features
@@ -11,4 +11,6 @@ FEATURES_PROVIDED += periph_uart
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m4_2
 
+include $(RIOTBOARD)/common/silabs/Makefile.features
+
 include $(RIOTCPU)/efm32/Makefile.features

--- a/boards/sltb001a/Makefile.features
+++ b/boards/sltb001a/Makefile.features
@@ -11,4 +11,6 @@ FEATURES_PROVIDED += periph_uart
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m4_2
 
+include $(RIOTBOARD)/common/silabs/Makefile.features
+
 include $(RIOTCPU)/efm32/Makefile.features

--- a/boards/slwstk6000b/Makefile.features
+++ b/boards/slwstk6000b/Makefile.features
@@ -11,4 +11,6 @@ FEATURES_PROVIDED += periph_uart
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m4_2
 
+include $(RIOTBOARD)/common/silabs/Makefile.features
+
 include $(RIOTCPU)/efm32/Makefile.features

--- a/boards/stk3600/Makefile.features
+++ b/boards/stk3600/Makefile.features
@@ -13,4 +13,6 @@ FEATURES_PROVIDED += periph_uart
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m3_2
 
+include $(RIOTBOARD)/common/silabs/Makefile.features
+
 include $(RIOTCPU)/efm32/Makefile.features

--- a/boards/stk3700/Makefile.features
+++ b/boards/stk3700/Makefile.features
@@ -13,4 +13,6 @@ FEATURES_PROVIDED += periph_uart
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m3_2
 
+include $(RIOTBOARD)/common/silabs/Makefile.features
+
 include $(RIOTCPU)/efm32/Makefile.features

--- a/tests/driver_hd44780/Makefile
+++ b/tests/driver_hd44780/Makefile
@@ -1,7 +1,8 @@
 include ../Makefile.tests_common
 
 # the stm32f4discovery does not have the arduino pinout
-BOARD_BLACKLIST := stm32f4discovery jiminy-mega256rfr2
+BOARD_BLACKLIST := stm32f4discovery jiminy-mega256rfr2 slstk3401a slstk3402a \
+                   sltb001a slwstk6000b stk3600 stk3700
 
 # currently the test provides config params for arduinos only
 FEATURES_REQUIRED += arduino


### PR DESCRIPTION
### Contribution description
Adds the Arduino API support for the Silicon Labs evaluation boards (ie. EFM32 STK3700 (Giant Gecko Starter Kit).
This enables Arduino-like programming supported by RIOT also on this boards.

### Testing procedure
Arduino automatic test sys_arduino can be used for basic functionalities tests, for example on the STK3700:
```
cd tests/sys_arduino/
BOARD=stk3700 make all flash test
```
Additionally one can manually use and play with the _examples/arduino_hello-world/_ for other tests (ie. playing with I/O and leds)

