### PR TITLE
build: remove hostname from RIOT_VERSION string

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -319,7 +319,7 @@ include $(RIOTMAKE)/cflags.inc.mk
 
 # make the RIOT version available to the program
 ifeq ($(origin RIOT_VERSION), undefined)
-  GIT_STRING := $(shell git --git-dir="$(RIOTBASE)/.git" describe --always --abbrev=4 --dirty=-`hostname` 2> /dev/null)
+  GIT_STRING := $(shell git --git-dir="$(RIOTBASE)/.git" describe --always --abbrev=4 2> /dev/null)
   ifneq (,$(GIT_STRING))
     GIT_BRANCH := $(shell git --git-dir="$(RIOTBASE)/.git" rev-parse --abbrev-ref HEAD)
     ifeq ($(strip $(GIT_BRANCH)),master)


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

The hostname does not provide any additional or necessary information to
the RIOT_VERSION string. On the contrary, some might consider the hostname
as personal information, which should not be exposed unsolicitedly.

### Testing procedure

Compile examples/hello-world with and without this PR. The hostname should be gone.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->