### PR TITLE
Makefile.include: Fix default RIOTBASE when there is Makefile.local

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -1,3 +1,6 @@
+# 'Makefile.include' directory, must be evaluated before other 'include'
+_riotbase := $(dir $(lastword $(MAKEFILE_LIST)))
+
 # Globally set default goal to `all`
 .DEFAULT_GOAL := all
 
@@ -5,7 +8,7 @@
 -include Makefile.local
 
 # set undefined variables
-RIOTBASE       ?= $(dir $(lastword $(MAKEFILE_LIST)))
+RIOTBASE       ?= $(_riotbase)
 CCACHE_BASEDIR ?= $(RIOTBASE)
 RIOTCPU        ?= $(RIOTBASE)/cpu
 RIOTBOARD      ?= $(RIOTBASE)/boards


### PR DESCRIPTION
### Contribution description

When an application only includes Makefile.include without specifying
RIOTBASE and uses a `Makefile.local` file, RIOTBASE would use a wrong
default value and get the value of the directory where `Makefile.local` is.


The line handling a default value for `RIOTBASE` would not work if a Makefile.local was present as it would have modified `MAKEFILE_LIST` 

https://github.com/RIOT-OS/RIOT/blob/fc139f30e31791ec6d29d244f44876b27b29eb70/Makefile.include#L5-L8

#### TODO ####

* [ ] Remove the test commit after ACK

### Testing procedure

Compiling an application that has a `Makefile.local` and includes `include ../../Makefile.include` without defining `RIOTBASE`.

 
I added a debug application in `examples/test_not_setting_riotbase/` that you can try compiling with and without the bugfix commit.

With the bug fix commit it compiles normally.
Without the fix (just discard the last commit), it tries to use the application directory as RIOTBASE:

```
/home/harter/work/git/RIOT/examples/test_not_setting_riotbase/Makefile.local
../../Makefile.include:80: /home/harter/work/git/RIOT/examples/test_not_setting_riotbase/makefiles/docker.inc.mk: No such file or directory
../../Makefile.include:83: /home/harter/work/git/RIOT/examples/test_not_setting_riotbase/makefiles/color.inc.mk: No such file or directory
../../Makefile.include:86: /home/harter/work/git/RIOT/examples/test_not_setting_riotbase/makefiles/info-nproc.inc.mk: No such file or directory
../../Makefile.include:100: /home/harter/work/git/RIOT/examples/test_not_setting_riotbase/makefiles/info.inc.mk: No such file or directory
../../Makefile.include:103: /home/harter/work/git/RIOT/examples/test_not_setting_riotbase/makefiles/scan-build.inc.mk: No such file or directory
../../Makefile.include:199: *** The specified board native does not exist..  Stop.
```



### Issues/PRs references

Detected when developing https://github.com/RIOT-OS/RIOT/pull/10270