### PR TITLE
drivers/motor_driver: driver for analogic H-bridge driving DC motors

### DIFF
--- a/boards/common/nucleo64/include/board.h
+++ b/boards/common/nucleo64/include/board.h
@@ -24,6 +24,7 @@
 
 #include "board_nucleo.h"
 #include "arduino_pinmap.h"
+#include "motor_driver.h"
 
 #ifdef __cplusplus
 extern "C" {
@@ -58,6 +59,37 @@ extern "C" {
 #else
 #define BTN0_MODE           GPIO_IN_PU
 #endif
+/** @} */
+
+/**
+ * @name Describe DC motors with PWM channel and GPIOs
+ * @{
+ */
+static const motor_driver_config_t motor_driver_config[] = {
+    {
+        .pwm_dev         = 1,
+        .mode            = MOTOR_DRIVER_1_DIR,
+        .mode_brake      = MOTOR_BRAKE_HIGH,
+        .pwm_mode        = PWM_LEFT,
+        .pwm_frequency   = 20000U,
+        .pwm_resolution  = 2250U,
+        .nb_motors       = 1,
+        .motors          = {
+            {
+                .pwm_channel            = 0,
+                .gpio_enable            = 0,
+                .gpio_dir0              = ARDUINO_PIN_15,
+                .gpio_dir1_or_brake     = 0,
+                .gpio_dir_reverse       = 0,
+                .gpio_enable_invert     = 0,
+                .gpio_brake_invert      = 0,
+            },
+        },
+        .cb = NULL,
+    },
+};
+
+#define MOTOR_DRIVER_NUMOF           (sizeof(motor_driver_config) / sizeof(motor_driver_config[0]))
 /** @} */
 
 #ifdef __cplusplus

--- a/boards/native/Makefile.features
+++ b/boards/native/Makefile.features
@@ -8,6 +8,7 @@ FEATURES_PROVIDED += periph_qdec
 
 # Various other features (if any)
 FEATURES_PROVIDED += ethernet
+FEATURES_PROVIDED += motor_driver
 
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = x86

--- a/boards/native/Makefile.features
+++ b/boards/native/Makefile.features
@@ -4,6 +4,7 @@ FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_gpio
 FEATURES_PROVIDED += periph_qdec
+FEATURES_PROVIDED += periph_pwm
 
 # Various other features (if any)
 FEATURES_PROVIDED += ethernet

--- a/boards/native/Makefile.features
+++ b/boards/native/Makefile.features
@@ -3,8 +3,8 @@ FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_gpio
-FEATURES_PROVIDED += periph_qdec
 FEATURES_PROVIDED += periph_pwm
+FEATURES_PROVIDED += periph_qdec
 
 # Various other features (if any)
 FEATURES_PROVIDED += ethernet

--- a/boards/native/board.c
+++ b/boards/native/board.c
@@ -1,0 +1,54 @@
+/**
+ * Native Board board implementation
+ *
+ * Copyright (C) 2018 Gilles DOFFE <g.doffe@gmail.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ *
+ * @ingroup boards_native
+ * @{
+ * @file
+ * @author  Gilles DOFFE <g.doffe@gmail.com>
+ * @}
+ */
+#include <inttypes.h>
+#include <stdio.h>
+
+/* RIOT includes */
+#include <board.h>
+#include <log.h>
+
+extern int32_t qdecs_value[QDEC_NUMOF];
+
+void native_motor_driver_qdec_simulation(
+    const motor_driver_t motor_driver, uint8_t motor_id,
+    int32_t pwm_duty_cycle)
+{
+    uint32_t id = 0;
+
+    for (uint32_t i = 0; i < motor_driver; i++) {
+        const motor_driver_config_t motor_driver_conf =
+            motor_driver_config[motor_driver];
+        id += motor_driver_conf.nb_motors;
+    }
+    id += motor_id;
+
+    if (id < QDEC_NUMOF) {
+        qdecs_value[id] = pwm_duty_cycle;
+
+        LOG_DEBUG("MOTOR-DRIVER=%u"             \
+            "    MOTOR_ID = %u"                 \
+            "    PWM_VALUE = %d"                \
+            "    QDEC_ID = %"PRIu32""           \
+            "    QDEC_VALUE = %d\n",            \
+            motor_driver, motor_id, pwm_duty_cycle, id, pwm_duty_cycle);
+    }
+    else {
+        LOG_ERROR("MOTOR-DRIVER=%u"             \
+            "    MOTOR_ID = %u"                 \
+            "    no QDEC device associated\n",  \
+            motor_driver, motor_id);
+    }
+}

--- a/boards/native/doc.txt
+++ b/boards/native/doc.txt
@@ -17,4 +17,6 @@ OS/RIOT/images/Native.jpg)
 - UART: Runtime configurable - `/dev/tty*` are supported
 - Timers: Host timer
 - LEDs: One red and one green LED - state changes are printed to the UART
+- PWM: Dummy PWM
+- QDEC: Emulated according to PWM
  */

--- a/boards/native/include/board.h
+++ b/boards/native/include/board.h
@@ -24,6 +24,9 @@
 
 #include <stdint.h>
 
+/* RIOT includes */
+#include <motor_driver.h>
+
 #ifdef __cplusplus
 extern "C" {
 #endif
@@ -123,6 +126,19 @@ extern mtd_dev_t *mtd0;
 #endif
 /** @} */
 #endif
+
+/**
+ * @brief Simulate QDEC on motor_set() calls
+ *
+ * @param[in] motor_driver      motor driver to which motor is attached
+ * @param[in] motor_id          motor ID on driver
+ * @param[in] pwm_duty_cycle    Signed PWM duty_cycle to set motor speed and direction
+ *
+ * @return                      0 on success
+ */
+void native_motor_driver_qdec_simulation( \
+    const motor_driver_t motor_driver, uint8_t motor_id, \
+    int32_t pwm_duty_cycle);
 
 #ifdef __cplusplus
 }

--- a/boards/native/include/board.h
+++ b/boards/native/include/board.h
@@ -140,6 +140,51 @@ void native_motor_driver_qdec_simulation( \
     const motor_driver_t motor_driver, uint8_t motor_id, \
     int32_t pwm_duty_cycle);
 
+/* C++ standard do not support designated initializers */
+#ifndef __cplusplus
+
+/**
+ * @name Describe DC motors with PWM channel and GPIOs
+ * @{
+ */
+static const motor_driver_config_t motor_driver_config[] = {
+    {
+        .pwm_dev         = 0,
+        .mode            = MOTOR_DRIVER_1_DIR_BRAKE,
+        .mode_brake      = MOTOR_BRAKE_LOW,
+        .pwm_mode        = PWM_LEFT,
+        .pwm_frequency   = 20000U,
+        .pwm_resolution  = 1000U,
+        .nb_motors       = 2,
+        .motors          = {
+            {
+                .pwm_channel            = 0,
+                .gpio_enable            = GPIO_PIN(0, 0),
+                .gpio_dir0              = GPIO_PIN(0, 0),
+                .gpio_dir1_or_brake     = GPIO_PIN(0, 0),
+                .gpio_dir_reverse       = 0,
+                .gpio_enable_invert     = 0,
+                .gpio_brake_invert      = 0,
+            },
+            {
+                .pwm_channel            = 1,
+                .gpio_enable            = GPIO_PIN(0, 0),
+                .gpio_dir0              = GPIO_PIN(0, 0),
+                .gpio_dir1_or_brake     = GPIO_PIN(0, 0),
+                .gpio_dir_reverse       = 1,
+                .gpio_enable_invert     = 0,
+                .gpio_brake_invert      = 0,
+            },
+        },
+        .cb = native_motor_driver_qdec_simulation,
+    },
+};
+
+#define MOTOR_DRIVER_NUMOF           (sizeof(motor_driver_config) / sizeof(motor_driver_config[0]))
+/** @} */
+
+#endif /* __cplusplus */
+
 #ifdef __cplusplus
 }
 #endif

--- a/boards/nucleo-f446re/Makefile.features
+++ b/boards/nucleo-f446re/Makefile.features
@@ -8,6 +8,9 @@ FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 FEATURES_PROVIDED += periph_qdec
 
+# Various other features (if any)
+FEATURES_PROVIDED += motor_driver
+
 # load the common Makefile.features for Nucleo boards
 include $(RIOTBOARD)/common/nucleo64/Makefile.features
 

--- a/cpu/native/Makefile.features
+++ b/cpu/native/Makefile.features
@@ -2,3 +2,4 @@ FEATURES_PROVIDED += cpp
 FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_hwrng
 FEATURES_PROVIDED += periph_pm
+FEATURES_PROVIDED += periph_pwm

--- a/cpu/native/include/periph_conf.h
+++ b/cpu/native/include/periph_conf.h
@@ -73,6 +73,13 @@
 /** @} */
 
 /**
+ * @brief PWM configuration
+ */
+#ifndef PWM_NUMOF
+#define PWM_NUMOF (8U)
+#endif
+
+/**
  * @brief QDEC configuration
  */
 #ifndef QDEC_NUMOF

--- a/cpu/native/periph/gpio.c
+++ b/cpu/native/periph/gpio.c
@@ -23,7 +23,10 @@ int gpio_init(gpio_t pin, gpio_mode_t mode) {
   (void) pin;
   (void) mode;
 
-  return -1;
+  if (mode >= GPIO_OUT)
+    return 0;
+  else
+    return -1;
 }
 
 int gpio_read(gpio_t pin) {

--- a/cpu/native/periph/pwm.c
+++ b/cpu/native/periph/pwm.c
@@ -1,0 +1,103 @@
+/*
+ * Copyright (C) 2018 Gilles DOFFE <g.doffe@gmail.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     cpu_native
+ * @ingroup     drivers_periph_pwm
+ * @{
+ *
+ * @file
+ * @brief       Low-level PWM driver implementation
+ *
+ * @author      Gilles DOFFE <g.doffe@gmail.com>
+ * @}
+ */
+
+#include <errno.h>
+
+#include "periph/pwm.h"
+
+#define ENABLE_DEBUG (0)
+#include "debug.h"
+
+#ifdef PWM_NUMOF
+
+#define NATIVE_PWM_SPEED    1000000
+#define NATIVE_PWM_NB_CHAN  2
+#define NATIVE_PWM_MAX      65535
+
+typedef struct {
+    uint16_t duty_cycle;
+    uint8_t on;
+} native_pwm_t;
+
+native_pwm_t pwms[PWM_NUMOF][NATIVE_PWM_NB_CHAN];
+
+uint32_t pwm_init(pwm_t pwm, pwm_mode_t mode, uint32_t freq, uint16_t res)
+{
+    uint8_t i = 0;
+
+    (void) mode;
+    (void) freq;
+    (void) res;
+
+    if (pwm >= PWM_NUMOF)
+    {
+        errno = ENODEV;
+        goto pwm_init_err;
+    }
+
+    /* reset pwm channels */
+    for (i = 0; i < NATIVE_PWM_NB_CHAN; i++)
+    {
+        pwms[pwm][i].duty_cycle = 0;
+        pwms[pwm][i].on = 0;
+    }
+
+    return freq;
+
+pwm_init_err:
+    return 0;
+}
+
+uint8_t pwm_channels(pwm_t pwm)
+{
+    (void) pwm;
+    return NATIVE_PWM_NB_CHAN;
+}
+
+void pwm_set(pwm_t pwm, uint8_t channel, uint16_t value)
+{
+    assert(pwm < PWM_NUMOF);
+
+    /* set new value */
+    pwms[pwm][channel].duty_cycle = value;
+    DEBUG("%s pwms[%u][%u] = %u\n", __func__, pwm, channel, value);
+}
+
+void pwm_poweron(pwm_t pwm)
+{
+    uint8_t i = 0;
+
+    assert(pwm < PWM_NUMOF);
+    /* reset pwm channels */
+    for (i = 0; i < NATIVE_PWM_NB_CHAN; i++)
+        pwms[pwm][i].on = 1;
+}
+
+void pwm_poweroff(pwm_t pwm)
+{
+    uint8_t i = 0;
+
+    assert(pwm < PWM_NUMOF);
+    /* reset pwm channels */
+    for (i = 0; i < NATIVE_PWM_NB_CHAN; i++)
+        pwms[pwm][i].on = 0;
+}
+
+#endif /* PWM_NUMOF */

--- a/cpu/native/periph/qdec.c
+++ b/cpu/native/periph/qdec.c
@@ -1,5 +1,5 @@
 /*
- * Copyright (C) 2017 Gilles DOFFE <gdoffe@gmail.com>
+ * Copyright (C) 2017 Gilles DOFFE <g.doffe@gmail.com>
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -14,7 +14,7 @@
  * @file
  * @brief       Low-level QDEC driver implementation
  *
- * @author      Gilles DOFFE <gilles.doffe@gmail.com>
+ * @author      Gilles DOFFE <g.doffe@gmail.com>
  *
  * @}
  */

--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -303,6 +303,10 @@ ifneq (,$(filter mma8x5x,$(USEMODULE)))
   FEATURES_REQUIRED += periph_i2c
 endif
 
+ifneq (,$(filter motor_driver,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_pwm
+endif
+
 ifneq (,$(filter mpl3115a2,$(USEMODULE)))
   FEATURES_REQUIRED += periph_i2c
 endif

--- a/drivers/include/motor_driver.h
+++ b/drivers/include/motor_driver.h
@@ -1,0 +1,233 @@
+/*
+ * Copyright (C) 2018 Gilles DOFFE <g.doffe@gmail.com>
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    drivers_motor DC Motor Driver
+ * @ingroup     drivers_actuators
+ * @brief       High-level driver for DC motors
+ *
+ * This API aims to handle DC motor analogic driver.
+ * Driver boards using serial communication protocols (I2C, UART, etc...) are not in the
+ * scope of this driver.
+ * Mainly designed for H-bridge, it could also drive some brushless drivers.
+ *
+ * Some H-bridge driver circuits handle several motors.
+ * Maximum motor number by H-bridge is set to 2 with MOTOR_DRIVER_MAX macro.
+ * This macro can be overridden to support H-bridge drivers with more outputs.
+ * However, MOTOR_DRIVER_MAX should not exceed PWM channels number.
+ *
+ * motor_driver_t structure represents an H-bridge.
+ * As several H-bridge can share a same PWM device, motor_driver_t can
+ * represent a group of H-bridge.
+ *
+ * Most of H-bridge boards uses the following I/Os for each motor :
+ * - Enable/disable GPIO
+ * - One or two direction GPIOs
+ * - A PWM signal
+ *
+ * @verbatim
+ *
+ * Each motor direction is controlled (assuming it is enabled) according to
+ * the following truth table :
+ *  __________________________
+ * | DIR0 | DIR1 |  BEHAVIOR  |
+ * |--------------------------|
+ * |  0   |  0   | BRAKE LOW  |
+ * |  0   |  1   |     CW     |
+ * |  1   |  0   |     CCW    |
+ * |  1   |  1   | BRAKE HIGH |
+ * |______|______|____________|
+ *
+ * In case of single GPIO for direction, only DIR0 is used without brake
+ * capability :
+ *  ___________________
+ * | DIR0 |  BEHAVIOR  |
+ * |-------------------|
+ * |   0  |     CW     |
+ * |   1  |     CCW    |
+ * |______|____________|
+ *
+ * Some boards add a brake pin with single direction GPIO :
+ *  ________________________
+ * | DIR | BRAKE | BEHAVIOR |
+ * |------------------------|
+ * |  0  |   0   |    CW    |
+ * |  0  |   1   |   BRAKE  |
+ * |  1  |   0   |    CCW   |
+ * |  1  |   1   |   BRAKE  |
+ * |_____|_______|__________|
+ *
+ * @endverbatim
+ *
+ * From this truth tables we can extract two direction states :
+ * - CW (ClockWise)
+ * - CCW (Counter ClockWise)
+ * and a brake capability
+ *
+ * BRAKE LOW is functionnaly the same than BRAKE HIGH but some H-bridge only
+ * brake on BRAKE HIGH due to hardware.
+ * In case of single direction GPIO, there is no BRAKE, PWM duty cycle is set
+ * to 0.
+
+ * @{
+ * @file
+ * @brief       High-level driver for DC motors
+ *
+ * @author      Gilles DOFFE <g.doffe@gmail.com>
+ */
+
+#ifndef MOTOR_DRIVER_H
+#define MOTOR_DRIVER_H
+
+#include "periph/pwm.h"
+#include "periph/gpio.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief Maximum number of motors by motor driver
+ */
+#ifndef MOTOR_DRIVER_MAX
+#define MOTOR_DRIVER_MAX    (2)
+#endif /* MOTOR_DRIVER_MAX */
+
+/**
+ * @brief Macro to return motor driver id
+ */
+#define MOTOR_DRIVER_DEV(x) (x)
+
+/**
+ * @brief Describe DC motor driver modes
+ */
+typedef enum {
+    MOTOR_DRIVER_2_DIRS         = 0,            /**< 2 GPIOS for direction, \
+                                                      handling BRAKE */
+    MOTOR_DRIVER_1_DIR          = 1,            /**< Single GPIO for direction, \
+                                                      no BRAKE */
+    MOTOR_DRIVER_1_DIR_BRAKE    = 2             /**< Single GPIO for direction, \
+                                                      Single GPIO for BRAKE */
+} motor_driver_mode_t;
+
+/**
+ * @brief Describe DC motor driver brake modes
+ */
+typedef enum {
+    MOTOR_BRAKE_LOW     = 0,        /**< Low stage brake */
+    MOTOR_BRAKE_HIGH    = 1,        /**< High stage brake */
+} motor_driver_mode_brake_t;
+
+/**
+ * @brief Describe DC motor direction states
+ */
+typedef enum {
+    MOTOR_CW    = 0,            /**< clockwise */
+    MOTOR_CCW   = 1,            /**< counter clockwise */
+} motor_direction_t;
+
+/**
+ * @brief Describe DC motor with PWM channel and GPIOs
+ */
+typedef struct {
+    int pwm_channel;            /**< PWM channel the motor is connected to */
+    gpio_t gpio_enable;         /**< GPIO to enable/disable motor */
+    gpio_t gpio_dir0;           /**< GPIO to control rotation direction */
+    gpio_t gpio_dir1_or_brake;  /**< GPIO to control rotation direction */
+    uint8_t gpio_dir_reverse;   /**< flag to reverse direction */
+    uint8_t gpio_enable_invert; /**< flag to set enable GPIO inverted mode */
+    uint8_t gpio_brake_invert;  /**< flag to make brake active low */
+} motor_t;
+
+/**
+ * @brief   Default motor driver type definition
+ */
+typedef unsigned int motor_driver_t;
+
+/**
+ * @brief   Motor callback. It is called at end of motor_set()
+ */
+typedef void (*motor_driver_cb_t)(const motor_driver_t motor_driver,
+                                  uint8_t motor_id,
+                                  int32_t pwm_duty_cycle);
+
+/**
+ * @brief Describe DC motor driver with PWM device and motors array
+ */
+typedef struct {
+    pwm_t pwm_dev;                          /**< PWM device driving motors */
+    motor_driver_mode_t mode;               /**< driver mode */
+    motor_driver_mode_brake_t mode_brake;   /**< driver brake mode */
+    pwm_mode_t pwm_mode;                    /**< PWM mode */
+    uint32_t pwm_frequency;                 /**< PWM device frequency */
+    uint32_t pwm_resolution;                /**< PWM device resolution */
+    uint8_t nb_motors;                      /**< number of moros */
+    motor_t motors[MOTOR_DRIVER_MAX];       /**< motors array */
+    motor_driver_cb_t cb;                   /**< callback on motor_set */
+} motor_driver_config_t;
+
+/**
+ * @brief Initialize DC motor driver board
+ *
+ * @param[out] motor_driver     motor driver to initialize
+ *
+ * @return                      0 on success
+ * @return                      -1 on error with errno set
+ */
+int motor_driver_init(const motor_driver_t motor_driver);
+
+/**
+ * @brief Set motor speed and direction
+ *
+ * @param[in] motor_driver      motor driver to which motor is attached
+ * @param[in] motor_id          motor ID on driver
+ * @param[in] pwm_duty_cycle    Signed PWM duty_cycle to set motor speed and direction
+ *
+ * @return                      0 on success
+ * @return                      -1 on error with errno set
+ */
+int motor_set(const motor_driver_t motor_driver, uint8_t motor_id, \
+              int32_t pwm_duty_cycle);
+
+/**
+ * @brief Brake the motor of a given motor driver
+ *
+ * @param[in] motor_driver      motor driver to which motor is attached
+ * @param[in] motor_id          motor ID on driver
+ *
+ * @return                      0 on success
+ * @return                      -1 on error with errno set
+ */
+int motor_brake(const motor_driver_t motor_driver, uint8_t motor_id);
+
+/**
+ * @brief Enable a motor of a given motor driver
+ *
+ * @param[in] motor_driver      motor driver to which motor is attached
+ * @param[in] motor_id          motor ID on driver
+ *
+ * @return
+ */
+void motor_enable(const motor_driver_t motor_driver, uint8_t motor_id);
+
+/**
+ * @brief Disable a motor of a given motor driver
+ *
+ * @param[in] motor_driver      motor driver to which motor is attached
+ * @param[in] motor_id          motor ID on driver
+ *
+ * @return
+ */
+void motor_disable(const motor_driver_t motor_driver, uint8_t motor_id);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MOTOR_DRIVER_H */
+/** @} */

--- a/drivers/motor_driver/Makefile
+++ b/drivers/motor_driver/Makefile
@@ -1,0 +1,3 @@
+MODULE = motor_driver
+
+include $(RIOTBASE)/Makefile.base

--- a/drivers/motor_driver/motor_driver.c
+++ b/drivers/motor_driver/motor_driver.c
@@ -1,0 +1,259 @@
+#include <errno.h>
+
+/* RIOT includes */
+#include <assert.h>
+#include <board.h>
+#include <irq.h>
+#include <log.h>
+#include <motor_driver.h>
+
+#define ENABLE_DEBUG    (0)
+#include <debug.h>
+
+int motor_driver_init(motor_driver_t motor_driver)
+{
+    int err = 0;
+
+    assert(motor_driver < MOTOR_DRIVER_NUMOF);
+
+    const motor_driver_config_t *motor_driver_conf = \
+        &motor_driver_config[motor_driver];
+
+    pwm_t pwm_dev = motor_driver_conf->pwm_dev;
+    pwm_mode_t mode = motor_driver_conf->pwm_mode;
+    uint32_t freq = motor_driver_conf->pwm_frequency;
+    uint16_t resol = motor_driver_conf->pwm_resolution;
+
+    uint32_t ret_pwm = pwm_init(pwm_dev, mode, freq, resol);
+    if (ret_pwm != freq) {
+        err = EINVAL;
+        LOG_ERROR("pwm_init failed\n");
+        goto motor_init_err;
+    }
+
+    for (uint8_t i = 0; i < motor_driver_conf->nb_motors; i++) {
+        if ((motor_driver_conf->motors[i].gpio_dir0 != GPIO_UNDEF)
+            && (gpio_init(motor_driver_conf->motors[i].gpio_dir0,
+                          GPIO_OUT))) {
+            err = EIO;
+            LOG_ERROR("gpio_dir0 init failed\n");
+            goto motor_init_err;
+        }
+        if ((motor_driver_conf->motors[i].gpio_dir1_or_brake != GPIO_UNDEF)
+            && (gpio_init(motor_driver_conf->motors[i].gpio_dir1_or_brake,
+                          GPIO_OUT))) {
+            err = EIO;
+            LOG_ERROR("gpio_dir1_or_brake init failed\n");
+            goto motor_init_err;
+        }
+        if (motor_driver_conf->motors[i].gpio_enable != GPIO_UNDEF) {
+            if (gpio_init(motor_driver_conf->motors[i].gpio_enable,
+                          GPIO_OUT)) {
+                err = EIO;
+                LOG_ERROR("gpio_enable init failed\n");
+                goto motor_init_err;
+            }
+            motor_enable(motor_driver, i);
+        }
+    }
+
+    return 0;
+
+motor_init_err:
+    return -err;
+}
+
+int motor_set(const motor_driver_t motor_driver, uint8_t motor_id, \
+              int32_t pwm_duty_cycle)
+{
+    int err = 0;
+
+    assert(motor_driver < MOTOR_DRIVER_NUMOF);
+
+    const motor_driver_config_t *motor_driver_conf =
+        &motor_driver_config[motor_driver];
+
+    assert(motor_id < motor_driver_conf->nb_motors);
+
+    const motor_t *dev = &motor_driver_conf->motors[motor_id];
+
+    int gpio_dir0_value = 0;
+    int gpio_dir1_or_brake_value = 0;
+
+    motor_direction_t direction = (pwm_duty_cycle < 0) ? MOTOR_CCW : MOTOR_CW;
+
+    direction = direction ^ dev->gpio_dir_reverse;
+
+    /* Two direction GPIO, handling brake */
+    if (motor_driver_conf->mode == MOTOR_DRIVER_2_DIRS) {
+        if ((dev->gpio_dir0 == GPIO_UNDEF) || \
+            (dev->gpio_dir1_or_brake == GPIO_UNDEF)) {
+            err = ENODEV;
+            goto motor_set_err;
+        }
+        switch (direction) {
+            case MOTOR_CW:
+            case MOTOR_CCW:
+                /* Direction */
+                gpio_dir0_value = direction;
+                gpio_dir1_or_brake_value = direction ^ 0x1;
+                break;
+            default:
+                pwm_duty_cycle = 0;
+                break;
+        }
+    }
+    /* Single direction GPIO */
+    else if (motor_driver_conf->mode == MOTOR_DRIVER_1_DIR) {
+        if (dev->gpio_dir0 == GPIO_UNDEF) {
+            err = ENODEV;
+            goto motor_set_err;
+        }
+        switch (direction) {
+            case MOTOR_CW:
+            case MOTOR_CCW:
+                /* Direction */
+                gpio_dir0_value = direction;
+                break;
+            default:
+                pwm_duty_cycle = 0;
+                break;
+        }
+    }
+    /* Single direction GPIO and brake GPIO */
+    else if (motor_driver_conf->mode == MOTOR_DRIVER_1_DIR_BRAKE) {
+        if ((dev->gpio_dir0 == GPIO_UNDEF) || \
+            (dev->gpio_dir1_or_brake == GPIO_UNDEF)) {
+            err = ENODEV;
+            goto motor_set_err;
+        }
+        switch (direction) {
+            case MOTOR_CW:
+            case MOTOR_CCW:
+                /* Direction */
+                gpio_dir0_value = direction;
+                /* No brake */
+                gpio_dir1_or_brake_value = dev->gpio_brake_invert;
+                break;
+            default:
+                pwm_duty_cycle = 0;
+                break;
+        }
+    }
+    else {
+        err = EINVAL;
+        goto motor_set_err;
+    }
+
+    /* Absolute value of pwm_duty_cycle */
+    int32_t pwm_duty_cycle_abs = pwm_duty_cycle;
+    pwm_duty_cycle_abs *= (pwm_duty_cycle < 0) ? -1 : 1;
+
+    irq_disable();
+    gpio_write(dev->gpio_dir0, gpio_dir0_value);
+    gpio_write(dev->gpio_dir1_or_brake, gpio_dir1_or_brake_value);
+    pwm_set(motor_driver_conf->pwm_dev, dev->pwm_channel, \
+            (uint16_t)pwm_duty_cycle_abs);
+    irq_enable();
+
+    motor_driver_cb_t cb = motor_driver_conf->cb;
+    if (cb) {
+        cb(motor_driver, motor_id, pwm_duty_cycle);
+    }
+
+    return 0;
+
+motor_set_err:
+    return -err;
+}
+
+int motor_brake(const motor_driver_t motor_driver, uint8_t motor_id)
+{
+    int err = 0;
+
+    assert(motor_driver < MOTOR_DRIVER_NUMOF);
+
+    const motor_driver_config_t *motor_driver_conf =
+        &motor_driver_config[motor_driver];
+
+    assert(motor_id < motor_driver_conf->nb_motors);
+
+    const motor_t *dev = &motor_driver_conf->motors[motor_id];
+
+    int gpio_dir0_value = 0;
+    int gpio_dir1_or_brake_value = 0;
+
+    /* Two direction GPIO, handling brake */
+    if (motor_driver_conf->mode == MOTOR_DRIVER_2_DIRS) {
+        if ((dev->gpio_dir0 == GPIO_UNDEF) || \
+            (dev->gpio_dir1_or_brake == GPIO_UNDEF)) {
+            err = ENODEV;
+            goto motor_brake_err;
+        }
+        /* Brake */
+        gpio_dir0_value =
+            motor_driver_conf->mode_brake;
+        gpio_dir1_or_brake_value =
+            motor_driver_conf->mode_brake;
+    }
+    /* Single direction GPIO */
+    else if (motor_driver_conf->mode == MOTOR_DRIVER_1_DIR) {
+        /* Nothing to do here */
+    }
+    /* Single direction GPIO and brake GPIO */
+    else if (motor_driver_conf->mode == MOTOR_DRIVER_1_DIR_BRAKE) {
+        if (dev->gpio_dir1_or_brake == GPIO_UNDEF) {
+            err = ENODEV;
+            goto motor_brake_err;
+        }
+        /* Brake */
+        gpio_dir1_or_brake_value = 1 ^ dev->gpio_brake_invert;
+    }
+    else {
+        err = EINVAL;
+        goto motor_brake_err;
+    }
+
+    irq_disable();
+    gpio_write(dev->gpio_dir0, gpio_dir0_value);
+    gpio_write(dev->gpio_dir1_or_brake, gpio_dir1_or_brake_value);
+    pwm_set(motor_driver_conf->pwm_dev, dev->pwm_channel, 0);
+    irq_enable();
+
+    return 0;
+
+motor_brake_err:
+    return -err;
+}
+
+void motor_enable(const motor_driver_t motor_driver, uint8_t motor_id)
+{
+    assert(motor_driver < MOTOR_DRIVER_NUMOF);
+
+    const motor_driver_config_t *motor_driver_conf =
+        &motor_driver_config[motor_driver];
+
+    assert(motor_id < motor_driver_conf->nb_motors);
+
+    const motor_t *dev = &motor_driver_conf->motors[motor_id];
+
+    assert(dev->gpio_enable != GPIO_UNDEF);
+
+    gpio_write(dev->gpio_enable, 1 ^ dev->gpio_enable_invert);
+}
+
+void motor_disable(const motor_driver_t motor_driver, uint8_t motor_id)
+{
+    assert(motor_driver < MOTOR_DRIVER_NUMOF);
+
+    const motor_driver_config_t *motor_driver_conf =
+        &motor_driver_config[motor_driver];
+
+    assert(motor_id < motor_driver_conf->nb_motors);
+
+    const motor_t *dev = &motor_driver_conf->motors[motor_id];
+
+    assert(dev->gpio_enable != GPIO_UNDEF);
+
+    gpio_write(dev->gpio_enable, dev->gpio_enable_invert);
+}

--- a/tests/driver_motor_driver/Makefile
+++ b/tests/driver_motor_driver/Makefile
@@ -1,0 +1,16 @@
+BOARD ?= native
+
+include ../Makefile.tests_common
+
+USEMODULE += motor_driver
+USEMODULE += shell
+USEMODULE += shell_commands
+USEMODULE += xtimer
+
+FEATURES_REQUIRED += periph_qdec
+FEATURES_REQUIRED += motor_driver
+
+CFLAGS += -DLOG_LEVEL=LOG_DEBUG
+CFLAGS += -DDEBUG_ASSERT_VERBOSE
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/driver_motor_driver/README.md
+++ b/tests/driver_motor_driver/README.md
@@ -1,0 +1,22 @@
+Motor driver test
+======
+
+Background
+------
+
+Test for the high level `motor_driver` driver.
+
+Expected result
+------
+
+Should do an infinite loop :
+    1) Both motors should turn at half pwm duty cycle speed in clowkwise
+       direction.
+    2) Both motors should turn at full pwm duty cycle speed in clowkwise
+       direction.
+    3) Both motors should brake.
+    4) Both motors should turn at half pwm duty cycle speed in counter
+       clowkwise direction.
+    5) Both motors should turn at full pwm duty cycle speed in counter
+       clowkwise direction.
+    6) Both motors should brake.

--- a/tests/driver_motor_driver/main.c
+++ b/tests/driver_motor_driver/main.c
@@ -1,0 +1,101 @@
+#include <stdio.h>
+#include <string.h>
+
+/* RIOT includes */
+#include <log.h>
+#include <motor_driver.h>
+#include <xtimer.h>
+
+/* set interval to 20 milli-second */
+#define INTERVAL (3000 * US_PER_MS)
+
+#define MOTOR_0_ID  0
+#define MOTOR_1_ID  1
+
+
+void motors_control(int32_t duty_cycle)
+{
+    char str[6];
+
+    if (duty_cycle >= 0) {
+        strncpy(str, "CW", 3);
+    }
+    else {
+        strncpy(str, "CCW", 4);
+    }
+
+    printf("Duty cycle = %" PRId32 "   Direction = %s\n", duty_cycle, str);
+
+    if (motor_set(MOTOR_DRIVER_DEV(0), MOTOR_0_ID, duty_cycle)) {
+        printf("Cannot set PWM duty cycle for motor %" PRIu32 "\n", \
+               (uint32_t)MOTOR_0_ID);
+    }
+    if (motor_set(MOTOR_DRIVER_DEV(0), MOTOR_1_ID, duty_cycle)) {
+        printf("Cannot set PWM duty cycle for motor %" PRIu32 "\n", \
+               (uint32_t)MOTOR_1_ID);
+    }
+}
+
+void motors_brake(void)
+{
+    puts("Brake motors !!!");
+
+    if (motor_brake(MOTOR_DRIVER_DEV(0), MOTOR_0_ID)) {
+        printf("Cannot brake motor %" PRIu32 "\n", (uint32_t)MOTOR_0_ID);
+    }
+    if (motor_brake(MOTOR_DRIVER_DEV(0), MOTOR_1_ID)) {
+        printf("Cannot brake motor %" PRIu32 "\n", (uint32_t)MOTOR_1_ID);
+    }
+}
+
+void motion_control(void)
+{
+    int8_t dir = 1;
+    int ret = 0;
+    xtimer_ticks32_t last_wakeup /*, start*/;
+    int32_t pwm_res = motor_driver_config[MOTOR_DRIVER_DEV(0)].pwm_resolution;
+
+    ret = motor_driver_init(MOTOR_DRIVER_DEV(0));
+    if (ret) {
+        LOG_ERROR("motor_driver_init failed with error code %d\n", ret);
+    }
+    assert(ret == 0);
+
+    for (;;) {
+        /* BRAKE - duty cycle 100% */
+        last_wakeup = xtimer_now();
+        motors_brake();
+        xtimer_periodic_wakeup(&last_wakeup, INTERVAL);
+
+        /* CW - duty cycle 50% */
+        last_wakeup = xtimer_now();
+        motors_control(dir * pwm_res / 2);
+        xtimer_periodic_wakeup(&last_wakeup, INTERVAL);
+
+        /* Disable motor during INTERVAL µs (motor driver must have enable
+           feature */
+        last_wakeup = xtimer_now();
+        motor_disable(MOTOR_DRIVER_DEV(0), MOTOR_0_ID);
+        motor_disable(MOTOR_DRIVER_DEV(0), MOTOR_1_ID);
+        xtimer_periodic_wakeup(&last_wakeup, INTERVAL);
+        motor_enable(MOTOR_DRIVER_DEV(0), MOTOR_0_ID);
+        motor_enable(MOTOR_DRIVER_DEV(0), MOTOR_1_ID);
+
+        /* CW - duty cycle 100% */
+        last_wakeup = xtimer_now();
+        motors_control(dir * pwm_res);
+        xtimer_periodic_wakeup(&last_wakeup, INTERVAL);
+
+        /* Reverse direction */
+        dir = dir * -1;
+    }
+}
+
+int main(void)
+{
+    xtimer_init();
+
+    motion_control();
+
+    return 0;
+}


### PR DESCRIPTION
This driver API aims to control DC motors.
It handles :
 * motor controller associated to a PWM device
 * several motors by controller
 * motor rotation direction
 * brake capability
 * enable/disable motor individually (if hardware driver has enable/disable capability)
 * callback on motor_set() calls to perform some actions once PWM is set.

### Contribution description

This contribution is a new feature adding a new actuator driver for nearly most kind of analogic H-bridge.
Support for nucleo-f446re board is added.
Support for native board is also added with a QDEC simulation callback. Native architecture pwm feature has been added for motor_driver simulation support. 

### Testing procedure

Go to tests/driver_motor_driver and build with BOARD=native:
`make BOARD=native`
Launch the binary:
`bin/native/tests_driver_motor_driver.elf`

Tests have been done on Nucleo-F446RE with a simple H-bridge from AliExpress and with Dual VNH3SP30 Motor Driver Carrier MD03A from Pololu:
- https://youtu.be/9qiPBo5LNIs
- https://youtu.be/rjKRhW8Ke18

To build for Nucleo-F446RE:
`make BOARD=nucleo-f446re flash`