### PR TITLE
pkg/baselibc: [WIP] a light-weight C library

### DIFF
--- a/examples/hello-world/Makefile
+++ b/examples/hello-world/Makefile
@@ -12,6 +12,9 @@ RIOTBASE ?= $(CURDIR)/../..
 # development process:
 DEVELHELP ?= 1
 
+
+USEPKG+=baselibc
+
 # Change this to 0 show compiler invocation lines by default:
 QUIET ?= 1
 

--- a/examples/hello-world/main.c
+++ b/examples/hello-world/main.c
@@ -21,6 +21,39 @@
 
 #include <stdio.h>
 
+#if MODULE_BASELIBC
+
+#include "periph/uart.h"
+#include "stdio_uart.h"
+#include "isrpipe.h"
+
+extern isrpipe_t stdio_uart_isrpipe;
+
+size_t stdio_read2(FILE* dummy, char* buffer, size_t count)
+{
+    (void) dummy;
+
+    return (ssize_t)isrpipe_read(&stdio_uart_isrpipe, buffer, count);
+}
+
+size_t stdio_write2(FILE* dummy, const char* buffer, size_t len)
+{
+    (void) dummy;
+    uart_write(STDIO_UART_DEV, (const uint8_t *)buffer, len);
+
+    return len;
+}
+
+const struct File_methods _uart_methods = {
+    stdio_write2, stdio_read2
+};
+
+FILE _stdout_uart = {&_uart_methods};
+
+FILE* const stdout = &_stdout_uart;
+
+#endif
+
 int main(void)
 {
     puts("Hello World!");

--- a/pkg/baselibc/Makefile
+++ b/pkg/baselibc/Makefile
@@ -1,0 +1,11 @@
+PKG_NAME=baselibc
+PKG_URL=https://github.com/PetteriAimonen/Baselibc.git
+PKG_VERSION=7e8e4a7353b1fd381e466349ff15bf821f688194
+PKG_LICENSE=BSD
+
+.PHONY: all
+
+all: Makefile.baselibc
+	"$(MAKE)" -C $(PKG_BUILDDIR)/src -f $(abspath $<)
+
+include $(RIOTBASE)/pkg/pkg.mk

--- a/pkg/baselibc/Makefile.baselibc
+++ b/pkg/baselibc/Makefile.baselibc
@@ -1,0 +1,5 @@
+MODULE = baselibc
+# enable long support in printf. Will probably be needed.
+CFLAGS += -Wno-error=unused-parameter -DPRINTF_LONG_SUPPORT -I ../include -I templates
+
+include $(RIOTBASE)/Makefile.base

--- a/pkg/baselibc/Makefile.include
+++ b/pkg/baselibc/Makefile.include
@@ -1,0 +1,2 @@
+INCLUDES += -I$(PKGDIRBASE)/baselibc/include
+


### PR DESCRIPTION
### Contribution description

I stole the C library from MyNewt, see https://mynewt.apache.org/latest/os/modules/baselibc.html . This is still a WIP, I'm publishing early to see if there is interest.

__33% reduction in code size for hello world__

Baselibc is derived from klibc (part of the linux kernel initialization system) with the GPL stuff removed. __It does not replace newlib__. Rather, it replaces several of it's functions by simpler, smaller and probably less efficient versions.

`printf` is based on tinyprintf, so many things won't be supported. The version in mynewt is slightly different from the one used here, so I might try pulling in those changes (their version has optional float support).

The interesting thing is that `stdio-uart` would need only small modifications to work both with and without this library (compare the stdio_read2, stdio_write2 functions I placed in main.c with the ones in stdio-uart).

### Testing procedure

I modified hello-world so that it uses this package:

1. Compile hello world (`BOARD=samr21-xpro WERROR=0 make`
2. Get the binary (`arm-none-eabi-objcopy -O binary bin/samr21-xpro/hello-world.elf new.bin`)
3. In the makefile, comment the line that says `USEPKG+=baselibc`.
4. Repeat (1) and (2)- use `old.bin` or another filename.
5. Compare sizes:

```sh
$ ls -l *.bin
-rwxr-xr-x 1 jcarrano jcarrano 5724 oct 29 17:19 new.bin
-rwxr-xr-x 1 jcarrano jcarrano 8572 oct 29 17:18 old.bin
```

### Related PRs

To integrate this properly, #9258 would be really helpful.
