### PR TITLE
cpu/stm32_common/i2c: Fix error handling in i2c_1.c

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -245,11 +245,11 @@ ifneq (,$(filter gnrc_icmpv6,$(USEMODULE)))
 endif
 
 ifneq (,$(filter gnrc_rpl_srh,$(USEMODULE)))
-  USEMODULE += ipv6_ext_rh
+  USEMODULE += gnrc_ipv6_ext_rh
 endif
 
-ifneq (,$(filter ipv6_ext_rh,$(USEMODULE)))
-  USEMODULE += ipv6_ext
+ifneq (,$(filter gnrc_ipv6_ext_rh,$(USEMODULE)))
+  USEMODULE += gnrc_ipv6_ext
 endif
 
 ifneq (,$(filter gnrc_ipv6_ext,$(USEMODULE)))

--- a/examples/gnrc_networking/README.md
+++ b/examples/gnrc_networking/README.md
@@ -1,22 +1,27 @@
 # gnrc_networking example
 
-This example shows you how to try out the code in two different ways: Either by communicating
-between the RIOT machine and its Linux host, or by communicating between two RIOT instances.
-Note that the former only works with native, i.e. if you run RIOT on your Linux machine.
+This example shows you how to try out the code in two different ways:
+Either by communicating between the RIOT machine and its Linux host,
+or by communicating between two RIOT instances.
+Note that the former only works with native, i.e. if you run RIOT on
+your Linux machine.
 
 ## Connecting RIOT native and the Linux host
 
-> **Note:** RIOT does not support IPv4, so you need to stick to IPv6 anytime. To
-establish a connection between RIOT and the Linux host, you will need `netcat`
-(with IPv6 support). Ubuntu 14.04 comes with netcat IPv6 support pre-installed.
-On Debian it's available in the package `netcat-openbsd`. Be aware that many
-programs require you to add an option such as -6 to tell them to use IPv6, otherwise they
-will fail. If you're using a _Raspberry Pi_, run `sudo modprobe ipv6` before trying
-this example, because raspbian does not load the IPv6 module automatically.
-On some systems (openSUSE for example), the _firewall_ may interfere, and prevent
-some packets to arrive at the application (they will however show up in Wireshark,
-which can be confusing). So be sure to adjust your firewall rules, or turn it off
-(who needs security anyway).
+> **Note:** RIOT does not support IPv4, so you need to stick to IPv6
+> anytime. To establish a connection between RIOT and the Linux host,
+> you will need `netcat` (with IPv6 support). Ubuntu 14.04 comes with
+> netcat IPv6 support pre-installed.
+> On Debian it's available in the package `netcat-openbsd`. Be aware
+> that many programs require you to add an option such as -6 to tell
+> them to use IPv6, otherwise they will fail. If you're using a
+> _Raspberry Pi_, run `sudo modprobe ipv6` before trying this example,
+> because raspbian does not load the IPv6 module automatically.
+> On some systems (openSUSE for example), the _firewall_ may interfere,
+> and prevent some packets to arrive at the application (they will
+> however show up in Wireshark, which can be confusing). So be sure to
+> adjust your firewall rules, or turn it off (who needs security
+> anyway).
 
 First, make sure you've compiled the application by calling `make`.
 
@@ -25,13 +30,15 @@ Now, create a tap interface:
     sudo ip tuntap add tap0 mode tap user ${USER}
     sudo ip link set tap0 up
 
-Now you can start the `gnrc_networking` example by invoking `make term`. This should
-automatically connect to the `tap0` interface. If this doesn't work for any reason,
-run make term with the tap0 interface as the PORT environment variable:
+Now you can start the `gnrc_networking` example by invoking `make term`.
+This should automatically connect to the `tap0` interface. If this
+doesn't work for any reason, run make term with the tap0 interface as
+the PORT environment variable:
 
     PORT=tap0 make term
 
-To verify that there is connectivity between RIOT and Linux, go to the RIOT console and run `ifconfig`:
+To verify that there is connectivity between RIOT and Linux, go to the
+RIOT console and run `ifconfig`:
 
     > ifconfig
     Iface  7   HWaddr: ce:f5:e1:c5:f7:5a
@@ -39,31 +46,35 @@ To verify that there is connectivity between RIOT and Linux, go to the RIOT cons
                inet6 addr: fe80::ccf5:e1ff:fec5:f75a/64  scope: local
                inet6 addr: ff02::1:ffc5:f75a/128  scope: local [multicast]
 
-Copy the [link-local address](https://en.wikipedia.org/wiki/Link-local_address)
-of the RIOT node (prefixed with `fe80`) and try to ping it **from the Linux node**:
+Copy the [link-local address] of the RIOT node (prefixed with `fe80`)
+and try to ping it **from the Linux node**:
+
+[link-local address]: https://gist.github.com/backenklee/dad5e80b764b3b3d0d3e
 
     ping6 fe80::ccf5:e1ff:fec5:f75a%tap0
 
-Note that the interface on which to send the ping needs to be appended to the IPv6
-address, `%tap0` in the above example. When talking to the RIOT node, you always want
-to send to/receive from the `tap0` interface.
+Note that the interface on which to send the ping needs to be appended
+to the IPv6 address, `%tap0` in the above example. When talking to the
+RIOT node, you always want to send to/receive from the `tap0` interface.
 
-If the pings succeed you can go on to send UDP packets. To do that, first start a
-UDP server on the RIOT node:
+If the pings succeed you can go on to send UDP packets. To do that,
+first start a UDP server on the RIOT node:
 
     > udp server start 8808
     Success: started UDP server on port 8808
 
-Now, on the Linux host, you can run netcat to connect with RIOT's UDP server:
+Now, on the Linux host, you can run netcat to connect with RIOT's UDP
+server:
 
     nc -6uv fe80::ccf5:e1ff:fec5:f75a%tap0 8808
 
-The `-6` option is necessary to tell netcat to use IPv6 only, the `-u` option tells
-it to use UDP only, and the `-v` option makes it give more verbose output (this one is optional).
+The `-6` option is necessary to tell netcat to use IPv6 only, the `-u`
+option tells it to use UDP only, and the `-v` option makes it give more
+verbose output (this one is optional).
 
-You should now see that UDP messages are received on the RIOT side. Opening a UDP
-server on the Linux side is also possible. To do that, write down the IP address
-of the host (run on Linux):
+You should now see that UDP messages are received on the RIOT side.
+Opening a UDP server on the Linux side is also possible. To do that,
+write down the IP address of the host (run on Linux):
 
     ifconfig tap0
     tap0     Link encap:Ethernet  HWaddr ce:f5:e1:c5:f7:59
@@ -74,7 +85,8 @@ of the host (run on Linux):
             collisions:0 txqueuelen:0
             RX bytes:488 (488.0 B)  TX bytes:3517 (3.5 KB)
 
-Then open a UDP server on Linux (the `-l` option makes netcat listen for incoming connections):
+Then open a UDP server on Linux (the `-l` option makes netcat listen for
+incoming connections):
 
     nc -6ul 8808
 
@@ -82,22 +94,25 @@ Now, on the RIOT side, send a UDP packet using:
 
     udp send fe80::4049:5fff:fe17:b3ae 8808 testmessage
 
-You should see `testmessage` appear in netcat. Instead of using netcat, you can of
-course write your own software, but you may have to bind the socket to a specific
-interface (tap0 in this case). For an example that shows how to do so, see
-[here](https://gist.github.com/backenklee/dad5e80b764b3b3d0d3e).
+You should see `testmessage` appear in netcat. Instead of using netcat,
+you can of course write your own software, but you may have to bind the
+socket to a specific interface (tap0 in this case). For an example that
+shows how to do so, see [here][tap-socket]
+
+[tap-socket]: (https://gist.github.com/backenklee/dad5e80b764b3b3d0d3e).
 
 ## Connecting two RIOT instances
 
-When using native (i.e. when you're trying this on your Linux machine), you first
-need to set up two tap devices and a bridge that connects them. This constitutes a
-virtual network that the RIOT instances can use to communicate.
+When using native (i.e. when you're trying this on your Linux machine),
+you first need to set up two tap devices and a bridge that connects
+them. This constitutes a virtual network that the RIOT instances can
+use to communicate.
 
     ./../../dist/tools/tapsetup/tapsetup --create 2
 
-Then, make sure you've compiled the application by calling `make` and start the
-first RIOT instance by invoking `make term`. In the RIOT shell, get to know the
-IP address of this node:
+Then, make sure you've compiled the application by calling `make` and
+start the first RIOT instance by invoking `make term`. In the RIOT
+shell, get to know the IP address of this node:
 
     > ifconfig
     Iface  7   HWaddr: ce:f5:e1:c5:f7:5a
@@ -111,17 +126,19 @@ and start a UDP server.
 
 This node is now ready to receive data on port `8808`.
 
-In a second terminal, start a second RIOT instance, this time listening on `tap1`:
+In a second terminal, start a second RIOT instance, this time listening
+on `tap1`:
 
     PORT=tap1 make term
 
-In the RIOT shell, you can now send a message to the first RIOT instance:
+In the RIOT shell, you can now send a message to the first RIOT
+instance:
 
     > udp send fe80::ccf5:e1ff:fec5:f75a 8808 testmessage
 
 *(Make sure to copy the actual
-[link-local address](https://en.wikipedia.org/wiki/Link-local_address) of your first
-RIOT instance into the above command)*
+[link-local address](https://en.wikipedia.org/wiki/Link-local_address)
+of your first RIOT instance into the above command)*
 
 In your first terminal, you should now see output that looks like this.
 

--- a/examples/gnrc_networking/README.md
+++ b/examples/gnrc_networking/README.md
@@ -18,7 +18,9 @@ some packets to arrive at the application (they will however show up in Wireshar
 which can be confusing). So be sure to adjust your firewall rules, or turn it off
 (who needs security anyway).
 
-First, create a tap interface:
+First, make sure you've compiled the application by calling `make`.
+
+Now, create a tap interface:
 
     sudo ip tuntap add tap0 mode tap user ${USER}
     sudo ip link set tap0 up

--- a/sys/Makefile
+++ b/sys/Makefile
@@ -46,9 +46,6 @@ endif
 ifneq (,$(filter ipv6_ext_rh,$(USEMODULE)))
   DIRS += net/network_layer/ipv6/ext/rh
 endif
-ifneq (,$(filter ipv6_ext,$(USEMODULE)))
-  DIRS += net/network_layer/ipv6/ext
-endif
 ifneq (,$(filter ipv6_hdr,$(USEMODULE)))
   DIRS += net/network_layer/ipv6/hdr
 endif

--- a/sys/Makefile
+++ b/sys/Makefile
@@ -43,9 +43,6 @@ endif
 ifneq (,$(filter ipv6_addr,$(USEMODULE)))
   DIRS += net/network_layer/ipv6/addr
 endif
-ifneq (,$(filter ipv6_ext_rh,$(USEMODULE)))
-  DIRS += net/network_layer/ipv6/ext/rh
-endif
 ifneq (,$(filter ipv6_hdr,$(USEMODULE)))
   DIRS += net/network_layer/ipv6/hdr
 endif

--- a/sys/include/net/gnrc/ipv6/ext.h
+++ b/sys/include/net/gnrc/ipv6/ext.h
@@ -31,6 +31,10 @@
 #include "net/gnrc/pkt.h"
 #include "net/ipv6/ext.h"
 
+#ifdef MODULE_GNRC_IPV6_EXT_RH
+#include "net/gnrc/ipv6/ext/rh.h"
+#endif
+
 #ifdef __cplusplus
 extern "C" {
 #endif

--- a/sys/include/net/gnrc/ipv6/ext/rh.h
+++ b/sys/include/net/gnrc/ipv6/ext/rh.h
@@ -37,7 +37,7 @@ enum {
      * @brief   The routing header was successfully processed and this node
      *          is the destination (i.e. ipv6_ext_rh_t::seg_left == 0)
      */
-    GNRC_IPV6_EXT_RH_OK,
+    GNRC_IPV6_EXT_RH_AT_DST,
     /**
      * @brief   The routing header was successfully processed and the packet
      *          was forwarded to another node or should be forwarded to another
@@ -59,7 +59,7 @@ enum {
  * @param[in, out] ipv6     An IPv6 packet.
  * @param[in] ext           A routing header of @p ipv6.
  *
- * @return  @ref GNRC_IPV6_EXT_RH_OK, on success
+ * @return  @ref GNRC_IPV6_EXT_RH_AT_DST, on success
  * @return  @ref GNRC_IPV6_EXT_RH_FORWARDED, when @p pkt was forwarded
  * @return  @ref GNRC_IPV6_EXT_RH_ERROR, on error
  */

--- a/sys/include/net/gnrc/ipv6/ext/rh.h
+++ b/sys/include/net/gnrc/ipv6/ext/rh.h
@@ -1,0 +1,73 @@
+/*
+ * Copyright (C) 2018 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    net_gnrc_ipv6_ext_rh Support for IPv6 routing header extension
+ * @ingroup     net_gnrc_ipv6_ext
+ * @brief       GNRC implementation of IPv6 routing header extension.
+ * @{
+ *
+ * @file
+ * @brief   GNRC routing extension header definitions.
+ *
+ * @author  Martine Lenders <m.lenders@fu-berlin.de>
+ */
+#ifndef NET_GNRC_IPV6_EXT_RH_H
+#define NET_GNRC_IPV6_EXT_RH_H
+
+#include "net/ipv6/hdr.h"
+
+#include "net/ipv6/ext/rh.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+enum {
+    /**
+     * @brief   An error occurred during routing header processing
+     */
+    GNRC_IPV6_EXT_RH_ERROR = 0,
+    /**
+     * @brief   The routing header was successfully processed and this node
+     *          is the destination (i.e. ipv6_ext_rh_t::seg_left == 0)
+     */
+    GNRC_IPV6_EXT_RH_OK,
+    /**
+     * @brief   The routing header was successfully processed and the packet
+     *          was forwarded to another node or should be forwarded to another
+     *          node.
+     *
+     * When @ref gnrc_ipv6_ext_rh_process() returns this value, the packet was
+     * already forwarded to another node. Implementations for specific routing
+     * header types should leave the forwarding to the calling @ref
+     * gnrc_ipv6_ext_rh_process() and should return @ref
+     * GNRC_IPV6_EXT_RH_FORWARDED if they want the packet to be forwarded. They
+     * should however set ipv6_hdr_t::dst accordingly.
+     */
+    GNRC_IPV6_EXT_RH_FORWARDED,
+};
+
+/**
+ * @brief   Process the routing header of an IPv6 packet.
+ *
+ * @param[in, out] ipv6     An IPv6 packet.
+ * @param[in] ext           A routing header of @p ipv6.
+ *
+ * @return  @ref GNRC_IPV6_EXT_RH_OK, on success
+ * @return  @ref GNRC_IPV6_EXT_RH_FORWARDED, when @p pkt was forwarded
+ * @return  @ref GNRC_IPV6_EXT_RH_ERROR, on error
+ */
+int gnrc_ipv6_ext_rh_process(ipv6_hdr_t *ipv6, ipv6_ext_rh_t *ext);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* NET_GNRC_IPV6_EXT_RH_H */
+/** @} */

--- a/sys/include/net/gnrc/pktbuf.h
+++ b/sys/include/net/gnrc/pktbuf.h
@@ -226,6 +226,24 @@ gnrc_pktsnip_t *gnrc_pktbuf_remove_snip(gnrc_pktsnip_t *pkt, gnrc_pktsnip_t *sni
 gnrc_pktsnip_t *gnrc_pktbuf_replace_snip(gnrc_pktsnip_t *pkt, gnrc_pktsnip_t *old, gnrc_pktsnip_t *add);
 
 /**
+ * @brief   Reverses snip order of a packet in a write-protected manner.
+ *
+ * This can be used to change the send/receive order of a packet (see
+ * @ref gnrc_pktsnip_t)
+ *
+ * @note    @p pkt is released on failure.
+ *
+ * @param[in] pkt   A packet. When this function fails (due to a full packet
+ *                  packet buffer) @p pkt will be released.
+ *
+ * @return  The reversed version of @p pkt on success
+ * @return  NULL, when there is not enough space in the packet buffer to reverse
+ *          the packet in a write-protected manner. @p pkt is released in that
+ *          case.
+ */
+gnrc_pktsnip_t *gnrc_pktbuf_reverse_snips(gnrc_pktsnip_t *pkt);
+
+/**
  * @brief Duplicates pktsnip chain upto (including) a snip with the given type
  *        as a continuous snip.
  *

--- a/sys/include/net/gnrc/rpl/srh.h
+++ b/sys/include/net/gnrc/rpl/srh.h
@@ -60,9 +60,9 @@ typedef struct __attribute__((packed)) {
  * @param[in,out] ipv6  The IPv6 header of the incoming packet.
  * @param[in] rh        A RPL source routing header.
  *
- * @return  EXT_RH_CODE_ERROR
- * @return  EXT_RH_CODE_FORWARD
- * @return  EXT_RH_CODE_OK
+ * @return  @ref GNRC_IPV6_EXT_RH_OK, on success
+ * @return  @ref GNRC_IPV6_EXT_RH_FORWARDED, when @p pkt *should be* forwarded
+ * @return  @ref GNRC_IPV6_EXT_RH_ERROR, on error
  */
 int gnrc_rpl_srh_process(ipv6_hdr_t *ipv6, gnrc_rpl_srh_t *rh);
 

--- a/sys/include/net/gnrc/rpl/srh.h
+++ b/sys/include/net/gnrc/rpl/srh.h
@@ -60,7 +60,7 @@ typedef struct __attribute__((packed)) {
  * @param[in,out] ipv6  The IPv6 header of the incoming packet.
  * @param[in] rh        A RPL source routing header.
  *
- * @return  @ref GNRC_IPV6_EXT_RH_OK, on success
+ * @return  @ref GNRC_IPV6_EXT_RH_AT_DST, on success
  * @return  @ref GNRC_IPV6_EXT_RH_FORWARDED, when @p pkt *should be* forwarded
  * @return  @ref GNRC_IPV6_EXT_RH_ERROR, on error
  */

--- a/sys/include/net/ipv6/ext/rh.h
+++ b/sys/include/net/ipv6/ext/rh.h
@@ -1,5 +1,6 @@
 /*
- * Copyright (C) 2015 Martine Lenders <mlenders@inf.fu-berlin.de>
+ * Copyright (C) 2015 Cenk Gündoğan <cnkgndgn@gmail.com>
+ * Copyright (C) 2018 Freie Universität Berlin
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -9,13 +10,14 @@
 /**
  * @defgroup    net_ipv6_ext_rh IPv6 routing header extension
  * @ingroup     net_ipv6_ext
- * @brief       Implementation of IPv6 routing header extension.
+ * @brief       Definitions for IPv6 routing header extension.
  * @{
  *
  * @file
  * @brief   Routing extension header definitions.
  *
- * @author  Martine Lenders <mlenders@inf.fu-berlin.de>
+ * @author  Cenk Gündoğan <cnkgndgn@gmail.com>
+ * @author  Martine Lenders <m.lenders@fu-berlin.de>
  */
 #ifndef NET_IPV6_EXT_RH_H
 #define NET_IPV6_EXT_RH_H
@@ -31,17 +33,6 @@ extern "C" {
 #endif
 
 /**
- * @name Return codes for routing header processing
- * @{
- */
-#define EXT_RH_CODE_ERROR       (-1)
-#define EXT_RH_CODE_FORWARD     (0)
-#define EXT_RH_CODE_OK          (1)
-/**
- * @}
- */
-
-/**
  * @brief   IPv6 routing extension header.
  *
  * @see [RFC 8200](https://tools.ietf.org/html/rfc8200#section-4.4)
@@ -54,18 +45,6 @@ typedef struct __attribute__((packed)) {
     uint8_t type;       /**< identifier of a particular routing header type */
     uint8_t seg_left;   /**< number of route segments remaining */
 } ipv6_ext_rh_t;
-
-/**
- * @brief   Process the routing header of an IPv6 packet.
- *
- * @param[in, out] ipv6     An IPv6 packet.
- * @param[in] ext           A routing header of @p ipv6.
- *
- * @return  EXT_RH_CODE_ERROR
- * @return  EXT_RH_CODE_FORWARD
- * @return  EXT_RH_CODE_OK
- */
-int ipv6_ext_rh_process(ipv6_hdr_t *ipv6, ipv6_ext_rh_t *ext);
 
 #ifdef __cplusplus
 }

--- a/sys/include/phydat.h
+++ b/sys/include/phydat.h
@@ -181,38 +181,34 @@ const char *phydat_unit_to_str(uint8_t unit);
 char phydat_prefix_from_scale(int8_t scale);
 
 /**
- * @brief   Scale an integer value to fit into a @ref phydat_t
+ * @brief   Scale integer value(s) to fit into a @ref phydat_t
  *
- * Insert @p value at position @p index in the given @p dat while rescaling all
- * numbers in @p dat->val so that @p value fits inside the limits of the data
- * type, [@ref PHYDAT_MIN, @ref PHYDAT_MAX], and update the stored scale factor.
- * The result will be rounded towards zero (the standard C99 integer division
- * behaviour).
- * The final parameter @p prescale can be used to chain multiple calls to
- * this function in order to fit multidimensional values into the same phydat_t.
- *
- * The code example below shows how to chain multiple calls via the @p prescale parameter
+ * Inserts the @p values in the given @p dat so that all @p dim values in
+ * @p values fit inside the limits of the data type,
+ * [@ref PHYDAT_MIN, @ref PHYDAT_MAX], and updates the stored scale factor.
+ * The value is rounded to the nearest integer if possible, otherwise away from
+ * zero. E.g. `0.5` and `0.6` are rounded to `1`, `0.4` and `-0.4` are rounded
+ * to `0`, `-0.5` and `-0.6` are rounded to `-1`.
  *
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~ {.c}
- * long val0 = 100000;
- * long val1 = 2000000;
- * long val2 = 30000000;
- * phydat_t dat;
- * dat.scale = 0;
- * phydat_fit(&dat, val0, 0, phydat_fit(&dat, val1, 1, phydat_fit(&dat, val2, 2, 0)));
+ * int32_t values[] = { 100000, 2000000, 30000000 };
+ * phydat_t dat = { .scale = 0 };
+ * phydat_fit(&dat, values, 3);
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  *
- * The prescale scaling is only applied to @p value, the existing values in
- * @p dat are only scaled if the prescaled @p value does not fit in phydat_t::val
+ * @note Unless compiled with `-DPHYDAT_FIT_TRADE_PRECISION_FOR_ROM=0`, this
+ *       function will scale the value `-32768`, even though it would fit into a
+ *       @ref phydat_t. Statistically, this precision loss happens in 0.00153%
+ *       of the calls. This optimization saves a bit more than 20 bytes.
+ *
+ * @pre  The @ref phydat_t::scale member in @p dat was initialized by the
+         caller prior to calling this function.
  *
  * @param[in, out]  dat         the value will be written into this data array
- * @param[in]       value       value to rescale
- * @param[in]       index       place the value at this position in the phydat_t::val array
- * @param[in]       prescale    start by scaling the value by this exponent
- *
- * @return  scaling offset that was applied
+ * @param[in]       values      value(s) to rescale
+ * @param[in]       dim         Number of elements in @p values
  */
-uint8_t phydat_fit(phydat_t *dat, long value, unsigned int index, uint8_t prescale);
+void phydat_fit(phydat_t *dat, const int32_t *values, unsigned int dim);
 
 #ifdef __cplusplus
 }

--- a/sys/net/gnrc/Makefile
+++ b/sys/net/gnrc/Makefile
@@ -13,6 +13,9 @@ endif
 ifneq (,$(filter gnrc_ipv6_ext,$(USEMODULE)))
   DIRS += network_layer/ipv6/ext
 endif
+ifneq (,$(filter gnrc_ipv6_ext_rh,$(USEMODULE)))
+  DIRS += network_layer/ipv6/ext/rh
+endif
 ifneq (,$(filter gnrc_ipv6_hdr,$(USEMODULE)))
   DIRS += network_layer/ipv6/hdr
 endif

--- a/sys/net/gnrc/network_layer/ipv6/ext/gnrc_ipv6_ext.c
+++ b/sys/net/gnrc/network_layer/ipv6/ext/gnrc_ipv6_ext.c
@@ -79,7 +79,7 @@ static enum gnrc_ipv6_ext_demux_status _handle_rh(gnrc_pktsnip_t *current, gnrc_
             }
             return GNRC_IPV6_EXT_FORWARDED;
 
-        case GNRC_IPV6_EXT_RH_OK:
+        case GNRC_IPV6_EXT_RH_AT_DST:
             /* this should not happen since we checked seg_left early */
             gnrc_pktbuf_release(pkt);
             return GNRC_IPV6_EXT_ERROR;

--- a/sys/net/gnrc/network_layer/ipv6/ext/rh/Makefile
+++ b/sys/net/gnrc/network_layer/ipv6/ext/rh/Makefile
@@ -1,3 +1,3 @@
-MODULE = ipv6_ext_rh
+MODULE = gnrc_ipv6_ext_rh
 
 include $(RIOTBASE)/Makefile.base

--- a/sys/net/gnrc/network_layer/ipv6/ext/rh/gnrc_ipv6_ext_rh.c
+++ b/sys/net/gnrc/network_layer/ipv6/ext/rh/gnrc_ipv6_ext_rh.c
@@ -16,10 +16,10 @@
 
 #include "net/protnum.h"
 #include "net/ipv6/ext.h"
-#include "net/ipv6/ext/rh.h"
+#include "net/gnrc/ipv6/ext/rh.h"
 #include "net/gnrc/rpl/srh.h"
 
-int ipv6_ext_rh_process(ipv6_hdr_t *hdr, ipv6_ext_rh_t *ext)
+int gnrc_ipv6_ext_rh_process(ipv6_hdr_t *hdr, ipv6_ext_rh_t *ext)
 {
     (void) hdr;
 
@@ -32,7 +32,7 @@ int ipv6_ext_rh_process(ipv6_hdr_t *hdr, ipv6_ext_rh_t *ext)
         default:
             break;
     }
-    return EXT_RH_CODE_ERROR;
+    return GNRC_IPV6_EXT_RH_ERROR;
 }
 
 /** @} */

--- a/sys/net/gnrc/pktbuf/gnrc_pktbuf.c
+++ b/sys/net/gnrc/pktbuf/gnrc_pktbuf.c
@@ -86,5 +86,28 @@ gnrc_pktsnip_t *gnrc_pktbuf_replace_snip(gnrc_pktsnip_t *pkt,
     return pkt;
 }
 
+gnrc_pktsnip_t *gnrc_pktbuf_reverse_snips(gnrc_pktsnip_t *pkt)
+{
+    gnrc_pktsnip_t *reversed = NULL, *ptr = pkt;
+
+    while (ptr != NULL) {
+        gnrc_pktsnip_t *next;
+
+        /* try to write-protect snip as its next-pointer is changed below */
+        pkt = gnrc_pktbuf_start_write(ptr); /* use pkt as temporary variable */
+        if (pkt == NULL) {
+            gnrc_pktbuf_release(reversed);
+            gnrc_pktbuf_release(ptr);
+            return NULL;
+        }
+        /* switch around pointers */
+        next = pkt->next;
+        pkt->next = reversed;
+        reversed = pkt;
+        ptr = next;
+    }
+    return reversed;
+}
+
 
 /** @} */

--- a/sys/net/gnrc/routing/rpl/srh/gnrc_rpl_srh.c
+++ b/sys/net/gnrc/routing/rpl/srh/gnrc_rpl_srh.c
@@ -29,7 +29,7 @@ static char addr_str[IPV6_ADDR_MAX_STR_LEN];
 int gnrc_rpl_srh_process(ipv6_hdr_t *ipv6, gnrc_rpl_srh_t *rh)
 {
     if (rh->seg_left == 0) {
-        return GNRC_IPV6_EXT_RH_OK;
+        return GNRC_IPV6_EXT_RH_AT_DST;
     }
 
     uint8_t n = (((rh->len * 8) - GNRC_RPL_SRH_PADDING(rh->pad_resv) -

--- a/sys/net/gnrc/routing/rpl/srh/gnrc_rpl_srh.c
+++ b/sys/net/gnrc/routing/rpl/srh/gnrc_rpl_srh.c
@@ -14,7 +14,7 @@
 
 #include <string.h>
 #include "net/gnrc/netif/internal.h"
-#include "net/ipv6/ext/rh.h"
+#include "net/gnrc/ipv6/ext/rh.h"
 #include "net/gnrc/rpl/srh.h"
 
 #define ENABLE_DEBUG    (0)
@@ -29,7 +29,7 @@ static char addr_str[IPV6_ADDR_MAX_STR_LEN];
 int gnrc_rpl_srh_process(ipv6_hdr_t *ipv6, gnrc_rpl_srh_t *rh)
 {
     if (rh->seg_left == 0) {
-        return EXT_RH_CODE_OK;
+        return GNRC_IPV6_EXT_RH_OK;
     }
 
     uint8_t n = (((rh->len * 8) - GNRC_RPL_SRH_PADDING(rh->pad_resv) -
@@ -45,7 +45,7 @@ int gnrc_rpl_srh_process(ipv6_hdr_t *ipv6, gnrc_rpl_srh_t *rh)
     if (rh->seg_left > n) {
         DEBUG("RPL SRH: number of segments left > number of addresses - discard\n");
         /* TODO ICMP Parameter Problem - Code 0 */
-        return EXT_RH_CODE_ERROR;
+        return GNRC_IPV6_EXT_RH_ERROR;
     }
 
     rh->seg_left--;
@@ -58,7 +58,7 @@ int gnrc_rpl_srh_process(ipv6_hdr_t *ipv6, gnrc_rpl_srh_t *rh)
     if (ipv6_addr_is_multicast(&ipv6->dst) || ipv6_addr_is_multicast(&addr)) {
         DEBUG("RPL SRH: found a multicast address - discard\n");
         /* TODO discard the packet */
-        return EXT_RH_CODE_ERROR;
+        return GNRC_IPV6_EXT_RH_ERROR;
     }
 
     /* check if multiple addresses of my interface exist */
@@ -75,7 +75,7 @@ int gnrc_rpl_srh_process(ipv6_hdr_t *ipv6, gnrc_rpl_srh_t *rh)
             if (found && ((k - found_pos) > 1)) {
                 DEBUG("RPL SRH: found multiple addresses that belong to me - discard\n");
                 /* TODO send an ICMP Parameter Problem (Code 0) and discard the packet */
-                return EXT_RH_CODE_ERROR;
+                return GNRC_IPV6_EXT_RH_ERROR;
             }
             found_pos = k;
             found = true;
@@ -89,7 +89,7 @@ int gnrc_rpl_srh_process(ipv6_hdr_t *ipv6, gnrc_rpl_srh_t *rh)
 
     ipv6->dst = addr;
 
-    return EXT_RH_CODE_FORWARD;
+    return GNRC_IPV6_EXT_RH_FORWARDED;
 }
 
 /** @} */

--- a/sys/net/network_layer/ipv6/ext/Makefile
+++ b/sys/net/network_layer/ipv6/ext/Makefile
@@ -1,3 +1,0 @@
-MODULE = ipv6_ext
-
-include $(RIOTBASE)/Makefile.base

--- a/sys/phydat/phydat.c
+++ b/sys/phydat/phydat.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2018 Eistec AB
+ *               2018 Otto-von-Guericke-Universität Magdeburg
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -14,6 +15,7 @@
  * @brief       Generic sensor/actuator data handling
  *
  * @author      Joakim Nohlgård <joakim.nohlgard@eistec.se>
+ * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
  *
  * @}
  */
@@ -24,24 +26,95 @@
 #define ENABLE_DEBUG 0
 #include "debug.h"
 
-uint8_t phydat_fit(phydat_t *dat, long value, unsigned int index, uint8_t prescale)
+#ifndef PHYDAT_FIT_TRADE_PRECISION_FOR_ROM
+#define PHYDAT_FIT_TRADE_PRECISION_FOR_ROM 1
+#endif
+
+static const uint32_t lookup_table_positive[] = {
+    327674999,
+    32767499,
+    3276749,
+    327674,
+    32767,
+};
+
+#if !(PHYDAT_FIT_TRADE_PRECISION_FOR_ROM)
+static const uint32_t lookup_table_negative[] = {
+    327684999,
+    32768499,
+    3276849,
+    327684,
+    32768,
+};
+#endif
+
+static const uint32_t divisors[] = {
+    100000,
+    10000,
+    1000,
+    100,
+    10,
+};
+
+#define LOOKUP_LEN (sizeof(lookup_table_positive) / sizeof(int32_t))
+
+void phydat_fit(phydat_t *dat, const int32_t *values, unsigned int dim)
 {
-    assert(index < (sizeof(dat->val) / sizeof(dat->val[0])));
-    uint8_t ret = prescale;
-    while (prescale > 0) {
-        value /= 10;
-        --prescale;
-    }
-    int8_t scale_offset = 0;
-    while ((value > PHYDAT_MAX) || (value < PHYDAT_MIN)) {
-        value /= 10;
-        for (unsigned int k = 0; k < (sizeof(dat->val) / sizeof(dat->val[0])); ++k) {
-            dat->val[k] /= 10;
+    assert(dim <= (sizeof(dat->val) / sizeof(dat->val[0])));
+    uint32_t divisor = 0;
+    uint32_t max = 0;
+    const uint32_t *lookup = lookup_table_positive;
+
+    /* Get the value with the highest magnitude and the correct lookup table.
+     * If PHYDAT_FIT_TRADE_PRECISION_FOR_ROM is true, the same lookup table will
+     * be used for both positive and negative values. As result, -32768 will be
+     * considered as out of range and scaled down. So statistically in 0.00153%
+     * of the cases an unneeded scaling is performed, when
+     * PHYDAT_FIT_TRADE_PRECISION_FOR_ROM is true.
+     */
+    for (unsigned int i = 0; i < dim; i++) {
+        if (values[i] > (int32_t)max) {
+            max = values[i];
+#if !(PHYDAT_FIT_TRADE_PRECISION_FOR_ROM)
+            lookup = lookup_table_positive;
+#endif
         }
-        ++scale_offset;
+        else if (-values[i] > (int32_t)max) {
+            max = -values[i];
+#if !(PHYDAT_FIT_TRADE_PRECISION_FOR_ROM)
+            lookup = lookup_table_negative;
+#endif
+        }
     }
-    dat->val[index] = value;
-    dat->scale += scale_offset;
-    ret += scale_offset;
-    return ret;
+
+    for (unsigned int i = 0; i < LOOKUP_LEN; i++) {
+        if (max > lookup[i]) {
+            divisor = divisors[i];
+            dat->scale += 5 - i;
+            break;
+        }
+    }
+
+    if (!divisor) {
+        /* No rescaling required */
+        for (unsigned int i = 0; i < dim; i++) {
+            dat->val[i] = values[i];
+        }
+        return;
+    }
+
+    /* Applying scale and add half of the divisor for correct rounding */
+    uint32_t divisor_half = divisor >> 1;
+    for (unsigned int i = 0; i < dim; i++) {
+        if (values[i] >= 0) {
+            dat->val[i] = (uint32_t)(values[i] + divisor_half) / divisor;
+        }
+        else {
+            /* For negative integers the C standards seems to lack information
+             * on whether to round down or towards zero. So using positive
+             * integer division as last resort here.
+             */
+            dat->val[i] = -((uint32_t)((-values[i]) + divisor_half) / divisor);
+        }
+    }
 }

--- a/tests/unittests/tests-pktbuf/tests-pktbuf.c
+++ b/tests/unittests/tests-pktbuf/tests-pktbuf.c
@@ -818,6 +818,43 @@ static void test_pktbuf_get_iovec__null(void)
     TEST_ASSERT_EQUAL_INT(0, len);
 }
 
+static void test_pktbuf_reverse_snips__too_full(void)
+{
+    gnrc_pktsnip_t *pkt, *pkt_next, *pkt_huge;
+    const size_t pkt_huge_size = GNRC_PKTBUF_SIZE - (3 * 8) -
+                                 (3 * sizeof(gnrc_pktsnip_t)) - 4;
+
+    pkt_next = gnrc_pktbuf_add(NULL, TEST_STRING8, 8, GNRC_NETTYPE_TEST);
+    TEST_ASSERT_NOT_NULL(pkt_next);
+    /* hold to enforce duplication */
+    gnrc_pktbuf_hold(pkt_next, 1);
+    pkt = gnrc_pktbuf_add(pkt_next, TEST_STRING8, 8, GNRC_NETTYPE_TEST);
+    TEST_ASSERT_NOT_NULL(pkt);
+    /* filling up rest of packet buffer */
+    pkt_huge = gnrc_pktbuf_add(NULL, NULL, pkt_huge_size, GNRC_NETTYPE_UNDEF);
+    TEST_ASSERT_NOT_NULL(pkt_huge);
+    TEST_ASSERT_NULL(gnrc_pktbuf_reverse_snips(pkt));
+    gnrc_pktbuf_release(pkt_huge);
+    /* release because of hold above */
+    gnrc_pktbuf_release(pkt_next);
+    TEST_ASSERT(gnrc_pktbuf_is_empty());
+}
+
+static void test_pktbuf_reverse_snips__success(void)
+{
+    gnrc_pktsnip_t *pkt, *pkt_next, *pkt_reversed;
+
+    pkt_next = gnrc_pktbuf_add(NULL, TEST_STRING8, 8, GNRC_NETTYPE_TEST);
+    TEST_ASSERT_NOT_NULL(pkt_next);
+    pkt = gnrc_pktbuf_add(pkt_next, TEST_STRING8, 8, GNRC_NETTYPE_TEST);
+    TEST_ASSERT_NOT_NULL(pkt);
+    pkt_reversed = gnrc_pktbuf_reverse_snips(pkt);
+    TEST_ASSERT(pkt_reversed == pkt_next);
+    TEST_ASSERT(pkt_reversed->next == pkt);
+    gnrc_pktbuf_release(pkt_reversed);
+    TEST_ASSERT(gnrc_pktbuf_is_empty());
+}
+
 Test *tests_pktbuf_tests(void)
 {
     EMB_UNIT_TESTFIXTURES(fixtures) {
@@ -870,6 +907,8 @@ Test *tests_pktbuf_tests(void)
         new_TestFixture(test_pktbuf_get_iovec__1_elem),
         new_TestFixture(test_pktbuf_get_iovec__3_elem),
         new_TestFixture(test_pktbuf_get_iovec__null),
+        new_TestFixture(test_pktbuf_reverse_snips__too_full),
+        new_TestFixture(test_pktbuf_reverse_snips__success),
     };
 
     EMB_UNIT_TESTCALLER(gnrc_pktbuf_tests, set_up, NULL, fixtures);

--- a/tests/unittests/tests-rpl_srh/tests-rpl_srh.c
+++ b/tests/unittests/tests-rpl_srh/tests-rpl_srh.c
@@ -19,6 +19,7 @@
 #include "net/ipv6/ext.h"
 #include "net/ipv6/hdr.h"
 #include "net/gnrc/rpl/srh.h"
+#include "net/gnrc/ipv6/ext/rh.h"
 
 #include "unittests-constants.h"
 #include "tests-rpl_srh.h"
@@ -61,13 +62,13 @@ static void test_rpl_srh_nexthop_no_prefix_elided(void)
 
     /* first hop */
     res = gnrc_rpl_srh_process(&hdr, srh);
-    TEST_ASSERT_EQUAL_INT(res, EXT_RH_CODE_FORWARD);
+    TEST_ASSERT_EQUAL_INT(res, GNRC_IPV6_EXT_RH_FORWARDED);
     TEST_ASSERT_EQUAL_INT(SRH_SEG_LEFT - 1, srh->seg_left);
     TEST_ASSERT(ipv6_addr_equal(&hdr.dst, &expected1));
 
     /* second hop */
     res = gnrc_rpl_srh_process(&hdr, srh);
-    TEST_ASSERT_EQUAL_INT(res, EXT_RH_CODE_FORWARD);
+    TEST_ASSERT_EQUAL_INT(res, GNRC_IPV6_EXT_RH_FORWARDED);
     TEST_ASSERT_EQUAL_INT(SRH_SEG_LEFT - 2, srh->seg_left);
     TEST_ASSERT(ipv6_addr_equal(&hdr.dst, &expected2));
 }
@@ -94,13 +95,13 @@ static void test_rpl_srh_nexthop_prefix_elided(void)
 
     /* first hop */
     res = gnrc_rpl_srh_process(&hdr, srh);
-    TEST_ASSERT_EQUAL_INT(res, EXT_RH_CODE_FORWARD);
+    TEST_ASSERT_EQUAL_INT(res, GNRC_IPV6_EXT_RH_FORWARDED);
     TEST_ASSERT_EQUAL_INT(SRH_SEG_LEFT - 1, srh->seg_left);
     TEST_ASSERT(ipv6_addr_equal(&hdr.dst, &expected1));
 
     /* second hop */
     res = gnrc_rpl_srh_process(&hdr, srh);
-    TEST_ASSERT_EQUAL_INT(res, EXT_RH_CODE_FORWARD);
+    TEST_ASSERT_EQUAL_INT(res, GNRC_IPV6_EXT_RH_FORWARDED);
     TEST_ASSERT_EQUAL_INT(SRH_SEG_LEFT - 2, srh->seg_left);
     TEST_ASSERT(ipv6_addr_equal(&hdr.dst, &expected2));
 }


### PR DESCRIPTION
### Contribution description

Errors flags could not clear making the i2c unusable after error.
This fix removes the error check in start so the error flags can clear and does proper checking for status bits before _bus_check.

### Testing procedure
Run periph_i2c on any STM32 F0, F3, F7, L0 and L4 family.  I connect a PHiLIP but any i2c sensor can be used.
`BOARD=nucleo-l476rg make flash term -C tests/periph_i2c`
```
i2c_read_regs 0 85 152 10 0    
2018-10-26 09:45:14,539 - INFO # i2c_read_regs 0 85 152 10 0
2018-10-26 09:45:14,545 - INFO # Command: i2c_read_regs(0, 0x55, 0x98, 10, 0x00)
2018-10-26 09:45:14,557 - INFO # Success: i2c_0 read 10 byte(s) from reg 0x98 : [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09]

i2c_read_regs 0 84 152 10 0    
2018-10-26 09:46:33,204 - INFO #  i2c_read_regs 0 84 152 10 0
2018-10-26 09:46:33,206 - INFO # Command: i2c_read_regs(0, 0x54, 0x98, 10, 0x00)
2018-10-26 09:46:33,216 - INFO # Error: ENXIO [6]

i2c_read_regs 0 85 152 10 0    
2018-10-26 09:46:49,596 - INFO #  i2c_read_regs 0 85 152 10 0
2018-10-26 09:46:49,601 - INFO # Command: i2c_read_regs(0, 0x55, 0x98, 10, 0x00)
2018-10-26 09:46:49,620 - INFO # Success: i2c_0 read 10 byte(s) from reg 0x98 : [0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, 0x08, 0x09]

i2c_write_regs 0 85 152 0 42   
2018-10-26 09:47:33,078 - INFO #  i2c_write_regs 0 85 152 0 42
2018-10-26 09:47:33,083 - INFO # Command: i2c_write_regs(0, 0x55, 0x98, 0x00, [0x2a])
2018-10-26 09:47:33,085 - INFO # Success: i2c_0 wrote 1 bytes to reg 0x98
```

### Issues/PRs references

Fixes #10254