### PR TITLE
example/nanocoap: fix block2 example [backport 2018.10]

### DIFF
--- a/examples/nanocoap_server/coap_handler.c
+++ b/examples/nanocoap_server/coap_handler.c
@@ -42,13 +42,13 @@ static ssize_t _riot_block2_handler(coap_pkt_t *pkt, uint8_t *buf, size_t len, v
     *bufpos++ = 0xff;
 
     /* Add actual content */
-    bufpos += coap_blockwise_put_bytes(&slicer, bufpos, block2_intro, sizeof(block2_intro));
-    bufpos += coap_blockwise_put_bytes(&slicer, bufpos, (uint8_t*)RIOT_VERSION, sizeof(RIOT_VERSION));
+    bufpos += coap_blockwise_put_bytes(&slicer, bufpos, block2_intro, sizeof(block2_intro)-1);
+    bufpos += coap_blockwise_put_bytes(&slicer, bufpos, (uint8_t*)RIOT_VERSION, strlen(RIOT_VERSION));
     bufpos += coap_blockwise_put_char(&slicer, bufpos, ')');
-    bufpos += coap_blockwise_put_bytes(&slicer, bufpos, block2_board, sizeof(block2_board));
-    bufpos += coap_blockwise_put_bytes(&slicer, bufpos, (uint8_t*)RIOT_BOARD, sizeof(RIOT_BOARD));
-    bufpos += coap_blockwise_put_bytes(&slicer, bufpos, block2_mcu, sizeof(block2_mcu));
-    bufpos += coap_blockwise_put_bytes(&slicer, bufpos, (uint8_t*)RIOT_MCU, sizeof(RIOT_MCU));
+    bufpos += coap_blockwise_put_bytes(&slicer, bufpos, block2_board, sizeof(block2_board)-1);
+    bufpos += coap_blockwise_put_bytes(&slicer, bufpos, (uint8_t*)RIOT_BOARD, strlen(RIOT_BOARD));
+    bufpos += coap_blockwise_put_bytes(&slicer, bufpos, block2_mcu, sizeof(block2_mcu)-1);
+    bufpos += coap_blockwise_put_bytes(&slicer, bufpos, (uint8_t*)RIOT_MCU, strlen(RIOT_MCU));
     /* To demonstrate individual chars */
     bufpos += coap_blockwise_put_char(&slicer, bufpos, ' ');
     bufpos += coap_blockwise_put_char(&slicer, bufpos, 'M');


### PR DESCRIPTION
## Backport of #10293

### Contribution description
The recent addition of Block2 support in nanocoap included a new resource for the nanocoap_server example, /riot/ver. This resource provides a description of the version of RIOT as well as the board and MCU. However, the construction of the payload includes the null terminator for the component strings. This PR reworks the construction to avoid addition of the \0 bytes.

### Testing procedure
To reproduce, send a GET request to the /riot/ver resource. Your implementation may require you to set a block size for the request. You also can use the attached Python script [task04_py.txt](https://github.com/RIOT-OS/RIOT/files/2526497/task04_py.txt) (renamed to satisfy GitHub), which requires a recent copy of [aiocoap](https://github.com/chrysn/aiocoap).

With aiocoap, the faulty response looks like:
```
Result: 2.05 Content
b'This is RIOT (Version: \x002018.04-devel-3293-g289e6\x00) running on a \x00native\x00 board with a \x00native\x00 MCU.'
```

The fixed response looks like:
```
Result: 2.05 Content
b'This is RIOT (Version: 2018.04-devel-3293-g289e6) running on a native board with a native MCU.'
```
### Issues/PRs references
N/A