### PR TITLE
drivers/at: Fix UART callback function signature

### DIFF
--- a/drivers/at/at.c
+++ b/drivers/at/at.c
@@ -22,11 +22,15 @@
 #define AT_PRINT_INCOMING (0)
 #endif
 
+static inline void _uart_rx_cb(void *arg, uint8_t data) {
+    isrpipe_write_one((isrpipe_t *)arg, (char)data);
+}
+
 int at_dev_init(at_dev_t *dev, uart_t uart, uint32_t baudrate, char *buf, size_t bufsize)
 {
     dev->uart = uart;
     isrpipe_init(&dev->isrpipe, buf, bufsize);
-    uart_init(uart, baudrate, (uart_rx_cb_t) isrpipe_write_one,
+    uart_init(uart, baudrate, _uart_rx_cb,
               &dev->isrpipe);
 
     return 0;


### PR DESCRIPTION
### Contribution description
This PR fixes the UART RX callback function signature to match the required by the `uart_init` function, by defining an intermediate function for callback. This problem appears when using GCC 8 or above apparently.

### Testing procedure
Try to compile `tests/driver_at` application, it should success.

### Issues/PRs references
None