### PR TITLE
boards/msba2: Added call to periph_init

### DIFF
--- a/boards/msba2/board_init.c
+++ b/boards/msba2/board_init.c
@@ -26,6 +26,7 @@
 
 #include "board.h"
 #include "cpu.h"
+#include "periph/init.h"
 
 void bl_init_ports(void)
 {
@@ -41,6 +42,7 @@ void bl_init_ports(void)
 
     LED0_OFF;
     LED0_OFF;
+    periph_init();
 }
 
 void init_clks1(void)


### PR DESCRIPTION
### Contribution description
Upon start up `periph_init()` should be called and initializes periphery such as SPI or I2C interface. `periph_init()` is called by other devices at the end of `cpu_init()` - however the start up process of the LPC2387 in RIOT is different and does use `cpu_init()`. Instead, the MSB-A2 is initialized in `board_init.c`. This PR adds the missing call to `periph_init()` to board initialization routine. (Obviously, it would be better to update the start up code of the LPC2387 to follow the same approach other RIOT platforms use, but with the MSB-A2 being an legacy platform that is barely used, the effort would be to high.)

### Testing procedure
#### Verifying that there is indeed a problem and this is addressed
E.g. by adding `assert(0);` into `periph_init()`. The expected result would be that the device does not boot because of the failed assertion. However, before this PR `periph_init()` is not called, thus the device will boot. With the PR applied the assertion will fail.

#### Testing for regressions
E.g. by checking if the MSB-A2 still boots reliable with this PR applied.

### Issues/PRs references
Fixes https://github.com/RIOT-OS/RIOT/issues/10276
