### PR TITLE
makefiles/docker.inc.mk: handle building in git worktree

### DIFF
--- a/makefiles/docker.inc.mk
+++ b/makefiles/docker.inc.mk
@@ -89,6 +89,11 @@ DOCKER ?= docker
 DOCKER_VOLUMES_AND_ENV += $(if $(wildcard $(GIT_CACHE_DIR)),-v $(GIT_CACHE_DIR):$(DOCKER_BUILD_ROOT)/gitcache)
 DOCKER_VOLUMES_AND_ENV += $(if $(wildcard $(GIT_CACHE_DIR)),-e GIT_CACHE_DIR=$(DOCKER_BUILD_ROOT)/gitcache)
 
+# Handle worktree by mounting the git common dir in the same location
+_is_git_worktree = $(shell grep '^gitdir: ' $(RIOTBASE)/.git 2>/dev/null)
+GIT_WORKTREE_COMMONDIR = $(shell git rev-parse --git-common-dir)
+DOCKER_VOLUMES_AND_ENV += $(if $(_is_git_worktree),-v $(GIT_WORKTREE_COMMONDIR):$(GIT_WORKTREE_COMMONDIR))
+
 # This will execute `make $(DOCKER_MAKECMDGOALS)` inside a Docker container.
 # We do not push the regular $(MAKECMDGOALS) to the container's make command in
 # order to only perform building inside the container and defer executing any


### PR DESCRIPTION
### Contribution description

When building from a worktree, the common git directory was not mounted in docker.

This lead to the version not being set and issues with git-cache in
ubuntu bionic that could not execute the 'git hash-object' command.


#### Implementation details

I just test that `.git` is a file starting with `gitdir` to know it is in a worktree.
Any other solution is welcomed.

I then mounted the whole `--git-common-dir` in the same location.
Using the `gitdir` pointed by the `.git` file was not enough to make it valid.

I aslo tested overwriting the `.git` file with the `.git` repository but docker did not allow that.

### Testing procedure

#### Original behavior untouched

In a normal repository, no `.git` directory is mounted when building with docker.

```
BUILD_IN_DOCKER=1 DOCKER="sudo docker" make -C examples/hello-world/ clean all

# There should be no output with `-v path_to_dir/RIOT/.git:path_to_dir/RIOT/.git`
```

#### New behavior

This must be run from a git worktree (replace `riot/master` to the upstream master branch if different)

``` bash
git worktree add ../git_test_worktree riot/master
cd ../git_test_worktree
```


##### Testing the RIOT_VERSION calculation from git


With `riot/master` we get an `UNKNOWN` version, (see the last line).

```
BUILD_IN_DOCKER=1 DOCKER="sudo docker" make -C examples/hello-world/ clean all && strings examples/hello-world/bin/native/hello-world.elf  | grep "This is RIOT"
make: Entering directory '/home/harter/work/git/worktree/riot_master/examples/hello-world'
Launching build container using image "riot/riotbuild:latest".
sudo docker run --rm -t -u "$(id -u)" \
    -v '/home/harter/work/git/worktree/riot_master:/data/riotbuild/riotbase' \
    -v '/home/harter/work/git/worktree/riot_master/cpu:/data/riotbuild/riotcpu' \
    -v '/home/harter/work/git/worktree/riot_master/boards:/data/riotbuild/riotboard' \
    -v '/home/harter/work/git/worktree/riot_master/makefiles:/data/riotbuild/riotmake' \
    -v '/home/harter/work/git/worktree/riot_master:/data/riotbuild/riotproject' \
    -v /etc/localtime:/etc/localtime:ro \
    -e 'RIOTBASE=/data/riotbuild/riotbase' \
    -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' \
    -e 'RIOTCPU=/data/riotbuild/riotcpu' \
    -e 'RIOTBOARD=/data/riotbuild/riotboard' \
    -e 'RIOTMAKE=/data/riotbuild/riotmake' \
    -e 'RIOTPROJECT=/data/riotbuild/riotproject' \
    -v /home/harter/.gitcache:/data/riotbuild/gitcache -e GIT_CACHE_DIR=/data/riotbuild/gitcache \
     \
    -w '/data/riotbuild/riotproject/examples/hello-world/' \
    'riot/riotbuild:latest' make all
Building application "hello-world" for "native" with MCU "native".

"make" -C /data/riotbuild/riotbase/core
"make" -C /data/riotbuild/riotbase/drivers
"make" -C /data/riotbuild/riotbase/drivers/periph_common
"make" -C /data/riotbuild/riotbase/sys
"make" -C /data/riotbuild/riotbase/sys/auto_init
"make" -C /data/riotbuild/riotboard/native
"make" -C /data/riotbuild/riotboard/native/drivers
"make" -C /data/riotbuild/riotcpu/native
"make" -C /data/riotbuild/riotcpu/native/periph
"make" -C /data/riotbuild/riotcpu/native/vfs
   text    data     bss     dec     hex filename
  20641     372   47684   68697   10c59 /data/riotbuild/riotproject/examples/hello-world/bin/native/hello-world.elf
make: Leaving directory '/home/harter/work/git/worktree/riot_master/examples/hello-world'
main(): This is RIOT! (Version: UNKNOWN (builddir: /data/riotbuild/riotbase))
```

With this PR the version is correctly detected (see the last line).


```
BUILD_IN_DOCKER=1 DOCKER="sudo docker" make -C examples/hello-world/ clean all && strings examples/hello-world/bin/native/hello-world.elf  | grep "This is RIOT"
make: Entering directory '/home/harter/work/git/worktree/riot_master/examples/hello-world'
Launching build container using image "riot/riotbuild:latest".
sudo docker run --rm -t -u "$(id -u)" \
    -v '/home/harter/work/git/worktree/riot_master:/data/riotbuild/riotbase' \
    -v '/home/harter/work/git/worktree/riot_master/cpu:/data/riotbuild/riotcpu' \
    -v '/home/harter/work/git/worktree/riot_master/boards:/data/riotbuild/riotboard' \
    -v '/home/harter/work/git/worktree/riot_master/makefiles:/data/riotbuild/riotmake' \
    -v '/home/harter/work/git/worktree/riot_master:/data/riotbuild/riotproject' \
    -v /etc/localtime:/etc/localtime:ro \
    -e 'RIOTBASE=/data/riotbuild/riotbase' \
    -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' \
    -e 'RIOTCPU=/data/riotbuild/riotcpu' \
    -e 'RIOTBOARD=/data/riotbuild/riotboard' \
    -e 'RIOTMAKE=/data/riotbuild/riotmake' \
    -e 'RIOTPROJECT=/data/riotbuild/riotproject' \
    -v /home/harter/.gitcache:/data/riotbuild/gitcache -e GIT_CACHE_DIR=/data/riotbuild/gitcache -v /home/harter/work/git/RIOT/.git:/home/harter/work/git/RIOT/.git \
     \
    -w '/data/riotbuild/riotproject/examples/hello-world/' \
    'riot/riotbuild:latest' make all 
Building application "hello-world" for "native" with MCU "native".

"make" -C /data/riotbuild/riotbase/core
"make" -C /data/riotbuild/riotbase/drivers
"make" -C /data/riotbuild/riotbase/drivers/periph_common
"make" -C /data/riotbuild/riotbase/sys
"make" -C /data/riotbuild/riotbase/sys/auto_init
"make" -C /data/riotbuild/riotboard/native
"make" -C /data/riotbuild/riotboard/native/drivers
"make" -C /data/riotbuild/riotcpu/native
"make" -C /data/riotbuild/riotcpu/native/periph
"make" -C /data/riotbuild/riotcpu/native/vfs
   text    data     bss     dec     hex filename
  20649     372   47684   68705   10c61 /data/riotbuild/riotproject/examples/hello-world/bin/native/hello-world.elf
make: Leaving directory '/home/harter/work/git/worktree/riot_master/examples/hello-world'
main(): This is RIOT! (Version: 2018.10-RC1-41-g72f71-pr/make/docker/handle_worktree)
```


##### Testing the behavior with  `ubuntu:bionic` docker image

You must have an initialized git cache

``` bash
./dist/tools/git/git-cache init
```

Build a docker image from https://github.com/RIOT-OS/riotdocker/pull/42
I used `docker build . -t riot/bionic` from the repository.

Compiling a package using the `bionic` image fails in master as `git hash-object` tries to detect the current directory as a git directory.

```
rm -rf examples/filesystem/bin/; BUILD_IN_DOCKER=1 DOCKER="sudo docker" DOCKER_IMAGE="riot/bionic:latest" RIOT_CI_BUILD=1  make -C examples/filesystem/ clean all
make: Entering directory '/home/harter/work/git/worktree/riot_master/examples/filesystem'
make[1]: Nothing to be done for 'Makefile.include'.
make: Nothing to be done for 'clean'.
Launching build container using image "riot/bionic:latest".
sudo docker run --rm -t -u "$(id -u)" \
    -v '/home/harter/work/git/worktree/riot_master:/data/riotbuild/riotbase' \
    -v '/home/harter/work/git/worktree/riot_master/cpu:/data/riotbuild/riotcpu' \
    -v '/home/harter/work/git/worktree/riot_master/boards:/data/riotbuild/riotboard' \
    -v '/home/harter/work/git/worktree/riot_master/makefiles:/data/riotbuild/riotmake' \
    -v '/home/harter/work/git/worktree/riot_master:/data/riotbuild/riotproject' \
    -v /etc/localtime:/etc/localtime:ro \
    -e 'RIOTBASE=/data/riotbuild/riotbase' \
    -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' \
    -e 'RIOTCPU=/data/riotbuild/riotcpu' \
    -e 'RIOTBOARD=/data/riotbuild/riotboard' \
    -e 'RIOTMAKE=/data/riotbuild/riotmake' \
    -e 'RIOTPROJECT=/data/riotbuild/riotproject' \
    -v /home/harter/.gitcache:/data/riotbuild/gitcache -e GIT_CACHE_DIR=/data/riotbuild/gitcache \
    -e 'RIOT_CI_BUILD=1' \
    -w '/data/riotbuild/riotproject/examples/filesystem/' \
    'riot/bionic:latest' make all
make[1]: Nothing to be done for 'Makefile.include'.
Building application "filesystem" for "native" with MCU "native".

rm -Rf /data/riotbuild/riotproject/examples/filesystem/bin/pkg/native/littlefs
mkdir -p /data/riotbuild/riotproject/examples/filesystem/bin/pkg/native/littlefs
/data/riotbuild/riotbase/dist/tools/git/git-cache clone "https://github.com/geky/littlefs.git" "0bb1f7af17755bd792f0c4966877fb1886dfc802" "/data/riotbuild/riotproject/examples/filesystem/bin/pkg/native/littlefs"
fatal: not a git repository: /home/harter/work/git/RIOT/.git/worktrees/riot_master
git-cache: cloning from cache. tag=commit0bb1f7af17755bd792f0c4966877fb1886dfc802
fatal: Invalid refspec 'refs/tags//*:refs/tags/*'
/data/riotbuild/riotbase/pkg/pkg.mk:33: recipe for target '/data/riotbuild/riotproject/examples/filesystem/bin/pkg/native/littlefs/.git-downloaded' failed
make[1]: *** [/data/riotbuild/riotproject/examples/filesystem/bin/pkg/native/littlefs/.git-downloaded] Error 128
/data/riotbuild/riotbase/Makefile.include:487: recipe for target 'pkg-prepare' failed
make: [pkg-prepare] Error 2 (ignored)
rm -Rf /data/riotbuild/riotproject/examples/filesystem/bin/pkg/native/littlefs
mkdir -p /data/riotbuild/riotproject/examples/filesystem/bin/pkg/native/littlefs
/data/riotbuild/riotbase/dist/tools/git/git-cache clone "https://github.com/geky/littlefs.git" "0bb1f7af17755bd792f0c4966877fb1886dfc802" "/data/riotbuild/riotproject/examples/filesystem/bin/pkg/native/littlefs"
fatal: not a git repository: /home/harter/work/git/RIOT/.git/worktrees/riot_master
git-cache: cloning from cache. tag=commit0bb1f7af17755bd792f0c4966877fb1886dfc802
fatal: Invalid refspec 'refs/tags//*:refs/tags/*'
/data/riotbuild/riotbase/pkg/pkg.mk:33: recipe for target '/data/riotbuild/riotproject/examples/filesystem/bin/pkg/native/littlefs/.git-downloaded' failed
make[1]: *** [/data/riotbuild/riotproject/examples/filesystem/bin/pkg/native/littlefs/.git-downloaded] Error 128
/data/riotbuild/riotbase/Makefile.include:491: recipe for target 'pkg-build-littlefs' failed
make: *** [pkg-build-littlefs] Error 2
/home/harter/work/git/worktree/riot_master/makefiles/docker.inc.mk:100: recipe for target '..in-docker-container' failed
make: *** [..in-docker-container] Error 2
make: Leaving directory '/home/harter/work/git/worktree/riot_master/examples/filesystem'
```

It works with this PR


```
rm -rf examples/filesystem/bin/; BUILD_IN_DOCKER=1 DOCKER="sudo docker" DOCKER_IMAGE="riot/bionic:latest" RIOT_CI_BUILD=1  make -C examples/filesystem/ clean all
make: Entering directory '/home/harter/work/git/worktree/riot_master/examples/filesystem'
make[1]: Nothing to be done for 'Makefile.include'.
make: Nothing to be done for 'clean'.
Launching build container using image "riot/bionic:latest".
sudo docker run --rm -t -u "$(id -u)" \
    -v '/home/harter/work/git/worktree/riot_master:/data/riotbuild/riotbase' \
    -v '/home/harter/work/git/worktree/riot_master/cpu:/data/riotbuild/riotcpu' \
    -v '/home/harter/work/git/worktree/riot_master/boards:/data/riotbuild/riotboard' \
    -v '/home/harter/work/git/worktree/riot_master/makefiles:/data/riotbuild/riotmake' \
    -v '/home/harter/work/git/worktree/riot_master:/data/riotbuild/riotproject' \
    -v /etc/localtime:/etc/localtime:ro \
    -e 'RIOTBASE=/data/riotbuild/riotbase' \
    -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' \
    -e 'RIOTCPU=/data/riotbuild/riotcpu' \
    -e 'RIOTBOARD=/data/riotbuild/riotboard' \
    -e 'RIOTMAKE=/data/riotbuild/riotmake' \
    -e 'RIOTPROJECT=/data/riotbuild/riotproject' \
    -v /home/harter/.gitcache:/data/riotbuild/gitcache -e GIT_CACHE_DIR=/data/riotbuild/gitcache -v /home/harter/work/git/RIOT/.git:/home/harter/work/git/RIOT/.git \
    -e 'RIOT_CI_BUILD=1' \
    -w '/data/riotbuild/riotproject/examples/filesystem/' \
    'riot/bionic:latest' make all
make[1]: Nothing to be done for 'Makefile.include'.
Building application "filesystem" for "native" with MCU "native".

rm -Rf /data/riotbuild/riotproject/examples/filesystem/bin/pkg/native/littlefs
mkdir -p /data/riotbuild/riotproject/examples/filesystem/bin/pkg/native/littlefs
/data/riotbuild/riotbase/dist/tools/git/git-cache clone "https://github.com/geky/littlefs.git" "0bb1f7af17755bd792f0c4966877fb1886dfc802" "/data/riotbuild/riotproject/examples/filesystem/bin/pkg/native/littlefs"
git-cache: cloning from cache. tag=commit0bb1f7af17755bd792f0c4966877fb1886dfc802
touch /data/riotbuild/riotproject/examples/filesystem/bin/pkg/native/littlefs/.git-downloaded
"make" -C /data/riotbuild/riotproject/examples/filesystem/bin/pkg/native/littlefs -f /data/riotbuild/riotbase/pkg/littlefs/Makefile.littlefs
   text    data     bss     dec     hex filename
  87035    1180   49336  137551   2194f /data/riotbuild/riotproject/examples/filesystem/bin/native/filesystem.elf
make: Leaving directory '/home/harter/work/git/worktree/riot_master/examples/filesystem'
```

### Issues/PRs references


The RIOT_VERSION issue was detected in https://github.com/RIOT-OS/RIOT/issues/9645#issuecomment-408454269 and the `git-cache` issue was detected when running Release compilation with `bionic` image https://github.com/RIOT-OS/Release-Specs/issues/76#issuecomment-433932317
