### PR TITLE
Do not try to continue reading shell commands if input source is closed

### DIFF
--- a/sys/include/shell.h
+++ b/sys/include/shell.h
@@ -69,10 +69,8 @@ typedef struct shell_command_t {
  * @param[in]       commands    ptr to array of command structs
  * @param[in]       line_buf    Buffer that will be used for reading a line
  * @param[in]       len         nr of bytes that fit in line_buf
- *
- * @returns         This function does not return.
  */
-void shell_run(const shell_command_t *commands, char *line_buf, int len) NORETURN;
+void shell_run(const shell_command_t *commands, char *line_buf, int len);
 
 #ifdef __cplusplus
 }

--- a/sys/shell/shell.c
+++ b/sys/shell/shell.c
@@ -228,7 +228,7 @@ static int readline(char *buf, size_t size)
 
         int c = getchar();
         if (c < 0) {
-            return 1;
+            return EOF;
         }
 
         /* We allow Unix linebreaks (\n), DOS linebreaks (\r\n), and Mac linebreaks (\r). */
@@ -286,6 +286,10 @@ void shell_run(const shell_command_t *shell_commands, char *line_buf, int len)
 
     while (1) {
         int res = readline(line_buf, len);
+
+        if (res == EOF) {
+            break;
+        }
 
         if (!res) {
             handle_input_line(shell_commands, line_buf);


### PR DESCRIPTION
Backport of #10105 to the 2018.10 release branch