### PR TITLE
tests/driver_my9221: fix for loop indexes

### DIFF
--- a/tests/driver_my9221/main.c
+++ b/tests/driver_my9221/main.c
@@ -51,7 +51,8 @@ int main(void)
         my9221_set_led(&dev, i, MY9221_LED_OFF);
     }
     xtimer_usleep(TEST_WAIT);
-    for (unsigned i=dev.params.leds; i > 0 ; --i) {
+    for (unsigned j=dev.params.leds; j > 0 ; --j) {
+        unsigned i = j-1;
         my9221_set_led(&dev, i, MY9221_LED_ON);
         xtimer_usleep(TEST_WAIT);
         my9221_set_led(&dev, i, MY9221_LED_OFF);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
In the `my9221` test there are some for loops used for testing each led in the driver. However, the indexes should go always from 0 to 9 and the actual test generate these indexes from 1 to 10, so there's a failed assertion [here](https://github.com/RIOT-OS/RIOT/blob/68dc5b0d6e0422df9c3653c2cb8021fc35974aae/drivers/my9221/my9221.c#L133).

This PR fixes this issue.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Configure `drivers_my9221` test in its Makefile, and run `make flash test`. Verify there's no `FAILED ASSERTION` => `[SUCCESS]` message in the end.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
