### PR TITLE
drivers/mma8x5x: remove useless type from initialization parameters

### DIFF
--- a/boards/microbit/Makefile.dep
+++ b/boards/microbit/Makefile.dep
@@ -5,6 +5,7 @@ endif
 
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
+  USEMODULE += mma8x5x
 endif
 
 ifneq (,$(filter gnrc_netdev_default netdev_default,$(USEMODULE)))

--- a/boards/microbit/include/board.h
+++ b/boards/microbit/include/board.h
@@ -69,7 +69,6 @@ extern "C" {
  */
 #define MMA8X5X_PARAM_I2C           I2C_DEV(0)
 #define MMA8X5X_PARAM_ADDR          0x1d
-#define MMA8X5X_PARAM_TYPE          0x5a
 /** @} */
 
 /**

--- a/drivers/include/mma8x5x.h
+++ b/drivers/include/mma8x5x.h
@@ -95,7 +95,6 @@ enum {
 typedef struct {
     i2c_t i2c;                  /**< I2C bus the device is connected to */
     uint8_t addr;               /**< I2C bus address of the device */
-    uint8_t type;               /**< device type */
     uint8_t rate;               /**< sampling rate to use */
     uint8_t range;              /**< scale range to use */
     uint8_t offset[3];          /**< data offset in X, Y, and Z direction */

--- a/drivers/mma8x5x/include/mma8x5x_params.h
+++ b/drivers/mma8x5x/include/mma8x5x_params.h
@@ -37,9 +37,6 @@ extern "C" {
 #ifndef MMA8X5X_PARAM_ADDR
 #define MMA8X5X_PARAM_ADDR      (MMA8X5X_I2C_ADDRESS)
 #endif
-#ifndef MMA8X5X_PARAM_TYPE
-#define MMA8X5X_PARAM_TYPE      (MMA8X5X_TYPE_MMA8652)
-#endif
 #ifndef MMA8X5X_PARAM_RATE
 #define MMA8X5X_PARAM_RATE      (MMA8X5X_RATE_200HZ)
 #endif
@@ -53,13 +50,12 @@ extern "C" {
 #ifndef MMA8X5X_PARAMS
 #define MMA8X5X_PARAMS          { .i2c    = MMA8X5X_PARAM_I2C,   \
                                   .addr   = MMA8X5X_PARAM_ADDR,  \
-                                  .type   = MMA8X5X_PARAM_TYPE,  \
                                   .rate   = MMA8X5X_PARAM_RATE,  \
                                   .range  = MMA8X5X_PARAM_RANGE, \
                                   .offset = MMA8X5X_PARAM_OFFSET }
 #endif
 #ifndef MMA8X5X_SAUL_INFO
-#define MMA8X5X_SAUL_INFO       { .name = "mma8652" }
+#define MMA8X5X_SAUL_INFO       { .name = "mma8x5x" }
 #endif
 /**@}*/
 

--- a/drivers/mma8x5x/mma8x5x.c
+++ b/drivers/mma8x5x/mma8x5x.c
@@ -51,11 +51,18 @@ int mma8x5x_init(mma8x5x_t *dev, const mma8x5x_params_t *params)
 
     /* test if the target device responds */
     i2c_read_reg(BUS, ADDR, MMA8X5X_WHO_AM_I, &reg, 0);
-    if (reg != dev->params.type) {
-        i2c_release(BUS);
-        DEBUG("[mma8x5x] init - error: invalid WHO_AM_I value [0x%02x]\n",
-               (int)reg);
-        return MMA8X5X_NODEV;
+    switch (reg) {
+        case MMA8X5X_TYPE_MMA8451:
+        case MMA8X5X_TYPE_MMA8452:
+        case MMA8X5X_TYPE_MMA8453:
+        case MMA8X5X_TYPE_MMA8652:
+        case MMA8X5X_TYPE_MMA8653:
+            break;
+        default: /* invalid device type */
+            i2c_release(BUS);
+            DEBUG("[mma8x5x] init - error: invalid WHO_AM_I value [0x%02x]\n",
+                  (int)reg);
+            return MMA8X5X_NODEV;
     }
 
     /* reset the device */

--- a/tests/driver_mma8x5x/Makefile
+++ b/tests/driver_mma8x5x/Makefile
@@ -1,6 +1,6 @@
 include ../Makefile.tests_common
 
-USEMODULE += mma8x5x
+USEMODULE += mma8x5x  # will work with all variants
 USEMODULE += xtimer
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/driver_mma8x5x/README.md
+++ b/tests/driver_mma8x5x/README.md
@@ -3,14 +3,13 @@ This is a manual test application for the MMA8x5x accelerometer driver.
 
 # Usage
 This test application will initialize the MMA8x5x sensor with the following parameters:
- - default device type: MMA8652
  - full scale parameter set to +/-2 g
  - 200 Hz output data-rate
 
 To change these parameters, you can override them by setting their corresponding
 defines in your build environment, e.g.
 ```bash
-CFLAGS=-DMMA8X5X_PARAM_TYPE=MMA8X5X_TYPE_MMA8451 make ...
+CFLAGS=-DMMA8X5X_PARAM_ADDR=0x1d make ...
 ```
 See RIOT/drivers/mma8x5x_params.h for the default configuration.
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR slightly rework the way variants of the mma8x5x (mma8451/2/3 and mma8652/3) can be used in RIOT: they are explicitly passed via USEMODULE as pseudomodules and preprocessor macros are used to determine the right device ID.

In the meantime, the microbit is activating its mma8653 when saul is loaded.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Try the test driver on a board that provides it (microbit provides mma8653 variant):
```
make BOARD=microbit DRIVER=mma8653 -C tests/driver_mma8x5x
```
- Try default with the microbit
```
make BOARD=microbit -C examples/default
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
