### PR TITLE
frdm-kw41z: Use 1280 multiplier for FEI

### DIFF
--- a/boards/frdm-kw41z/include/periph_conf.h
+++ b/boards/frdm-kw41z/include/periph_conf.h
@@ -34,9 +34,9 @@ static const clock_config_t clock_config = {
     /*
      * This configuration results in the system running with the internal clock
      * with the following clock frequencies:
-     * Core:  48 MHz
-     * Bus:   24 MHz
-     * Flash: 24 MHz
+     * Core:  41.94 MHz
+     * Bus:   20.97 MHz
+     * Flash: 20.97 MHz
      */
     .clkdiv1            = SIM_CLKDIV1_OUTDIV1(0) | SIM_CLKDIV1_OUTDIV4(1),
     /* unsure if this RTC load cap configuration is correct, but it matches the
@@ -61,13 +61,13 @@ static const clock_config_t clock_config = {
     .oscsel             = MCG_C7_OSCSEL(0), /* Use RSIM for external clock */
     .fcrdiv             = MCG_SC_FCRDIV(0), /* Fast IRC divide by 1 => 4 MHz */
     .fll_frdiv          = MCG_C1_FRDIV(0b101), /* Divide by 1024 */
-    .fll_factor_fei     = KINETIS_MCG_FLL_FACTOR_1464, /* FEI FLL freq = 48 MHz */
+    .fll_factor_fei     = KINETIS_MCG_FLL_FACTOR_1280, /* FEI FLL freq = 41.94 MHz */
     .fll_factor_fee     = KINETIS_MCG_FLL_FACTOR_1280, /* FEE FLL freq = 40 MHz */
 };
 /* Radio xtal frequency, either 32 MHz or 26 MHz */
 #define CLOCK_RADIOXTAL              (32000000ul)
 /* CPU core clock, the MCG clock output frequency */
-#define CLOCK_CORECLOCK              (48000000ul)
+#define CLOCK_CORECLOCK              (32768 * 1280)
 #define CLOCK_BUSCLOCK               (CLOCK_CORECLOCK / 2)
 #define CLOCK_MCGIRCLK               (4000000ul)
 /** @} */


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

The reference manual recommends not using the DMX32 setting (1464
multiplier) when using the internal reference clock as the FLL clock
source (FEI, FBI modes).

> **25.5.2 Using a 32.768 kHz reference**
> ... snip ...
>In FBI and FEI modes, setting C4[DMX32] bit is not recommended. If the internal
reference is trimmed to a frequency above 32.768 kHz, the greater FLL multiplication
factor could potentially push the microcontroller system clock out of specification,
potentially resulting in unpredictable behavior.

This risk is likely very small because the slow IRC should be factory trimmed to 32768 Hz @ 25 C, but it may be up to +/- 3 % wrong in certain environmental conditions, according to the CPU data sheet.

### Testing procedure

Build and run some of the test applications, see that it runs and that the UART shell output works correctly.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
