### PR TITLE
sys/stdio_uart: do not cast function pointer.

### DIFF
--- a/drivers/at/at.c
+++ b/drivers/at/at.c
@@ -22,17 +22,12 @@
 #define AT_PRINT_INCOMING (0)
 #endif
 
-static void _isrpipe_write_one_wrapper(void *_isrpipe, uint8_t data)
-{
-    isrpipe_write_one(_isrpipe, (char)data);
-}
-
 int at_dev_init(at_dev_t *dev, uart_t uart, uint32_t baudrate, char *buf, size_t bufsize)
 {
     dev->uart = uart;
     isrpipe_init(&dev->isrpipe, buf, bufsize);
 
-    return uart_init(uart, baudrate, _isrpipe_write_one_wrapper,
+    return uart_init(uart, baudrate, isrpipe_write_uartcb,
                      &dev->isrpipe);
 }
 

--- a/sys/include/isrpipe.h
+++ b/sys/include/isrpipe.h
@@ -65,6 +65,13 @@ void isrpipe_init(isrpipe_t *isrpipe, char *buf, size_t bufsize);
 int isrpipe_write_one(isrpipe_t *isrpipe, char c);
 
 /**
+ * @brief   Wrapper around isrpipe_write_one() to make it compatible with uart_rx_cb_t.
+ *
+ * The parameters are the same as isrpipe_write_one().
+ */
+void isrpipe_write_uartcb(void *_isrpipe, uint8_t data);
+
+/**
  * @brief   Read data from isrpipe (blocking)
  *
  * @param[in]   isrpipe    isrpipe object to operate on

--- a/sys/isrpipe/isrpipe.c
+++ b/sys/isrpipe/isrpipe.c
@@ -17,6 +17,7 @@
  * @}
  */
 
+#include <stdint.h>
 #include "isrpipe.h"
 
 void isrpipe_init(isrpipe_t *isrpipe, char *buf, size_t bufsize)
@@ -35,6 +36,11 @@ int isrpipe_write_one(isrpipe_t *isrpipe, char c)
     mutex_unlock(&isrpipe->mutex);
 
     return res;
+}
+
+void isrpipe_write_uartcb(void *_isrpipe, uint8_t data)
+{
+    isrpipe_write_one(_isrpipe, (char)data);
 }
 
 int isrpipe_read(isrpipe_t *isrpipe, char *buffer, size_t count)

--- a/sys/stdio_uart/Makefile
+++ b/sys/stdio_uart/Makefile
@@ -1,4 +1,1 @@
-ifeq (gnu, $(TOOLCHAIN))
-  CFLAGS += -Wno-cast-function-type
-endif
 include $(RIOTBASE)/Makefile.base

--- a/sys/stdio_uart/stdio_uart.c
+++ b/sys/stdio_uart/stdio_uart.c
@@ -58,7 +58,7 @@ void stdio_init(void)
     void *arg;
 
 #ifdef MODULE_STDIO_UART_RX
-    cb = (uart_rx_cb_t) isrpipe_write_one;
+    cb = isrpipe_write_uartcb;
     arg = &stdio_uart_isrpipe;
 #else
 #ifdef USE_ETHOS_FOR_STDIO


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

There was a function pointer cast in stdio_uart. The warning was being explicitly supressed in the module's makefile (see #9121).

This commit removes the suppression and fixes the warning by providing a wrapper function.

The wrapper was already defined in the AT driver (see #9740), as part of a fix for a similar bug there, so the definition was moved to the isrpipe module, the logic being that using isrpipe in conjunction with a periph_uart is a common enough use-case.


### Testing procedure

`tests/driver_at` should still compile, same as `examples/hello_world`.

### Issues/PRs references

Undoes #9121.