### PR TITLE
Makefile.include: Fix BUILDRELPATH when RIOTPROJECT is CURDIR [backport 2018.10]

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -66,7 +66,8 @@ endif
 MAKEOVERRIDES += $(foreach v,$(__DIRECTORY_VARIABLES),$(v)=$($(v)))
 
 # Path to the current directory relative to RIOTPROJECT
-BUILDRELPATH ?= $(CURDIR:$(RIOTPROJECT)/%=%)/
+# trailing '/' is important when RIOTPROJECT == CURDIR
+BUILDRELPATH ?= $(patsubst $(RIOTPROJECT)/%,%,$(CURDIR)/)
 
 # get host operating system
 OS := $(shell uname)


### PR DESCRIPTION
# Backport of #10302 
### Contribution description

This fixes building an example that is outside of RIOT with docker and
also fixes building from a release archive.


This currently prevents building from the release archive with our docker image.

It is the first commit split from https://github.com/RIOT-OS/RIOT/pull/9646 so that it could go in the release.

### Testing procedure

It does not compile in `master` as the build path is wrongly set:

`-w '/data/riotbuild/riotproject//home/harter/work/git/riot_master_test/examples/hello-world/' \`


```
# Simulate a release archive
git archive --format=tar --prefix=riot_master_test/ riot/master  | tar -C .. -x

# compiling fails with docker
DOCKER="sudo docker" BUILD_IN_DOCKER=1 make -C ../riot_master_test/examples/hello-world/
make: Entering directory '/home/harter/work/git/riot_master_test/examples/hello-world'
Launching build container using image "riot/riotbuild:latest".
sudo docker run --rm -t -u "$(id -u)" \
    -v '/home/harter/work/git/riot_master_test:/data/riotbuild/riotbase' \
    -v '/home/harter/work/git/riot_master_test/cpu:/data/riotbuild/riotcpu' \
    -v '/home/harter/work/git/riot_master_test/boards:/data/riotbuild/riotboard' \
    -v '/home/harter/work/git/riot_master_test/makefiles:/data/riotbuild/riotmake' \
    -v '/home/harter/work/git/riot_master_test/examples/hello-world:/data/riotbuild/riotproject' \
    -v /etc/localtime:/etc/localtime:ro \
    -e 'RIOTBASE=/data/riotbuild/riotbase' \
    -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' \
    -e 'RIOTCPU=/data/riotbuild/riotcpu' \
    -e 'RIOTBOARD=/data/riotbuild/riotboard' \
    -e 'RIOTMAKE=/data/riotbuild/riotmake' \
    -e 'RIOTPROJECT=/data/riotbuild/riotproject' \
    -v /home/harter/.gitcache:/data/riotbuild/gitcache -e GIT_CACHE_DIR=/data/riotbuild/gitcache \
     \
    -w '/data/riotbuild/riotproject//home/harter/work/git/riot_master_test/examples/hello-world/' \
    'riot/riotbuild:latest' make
make: *** No targets specified and no makefile found.  Stop.
/home/harter/work/git/riot_master_test/makefiles/docker.inc.mk:100: recipe for target '..in-docker-container' failed
make: *** [..in-docker-container] Error 2
make: Leaving directory '/home/harter/work/git/riot_master_test/examples/hello-world'
```

With this PR it is set correctly `-w '/data/riotbuild/riotproject/' \` and it compiles:


```
git archive --format=tar --prefix=riot_buildrelpath_fix/ HEAD  | tar -C .. -x

DOCKER="sudo docker" BUILD_IN_DOCKER=1 make -C ../riot_buildrelpath_fix/examples/hello-world/
make: Entering directory '/home/harter/work/git/riot_buildrelpath_fix/examples/hello-world'
Launching build container using image "riot/riotbuild:latest".
sudo docker run --rm -t -u "$(id -u)" \
    -v '/home/harter/work/git/riot_buildrelpath_fix:/data/riotbuild/riotbase' \
    -v '/home/harter/work/git/riot_buildrelpath_fix/cpu:/data/riotbuild/riotcpu' \
    -v '/home/harter/work/git/riot_buildrelpath_fix/boards:/data/riotbuild/riotboard' \
    -v '/home/harter/work/git/riot_buildrelpath_fix/makefiles:/data/riotbuild/riotmake' \
    -v '/home/harter/work/git/riot_buildrelpath_fix/examples/hello-world:/data/riotbuild/riotproject' \
    -v /etc/localtime:/etc/localtime:ro \
    -e 'RIOTBASE=/data/riotbuild/riotbase' \
    -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' \
    -e 'RIOTCPU=/data/riotbuild/riotcpu' \
    -e 'RIOTBOARD=/data/riotbuild/riotboard' \
    -e 'RIOTMAKE=/data/riotbuild/riotmake' \
    -e 'RIOTPROJECT=/data/riotbuild/riotproject' \
    -v /home/harter/.gitcache:/data/riotbuild/gitcache -e GIT_CACHE_DIR=/data/riotbuild/gitcache \
     \
    -w '/data/riotbuild/riotproject/' \
    'riot/riotbuild:latest' make
Building application "hello-world" for "native" with MCU "native".

"make" -C /data/riotbuild/riotbase/core
"make" -C /data/riotbuild/riotbase/drivers
"make" -C /data/riotbuild/riotbase/drivers/periph_common
"make" -C /data/riotbuild/riotbase/sys
"make" -C /data/riotbuild/riotbase/sys/auto_init
"make" -C /data/riotbuild/riotboard/native
"make" -C /data/riotbuild/riotboard/native/drivers
"make" -C /data/riotbuild/riotcpu/native
"make" -C /data/riotbuild/riotcpu/native/periph
"make" -C /data/riotbuild/riotcpu/native/vfs
   text    data     bss     dec     hex filename
  20641     372   47684   68697   10c59 /data/riotbuild/riotproject/bin/native/hello-world.elf
make: Leaving directory '/home/harter/work/git/riot_buildrelpath_fix/examples/hello-world'
```

Another testing procedure is to copy an application outside of a git repository.
The behavior is the same as with the archive.

```
cp -r examples/hello-world/ ..
RIOTBASE=${PWD}  DOCKER="sudo docker" BUILD_IN_DOCKER=1 make -C ../hello-world/ clean all
```

### Issues/PRs references

The "external application" case was found in https://github.com/RIOT-OS/RIOT/pull/9646 and the from an archive case was found during release tests https://github.com/RIOT-OS/Release-Specs/issues/76