### PR TITLE
boards/saml21-xpro: add Arduino API support for saml21-xpro board

### DIFF
--- a/boards/saml21-xpro/include/arduino_board.h
+++ b/boards/saml21-xpro/include/arduino_board.h
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C)  2018 Federico Pellegrin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_saml21-xpro
+ * @brief       Board configuration for the Arduino API
+ * @file
+ * @author      Federico Pellegrin <fede@evolware.org>
+ * @{
+ */
+
+#ifndef ARDUINO_BOARD_H
+#define ARDUINO_BOARD_H
+
+#include "arduino_pinmap.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Arduino's digital pins mappings
+ */
+static const gpio_t arduino_pinmap[] = {
+    ARDUINO_PIN_0,
+    ARDUINO_PIN_1
+};
+
+/**
+ * @brief   Arduino's analog pins mappings
+ */
+static const adc_t arduino_analog_map[] = {
+    ARDUINO_A0,
+    ARDUINO_A1,
+    ARDUINO_A2
+};
+
+/**
+ * @brief   On-board LED mapping
+ */
+#define ARDUINO_LED         (0)
+
+/**
+ * @brief   On-board serial port mapping
+ */
+#define ARDUINO_UART_DEV         UART_DEV(0)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ARDUINO_BOARD_H */
+/** @} */

--- a/boards/saml21-xpro/include/arduino_pinmap.h
+++ b/boards/saml21-xpro/include/arduino_pinmap.h
@@ -1,0 +1,46 @@
+/*
+ * Copyright (C)  2018 Federico Pellegrin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_saml21-xpro
+ * @brief       Mapping from board pins to Arduino pins
+ * @file
+ * @author      Federico Pellegrin <fede@evolware.org>
+ * @{
+ */
+
+#ifndef ARDUINO_PINMAP_H
+#define ARDUINO_PINMAP_H
+
+#include "board.h"
+#include "periph_cpu.h"
+#include "periph/adc.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Arduino's digital pins mappings
+ */
+#define ARDUINO_PIN_0   LED0_PIN
+#define ARDUINO_PIN_1   BTN0_PIN
+
+/**
+ * @brief   Arduino's analog pins mappings
+ */
+#define ARDUINO_A0      ADC_LINE(0)
+#define ARDUINO_A1      ADC_LINE(1)
+#define ARDUINO_A2      ADC_LINE(2)
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ARDUINO_PINMAP_H */
+/** @} */


### PR DESCRIPTION
### Contribution description
Adds the Arduino API support for the Atmel SAML21-XPRO board.
This enables Arduino-like programming supported by RIOT also on this board.

### Testing procedure
Arduino automatic test sys_arduino can be used for basic functionalities tests:

```
cd tests/sys_arduino/
BOARD=saml21-xpro make all flash test
```

Additionally one can manually use and play with the examples/arduino_hello-world/ for other tests (ie. playing with I/O and leds)