### PR TITLE
suit: Initial minimal CBOR-based SUIT manifest parser

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -813,6 +813,10 @@ ifneq (,$(filter riotboot_hdr, $(USEMODULE)))
   USEMODULE += riotboot
 endif
 
+ifneq (,$(filter suit_cbor,$(USEMODULE)))
+  USEPKG += tinycbor
+endif
+
 # Enable periph_gpio when periph_gpio_irq is enabled
 ifneq (,$(filter periph_gpio_irq,$(USEMODULE)))
   FEATURES_REQUIRED += periph_gpio

--- a/sys/include/suit/cbor.h
+++ b/sys/include/suit/cbor.h
@@ -1,0 +1,274 @@
+/*
+ * Copyright (C) 2018 Freie Universität Berlin
+ * Copyright (C) 2018 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    sys_suit SUIT manifest parsers
+ * @ingroup     sys
+ * @brief       SUIT manifest parser for CBOR based manifests
+ *
+ * This is a simple suit manifest parser for RIOT. The high level assumption is
+ * that the raw manifest data is stored in a buffered location where raw values
+ * or strings can be left during the lifetime of the suit_manifest_t struct.
+ * This assumption is valid in the case where a (network based) transfer
+ * mechanism is used to transfer the manifest to the node and an intermediate
+ * buffer is necessary to validate the manifest.
+ *
+ * The parser is based on draft version 1 of the specification, restricted to
+ * handling CBOR based manifests.
+ *
+ * @see https://tools.ietf.org/html/draft-moran-suit-manifest-01
+ * @experimental
+ *
+ * @{
+ *
+ * @brief       Decoding functions for a CBOR encoded SUIT manifest
+ * @author      Koen Zandberg <koen@bergzand.net>
+ */
+
+#ifndef SUIT_CBOR_H
+#define SUIT_CBOR_H
+
+#include <stddef.h>
+#include <stdint.h>
+#include <stdlib.h>
+#include <unistd.h>
+
+#include "cbor.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define SUIT_CBOR_MANIFEST_MIN_LENGTH            9  /**< Minimum length of a
+                                                         manifest array */
+#define SUIT_CBOR_MANIFEST_PAYLOADINFO_LENGTH    7  /**< Length of the payload
+                                                         info array   */
+
+/**
+ * @name Manifest array member indices
+ * @{
+ */
+#define SUIT_CBOR_MANIFEST_IDX_MANIFESTVERSION   0  /**< Manifest version     */
+#define SUIT_CBOR_MANIFEST_IDX_TEXT              1  /**< Text section         */
+#define SUIT_CBOR_MANIFEST_IDX_NONCE             2  /**< Nonce                */
+#define SUIT_CBOR_MANIFEST_IDX_SEQ_NO            3  /**< Sequence number      */
+#define SUIT_CBOR_MANIFEST_IDX_CONDITIONS        4  /**< Conditionals         */
+#define SUIT_CBOR_MANIFEST_IDX_DIRECTIVES        5  /**< Directives           */
+#define SUIT_CBOR_MANIFEST_IDX_ALIASES           6  /**< Aliases              */
+#define SUIT_CBOR_MANIFEST_IDX_DEPENDENCIES      7  /**< Dependencies         */
+#define SUIT_CBOR_MANIFEST_IDX_EXTENSIONS        8  /**< Extensions           */
+#define SUIT_CBOR_MANIFEST_IDX_PAYLOADINFO       9  /**< Optional PayloadInfo */
+/** @} */
+
+/**
+ * @name Manifest PayloadInfo member indices
+ * @{
+ */
+#define SUIT_CBOR_PAYLOADINFO_IDX_FORMAT         0  /**< Payload format       */
+#define SUIT_CBOR_PAYLOADINFO_IDX_SIZE           1  /**< Firmware size        */
+#define SUIT_CBOR_PAYLOADINFO_IDX_STORID         2  /**< Storage ID           */
+#define SUIT_CBOR_PAYLOADINFO_IDX_URIS           3  /**< URI list             */
+#define SUIT_CBOR_PAYLOADINFO_IDX_DIGESTALGO     4  /**< Digest algorithm     */
+#define SUIT_CBOR_PAYLOADINFO_IDX_DIGESTS        5  /**< Digests              */
+#define SUIT_CBOR_PAYLOADINFO_IDX_PAYLOAD        6  /**< Optional payload     */
+/** @} */
+
+/**
+ * @brief TinyCBOR validation mode to use
+ */
+#define SUIT_TINYCBOR_VALIDATION_MODE       CborValidateStrictMode
+
+/**
+ * @brief suit parser error codes
+ */
+typedef enum {
+    SUIT_OK                     = 0,    /**< Manifest parsed and validated */
+    SUIT_ERR_INVALID_MANIFEST   = -1,   /**< Unexpected CBOR structure detected */
+    SUIT_ERR_NOT_SUPPORTED      = -2,   /**< Unsupported manifest features detected */
+    SUIT_ERR_COND               = -3,   /**< Conditionals evaluate to false */
+} suit_error_t;
+
+/**
+ * @brief SUIT conditionals
+ */
+enum {
+    SUIT_COND_VENDOR_ID     = 1,    /**< Vendor ID match conditional */
+    SUIT_COND_CLASS_ID      = 2,    /**< Class ID match conditional */
+    SUIT_COND_DEV_ID        = 3,    /**< Device ID match conditional */
+    SUIT_COND_BEST_BEFORE   = 4,    /**< Best before conditional */
+};
+
+/**
+ * @brief SUIT payload digest algorithms
+ *
+ * Unofficial list from
+ * [suit-manifest-generator](https://github.com/ARMmbed/suit-manifest-generator)
+ */
+typedef enum {
+    SUIT_DIGEST_NONE    = 0,    /**< No digest algo supplied */
+    SUIT_DIGEST_SHA256  = 1,    /**< SHA256 */
+    SUIT_DIGEST_SHA384  = 2,    /**< SHA384 */
+    SUIT_DIGEST_SHA512  = 3,    /**< SHA512 */
+} suit_cbor_digest_t;
+
+/**
+ * @brief SUIT payload digest types
+ *
+ * Unofficial list from
+ * [suit-manifest-generator](https://github.com/ARMmbed/suit-manifest-generator)
+ */
+typedef enum {
+    SUIT_DIGEST_TYPE_RAW        = 1,    /**< Raw payload digest */
+    SUIT_DIGEST_TYPE_INSTALLED  = 2,    /**< Installed firmware digest */
+    SUIT_DIGEST_TYPE_CIPHERTEXT = 3,    /**< Ciphertext digest */
+    SUIT_DIGEST_TYPE_PREIMAGE   = 4     /**< Pre-image digest */
+} suit_cbor_digest_type_t;
+
+/**
+ * @brief SUIT manifest struct
+ */
+typedef struct {
+    const uint8_t *buf; /**< ptr to the buffer of the manifest */
+    size_t len;         /**< length of the manifest */
+} suit_cbor_manifest_t;
+
+/**
+ * @brief Parse a buffer containing a cbor encoded manifest into a
+ * suit_cbor_manifest_t struct
+ *
+ * @param   manifest    manifest to fill
+ * @param   buf         Buffer to read from
+ * @param   len         Size of the buffer
+ *
+ * return               @ref SUIT_OK on success
+ * return               negative on parsing error
+ */
+int suit_cbor_parse(suit_cbor_manifest_t *manifest, const uint8_t *buf,
+                    size_t len);
+
+/**
+ * @brief Copy the url from the manifest into the supplied buffer
+ *
+ * @param       manifest    manifest to retrieve the url from
+ * @param[out]  buf         buffer to write into
+ * @param       len         size of the buffer
+ *
+ * @return                  Length of the url
+ * @return                  negative on error
+ */
+ssize_t suit_cbor_get_url(const suit_cbor_manifest_t *manifest, char *buf, size_t len);
+
+/**
+ * @brief Copy the version from the manifest into the supplied uint32_t
+ *
+ * @param       manifest    manifest to retrieve the version from
+ * @param[out]  version     version number to set
+ *
+ * @return                  @ref SUIT_OK on success
+ * @return                  negative on error
+ */
+int suit_cbor_get_version(const suit_cbor_manifest_t *manifest, uint32_t *version);
+
+/**
+ * @brief Retrieve the sequence number of the manifest
+ *
+ * @note The sequence number is called timestamp in the first version of the
+ *       spec, but called sequence number in later versions.
+ *
+ * @param       manifest    manifest to retrieve the sequence number from
+ * @param[out]  seq_no      sequence number
+ *
+ * @return                  @ref SUIT_OK on success
+ * @return                  negative on error
+ */
+int suit_cbor_get_seq_no(const suit_cbor_manifest_t *manifest, uint32_t *seq_no);
+
+/**
+ * @brief Retrieve the condition type at position \p idx from the manifest
+ *
+ * @param[in]       manifest    manifest to retrieve the condition from
+ * @param[in]       idx         index of the condition in the array
+ * @param[out]      condition   condition type value
+ *
+ * @return                      Length of the parameter
+ * @return                      Negative on error
+ */
+ssize_t suit_cbor_get_condition_type(const suit_cbor_manifest_t *manifest,
+                                     unsigned idx, signed *condition);
+
+/**
+ * @brief Retrieve the condition parameter at position \p idx from the manifest
+ *
+ * @param[in]       manifest    manifest to retrieve the condition from
+ * @param[in]       idx         index of the condition in the array
+ * @param[out]      buf         buffer to store the parameter in
+ * @param[inout]    len         length of the buffer and length of the returned
+ *                              parameter
+ *
+ * @return                      Length of the parameter
+ * @return                      Negative on error
+ */
+int suit_cbor_get_condition_parameter(const suit_cbor_manifest_t *manifest,
+                                      unsigned idx, uint8_t *buf, size_t *len);
+
+/**
+ * @brief Retrieve the size from the payloadinfo in the manifest
+ *
+ * @param       manifest    manifest to retrieve the size from
+ * @param[out]  size        Size of the firmware
+ *
+ * @return                  @ref SUIT_OK on success
+ * @return                  negative on error
+ */
+int suit_cbor_payload_get_size(const suit_cbor_manifest_t *manifest, uint32_t *size);
+
+/**
+ * @brief Retrieve the digest algorithm from the payloadinfo in the manifest
+ *
+ * @param       manifest    manifest to retrieve the algo from
+ * @param[out]  algo        algorithm used
+ *
+ * @return                  @ref SUIT_OK on success
+ * @return                  negative on error
+ */
+int suit_cbor_payload_get_digestalgo(const suit_cbor_manifest_t *manifest,
+                                     suit_cbor_digest_t *algo);
+
+/**
+ * @brief Retrieve the storage id from the payloadinfo in the manifest
+ *
+ * @param           manifest    manifest to retrieve the storage id from
+ * @param[inout]    buf         buffer to write the storage id in
+ * @param[inout]    len         size of the buffer and length of the storage id
+ *
+ * @return                      @ref SUIT_OK on success
+ * @return                      negative on error
+ */
+int suit_cbor_payload_get_storid(const suit_cbor_manifest_t *manifest, uint8_t *buf, size_t *len);
+
+/**
+ * @brief Retrieve the digest from the payloadinfo in the manifest
+ *
+ * @param           manifest    manifest to retrieve the digest from
+ * @param           digest      type of digest to retrieve
+ * @param[inout]    buf         buffer to write the digest in
+ * @param[inout]    len         size of the buffer and length of the digest
+ *
+ * @return                      @ref SUIT_OK on success
+ * @return                      negative on error
+ */
+int suit_cbor_payload_get_digest(const suit_cbor_manifest_t *manifest,
+                                 suit_cbor_digest_type_t digest, uint8_t *buf, size_t *len);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* SUIT_CBOR_H */
+/** @} */

--- a/sys/suit_cbor/Makefile
+++ b/sys/suit_cbor/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/sys/suit_cbor/suit_cbor.c
+++ b/sys/suit_cbor/suit_cbor.c
@@ -1,0 +1,446 @@
+/*
+ * Copyright (C) 2018 Freie Universität Berlin
+ * Copyright (C) 2018 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     sys_suit
+ * @{
+ *
+ * @file
+ * @brief       SUIT manifest parser library for CBOR based manifests
+ *
+ * @author      Koen Zandberg <koen@bergzand.net>
+ *
+ * @}
+ */
+#include <string.h>
+#include <stdint.h>
+#include <stdbool.h>
+
+#include "suit/cbor.h"
+#include "cbor.h"
+
+#define ENABLE_DEBUG (0)
+#include "debug.h"
+
+static int _advance_x(CborValue *it, unsigned x)
+{
+    for (unsigned i = 0; i < x; i++) {
+        cbor_value_advance(it);
+        if (cbor_value_at_end(it)) {
+            return -1;
+        }
+    }
+    return 0;
+}
+
+static int _parse_manifest_version(CborValue *it,
+                                   uint32_t *version)
+{
+    uint64_t value;
+
+    if (!cbor_value_is_unsigned_integer(it)) {
+        return SUIT_ERR_INVALID_MANIFEST;
+    }
+    cbor_value_get_uint64(it, &value);
+    *version = (uint32_t)value;
+    return SUIT_OK;
+}
+
+static int _parse_manifest_seq_no(CborValue *it, uint32_t *seq_no)
+{
+    uint64_t value;
+
+    if (!cbor_value_is_unsigned_integer(it)) {
+        return SUIT_ERR_INVALID_MANIFEST;
+    }
+    cbor_value_get_uint64(it, &value);
+    *seq_no = (uint32_t)value;
+    return SUIT_OK;
+}
+
+static ssize_t _parse_manifest_condition(CborValue *it, CborValue *cond,
+                                         CborValue *props, size_t idx)
+{
+    size_t condlen = 0;
+
+    if (!cbor_value_is_array(it)) {
+        return SUIT_ERR_INVALID_MANIFEST;
+    }
+    cbor_value_enter_container(it, cond);
+
+    /* Conditions array is nonzero in length */
+    if (cbor_value_at_end(cond)) {
+        return SUIT_ERR_COND;
+    }
+
+    /* Iterate to idx and check if it is within the array bounds */
+    if (_advance_x(cond, idx) < 0) {
+        return SUIT_ERR_COND;
+    }
+
+    /* Condition must be a valid array of length 2 */
+    if (!cbor_value_is_array(cond) ||
+        (cbor_value_get_array_length(cond, &condlen) < 0) ||
+        condlen != 2) {
+        return SUIT_ERR_INVALID_MANIFEST;
+    }
+
+    cbor_value_enter_container(cond, props);
+
+    /* First element must be an integer */
+    if (!cbor_value_is_integer(props)) {
+        return SUIT_ERR_INVALID_MANIFEST;
+    }
+    return SUIT_OK;
+}
+
+static ssize_t _parse_manifest_condition_param(CborValue *it, size_t idx,
+                                               uint8_t *buf, size_t *len)
+{
+    CborValue cond, props;
+
+    int res = _parse_manifest_condition(it, &cond, &props, idx);
+    if (res < 0) {
+        return res;
+    }
+    /* At this point props points to the condition type of the condition at
+     * position idx */
+
+    /* Advance to the argument */
+    cbor_value_advance(&props);
+    if (!cbor_value_is_byte_string(&props)) {
+        return SUIT_ERR_INVALID_MANIFEST;
+    }
+    if (cbor_value_copy_byte_string(&props, buf, len, NULL) < 0) {
+        return SUIT_ERR_COND;
+    }
+    return *len;
+}
+
+static ssize_t _parse_manifest_condition_type(CborValue *it, size_t idx,
+                                              int *type)
+{
+    CborValue cond, props;
+
+    int res = _parse_manifest_condition(it, &cond, &props, idx);
+    if (res < 0) {
+        return res;
+    }
+    /* At this point props points to the condition type of the condition at
+     * position idx */
+
+    cbor_value_get_int(&props, type);
+    cbor_value_advance(&props);
+    if (!cbor_value_is_byte_string(&props)) {
+        return SUIT_ERR_INVALID_MANIFEST;
+    }
+    size_t arglen = 0;
+    cbor_value_get_string_length(&props, &arglen);
+    return arglen;
+}
+
+static int _parse_payload_size(CborValue *it, uint32_t *size)
+{
+    uint64_t value;
+
+    if (!cbor_value_is_unsigned_integer(it)) {
+        return SUIT_ERR_INVALID_MANIFEST;
+    }
+    cbor_value_get_uint64(it, &value);
+    *size = (uint32_t)value;
+    return SUIT_OK;
+}
+
+static int _parse_payload_storage_id(CborValue *it, uint8_t *buf, size_t *len)
+{
+    if (!cbor_value_is_byte_string(it)) {
+        return SUIT_ERR_INVALID_MANIFEST;
+    }
+    cbor_value_copy_byte_string(it, buf, len, NULL);
+    return SUIT_OK;
+}
+
+static int _parse_manifest_digestalgo(CborValue *it,
+                                      suit_cbor_digest_t *algo)
+{
+    CborValue arr;
+    uint64_t value;
+
+    if (cbor_value_is_null(it)) {
+        *algo = SUIT_DIGEST_NONE;
+        return SUIT_OK;
+    }
+    if (!cbor_value_is_array(it)) {
+        return SUIT_ERR_INVALID_MANIFEST;
+    }
+    size_t len = 0;
+    if (cbor_value_get_array_length(it, &len) || len > 2) {
+        return SUIT_ERR_INVALID_MANIFEST;
+    }
+    if (cbor_value_enter_container(it, &arr)) {
+        return SUIT_ERR_INVALID_MANIFEST;
+    }
+    cbor_value_get_uint64(&arr, &value);
+    *algo = (suit_cbor_digest_t)value;
+    return SUIT_OK;
+}
+
+int _validate_manifest(CborValue *it)
+{
+    if (!cbor_value_is_array(it)) {
+        return SUIT_ERR_INVALID_MANIFEST;
+    }
+    size_t len;
+    CborError err = cbor_value_get_array_length(it, &len);
+    if (err != 0 || len < SUIT_CBOR_MANIFEST_MIN_LENGTH) {
+        return SUIT_ERR_INVALID_MANIFEST;
+    }
+    return SUIT_OK;
+}
+
+int _validate_payloadinfo(CborValue *it)
+{
+    if (!cbor_value_is_array(it)) {
+        return SUIT_ERR_INVALID_MANIFEST;
+    }
+    size_t len;
+    CborError err = cbor_value_get_array_length(it, &len);
+    if (err != 0 || len != SUIT_CBOR_MANIFEST_PAYLOADINFO_LENGTH) {
+        return SUIT_ERR_INVALID_MANIFEST;
+    }
+    return SUIT_OK;
+}
+
+int suit_cbor_parse(suit_cbor_manifest_t *manifest, const uint8_t *buf, size_t len)
+{
+    CborParser parser;
+    CborValue it, arr;
+    CborError err = cbor_parser_init(buf, len, SUIT_TINYCBOR_VALIDATION_MODE,
+                                     &parser, &it);
+
+    if (err != 0) {
+        return SUIT_ERR_INVALID_MANIFEST;
+    }
+    /* Validate manifest size */
+    if (_validate_manifest(&it)) {
+        return SUIT_ERR_INVALID_MANIFEST;
+    }
+
+    /* At this point the manifest should be valid enough */
+    manifest->buf = buf;
+    manifest->len = len;
+
+    err = cbor_value_enter_container(&it, &arr);
+    if (err != 0) {
+        return SUIT_ERR_INVALID_MANIFEST;
+    }
+
+    if (_advance_x(&arr, SUIT_CBOR_MANIFEST_IDX_PAYLOADINFO) < 0) {
+        /* If it is impossible to advance to the payloadinfo we assume that
+         * there is no payloadinfo. Length validation is already done by
+         * _validate_manifest, an invalid array length should not be possible
+         * at this point.
+         */
+        return SUIT_OK;
+    }
+
+    if (_validate_payloadinfo(&arr)) {
+        return SUIT_ERR_INVALID_MANIFEST;
+    }
+    return SUIT_OK;
+}
+
+static int _init_and_advance(const suit_cbor_manifest_t *manifest,
+                             CborParser *parser, CborValue *it,
+                             CborValue *arr, size_t offset)
+{
+    cbor_parser_init(manifest->buf, manifest->len,
+                     SUIT_TINYCBOR_VALIDATION_MODE, parser, it);
+    cbor_value_enter_container(it, arr);
+    if (_advance_x(arr, offset) < 0) {
+        return SUIT_ERR_INVALID_MANIFEST;
+    }
+    return SUIT_OK;
+}
+
+static int _init_and_advance_info(const suit_cbor_manifest_t *manifest,
+                                  CborParser *parser, CborValue *it,
+                                  CborValue *arr, CborValue *payloadinfo,
+                                  size_t offset)
+{
+    if (_init_and_advance(manifest, parser, it,
+                          arr, SUIT_CBOR_MANIFEST_IDX_PAYLOADINFO) < 0) {
+        return SUIT_ERR_INVALID_MANIFEST;
+    }
+    cbor_value_enter_container(arr, payloadinfo);
+    if (_advance_x(payloadinfo, offset) < 0) {
+        return SUIT_ERR_INVALID_MANIFEST;
+    }
+    return SUIT_OK;
+}
+
+int suit_cbor_get_version(const suit_cbor_manifest_t *manifest,
+                          uint32_t *version)
+{
+    CborParser parser;
+    CborValue it, arr;
+
+    cbor_parser_init(manifest->buf, manifest->len,
+                     SUIT_TINYCBOR_VALIDATION_MODE, &parser, &it);
+    cbor_value_enter_container(&it, &arr);
+    return _parse_manifest_version(&arr, version);
+}
+
+int suit_cbor_get_seq_no(const suit_cbor_manifest_t *manifest,
+                         uint32_t *seq_no)
+{
+    CborParser parser;
+    CborValue it, arr;
+
+    if (_init_and_advance(manifest, &parser, &it,
+                          &arr, SUIT_CBOR_MANIFEST_IDX_SEQ_NO) < 0) {
+        return SUIT_ERR_INVALID_MANIFEST;
+    }
+    return _parse_manifest_seq_no(&arr, seq_no);
+}
+
+ssize_t suit_cbor_get_condition_type(const suit_cbor_manifest_t *manifest,
+                                     unsigned idx, signed *condition)
+{
+    CborParser parser;
+    CborValue it, arr;
+
+    if (_init_and_advance(manifest, &parser, &it,
+                          &arr, SUIT_CBOR_MANIFEST_IDX_CONDITIONS) < 0) {
+        return SUIT_ERR_INVALID_MANIFEST;
+    }
+    return _parse_manifest_condition_type(&arr, idx, condition);
+}
+
+int suit_cbor_get_condition_parameter(const suit_cbor_manifest_t *manifest,
+                                      unsigned idx, uint8_t *buf, size_t *len)
+{
+    CborParser parser;
+    CborValue it, arr;
+
+    if (_init_and_advance(manifest, &parser, &it,
+                          &arr, SUIT_CBOR_MANIFEST_IDX_CONDITIONS) < 0) {
+        return SUIT_ERR_INVALID_MANIFEST;
+    }
+    return _parse_manifest_condition_param(&arr, idx, buf, len);
+}
+
+int suit_cbor_payload_get_digestalgo(const suit_cbor_manifest_t *manifest,
+                                     suit_cbor_digest_t *algo)
+{
+    CborParser parser;
+    CborValue it, arr, payloadinfo;
+
+    if (_init_and_advance_info(manifest, &parser, &it, &arr, &payloadinfo,
+                               SUIT_CBOR_PAYLOADINFO_IDX_DIGESTALGO) < 0) {
+        return SUIT_ERR_INVALID_MANIFEST;
+    }
+    return _parse_manifest_digestalgo(&payloadinfo, algo);
+}
+
+int suit_cbor_payload_get_digest(const suit_cbor_manifest_t *manifest,
+                                 suit_cbor_digest_type_t digest, uint8_t *buf,
+                                 size_t *len)
+{
+    CborParser parser;
+    CborValue it, arr, payloadinfo, map;
+
+    if (_init_and_advance_info(manifest, &parser, &it, &arr, &payloadinfo,
+                               SUIT_CBOR_PAYLOADINFO_IDX_DIGESTS) < 0) {
+        return SUIT_ERR_INVALID_MANIFEST;
+    }
+    if (!cbor_value_is_map(&payloadinfo)) {
+        return SUIT_ERR_INVALID_MANIFEST;
+    }
+    cbor_value_enter_container(&payloadinfo, &map);
+    while (!cbor_value_at_end(&map)) {
+        int64_t type;
+        cbor_value_get_int64(&map, &type);
+        cbor_value_advance(&map);
+        if (type == digest) {
+            cbor_value_copy_byte_string(&map, buf, len, NULL);
+            return 1;
+        }
+        cbor_value_advance(&map);
+    }
+    return 0;
+}
+
+int suit_cbor_payload_get_size(const suit_cbor_manifest_t *manifest,
+                               uint32_t *size)
+{
+    CborParser parser;
+    CborValue it, arr, payloadinfo;
+
+    if (_init_and_advance_info(manifest, &parser, &it, &arr, &payloadinfo,
+                               SUIT_CBOR_PAYLOADINFO_IDX_SIZE) < 0) {
+        return SUIT_ERR_INVALID_MANIFEST;
+    }
+    return _parse_payload_size(&payloadinfo, size);
+}
+
+int suit_cbor_payload_get_storid(const suit_cbor_manifest_t *manifest,
+                                 uint8_t *buf, size_t *len)
+{
+    CborParser parser;
+    CborValue it, arr, payloadinfo;
+
+    if (_init_and_advance_info(manifest, &parser, &it, &arr, &payloadinfo,
+                               SUIT_CBOR_PAYLOADINFO_IDX_STORID) < 0) {
+        return SUIT_ERR_INVALID_MANIFEST;
+    }
+    return _parse_payload_storage_id(&payloadinfo, buf, len);
+}
+
+ssize_t suit_cbor_get_url(const suit_cbor_manifest_t *manifest, char *buf,
+                          size_t len)
+{
+    CborParser parser;
+    CborValue it, arr, payloadinfo, urilist, uri;
+
+    if (_init_and_advance_info(manifest, &parser, &it, &arr, &payloadinfo,
+                               SUIT_CBOR_PAYLOADINFO_IDX_URIS) < 0) {
+        return SUIT_ERR_INVALID_MANIFEST;
+    }
+    if (!cbor_value_is_array(&payloadinfo)) {
+        return SUIT_ERR_INVALID_MANIFEST;
+    }
+    size_t arr_len;
+    cbor_value_get_array_length(&payloadinfo, &arr_len);
+    if (arr_len == 0) {
+        return SUIT_ERR_INVALID_MANIFEST;
+    }
+    cbor_value_enter_container(&payloadinfo, &urilist);
+    if (!cbor_value_is_array(&urilist)) {
+        return SUIT_ERR_INVALID_MANIFEST;
+    }
+    cbor_value_get_array_length(&urilist, &arr_len);
+    if (arr_len != 2) {
+        return SUIT_ERR_INVALID_MANIFEST;
+    }
+    cbor_value_enter_container(&urilist, &uri);
+    cbor_value_advance(&uri);
+    if (!cbor_value_is_text_string(&uri)) {
+        return SUIT_ERR_INVALID_MANIFEST;
+    }
+    size_t uri_len = 0;
+    cbor_value_get_string_length(&uri, &uri_len);
+    if (uri_len > len) {
+        return SUIT_ERR_INVALID_MANIFEST;
+    }
+    else {
+        cbor_value_copy_text_string(&uri, buf, &len, NULL);
+        return uri_len;
+    }
+}

--- a/tests/unittests/tests-suit/Makefile
+++ b/tests/unittests/tests-suit/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/tests/unittests/tests-suit/Makefile.include
+++ b/tests/unittests/tests-suit/Makefile.include
@@ -1,0 +1,1 @@
+USEMODULE += suit_cbor

--- a/tests/unittests/tests-suit/tests-suit.c
+++ b/tests/unittests/tests-suit/tests-suit.c
@@ -1,0 +1,163 @@
+/*
+ * Copyright (C) 2018 Freie Universität Berlin
+ * Copyright (C) 2018 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+#include <string.h>
+#include <stdio.h>
+#include "embUnit.h"
+
+#include "tests-suit.h"
+#include "suit/cbor.h"
+
+/**
+ * A nice example CBOR-encoded manifest:
+ *
+ * [
+ *  2,
+ *  None,
+ *  b'\xc4>92\xee.\x15\x10',
+ *  1527518505,
+ *  [[1, b'T}\rtm:Z\x92\x96bH\x81\xaf\xd9@{'],
+ *   [2, b'\xbc\xc9\t\x84\xfe}V+\xb4\xc9\xa2O&\xa3\xa9\xcd'],
+ *   [3, b'T\x8a\xb6\xc8\xdfXS-\xbe\x0e\n\x1d\xc9\r\xcf\xeb']],
+ *  None,
+ *  None,
+ *  None,
+ *  None,
+ *  [
+ *   [1],
+ *   71480,
+ *   b'\x00\01',
+ *   [[1, 'coap://[ff02::1]/fw/test']],
+ *   [1],
+ *   {1: b'\x0e\x06=\xb2\xf3T\xe5\xabG\xcf\xd6\x9a\xbbe\x17e\xcd\x9d\xf3\\6S\\\xf5'
+ *       b'2\xde\xfe\x9c\xe36\x8an'},
+ *   None
+ *  ]
+ * ]
+ */
+static unsigned char test_suit_cbor_full[] = {
+    0x8a, 0x02, 0xf6, 0x48, 0xc4, 0x3e, 0x39, 0x32, 0xee, 0x2e, 0x15, 0x10,
+    0x1a, 0x5b, 0x0c, 0x15, 0x29, 0x83, 0x82, 0x01, 0x50, 0x54, 0x7d, 0x0d,
+    0x74, 0x6d, 0x3a, 0x5a, 0x92, 0x96, 0x62, 0x48, 0x81, 0xaf, 0xd9, 0x40,
+    0x7b, 0x82, 0x02, 0x50, 0xbc, 0xc9, 0x09, 0x84, 0xfe, 0x7d, 0x56, 0x2b,
+    0xb4, 0xc9, 0xa2, 0x4f, 0x26, 0xa3, 0xa9, 0xcd, 0x82, 0x03, 0x50, 0x54,
+    0x8a, 0xb6, 0xc8, 0xdf, 0x58, 0x53, 0x2d, 0xbe, 0x0e, 0x0a, 0x1d, 0xc9,
+    0x0d, 0xcf, 0xeb, 0xf6, 0xf6, 0xf6, 0xf6, 0x87, 0x81, 0x01, 0x1a, 0x00,
+    0x01, 0x17, 0x38, 0x42, 0x00, 0x01, 0x81, 0x82, 0x01, 0x78, 0x18, 0x63,
+    0x6f, 0x61, 0x70, 0x3a, 0x2f, 0x2f, 0x5b, 0x66, 0x66, 0x30, 0x32, 0x3a,
+    0x3a, 0x31, 0x5d, 0x2f, 0x66, 0x77, 0x2f, 0x74, 0x65, 0x73, 0x74, 0x81,
+    0x01, 0xa1, 0x01, 0x58, 0x20, 0x0e, 0x06, 0x3d, 0xb2, 0xf3, 0x54, 0xe5,
+    0xab, 0x47, 0xcf, 0xd6, 0x9a, 0xbb, 0x65, 0x17, 0x65, 0xcd, 0x9d, 0xf3,
+    0x5c, 0x36, 0x53, 0x5c, 0xf5, 0x32, 0xde, 0xfe, 0x9c, 0xe3, 0x36, 0x8a,
+    0x6e, 0xf6
+};
+
+/* Parameters from the conditions belonging to the manifest above */
+static const uint8_t cond[][16] = {
+    { 0x54, 0x7d, 0x0d, 0x74, 0x6d, 0x3a, 0x5a, 0x92, 0x96, 0x62, 0x48, 0x81,
+      0xaf, 0xd9, 0x40, 0x7b },
+    { 0xbc, 0xc9, 0x09, 0x84, 0xfe, 0x7d, 0x56, 0x2b, 0xb4, 0xc9, 0xa2, 0x4f,
+      0x26, 0xa3, 0xa9, 0xcd },
+    { 0x54, 0x8a, 0xb6, 0xc8, 0xdf, 0x58, 0x53, 0x2d, 0xbe, 0x0e, 0x0a, 0x1d,
+      0xc9, 0x0d, 0xcf, 0xeb },
+};
+
+static const char test_uri[] = "coap://[ff02::1]/fw/test";
+static const uint8_t test_storid[] = { 0x00, 0x01 };
+
+static char uri_buf[128];
+
+static void _test_cond(const suit_cbor_manifest_t *manifest,
+                       size_t idx, int expected_type)
+{
+    int cond_type = 0;
+    uint8_t param[16];
+
+    TEST_ASSERT(suit_cbor_get_condition_type(manifest, idx, &cond_type) >= 0);
+    TEST_ASSERT_EQUAL_INT(expected_type, cond_type);
+
+    size_t param_len = sizeof(param);
+    size_t res = suit_cbor_get_condition_parameter(manifest, idx, param,
+                                                   &param_len);
+
+    TEST_ASSERT_EQUAL_INT(param_len, res);
+    TEST_ASSERT_EQUAL_INT(0, memcmp(param, cond[idx], res));
+}
+
+void test_suit_cbor_parse(void)
+{
+    suit_cbor_manifest_t manifest;
+
+    uint8_t digest[64];
+    size_t dlen = sizeof(digest);
+
+    TEST_ASSERT_EQUAL_INT(suit_cbor_parse(&manifest, test_suit_cbor_full,
+                                          sizeof(test_suit_cbor_full)), 0);
+
+    uint32_t version = 0;
+    TEST_ASSERT_EQUAL_INT(suit_cbor_get_version(&manifest, &version), SUIT_OK);
+    TEST_ASSERT_EQUAL_INT(version, 2);
+
+    uint32_t seq_no;
+    TEST_ASSERT_EQUAL_INT(suit_cbor_get_seq_no(&manifest, &seq_no), SUIT_OK);
+    TEST_ASSERT_EQUAL_INT(seq_no, 1527518505);
+
+    /* Test conditional types */
+    _test_cond(&manifest, 0, 1);    /* First condition, type 1 */
+    _test_cond(&manifest, 1, 2);    /* Second condition, type 2 */
+    _test_cond(&manifest, 2, 3);    /* Third condition, type 3 */
+
+
+    /* Nonexisting condition */
+    TEST_ASSERT_EQUAL_INT(SUIT_ERR_COND,
+                          suit_cbor_get_condition_type(&manifest, 3,
+                                                       NULL));
+
+    uint32_t size;
+    TEST_ASSERT_EQUAL_INT(suit_cbor_payload_get_size(&manifest, &size), SUIT_OK);
+    TEST_ASSERT_EQUAL_INT(size, 71480);
+
+    suit_cbor_digest_t algo = -1;
+    TEST_ASSERT_EQUAL_INT(suit_cbor_payload_get_digestalgo(&manifest, &algo),
+                          SUIT_OK);
+    TEST_ASSERT_EQUAL_INT(algo, SUIT_DIGEST_SHA256);
+
+    int res = suit_cbor_payload_get_digest(&manifest, SUIT_DIGEST_TYPE_RAW,
+                                           digest, &dlen);
+    TEST_ASSERT_EQUAL_INT(1, res);
+
+    res = suit_cbor_payload_get_digest(&manifest, SUIT_DIGEST_TYPE_CIPHERTEXT,
+                                       digest, &dlen);
+    TEST_ASSERT_EQUAL_INT(0, res);
+
+    TEST_ASSERT_EQUAL_INT(suit_cbor_get_url(&manifest, uri_buf, sizeof(uri_buf)), 24);
+    TEST_ASSERT_EQUAL_STRING((char *)test_uri, (char *)uri_buf);
+
+    uint8_t storid[4];
+    size_t storid_len = sizeof(storid);
+    TEST_ASSERT_EQUAL_INT(suit_cbor_payload_get_storid(&manifest, storid,
+                                                       &storid_len), SUIT_OK);
+    TEST_ASSERT_EQUAL_INT(storid_len, 2);
+    TEST_ASSERT_EQUAL_INT(memcmp(test_storid, storid, storid_len), 0);
+}
+
+Test *tests_suit_tests(void)
+{
+    EMB_UNIT_TESTFIXTURES(fixtures) {
+        new_TestFixture(test_suit_cbor_parse),
+    };
+
+    EMB_UNIT_TESTCALLER(suit_cbor_tests, NULL, NULL, fixtures);
+
+    return (Test *)&suit_cbor_tests;
+}
+
+void tests_suit(void)
+{
+    TESTS_RUN(tests_suit_tests());
+}

--- a/tests/unittests/tests-suit/tests-suit.h
+++ b/tests/unittests/tests-suit/tests-suit.h
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2018 Freie Universität Berlin
+ * Copyright (C) 2018 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @addtogroup  unittests
+ * @{
+ *
+ * @file
+ * @brief       Unittests for the ``suit`` module
+ *
+ * @author      Koen Zandberg <koen@bergzand.net>
+ */
+#ifndef TESTS_SUIT_H
+#define TESTS_SUIT_H
+
+#include "embUnit.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   The entry point of this test suite.
+ */
+void tests_suit(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* TESTS_SUIT_H */
+/** @} */


### PR DESCRIPTION
### Contribution description

Minimal version of the CBOR-based SUIT parser, provides minimal supports for [version 1 of the draft specification](https://tools.ietf.org/html/draft-moran-suit-manifest-01).
Supported retrieval functions are:
 - manifest version
 - timestamp/sequence number
 - conditions
 - url
 - payloadinfo:
    - digest algorithm
    - digest
    - storage ID
    - size

### Testing procedure

Unittest included :)

### Issues/PRs references

#### Todo:
 - [x] split uuid generation