### PR TITLE
tests/leds: initialize led0 by default

### DIFF
--- a/boards/common/nucleo144/include/board.h
+++ b/boards/common/nucleo144/include/board.h
@@ -63,7 +63,9 @@ extern "C" {
 #define LED2_TOGGLE         (GPIOB->ODR  ^= LED2_MASK)
 
 /* the Nucleo144 boards always use LED0, as there is no dual use of its pin */
+#ifndef AUTO_INIT_LED0
 #define AUTO_INIT_LED0
+#endif
 /** @} */
 
 /**

--- a/tests/leds/Makefile
+++ b/tests/leds/Makefile
@@ -1,3 +1,6 @@
 include ../Makefile.tests_common
 
+# Some boards do not initialize LED0 by default
+CFLAGS=-DAUTO_INIT_LED0
+
 include $(RIOTBASE)/Makefile.include


### PR DESCRIPTION
### Contribution description

Test do not work on every board properly. LED0 is not initialized by every board and the test does not what is expected.


### Testing procedure

- compile
- flash
- led blinks

### Issues/PRs references

reference #9949
reference #10294
