### PR TITLE
boards: Enable STM32F103C8 ROM hack via env var

### DIFF
--- a/boards/bluepill/doc.txt
+++ b/boards/bluepill/doc.txt
@@ -61,12 +61,12 @@ you can flash the device with:
 
 To make use of the entire 128 KB flash, compile your application with:
 
-    $ make BOARD=bluepill CPU_MODEL=stm32f103cb
+    $ make STM32F103C8_FLASH_HACK=1 BOARD=bluepill
 
 This sets the `CPU_MODEL` make variable to `stm32f103cb`, the default
 value is `stm32f103c8`. These two CPU models basically only have one
 major difference, the latter has 128 KB flash while the former has 64
-KB.
+KB. You may also set `STM32F103C8_FLASH_HACK` as environment variable.
 
 If you want to flash a binary compiled this way you either need to
 figure out how to adjust the OpenOCD configuration to make it use 128 KB

--- a/boards/common/stm32f103c8/Makefile.include
+++ b/boards/common/stm32f103c8/Makefile.include
@@ -1,6 +1,11 @@
 ## the cpu to build for
 export CPU = stm32f1
-export CPU_MODEL = stm32f103c8
+STM32F103C8_FLASH_HACK ?= 0
+ifneq ($(STM32F103C8_FLASH_HACK),0)
+  export CPU_MODEL = stm32f103cb
+else
+  export CPU_MODEL = stm32f103c8
+endif
 
 INCLUDES += -I$(RIOTBOARD)/common/stm32f103c8/include
 


### PR DESCRIPTION
The STM32F103C8 secretly comes with 128KiB flash instead of 64KiB. Still, only
64KiB of it are tested and guaranteed to work. However, most of the times the
whole 128KiB flash works just fine. In the BluePill documentation this fact is
already documented and by using

    $ make BOARD=bluepill CPU_MODEL=stm32f103cb

the whole 128 KiB can be used by RIOT. When using this hack routinely, it easier
to use environment variables instead. But allowing to overwrite CPU_MODEL via
environment variables seems to be a bad thing, as it is easy to forget to clear
that environment variable when changing the BOARD variable.

This commit introduces the new STM32F103C8_ROM_HACK variable, which unlocks the
128KiB ROM when set to "y". The BluePill documentation has been updated
accordingly.