### PR TITLE
cpu/esp8266: doxygen fix for periph/gpio

### DIFF
--- a/cpu/esp8266/include/gpio_common.h
+++ b/cpu/esp8266/include/gpio_common.h
@@ -8,7 +8,6 @@
 
 /**
  * @ingroup     cpu_esp8266
- * @ingroup     drivers_periph_gpio
  * @{
  *
  * @file


### PR DESCRIPTION
### Contribution description

This PR fixes the documentation generated with doxygen for module **Peripheral Driver Interface / GPIO**. An architecture specific header file for the ESP8266 was added to the doxygen module ```drivers_periph_gpio``` by mistake. The PR removes this architecture specific header file from the documentation.

### Testing procedure

1. Generate the API reference with command: ```make doc```
2. Check section ```Files``` of page **Drivers » Peripheral Driver Interface » GPIO** in the generated API reference.
