### PR TITLE
sys/auto_init: Fixed initialization of sht1x [backport 2018.10]

### DIFF
--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -428,10 +428,6 @@ void auto_init(void)
     extern void auto_init_pulse_counter(void);
     auto_init_pulse_counter();
 #endif
-#ifdef MODULE_SHT1X
-    extern void auto_init_sht1x(void);
-    auto_init_sht1x();
-#endif
 #ifdef MODULE_SI114X
     extern void auto_init_si114x(void);
     auto_init_si114x();

--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -296,6 +296,10 @@ void auto_init(void)
 
 /* initialize sensors and actuators */
 #ifdef MODULE_SHT1X
+    /* The sht1x module needs to be initialized regardless of SAUL being used,
+     * as the shell commands rely on auto-initialization. auto_init_sht1x also
+     * performs SAUL registration, but only if module auto_init_saul is used.
+     */
     DEBUG("Auto init SHT1X module (SHT10/SHT11/SHT15 sensor driver).\n");
     extern void auto_init_sht1x(void);
     auto_init_sht1x();

--- a/sys/auto_init/saul/auto_init_sht1x.c
+++ b/sys/auto_init/saul/auto_init_sht1x.c
@@ -16,6 +16,11 @@
  *
  * @author      Marian Buschsieweke <marian.buschsieweke@ovgu.de>
  *
+ * Please note that the sht1x differs from other sensor modules, as
+ * initialization is performed regardless of the use of SAUL. However, when
+ * the module `auto_init_saul` is *not* used, the SAUL registration is skipped
+ * and the initialization does *not* depend on SAUL in this case.
+ *
  * @}
  */
 


### PR DESCRIPTION
# Backport of #10267

### Contribution description
(Same as #10289 but pointing to the release branch)

Commit cef81a102c61455dd418225a009ff78558b5b9c2 introduced two bugs:

 - the driver for sht1x is initialized two times
 - the second initialization is done only when SAUL is used, but sht1x needs
   to be initialized in any case. (SAUL registration is also done there, but
   only when SAUL is actually being used.)

This commit fixes both.

### Testing procedure

E.g. use `examples/default` on a board that features an SHT1x sensor, e.g. the MSB-A2. Prior to this PR RIOT will not boot due to the double initialization, with this PR applied RIOT will boot again.