### PR TITLE
cpu/esp32: doxygen fix

### DIFF
--- a/cpu/esp32/include/adc_arch.h
+++ b/cpu/esp32/include/adc_arch.h
@@ -8,11 +8,10 @@
 
 /**
  * @ingroup     cpu_esp32
- * @ingroup     drivers_periph_gpio
  * @{
  *
  * @file
- * @brief       Architecture specific ADC functions ESP32
+ * @brief       Architecture specific ADC functions for ESP32
  *
  * @author      Gunar Schorcht <gunar@schorcht.net>
  * @}

--- a/cpu/esp32/include/gpio_arch.h
+++ b/cpu/esp32/include/gpio_arch.h
@@ -8,11 +8,10 @@
 
 /**
  * @ingroup     cpu_esp32
- * @ingroup     drivers_periph_gpio
  * @{
  *
  * @file
- * @brief       Architecture specific GPIO functions ESP32
+ * @brief       Architecture specific GPIO functions for ESP32
  *
  * @author      Gunar Schorcht <gunar@schorcht.net>
  * @}


### PR DESCRIPTION
### Contribution description

This PR is a backport of PR #10325. This PR fixes the documentation generated with doxygen for module **Peripheral Driver Interface / GPIO**. Architecture specific header files for the ESP32 were added to the doxygen module ```drivers_periph_gpio``` by mistake. The PR removes these architecture specific header files from the documentation.

### Testing procedure

1. Generate the API reference with command: ```make doc```
2. Check section Files of page **Drivers » Peripheral Driver Interface » GPIO** in the generated API reference.

