### PR TITLE
test: trickle: fix condition for success

### DIFF
--- a/tests/trickle/tests/01-run.py
+++ b/tests/trickle/tests/01-run.py
@@ -14,12 +14,12 @@ def testfunc(child):
     child.expect_exact("[START]")
 
     for i in range(5):
-        child.expect(u"now = \d+, prev_now = \d+, diff = \d+")
+        child.expect(u"now = \\d+, t = \\d+")
 
     child.expect_exact("[TRICKLE_RESET]")
 
     for i in range(7):
-        child.expect(u"now = \d+, prev_now = \d+, diff = \d+")
+        child.expect(u"now = \\d+, t = \\d+")
 
     child.expect_exact("[SUCCESS]")
 


### PR DESCRIPTION
### Contribution description

The current test implementation wrongly assumes that the diff between
two fired events (e1, e2) must always increase. That is not true, as
event e1 may reside on the upper part of [I/2, I) and e2 on the lower
part of [I, 2*I).

This commit fixes the test to look at the actual time that was randonmly
chosen from both intervals (t1, t2). Given that the intervals are
doubled, t1 must always be smaller than t2.

### Testing procedure
--


### Issues/PRs references
Fixes #10317
