### PR TITLE
emb6_sock_udp: make address a value

### DIFF
--- a/pkg/emb6/contrib/sock/udp/emb6_sock_udp.c
+++ b/pkg/emb6/contrib/sock/udp/emb6_sock_udp.c
@@ -290,7 +290,7 @@ static void _input_callback(struct udp_socket *c, void *ptr,
     (void)dst_port;
     mutex_lock(&sock->mutex);
     sock->recv_info.src_port = src_port;
-    sock->recv_info.src = (const ipv6_addr_t *)src_addr;
+    memcpy(&sock->recv_info.src, src_addr, sizeof(sock->recv_info.src));
     sock->recv_info.data = data;
     sock->recv_info.datalen = datalen - sizeof(ipv6_hdr_t);
     mutex_unlock(&sock->mutex);

--- a/pkg/emb6/include/sock_types.h
+++ b/pkg/emb6/include/sock_types.h
@@ -51,7 +51,7 @@ struct sock_udp {
     msg_t mbox_queue[SOCK_MBOX_SIZE];   /**< queue for mbox */
     atomic_int receivers;               /**< current number of recv calls */
     struct {
-        const ipv6_addr_t *src;         /**< source address */
+        ipv6_addr_t src;                /**< source address */
         const void *data;               /**< data of received packet */
         size_t datalen;                 /**< length of received packet data */
         uint16_t src_port;              /**< source port */


### PR DESCRIPTION
### Contribution description
I can't follow exactly what's happening, but apparently the source
address of the pointer is switched out before `sock_udp_recv()` (while
the `data` is not), but this fixes the output issue encountered during
the [2018.10 RC1 testing][RC1].

[RC1]: https://github.com/RIOT-OS/Release-Specs/issues/76#issuecomment-435924505

### Testing procedure
Flash `tests/emb6` to one board and another UDP-capable networking application (e.g. `tests/emb6`) to another. Then open a udp server on (one of) the emb6 side(s) 

```
udp server start 61616
```

and send a UDP packet from the other (with `tests/emb6` that is `udp send <addr> 61616 abcdef`).

You will see something like

```
Received from [<addr>]:61616:
```

With this patch `<addr>` will be the address of the sender, without it will be some garbage bytes.

### Issues/PRs references
See https://github.com/RIOT-OS/Release-Specs/issues/76#issuecomment-435924505