### PR TITLE
emb6_sock_udp: copy receive remote correctly

### DIFF
--- a/pkg/emb6/contrib/sock/udp/emb6_sock_udp.c
+++ b/pkg/emb6/contrib/sock/udp/emb6_sock_udp.c
@@ -235,7 +235,7 @@ int sock_udp_send(sock_udp_t *sock, const void *data, size_t len,
     else if (sock->sock.udp_conn->rport == 0) {
         return -ENOTCONN;
     }
-    /* cppcheck-supress nullPointerRedundantCheck
+    /* cppcheck-suppress nullPointerRedundantCheck
      * remote == NULL implies that sock != NULL (see assert at start of
      * function) * that's why it is okay in the if-statement above to check
      * sock->... without checking (sock != NULL) first => this check afterwards

--- a/pkg/emb6/contrib/sock/udp/emb6_sock_udp.c
+++ b/pkg/emb6/contrib/sock/udp/emb6_sock_udp.c
@@ -187,7 +187,7 @@ int sock_udp_recv(sock_udp_t *sock, void *data, size_t max_len,
             if (remote != NULL) {
                 remote->family = AF_INET6;
                 remote->netif = SOCK_ADDR_ANY_NETIF;
-                memcpy(&remote->addr, &sock->recv_info.src, sizeof(ipv6_addr_t));
+                memcpy(&remote->addr, sock->recv_info.src, sizeof(ipv6_addr_t));
                 remote->port = sock->recv_info.src_port;
             }
             res = (int)sock->recv_info.datalen;

--- a/pkg/emb6/contrib/sock/udp/emb6_sock_udp.c
+++ b/pkg/emb6/contrib/sock/udp/emb6_sock_udp.c
@@ -236,10 +236,10 @@ int sock_udp_send(sock_udp_t *sock, const void *data, size_t len,
         return -ENOTCONN;
     }
     /* cppcheck-suppress nullPointerRedundantCheck
-     * remote == NULL implies that sock != NULL (see assert at start of
+     * (reason: remote == NULL implies that sock != NULL (see assert at start of
      * function) * that's why it is okay in the if-statement above to check
      * sock->... without checking (sock != NULL) first => this check afterwards
-     * isn't redundant */
+     * isn't redundant) */
     if (sock == NULL) {
         int res;
         if ((res = _reg(&tmp, NULL, NULL, NULL, NULL)) < 0) {


### PR DESCRIPTION
### Contribution description
The `src` member of `sock_udp_t` for `emb6` is a pointer, not a value, so it should not be referenced.

[RC1]: https://github.com/RIOT-OS/Release-Specs/issues/76#issuecomment-435924505


### Testing procedure
Flash `tests/emb6` to one board and another UDP-capable networking application (e.g. `tests/emb6`) to another. Then open a udp server on (one of) the emb6 side(s) 

```
udp server start 61616
```

and send a UDP packet from the other (with `tests/emb6` that is `udp send <addr> 61616 abcdef`).

You will see something like

```
Received from [<addr>]:61616:
```

With this patch `<addr>` will be the address of the sender, without it will be some garbage bytes.

### Issues/PRs references
See https://github.com/RIOT-OS/Release-Specs/issues/76#issuecomment-435924505
