### PR TITLE
{drivers/saul,sys/phydat}: Added RSSI sensor and dBm unit

### DIFF
--- a/drivers/include/saul.h
+++ b/drivers/include/saul.h
@@ -98,6 +98,7 @@ enum {
     SAUL_SENSE_TVOC     = 0x90,     /**< sensor: TVOC Gas */
     SAUL_SENSE_OCCUP    = 0x91,     /**< sensor: occupancy */
     SAUL_SENSE_PROXIMITY= 0x92,     /**< sensor: proximity */
+    SAUL_SENSE_RSSI     = 0x93,     /**< sensor: RSSI */
     SAUL_CLASS_ANY      = 0xff      /**< any device - wildcard */
     /* extend this list as needed... */
 };

--- a/drivers/saul/saul_str.c
+++ b/drivers/saul/saul_str.c
@@ -54,6 +54,7 @@ const char *saul_class_to_str(const uint8_t class_id)
         case SAUL_SENSE_CO2:       return "SENSE_CO2";
         case SAUL_SENSE_TVOC:      return "SENSE_TVOC";
         case SAUL_SENSE_PROXIMITY: return "SENSE_PROXIMITY";
+        case SAUL_SENSE_RSSI:      return "SENSE_RSSI";
         case SAUL_CLASS_ANY:       return "CLASS_ANY";
         case SAUL_SENSE_OCCUP:     return "SENSE_OCCUP";
         default:                   return "CLASS_UNKNOWN";

--- a/sys/include/phydat.h
+++ b/sys/include/phydat.h
@@ -94,6 +94,7 @@ enum {
     UNIT_A,         /**< Ampere */
     UNIT_V,         /**< Volts */
     UNIT_GS,        /**< gauss */
+    UNIT_DBM,       /**< decibel-milliwatts */
     /* pressure */
     UNIT_BAR,       /**< Beer? */
     UNIT_PA,        /**< Pascal */

--- a/sys/phydat/phydat_str.c
+++ b/sys/phydat/phydat_str.c
@@ -42,6 +42,7 @@ void phydat_dump(phydat_t *data, uint8_t dim)
             case UNIT_PERCENT:
             case UNIT_TEMP_C:
             case UNIT_TEMP_F:
+            case UNIT_DBM:
                 /* no string conversion */
                 scale_prefix = '\0';
                 break;
@@ -91,6 +92,7 @@ const char *phydat_unit_to_str(uint8_t unit)
         case UNIT_GR:       return "G";
         case UNIT_A:        return "A";
         case UNIT_V:        return "V";
+        case UNIT_DBM:      return "dBm";
         case UNIT_GS:       return "Gs";
         case UNIT_BAR:      return "Bar";
         case UNIT_PA:       return "Pa";


### PR DESCRIPTION
### Contribution description

The contribution is as minor as the title suggest:
 - An RSSI sensor type was added to SAUL
 - The unit dBm was added to sys/phydat (used by RSSI sensors)

### Motivation

Some network cards allow constant reading of the current RSSI value (e.g. the CC110x transceivers). This could be used for channel monitoring.

### Testing procedure

I think with only 5 lines added real testing is not required. I think if murdock still builds this should be fine.

However: In my [cc110x branch](https://github.com/maribu/RIOT/tree/cc110x) the rewrite of the cc110x driver I'm working on is providing a constant RSSI output via SAUL. This could be tested e.g. on the MSB-A2 or the MSB-IoT. (I did this and it works fine, even though the CC110x transceiver's RSSI is not too accurate.)

### Issues/PRs references

This might also be a solution to issue https://github.com/RIOT-OS/RIOT/issues/10134.