### PR TITLE
[doc] http -> https for *.riot-os.org

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -35,7 +35,7 @@ welcome:
 	@echo "Please see our Quick Start Guide at:"
 	@echo "    https://doc.riot-os.org/getting-started.html"
 	@echo "Or ask questions on our mailing list:"
-	@echo "    users@riot-os.org (http://lists.riot-os.org/mailman/listinfo/users)"
+	@echo "    users@riot-os.org (https://lists.riot-os.org/mailman/listinfo/users)"
 
 include makefiles/app_dirs.inc.mk
 

--- a/boards/chronos/doc.txt
+++ b/boards/chronos/doc.txt
@@ -5,7 +5,7 @@
 
 # Hardware
 
-![TI eZ430-Chronos running RIOT](http://riot-os.org/images/hardware-watch-
+![TI eZ430-Chronos running RIOT](https://riot-os.org/images/hardware-watch-
 riot.png)
 
 # MCU

--- a/boards/msb-430h/doc.txt
+++ b/boards/msb-430h/doc.txt
@@ -5,7 +5,7 @@
 
 ## Hardware
 
-![ScatterWeb MSB-430H](http://riot-os.org/images/msb-430h_2.png)
+![ScatterWeb MSB-430H](https://riot-os.org/images/msb-430h_2.png)
 
 ## MCU
 | MCU        | TI MSP430F1612        |

--- a/cpu/esp32/gen_esp32part.py
+++ b/cpu/esp32/gen_esp32part.py
@@ -13,7 +13,7 @@
 # you may not use this file except in compliance with the License.
 # You may obtain a copy of the License at
 #
-#     http:#www.apache.org/licenses/LICENSE-2.0
+#     https://www.apache.org/licenses/LICENSE-2.0
 #
 # Unless required by applicable law or agreed to in writing, software
 # distributed under the License is distributed on an "AS IS" BASIS,

--- a/cpu/esp8266/README.md
+++ b/cpu/esp8266/README.md
@@ -527,8 +527,8 @@ The ESP8266 port of RIOT has been tested with several common external devices th
 
 RIOT provides a number of driver modules for different types of network devices, e.g., IEEE 802.15.4 radio modules and Ethernet modules. The RIOT ESP8266 port has been tested with the following network devices and is preconfigured to create RIOT network applications with these devices:
 
-- [mrf24j40](http://riot-os.org/api/group__drivers__mrf24j40.html) (driver for Microchip MRF24j40 based IEEE 802.15.4
-- [enc28j60](http://riot-os.org/api/group__drivers__enc28j60.html) (driver for Microchip ENC28J60 based Ethernet modules)
+- [mrf24j40](https://riot-os.org/api/group__drivers__mrf24j40.html) (driver for Microchip MRF24j40 based IEEE 802.15.4
+- [enc28j60](https://riot-os.org/api/group__drivers__enc28j60.html) (driver for Microchip ENC28J60 based Ethernet modules)
 
 If the RIOT network application uses a default network device (module ```netdev_default```), the ```NETDEV_DEFAULT``` make command variable can be used to define the device that will be used as the default network device. The value of this variable must match the name of the driver module for this network device. If ```NETDEV_DEFAULT``` is not defined, the ```mrf24j40```  module is used as default network device.
 
@@ -596,7 +596,7 @@ make flash BOARD=esp8266-esp-12x -C examples/gnrc_networking NETDEV_DEFAULT=enc2
 
 ## <a name="esp8266_sd_card_device"> SD-Card Device </a> &nbsp;[[TOC](#esp8266_toc)]
 
-ESP8266 port of RIOT is preconfigured for RIOT applications that use the [SPI SD-Card driver](http://riot-os.org/api/group__drivers__sdcard__spi.html). To use SPI SD-Card driver, the ```sdcard_spi``` module has to be added to a makefile:
+ESP8266 port of RIOT is preconfigured for RIOT applications that use the [SPI SD-Card driver](https://riot-os.org/api/group__drivers__sdcard__spi.html). To use SPI SD-Card driver, the ```sdcard_spi``` module has to be added to a makefile:
 
 ```
 USEMODULE += sdcard_spi

--- a/cpu/esp8266/doc.txt
+++ b/cpu/esp8266/doc.txt
@@ -532,8 +532,8 @@ The ESP8266 port of RIOT has been tested with several common external devices th
 
 RIOT provides a number of driver modules for different types of network devices, e.g., IEEE 802.15.4 radio modules and Ethernet modules. The RIOT ESP8266 port has been tested with the following network devices and is preconfigured to create RIOT network applications with these devices:
 
-- [mrf24j40](http://riot-os.org/api/group__drivers__mrf24j40.html) (driver for Microchip MRF24j40 based IEEE 802.15.4
-- [enc28j60](http://riot-os.org/api/group__drivers__enc28j60.html) (driver for Microchip ENC28J60 based Ethernet modules)
+- [mrf24j40](https://riot-os.org/api/group__drivers__mrf24j40.html) (driver for Microchip MRF24j40 based IEEE 802.15.4
+- [enc28j60](https://riot-os.org/api/group__drivers__enc28j60.html) (driver for Microchip ENC28J60 based Ethernet modules)
 
 If the RIOT network application uses a default network device (module ```netdev_default```), the ```NETDEV_DEFAULT``` make command variable can be used to define the device that will be used as the default network device. The value of this variable must match the name of the driver module for this network device. If ```NETDEV_DEFAULT``` is not defined, the ```mrf24j40```  module is used as default network device.
 
@@ -601,7 +601,7 @@ make flash BOARD=esp8266-esp-12x -C examples/gnrc_networking NETDEV_DEFAULT=enc2
 
 ## <a name="esp8266_sd_card_device"> SD-Card Device </a> &nbsp;[[TOC](#esp8266_toc)]
 
-ESP8266 port of RIOT is preconfigured for RIOT applications that use the [SPI SD-Card driver](http://riot-os.org/api/group__drivers__sdcard__spi.html). To use SPI SD-Card driver, the ```sdcard_spi``` module has to be added to a makefile:
+ESP8266 port of RIOT is preconfigured for RIOT applications that use the [SPI SD-Card driver](https://riot-os.org/api/group__drivers__sdcard__spi.html). To use SPI SD-Card driver, the ```sdcard_spi``` module has to be added to a makefile:
 
 ```
 USEMODULE += sdcard_spi

--- a/dist/tools/pyterm/setup.py
+++ b/dist/tools/pyterm/setup.py
@@ -10,6 +10,6 @@ setup(name="pyterm",
       description="Python-based terminal emulator for serial communication",
       author="Oliver Hahm",
       author_email="ohahm@fu-berlin.de",
-      url="http://riot-os.org/",
+      url="https://riot-os.org/",
       install_requires=["pyserial"],
       scripts=["pyterm"])

--- a/doc/doxygen/header.html
+++ b/doc/doxygen/header.html
@@ -43,7 +43,7 @@
                 <span class="icon-bar"></span>
                 <span class="icon-bar"></span>
               </button>
-              <a class="navbar-brand" id="brand-logo" href="http://riot-os.org"><img height="40px" src="$projectlogo" /></a>
+              <a class="navbar-brand" id="brand-logo" href="https://riot-os.org"><img height="40px" src="$projectlogo" /></a>
               <p class="navbar-text text-center visible-xs">Documentation</p>
             </div>
             <!-- Collect the nav links, forms, and other content for toggling -->

--- a/doc/doxygen/src/mainpage.md
+++ b/doc/doxygen/src/mainpage.md
@@ -30,11 +30,11 @@ RIOT is developed by an open community that anyone is welcome to join:
    [GitHub](https://github.com/RIOT-OS/RIOT). You can read about how to
    contribute [in our GitHub
    Wiki](https://github.com/RIOT-OS/RIOT/wiki/Contributing-to-RIOT).
- - [Subscribe](http://lists.riot-os.org/mailman/listinfo/users) to
+ - [Subscribe](https://lists.riot-os.org/mailman/listinfo/users) to
    users@riot-os.org to ask for help using RIOT or writing an application for
    RIOT (or to just stay in the loop). An archive of this list [is available
    here](https://lists.riot-os.org/pipermail/users/).
- - [Subscribe](http://lists.riot-os.org/mailman/listinfo/devel) to
+ - [Subscribe](https://lists.riot-os.org/mailman/listinfo/devel) to
    devel@riot-os.org to follow and discuss kernel and network stack
    development, or hardware support. An archive of this list [is available
    here](https://lists.riot-os.org/pipermail/devel/).

--- a/examples/arduino_hello-world/README.md
+++ b/examples/arduino_hello-world/README.md
@@ -17,7 +17,7 @@ purposes:
 Arduino and RIOT
 ================
 For information on the Arduino support in RIOT please refer to the API
-documentation at http://doc.riot-os.org/group__sys__arduino.html
+documentation at https://doc.riot-os.org/group__sys__arduino.html
 
 Usage
 =====

--- a/examples/nanocoap_server/README.md
+++ b/examples/nanocoap_server/README.md
@@ -3,7 +3,7 @@ nanocoap server example
 
 This application is meant to get you started with implementing a CoAP server on RIOT.
 It uses the GNRC network stack through RIOT's
-[sock API](http://doc.riot-os.org/group__net__sock.html).
+[sock API](https://doc.riot-os.org/group__net__sock.html).
 
 Usage
 =====

--- a/release-notes.txt
+++ b/release-notes.txt
@@ -256,18 +256,18 @@ to all of you contributing in so many different ways to make RIOT worthwhile!
 
 More information
 ================
-http://www.riot-os.org
+https://www.riot-os.org
 
 Mailing lists
 -------------
 * RIOT OS kernel developers list
-  devel@riot-os.org (http://lists.riot-os.org/mailman/listinfo/devel)
+  devel@riot-os.org (https://lists.riot-os.org/mailman/listinfo/devel)
 * RIOT OS users list
-  users@riot-os.org (http://lists.riot-os.org/mailman/listinfo/users)
+  users@riot-os.org (https://lists.riot-os.org/mailman/listinfo/users)
 * RIOT commits
-  commits@riot-os.org (http://lists.riot-os.org/mailman/listinfo/commits)
+  commits@riot-os.org (https://lists.riot-os.org/mailman/listinfo/commits)
 * Github notifications
-  notifications@riot-os.org (http://lists.riot-os.org/mailman/listinfo/notifications)
+  notifications@riot-os.org (https://lists.riot-os.org/mailman/listinfo/notifications)
 
 IRC
 ---
@@ -385,18 +385,18 @@ to all of you contributing in so many different ways to make RIOT worthwhile!
 
 More information
 ================
-http://www.riot-os.org
+https://www.riot-os.org
 
 Mailing lists
 -------------
 * RIOT OS kernel developers list
-  devel@riot-os.org (http://lists.riot-os.org/mailman/listinfo/devel)
+  devel@riot-os.org (https://lists.riot-os.org/mailman/listinfo/devel)
 * RIOT OS users list
-  users@riot-os.org (http://lists.riot-os.org/mailman/listinfo/users)
+  users@riot-os.org (https://lists.riot-os.org/mailman/listinfo/users)
 * RIOT commits
-  commits@riot-os.org (http://lists.riot-os.org/mailman/listinfo/commits)
+  commits@riot-os.org (https://lists.riot-os.org/mailman/listinfo/commits)
 * Github notifications
-  notifications@riot-os.org (http://lists.riot-os.org/mailman/listinfo/notifications)
+  notifications@riot-os.org (https://lists.riot-os.org/mailman/listinfo/notifications)
 
 IRC
 ---
@@ -592,18 +592,18 @@ to all of you contributing in so many different ways to make RIOT worthwhile!
 
 More information
 ================
-http://www.riot-os.org
+https://www.riot-os.org
 
 Mailing lists
 -------------
 * RIOT OS kernel developers list
-  devel@riot-os.org (http://lists.riot-os.org/mailman/listinfo/devel)
+  devel@riot-os.org (https://lists.riot-os.org/mailman/listinfo/devel)
 * RIOT OS users list
-  users@riot-os.org (http://lists.riot-os.org/mailman/listinfo/users)
+  users@riot-os.org (https://lists.riot-os.org/mailman/listinfo/users)
 * RIOT commits
-  commits@riot-os.org (http://lists.riot-os.org/mailman/listinfo/commits)
+  commits@riot-os.org (https://lists.riot-os.org/mailman/listinfo/commits)
 * Github notifications
-  notifications@riot-os.org (http://lists.riot-os.org/mailman/listinfo/notifications)
+  notifications@riot-os.org (https://lists.riot-os.org/mailman/listinfo/notifications)
 
 IRC
 ---
@@ -850,18 +850,18 @@ OpenThread integration and Semtech LoRa drivers.
 
 More information
 ================
-http://www.riot-os.org
+https://www.riot-os.org
 
 Mailing lists
 -------------
 * RIOT OS kernel developers list
-  devel@riot-os.org (http://lists.riot-os.org/mailman/listinfo/devel)
+  devel@riot-os.org (https://lists.riot-os.org/mailman/listinfo/devel)
 * RIOT OS users list
-  users@riot-os.org (http://lists.riot-os.org/mailman/listinfo/users)
+  users@riot-os.org (https://lists.riot-os.org/mailman/listinfo/users)
 * RIOT commits
-  commits@riot-os.org (http://lists.riot-os.org/mailman/listinfo/commits)
+  commits@riot-os.org (https://lists.riot-os.org/mailman/listinfo/commits)
 * Github notifications
-  notifications@riot-os.org (http://lists.riot-os.org/mailman/listinfo/notifications)
+  notifications@riot-os.org (https://lists.riot-os.org/mailman/listinfo/notifications)
 
 IRC
 ---
@@ -999,18 +999,18 @@ OpenThread integration and Semtech LoRa drivers.
 
 More information
 ================
-http://www.riot-os.org
+https://www.riot-os.org
 
 Mailing lists
 -------------
 * RIOT OS kernel developers list
-  devel@riot-os.org (http://lists.riot-os.org/mailman/listinfo/devel)
+  devel@riot-os.org (https://lists.riot-os.org/mailman/listinfo/devel)
 * RIOT OS users list
-  users@riot-os.org (http://lists.riot-os.org/mailman/listinfo/users)
+  users@riot-os.org (https://lists.riot-os.org/mailman/listinfo/users)
 * RIOT commits
-  commits@riot-os.org (http://lists.riot-os.org/mailman/listinfo/commits)
+  commits@riot-os.org (https://lists.riot-os.org/mailman/listinfo/commits)
 * Github notifications
-  notifications@riot-os.org (http://lists.riot-os.org/mailman/listinfo/notifications)
+  notifications@riot-os.org (https://lists.riot-os.org/mailman/listinfo/notifications)
 
 IRC
 ---
@@ -1116,18 +1116,18 @@ sponsored development time: Cisco Systems, Eistec, Ell-i, Enigeering Spirit, Nor
 
 More information
 ================
-http://www.riot-os.org
+https://www.riot-os.org
 
 Mailing lists
 -------------
 * RIOT OS kernel developers list
-  devel@riot-os.org (http://lists.riot-os.org/mailman/listinfo/devel)
+  devel@riot-os.org (https://lists.riot-os.org/mailman/listinfo/devel)
 * RIOT OS users list
-  users@riot-os.org (http://lists.riot-os.org/mailman/listinfo/users)
+  users@riot-os.org (https://lists.riot-os.org/mailman/listinfo/users)
 * RIOT commits
-  commits@riot-os.org (http://lists.riot-os.org/mailman/listinfo/commits)
+  commits@riot-os.org (https://lists.riot-os.org/mailman/listinfo/commits)
 * Github notifications
-  notifications@riot-os.org (http://lists.riot-os.org/mailman/listinfo/notifications)
+  notifications@riot-os.org (https://lists.riot-os.org/mailman/listinfo/notifications)
 
 IRC
 ---
@@ -1400,18 +1400,18 @@ sponsored development time: Cisco Systems, Eistec, Ell-i, Enigeering Spirit, Nor
 
 More information
 ================
-http://www.riot-os.org
+https://www.riot-os.org
 
 Mailing lists
 -------------
 * RIOT OS kernel developers list
-  devel@riot-os.org (http://lists.riot-os.org/mailman/listinfo/devel)
+  devel@riot-os.org (https://lists.riot-os.org/mailman/listinfo/devel)
 * RIOT OS users list
-  users@riot-os.org (http://lists.riot-os.org/mailman/listinfo/users)
+  users@riot-os.org (https://lists.riot-os.org/mailman/listinfo/users)
 * RIOT commits
-  commits@riot-os.org (http://lists.riot-os.org/mailman/listinfo/commits)
+  commits@riot-os.org (https://lists.riot-os.org/mailman/listinfo/commits)
 * Github notifications
-  notifications@riot-os.org (http://lists.riot-os.org/mailman/listinfo/notifications)
+  notifications@riot-os.org (https://lists.riot-os.org/mailman/listinfo/notifications)
 
 IRC
 ---
@@ -1710,18 +1710,18 @@ Spirit, Nordic, FreshTemp LLC, OTAkeys and Phytec.
 
 More information
 ================
-http://www.riot-os.org
+https://www.riot-os.org
 
 Mailing lists
 -------------
 * RIOT OS kernel developers list
-  devel@riot-os.org (http://lists.riot-os.org/mailman/listinfo/devel)
+  devel@riot-os.org (https://lists.riot-os.org/mailman/listinfo/devel)
 * RIOT OS users list
-  users@riot-os.org (http://lists.riot-os.org/mailman/listinfo/users)
+  users@riot-os.org (https://lists.riot-os.org/mailman/listinfo/users)
 * RIOT commits
-  commits@riot-os.org (http://lists.riot-os.org/mailman/listinfo/commits)
+  commits@riot-os.org (https://lists.riot-os.org/mailman/listinfo/commits)
 * Github notifications
-  notifications@riot-os.org (http://lists.riot-os.org/mailman/listinfo/notifications)
+  notifications@riot-os.org (https://lists.riot-os.org/mailman/listinfo/notifications)
 
 IRC
 ---
@@ -1919,18 +1919,18 @@ Eistec, Ell-i, Enigeering Spirit, Nordic, FreshTemp LLC, and Phytec.
 
 More information
 ================
-http://www.riot-os.org
+https://www.riot-os.org
 
 Mailing lists
 -------------
 * RIOT OS kernel developers list
- * devel@riot-os.org (http://lists.riot-os.org/mailman/listinfo/devel)
+ * devel@riot-os.org (https://lists.riot-os.org/mailman/listinfo/devel)
 * RIOT OS users list
- * users@riot-os.org (http://lists.riot-os.org/mailman/listinfo/users)
+ * users@riot-os.org (https://lists.riot-os.org/mailman/listinfo/users)
  * RIOT commits
-  * commits@riot-os.org (http://lists.riot-os.org/mailman/listinfo/commits)
+  * commits@riot-os.org (https://lists.riot-os.org/mailman/listinfo/commits)
 * Github notifications
- * notifications@riot-os.org  (http://lists.riot-os.org/mailman/listinfo/notifications)
+ * notifications@riot-os.org  (https://lists.riot-os.org/mailman/listinfo/notifications)
 
 IRC
 ---
@@ -2144,18 +2144,18 @@ Cisco Systems, Eistec, Ell-i, Enigeering Spirit, FreshTemp LLC, and Phytec.
 
 More information
 ================
-http://www.riot-os.org
+https://www.riot-os.org
 
 Mailing lists
 -------------
 * RIOT OS kernel developers list
- * devel@riot-os.org (http://lists.riot-os.org/mailman/listinfo/devel)
+ * devel@riot-os.org (https://lists.riot-os.org/mailman/listinfo/devel)
 * RIOT OS users list
- * users@riot-os.org (http://lists.riot-os.org/mailman/listinfo/users)
+ * users@riot-os.org (https://lists.riot-os.org/mailman/listinfo/users)
  * RIOT commits
-  * commits@riot-os.org (http://lists.riot-os.org/mailman/listinfo/commits)
+  * commits@riot-os.org (https://lists.riot-os.org/mailman/listinfo/commits)
 * Github notifications
- * notifications@riot-os.org  (http://lists.riot-os.org/mailman/listinfo/notifications)
+ * notifications@riot-os.org  (https://lists.riot-os.org/mailman/listinfo/notifications)
 
  IRC
  -----
@@ -2195,7 +2195,7 @@ This release is mostly a clean-up and bug-fixing release. Besides that, it intro
 the [S]ensor [A]ctuator [U]ber [L]ayer, which offers a unified API to interact with all
 different types of sensors and actuators on RIOT supported hardware. Furthermore, it re-enables
 the support for ICN by integrating CCN-Lite as a package. A lot of new overall documentation was
-added and existing documentation was improved (http://riot-os.org/api/). In addition,
+added and existing documentation was improved (https://riot-os.org/api/). In addition,
 a Vagrant (https://www.vagrantup.com/) configuration file was added to the RIOT repository in
 order to create reproducible and portable environments that contain all necessary toolchains.
 
@@ -2371,18 +2371,18 @@ Cisco Systems, Google, Eistec, Ell-i, Engineering Spirit, FreshTemp LLC, and Phy
 
 More information
 ================
-http://www.riot-os.org
+https://www.riot-os.org
 
 Mailing lists
 -------------
 * RIOT OS kernel developers list
- * devel@riot-os.org (http://lists.riot-os.org/mailman/listinfo/devel)
+ * devel@riot-os.org (https://lists.riot-os.org/mailman/listinfo/devel)
 * RIOT OS users list
- * users@riot-os.org (http://lists.riot-os.org/mailman/listinfo/users)
+ * users@riot-os.org (https://lists.riot-os.org/mailman/listinfo/users)
 * RIOT commits
- * commits@riot-os.org (http://lists.riot-os.org/mailman/listinfo/commits)
+ * commits@riot-os.org (https://lists.riot-os.org/mailman/listinfo/commits)
 * Github notifications
- * notifications@riot-os.org  (http://lists.riot-os.org/mailman/listinfo/notifications)
+ * notifications@riot-os.org  (https://lists.riot-os.org/mailman/listinfo/notifications)
 
 IRC
 -----
@@ -2663,18 +2663,18 @@ Ell-i, FreshTemp LLC, and Phytec.
 
 More information
 ================
-http://www.riot-os.org
+https://www.riot-os.org
 
 Mailing lists
 -------------
 * RIOT OS kernel developers list
- * devel@riot-os.org (http://lists.riot-os.org/mailman/listinfo/devel)
+ * devel@riot-os.org (https://lists.riot-os.org/mailman/listinfo/devel)
 * RIOT OS users list
- * users@riot-os.org (http://lists.riot-os.org/mailman/listinfo/users)
+ * users@riot-os.org (https://lists.riot-os.org/mailman/listinfo/users)
 * RIOT commits
- * commits@riot-os.org (http://lists.riot-os.org/mailman/listinfo/commits)
+ * commits@riot-os.org (https://lists.riot-os.org/mailman/listinfo/commits)
 * Github notifications
- * notifications@riot-os.org  (http://lists.riot-os.org/mailman/listinfo/notifications)
+ * notifications@riot-os.org  (https://lists.riot-os.org/mailman/listinfo/notifications)
 
 IRC
 -----
@@ -2900,18 +2900,18 @@ We like to give our special thanks to all the companies that provided us with th
 
 More information
 ================
-http://www.riot-os.org
+https://www.riot-os.org
 
 Mailing lists
 -------------
 * RIOT OS kernel developers list
- * devel@riot-os.org (http://lists.riot-os.org/mailman/listinfo/devel)
+ * devel@riot-os.org (https://lists.riot-os.org/mailman/listinfo/devel)
 * RIOT OS users list
- * users@riot-os.org (http://lists.riot-os.org/mailman/listinfo/users)
+ * users@riot-os.org (https://lists.riot-os.org/mailman/listinfo/users)
 * RIOT commits
- * commits@riot-os.org (http://lists.riot-os.org/mailman/listinfo/commits)
+ * commits@riot-os.org (https://lists.riot-os.org/mailman/listinfo/commits)
 * Github notifications
- * notifications@riot-os.org  (http://lists.riot-os.org/mailman/listinfo/notifications)
+ * notifications@riot-os.org  (https://lists.riot-os.org/mailman/listinfo/notifications)
 
 License
 =======
@@ -3094,18 +3094,18 @@ https://github.com/RIOT-OS/RIOT/issues
 
 More information
 ================
-http://www.riot-os.org
+https://www.riot-os.org
 
 Mailing lists
 -------------
 * RIOT OS kernel developers list
- * devel@riot-os.org (http://lists.riot-os.org/mailman/listinfo/devel)
+ * devel@riot-os.org (https://lists.riot-os.org/mailman/listinfo/devel)
 * RIOT OS users list
- * users@riot-os.org (http://lists.riot-os.org/mailman/listinfo/users)
+ * users@riot-os.org (https://lists.riot-os.org/mailman/listinfo/users)
 * RIOT commits
- * commits@riot-os.org (http://lists.riot-os.org/mailman/listinfo/commits)
+ * commits@riot-os.org (https://lists.riot-os.org/mailman/listinfo/commits)
 * Github notifications
- * notifications@riot-os.org  (http://lists.riot-os.org/mailman/listinfo/notifications)
+ * notifications@riot-os.org  (https://lists.riot-os.org/mailman/listinfo/notifications)
 
 License
 =======
@@ -3255,18 +3255,18 @@ Hardware Support
 
 More information
 ================
-http://www.riot-os.org
+https://www.riot-os.org
 
 Mailing lists
 -------------
 * RIOT OS kernel developers list
- * devel@riot-os.org (http://lists.riot-os.org/mailman/listinfo/devel)
+ * devel@riot-os.org (https://lists.riot-os.org/mailman/listinfo/devel)
 * RIOT OS users list
- * users@riot-os.org (http://lists.riot-os.org/mailman/listinfo/users)
+ * users@riot-os.org (https://lists.riot-os.org/mailman/listinfo/users)
 * RIOT commits
- * commits@riot-os.org (http://lists.riot-os.org/mailman/listinfo/commits)
+ * commits@riot-os.org (https://lists.riot-os.org/mailman/listinfo/commits)
 * Github notifications
- * notifications@riot-os.org  (http://lists.riot-os.org/mailman/listinfo/notifications)
+ * notifications@riot-os.org  (https://lists.riot-os.org/mailman/listinfo/notifications)
 
 License
 =======

--- a/sys/include/net/gnrc.h
+++ b/sys/include/net/gnrc.h
@@ -10,9 +10,9 @@
  * @defgroup    net_gnrc    Generic (GNRC) network stack
  * @ingroup     net
  * @brief       RIOT's modular default IP network stack.
- * @see         [Martine Lenders' master thesis](http://doc.riot-os.org/mlenders_msc.pdf)
+ * @see         [Martine Lenders' master thesis](https://doc.riot-os.org/mlenders_msc.pdf)
  *              about GNRC's design and evaluation and the slide set of
- *              [its defense](http://doc.riot-os.org/mlenders_msc_def.pdf).
+ *              [its defense](https://doc.riot-os.org/mlenders_msc_def.pdf).
  *
  * About
  * =====

--- a/tests/lwip_sock_ip/README.md
+++ b/tests/lwip_sock_ip/README.md
@@ -2,7 +2,7 @@ Tests for lwIP's sock_ip port
 =============================
 
 This tests the `sock_ip` port of lwIP. There is no network device needed since
-a [virtual device](http://doc.riot-os.org/group__sys__netdev__test.html) is
+a [virtual device](https://doc.riot-os.org/group__sys__netdev__test.html) is
 provided at the backend.
 
 These tests test both IPv4 and IPv6 capabilities. They can be activated by

--- a/tests/lwip_sock_tcp/README.md
+++ b/tests/lwip_sock_tcp/README.md
@@ -2,7 +2,7 @@ Tests for lwIP's sock_tcp port
 ==============================
 
 This tests the `sock_tcp` port of lwIP. There is no network device needed since
-a [virtual device](http://doc.riot-os.org/group__sys__netdev__test.html) is
+a [virtual device](https://doc.riot-os.org/group__sys__netdev__test.html) is
 provided at the backend.
 
 These tests test both IPv4 and IPv6 capabilities. They can be activated by

--- a/tests/lwip_sock_udp/README.md
+++ b/tests/lwip_sock_udp/README.md
@@ -2,7 +2,7 @@ Tests for lwIP's sock_udp port
 ==============================
 
 This tests the `sock_udp` port of lwIP. There is no network device needed since
-a [virtual device](http://doc.riot-os.org/group__sys__netdev__test.html) is
+a [virtual device](https://doc.riot-os.org/group__sys__netdev__test.html) is
 provided at the backend.
 
 These tests test both IPv4 and IPv6 capabilities. They can be activated by


### PR DESCRIPTION
### Contribution description

Just changed all links of riot-os.org from http to https

### Testing procedure

Click and check links -> every website supports https

### Issues/PRs references

nope