### PR TITLE
gnrc_pktbuf: deprecate gnrc_pktbuf_duplicate_upto

### DIFF
--- a/sys/include/net/gnrc/pktbuf.h
+++ b/sys/include/net/gnrc/pktbuf.h
@@ -285,6 +285,11 @@ gnrc_pktsnip_t *gnrc_pktbuf_reverse_snips(gnrc_pktsnip_t *pkt);
  *
  *        The original snip is keeped as is except `users` decremented.
  *
+ * @deprecated  This function breaks the abstraction of `gnrc_pktbuf` and its
+ *              only user within the RIOT code base `gnrc_ipv6_ext` is going to
+ *              be reworked so it isn't needed anymore.
+ *              It will be removed after the 2019.04 release.
+ *
  * @param[in,out] pkt   The snip to duplicate.
  * @param[in]     type  The type of snip to stop duplication.
  *


### PR DESCRIPTION
### Contribution description
The function `gnrc_pktbuf_duplicate_upto()` breaks the abstraction of `gnrc_pktbuf` and its only user within the RIOT code base `gnrc_ipv6_ext` was reworked in #10234 so it isn't needed anymore.

### Testing procedure
Compile doxygen `make doc` and have a look at `doc/doxygen/html/deprecated.html`.

### Issues/PRs references
The function becomes obsolete with #10234, but it doesn't hurt to deprecate the function beforehand.