### PR TITLE
makefiles/tools/serial: Check empty port

### DIFF
--- a/.murdock
+++ b/.murdock
@@ -194,6 +194,11 @@ compile() {
     [ ! -d "$appdir" ] && error "$0: compile: error: application directory \"$appdir\" doesn't exist"
     [ ! -d "boards/$board" ] && error "$0: compile: error: board directory \"boards/$board\" doesn't exist"
 
+    # Try removing PORT that should be already be set by murdock
+    #     https://github.com/RIOT-OS/RIOT/pull/7695#discussion_r180896514
+    # to let the auto-detection work and fail in murdock
+    unset PORT
+
     # compile
     CCACHE_BASEDIR="$(pwd)" BOARD=$board TOOLCHAIN=$toolchain RIOT_CI_BUILD=1 \
         make -C${appdir} clean all test-input-hash -j${JOBS:-4}

--- a/Makefile.include
+++ b/Makefile.include
@@ -86,6 +86,9 @@ OS := $(shell uname)
 # set python path, e.g. for tests
 PYTHONPATH := $(RIOTBASE)/dist/pythonlibs/:$(PYTHONPATH)
 
+# Basic utilities included before anything else
+include $(RIOTMAKE)/utils/checks.mk
+
 # Include Docker settings near the top because we need to build the environment
 # command line before some of the variable origins are overwritten below when
 # using abspath, strip etc.

--- a/boards/native/Makefile.include
+++ b/boards/native/Makefile.include
@@ -95,9 +95,9 @@ export LINKFLAGS += -ffunction-sections
 
 # set the tap interface for term/valgrind
 ifneq (,$(filter netdev_default gnrc_netdev_default,$(USEMODULE)))
-  export PORT ?= tap0
+  PORT ?= tap0
 else
-  export PORT =
+  PORT =
 endif
 
 TERMFLAGS := $(PORT) $(TERMFLAGS)

--- a/dist/tools/usb-serial/README.md
+++ b/dist/tools/usb-serial/README.md
@@ -41,29 +41,14 @@ solution):
     # Add serial matching command
     ifneq ($(PROGRAMMER_SERIAL),)
       OOCD_BOARD_FLAGS += -c 'ftdi_serial $(PROGRAMMER_SERIAL)'
-
-      ifeq ($(PORT),)
-        # try to find tty name by serial number, only works on Linux currently.
-        ifeq ($(OS),Linux)
-          PORT := $(firstword $(shell $(RIOTTOOLS)/usb-serial/find-tty.sh "^$(PROGRAMMER_SERIAL)$$"))
-        endif
-      endif
     endif
 
-    # Fallback PORT if no serial was specified or if the specified serial was not found
-    ifeq ($(PORT),)
-        ifeq ($(OS),Linux)
-          PORT := $(firstword $(shell $(RIOTTOOLS)/usb-serial/find-tty.sh))
-        else ifeq ($(OS),Darwin)
-          PORT := $(shell ls -1 /dev/tty.SLAB_USBtoUART* | head -n 1)
-        endif
-    endif
+    PORT_LINUX_EXACT = $(if $(PROGRAMMER_SERIAL),$(firstword $(shell $(RIOTTOOLS)/usb-serial/find-tty.sh "^$(PROGRAMMER_SERIAL)$$")),)
 
-    # TODO: add support for windows as host platform
-    ifeq ($(PORT),)
-      $(info CAUTION: No terminal port for your host system found!)
-    endif
-    export PORT
+    PORT_LINUX = $(if $(PORT_LINUX_EXACT),$(PORT_LINUX_EXACT),$(firstword $(shell $(RIOTTOOLS)/usb-serial/find-tty.sh)))
+
+    PORT_DARWIN = $(shell ls -1 /dev/tty.SLAB_USBtoUART* | head -n 1)
+
 
 
 Limitations

--- a/makefiles/tools/serial.inc.mk
+++ b/makefiles/tools/serial.inc.mk
@@ -1,12 +1,9 @@
 # set default port depending on operating system
 OS := $(shell uname)
 ifeq ($(OS),Linux)
-  PORT ?= $(PORT_LINUX)
+  PORT ?= $(call ensure_value,$(PORT_LINUX),No port set)
 else ifeq ($(OS),Darwin)
-  PORT ?= $(PORT_DARWIN)
-endif
-ifeq ($(PORT),)
-  $(info Warning: no PORT set!)
+  PORT ?= $(call ensure_value,$(PORT_DARWIN),No port set)
 endif
 
 export BAUD ?= 115200

--- a/makefiles/tools/serial.inc.mk
+++ b/makefiles/tools/serial.inc.mk
@@ -8,7 +8,6 @@ endif
 ifeq ($(PORT),)
   $(info Warning: no PORT set!)
 endif
-export PORT
 
 export BAUD ?= 115200
 

--- a/makefiles/vars.inc.mk
+++ b/makefiles/vars.inc.mk
@@ -74,7 +74,7 @@ export GIT_CACHE_DIR         # path to git-cache cache directory
 export FLASH_ADDR            # Define an offset to flash code into ROM memory.
 # TERMPROG                   # The command to call on "make term".
 # TERMFLAGS                  # Additional parameters to supply to TERMPROG.
-export PORT                  # The port to connect the TERMPROG to.
+# PORT                       # The port to connect the TERMPROG to.
 export ELFFILE               # The unstripped result of the compilation.
 export HEXFILE               # The stripped result of the compilation.
 # FLASHFILE                  # The output file used for flashing (transition phase: only if defined)


### PR DESCRIPTION
___Please note, the github UI shows commits in the wrong order.___

### Contribution description

By ensuring the PORT auto-detection worked, we can give meaningful error messages and fail earlier.

### Remarks

Hopefully this serves to illustrate why gratuitous usage of `export` and `:=` should be avoided in makefiles. 

I'm thinking on putting these kind of helper functions in a separate `utils.mk` modules.

### Testing procedure

Try to `make term` for `BOARD=cc2538dk` without any connected board and see how it fails. You should still be able to `make` with no problems or warnings.

### Issues/PRs references

Parallel to #7695.
Contains some changes by (and made on request of, and with assistance of) @cladmi 
Depends on ~#10439~, ~#10440~

