### PR TITLE
boards/stm32l0: Fix openocd to prevent flash locking

### DIFF
--- a/boards/b-l072z-lrwan1/dist/openocd.cfg
+++ b/boards/b-l072z-lrwan1/dist/openocd.cfg
@@ -1,5 +1,0 @@
-source [find target/stm32l0.cfg]
-
-reset_config srst_only connect_assert_srst
-
-$_TARGETNAME configure -rtos auto

--- a/boards/common/stm32/dist/stm32l0.cfg
+++ b/boards/common/stm32/dist/stm32l0.cfg
@@ -1,3 +1,3 @@
 source [find target/stm32l0.cfg]
-reset_config srst_only
+reset_config srst_only connect_assert_srst
 $_TARGETNAME configure -rtos auto


### PR DESCRIPTION
### Contribution description

This commit add the connect_assert_srst which requires the SRST to be asserted before trying to connect.
Certain firmwares will cause it to get to a state where flashing fails and the reset button must be pushed at the correct time to recover.

### Testing procedure
on 7645c66aeb584a643d7356ba41f1ecf80b06dfe8 commit
`BOARD=nucleo-l073rz make flash -C tests/driver_my9221`
then try flashing anything after.
_It seems in master the driver_my9221 doesn't cause lockup anymore but if it is already locked up it doesn't fix it (this pr does)._


### Issues/PRs references
Fixes #10341
