### PR TITLE
Makefile.include: remove rule to remake PKGs' Makefile.include

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -357,10 +357,6 @@ include $(RIOTBASE)/sys/Makefile.include
 include $(RIOTBASE)/drivers/Makefile.include
 
 # include Makefile.includes for packages in $(USEPKG)
-$(RIOTPKG)/%/Makefile.include::
-	$(Q)"$(MAKE)" -C $(RIOTPKG)/$* Makefile.include
-
-$(USEPKG:%=$(RIOTPKG)/%/Makefile.include): FORCE
 -include $(USEPKG:%=$(RIOTPKG)/%/Makefile.include)
 
 # include external modules configuration
@@ -488,7 +484,7 @@ endef
 
 # The `clean` needs to be serialized before everything else.
 ifneq (, $(filter clean, $(MAKECMDGOALS)))
-    all $(BASELIBS) $(USEPKG:%=$(RIOTPKG)/%/Makefile.include) $(BUILDDEPS) ..in-docker-container: clean
+    all $(BASELIBS) $(BUILDDEPS) ..in-docker-container: clean
 endif
 
 .PHONY: pkg-prepare pkg-build pkg-build-%


### PR DESCRIPTION
### Contribution description

This rule is not being used, it complicates the makefile and causes make clean to permform unnecessary actions.

All packages have a Makefile.include, so the rule is not needed anyways:

1. Generating a file in the source tree is bad practice.
2. The contents of Makefile.include should be fixed.

Also, it is defined with a double colon for no reason.


### Testing procedure

Everything should continue to work as always (this can be tested by the CI.)

Run `make clean` from the RIOT base with and without this commit. Without this commit you will see that there are several `Makefile.include` that are processed for nothing.

### Issues/PRs references

Undoes part of #576.
Depends on #10456 (fixes weird make concurrency issues).