### PR TITLE
gnrc_ipv6: don't recurse into receive for encapsulated IPv6 [backport 2018.10]

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
+++ b/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
@@ -907,7 +907,10 @@ static void _decapsulate(gnrc_pktsnip_t *pkt)
 
     pkt->type = GNRC_NETTYPE_IPV6;
 
-    _receive(pkt);
+    if (gnrc_netapi_dispatch_receive(GNRC_NETTYPE_IPV6,
+                                     GNRC_NETREG_DEMUX_CTX_ALL, pkt) == 0) {
+        gnrc_pktbuf_release(pkt);
+    }
 }
 
 /** @} */

--- a/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
+++ b/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
@@ -213,9 +213,11 @@ static void _dispatch_next_header(gnrc_pktsnip_t *current, gnrc_pktsnip_t *pkt,
 {
 #ifdef MODULE_GNRC_IPV6_EXT
     const bool should_dispatch_current_type = ((current->type != GNRC_NETTYPE_IPV6_EXT) ||
-                                               (current->next->type == GNRC_NETTYPE_IPV6));
+                                               (current->next->type == GNRC_NETTYPE_IPV6)) &&
+                                              (current->type != GNRC_NETTYPE_IPV6);
 #else
-    const bool should_dispatch_current_type = (current->next->type == GNRC_NETTYPE_IPV6);
+    const bool should_dispatch_current_type = (current->next->type == GNRC_NETTYPE_IPV6) &&
+                                              (current->type != GNRC_NETTYPE_IPV6);
 #endif
 
     DEBUG("ipv6: forward nh = %u to other threads\n", nh);


### PR DESCRIPTION
# Backport of #10246

### Contribution description
`_decapsulate()` is called by callees of `_receive()` so the call to
the latter function within the first creates a recursion we don't want.
Using `gnrc_netapi` instead removes that and provides the added benefit
that other subscribers to IPv6 are also informed.

### Testing procedure
Send an encapsulated IPv6 packet to a node. It should still be parsed properly.

### Issues/PRs references
~~None, but related to the IPv6 refactoring project~~ (the project is not required for the release ;-))