### PR TITLE
gnrc: fix several issues found with LLVM's static code analyzer

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-router.h
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-router.h
@@ -57,6 +57,8 @@ static inline void _init_iface_router(gnrc_netif_t *netif)
  *          [route info callback](@ref gnrc_netif_ipv6_t::route_info_cb) of an
  *          interface
  *
+ * @pre `netif != NULL`.
+ *
  * @param[in] netif     An interface.
  * @param[in] type      [Type](@ref net_gnrc_ipv6_nib_route_info_type) of the
  *                      route info.
@@ -67,6 +69,7 @@ static inline void _call_route_info_cb(gnrc_netif_t *netif, unsigned type,
                                        const ipv6_addr_t *ctx_addr,
                                        const void *ctx)
 {
+    assert(netif != NULL);
     if (netif->ipv6.route_info_cb != NULL) {
         netif->ipv6.route_info_cb(type, ctx_addr, ctx);
     }

--- a/sys/net/gnrc/network_layer/sixlowpan/iphc/gnrc_sixlowpan_iphc.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/iphc/gnrc_sixlowpan_iphc.c
@@ -454,6 +454,7 @@ void gnrc_sixlowpan_iphc_recv(gnrc_pktsnip_t *sixlo, void *rbuf_ptr,
             break;
 
         case IPHC_M_DAC_DAM_U_CTX_64:
+            assert(ctx != NULL);
             memcpy(ipv6_hdr->dst.u8 + 8, iphc_hdr + payload_offset, 8);
             ipv6_addr_init_prefix(&ipv6_hdr->dst, &ctx->prefix,
                                   ctx->prefix_len);
@@ -464,6 +465,7 @@ void gnrc_sixlowpan_iphc_recv(gnrc_pktsnip_t *sixlo, void *rbuf_ptr,
             ipv6_hdr->dst.u32[2] = byteorder_htonl(0x000000ff);
             ipv6_hdr->dst.u16[6] = byteorder_htons(0xfe00);
             memcpy(ipv6_hdr->dst.u8 + 14, iphc_hdr + payload_offset, 2);
+            assert(ctx != NULL);
             ipv6_addr_init_prefix(&ipv6_hdr->dst, &ctx->prefix,
                                   ctx->prefix_len);
             payload_offset += 2;
@@ -477,6 +479,7 @@ void gnrc_sixlowpan_iphc_recv(gnrc_pktsnip_t *sixlo, void *rbuf_ptr,
                 _recv_error_release(sixlo, ipv6, rbuf);
                 return;
             }
+            assert(ctx != NULL);
             ipv6_addr_init_prefix(&ipv6_hdr->dst, &ctx->prefix,
                                   ctx->prefix_len);
             break;
@@ -509,6 +512,7 @@ void gnrc_sixlowpan_iphc_recv(gnrc_pktsnip_t *sixlo, void *rbuf_ptr,
 
         case IPHC_M_DAC_DAM_M_UC_PREFIX:
             do {
+                assert(ctx != NULL);
                 uint8_t orig_ctx_len = ctx->prefix_len;
 
                 ipv6_addr_set_unspecified(&ipv6_hdr->dst);

--- a/sys/net/gnrc/routing/rpl/gnrc_rpl_dodag.c
+++ b/sys/net/gnrc/routing/rpl/gnrc_rpl_dodag.c
@@ -305,7 +305,7 @@ void gnrc_rpl_parent_update(gnrc_rpl_dodag_t *dodag, gnrc_rpl_parent_t *parent)
 static gnrc_rpl_parent_t *_gnrc_rpl_find_preferred_parent(gnrc_rpl_dodag_t *dodag)
 {
     gnrc_rpl_parent_t *old_best = dodag->parents;
-    gnrc_rpl_parent_t *new_best = old_best;
+    gnrc_rpl_parent_t *new_best;
     uint16_t old_rank = dodag->my_rank;
     gnrc_rpl_parent_t *elt = NULL;
     gnrc_rpl_parent_t *tmp = NULL;

--- a/sys/shell/commands/sc_gnrc_netif.c
+++ b/sys/shell/commands/sc_gnrc_netif.c
@@ -348,7 +348,6 @@ static unsigned _netif_list_flag(kernel_pid_t iface, netopt_t opt, char *str,
 static void _netif_list_ipv6(ipv6_addr_t *addr, uint8_t flags)
 {
     char addr_str[IPV6_ADDR_MAX_STR_LEN];
-    unsigned line_thresh = _LINE_THRESHOLD;
 
     printf("inet6 addr: ");
     ipv6_addr_to_str(addr_str, addr, sizeof(addr_str));
@@ -379,19 +378,16 @@ static void _netif_list_ipv6(ipv6_addr_t *addr, uint8_t flags)
                 break;
         }
     }
-    line_thresh = _newline(0U, line_thresh);
+    puts("");
 }
 
 static void _netif_list_groups(ipv6_addr_t *addr)
 {
-    unsigned line_thresh = _LINE_THRESHOLD;
-
     if ((ipv6_addr_is_multicast(addr))) {
         char addr_str[IPV6_ADDR_MAX_STR_LEN];
         ipv6_addr_to_str(addr_str, addr, sizeof(addr_str));
-        printf("inet6 group: %s", addr_str);
+        printf("inet6 group: %s\n", addr_str);
     }
-    line_thresh = _newline(0U, line_thresh);
 }
 #endif
 
@@ -547,7 +543,7 @@ static void _netif_list(kernel_pid_t iface)
     printf("Link type: %s",
            (gnrc_netapi_get(iface, NETOPT_IS_WIRED, 0, &u16, sizeof(u16)) > 0) ?
             "wired" : "wireless");
-    line_thresh = _newline(0U, ++line_thresh);
+    _newline(0U, ++line_thresh);
     res = gnrc_netapi_get(iface, NETOPT_IPV6_ADDR, 0, ipv6_addrs,
                           sizeof(ipv6_addrs));
     if (res >= 0) {


### PR DESCRIPTION
### Contribution description
Fixes a few issues that were found when checking `gnrc_networking` with LLVM's static code analyzer.

### Testing procedure
Execute `make -C examples/gnrc_networking scan-build`. It should pass. For functionality tests I recommend to use the a subset of the tests outlined in the release specifications.

### Issues/PRs references
None