### PR TITLE
core: mutex: fix DEBUG pointer output

### DIFF
--- a/core/mutex.c
+++ b/core/mutex.c
@@ -74,8 +74,8 @@ void mutex_unlock(mutex_t *mutex)
 {
     unsigned irqstate = irq_disable();
 
-    DEBUG("mutex_unlock(): queue.next: 0x%08x pid: %" PRIkernel_pid "\n",
-          (unsigned)mutex->queue.next, sched_active_pid);
+    DEBUG("mutex_unlock(): queue.next: %p pid: %" PRIkernel_pid "\n",
+          (void *)mutex->queue.next, sched_active_pid);
 
     if (mutex->queue.next == NULL) {
         /* the mutex was not locked */
@@ -109,8 +109,8 @@ void mutex_unlock(mutex_t *mutex)
 
 void mutex_unlock_and_sleep(mutex_t *mutex)
 {
-    DEBUG("PID[%" PRIkernel_pid "]: unlocking mutex. queue.next: 0x%08x, and "
-          "taking a nap\n", sched_active_pid, (unsigned)mutex->queue.next);
+    DEBUG("PID[%" PRIkernel_pid "]: unlocking mutex. queue.next: %p, and "
+          "taking a nap\n", sched_active_pid, (void *)mutex->queue.next);
     unsigned irqstate = irq_disable();
 
     if (mutex->queue.next) {


### PR DESCRIPTION
### Contribution description
Out of interest after some offline discussions regarding #10121 I tried to compile `hello-world` for `native` without the `-m32` flag. Apart from obviously required adaptations in `cpu/native` (which needs some rework for 64-bit support), I only found some pointer conversion errors in the debug output of `core/mutex`. I don't know why the output originally was converted to an integer in 350c341ce1b1da19f840a12fc2c29bf3fab9647e, but maybe @kaspar030 can answer that?

### Testing procedure
`tests/mutex_order` should still compile with `ENABLE_DEBUG == 1` in `core/mutex.c` and provide sensible debug output.

### Issues/PRs references
None, but out of curiosity if #10121 can be fixed by providing 64-bit support.