### PR TITLE
gnrc_ipv6_nib: provide interface on packet queueing

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/nib/nib.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib.c
@@ -1151,6 +1151,19 @@ static bool _resolve_addr(const ipv6_addr_t *dst, gnrc_netif_t *netif,
                 gnrc_pktqueue_t *queue_entry = _alloc_queue_entry(pkt);
 
                 if (queue_entry != NULL) {
+                    if (netif != NULL) {
+                        gnrc_pktsnip_t *netif_hdr = gnrc_netif_hdr_build(
+                                NULL, 0, NULL, 0
+                            );
+                        if (netif_hdr == NULL) {
+                            DEBUG("nib: can't allocate netif header for queue\n");
+                            gnrc_pktbuf_release(pkt);
+                            queue_entry->pkt = NULL;
+                            return false;
+                        }
+                        ((gnrc_netif_hdr_t *)netif_hdr->data)->if_pid = netif->pid;
+                        LL_PREPEND(queue_entry->pkt, netif_hdr);
+                    }
                     gnrc_pktqueue_add(&entry->pktqueue, queue_entry);
                 }
             }


### PR DESCRIPTION
### Contribution description
During release testing I noticed that reproducibly the first ping is always timing out. Some investigation revealed that this is a bug in the address resolver that involves dropping any interface information it has, when it is queueing a packet for which it doesn't know the link-layer address yet.

Without this the first packet to a new link-local address will not be delivered in non-6Lo environments, since the interface is not provided. With this change, if an internet was provided to the address resolver it
will be stored within an allocated `gnrc_netif_hdr_t`.

At this point [IPv6 already striped](netif strip) the packet of its netif header, so there is no risk that there will be to, in case it was provided and the `netif` came from its existence.

### Testing procedure
Compile `gnrc_networking` for `native` and try to ping your TAP interface's / bridge's link-local address. The first ping will fail without this commit. With it it will succeed.

### Issues/PRs references
None