### PR TITLE
gnrc_ipv6_nib: fix several issues found with LLVM's static code analyzer (only critical)

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/nib/nib.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib.c
@@ -240,7 +240,7 @@ int gnrc_ipv6_nib_get_next_hop_l2addr(const ipv6_addr_t *dst,
                 gnrc_netif_acquire(netif);
             }
             node = _nib_onl_get(&route.next_hop,
-                                (netif == NULL) ? netif->pid : 0);
+                                (netif != NULL) ? netif->pid : 0);
             if (_resolve_addr(&route.next_hop, netif, pkt, nce, node)) {
                 _call_route_info_cb(netif,
                                     GNRC_IPV6_NIB_ROUTE_INFO_TYPE_RN,

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib_pl.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib_pl.c
@@ -29,7 +29,6 @@ int gnrc_ipv6_nib_pl_set(unsigned iface,
                          const ipv6_addr_t *pfx, unsigned pfx_len,
                          uint32_t valid_ltime, uint32_t pref_ltime)
 {
-    int res = 0;
     _nib_offl_entry_t *dst;
     ipv6_addr_t tmp = IPV6_ADDR_UNSPECIFIED;
 
@@ -47,7 +46,8 @@ int gnrc_ipv6_nib_pl_set(unsigned iface,
     dst = _nib_pl_add(iface, pfx, pfx_len, valid_ltime,
                       pref_ltime);
     if (dst == NULL) {
-        res = -ENOMEM;
+        mutex_unlock(&_nib_mutex);
+        return -ENOMEM;
     }
 #ifdef MODULE_GNRC_NETIF
     gnrc_netif_t *netif = gnrc_netif_get_by_pid(iface);
@@ -55,7 +55,7 @@ int gnrc_ipv6_nib_pl_set(unsigned iface,
 
     if (netif == NULL) {
         mutex_unlock(&_nib_mutex);
-        return res;
+        return 0;
     }
     gnrc_netif_acquire(netif);
     if (!gnrc_netif_is_6ln(netif) &&
@@ -83,7 +83,7 @@ int gnrc_ipv6_nib_pl_set(unsigned iface,
     /* update prefixes down-stream */
     _handle_snd_mc_ra(netif);
 #endif
-    return res;
+    return 0;
 }
 
 void gnrc_ipv6_nib_pl_del(unsigned iface,


### PR DESCRIPTION
### Contribution description
This takes out the most critical fixes out of #10350.

### Testing procedure
Execute make -C examples/gnrc_networking scan-build. It should pass. For functionality tests I recommend to use the a subset of the tests outlined in the release specifications.

### Issues/PRs references
Contains parts of #10350 but can be merged independently.