### PR TITLE
cpu/esp32: fixes compile problems

### DIFF
--- a/boards/common/esp32/include/board_common.h
+++ b/boards/common/esp32/include/board_common.h
@@ -23,6 +23,9 @@
 #ifndef BOARD_COMMON_H
 #define BOARD_COMMON_H
 
+/* not required when compiling ESP32 vendor code parts */
+#ifndef ESP32_IDF_CODE
+
 #include <stdint.h>
 
 #include "cpu.h"
@@ -161,5 +164,6 @@ void print_board_config (void);
 } /* end extern "C" */
 #endif
 
+#endif /* ESP32_IDF_CODE */
 #endif /* BOARD_COMMON_H */
 /** @} */

--- a/cpu/esp32/Makefile.dep
+++ b/cpu/esp32/Makefile.dep
@@ -31,6 +31,7 @@ ifneq (,$(filter esp_wifi_any,$(USEMODULE)))
     USEMODULE += esp_idf_wpa_supplicant_crypto
     USEMODULE += esp_idf_wpa_supplicant_port
     USEMODULE += esp_idf_nvs_flash
+    USEMODULE += riot_freertos
 
     # crypto and hashes produce symbol conflicts with esp_idf_wpa_supplicant_crypto
     DISABLE_MODULE += crypto
@@ -39,11 +40,12 @@ endif
 
 ifneq (,$(filter esp_idf_nvs_flash,$(USEMODULE)))
     # add additional modules required by esp_idf_nvs_flash
+    USEMODULE += mtd
     USEMODULE += pthread
 endif
 
-ifneq (,$(filter esp_idf_nvs_flash,$(USEMODULE)))
-    # add additional modules required by riot_riot_freertos
+ifneq (,$(filter riot_freertos,$(USEMODULE)))
+    # add additional modules required by riot_freertos
     USEMODULE += xtimer
 endif
 

--- a/cpu/esp32/Makefile.dep
+++ b/cpu/esp32/Makefile.dep
@@ -37,6 +37,16 @@ ifneq (,$(filter esp_wifi_any,$(USEMODULE)))
     DISABLE_MODULE += hashes
 endif
 
+ifneq (,$(filter esp_idf_nvs_flash,$(USEMODULE)))
+    # add additional modules required by esp_idf_nvs_flash
+    USEMODULE += pthread
+endif
+
+ifneq (,$(filter esp_idf_nvs_flash,$(USEMODULE)))
+    # add additional modules required by riot_riot_freertos
+    USEMODULE += xtimer
+endif
+
 ifneq (,$(filter esp_i2c_hw,$(USEMODULE)))
     USEMODULE += xtimer
 else
@@ -52,12 +62,11 @@ endif
 
 # each device has SPI flash memory, but must be explicitly enabled
 ifneq (,$(filter esp_spiffs,$(USEMODULE)))
-    USEMODULE += esp_idf_spi_flash
     USEMODULE += spiffs
-    USEMODULE += vfs
-    export SPIFFS_STD_OPTION = -std=c99
-    INCLUDES += -I$(RIOTBASE)/sys/include
-    INCLUDES += -I$(RIOTBASE)/sys/posix/include
+endif
+
+ifneq (,$(filter mtd,$(USEMODULE)))
+    USEMODULE += esp_idf_spi_flash
 endif
 
 ifneq (,$(filter ndn-riot,$(USEPKG)))

--- a/cpu/esp32/Makefile.include
+++ b/cpu/esp32/Makefile.include
@@ -126,7 +126,9 @@ ifneq (,$(filter esp_wifi_any,$(USEMODULE)))
     LINKFLAGS += $(BINDIR)/esp_idf_esp32.a
     LINKFLAGS += $(BINDIR)/esp_idf_nvs_flash.a
     LINKFLAGS += $(BINDIR)/esp_idf_spi_flash.a
+    LINKFLAGS += $(BINDIR)/pthread.a
     LINKFLAGS += $(BINDIR)/riot_freertos.a
+    LINKFLAGS += $(BINDIR)/xtimer.a
     LINKFLAGS += -lcore -lrtc -lnet80211 -lpp -lsmartconfig -lcoexist
     LINKFLAGS += -lwps -lwpa -lwpa2 -lespnow -lmesh -lphy -lstdc++
 endif

--- a/cpu/esp32/vendor/esp-idf/wpa_supplicant/src/crypto/Makefile
+++ b/cpu/esp32/vendor/esp-idf/wpa_supplicant/src/crypto/Makefile
@@ -7,14 +7,11 @@ include $(RIOTBASE)/Makefile.base
 INCLUDES  = -I$(RIOTCPU)/$(CPU)/vendor/esp-idf/wpa_supplicant/port/include
 INCLUDES += -I$(ESP32_SDK_DIR)/components/wpa_supplicant/include
 INCLUDES += -I$(ESP32_SDK_DIR)/components/wpa_supplicant/port/include
-CFLAGS += -D__ets__ -DESPRESSIF_USE
+CFLAGS += -D__ets__ -DESPRESSIF_USE -DESP32_IDF_CODE=1
 
 include $(RIOTCPU)/$(CPU)/Makefile.include
 
 INCLUDES += -I$(RIOTBASE)/core/include
-INCLUDES += -I$(RIOTBASE)/drivers/include
-INCLUDES += -I$(RIOTBASE)/sys/include
-INCLUDES += -I$(RIOTBASE)/sys/posix/include
 INCLUDES += -I$(RIOTCPU)/$(CPU)/vendor/esp-idf/include/log
 INCLUDES += -I$(RIOTCPU)/$(CPU)/include
 INCLUDES += -I$(RIOTBOARD)/$(BOARD)/include


### PR DESCRIPTION
### Contribution description

This PR fixes the following compilation problems:

-  bypassing the module management system by directly accesing posix headers without depending on the ```posix``` module as described in PR #10357 
- compile error when using a WiFi module such as ```esp_now``` due to lack of dependency on the pthread module
- different other minor dependency inconsistencies when WiFi modules like ```esp_now``` are used

### Testing procedure

Try to compile a test application with a combination of ```spiffs``` and ```esp_now``` modules, e.g.:
```
USEMODULE="spiffs esp_now" make BOARD=esp32-wroom-32 -C tests/shell
```
The compilation should be successful.

### Issues/PRs references

See also PR #10357.