### PR TITLE
print_toolchain_versions.sh: Add make command version

### DIFF
--- a/dist/tools/ci/print_toolchain_versions.sh
+++ b/dist/tools/ci/print_toolchain_versions.sh
@@ -98,7 +98,7 @@ printf "%23s: %s\n" "avr-libc" "$(avr_libc_version avr-gcc)"
 printf "\n"
 printf "%s\n" "Installed development tools"
 printf "%s\n" "---------------------------"
-for c in cmake cppcheck doxygen flake8 git openocd python python2 python3; do
+for c in cmake cppcheck doxygen flake8 git make openocd python python2 python3; do
     printf "%23s: %s\n" "$c" "$(get_cmd_version $c)"
 done
 printf "%23s: %s\n" "coccinelle" "$(get_cmd_version spatch)"


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Adds a line for the version of the `make` program installed.

### Testing procedure

run dist/tools/ci/print_toolchain_versions.sh


### Issues/PRs references

#9961 