### PR TITLE
gnrc_ipv6_nib/arsm: ensure proper int width in backoff calculation

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-arsm.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-arsm.c
@@ -514,18 +514,10 @@ bool _is_reachable(_nib_onl_entry_t *entry)
 static inline uint32_t _exp_backoff_retrans_timer(uint8_t ns_sent,
                                                   uint32_t retrans_timer)
 {
-    uint32_t tmp = random_uint32_range(NDP_MIN_RANDOM_FACTOR,
-                                       NDP_MAX_RANDOM_FACTOR);
+    uint32_t factor = random_uint32_range(NDP_MIN_RANDOM_FACTOR,
+                                          NDP_MAX_RANDOM_FACTOR);
 
-    /* backoff according to  https://tools.ietf.org/html/rfc7048 with
-     * BACKOFF_MULTIPLE == 2 */
-    tmp = (uint32_t)(((uint64_t)(((uint32_t) 1) << ns_sent) * retrans_timer *
-                     tmp) / US_PER_MS);
-    /* random factors were statically multiplied with 1000 ^ */
-    if (tmp > NDP_MAX_RETRANS_TIMER_MS) {
-        tmp = NDP_MAX_RETRANS_TIMER_MS;
-    }
-    return tmp;
+    return _exp_backoff_retrans_timer_factor(ns_sent, retrans_timer, factor);
 }
 
 #if GNRC_IPV6_NIB_CONF_REDIRECT

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-arsm.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-arsm.c
@@ -519,7 +519,8 @@ static inline uint32_t _exp_backoff_retrans_timer(uint8_t ns_sent,
 
     /* backoff according to  https://tools.ietf.org/html/rfc7048 with
      * BACKOFF_MULTIPLE == 2 */
-    tmp = ((1 << ns_sent) * retrans_timer * tmp) / US_PER_MS;
+    tmp = (uint32_t)(((uint64_t)(((uint32_t) 1) << ns_sent) * retrans_timer *
+                     tmp) / US_PER_MS);
     /* random factors were statically multiplied with 1000 ^ */
     if (tmp > NDP_MAX_RETRANS_TIMER_MS) {
         tmp = NDP_MAX_RETRANS_TIMER_MS;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Otherwise, the result might flow over on 8/16-bit platforms

### Testing procedure
I'm not sure the address resolution state machine fits on any of our 8/16-bit platforms... But otherwise: 

* flash an application with `gnrc_ipv6_default` an `GNRC_IPV6_NIB_CONF_ARSM == 1` to two 8- or 16-bit boards with networking capabilities
* let them find via neighbor discovery (e.g. by pinging one from the other)
* let the neighbor information go STALE (check with `nib neigh`)
* let one of the nodes become unreachable (e.g. by turning it off)
* try to update stale neighbor information (e.g. by pinging again)
* let the neighbor information go to UNREACHABLE (check with `nib neigh`)
* see (e.g. with wireshark) that the neighbor solicitations go out ad infinitum but with an truncated (at `NDP_MAX_RETRANS_TIMER_MS` == 1min) exponential (base 2) backoff between them.
* run `unittests` with `tests-gnrc_ipv6_nib` on various platforms.

### Issues/PRs references
Pointed out in https://github.com/RIOT-OS/RIOT/pull/10350#discussion_r231905390
