### PR TITLE
gnrc_netif: Also call init on reset

### DIFF
--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -345,6 +345,9 @@ int gnrc_netif_set_from_netdev(gnrc_netif_t *netif,
                 case NETOPT_STATE:
                     if (*((netopt_state_t *)opt->data) == NETOPT_STATE_RESET) {
                         _configure_netdev(netif->dev);
+                        if (netif->ops->init) {
+                            netif->ops->init(netif);
+                        }
                     }
                     break;
                 default:


### PR DESCRIPTION
### Contribution description

This enhancement modifies gnrc_netif to also call the link layer specific init function when a device is reset.

### Testing procedure

AFAIK only gomach and lwmac make use of the init functions at the moment and both don't handle a RESET correctly. I honestly don't really know how to test this except by checking the code.

### Issues/PRs references

Nothing immediately.