### PR TITLE
WIP: pm_layered: print block/unblock

### DIFF
--- a/sys/include/pm_layered.h
+++ b/sys/include/pm_layered.h
@@ -54,14 +54,24 @@ extern "C" {
  *
  * @param[in]   mode      power mode to block
  */
+#ifdef PM_PRINT
+void _pm_block(unsigned mode, const char *caller);
+#define pm_block(x) _pm_block((x), __func__)
+#else
 void pm_block(unsigned mode);
+#endif
 
 /**
  * @brief   Unblock a power mode
  *
  * @param[in]   mode      power mode to unblock
  */
+#ifdef PM_PRINT
+void _pm_unblock(unsigned mode, const char *caller);
+#define pm_unblock(x) _pm_unblock((x), __func__)
+#else
 void pm_unblock(unsigned mode);
+#endif
 
 /**
  * @brief   Switches the MCU to a new power mode

--- a/sys/pm_layered/pm.c
+++ b/sys/pm_layered/pm.c
@@ -19,6 +19,7 @@
  */
 
 #include "irq.h"
+#include "log.h"
 #include "periph/pm.h"
 #include "pm_layered.h"
 
@@ -69,21 +70,35 @@ void pm_set_lowest(void)
     irq_restore(state);
 }
 
+#ifndef PM_PRINT
 void pm_block(unsigned mode)
+#else
+void _pm_block(unsigned mode, const char *caller)
+#endif
 {
     assert(pm_blocker.val_u8[mode] != 255);
 
     unsigned state = irq_disable();
     pm_blocker.val_u8[mode]++;
+#ifdef PM_PRINT
+    LOG_INFO("pm_block %s mode: %d, value:%d\n", caller, mode, pm_blocker.val_u8[mode]);
+#endif
     irq_restore(state);
 }
 
+#ifndef PM_PRINT
 void pm_unblock(unsigned mode)
+#else
+void _pm_unblock(unsigned mode, const char *caller)
+#endif
 {
     assert(pm_blocker.val_u8[mode] > 0);
 
     unsigned state = irq_disable();
     pm_blocker.val_u8[mode]--;
+#ifdef PM_PRINT
+    LOG_INFO("pm_unblock %s mode: %d, value:%d\n", caller, mode, pm_blocker.val_u8[mode]);
+#endif
     irq_restore(state);
 }
 

--- a/tests/periph_pm/Makefile
+++ b/tests/periph_pm/Makefile
@@ -6,6 +6,8 @@ BOARD_BLACKLIST := chronos msb-430h msb-430 telosb wsn430-v1_3b wsn430-v1_4 z1
 
 FEATURES_OPTIONAL += periph_rtc
 
+CFLAGS += -DPM_PRINT
+
 USEMODULE += shell
 
 include $(RIOTBASE)/Makefile.include


### PR DESCRIPTION
can be used to debug or as a basis for a pm test. 

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This still has a problem: `LOG_INFO` is called from within `pm_block` in the `uart_init`, making the test app block. Suggestions are welcome.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->
Run tests/periph_pm.

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
