### PR TITLE
gnrc_sock_[udp|ip]: read return value for _recv after release [backport 2018.10]

### DIFF
--- a/sys/net/gnrc/sock/ip/gnrc_sock_ip.c
+++ b/sys/net/gnrc/sock/ip/gnrc_sock_ip.c
@@ -120,8 +120,9 @@ ssize_t sock_ip_recv(sock_ip_t *sock, void *data, size_t max_len,
         return -EPROTO;
     }
     memcpy(data, pkt->data, pkt->size);
+    res = (int)pkt->size;
     gnrc_pktbuf_release(pkt);
-    return (int)pkt->size;
+    return res;
 }
 
 ssize_t sock_ip_send(sock_ip_t *sock, const void *data, size_t len,

--- a/sys/net/gnrc/sock/udp/gnrc_sock_udp.c
+++ b/sys/net/gnrc/sock/udp/gnrc_sock_udp.c
@@ -215,8 +215,9 @@ ssize_t sock_udp_recv(sock_udp_t *sock, void *data, size_t max_len,
         return -EPROTO;
     }
     memcpy(data, pkt->data, pkt->size);
+    res = (int)pkt->size;
     gnrc_pktbuf_release(pkt);
-    return (int)pkt->size;
+    return res;
 }
 
 ssize_t sock_udp_send(sock_udp_t *sock, const void *data, size_t len,


### PR DESCRIPTION
# Backport of #10366

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Sometimes the sock_udp_recv function in the implementation provided by gnrc_sock_udp returns unexpected values (-12736 or -1 for example). This is probably due to a use after free in this functions return statement. This PR fixes the bug for me.


### Testing procedure
"ALL TESTS SUCCESSFUL" for tests/gnrc_sock_ip and tests/gnrc_sock_udp as well as my application which triggered the error before.


### Issues/PRs references
Fixes #10365 
