### PR TITLE
crypto/modes/ccm: update api to const input buffers

### DIFF
--- a/sys/crypto/modes/ccm.c
+++ b/sys/crypto/modes/ccm.c
@@ -34,8 +34,8 @@ static inline int min(int a, int b)
     }
 }
 
-int ccm_compute_cbc_mac(cipher_t* cipher, uint8_t iv[16],
-                        uint8_t* input, size_t length, uint8_t* mac)
+int ccm_compute_cbc_mac(cipher_t* cipher, const uint8_t iv[16],
+                        const uint8_t* input, size_t length, uint8_t* mac)
 {
     uint8_t offset, block_size, mac_enc[16] = {0};
 
@@ -64,7 +64,7 @@ int ccm_compute_cbc_mac(cipher_t* cipher, uint8_t iv[16],
 
 
 int ccm_create_mac_iv(cipher_t* cipher, uint8_t auth_data_len, uint8_t M,
-                      uint8_t L, uint8_t* nonce, uint8_t nonce_len,
+                      uint8_t L, const uint8_t* nonce, uint8_t nonce_len,
                       size_t plaintext_len, uint8_t X1[16])
 {
     uint8_t M_, L_;
@@ -99,7 +99,7 @@ int ccm_create_mac_iv(cipher_t* cipher, uint8_t auth_data_len, uint8_t M,
     return 0;
 }
 
-int ccm_compute_adata_mac(cipher_t* cipher, uint8_t* auth_data,
+int ccm_compute_adata_mac(cipher_t* cipher, const uint8_t* auth_data,
                           uint32_t auth_data_len, uint8_t X1[16])
 {
     if (auth_data_len > 0) {

--- a/sys/crypto/modes/ccm.c
+++ b/sys/crypto/modes/ccm.c
@@ -144,10 +144,11 @@ static inline int _fits_in_nbytes(size_t value, uint8_t num_bytes)
 }
 
 
-int cipher_encrypt_ccm(cipher_t* cipher, uint8_t* auth_data, uint32_t auth_data_len,
+int cipher_encrypt_ccm(cipher_t* cipher,
+                       const uint8_t* auth_data, uint32_t auth_data_len,
                        uint8_t mac_length, uint8_t length_encoding,
-                       uint8_t* nonce, size_t nonce_len,
-                       uint8_t* input, size_t input_len,
+                       const uint8_t* nonce, size_t nonce_len,
+                       const uint8_t* input, size_t input_len,
                        uint8_t* output)
 {
     int len = -1;
@@ -207,10 +208,12 @@ int cipher_encrypt_ccm(cipher_t* cipher, uint8_t* auth_data, uint32_t auth_data_
 }
 
 
-int cipher_decrypt_ccm(cipher_t* cipher, uint8_t* auth_data,
-                       uint32_t auth_data_len, uint8_t mac_length,
-                       uint8_t length_encoding, uint8_t* nonce, size_t nonce_len,
-                       uint8_t* input, size_t input_len, uint8_t* plain)
+int cipher_decrypt_ccm(cipher_t* cipher,
+                       const uint8_t* auth_data, uint32_t auth_data_len,
+                       uint8_t mac_length, uint8_t length_encoding,
+                       const uint8_t* nonce, size_t nonce_len,
+                       const uint8_t* input, size_t input_len,
+                       uint8_t* plain)
 {
     int len = -1;
     uint8_t nonce_counter[16] = {0}, mac_iv[16] = {0}, mac[16] = {0},

--- a/sys/crypto/modes/ctr.c
+++ b/sys/crypto/modes/ctr.c
@@ -22,7 +22,7 @@
 #include "crypto/modes/ctr.h"
 
 int cipher_encrypt_ctr(cipher_t* cipher, uint8_t nonce_counter[16],
-                       uint8_t nonce_len, uint8_t* input, size_t length,
+                       uint8_t nonce_len, const uint8_t* input, size_t length,
                        uint8_t* output)
 {
     size_t offset = 0;
@@ -50,7 +50,7 @@ int cipher_encrypt_ctr(cipher_t* cipher, uint8_t nonce_counter[16],
 }
 
 int cipher_decrypt_ctr(cipher_t* cipher, uint8_t nonce_counter[16],
-                       uint8_t nonce_len, uint8_t* input, size_t length,
+                       uint8_t nonce_len, const uint8_t* input, size_t length,
                        uint8_t* output)
 {
     return cipher_encrypt_ctr(cipher, nonce_counter, nonce_len, input,

--- a/sys/include/crypto/modes/ccm.h
+++ b/sys/include/crypto/modes/ccm.h
@@ -57,10 +57,12 @@ extern "C" {
  * @return                 Length of encrypted data on a successful encryption
  * @return                 A negative error code if something went wrong
  */
-int cipher_encrypt_ccm(cipher_t* cipher, uint8_t* auth_data,
-                       uint32_t auth_data_len, uint8_t mac_length,
-                       uint8_t length_encoding, uint8_t* nonce, size_t nonce_len,
-                       uint8_t* input, size_t input_len, uint8_t* output);
+int cipher_encrypt_ccm(cipher_t* cipher,
+                       const uint8_t* auth_data, uint32_t auth_data_len,
+                       uint8_t mac_length, uint8_t length_encoding,
+                       const uint8_t* nonce, size_t nonce_len,
+                       const uint8_t* input, size_t input_len,
+                       uint8_t* output);
 
 
 /**
@@ -84,10 +86,12 @@ int cipher_encrypt_ccm(cipher_t* cipher, uint8_t* auth_data,
  * @return                 Length of the decrypted data on a successful decryption
  * @return                 A negative error code if something went wrong
  */
-int cipher_decrypt_ccm(cipher_t* cipher, uint8_t* auth_data,
-                       uint32_t auth_data_len, uint8_t mac_length,
-                       uint8_t length_encoding, uint8_t* nonce, size_t nonce_len,
-                       uint8_t* input, size_t input_len, uint8_t* output);
+int cipher_decrypt_ccm(cipher_t* cipher,
+                       const uint8_t* auth_data, uint32_t auth_data_len,
+                       uint8_t mac_length, uint8_t length_encoding,
+                       const uint8_t* nonce, size_t nonce_len,
+                       const uint8_t* input, size_t input_len,
+                       uint8_t* output);
 
 #ifdef __cplusplus
 }

--- a/sys/include/crypto/modes/ctr.h
+++ b/sys/include/crypto/modes/ctr.h
@@ -45,7 +45,7 @@ extern "C" {
  * @return              A negative error code if something went wrong
  */
 int cipher_encrypt_ctr(cipher_t* cipher, uint8_t nonce_counter[16],
-                       uint8_t nonce_len, uint8_t* input, size_t length,
+                       uint8_t nonce_len, const uint8_t* input, size_t length,
                        uint8_t* output);
 
 
@@ -69,7 +69,7 @@ int cipher_encrypt_ctr(cipher_t* cipher, uint8_t nonce_counter[16],
  * @return              A negative error code if something went wrong
  */
 int cipher_decrypt_ctr(cipher_t* cipher, uint8_t nonce_counter[16],
-                       uint8_t nonce_len, uint8_t* input, size_t length,
+                       uint8_t nonce_len, const uint8_t* input, size_t length,
                        uint8_t* output);
 
 #ifdef __cplusplus

--- a/tests/unittests/tests-crypto/tests-crypto-modes-ccm.c
+++ b/tests/unittests/tests-crypto/tests-crypto-modes-ccm.c
@@ -190,8 +190,9 @@ static void test_crypto_modes_ccm_decrypt(void)
 }
 
 
-typedef int (*func_ccm_t)(cipher_t*, uint8_t*, uint32_t, uint8_t, uint8_t,
-                          uint8_t*, size_t, uint8_t*, size_t, uint8_t*);
+typedef int (*func_ccm_t)(cipher_t*, const uint8_t*, uint32_t,
+                          uint8_t, uint8_t, const uint8_t*, size_t,
+                          const uint8_t*, size_t, uint8_t*);
 
 static int _test_ccm_len(func_ccm_t func, uint8_t len_encoding,
                          uint8_t *input, size_t input_len, size_t adata_len)

--- a/tests/unittests/tests-crypto/tests-crypto-modes-ccm.c
+++ b/tests/unittests/tests-crypto/tests-crypto-modes-ccm.c
@@ -20,79 +20,79 @@
 static const size_t nonce_and_len_encoding_size = 15;
 
 /* PACKET VECTOR #1 (RFC 3610 - Page 10) */
-static uint8_t TEST_1_KEY[] = {
+static const uint8_t TEST_1_KEY[] = {
     0xC0, 0xC1, 0xC2, 0xC3, 0xC4, 0xC5, 0xC6, 0xC7,
     0xC8, 0xC9, 0xCA, 0xCB, 0xCC, 0xCD, 0xCE, 0xCF
 };
-static size_t TEST_1_KEY_LEN = 16;
+static const size_t TEST_1_KEY_LEN = 16;
 
-static uint8_t TEST_1_NONCE[] = {
+static const uint8_t TEST_1_NONCE[] = {
     0x00, 0x00, 0x00, 0x03, 0x02, 0x01, 0x00, 0xA0,
     0xA1, 0xA2, 0xA3, 0xA4, 0xA5
 };
-static size_t TEST_1_NONCE_LEN = 13;
+static const size_t TEST_1_NONCE_LEN = 13;
 
-static size_t TEST_1_MAC_LEN = 8;
+static const size_t TEST_1_MAC_LEN = 8;
 
-static uint8_t TEST_1_INPUT[] = {
+static const uint8_t TEST_1_INPUT[] = {
     0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07, /* additional auth data */
     0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F, /* input */
     0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17, /* input */
     0x18, 0x19, 0x1A, 0x1B, 0x1C, 0x1D, 0x1E        /* input */
 };
-static size_t TEST_1_INPUT_LEN = 23;
-static size_t TEST_1_ADATA_LEN = 8;
+static const size_t TEST_1_INPUT_LEN = 23;
+static const size_t TEST_1_ADATA_LEN = 8;
 
-static uint8_t TEST_1_EXPECTED[] = {
+static const uint8_t TEST_1_EXPECTED[] = {
     0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
     0x58, 0x8C, 0x97, 0x9A, 0x61, 0xC6, 0x63, 0xD2,
     0xF0, 0x66, 0xD0, 0xC2, 0xC0, 0xF9, 0x89, 0x80,
     0x6D, 0x5F, 0x6B, 0x61, 0xDA, 0xC3, 0x84, 0x17,
     0xE8, 0xD1, 0x2C, 0xFD, 0xF9, 0x26, 0xE0
 };
-static size_t TEST_1_EXPECTED_LEN = 39;
+static const size_t TEST_1_EXPECTED_LEN = 39;
 
 /* PACKET VECTOR #2 (RFC 3610 - Page 10) */
-static uint8_t TEST_2_KEY[] = {
+static const uint8_t TEST_2_KEY[] = {
     0xC0, 0xC1, 0xC2, 0xC3, 0xC4, 0xC5, 0xC6, 0xC7,
     0xC8, 0xC9, 0xCA, 0xCB, 0xCC, 0xCD, 0xCE, 0xCF
 };
-static size_t TEST_2_KEY_LEN = 16;
+static const size_t TEST_2_KEY_LEN = 16;
 
-static uint8_t TEST_2_NONCE[] = {
+static const uint8_t TEST_2_NONCE[] = {
     0x00, 0x00, 0x00, 0x04, 0x03, 0x02, 0x01, 0xA0,
     0xA1, 0xA2, 0xA3, 0xA4, 0xA5
 };
-static size_t TEST_2_NONCE_LEN = 13;
+static const size_t TEST_2_NONCE_LEN = 13;
 
-static size_t TEST_2_MAC_LEN = 8;
+static const size_t TEST_2_MAC_LEN = 8;
 
-static uint8_t TEST_2_INPUT[] = {
+static const uint8_t TEST_2_INPUT[] = {
     0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
     0x08, 0x09, 0x0A, 0x0B, 0x0C, 0x0D, 0x0E, 0x0F,
     0x10, 0x11, 0x12, 0x13, 0x14, 0x15, 0x16, 0x17,
     0x18, 0x19, 0x1A, 0x1B, 0x1C, 0x1D, 0x1E, 0x1F
 };
-static size_t TEST_2_INPUT_LEN = 24;
-static size_t TEST_2_ADATA_LEN = 8;
+static const size_t TEST_2_INPUT_LEN = 24;
+static const size_t TEST_2_ADATA_LEN = 8;
 
-static uint8_t TEST_2_EXPECTED[] = {
+static const uint8_t TEST_2_EXPECTED[] = {
     0x00, 0x01, 0x02, 0x03, 0x04, 0x05, 0x06, 0x07,
     0x72, 0xC9, 0x1A, 0x36, 0xE1, 0x35, 0xF8, 0xCF,
     0x29, 0x1C, 0xA8, 0x94, 0x08, 0x5C, 0x87, 0xE3,
     0xCC, 0x15, 0xC4, 0x39, 0xC9, 0xE4, 0x3A, 0x3B,
     0xA0, 0x91, 0xD5, 0x6E, 0x10, 0x40, 0x09, 0x16
 };
-static size_t TEST_2_EXPECTED_LEN = 40;
+static const size_t TEST_2_EXPECTED_LEN = 40;
 
 /* Share test buffer output */
 static uint8_t data[60];
 
-static void test_encrypt_op(uint8_t* key, uint8_t key_len,
-                            uint8_t* adata, size_t adata_len,
-                            uint8_t* nonce, uint8_t nonce_len,
-                            uint8_t* plain, size_t plain_len,
-                            uint8_t* output_expected,
+static void test_encrypt_op(const uint8_t* key, uint8_t key_len,
+                            const uint8_t* adata, size_t adata_len,
+                            const uint8_t* nonce, uint8_t nonce_len,
+                            const uint8_t* plain, size_t plain_len,
+                            const uint8_t* output_expected,
                             size_t output_expected_len,
                             uint8_t mac_length)
 {
@@ -117,11 +117,11 @@ static void test_encrypt_op(uint8_t* key, uint8_t key_len,
 
 }
 
-static void test_decrypt_op(uint8_t* key, uint8_t key_len,
-                            uint8_t* adata, size_t adata_len,
-                            uint8_t* nonce, uint8_t nonce_len,
-                            uint8_t* encrypted, size_t encrypted_len,
-                            uint8_t* output_expected,
+static void test_decrypt_op(const uint8_t* key, uint8_t key_len,
+                            const uint8_t* adata, size_t adata_len,
+                            const uint8_t* nonce, uint8_t nonce_len,
+                            const uint8_t* encrypted, size_t encrypted_len,
+                            const uint8_t* output_expected,
                             size_t output_expected_len,
                             uint8_t mac_length)
 {
@@ -195,7 +195,7 @@ typedef int (*func_ccm_t)(cipher_t*, const uint8_t*, uint32_t,
                           const uint8_t*, size_t, uint8_t*);
 
 static int _test_ccm_len(func_ccm_t func, uint8_t len_encoding,
-                         uint8_t *input, size_t input_len, size_t adata_len)
+                         const uint8_t *input, size_t input_len, size_t adata_len)
 {
     int ret;
     cipher_t cipher;

--- a/tests/unittests/tests-crypto/tests-crypto.h
+++ b/tests/unittests/tests-crypto/tests-crypto.h
@@ -40,7 +40,7 @@ void tests_crypto(void);
  */
 Test *tests_crypto_chacha_tests(void);
 
-static inline int compare(uint8_t *a, uint8_t *b, uint8_t len)
+static inline int compare(const uint8_t *a, const uint8_t *b, uint8_t len)
 {
     int result = 1;
 


### PR DESCRIPTION
### Contribution description

This changes the `cipher_encrypt_ccm` and `cipher_decrypt_ccm` functions to declare input buffers as `const`, and also the required dependencies to do it.

The tests have been updated to use `const` buffers too.


It is a API change but it is compatible as it is just adding more compatibility except if you use the function signature as the tests did.
Not sure if it requires an "API change" label in that case, I let reviewers remove it if they think it is not required.

### Testing procedure

Run the tests on a board that was working before and also compare the size difference

```
BOARD=samr21-xpro RIOT_VERSION_OVERRIDE=buildtest make  -C tests/unittests/ tests-crypto  flash test
```

The size difference I got: It removes `200` bytes ram and only adds `64` rom.

```
# master
   text    data     bss     dec     hex filename
  29292     948    2696   32936    80a8 /home/harter/work/git/RIOT/tests/unittests/bin/samr21-xpro/tests_unittests.elf

# const inputs
   text    data     bss     dec     hex filename
  29356     748    2696   32800    8020 /home/harter/work/git/RIOT/tests/unittests/bin/samr21-xpro/tests_unittests.elf
```

### Issues/PRs references

Found in https://github.com/RIOT-OS/RIOT/pull/7968#issuecomment-437962046 which is part of https://github.com/RIOT-OS/RIOT/issues/8107 resolution.