### PR TITLE
gnrc_pktdump: add GNRC_NETTYPE_IPV6_EXT output

### DIFF
--- a/sys/net/gnrc/pktdump/gnrc_pktdump.c
+++ b/sys/net/gnrc/pktdump/gnrc_pktdump.c
@@ -73,6 +73,12 @@ static void _dump_snip(gnrc_pktsnip_t *pkt)
             hdr_len = sizeof(ipv6_hdr_t);
             break;
 #endif
+#ifdef MODULE_GNRC_IPV6_EXT
+        case GNRC_NETTYPE_IPV6_EXT:
+            printf("NETTYPE_IPV6_EXT (%i)\n", pkt->type);
+            od_hex_dump(pkt->data, pkt->size, OD_WIDTH_DEFAULT);
+            break;
+#endif
 #ifdef MODULE_GNRC_ICMPV6
         case GNRC_NETTYPE_ICMPV6:
             printf("NETTYPE_ICMPV6 (%i)\n", pkt->type);


### PR DESCRIPTION
### Contribution description
Just noticed in #10382 that `GNRC_NETTYPE_IPV6_EXT` snips are marked as `NETTYPE_UNKNOWN` in `gnrc_pktdump` (but the PRs are independent).

### Testing procedure
Compile #10382 with and without this PR. If you set `echo` in the testrunner to `True` you will see that the marked extension headers are shown as `NETTYPE_IPV6_EXT` instead of `NETTYPE_UNKNOWN` (remark: extension headers shown with `NETTYPE_UNDEF` are unmarked and thus shown correctly in that test).

### Issues/PRs references
None (but #10382 required for testing)