### PR TITLE
netdev_ieee802154/radios: refactor PAN ID reset to generic ieee802154 reset

### DIFF
--- a/cpu/cc2538/include/cc2538_rf.h
+++ b/cpu/cc2538/include/cc2538_rf.h
@@ -57,7 +57,6 @@ extern "C" {
 
 #define CC2538_RF_POWER_DEFAULT     (IEEE802154_DEFAULT_TXPOWER)    /**< Default output power in dBm */
 #define CC2538_RF_CHANNEL_DEFAULT   (IEEE802154_DEFAULT_CHANNEL)
-#define CC2538_RF_PANID_DEFAULT     (IEEE802154_DEFAULT_PANID)
 
 #define OUTPUT_POWER_MIN            (-24)  /**< Min output power in dBm */
 #define OUTPUT_POWER_MAX            (7)    /**< Max output power in dBm */

--- a/cpu/cc2538/radio/cc2538_rf.c
+++ b/cpu/cc2538/radio/cc2538_rf.c
@@ -88,7 +88,6 @@ void cc2538_init(void)
 
     cc2538_set_tx_power(CC2538_RF_POWER_DEFAULT);
     cc2538_set_chan(CC2538_RF_CHANNEL_DEFAULT);
-    cc2538_set_pan(CC2538_RF_PANID_DEFAULT);
     cc2538_set_addr_long(cc2538_get_eui64_primary());
 
     /* Select the observable signals (maximum of three) */

--- a/cpu/cc2538/radio/cc2538_rf_netdev.c
+++ b/cpu/cc2538/radio/cc2538_rf_netdev.c
@@ -353,7 +353,6 @@ static int _init(netdev_t *netdev)
     cc2538_rf_t *dev = (cc2538_rf_t *) netdev;
     _dev = netdev;
 
-    uint16_t pan = cc2538_get_pan();
     uint16_t chan = cc2538_get_chan();
     uint16_t addr_short = cc2538_get_addr_short();
     uint64_t addr_long = cc2538_get_addr_long();
@@ -361,8 +360,6 @@ static int _init(netdev_t *netdev)
     netdev_ieee802154_reset(&dev->netdev);
 
     /* Initialise netdev_ieee802154_t struct */
-    netdev_ieee802154_set(&dev->netdev, NETOPT_NID,
-                          &pan, sizeof(pan));
     netdev_ieee802154_set(&dev->netdev, NETOPT_CHANNEL,
                           &chan, sizeof(chan));
     netdev_ieee802154_set(&dev->netdev, NETOPT_ADDRESS,

--- a/cpu/native/socket_zep/socket_zep.c
+++ b/cpu/native/socket_zep/socket_zep.c
@@ -297,7 +297,6 @@ static int _init(netdev_t *netdev)
 
     assert(dev != NULL);
     dev->netdev.chan = IEEE802154_DEFAULT_CHANNEL;
-    dev->netdev.pan = IEEE802154_DEFAULT_PANID;
 
     return 0;
 }

--- a/drivers/at86rf2xx/at86rf2xx.c
+++ b/drivers/at86rf2xx/at86rf2xx.c
@@ -73,8 +73,6 @@ void at86rf2xx_reset(at86rf2xx_t *dev)
     at86rf2xx_set_addr_long(dev, ntohll(addr_long.uint64.u64));
     at86rf2xx_set_addr_short(dev, ntohs(addr_long.uint16[0].u16));
 
-    /* set default PAN id */
-    at86rf2xx_set_pan(dev, AT86RF2XX_DEFAULT_PANID);
     /* set default channel */
     at86rf2xx_set_chan(dev, AT86RF2XX_DEFAULT_CHANNEL);
     /* set default TX power */

--- a/drivers/at86rf2xx/at86rf2xx_getset.c
+++ b/drivers/at86rf2xx/at86rf2xx_getset.c
@@ -222,7 +222,6 @@ void at86rf2xx_set_pan(at86rf2xx_t *dev, uint16_t pan)
 {
     le_uint16_t le_pan = byteorder_btols(byteorder_htons(pan));
 
-    dev->netdev.pan = pan;
     DEBUG("pan0: %u, pan1: %u\n", le_pan.u8[0], le_pan.u8[1]);
     at86rf2xx_reg_write(dev, AT86RF2XX_REG__PAN_ID_0, le_pan.u8[0]);
     at86rf2xx_reg_write(dev, AT86RF2XX_REG__PAN_ID_1, le_pan.u8[1]);

--- a/drivers/cc2420/cc2420.c
+++ b/drivers/cc2420/cc2420.c
@@ -58,7 +58,6 @@ int cc2420_init(cc2420_t *dev)
     addr[0] |= 0x02;
     cc2420_set_addr_short(dev, &addr[6]);
     cc2420_set_addr_long(dev, addr);
-    cc2420_set_pan(dev, CC2420_PANID_DEFAULT);
     cc2420_set_chan(dev, CC2420_CHAN_DEFAULT);
     cc2420_set_txpower(dev, CC2420_TXPOWER_DEFAULT);
 

--- a/drivers/cc2420/cc2420_getset.c
+++ b/drivers/cc2420/cc2420_getset.c
@@ -114,7 +114,6 @@ uint16_t cc2420_get_pan(cc2420_t *dev)
 
 void cc2420_set_pan(cc2420_t *dev, uint16_t pan)
 {
-    dev->netdev.pan = pan;
     cc2420_ram_write(dev, CC2420_RAM_PANID, (uint8_t *)&pan, 2);
 }
 

--- a/drivers/include/at86rf2xx.h
+++ b/drivers/include/at86rf2xx.h
@@ -68,13 +68,6 @@ extern "C" {
 /** @} */
 
 /**
- * @brief   Default PAN ID
- *
- * @todo    Read some global network stack specific configuration value
- */
-#define AT86RF2XX_DEFAULT_PANID         (IEEE802154_DEFAULT_PANID)
-
-/**
  * @brief   Default TX power (0dBm)
  */
 #define AT86RF2XX_DEFAULT_TXPOWER       (IEEE802154_DEFAULT_TXPOWER)

--- a/drivers/include/cc2420.h
+++ b/drivers/include/cc2420.h
@@ -39,11 +39,6 @@ extern "C" {
 #define CC2420_PKT_MAXLEN       (IEEE802154_FRAME_LEN_MAX)
 
 /**
- * @brief   PAN ID configuration
- */
-#define CC2420_PANID_DEFAULT    (IEEE802154_DEFAULT_PANID)
-
-/**
   * @name    Channel configuration
   * @{
   */

--- a/drivers/include/kw2xrf.h
+++ b/drivers/include/kw2xrf.h
@@ -43,11 +43,6 @@ extern "C" {
 #define KW2XRF_MAX_PKT_LENGTH           (IEEE802154_FRAME_LEN_MAX)
 
 /**
- * @brief   Default PAN ID used after initialization
- */
-#define KW2XRF_DEFAULT_PANID            (IEEE802154_DEFAULT_PANID)
-
-/**
  * @name    Default channel used after initialization
  *
  * @{

--- a/drivers/kw2xrf/kw2xrf.c
+++ b/drivers/kw2xrf/kw2xrf.c
@@ -97,7 +97,6 @@ void kw2xrf_reset_phy(kw2xrf_t *dev)
 
     kw2xrf_set_channel(dev, KW2XRF_DEFAULT_CHANNEL);
 
-    kw2xrf_set_pan(dev, KW2XRF_DEFAULT_PANID);
     kw2xrf_set_address(dev);
 
     kw2xrf_set_cca_mode(dev, 1);
@@ -115,6 +114,6 @@ void kw2xrf_reset_phy(kw2xrf_t *dev)
 
     kw2xrf_enable_irq_b(dev);
 
-    DEBUG("[kw2xrf] init phy and (re)set to channel %d and pan %d.\n",
-          KW2XRF_DEFAULT_CHANNEL, KW2XRF_DEFAULT_PANID);
+    DEBUG("[kw2xrf] init phy and (re)set to channel %d.\n",
+          KW2XRF_DEFAULT_CHANNEL);
 }

--- a/drivers/kw2xrf/kw2xrf_getset.c
+++ b/drivers/kw2xrf/kw2xrf_getset.c
@@ -255,14 +255,11 @@ void kw2xrf_set_sequence(kw2xrf_t *dev, kw2xrf_physeq_t seq)
 
 void kw2xrf_set_pan(kw2xrf_t *dev, uint16_t pan)
 {
-    dev->netdev.pan = pan;
-
     uint8_t val_ar[2];
     val_ar[1] = (pan >> 8);
     val_ar[0] = (uint8_t)pan;
     kw2xrf_write_iregs(dev, MKW2XDMI_MACPANID0_LSB, val_ar, 2);
     LOG_DEBUG("[kw2xrf] set pan to: 0x%x\n", pan);
-    dev->netdev.pan = pan;
 }
 
 void kw2xrf_set_addr_short(kw2xrf_t *dev, uint16_t addr)

--- a/drivers/mrf24j40/mrf24j40.c
+++ b/drivers/mrf24j40/mrf24j40.c
@@ -56,8 +56,6 @@ void mrf24j40_reset(mrf24j40_t *dev)
     mrf24j40_set_addr_long(dev, ntohll(addr_long.uint64.u64));
     mrf24j40_set_addr_short(dev, ntohs(addr_long.uint16[0].u16));
 
-    /* set default PAN id */
-    mrf24j40_set_pan(dev, IEEE802154_DEFAULT_PANID);
     mrf24j40_set_chan(dev, IEEE802154_DEFAULT_CHANNEL);
 
     /* configure Immediate Sleep and Wake-Up mode */

--- a/drivers/mrf24j40/mrf24j40_getset.c
+++ b/drivers/mrf24j40/mrf24j40_getset.c
@@ -252,7 +252,6 @@ void mrf24j40_set_pan(mrf24j40_t *dev, uint16_t pan)
 {
     le_uint16_t le_pan = byteorder_btols(byteorder_htons(pan));
 
-    dev->netdev.pan = pan;
     DEBUG("pan0: %u, pan1: %u\n", le_pan.u8[0], le_pan.u8[1]);
     mrf24j40_reg_write_short(dev, MRF24J40_REG_PANIDL, le_pan.u8[0]);
     mrf24j40_reg_write_short(dev, MRF24J40_REG_PANIDH, le_pan.u8[1]);

--- a/drivers/netdev_ieee802154/netdev_ieee802154.c
+++ b/drivers/netdev_ieee802154/netdev_ieee802154.c
@@ -63,6 +63,10 @@ void netdev_ieee802154_reset(netdev_ieee802154_t *dev)
 #elif MODULE_GNRC
     dev->proto = GNRC_NETTYPE_UNDEF;
 #endif
+
+    /* Initialize PAN ID and call netdev::set to propagate it */
+    dev->pan = IEEE802154_DEFAULT_PANID;
+    dev->netdev.driver->set(&dev->netdev, NETOPT_NID, &dev->pan, sizeof(dev->pan));
 }
 
 int netdev_ieee802154_get(netdev_ieee802154_t *dev, netopt_t opt, void *value,


### PR DESCRIPTION
### Contribution description

This PR refactors the PAN ID from the radio reset function to the generic `netdev_ieee802154_reset` and sets it via the `netdev::set` call. This allows for removal of the `dev->netdev` accesses in the radio specific `set_pan` calls.

### Testing procedure

Verify that initialization and reset of the PAN ID works for the affected radios

- [x] cc2538
- [x] socket_zep
- [x] at86rf2xx
- [x] cc2420
- [x] kw2xrf
- [x] mrf24j40

### Issues/PRs references

Chipping away at dependencies for #7736 