### PR TITLE
tests/puf_sram: add input args to automation script

### DIFF
--- a/tests/puf_sram/tests/example_test.py
+++ b/tests/puf_sram/tests/example_test.py
@@ -7,8 +7,15 @@
 # General Public License v2.1. See the file LICENSE in the top level
 # directory for more details.
 
+import argparse
 import puf_sram_if
 import numpy
+
+DEFAULT_POWER_CYCLES = 500
+DEFAULT_OFF_TIME = 1
+DEFAULT_BAUDRATE = 115200
+DEFAULT_PORT = '/dev/ttyUSB0'
+DEFAULT_INFO = True
 
 
 def min_erntropy(all_meas):
@@ -32,8 +39,22 @@ def min_erntropy(all_meas):
 
 
 def main_func():
-    puf_sram = puf_sram_if.PufSram()
-    seeds = puf_sram.get_seed_list(n=500, off_time=1, allow_print=True)
+    p = argparse.ArgumentParser()
+    p.add_argument("-n", "--number", type=int, default=DEFAULT_POWER_CYCLES,
+                   help="Number of iterations, default: %s" % DEFAULT_POWER_CYCLES)
+    p.add_argument("-t", "--off_time", type=int, default=DEFAULT_OFF_TIME,
+                   help="Off time, default: %s [s]" % DEFAULT_OFF_TIME)
+    p.add_argument("-p", "--port", type=str, default=DEFAULT_PORT,
+                   help="Serial port, default: %s" % DEFAULT_PORT)
+    p.add_argument("-b", "--baudrate", type=int, default=DEFAULT_BAUDRATE,
+                   help="Baudrate of the serial port, default: %d" % DEFAULT_BAUDRATE)
+    p.add_argument("-d", "--disable_output", default=DEFAULT_INFO, action='store_false',
+                   help="Disable verbose output")
+    args = p.parse_args()
+
+    puf_sram = puf_sram_if.PufSram(port=args.port, baud=args.baudrate)
+    seeds = puf_sram.get_seed_list(n=args.number, off_time=args.off_time,
+                                   allow_print=args.disable_output)
     seeds = [format(x, '0>32b') for x in seeds]
     H_min, H_min_rel = min_erntropy(seeds)
 

--- a/tests/puf_sram/tests/puf_sram_if.py
+++ b/tests/puf_sram/tests/puf_sram_if.py
@@ -12,12 +12,12 @@ import time
 
 class PufSram:
 
-    def __init__(self, port='/dev/ttyUSB0', baud=115200):
+    def __init__(self, port, baud):
         self.__dev = serial.Serial(port, baud, timeout=10)
         if(self.__dev.isOpen() is False):
             self.__dev.open()
 
-    def repower(self, shutdown_time=1):
+    def repower(self, shutdown_time):
         self.__dev.setRTS(True)
         time.sleep(shutdown_time)
         self.__dev.setRTS(False)
@@ -38,7 +38,7 @@ class PufSram:
                 return data
         return None
 
-    def get_seed_list(self, n=10000, off_time=1, allow_print=False):
+    def get_seed_list(self, n, off_time, allow_print):
         data = list()
         for i in range(0, n):
             self.repower(off_time)


### PR DESCRIPTION
### Contribution description

This PR adds optional input arguments to the automation script for estimating the minimum entropy of the SRAM based random seed (*tests/puf_sram*). It is needed to change the serial port or baudrate when changing to platforms with different serial parameters.

### Testing procedure

- Calling the script without parameters should lead to the same behavior as before
- Calling script help (`example_test.py -h`) should show information about input parameters
```
usage: example_test.py [-h] [-n NUMBER] [-t OFF_TIME] [-p PORT] [-b BAUDRATE]
                       [-d]

optional arguments:
  -h, --help            show this help message and exit
  -n NUMBER, --number NUMBER
                        Number of iterations, default: 500
  -t OFF_TIME, --off_time OFF_TIME
                        Off time, default: 1 [s]
  -p PORT, --port PORT  Serial port, default: /dev/ttyUSB0
  -b BAUDRATE, --baudrate BAUDRATE
                        Baudrate of the serial port, default: 115200
  -d, --disable_output  Disable verbose output
```
- `example_test.py -n 3 -t 10` should reduce the number of iterations to 3 and the power-off time before restart to 10 seconds
- - `example_test.py -d` disables intermediate status reports but the board reboots anyway (status LEDs turn of repeatedly)
- Changing the `-p` or `-b` parameters doesn't make sense right now, as these parameters are fixed for boards

### Issues/PRs references
n/a