### PR TITLE
sys/puf_sram: CPU specific variable allocation

### DIFF
--- a/cpu/cortexm_common/include/cpu_conf_common.h
+++ b/cpu/cortexm_common/include/cpu_conf_common.h
@@ -68,6 +68,11 @@ extern "C" {
 #endif
 /** @} */
 
+/**
+ * @brief   Attribute for memory sections required by SRAM PUF
+ */
+#define PUF_SRAM_ATTRIBUTES __attribute__((used, section(".puf")))
+
 #ifdef __cplusplus
 }
 #endif

--- a/sys/puf_sram/puf_sram.c
+++ b/sys/puf_sram/puf_sram.c
@@ -19,13 +19,13 @@
 #include "puf_sram.h"
 
 /* Allocation of the PUF seed variable */
-__attribute__((used,section(".puf"))) uint32_t puf_sram_seed;
+PUF_SRAM_ATTRIBUTES uint32_t puf_sram_seed;
 
 /* Allocation of the PUF seed state */
-__attribute__((used,section(".puf"))) uint32_t puf_sram_state;
+PUF_SRAM_ATTRIBUTES uint32_t puf_sram_state;
 
 /* Allocation of the memory marker */
-__attribute__((used,section(".puf"))) uint32_t puf_sram_marker;
+PUF_SRAM_ATTRIBUTES uint32_t puf_sram_marker;
 
 void puf_sram_init(const uint8_t *ram, size_t len)
 {


### PR DESCRIPTION
### Contribution description

This PR moves memory allocation for the SRAM based seed generator from the generic implementation to cortex specific initialization. So far these platforms were the only ones supporting `puf_sram`. However, when adding different architectures the allocation might look different. Results for the entropy of SRAM seeds remain the same. 


### Testing procedure

Run the test as described in [tests/puf_sram/README.md](https://github.com/RIOT-OS/RIOT/blob/master/tests/puf_sram/README.md) and check if the calculated entries show expected values (around 30 bit)


### Issues/PRs references
n/a