### PR TITLE
cpu/atmega_common: add mega2560 puf_sram feature 

### DIFF
--- a/boards/arduino-mega2560/Makefile.features
+++ b/boards/arduino-mega2560/Makefile.features
@@ -1,3 +1,4 @@
+FEATURES_PROVIDED += puf_sram
 include $(RIOTBOARD)/common/arduino-atmega/Makefile.features
 
 include $(RIOTCPU)/atmega2560/Makefile.features

--- a/cpu/atmega_common/include/cpu_conf.h
+++ b/cpu/atmega_common/include/cpu_conf.h
@@ -51,6 +51,11 @@ extern "C" {
 #define THREAD_STACKSIZE_IDLE      (128)
 /** @} */
 
+/**
+ * @brief   Attribute for memory sections required by SRAM PUF
+ */
+#define PUF_SRAM_ATTRIBUTES __attribute__((used, section(".noinit")))
+
 #ifdef __cplusplus
 }
 #endif

--- a/cpu/atmega_common/startup.c
+++ b/cpu/atmega_common/startup.c
@@ -25,6 +25,9 @@
 
 /* For Catchall-Loop */
 #include "board.h"
+#ifdef MODULE_PUF_SRAM
+#include "puf_sram.h"
+#endif
 
 /**
  * @brief functions for initializing the board, std-lib and kernel
@@ -65,6 +68,9 @@ __attribute__((used, naked)) void init8_ovr(void)
  */
 __attribute__((used)) void reset_handler(void)
 {
+#ifdef MODULE_PUF_SRAM
+    puf_sram_init((uint8_t *)RAMEND-SEED_RAM_LEN, SEED_RAM_LEN);
+#endif
     /* initialize the board and startup the kernel */
     board_init();
     /* startup the kernel */


### PR DESCRIPTION
### Contribution description

This PR adds the SRAM based random seed generation feature for mega2560 8-bit platforms.

```
Number of seeds: 500       
Seed length    : 32 Bit   
Abs. Entropy   : 30.04 Bit   
Rel. Entropy   : 93.89 perc. 
```
### Testing procedure
- flash *tests/puf_sram* to your arduino-mega2560
- follow instructions in the respective README.md
- Call the example script like `python tests/example_test.py -b 9600`


### Issues/PRs references
based on #10385, #10386
