### PR TITLE
Improve and debug Xtimer

### DIFF
--- a/sys/xtimer/xtimer_core.c
+++ b/sys/xtimer/xtimer_core.c
@@ -487,17 +487,13 @@ static void _timer_callback(void)
         _next_period();
 
         reference = 0;
-
-        /* make sure the timer counter also arrived
-         * in the next timer period */
+        /* make sure the timer counter also arrived in the next timer period */
         while (_xtimer_lltimer_now() == _xtimer_lltimer_mask(0xFFFFFFFF)) {}
     }
     else {
-        /* we ended up in _timer_callback and there is
-         * a timer waiting.
-         */
-        /* set our period reference to the current time. */
-        reference = _xtimer_lltimer_now();
+        /* we ended up in _timer_callback and there is a timer waiting.
+         * set our period reference to the expected target. */
+        reference = _xtimer_lltimer_mask(timer_list_head->target - XTIMER_OVERHEAD);
     }
 
 overflow:

--- a/tests/xtimer_drift/main.c
+++ b/tests/xtimer_drift/main.c
@@ -163,7 +163,7 @@ int main(void)
 
     /* create and trigger worker thread */
     kernel_pid_t pid3 = thread_create(worker_stack, sizeof(worker_stack),
-                                      THREAD_PRIORITY_MAIN - 1,
+                                      THREAD_PRIORITY_MAIN - 2,
                                       THREAD_CREATE_STACKTEST,
                                       worker_thread, NULL, "worker");
 

--- a/tests/xtimer_hang/Makefile
+++ b/tests/xtimer_hang/Makefile
@@ -17,7 +17,8 @@ TEST_ON_CI_WHITELIST += all
 # Port number should be found in port enum e.g in cpu/include/periph_cpu.h
 #FEATURES_REQUIRED += periph_gpio
 # Jiminy probing Pins
-#CFLAGS += -DWORKER_THREAD_PIN=GPIO_PIN\(5,7\)
-#CFLAGS += -DMAIN_THREAD_PIN=GPIO_PIN\(5,6\)
+#CFLAGS += -DWORKER_THREAD_PIN_1=GPIO_PIN\(5,7\)
+#CFLAGS += -DWORKER_THREAD_PIN_2=GPIO_PIN\(5,6\)
+#CFLAGS += -DMAIN_THREAD_PIN=GPIO_PIN\(5,5\)
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/xtimer_hang/main.c
+++ b/tests/xtimer_hang/main.c
@@ -29,7 +29,7 @@
 #include "thread.h"
 #include "log.h"
 
-#if defined(MAIN_THREAD_PIN) || defined(WORKER_THREAD_PIN)
+#if defined(MAIN_THREAD_PIN) || defined(WORKER_THREAD_PIN_1) || defined(WORKER_THREAD_PIN_2)
 #include "board.h"
 #include "periph/gpio.h"
 #endif

--- a/tests/xtimer_hang/main.c
+++ b/tests/xtimer_hang/main.c
@@ -78,13 +78,16 @@ int main(void)
     uint32_t now = 0;
     uint32_t start = xtimer_now_usec();
     uint32_t until = start + (TEST_TIME_S * US_PER_SEC);
+    uint32_t interval = TEST_INTERVAL_MS * US_PER_MS;
+    xtimer_ticks32_t last_wakeup = xtimer_now();
+
     puts("[START]");
     while((now = xtimer_now_usec()) < until) {
         unsigned percent = (100 * (now - start)) / (until - start);
 #if defined(MAIN_THREAD_PIN)
         gpio_set(main_pin);
 #endif
-        xtimer_usleep(TEST_INTERVAL_MS * US_PER_MS);
+        xtimer_periodic_wakeup(&last_wakeup, interval);
 #if defined(MAIN_THREAD_PIN)
         gpio_clear(main_pin);
 #endif

--- a/tests/xtimer_hang/main.c
+++ b/tests/xtimer_hang/main.c
@@ -38,20 +38,35 @@
 #define TEST_INTERVAL_MS        (100LU)
 #define TEST_TIMER_STACKSIZE    (THREAD_STACKSIZE_DEFAULT)
 
+#define TEST_SLEEP_TIME_1             (1000)
+#define TEST_SLEEP_TIME_2             (1100)
+
 char stack_timer1[TEST_TIMER_STACKSIZE];
 char stack_timer2[TEST_TIMER_STACKSIZE];
 
 void* timer_func(void* arg)
 {
-#if defined(WORKER_THREAD_PIN)
-    gpio_t worker_pin = WORKER_THREAD_PIN;
-    gpio_init(worker_pin, GPIO_OUT);
+#if defined(WORKER_THREAD_PIN_1)
+    gpio_t worker_pin_1 = WORKER_THREAD_PIN_1;
+    gpio_init(worker_pin_1, GPIO_OUT);
+#endif
+#if defined(WORKER_THREAD_PIN_2)
+    gpio_t worker_pin_2 = WORKER_THREAD_PIN_2;
+    gpio_init(worker_pin_2, GPIO_OUT);
 #endif
     LOG_DEBUG("run thread %" PRIkernel_pid "\n", thread_getpid());
+
+
     while(1) {
-#if defined(WORKER_THREAD_PIN)
-        gpio_set(worker_pin);
-        gpio_clear(worker_pin);
+#if defined(WORKER_THREAD_PIN_1) && defined(WORKER_THREAD_PIN_2)
+        if( *(uint32_t*)(arg) == TEST_SLEEP_TIME_1) {
+            gpio_set(worker_pin_1);
+            gpio_clear(worker_pin_1);
+        } 
+        else {
+            gpio_set(worker_pin_2);
+            gpio_clear(worker_pin_2);
+        }
 #endif
         xtimer_usleep(*(uint32_t *)(arg));
     }
@@ -65,8 +80,8 @@ int main(void)
 #endif
 
     LOG_DEBUG("[INIT]\n");
-    uint32_t sleep_timer1 = 1000;
-    uint32_t sleep_timer2 = 1100;
+    uint32_t sleep_timer1 = TEST_SLEEP_TIME_1;
+    uint32_t sleep_timer2 = TEST_SLEEP_TIME_2;
 
     thread_create(stack_timer1, TEST_TIMER_STACKSIZE,
                   2, THREAD_CREATE_STACKTEST,


### PR DESCRIPTION
This PR is a stack of commits which depends upon each other and are a rework of some things done in https://github.com/RIOT-OS/RIOT/pull/8990.

1. Tries to handle the same problem as https://github.com/RIOT-OS/RIOT/pull/7629 and https://github.com/RIOT-OS/RIOT/pull/9595 .

2. _timer_callback changed to only check once for an overflow. Avoiding early firing of xtimer when _next_period is called 2 times. Encountered when testing with xtimer_drift.

3. xtimer_hang test schould use xtimer_periodic_wakeup instead of sleep. This will ensure that all percentage values are printed.

4. Using multiple pins to distinguish the threads.

5. Ensure that worker_thread is higher prior than slacker_thread.

6. _time_left was not able to calculate the time left for a target which is at the beginning of the next period, but has to be fired in this period because of XTIMER_OVERHEAD.

7. Xtimer where fired to early when running xtimer_drift. Which was caused by a overflowing llcounter. As the reference was set to now. The function _time_left calculated the wrong time to wait.

See the commit messages for more details.

Following Test run with good results on the jiminy rfr2
``` 
xtimer_usleep_short
xtimer_usleep
xtimer_reset
xtimer_remove
xtimer_periodic_wakeup
xtimer_msg_receive_timeout
xtimer_hang
xtimer_drift
```
