### PR TITLE
boards/frdm-kw41z: update i2c configuration

### DIFF
--- a/boards/frdm-kw41z/include/board.h
+++ b/boards/frdm-kw41z/include/board.h
@@ -88,7 +88,7 @@ extern "C"
  * @name    FXOS8700CQ 3-axis accelerometer and magnetometer bus configuration
  * @{
  */
-#define FXOS8700_PARAM_I2C          I2C_DEV(1)
+#define FXOS8700_PARAM_I2C          I2C_DEV(0)
 #define FXOS8700_PARAM_ADDR         0x1F
 /** @} */
 

--- a/boards/frdm-kw41z/include/periph_conf.h
+++ b/boards/frdm-kw41z/include/periph_conf.h
@@ -246,16 +246,6 @@ static const spi_conf_t spi_config[] = {
 */
 static const i2c_conf_t i2c_config[] = {
     {
-        .i2c = I2C0,
-        .scl_pin = GPIO_PIN(PORT_B, 0),
-        .sda_pin = GPIO_PIN(PORT_B, 1),
-        .freq = CLOCK_BUSCLOCK,
-        .speed = I2C_SPEED_FAST,
-        .irqn = I2C0_IRQn,
-        .scl_pcr = (PORT_PCR_MUX(3)),
-        .sda_pcr = (PORT_PCR_MUX(3)),
-    },
-    {
         .i2c = I2C1,
         .scl_pin = GPIO_PIN(PORT_C, 2),
         .sda_pin = GPIO_PIN(PORT_C, 3),
@@ -267,8 +257,7 @@ static const i2c_conf_t i2c_config[] = {
     },
 };
 #define I2C_NUMOF           (sizeof(i2c_config) / sizeof(i2c_config[0]))
-#define I2C_0_ISR           (isr_i2c0)
-#define I2C_1_ISR           (isr_i2c1)
+#define I2C_0_ISR           (isr_i2c1)
 /** @} */
 
 /**


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR updates the I2C configuration of the FRDM-KW41Z board:
- Remove first I2C (I2C0) that is not reachable by default from the arduino pinout.
- Move I2C1 as the first I2C device. I2C1 is the device connected to the I2C pins of the arduino pinout. Making it easily usable with Arduino compatible shields that provide I2C sensors (HTS221 from X-Nucleo for example)
- Update FXOS8700 I2C device in board configuration

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
1. Build, flash and run the `driver_fxos8700` application: device should initialize correctly and data are printed:
```
$ make BOARD=frdm-kw41z -C tests/driver_fxos8700 flash term
2018-11-15 08:52:58,195 - INFO # magnetic field: (-135, -1007, 420)
2018-11-15 08:52:58,196 - INFO # acceleration: (-3, -22, 985)
2018-11-15 08:52:58,197 - INFO # magnetic field: (-254, -1120, 233)
2018-11-15 08:52:59,049 - INFO # acceleration: (147, -619, 626)
2018-11-15 08:52:59,054 - INFO # magnetic field: (-251, -1169, 252)
2018-11-15 08:53:00,058 - INFO # acceleration: (283, 344, 949)
2018-11-15 08:53:00,062 - INFO # magnetic field: (-322, -940, 285)
2018-11-15 08:53:01,066 - INFO # acceleration: (483, -739, 346)
2018-11-15 08:53:01,077 - INFO # magnetic field: (-359, -1165, 304)
```
2. Plug an X-NUCLEO-IKS01A2 extension on the Arduino pinout, build and flash the `driver_hts221` application:
```
$ make BOARD=frdm-kw41z -C tests/driver_hts221 flash term
2018-11-15 09:05:55,492 - INFO # H: 48.9%, T: 25.1°C
2018-11-15 09:05:57,493 - INFO # H: 48.9%, T: 25.0°C
2018-11-15 09:05:59,495 - INFO # H: 49.2%, T: 25.0°C
2018-11-15 09:06:01,501 - INFO # H: 49.1%, T: 25.0°C
```
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
