### PR TITLE
test/xtimer hang: separate debug pins

### DIFF
--- a/tests/xtimer_hang/Makefile
+++ b/tests/xtimer_hang/Makefile
@@ -17,7 +17,8 @@ TEST_ON_CI_WHITELIST += all
 # Port number should be found in port enum e.g in cpu/include/periph_cpu.h
 #FEATURES_REQUIRED += periph_gpio
 # Jiminy probing Pins
-#CFLAGS += -DWORKER_THREAD_PIN=GPIO_PIN\(5,7\)
-#CFLAGS += -DMAIN_THREAD_PIN=GPIO_PIN\(5,6\)
+#CFLAGS += -DWORKER_THREAD_PIN_1=GPIO_PIN\(5,7\)
+#CFLAGS += -DWORKER_THREAD_PIN_2=GPIO_PIN\(5,6\)
+#CFLAGS += -DMAIN_THREAD_PIN=GPIO_PIN\(5,5\)
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/xtimer_hang/main.c
+++ b/tests/xtimer_hang/main.c
@@ -20,6 +20,7 @@
  * @author      Daniel Krebs <github@daniel-krebs.net>
  * @author      Kaspar Schleiser <kaspar@schleiser.de>
  * @author      Sebastian Meiling <s@mlng.net>
+ * @author      Josua Arndt <jarndt@ias.rwth-aachen.de>
  *
  * @}
  */
@@ -29,29 +30,40 @@
 #include "thread.h"
 #include "log.h"
 
-#if defined(MAIN_THREAD_PIN) || defined(WORKER_THREAD_PIN)
+#if defined(MAIN_THREAD_PIN) || defined(WORKER_THREAD_PIN_1)
 #include "board.h"
 #include "periph/gpio.h"
+
+typedef struct {
+    uint32_t time;
+    gpio_t pin;
+} timer_arg_t;
 #endif
+
+
 
 #define TEST_TIME_S             (10LU)
 #define TEST_INTERVAL_MS        (100LU)
 #define TEST_TIMER_STACKSIZE    (THREAD_STACKSIZE_DEFAULT)
 
+#define TEST_SLEEP_TIME_1 (1000)
+#define TEST_SLEEP_TIME_2 (1100)
+
 char stack_timer1[TEST_TIMER_STACKSIZE];
 char stack_timer2[TEST_TIMER_STACKSIZE];
 
-void* timer_func(void* arg)
+void *timer_func(void *arg)
 {
-#if defined(WORKER_THREAD_PIN)
-    gpio_t worker_pin = WORKER_THREAD_PIN;
-    gpio_init(worker_pin, GPIO_OUT);
-#endif
     LOG_DEBUG("run thread %" PRIkernel_pid "\n", thread_getpid());
-    while(1) {
-#if defined(WORKER_THREAD_PIN)
-        gpio_set(worker_pin);
-        gpio_clear(worker_pin);
+
+#if defined(WORKER_THREAD_PIN_1) && defined(WORKER_THREAD_PIN_2)
+    gpio_init((*(timer_arg_t *)(arg)).pin, GPIO_OUT);
+#endif
+
+    while (1) {
+#if defined(WORKER_THREAD_PIN_1) && defined(WORKER_THREAD_PIN_2)
+        gpio_set((*(timer_arg_t *)(arg)).pin);
+        gpio_clear((*(timer_arg_t *)(arg)).pin);
 #endif
         xtimer_usleep(*(uint32_t *)(arg));
     }
@@ -64,9 +76,15 @@ int main(void)
     gpio_init(main_pin, GPIO_OUT);
 #endif
 
+#if defined(WORKER_THREAD_PIN_1) && defined(WORKER_THREAD_PIN_2)
+    timer_arg_t sleep_timer1 = { TEST_SLEEP_TIME_1, WORKER_THREAD_PIN_1 };
+    timer_arg_t sleep_timer2 = { TEST_SLEEP_TIME_2, WORKER_THREAD_PIN_2 };
+#else
+    uint32_t sleep_timer1 = TEST_SLEEP_TIME_1;
+    uint32_t sleep_timer2 = TEST_SLEEP_TIME_2;
+#endif
     LOG_DEBUG("[INIT]\n");
-    uint32_t sleep_timer1 = 1000;
-    uint32_t sleep_timer2 = 1100;
+
 
     thread_create(stack_timer1, TEST_TIMER_STACKSIZE,
                   2, THREAD_CREATE_STACKTEST,
@@ -82,7 +100,7 @@ int main(void)
     xtimer_ticks32_t last_wakeup = xtimer_now();
 
     puts("[START]");
-    while((now = xtimer_now_usec()) < until) {
+    while ((now = xtimer_now_usec()) < until) {
         unsigned percent = (100 * (now - start)) / (until - start);
 #if defined(MAIN_THREAD_PIN)
         gpio_set(main_pin);


### PR DESCRIPTION
Previously one pin was used for both slacker threads.
For better debugging seperating the threads to use one pin each is better.