### PR TITLE
tests/xtimer_drift: increase priority of worker

### DIFF
--- a/tests/xtimer_drift/main.c
+++ b/tests/xtimer_drift/main.c
@@ -163,7 +163,7 @@ int main(void)
 
     /* create and trigger worker thread */
     kernel_pid_t pid3 = thread_create(worker_stack, sizeof(worker_stack),
-                                      THREAD_PRIORITY_MAIN - 1,
+                                      THREAD_PRIORITY_MAIN - 2,
                                       THREAD_CREATE_STACKTEST,
                                       worker_thread, NULL, "worker");
 


### PR DESCRIPTION
If the worker thread and the slacker thread have the same priority they will be handle after each other.
Setting the worker tread to a higher priority ensures that the printed jitter is the best achievable.