### PR TITLE
 core: provide function to check msg queue initialization

### DIFF
--- a/core/include/thread.h
+++ b/core/include/thread.h
@@ -527,6 +527,26 @@ void thread_stack_print(void);
  */
 void thread_print_stack(void);
 
+/**
+ * @brief   Checks if a thread has an initialized message queue
+ *
+ * @see @ref msg_init_queue()
+ *
+ * @param[in] thread    The thread to check for
+ *
+ * @return  `== 0`, if @p thread has no initialized message queue
+ * @return  `!= 0`, if @p thread has its message queue initialized
+ */
+static inline int thread_has_msg_queue(const volatile struct _thread *thread)
+{
+#if defined(MODULE_CORE_MSG) || defined(DOXYGEN)
+    return (thread->msg_array != NULL);
+#else
+    (void)thread;
+    return 0;
+#endif
+}
+
 #ifdef __cplusplus
 }
 #endif

--- a/core/msg.c
+++ b/core/msg.c
@@ -296,7 +296,7 @@ static int _msg_receive(msg_t *m, int block)
 
     int queue_index = -1;
 
-    if (me->msg_array) {
+    if (thread_has_msg_queue(me)) {
         queue_index = cib_get(&(me->msg_queue));
     }
 
@@ -381,7 +381,7 @@ int msg_avail(void)
 
     int queue_index = -1;
 
-    if (me->msg_array) {
+    if (thread_has_msg_queue(me)) {
         queue_index = cib_avail(&(me->msg_queue));
     }
 

--- a/sys/net/gnrc/netreg/gnrc_netreg.c
+++ b/sys/net/gnrc/netreg/gnrc_netreg.c
@@ -39,13 +39,14 @@ void gnrc_netreg_init(void)
 
 int gnrc_netreg_register(gnrc_nettype_t type, gnrc_netreg_entry_t *entry)
 {
-#ifdef DEVELHELP
-#if defined(MODULE_GNRC_NETAPI_MBOX) || defined(MODULE_GNRC_NETAPI_CALLBACKS)
+#if DEVELHELP
+
+# if defined(MODULE_GNRC_NETAPI_MBOX) || defined(MODULE_GNRC_NETAPI_CALLBACKS)
     bool has_msg_q = (entry->type != GNRC_NETREG_TYPE_DEFAULT) ||
-                     sched_threads[entry->target.pid]->msg_array;
-#else
-    bool has_msg_q = sched_threads[entry->target.pid]->msg_array;
-#endif
+                     (sched_threads[entry->target.pid]->msg_array != NULL);
+# else
+    bool has_msg_q = (sched_threads[entry->target.pid]->msg_array != NULL);
+# endif
 
     /* only threads with a message queue are allowed to register at gnrc */
     if (!has_msg_q) {
@@ -53,7 +54,7 @@ int gnrc_netreg_register(gnrc_nettype_t type, gnrc_netreg_entry_t *entry)
                   "using msg_init_queue() !!!!\n\n", entry->target.pid);
     }
     assert(has_msg_q);
-#endif
+#endif /* DEVELHELP */
 
     if (_INVALID_TYPE(type)) {
         return -EINVAL;

--- a/sys/net/gnrc/netreg/gnrc_netreg.c
+++ b/sys/net/gnrc/netreg/gnrc_netreg.c
@@ -40,12 +40,11 @@ void gnrc_netreg_init(void)
 int gnrc_netreg_register(gnrc_nettype_t type, gnrc_netreg_entry_t *entry)
 {
 #if DEVELHELP
-
 # if defined(MODULE_GNRC_NETAPI_MBOX) || defined(MODULE_GNRC_NETAPI_CALLBACKS)
     bool has_msg_q = (entry->type != GNRC_NETREG_TYPE_DEFAULT) ||
-                     (sched_threads[entry->target.pid]->msg_array != NULL);
+                     thread_has_msg_queue(sched_threads[entry->target.pid]);
 # else
-    bool has_msg_q = (sched_threads[entry->target.pid]->msg_array != NULL);
+    bool has_msg_q = thread_has_msg_queue(sched_threads[entry->target.pid]);
 # endif
 
     /* only threads with a message queue are allowed to register at gnrc */

--- a/tests/gnrc_netif/main.c
+++ b/tests/gnrc_netif/main.c
@@ -131,7 +131,7 @@ static void test_creation(void)
 #ifdef DEVELHELP
     TEST_ASSERT_EQUAL_STRING("eth", sched_threads[ethernet_netif->pid]->name);
 #endif
-    TEST_ASSERT_NOT_NULL(sched_threads[ethernet_netif->pid]->msg_array);
+    TEST_ASSERT(thread_has_msg_queue(sched_threads[ethernet_netif->pid]));
 
     TEST_ASSERT_NOT_NULL((ieee802154_netif = gnrc_netif_ieee802154_create(
             ieee802154_netif_stack, IEEE802154_STACKSIZE, GNRC_NETIF_PRIO,
@@ -153,7 +153,7 @@ static void test_creation(void)
 #ifdef DEVELHELP
     TEST_ASSERT_EQUAL_STRING("wpan", sched_threads[ieee802154_netif->pid]->name);
 #endif
-    TEST_ASSERT_NOT_NULL(sched_threads[ieee802154_netif->pid]->msg_array);
+    TEST_ASSERT(thread_has_msg_queue(sched_threads[ieee802154_netif->pid]));
 
     for (unsigned i = 0; i < DEFAULT_DEVS_NUMOF; i++) {
         TEST_ASSERT_NOT_NULL((netifs[i] = gnrc_netif_create(
@@ -165,7 +165,7 @@ static void test_creation(void)
         TEST_ASSERT_EQUAL_INT(GNRC_NETIF_DEFAULT_HL, netifs[i]->cur_hl);
         TEST_ASSERT_EQUAL_INT(NETDEV_TYPE_UNKNOWN, netifs[i]->device_type);
         TEST_ASSERT(netifs[i]->pid > KERNEL_PID_UNDEF);
-        TEST_ASSERT_NOT_NULL(sched_threads[netifs[i]->pid]->msg_array);
+        TEST_ASSERT(thread_has_msg_queue(sched_threads[netifs[i]->pid]));
         TEST_ASSERT_EQUAL_INT(i + SPECIAL_DEVS + 1, gnrc_netif_numof());
         for (unsigned j = 0; j < (i + SPECIAL_DEVS + 1); j++) {
             TEST_ASSERT_NOT_NULL((ptr = gnrc_netif_iter(ptr)));


### PR DESCRIPTION
### Contribution description
I introduced this in my reference implementation for #10399, but I think readability of the code base can benefit from this regardless if we go forward with this issue or not.

### Testing procedure
- `examples/gnrc_networking` should still work without hitting an assertion on initialization
- `tests/gnrc_netif` should still pass
- `tests/msg_*` should still pass

### Issues/PRs references
Introduced in reference implementation for #10399 but factually independent of that issue.
