### PR TITLE
at86rf2xx: Don't use netdev_ieee802154_t for link layer address

### DIFF
--- a/drivers/at86rf2xx/at86rf2xx_getset.c
+++ b/drivers/at86rf2xx/at86rf2xx_getset.c
@@ -143,17 +143,18 @@ uint16_t at86rf2xx_get_addr_short(const at86rf2xx_t *dev)
 
 void at86rf2xx_set_addr_short(at86rf2xx_t *dev, uint16_t addr)
 {
-    dev->netdev.short_addr[0] = (uint8_t)(addr);
-    dev->netdev.short_addr[1] = (uint8_t)(addr >> 8);
+    /* addr is in network byte order */
+    network_uint16_t ap;
+    ap.u16 = addr;
 #ifdef MODULE_SIXLOWPAN
     /* https://tools.ietf.org/html/rfc4944#section-12 requires the first bit to
      * 0 for unicast addresses */
-    dev->netdev.short_addr[0] &= 0x7F;
+    ap.u8[0] &= 0x7F;
 #endif
     at86rf2xx_reg_write(dev, AT86RF2XX_REG__SHORT_ADDR_0,
-                        dev->netdev.short_addr[1]);
+                        ap.u8[1]);
     at86rf2xx_reg_write(dev, AT86RF2XX_REG__SHORT_ADDR_1,
-                        dev->netdev.short_addr[0]);
+                        ap.u8[0]);
 }
 
 uint64_t at86rf2xx_get_addr_long(const at86rf2xx_t *dev)
@@ -168,10 +169,12 @@ uint64_t at86rf2xx_get_addr_long(const at86rf2xx_t *dev)
 
 void at86rf2xx_set_addr_long(at86rf2xx_t *dev, uint64_t addr)
 {
-    for (int i = 0; i < 8; i++) {
-        dev->netdev.long_addr[i] = (uint8_t)(addr >> (i * 8));
+    network_uint64_t ap;
+    ap.u64 = addr;
+
+    for (unsigned i = 0; i < 8; i++) {
         at86rf2xx_reg_write(dev, (AT86RF2XX_REG__IEEE_ADDR_0 + i),
-                            (addr >> ((7 - i) * 8)));
+                            ap.u8[7 - i]);
     }
 }
 

--- a/drivers/at86rf2xx/at86rf2xx_netdev.c
+++ b/drivers/at86rf2xx/at86rf2xx_netdev.c
@@ -296,6 +296,16 @@ static int _get(netdev_t *netdev, netopt_t opt, void *val, size_t max_len)
 
     /* getting these options doesn't require the transceiver to be responsive */
     switch (opt) {
+        case NETOPT_ADDRESS:
+            assert(max_len >= sizeof(uint16_t));
+            *((uint16_t*)val) = at86rf2xx_get_addr_short(dev);
+            return sizeof(uint16_t);
+
+        case NETOPT_ADDRESS_LONG:
+            assert(max_len >= sizeof(uint64_t));
+            *((uint64_t*)val) = at86rf2xx_get_addr_long(dev);
+            return sizeof(uint64_t);
+
         case NETOPT_CHANNEL_PAGE:
             assert(max_len >= sizeof(uint16_t));
             ((uint8_t *)val)[1] = 0;


### PR DESCRIPTION
### Contribution description

This PR modifies the behaviour of the at86rf2xx driver to not propagate the link layer address to the `netdev_ieee802154_t` struct. This helps the goal of separating the netdev and the ieee802154_t layer by another bit. The end goal is to remove the short and long address from the `netdev_ieee802154_t` struct and match the behaviour of the ethernet drivers.

The performance impact of this change should be negligible, the `NETOPT_ADDRESS(_LONG)` call is only used on initialization and by the `ifconfig` command.

### Testing procedure

Test whether:
 - ifconfig still shows the correct link layer addresses. These should not have changed between this PR and master.
 - ping still works. This to verify that the link layer address is also properly configured in the radio, if the ping echo/reply fails, the address filter of the radio might be configured in the wrong endianness.

### Issues/PRs references

First part in a sequence to remove the link layer address from the `netdev_ieee802154_t` struct