### PR TITLE
mrf24j40: Don't use netdev_ieee802154_t for link layer address

### DIFF
--- a/drivers/mrf24j40/mrf24j40_getset.c
+++ b/drivers/mrf24j40/mrf24j40_getset.c
@@ -131,14 +131,12 @@ void mrf24j40_set_addr_short(mrf24j40_t *dev, uint16_t addr)
 #ifdef MODULE_SIXLOWPAN
     /* https://tools.ietf.org/html/rfc4944#section-12 requires the first bit to
      * 0 for unicast addresses */
-    dev->netdev.short_addr[0] &= 0x7F;
+    addr &= 0xFF7F;
 #endif
-    dev->netdev.short_addr[0] = (uint8_t)(addr);
-    dev->netdev.short_addr[1] = (uint8_t)(addr >> 8);
     mrf24j40_reg_write_short(dev, MRF24J40_REG_SADRL,
-                             dev->netdev.short_addr[1]);
+                             (uint8_t)(addr >> 8));
     mrf24j40_reg_write_short(dev, MRF24J40_REG_SADRH,
-                             dev->netdev.short_addr[0]);
+                             (uint8_t)addr);
 }
 
 uint64_t mrf24j40_get_addr_long(mrf24j40_t *dev)
@@ -156,7 +154,6 @@ uint64_t mrf24j40_get_addr_long(mrf24j40_t *dev)
 void mrf24j40_set_addr_long(mrf24j40_t *dev, uint64_t addr)
 {
     for (int i = 0; i < 8; i++) {
-        dev->netdev.long_addr[i] = (uint8_t)(addr >> (i * 8));
         mrf24j40_reg_write_short(dev, (MRF24J40_REG_EADR0 + i),
                                  (addr >> ((7 - i) * 8)));
     }

--- a/drivers/mrf24j40/mrf24j40_getset.c
+++ b/drivers/mrf24j40/mrf24j40_getset.c
@@ -122,7 +122,8 @@ static const uint8_t RSSI_value[] = { 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 0xff, 
 
 uint16_t mrf24j40_get_addr_short(mrf24j40_t *dev)
 {
-    return (dev->netdev.short_addr[0] << 8) | dev->netdev.short_addr[1];
+    return (mrf24j40_reg_read_short(dev, MRF24J40_REG_SADRL) << 8) |
+        mrf24j40_reg_read_short(dev, MRF24J40_REG_SADRH);
 }
 
 void mrf24j40_set_addr_short(mrf24j40_t *dev, uint16_t addr)
@@ -147,7 +148,7 @@ uint64_t mrf24j40_get_addr_long(mrf24j40_t *dev)
     uint8_t *ap = (uint8_t *)(&addr);
 
     for (int i = 0; i < 8; i++) {
-        ap[i] = dev->netdev.long_addr[i];
+        ap[7 - i] = mrf24j40_reg_read_short(dev, (MRF24J40_REG_EADR0 + i));
     }
     return addr;
 }

--- a/drivers/mrf24j40/mrf24j40_netdev.c
+++ b/drivers/mrf24j40/mrf24j40_netdev.c
@@ -371,7 +371,7 @@ static int _set(netdev_t *netdev, netopt_t opt, const void *val, size_t len)
             }
             else {
                 mrf24j40_set_addr_short(dev, *((const uint16_t *)val));
-                /* don't set res to set netdev_ieee802154_t::short_addr */
+                res = sizeof(uint16_t);
             }
             break;
 
@@ -381,7 +381,7 @@ static int _set(netdev_t *netdev, netopt_t opt, const void *val, size_t len)
             }
             else {
                 mrf24j40_set_addr_long(dev, *((const uint64_t *)val));
-                /* don't set res to set netdev_ieee802154_t::long_addr */
+                res = sizeof(uint64_t);
             }
             break;
 

--- a/drivers/mrf24j40/mrf24j40_netdev.c
+++ b/drivers/mrf24j40/mrf24j40_netdev.c
@@ -174,6 +174,26 @@ static int _get(netdev_t *netdev, netopt_t opt, void *val, size_t max_len)
 
     int res;
     switch (opt) {
+        case NETOPT_ADDRESS:
+            if (max_len < sizeof(uint16_t)) {
+                res = -EOVERFLOW;
+            }
+            else {
+                *(uint16_t*)val = mrf24j40_get_addr_short(dev);
+                res = sizeof(uint16_t);
+            }
+            break;
+
+        case NETOPT_ADDRESS_LONG:
+            if (max_len < sizeof(uint64_t)) {
+                res = -EOVERFLOW;
+            }
+            else {
+                *(uint64_t*)val = mrf24j40_get_addr_long(dev);
+                res = sizeof(uint64_t);
+            }
+            break;
+
         case NETOPT_CHANNEL_PAGE:
             if (max_len < sizeof(uint16_t)) {
                 res = -EOVERFLOW;


### PR DESCRIPTION
### Contribution description

This PR modifies the behaviour of the mrf24j40 driver to not propagate the link layer address to the netdev_ieee802154_t struct. This helps the goal of separating the netdev and the ieee802154_t layer by another bit. The end goal is to remove the short and long address from the netdev_ieee802154_t struct and match the behaviour of the ethernet drivers.

The performance impact of this change should be negligible, the NETOPT_ADDRESS(_LONG) call is only used on initialization and by the ifconfig command.

### Testing procedure

Test whether:

 -  ifconfig still shows the correct link layer addresses. These should not have changed between this PR and master.
 - ping still works. This to verify that the link layer address is also properly configured in the radio, if the ping echo/reply fails, the address filter of the radio might be configured in the wrong endianness.

### Issues/PRs references

related to #10401, part of #7736 