### PR TITLE
gnrc_netif: sync TX with network device

### DIFF
--- a/sys/include/net/gnrc/netif/flags.h
+++ b/sys/include/net/gnrc/netif/flags.h
@@ -119,6 +119,11 @@ enum {
 #define GNRC_NETIF_FLAGS_6LO_BACKBONE              (0x00000800U)
 
 /**
+ * @brief   Network device did not return @ref NETDEV_EVENT_TX_COMPLETE yet
+ */
+#define GNRC_NETIF_FLAGS_TX_PENDING                (0x00001000U)
+
+/**
  * @brief   Mask for @ref gnrc_mac_tx_feedback_t
  */
 #define GNRC_NETIF_FLAGS_MAC_TX_FEEDBACK_MASK      (0x00006000U)


### PR DESCRIPTION
### Contribution description
Otherwise, a radio might get bombarded with frames (e.g. when 6LoWPAN is sending fragments) without the device being ready yet.

### Testing procedure
Check if `ping6` with fragmented packets still works on all IEEE 802.15.4 device. For some device drivers this might actually make it possible in the first place. I expect problems with some devices (especially some of the Ethernet ones), as they don't implement the `TX_COMPLETE` event.

### Issues/PRs references
Implemented as a solution to a problem in #10268.