### PR TITLE
makefiles/color: Add color functions.

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -470,7 +470,7 @@ endif # BUILD_IN_DOCKER
 define check_cmd
 	@command -v $1 >/dev/null 2>&1 || \
 	  { $(COLOR_ECHO) \
-	    '$(COLOR_RED)$2 $1 is required but not found in PATH.  Aborting.$(COLOR_RESET)'; \
+	    '$(call c_red,$2 $1 is required but not found in PATH.  Aborting.)'; \
 	    exit 1;}
 endef
 
@@ -478,7 +478,7 @@ endef
 	$(call check_cmd,$(CC),Compiler)
 
 ..build-message:
-	@$(COLOR_ECHO) '$(COLOR_GREEN)Building application "$(APPLICATION)" for "$(BOARD)" with MCU "$(MCU)".$(COLOR_RESET)'
+	@$(COLOR_ECHO) '$(call c_green,Building application "$(APPLICATION)" for "$(BOARD)" with MCU "$(MCU)".)'
 	@$(COLOR_ECHO)
 
 # The `clean` needs to be serialized before everything else.
@@ -588,26 +588,26 @@ ifneq (, $(filter all flash, $(if $(MAKECMDGOALS), $(MAKECMDGOALS), all)))
 
   # Test if there where dependencies against a module in DISABLE_MODULE.
   ifneq (, $(filter $(DISABLE_MODULE), $(USEMODULE)))
-    $(shell $(COLOR_ECHO) "$(COLOR_RED)Required modules were disabled using DISABLE_MODULE:$(COLOR_RESET)"\
-                          "$(sort $(filter $(DISABLE_MODULE), $(USEMODULE)))" 1>&2)
+    $(call color_info,"$(call c_red,Required modules were disabled using DISABLE_MODULE:)" \
+                          "$(sort $(filter $(DISABLE_MODULE), $(USEMODULE)))")
     USEMODULE := $(filter-out $(DISABLE_MODULE), $(USEMODULE))
     EXPECT_ERRORS := 1
   endif
 
   # Test if all feature requirements were met by the selected board.
   ifneq (, $(filter-out $(FEATURES_PROVIDED) $(FEATURES_OPTIONAL), $(FEATURES_REQUIRED)))
-    $(shell $(COLOR_ECHO) "$(COLOR_RED)There are unsatisfied feature requirements:$(COLOR_RESET)"\
-                          "$(sort $(filter-out $(FEATURES_PROVIDED) $(FEATURES_OPTIONAL), $(FEATURES_REQUIRED)))" 1>&2)
+    $(call color_info,"$(call c_red,There are unsatisfied feature requirements:)" \
+                          "$(sort $(filter-out $(FEATURES_PROVIDED) $(FEATURES_OPTIONAL), $(FEATURES_REQUIRED)))")
     EXPECT_ERRORS := 1
   endif
 
   # Test if any used feature conflict with another one.
   CONFLICT := $(foreach var,$(FEATURES_CONFLICT),$(if $(filter $(words $(subst :, ,$(var))),$(words $(filter $(FEATURES_USED),$(subst :, ,$(var))))),$(subst :, ,$(var))))
   ifneq (, $(strip $(CONFLICT)))
-    $(shell $(COLOR_ECHO) "$(COLOR_YELLOW)The following features may conflict:$(COLOR_RESET)"\
-                          "$(COLOR_GREEN)$(sort $(filter $(FEATURES_USED), $(CONFLICT)))$(COLOR_RESET)" 1>&2)
+    $(call color_info,"$(call c_red,The following features may conflict:)" \
+                          "$(call c_green,$(sort $(filter $(FEATURES_USED), $(CONFLICT))))")
     ifneq (, $(FEATURES_CONFLICT_MSG))
-        $(shell $(COLOR_ECHO) "$(COLOR_YELLOW)Rationale: $(COLOR_RESET)$(FEATURES_CONFLICT_MSG)" 1>&2)
+        $(call color_info,"$(call c_yellow,Rationale:) $(FEATURES_CONFLICT_MSG)")
     endif
     EXPECT_CONFLICT := 1
   endif
@@ -615,7 +615,7 @@ ifneq (, $(filter all flash, $(if $(MAKECMDGOALS), $(MAKECMDGOALS), all)))
   # If there is a whitelist, then test if the board is whitelisted.
   ifneq (, $(BOARD_WHITELIST))
     ifeq (, $(filter $(BOARD_WHITELIST), $(BOARD)))
-      $(shell $(COLOR_ECHO) "$(COLOR_RED)The selected BOARD=$(BOARD) is not whitelisted:$(COLOR_RESET) $(BOARD_WHITELIST)" 1>&2)
+      $(call color_info,"$(call c_red,The selected BOARD=$(BOARD) is not whitelisted:) $(BOARD_WHITELIST)")
       EXPECT_ERRORS := 1
     endif
   endif
@@ -623,31 +623,31 @@ ifneq (, $(filter all flash, $(if $(MAKECMDGOALS), $(MAKECMDGOALS), all)))
   # If there is a blacklist, then test if the board is blacklisted.
   ifneq (, $(BOARD_BLACKLIST))
     ifneq (, $(filter $(BOARD_BLACKLIST), $(BOARD)))
-      $(shell $(COLOR_ECHO) "$(COLOR_RED)The selected BOARD=$(BOARD) is blacklisted:$(COLOR_RESET) $(BOARD_BLACKLIST)" 1>&2)
+      $(call color_info,"$(call c_red,The selected BOARD=$(BOARD) is blacklisted:) $(BOARD_BLACKLIST)")
       EXPECT_ERRORS := 1
     endif
   endif
 
   #  test if toolchain is supported.
   ifeq (,$(filter $(TOOLCHAIN),$(TOOLCHAINS_SUPPORTED)))
-    $(shell $(COLOR_ECHO) "$(COLOR_RED)The selected TOOLCHAIN=$(TOOLCHAIN) is not supported.$(COLOR_RESET)\nSupported toolchains: $(TOOLCHAINS_SUPPORTED)" 1>&2)
+    $(call color_info,"$(call c_red,The selected TOOLCHAIN=$(TOOLCHAIN) is not supported.)\nSupported toolchains: $(TOOLCHAINS_SUPPORTED)")
     EXPECT_ERRORS := 1
   endif
 
   # If there is a blacklist, then test if the board is blacklisted.
   ifneq (,$(TOOLCHAINS_BLACKLIST))
     ifneq (,$(filter $(TOOLCHAIN),$(TOOLCHAINS_BLACKLIST)))
-      $(shell $(COLOR_ECHO) "$(COLOR_RED)The selected TOOLCHAIN=$(TOOLCHAIN) is blacklisted:$(COLOR_RESET) $(TOOLCHAINS_BLACKLIST)" 1>&2)
+      $(call color_info,"$(call c_red,The selected TOOLCHAIN=$(TOOLCHAIN) is blacklisted:) $(TOOLCHAINS_BLACKLIST)")
       EXPECT_ERRORS := 1
     endif
   endif
 
   ifneq (, $(EXPECT_CONFLICT))
-    $(shell $(COLOR_ECHO) "\n$(COLOR_YELLOW)EXPECT undesired behaviour!$(COLOR_RESET)" 1>&2)
+    $(call color_info,"\n$(call c_yellow,EXPECT undesired behaviour!)")
   endif
 
   ifneq (, $(EXPECT_ERRORS))
-    $(shell $(COLOR_ECHO) "\n\n$(COLOR_RED)EXPECT ERRORS!$(COLOR_RESET)\n\n" 1>&2)
+    $(call color_info,"\n\n$(call c_red,EXPECT ERRORS!)\n\n")
   endif
 
 endif
@@ -675,7 +675,7 @@ else # RIOT_VERSION
 	$(Q)cd $(RIOTBASE) && git archive --format=tar $(NUM_RIOT_VERSION) | ( cd $(@D) && tar x 1>&2 )
 
   ..delegate: $(BINDIR)/riot-version/$(NUM_RIOT_VERSION)/Makefile.include
-	@$(COLOR_ECHO) '$(COLOR_GREEN)Using RIOT_VERSION=$(NUM_RIOT_VERSION)$(COLOR_RESET)' 1>&2
+	@$(COLOR_ECHO) '$(call c_green,Using RIOT_VERSION=$(NUM_RIOT_VERSION))' 1>&2
 	@$(COLOR_ECHO)
 	$(MAKE) RIOTBASE=$(<D) $(filter-out clean, $(MAKECMDGOALS))
 

--- a/Makefile.include
+++ b/Makefile.include
@@ -469,7 +469,7 @@ endif # BUILD_IN_DOCKER
 #   check_cmd 'command' 'description'
 define check_cmd
 	@command -v $1 >/dev/null 2>&1 || \
-	  { $(COLOR_ECHO) \
+	  { echo \
 	    '$(call c_red,$2 $1 is required but not found in PATH.  Aborting.)'; \
 	    exit 1;}
 endef
@@ -478,8 +478,7 @@ endef
 	$(call check_cmd,$(CC),Compiler)
 
 ..build-message:
-	@$(COLOR_ECHO) '$(call c_green,Building application "$(APPLICATION)" for "$(BOARD)" with MCU "$(MCU)".)'
-	@$(COLOR_ECHO)
+	$(info $(call c_green,Building application "$(APPLICATION)" for "$(BOARD)" with MCU "$(MCU)".))
 
 # The `clean` needs to be serialized before everything else.
 ifneq (, $(filter clean, $(MAKECMDGOALS)))
@@ -588,26 +587,26 @@ ifneq (, $(filter all flash, $(if $(MAKECMDGOALS), $(MAKECMDGOALS), all)))
 
   # Test if there where dependencies against a module in DISABLE_MODULE.
   ifneq (, $(filter $(DISABLE_MODULE), $(USEMODULE)))
-    $(call color_info,"$(call c_red,Required modules were disabled using DISABLE_MODULE:)" \
-                          "$(sort $(filter $(DISABLE_MODULE), $(USEMODULE)))")
+    $(call warn,$(call c_red,Required modules were disabled using DISABLE_MODULE:) \
+                          $(sort $(filter $(DISABLE_MODULE), $(USEMODULE))))
     USEMODULE := $(filter-out $(DISABLE_MODULE), $(USEMODULE))
     EXPECT_ERRORS := 1
   endif
 
   # Test if all feature requirements were met by the selected board.
   ifneq (, $(filter-out $(FEATURES_PROVIDED) $(FEATURES_OPTIONAL), $(FEATURES_REQUIRED)))
-    $(call color_info,"$(call c_red,There are unsatisfied feature requirements:)" \
-                          "$(sort $(filter-out $(FEATURES_PROVIDED) $(FEATURES_OPTIONAL), $(FEATURES_REQUIRED)))")
+    $(call warn,$(call c_red,There are unsatisfied feature requirements:) \
+                          $(sort $(filter-out $(FEATURES_PROVIDED) $(FEATURES_OPTIONAL), $(FEATURES_REQUIRED))))
     EXPECT_ERRORS := 1
   endif
 
   # Test if any used feature conflict with another one.
   CONFLICT := $(foreach var,$(FEATURES_CONFLICT),$(if $(filter $(words $(subst :, ,$(var))),$(words $(filter $(FEATURES_USED),$(subst :, ,$(var))))),$(subst :, ,$(var))))
   ifneq (, $(strip $(CONFLICT)))
-    $(call color_info,"$(call c_red,The following features may conflict:)" \
-                          "$(call c_green,$(sort $(filter $(FEATURES_USED), $(CONFLICT))))")
+    $(call warn,$(call c_red,The following features may conflict:) \
+                          $(call c_green,$(sort $(filter $(FEATURES_USED), $(CONFLICT)))))
     ifneq (, $(FEATURES_CONFLICT_MSG))
-        $(call color_info,"$(call c_yellow,Rationale:) $(FEATURES_CONFLICT_MSG)")
+        $(call warn,$(call c_yellow,Rationale:) $(FEATURES_CONFLICT_MSG))
     endif
     EXPECT_CONFLICT := 1
   endif
@@ -615,7 +614,7 @@ ifneq (, $(filter all flash, $(if $(MAKECMDGOALS), $(MAKECMDGOALS), all)))
   # If there is a whitelist, then test if the board is whitelisted.
   ifneq (, $(BOARD_WHITELIST))
     ifeq (, $(filter $(BOARD_WHITELIST), $(BOARD)))
-      $(call color_info,"$(call c_red,The selected BOARD=$(BOARD) is not whitelisted:) $(BOARD_WHITELIST)")
+      $(call warn,$(call c_red,The selected BOARD=$(BOARD) is not whitelisted:) $(BOARD_WHITELIST))
       EXPECT_ERRORS := 1
     endif
   endif
@@ -623,31 +622,31 @@ ifneq (, $(filter all flash, $(if $(MAKECMDGOALS), $(MAKECMDGOALS), all)))
   # If there is a blacklist, then test if the board is blacklisted.
   ifneq (, $(BOARD_BLACKLIST))
     ifneq (, $(filter $(BOARD_BLACKLIST), $(BOARD)))
-      $(call color_info,"$(call c_red,The selected BOARD=$(BOARD) is blacklisted:) $(BOARD_BLACKLIST)")
+      $(call warn,$(call c_red,The selected BOARD=$(BOARD) is blacklisted:) $(BOARD_BLACKLIST))
       EXPECT_ERRORS := 1
     endif
   endif
 
   #  test if toolchain is supported.
   ifeq (,$(filter $(TOOLCHAIN),$(TOOLCHAINS_SUPPORTED)))
-    $(call color_info,"$(call c_red,The selected TOOLCHAIN=$(TOOLCHAIN) is not supported.)\nSupported toolchains: $(TOOLCHAINS_SUPPORTED)")
+    $(call warn,$(call c_red,The selected TOOLCHAIN=$(TOOLCHAIN) is not supported.)\nSupported toolchains: $(TOOLCHAINS_SUPPORTED))
     EXPECT_ERRORS := 1
   endif
 
   # If there is a blacklist, then test if the board is blacklisted.
   ifneq (,$(TOOLCHAINS_BLACKLIST))
     ifneq (,$(filter $(TOOLCHAIN),$(TOOLCHAINS_BLACKLIST)))
-      $(call color_info,"$(call c_red,The selected TOOLCHAIN=$(TOOLCHAIN) is blacklisted:) $(TOOLCHAINS_BLACKLIST)")
+      $(call warn,$(call c_red,The selected TOOLCHAIN=$(TOOLCHAIN) is blacklisted:) $(TOOLCHAINS_BLACKLIST))
       EXPECT_ERRORS := 1
     endif
   endif
 
   ifneq (, $(EXPECT_CONFLICT))
-    $(call color_info,"\n$(call c_yellow,EXPECT undesired behaviour!)")
+    $(call warn,\n$(call c_yellow,EXPECT undesired behaviour!))
   endif
 
   ifneq (, $(EXPECT_ERRORS))
-    $(call color_info,"\n\n$(call c_red,EXPECT ERRORS!)\n\n")
+    $(call warn,\n\n$(call c_red,EXPECT ERRORS!)\n\n)
   endif
 
 endif
@@ -675,8 +674,8 @@ else # RIOT_VERSION
 	$(Q)cd $(RIOTBASE) && git archive --format=tar $(NUM_RIOT_VERSION) | ( cd $(@D) && tar x 1>&2 )
 
   ..delegate: $(BINDIR)/riot-version/$(NUM_RIOT_VERSION)/Makefile.include
-	@$(COLOR_ECHO) '$(call c_green,Using RIOT_VERSION=$(NUM_RIOT_VERSION))' 1>&2
-	@$(COLOR_ECHO)
+	@echo '$(call c_green,Using RIOT_VERSION=$(NUM_RIOT_VERSION))' 1>&2
+	@echo
 	$(MAKE) RIOTBASE=$(<D) $(filter-out clean, $(MAKECMDGOALS))
 
 endif
@@ -731,7 +730,7 @@ endif
 
 # Detect if BASELIBS changed since its first use
 ifneq ($(_BASELIBS_VALUE_BEFORE_USAGE),$(BASELIBS))
-  $(warning $(sort $(filter-out $(_BASELIBS_VALUE_BEFORE_USAGE), $(BASELIBS)) \
+  $(call warn,$(sort $(filter-out $(_BASELIBS_VALUE_BEFORE_USAGE), $(BASELIBS)) \
                    $(filter-out $(BASELIBS), $(_BASELIBS_VALUE_BEFORE_USAGE))))
   $(error BASELIBS value changed)
 endif

--- a/cpu/stm32_common/Makefile.include
+++ b/cpu/stm32_common/Makefile.include
@@ -30,11 +30,11 @@ export CFLAGS += -D$(CPU_LINE) -DCPU_LINE_$(CPU_LINE)
 export CFLAGS += -DSTM32_FLASHSIZE=$(FLASHSIZE)U
 
 info-stm32:
-	@$(COLOR_ECHO) "CPU: $(CPU_MODEL)"
-	@$(COLOR_ECHO) "\tLine: $(CPU_LINE)"
-	@$(COLOR_ECHO) "\tPin count:\t$(STM32_PINCOUNT)"
-	@$(COLOR_ECHO) "\tROM size:\t$(ROM_LEN) ($(FLASHSIZE) Bytes)"
-	@$(COLOR_ECHO) "\tRAM size:\t$(RAM_LEN)"
+	@echo -e "CPU: $(CPU_MODEL)"
+	@echo -e "\tLine: $(CPU_LINE)"
+	@echo -e "\tPin count:\t$(STM32_PINCOUNT)"
+	@echo -e "\tROM size:\t$(ROM_LEN) ($(FLASHSIZE) Bytes)"
+	@echo -e "\tRAM size:\t$(RAM_LEN)"
 
 ifneq (,$(CCMRAM_LEN))
   LINKFLAGS += $(LINKFLAGPREFIX)--defsym=_ccmram_length=$(CCMRAM_LEN)

--- a/makefiles/buildtests.inc.mk
+++ b/makefiles/buildtests.inc.mk
@@ -15,9 +15,9 @@ buildtest:
 				$(MAKE) clean all -j $(NPROC) $(BUILDTEST_MAKE_REDIRECT); \
 			RES=$$? ; \
 			if [ $$RES -eq 0 ]; then \
-				$(COLOR_ECHO) "$(COLOR_GREEN)success.$(COLOR_RESET)" ; \
+				$(COLOR_ECHO) "$(call c_green,success.)" ; \
 			else \
-				$(COLOR_ECHO) "$(COLOR_RED)failed!$(COLOR_RESET)" ; \
+				$(COLOR_ECHO) "$(call c_red,failed!)" ; \
 				RESULT=false ; \
 			fi ; \
 			BOARD=$${board} $(MAKE) clean-intermediates >/dev/null 2>&1 || true; \

--- a/makefiles/buildtests.inc.mk
+++ b/makefiles/buildtests.inc.mk
@@ -10,14 +10,14 @@ buildtest:
 	RESULT=true ; \
 	for board in $(BOARDS); do \
 		if BOARD=$${board} $(MAKE) check-toolchain-supported > /dev/null 2>&1; then \
-			$(COLOR_ECHO) -n "Building for $$board ... " ; \
+			echo "Building for $$board ... " ; \
 			BOARD=$${board} RIOT_CI_BUILD=1 RIOT_VERSION_OVERRIDE=buildtest \
 				$(MAKE) clean all -j $(NPROC) $(BUILDTEST_MAKE_REDIRECT); \
 			RES=$$? ; \
 			if [ $$RES -eq 0 ]; then \
-				$(COLOR_ECHO) "$(call c_green,success.)" ; \
+				echo -e "$(call c_green,success.)" ; \
 			else \
-				$(COLOR_ECHO) "$(call c_red,failed!)" ; \
+				echo -e "$(call c_red,failed!)" ; \
 				RESULT=false ; \
 			fi ; \
 			BOARD=$${board} $(MAKE) clean-intermediates >/dev/null 2>&1 || true; \

--- a/makefiles/color.inc.mk
+++ b/makefiles/color.inc.mk
@@ -1,12 +1,6 @@
 # Set colored output control sequences if the terminal supports it and if
 # not disabled by the user
 
-COLOR_GREEN  :=
-COLOR_RED    :=
-COLOR_PURPLE :=
-COLOR_RESET  :=
-COLOR_ECHO   := /bin/echo
-
 ifeq ($(CC_NOCOLOR),)
   available_colors:=$(shell tput colors 2> /dev/null)
   ifeq ($(available_colors),)
@@ -32,4 +26,17 @@ ifeq ($(CC_NOCOLOR),0)
   else
     COLOR_ECHO   := /bin/echo -e
   endif
+else
+  COLOR_ECHO   := /bin/echo
 endif
+
+# Colorizer functions:
+#  These functions wrap a block of text in $(COLOR_X)...$(COLOR_RESET).
+#  Do not nest calls to this functions or the colors will be wrong.
+c_green = $(COLOR_GREEN)$(1)$(COLOR_RESET)
+c_red = $(COLOR_RED)$(1)$(COLOR_RESET)
+c_yellow = $(COLOR_YELLOW)$(1)$(COLOR_RESET)
+c_purple = $(COLOR_PURPLE)$(1)$(COLOR_RESET)
+
+# Output a color message to standard output.
+color_info = $(shell $(COLOR_ECHO) $(1) 1>&2)

--- a/makefiles/color.inc.mk
+++ b/makefiles/color.inc.mk
@@ -15,19 +15,12 @@ ifeq ($(CC_NOCOLOR),)
 endif
 
 ifeq ($(CC_NOCOLOR),0)
-  COLOR_GREEN  := \033[1;32m
-  COLOR_RED    := \033[1;31m
-  COLOR_YELLOW := \033[1;33m
-  COLOR_PURPLE := \033[1;35m
-  COLOR_RESET  := \033[0m
-  ifeq ($(OS),Darwin)
-    COLOR_ECHO   := echo -e
-    SHELL=bash
-  else
-    COLOR_ECHO   := /bin/echo -e
-  endif
-else
-  COLOR_ECHO   := /bin/echo
+  _COLOR_ECHO  = $(shell /bin/echo -e "$(1)")
+  COLOR_GREEN  := $(call _COLOR_ECHO,\033[1;32m)
+  COLOR_RED    := $(call _COLOR_ECHO,\033[1;31m)
+  COLOR_YELLOW := $(call _COLOR_ECHO,\033[1;33m)
+  COLOR_PURPLE := $(call _COLOR_ECHO,\033[1;35m)
+  COLOR_RESET  := $(call _COLOR_ECHO,\033[0m)
 endif
 
 # Colorizer functions:
@@ -38,5 +31,6 @@ c_red = $(COLOR_RED)$(1)$(COLOR_RESET)
 c_yellow = $(COLOR_YELLOW)$(1)$(COLOR_RESET)
 c_purple = $(COLOR_PURPLE)$(1)$(COLOR_RESET)
 
-# Output a color message to standard output.
-color_info = $(shell $(COLOR_ECHO) $(1) 1>&2)
+# Like Make's "warning" function, except the file and line number are not
+# printed, and backlash escapes are interpreted.
+warn = $(shell echo -e "$(1)" 1>&2)

--- a/makefiles/docker.inc.mk
+++ b/makefiles/docker.inc.mk
@@ -102,7 +102,7 @@ DOCKER_VOLUMES_AND_ENV += $(if $(_is_git_worktree),-v $(GIT_WORKTREE_COMMONDIR):
 # The `flash`, `term`, `debugserver` etc. targets usually require access to
 # hardware which may not be reachable from inside the container.
 ..in-docker-container:
-	@$(COLOR_ECHO) '$(COLOR_GREEN)Launching build container using image "$(DOCKER_IMAGE)".$(COLOR_RESET)'
+	@$(COLOR_ECHO) '$(call c_green,Launching build container using image "$(DOCKER_IMAGE)".)'
 	$(DOCKER) run $(DOCKER_FLAGS) -t -u "$$(id -u)" \
 	    -v '$(RIOTBASE):$(DOCKER_BUILD_ROOT)/riotbase' \
 	    -v '$(RIOTCPU):$(DOCKER_BUILD_ROOT)/riotcpu' \

--- a/makefiles/info-global.inc.mk
+++ b/makefiles/info-global.inc.mk
@@ -62,8 +62,8 @@ info-buildsizes-diff:
 	    for I in 0 1 2 3; do \
 	      if [[ -n "$${NEW[I]}" && -n "$${OLD[I]}" ]]; then \
 	        DIFF=$$(($${NEW[I]} - $${OLD[I]})); \
-	        if [[ "$${DIFF}" -gt 0 ]]; then $(COLOR_ECHO) -n "$(COLOR_RED)"; fi; \
-	        if [[ "$${DIFF}" -lt 0 ]]; then $(COLOR_ECHO) -n "$(COLOR_GREEN)"; fi; \
+	        if [[ "$${DIFF}" -gt 0 ]]; then echo "$(COLOR_RED)"; fi; \
+	        if [[ "$${DIFF}" -lt 0 ]]; then echo "$(COLOR_GREEN)"; fi; \
 	      else \
 	        DIFF="$(COLOR_RED)ERR"; \
 	      fi; \

--- a/makefiles/mcuboot.mk
+++ b/makefiles/mcuboot.mk
@@ -21,18 +21,18 @@ $(MCUBOOT_KEYFILE):
 endif
 
 mcuboot: mcuboot-create-key link
-	@$(COLOR_ECHO)
-	@$(COLOR_ECHO) '$(call c_purple,Re-linking for MCUBoot at $(MCUBOOT_SLOT0_SIZE)...)'
-	@$(COLOR_ECHO)
+	@echo
+	@echo '$(call c_purple,Re-linking for MCUBoot at $(MCUBOOT_SLOT0_SIZE)...)'
+	@echo
 	$(Q)$(_LINK) $(LINKFLAGPREFIX)--defsym=offset="$$(($(MCUBOOT_SLOT0_SIZE) + $(IMAGE_HDR_SIZE)))" \
 	$(LINKFLAGPREFIX)--defsym=length="$$(($(MCUBOOT_SLOT1_SIZE) - $(IMAGE_HDR_SIZE)))" \
 	$(LINKFLAGPREFIX)--defsym=image_header="$(IMAGE_HDR_SIZE)" -o $(ELFFILE) && \
 	$(OBJCOPY) $(OFLAGS) -Obinary $(ELFFILE) $(BINFILE) && \
 	$(IMGTOOL) sign --key $(MCUBOOT_KEYFILE) --version $(IMAGE_VERSION) --align \
 	$(MCUBOOT_IMAGE_ALIGN) -H $(IMAGE_HDR_SIZE) $(BINFILE) $(SIGN_BINFILE)
-	@$(COLOR_ECHO)
-	@$(COLOR_ECHO) '$(call c_purple,Signed with $(MCUBOOT_KEYFILE) for version $(IMAGE_VERSION))'
-	@$(COLOR_ECHO)
+	@echo
+	@echo '$(call c_purple,Signed with $(MCUBOOT_KEYFILE) for version $(IMAGE_VERSION))'
+	@echo
 
 $(MCUBOOT_BIN):
 	$(Q)$(DLCACHE) $(MCUBOOT_BIN_URL) $(MCUBOOT_BIN_MD5) $@

--- a/makefiles/mcuboot.mk
+++ b/makefiles/mcuboot.mk
@@ -22,7 +22,7 @@ endif
 
 mcuboot: mcuboot-create-key link
 	@$(COLOR_ECHO)
-	@$(COLOR_ECHO) '$(COLOR_PURPLE)Re-linking for MCUBoot at $(MCUBOOT_SLOT0_SIZE)...$(COLOR_RESET)'
+	@$(COLOR_ECHO) '$(call c_purple,Re-linking for MCUBoot at $(MCUBOOT_SLOT0_SIZE)...)'
 	@$(COLOR_ECHO)
 	$(Q)$(_LINK) $(LINKFLAGPREFIX)--defsym=offset="$$(($(MCUBOOT_SLOT0_SIZE) + $(IMAGE_HDR_SIZE)))" \
 	$(LINKFLAGPREFIX)--defsym=length="$$(($(MCUBOOT_SLOT1_SIZE) - $(IMAGE_HDR_SIZE)))" \
@@ -31,8 +31,7 @@ mcuboot: mcuboot-create-key link
 	$(IMGTOOL) sign --key $(MCUBOOT_KEYFILE) --version $(IMAGE_VERSION) --align \
 	$(MCUBOOT_IMAGE_ALIGN) -H $(IMAGE_HDR_SIZE) $(BINFILE) $(SIGN_BINFILE)
 	@$(COLOR_ECHO)
-	@$(COLOR_ECHO) '$(COLOR_PURPLE)Signed with $(MCUBOOT_KEYFILE) for version $(IMAGE_VERSION)\
-	$(COLOR_RESET)'
+	@$(COLOR_ECHO) '$(call c_purple,Signed with $(MCUBOOT_KEYFILE) for version $(IMAGE_VERSION))'
 	@$(COLOR_ECHO)
 
 $(MCUBOOT_BIN):

--- a/makefiles/scan-build.inc.mk
+++ b/makefiles/scan-build.inc.mk
@@ -80,13 +80,13 @@ endif # BUILD_IN_DOCKER
 
 
 ..scan-build-analyze: clean
-	@$(COLOR_ECHO) '$(call c_green,Performing Clang static code analysis using toolchain "$(TOOLCHAIN)".)'
+	@echo '$(call c_green,Performing Clang static code analysis using toolchain "$(TOOLCHAIN)".)'
 # ccc-analyzer needs to be told the proper -target setting for best results,
 # otherwise false error reports about unknown register names etc will be produced.
 # These kinds of errors can be safely ignored as long as they only come from LLVM
 	@if [ "$${TOOLCHAIN}" != "llvm" -a "$${BOARD}" != "native" ]; then \
-	  $(COLOR_ECHO) '$(call c_yellow,Recommend using TOOLCHAIN=llvm for best results.)'; \
-	  $(COLOR_ECHO) '$(call c_yellow,Ignore any "error: unknown register name '\''rX'\'' in asm" messages.)'; \
+	  echo '$(call c_yellow,Recommend using TOOLCHAIN=llvm for best results.)'; \
+	  echo '$(call c_yellow,Ignore any "error: unknown register name '\''rX'\'' in asm" messages.)'; \
 	fi
 	$(Q)mkdir -p '$(SCANBUILD_OUTPUTDIR)'
 	$(Q)env -i $(ENVVARS) \

--- a/makefiles/scan-build.inc.mk
+++ b/makefiles/scan-build.inc.mk
@@ -80,13 +80,13 @@ endif # BUILD_IN_DOCKER
 
 
 ..scan-build-analyze: clean
-	@$(COLOR_ECHO) '$(COLOR_GREEN)Performing Clang static code analysis using toolchain "$(TOOLCHAIN)".$(COLOR_RESET)'
+	@$(COLOR_ECHO) '$(call c_green,Performing Clang static code analysis using toolchain "$(TOOLCHAIN)".)'
 # ccc-analyzer needs to be told the proper -target setting for best results,
 # otherwise false error reports about unknown register names etc will be produced.
 # These kinds of errors can be safely ignored as long as they only come from LLVM
 	@if [ "$${TOOLCHAIN}" != "llvm" -a "$${BOARD}" != "native" ]; then \
-	  $(COLOR_ECHO) '$(COLOR_YELLOW)Recommend using TOOLCHAIN=llvm for best results.$(COLOR_RESET)'; \
-	  $(COLOR_ECHO) '$(COLOR_YELLOW)Ignore any "error: unknown register name '\''rX'\'' in asm" messages.$(COLOR_RESET)'; \
+	  $(COLOR_ECHO) '$(call c_yellow,Recommend using TOOLCHAIN=llvm for best results.)'; \
+	  $(COLOR_ECHO) '$(call c_yellow,Ignore any "error: unknown register name '\''rX'\'' in asm" messages.)'; \
 	fi
 	$(Q)mkdir -p '$(SCANBUILD_OUTPUTDIR)'
 	$(Q)env -i $(ENVVARS) \


### PR DESCRIPTION
### Contribution description

This PR is split into 2  commits.

First, add a set of `c_xxxx` functions that can be used to wrap a piece of text in a `$(COLOR_X)...$(COLOR_RESET)` block, thereby avoiding the easy mistake of forgetting to place a COLOR_RESET. Existing instances if this construct are rewritten to use the new functions. Also, the construct `$(COLOR_ECHO) ..... 1>&2` is replaced by a function `color_info`.

For the second change, the `COLOR_XXX` are redefined so that they can be used from within make's
`error`, `warning` and `info` functions, in addition to `echo`. The color_info function is removed: with the new definitions of the color variables COLOR_ECHO is no longer necessary. In it's place new function `warn` is introduced that serves as a replacement for `warning` (that does not print the source line) or as a `info` that prints to stdout.

### Testing procedure

This is a build system enhancement, a successful build in Murdock should confirm nothing is broken.

To test the color, try to force an error or a warning, for example:

`BOARD=samr21-xpro make -C tests/periph_qdec`

