### PR TITLE
netstats: at86rf2xx: tx_bytes only includes 15.4. header, no payload

### DIFF
--- a/drivers/at86rf2xx/at86rf2xx_netdev.c
+++ b/drivers/at86rf2xx/at86rf2xx_netdev.c
@@ -110,9 +110,6 @@ static int _send(netdev_t *netdev, const iolist_t *iolist)
                   (unsigned)len + 2);
             return -EOVERFLOW;
         }
-#ifdef MODULE_NETSTATS_L2
-        netdev->stats.tx_bytes += len;
-#endif
         len = at86rf2xx_tx_load(dev, iol->iol_base, iol->iol_len, len);
     }
 
@@ -120,6 +117,11 @@ static int _send(netdev_t *netdev, const iolist_t *iolist)
     if (!(dev->flags & AT86RF2XX_OPT_PRELOADING)) {
         at86rf2xx_tx_exec(dev);
     }
+
+#ifdef MODULE_NETSTATS_L2
+    netdev->stats.tx_bytes += len;
+#endif
+
     /* return the number of bytes that were actually loaded into the frame
      * buffer/send out */
     return (int)len;


### PR DESCRIPTION
### Contribution description

The values returned by the shell command `ifconfig` display a rather
small value for the actual sent out bytes on L2 level.

This commit moves the `tx_bytes` calculation further down, until `len`
includes the 15.4. header *and* the payload length (no FCS).

### Testing procedure

Observe the output of `ifconfig` using the `netstats_l2` module.

### Issues/PRs references
