### PR TITLE
boards/frdm-kw41z: autoload fxos8700 with saul_default

### DIFF
--- a/boards/frdm-kw41z/Makefile.dep
+++ b/boards/frdm-kw41z/Makefile.dep
@@ -1,6 +1,7 @@
 ifneq (,$(filter saul_default,$(USEMODULE)))
   USEMODULE += saul_gpio
   USEMODULE += saul_adc
+  USEMODULE += fxos8700
 endif
 
 include $(RIOTCPU)/kinetis/Makefile.dep


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This is a small update of the frdm-kw41z boards: it adds the fxos8700 module to the default loaded modules when saul is loaded.

This way the accelerometer values are available from saul in the `default` application.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Just build and flash the `examples/default` application for frdm-kw41z and verify the fxos8700 values can be read:

```
$ make BOARD=frdm-kw41z -C examples/default flash term
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
