### PR TITLE
tests/eepreg: remove duplicate FEATURES_REQUIRED

### DIFF
--- a/tests/eepreg/Makefile
+++ b/tests/eepreg/Makefile
@@ -1,7 +1,5 @@
 include ../Makefile.tests_common
 
-FEATURES_REQUIRED = periph_eeprom
-
 USEMODULE += eepreg
 
 include $(RIOTBASE)/Makefile.include


### PR DESCRIPTION
### Contribution description

The dependency from eepreg to FEATURES_REQUIRED is already defined in
`sys/Makefile.dep` so should not need to be duplicated in the
application Makefile.

I imagine it could have been necessary before for `stm32` boards because of the bug in the CPU dependency handling that was resolved by https://github.com/RIOT-OS/RIOT/pull/10153


### Testing procedure

The list of supported boards did not changed:

```
make --no-print-directory -C tests/eepreg/ info-boards-supported
arduino-duemilanove arduino-mega2560 arduino-uno b-l072z-lrwan1 jiminy-mega256rfr2 limifrog-v1 lobaro-lorabox mega-xplained nucleo-l031k6 nucleo-l053r8 nucleo-l073rz nucleo-l152re nz32-sc151 waspmote-pro
```

```
make --no-print-directory -C tests/eepreg/ info-debug-variable-FEATURES_REQUIRED
periph_eeprom periph_eeprom periph_eeprom
```

* [ ] Verify why it was required
* [ ] Check there are no other boards that secretly need it?


And murdock should still build properly.


### Issues/PRs references

Just doing grep for `FEATURES_REQUIRED += periph_eeprom`.
