### PR TITLE
frdm-kw41z: Define BTNx macros for user pushbuttons

### DIFF
--- a/boards/frdm-kw41z/include/board.h
+++ b/boards/frdm-kw41z/include/board.h
@@ -54,6 +54,20 @@ extern "C"
 /** @} */
 
 /**
+ * @name    Button pin definitions
+ * @{
+ */
+/* SW3, SW4 will short these pins to ground when pushed but there are no
+ * external pull resistors, use internal pull-ups on the pins */
+/* BTN0 is mapped to SW3 */
+#define BTN0_PIN            GPIO_PIN(PORT_C,  4)
+#define BTN0_MODE           GPIO_IN_PU
+/* BTN1 is mapped to SW4 */
+#define BTN1_PIN            GPIO_PIN(PORT_C,  5)
+#define BTN1_MODE           GPIO_IN_PU
+/** @} */
+
+/**
  * @name    xtimer configuration
  * @{
  */

--- a/boards/frdm-kw41z/include/gpio_params.h
+++ b/boards/frdm-kw41z/include/gpio_params.h
@@ -62,13 +62,13 @@ static const  saul_gpio_params_t saul_gpio_params[] =
     },
     {
         .name = "SW3",
-        .pin = GPIO_PIN(PORT_C, 4),
-        .mode = GPIO_IN_PU
+        .pin = BTN0_PIN,
+        .mode = BTN0_MODE,
     },
     {
         .name = "SW4",
-        .pin = GPIO_PIN(PORT_C, 5),
-        .mode = GPIO_IN_PU
+        .pin = BTN1_PIN,
+        .mode = BTN1_MODE,
     },
 };
 

--- a/boards/frdm-kw41z/include/gpio_params.h
+++ b/boards/frdm-kw41z/include/gpio_params.h
@@ -64,11 +64,13 @@ static const  saul_gpio_params_t saul_gpio_params[] =
         .name = "SW3",
         .pin = BTN0_PIN,
         .mode = BTN0_MODE,
+        .flags = (SAUL_GPIO_INVERTED),
     },
     {
         .name = "SW4",
         .pin = BTN1_PIN,
         .mode = BTN1_MODE,
+        .flags = (SAUL_GPIO_INVERTED),
     },
 };
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

The configuration was missing definitions for the BTN0_PIN, BTN0_MODE macros used by some applications, e.g. tests/buttons.
Set SAUL_GPIO_INVERTED on the SAUL definitions for the buttons to make 1 mean that the button is being pressed, this may be subjective but seems more semantically correct with the meaning of pushing a button rather than reading a GPIO pin input signal.

### Testing procedure

- [x] SAUL test:
  - compile and run `examples/default`
  - type `saul read all` in the shell
  - verify that SW3 and SW4 show 1 when the corresponding user button on the board is held down.

- [x] Non-SAUL test:
  - compile and run `tests/buttons`
  - Press the user buttons
  - Verify in the terminal output that pressing SW3 generates an interrupt `Pressed BTN0`, SW4 generates an interrupt `Pressed BTN1`


### Issues/PRs references

