### PR TITLE
drivers/encx24j600: Implemented missing drop case

### DIFF
--- a/drivers/encx24j600/encx24j600.c
+++ b/drivers/encx24j600/encx24j600.c
@@ -373,7 +373,10 @@ static int _recv(netdev_t *netdev, void *buf, size_t len, void *info)
 #endif
         /* read packet (without 4 bytes checksum) */
         sram_op(dev, ENC_RRXDATA, 0xFFFF, buf, payload_len);
+    }
 
+    /* Frame was retrieved or drop was requested --> remove it from buffer */
+    if (buf || (len > 0)) {
         /* decrement available packet count */
         cmd(dev, ENC_SETPKTDEC);
 


### PR DESCRIPTION
### Contribution description

The netdev_driver_t::recv implementation of the encx24j600 does not provide the drop feature. This PR adds it.

### Testing procedure

It would be nice to add a test application for this, as many drivers are affected...

### Issues/PRs references

#10410