### PR TITLE
 gnrc_ipv6: fix _fill_ipv6_hdr() for pure IPv6 packets

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
+++ b/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
@@ -442,7 +442,7 @@ static int _fill_ipv6_hdr(gnrc_netif_t *netif, gnrc_pktsnip_t *ipv6)
         }
         prev->next = payload;
         prev = payload;
-    } while (_is_ipv6_hdr(payload));
+    } while (_is_ipv6_hdr(payload) && (payload->next != NULL));
     DEBUG("ipv6: calculate checksum for upper header.\n");
     if ((res = gnrc_netreg_calc_csum(payload, ipv6)) < 0) {
         if (res != -ENOENT) {   /* if there is no checksum we are okay */

--- a/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
+++ b/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
@@ -392,11 +392,16 @@ static int _fill_ipv6_hdr(gnrc_netif_t *netif, gnrc_pktsnip_t *ipv6)
 
     /* check if e.g. extension header was not already marked */
     if (hdr->nh == PROTNUM_RESERVED) {
-        hdr->nh = gnrc_nettype_to_protnum(ipv6->next->type);
-
-        /* if still reserved: mark no next header */
-        if (hdr->nh == PROTNUM_RESERVED) {
+        if (ipv6->next == NULL) {
             hdr->nh = PROTNUM_IPV6_NONXT;
+        }
+        else {
+            hdr->nh = gnrc_nettype_to_protnum(ipv6->next->type);
+
+            /* if still reserved: mark no next header */
+            if (hdr->nh == PROTNUM_RESERVED) {
+                hdr->nh = PROTNUM_IPV6_NONXT;
+            }
         }
     }
 


### PR DESCRIPTION
### Contribution description
If an empty IPv6 packet or a packet only containing extension headers (or unparsed extension headers in case of routing and fragmentation headers) is sent the packet is currently dropped (or the node might even crash) due to this bug.

### Testing procedure
Send an empty IPv6 packet or try the testing procedures I lined out in https://github.com/RIOT-OS/RIOT/pull/10229#issuecomment-439611720

### Issues/PRs references
Discovered while testing https://github.com/RIOT-OS/RIOT/pull/10229