### PR TITLE
frdm-k64f: Define BTNx macros for user pushbuttons

### DIFF
--- a/boards/frdm-k64f/include/board.h
+++ b/boards/frdm-k64f/include/board.h
@@ -54,6 +54,20 @@ extern "C"
 /** @} */
 
 /**
+ * @name    Button pin definitions
+ * @{
+ */
+/* SW2, SW3 will short these pins to ground when pushed. PTA4 has an external
+ * pull-up resistor to VDD, but there is no external pull resistor on PTC6 */
+/* BTN0 is mapped to SW2 */
+#define BTN0_PIN            GPIO_PIN(PORT_C,  6)
+#define BTN0_MODE           GPIO_IN_PU
+/* BTN1 is mapped to SW3 */
+#define BTN1_PIN            GPIO_PIN(PORT_A,  4)
+#define BTN1_MODE           GPIO_IN_PU
+/** @} */
+
+/**
  * @name    FXOS8700CQ 3-axis accelerometer and magnetometer bus configuration
  * @{
  */

--- a/drivers/include/periph/i2c.h
+++ b/drivers/include/periph/i2c.h
@@ -243,6 +243,8 @@ int i2c_release(i2c_t dev);
  * @note    This function is using a repeated start sequence for reading from
  *          the specified register address.
  *
+ * @pre     i2c_acquire must be called before accessing the bus
+ *
  * @param[in]  dev          I2C peripheral device
  * @param[in]  reg          register address to read from (8- or 16-bit,
  *                          right-aligned)
@@ -269,6 +271,8 @@ int i2c_read_reg(i2c_t dev, uint16_t addr, uint16_t reg,
  * @note    This function is using a repeated start sequence for reading from
  *          the specified register address.
  *
+ * @pre     i2c_acquire must be called before accessing the bus
+ *
  * @param[in]  dev          I2C peripheral device
  * @param[in]  reg          register address to read from (8- or 16-bit,
  *                          right-aligned)
@@ -294,6 +298,8 @@ int i2c_read_regs(i2c_t dev, uint16_t addr, uint16_t reg,
  * @note    This function is using a repeated start sequence for reading from
  *          the specified register address.
  *
+ * @pre     i2c_acquire must be called before accessing the bus
+ *
  * @param[in]  dev          I2C peripheral device
  * @param[in]  addr         7-bit or 10-bit device address (right-aligned)
  * @param[out] data         memory location to store received data
@@ -316,6 +322,8 @@ int i2c_read_byte(i2c_t dev, uint16_t addr, void *data, uint8_t flags);
  * @note    This function is using a repeated start sequence for reading from
  *          the specified register address.
  *
+ * @pre     i2c_acquire must be called before accessing the bus
+ *
  * @param[in]  dev          I2C peripheral device
  * @param[in]  addr         7-bit or 10-bit device address (right-aligned)
  * @param[out] data         memory location to store received data
@@ -337,6 +345,8 @@ int i2c_read_bytes(i2c_t dev, uint16_t addr,
 /**
  * @brief   Convenience function for writing a single byte onto the bus
  *
+ * @pre     i2c_acquire must be called before accessing the bus
+ *
  * @param[in] dev           I2C peripheral device
  * @param[in] addr          7-bit or 10-bit device address (right-aligned)
  * @param[in] data          byte to write to the device
@@ -354,6 +364,8 @@ int i2c_write_byte(i2c_t dev, uint16_t addr, uint8_t data, uint8_t flags);
 
 /**
  * @brief   Convenience function for writing several bytes onto the bus
+ *
+ * @pre     i2c_acquire must be called before accessing the bus
  *
  * @param[in] dev           I2C peripheral device
  * @param[in] addr          7-bit or 10-bit device address (right-aligned)
@@ -379,6 +391,8 @@ int i2c_write_bytes(i2c_t dev, uint16_t addr, const void *data,
  * @note    This function is using a repeated start sequence for writing to the
  *          specified register address.
  *
+ * @pre     i2c_acquire must be called before accessing the bus
+ *
  * @param[in]  dev          I2C peripheral device
  * @param[in]  reg          register address to read from (8- or 16-bit,
  *                          right-aligned)
@@ -402,6 +416,8 @@ int i2c_write_reg(i2c_t dev, uint16_t addr, uint16_t reg,
  *
  * @note    This function is using a repeated start sequence for writing to the
  *          specified register address.
+ *
+ * @pre     i2c_acquire must be called before accessing the bus
  *
  * @param[in]  dev          I2C peripheral device
  * @param[in]  reg          register address to read from (8- or 16-bit,


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

The configuration was missing definitions for the BTN0_PIN, BTN0_MODE macros used by some applications, e.g. tests/buttons.


### Testing procedure

- [ ] tests/buttons
  - compile and run `tests/buttons`
  - Press the user buttons SW2, SW3
  - Verify in the terminal output that pressing SW2 generates an interrupt `Pressed BTN0`, SW3 generates an interrupt `Pressed BTN1`


### Issues/PRs references

Same as #10414 but for a different board.