### PR TITLE
frdm-k22f: Define BTNx macros for user pushbuttons

### DIFF
--- a/boards/frdm-k22f/include/board.h
+++ b/boards/frdm-k22f/include/board.h
@@ -53,6 +53,20 @@ extern "C"
 /** @} */
 
 /**
+ * @name    Button pin definitions
+ * @{
+ */
+/* SW2, SW3 will short these pins to ground when pushed. Both pins have external
+ * pull-up resistors to VDD */
+/* BTN0 is mapped to SW2 */
+#define BTN0_PIN            GPIO_PIN(PORT_C,  1)
+#define BTN0_MODE           GPIO_IN
+/* BTN1 is mapped to SW3 */
+#define BTN1_PIN            GPIO_PIN(PORT_B, 17)
+#define BTN1_MODE           GPIO_IN
+/** @} */
+
+/**
  * @name    FXOS8700CQ 3-axis accelerometer and magnetometer bus configuration
  * @{
  */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

The configuration was missing definitions for the BTN0_PIN, BTN0_MODE macros used by some applications, e.g. tests/buttons.


### Testing procedure

- [ ] tests/buttons
  - compile and run `tests/buttons`
  - Press the user buttons SW2, SW3
  - Verify in the terminal output that pressing SW2 generates an interrupt `Pressed BTN0`, SW3 generates an interrupt `Pressed BTN1`


### Issues/PRs references

Same as #10414, #10423 but for a different board.