### PR TITLE
cc2538_rf: Don't use netdev_ieee802154_t for link layer address

### DIFF
--- a/cpu/cc2538/radio/cc2538_rf_netdev.c
+++ b/cpu/cc2538/radio/cc2538_rf_netdev.c
@@ -157,6 +157,7 @@ static int _set(netdev_t *netdev, netopt_t opt, const void *value, size_t value_
             }
             else {
                 cc2538_set_addr_short(*((const uint16_t*)value));
+                res = sizeof(uint16_t);
             }
             break;
 
@@ -166,6 +167,7 @@ static int _set(netdev_t *netdev, netopt_t opt, const void *value, size_t value_
             }
             else {
                 cc2538_set_addr_long(*((const uint64_t*)value));
+                res = sizeof(uint64_t);
             }
             break;
 

--- a/cpu/cc2538/radio/cc2538_rf_netdev.c
+++ b/cpu/cc2538/radio/cc2538_rf_netdev.c
@@ -50,6 +50,24 @@ static int _get(netdev_t *netdev, netopt_t opt, void *value, size_t max_len)
     }
 
     switch (opt) {
+        case NETOPT_ADDRESS:
+            if (max_len < sizeof(uint16_t)) {
+                return -EOVERFLOW;
+            }
+            else {
+                *(uint16_t*)value = cc2538_get_addr_short();
+            }
+            return sizeof(uint16_t);
+
+        case NETOPT_ADDRESS_LONG:
+            if (max_len < sizeof(uint64_t)) {
+                return -EOVERFLOW;
+            }
+            else {
+                *(uint64_t*)value = cc2538_get_addr_long();
+            }
+            return sizeof(uint64_t);
+
         case NETOPT_AUTOACK:
             if (RFCORE->XREG_FRMCTRL0bits.AUTOACK) {
                 *((netopt_enable_t *)value) = NETOPT_ENABLE;


### PR DESCRIPTION
### Contribution description

This PR modifies the behaviour of the cc2538_rf driver to not propagate the link layer address to the netdev_ieee802154_t struct. This helps the goal of separating the netdev and the ieee802154_t layer by another bit. The end goal is to remove the short and long address from the netdev_ieee802154_t struct and match the behaviour of the ethernet drivers.

The performance impact of this change should be negligible, the NETOPT_ADDRESS(_LONG) call is only used on initialization and by the ifconfig command.

### Testing procedure

Test whether:

 -  ifconfig still shows the correct link layer addresses. These should not have changed between this PR and master.
 - ping still works. This to verify that the link layer address is also properly configured in the radio, if the ping echo/reply fails, the address filter of the radio might be configured in the wrong endianness.

### Issues/PRs references

related to #10401, part of #7736 

**disclaimer**: I don't own a board with the cc2538 on it so I'm flying blind here. As long as the actual address getters work, the code *should* work.