### PR TITLE
 cc2538_rf: Don't use netdev_ieee802154_t for channel

### DIFF
--- a/cpu/cc2538/radio/cc2538_rf_netdev.c
+++ b/cpu/cc2538/radio/cc2538_rf_netdev.c
@@ -59,6 +59,13 @@ static int _get(netdev_t *netdev, netopt_t opt, void *value, size_t max_len)
             }
             return sizeof(netopt_enable_t);
 
+        case NETOPT_CHANNEL:
+            if (max_len < sizeof(uint16_t)) {
+                return -EOVERFLOW;
+            }
+            *((uint16_t *)value) = (uint16_t)cc2538_get_chan();
+            return sizeof(uint8_t);
+
         case NETOPT_CHANNEL_PAGE:
             if (max_len < sizeof(uint16_t)) {
                 return -EOVERFLOW;

--- a/cpu/cc2538/radio/cc2538_rf_netdev.c
+++ b/cpu/cc2538/radio/cc2538_rf_netdev.c
@@ -175,6 +175,7 @@ static int _set(netdev_t *netdev, netopt_t opt, const void *value, size_t value_
                 }
                 else {
                     cc2538_set_chan(chan);
+                    res = sizeof(uint16_t)
                 }
             }
             break;


### PR DESCRIPTION
### Contribution description

This PR modifies the behaviour of the cc2538_rf driver to not propagate the *channel* to the netdev_ieee802154_t struct. This helps the goal of separating the netdev and the ieee802154_t layer by another bit. The end goal is to remove the *channel* from the netdev_ieee802154_t struct.

The performance impact of this change should be negligible, the NETOPT_CHANNEL call is only used by the ifconfig command.

### Testing procedure

Test whether:

 -  ifconfig still shows the correct channel. These should not have changed between this PR and master.

### Issues/PRs references

related to #10401, part of #7736 

**disclaimer**: I don't own a board with the cc2538 on it so I'm flying blind here. As long as the actual channel getter work, the code *should* work.