### PR TITLE
make: Add staging keywords. 

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -818,6 +818,7 @@ USEMODULE += $(filter periph_%,$(FEATURES_USED))
 # recursively catch transitive dependencies
 USEMODULE := $(sort $(USEMODULE))
 USEPKG := $(sort $(USEPKG))
+STAGING_MODULES := $(sort $(STAGING_MODULES))
 ifneq ($(OLD_USEMODULE) $(OLD_USEPKG),$(USEMODULE) $(USEPKG))
   include $(RIOTBASE)/Makefile.dep
 endif

--- a/Makefile.include
+++ b/Makefile.include
@@ -437,9 +437,9 @@ ifeq ($(BUILD_IN_DOCKER),1)
 link: ..in-docker-container
 else
 ifeq (,$(RIOTNOLINK))
-link: ..compiler-check ..build-message $(ELFFILE) $(HEXFILE) print-size
+link: ..compiler-check ..build-message ..staging-check $(ELFFILE) $(HEXFILE) print-size
 else
-link: ..compiler-check ..build-message $(BASELIBS)
+link: ..compiler-check ..build-message ..staging-check $(BASELIBS)
 endif # RIOTNOLINK
 
 $(ELFFILE): $(BASELIBS)
@@ -473,6 +473,13 @@ define check_cmd
 	    '$(COLOR_RED)$2 $1 is required but not found in PATH.  Aborting.$(COLOR_RESET)'; \
 	    exit 1;}
 endef
+
+STAGING_USED=$(filter $(STAGING_MODULES),$(USEMODULE) $(USEPKG))
+STAGING_NOT_ALLOWED=$(filter-out $(STAGING_ALLOWED),$(STAGING_USED))
+STAGING_ERR_MSG=The following modules are in staging area but are not specifically enabled $(STAGING_NOT_ALLOWED)
+
+..staging-check:
+	$(if $(STAGING_NOT_ALLOWED),$(error $(STAGING_ERR_MSG)),$(info $(USEMODULE)))
 
 ..compiler-check:
 	$(call check_cmd,$(CC),Compiler)

--- a/examples/ccn-lite-relay/Makefile
+++ b/examples/ccn-lite-relay/Makefile
@@ -37,4 +37,6 @@ USEMODULE += prng_xorshift
 
 USEPKG += ccn-lite
 
+STAGING_ALLOWED = ccn-lite
+
 include $(RIOTBASE)/Makefile.include

--- a/pkg/ccn-lite/Makefile.dep
+++ b/pkg/ccn-lite/Makefile.dep
@@ -5,3 +5,5 @@ ifneq (,$(filter ccn-lite,$(USEPKG)))
   USEMODULE += timex
   USEMODULE += tlsf-malloc
 endif
+
+STAGING_MODULES += ccn-lite


### PR DESCRIPTION
_**IMPORTANT: this is just a demo, I do not intend it to be merged!**_

### Contribution description

Following the discussion in #9430 , I figured it was a good idea to show a demo of how _staging keywording_ can be implemente (see [this comment](https://github.com/RIOT-OS/RIOT/pull/9430#issuecomment-429912408)). I was a bit uneasy with the amount of changes introduced by that PR.

This commit allows modules and packages to be added to a "staging" list, by using `STAGING_MODULES += module_name` in Makefile.dep.

If any "staging" modules is used, the build will fail unless the used staging modules are explicitly added to the `STAGING_ALLOWED` variable.

My philosophy with regards to this feature is that where the code is located and how it is handled need not be coupled. Note that this is not _alternative_, but rather _complementary_ to #9430: nobody says that the modules keyworded as staging cannot all be placed in a separate directory, enforced by static checks. The point I want to make with this PR is that having the build system behave differently depending on which path code is located introduces more complexity than necessary, while reducing flexibility.

### Testing procedure

There is a disposable commit only to show how the STAGING_ALLOWED variable is used.

The ccn-lite package was arbitrarily chosen.

1. ccn-lite was added to STAGING_MODULES
2. examples/ccn-lite-relays contains `STAGING_ALLOWED = ccn-lite` to allow
   it to be built.
3. To test the feature, remove the STAGING_ALLOWED and try compiling.

### Issues/PRs references

See #9430.
