### PR TITLE
dist/pythonlibs: provide unittest TestCase wrapper for testrunner

### DIFF
--- a/dist/pythonlibs/testrunner/__init__.py
+++ b/dist/pythonlibs/testrunner/__init__.py
@@ -1,4 +1,5 @@
-# Copyright (C) 2017 Cenk Gündoğan <cenk.guendogan@haw-hamburg.de>
+# Copyright (C) 2018-19 Freie Universität Berlin
+#               2017 Cenk Gündoğan <cenk.guendogan@haw-hamburg.de>
 #               2016 Kaspar Schleiser <kaspar@schleiser.de>
 #               2014 Martine Lenders <mlenders@inf.fu-berlin.de>
 #
@@ -7,51 +8,16 @@
 # directory for more details.
 
 import os
-import signal
 import sys
-import subprocess
-import time
-from traceback import extract_tb, print_tb
-
+from traceback import print_tb
 import pexpect
 
-PEXPECT_PATH = os.path.dirname(pexpect.__file__)
-RIOTBASE = (os.environ.get('RIOTBASE') or
-            os.path.abspath(os.path.join(os.path.dirname(__file__),
-                                         "..", "..", "..")))
-
-# Setting an empty 'TESTRUNNER_START_DELAY' environment variable use the
-# default value (3)
-MAKE_TERM_STARTED_DELAY = int(os.environ.get('TESTRUNNER_START_DELAY') or 3)
-
-
-def list_until(l, cond):
-    return l[:([i for i, e in enumerate(l) if cond(e)][0])]
-
-
-def find_exc_origin(exc_info):
-    pos = list_until(extract_tb(exc_info),
-                     lambda frame: frame[0].startswith(PEXPECT_PATH)
-                     )[-1]
-    return (pos[3], os.path.relpath(os.path.abspath(pos[0]), RIOTBASE), pos[1])
+from .spawn import find_exc_origin, setup_child, teardown_child
 
 
 def run(testfunc, timeout=10, echo=True, traceback=False):
-    env = os.environ.copy()
-    child = pexpect.spawnu("make term", env=env, timeout=timeout, codec_errors='replace')
-
-    # on many platforms, the termprog needs a short while to be ready...
-    time.sleep(MAKE_TERM_STARTED_DELAY)
-
-    if echo:
-        child.logfile = sys.stdout
-
-    try:
-        subprocess.check_output(('make', 'reset'), env=env,
-                                stderr=subprocess.PIPE)
-    except subprocess.CalledProcessError:
-        # make reset yields error on some boards even if successful
-        pass
+    child = setup_child(timeout, env=os.environ,
+                        logfile=sys.stdout if echo else None)
     try:
         testfunc(child)
     except pexpect.TIMEOUT:
@@ -62,16 +28,12 @@ def run(testfunc, timeout=10, echo=True, traceback=False):
         return 1
     except pexpect.EOF:
         trace = find_exc_origin(sys.exc_info()[2])
-        print("Unexpected end of file in expect script at \"%s\" (%s:%d)" % trace)
+        print("Unexpected end of file in expect script at \"%s\" (%s:%d)" %
+              trace)
         if traceback:
             print_tb(sys.exc_info()[2])
         return 1
     finally:
         print("")
-        try:
-            os.killpg(os.getpgid(child.pid), signal.SIGKILL)
-        except ProcessLookupError:
-            print("Process already stopped")
-
-        child.close()
+        teardown_child(child)
     return 0

--- a/dist/pythonlibs/testrunner/__init__.py
+++ b/dist/pythonlibs/testrunner/__init__.py
@@ -13,6 +13,7 @@ from traceback import print_tb
 import pexpect
 
 from .spawn import find_exc_origin, setup_child, teardown_child
+from .unittest import PexpectTestCase   # noqa, F401 expose to users
 
 
 def run(testfunc, timeout=10, echo=True, traceback=False):

--- a/dist/pythonlibs/testrunner/spawn.py
+++ b/dist/pythonlibs/testrunner/spawn.py
@@ -1,0 +1,62 @@
+# Copyright (C) 2018-19 Freie Universität Berlin
+#               2017 Cenk Gündoğan <cenk.guendogan@haw-hamburg.de>
+#               2016 Kaspar Schleiser <kaspar@schleiser.de>
+#               2014 Martine Lenders <mlenders@inf.fu-berlin.de>
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import os
+import pexpect
+import signal
+import subprocess
+import time
+from traceback import extract_tb
+
+PEXPECT_PATH = os.path.dirname(pexpect.__file__)
+RIOTBASE = (os.environ.get('RIOTBASE') or
+            os.path.abspath(os.path.join(os.path.dirname(__file__),
+                                         "..", "..", "..")))
+
+# Setting an empty 'TESTRUNNER_START_DELAY' environment variable use the
+# default value (3)
+MAKE_TERM_STARTED_DELAY = int(os.environ.get('TESTRUNNER_START_DELAY') or 3)
+
+
+def list_until(l, cond):
+    return l[:([i for i, e in enumerate(l) if cond(e)][0])]
+
+
+def find_exc_origin(exc_info):
+    pos = list_until(extract_tb(exc_info),
+                     lambda frame: frame[0].startswith(PEXPECT_PATH)
+                     )[-1]
+    return (pos[3], os.path.relpath(os.path.abspath(pos[0]), RIOTBASE), pos[1])
+
+
+def setup_child(timeout=10, spawnclass=pexpect.spawnu, env=None, logfile=None):
+    child = spawnclass("make term", env=env, timeout=timeout,
+                       codec_errors='replace')
+
+    # on many platforms, the termprog needs a short while to be ready...
+    time.sleep(MAKE_TERM_STARTED_DELAY)
+
+    child.logfile = logfile
+
+    try:
+        subprocess.check_output(('make', 'reset'), env=env,
+                                stderr=subprocess.PIPE)
+    except subprocess.CalledProcessError:
+        # make reset yields error on some boards even if successful
+        pass
+    return child
+
+
+def teardown_child(child):
+    try:
+        os.killpg(os.getpgid(child.pid), signal.SIGKILL)
+    except ProcessLookupError:
+        print("Process already stopped")
+
+    child.close()

--- a/dist/pythonlibs/testrunner/unittest.py
+++ b/dist/pythonlibs/testrunner/unittest.py
@@ -1,0 +1,23 @@
+# Copyright (C) 2018-19 Freie Universität Berlin
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import unittest
+from testrunner import setup_child, teardown_child
+
+
+class PexpectTestCase(unittest.TestCase):
+    TIMEOUT = 10
+    LOGFILE = None
+
+    """A unittest TestCase providing a pexpect spawn object to it's tests
+    """
+    @classmethod
+    def setUpClass(cls):
+        cls.spawn = setup_child(cls.TIMEOUT, logfile=cls.LOGFILE)
+
+    @classmethod
+    def tearDownClass(cls):
+        teardown_child(cls.spawn)


### PR DESCRIPTION
### Contribution description
I had this idea when implementing #10382 and #10392 as I introduced a very similar structure to python's standard unittests in those and it could also reduce some code duplication between those two tests.

### Regarding [ongoing discussions about test frameworks](https://github.com/RIOT-OS/RIOT/issues/10241#issuecomment-438277919)

As far as I [understand `pytest` so far][pytest_unittests] it would also be beneficial for porting our current tests with this approach. I don't know how this looks like for RobotFramework.

[pytest_unittests]: https://docs.pytest.org/en/latest/unittest.html

### Testing procedure
Currently no tests are ported and this is just an RFC. If the discussion steers into the direction of approval (or indecisiveness ;-)) I'll try to port one or two tests to this approach.

### Issues/PRs references
#10382 and #10392 could greatly benefit from it, discussions after https://github.com/RIOT-OS/RIOT/issues/10241#issuecomment-438277919 could be related.
