### PR TITLE
boards/sodaq-sara-aff: Initial support

### DIFF
--- a/boards/sodaq-sara-aff/Makefile
+++ b/boards/sodaq-sara-aff/Makefile
@@ -1,0 +1,3 @@
+MODULE = board
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/sodaq-sara-aff/Makefile.dep
+++ b/boards/sodaq-sara-aff/Makefile.dep
@@ -1,0 +1,3 @@
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += saul_gpio
+endif

--- a/boards/sodaq-sara-aff/Makefile.features
+++ b/boards/sodaq-sara-aff/Makefile.features
@@ -1,0 +1,11 @@
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_adc
+FEATURES_PROVIDED += periph_gpio periph_gpio_irq
+FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_rtc
+FEATURES_PROVIDED += periph_rtt
+FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_timer
+FEATURES_PROVIDED += periph_uart
+
+include $(RIOTCPU)/samd21/Makefile.features

--- a/boards/sodaq-sara-aff/Makefile.include
+++ b/boards/sodaq-sara-aff/Makefile.include
@@ -1,0 +1,19 @@
+# define the cpu used by the SODAQ SARA AFF boards
+export CPU = samd21
+export CPU_MODEL = samd21j18a
+
+#export needed for flash rule
+export PORT_LINUX ?= /dev/ttyACM0
+export PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
+
+# setup serial terminal
+include $(RIOTMAKE)/tools/serial.inc.mk
+
+# setup the flash tool used
+# we use BOSSA to flash this board since there's an Arduino bootloader
+# preflashed on it. ROM_OFFSET skips the space taken by such bootloader.
+ROM_OFFSET ?= 0x2000
+include $(RIOTMAKE)/tools/bossa.inc.mk
+
+# setup the boards dependencies
+include $(RIOTBOARD)/$(BOARD)/Makefile.dep

--- a/boards/sodaq-sara-aff/board.c
+++ b/boards/sodaq-sara-aff/board.c
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2018 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_sodaq-sara-aff
+ * @{
+ *
+ * @file
+ * @brief       Board common implementations for the SODAQ SARA AFF boards
+ *
+ * @author      Leandro Lanzieri <leandro.lanzieri@haw-hamburg.de>
+ * @}
+ */
+
+#include "cpu.h"
+#include "board.h"
+#include "periph/gpio.h"
+
+void board_init(void)
+{
+    #ifdef AUTO_INIT_LED0
+    /* The LED pin is also used for SPI, so we enable it
+       only if explicitly wanted by the user */
+    LED0_OFF;
+    gpio_init(LED0_PIN, GPIO_OUT);
+    #endif
+
+    LED_RED_OFF;
+    gpio_init(LED_RED_PIN, GPIO_OUT);
+    LED_GREEN_OFF;
+    gpio_init(LED_GREEN_PIN, GPIO_OUT);
+    LED_BLUE_OFF;
+    gpio_init(LED_BLUE_PIN, GPIO_OUT);
+
+    /* set NB-IoT device off by default */
+    NB_IOT_DISABLE;
+    gpio_init(NB_IOT_ENABLE_PIN, GPIO_OUT);
+    NB_IOT_TX_EN_OFF;
+    gpio_init(NB_IOT_TX_EN_PIN, GPIO_OUT);
+    NB_IOT_TOGGLE_ON;
+    gpio_init(NB_IOT_TOGGLE_PIN, GPIO_OUT);
+
+    /* set GPS off by default */
+    GPS_ENABLE_OFF;
+    gpio_init(GPS_ENABLE_PIN, GPIO_OUT);
+
+    /* initialize the CPU */
+    cpu_init();
+}

--- a/boards/sodaq-sara-aff/doc.txt
+++ b/boards/sodaq-sara-aff/doc.txt
@@ -1,0 +1,32 @@
+/**
+ * @defgroup    boards_sodaq-sara-aff SODAQ SARA AFF
+ * @ingroup     boards
+ * @brief       Support for the SODAQ SARA AFF boards
+ *
+ * ### General information
+ *
+ * General information about this board can be found on the
+ * [SODAQ support](http://support.sodaq.com/sodaq-one/sodaq-sara-r410m/)
+ * website.
+ * ![SODAQ SARA AFF]( https://support.sodaq.com/wp-content/uploads/2018/07/sodaq-sara-pins-768x862.png
+)
+ *
+ * ### Flash the board
+ *
+ * 1. Put the board in bootloader mode by double tapping the reset button.<br/>
+ *    When the board is in bootloader mode, the user led (blue) oscillates
+ *    smoothly.
+ *
+ *
+ * 2. Use `BOARD=sodaq-sara-aff` with the `make` command.<br/>
+ *    Example with `hello-world` application:
+ * ```
+ *      make BOARD=sodaq-sara-aff -C examples/hello-world flash
+ * ```
+ *
+ * ### Accessing STDIO via UART
+ *
+ * To access the STDIO of RIOT, a FTDI to USB converter needs to be plugged to
+ * the RX/TX pins on the board.
+ *
+ */

--- a/boards/sodaq-sara-aff/include/board.h
+++ b/boards/sodaq-sara-aff/include/board.h
@@ -1,0 +1,168 @@
+/*
+ * Copyright (C) 2018 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_sodaq-sara-aff
+ * @{
+ *
+ * @file
+ * @brief       Board specific definitions for the SODAQ SARA AFF boards
+ *
+ * @author      Leandro Lanzieri <leandro.lanzieri@haw-hamburg.de>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include "cpu.h"
+#include "periph_conf.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    xtimer configuration
+ * @{
+ */
+#define XTIMER_WIDTH        (16)
+/** @} */
+
+/**
+ * @name    LED pin definitions and handlers
+ * @{
+ */
+#define LED0_PIN            GPIO_PIN(PA, 21)
+
+#define LED0_PORT           PORT->Group[PA]
+#define LED0_MASK           (1 << 21)
+
+#define LED0_OFF            (LED0_PORT.OUTCLR.reg = LED0_MASK)
+#define LED0_ON             (LED0_PORT.OUTSET.reg = LED0_MASK)
+#define LED0_TOGGLE         (LED0_PORT.OUTTGL.reg = LED0_MASK)
+
+#define LED1_PIN            GPIO_PIN(PA, 12)
+
+#define LED1_PORT           PORT->Group[PA]
+#define LED1_MASK           (1 << 12)
+
+#define LED1_OFF            (LED1_PORT.OUTSET.reg = LED1_MASK)
+#define LED1_ON             (LED1_PORT.OUTCLR.reg = LED1_MASK)
+#define LED1_TOGGLE         (LED1_PORT.OUTTGL.reg = LED1_MASK)
+
+#define LED_RED_PIN         LED1_PIN
+#define LED_RED_OFF         LED1_OFF
+#define LED_RED_ON          LED1_ON
+#define LED_RED_TOGGLE      LED1_TOGGLE
+
+#define LED2_PIN            GPIO_PIN(PB, 15)
+
+#define LED2_PORT           PORT->Group[PB]
+#define LED2_MASK           (1 << 15)
+
+#define LED2_OFF            (LED2_PORT.OUTSET.reg = LED2_MASK)
+#define LED2_ON             (LED2_PORT.OUTCLR.reg = LED2_MASK)
+#define LED2_TOGGLE         (LED2_PORT.OUTTGL.reg = LED2_MASK)
+
+#define LED_GREEN_PIN         LED2_PIN
+#define LED_GREEN_OFF         LED2_OFF
+#define LED_GREEN_ON          LED2_ON
+#define LED_GREEN_TOGGLE      LED2_TOGGLE
+
+#define LED3_PIN            GPIO_PIN(PA, 13)
+
+#define LED3_PORT           PORT->Group[PA]
+#define LED3_MASK           (1 << 13)
+
+#define LED3_OFF            (LED3_PORT.OUTSET.reg = LED3_MASK)
+#define LED3_ON             (LED3_PORT.OUTCLR.reg = LED3_MASK)
+#define LED3_TOGGLE         (LED3_PORT.OUTTGL.reg = LED3_MASK)
+
+#define LED_BLUE_PIN         LED3_PIN
+#define LED_BLUE_OFF         LED3_OFF
+#define LED_BLUE_ON          LED3_ON
+#define LED_BLUE_TOGGLE      LED3_TOGGLE
+/** @} */
+
+/**
+ * @name    GPS Time Pulse
+ * @{
+ */
+#define GPS_TIMEPULSE_PIN   GPIO_PIN(PA, 7)
+#define GPS_TIMEPULSE_MODE  GPIO_IN
+/** @} */
+
+/**
+ * @name    GPS Enable
+ * @{
+ */
+#define GPS_ENABLE_PIN      GPIO_PIN(PA, 28)
+
+#define GPS_ENABLE_PORT     PORT->Group[PA]
+#define GPS_ENABLE_MASK     (1 << 28)
+
+#define GPS_ENABLE_ON       (GPS_ENABLE_PORT.OUTSET.reg = GPS_ENABLE_MASK)
+#define GPS_ENABLE_OFF      (GPS_ENABLE_PORT.OUTCLR.reg = GPS_ENABLE_MASK)
+/** @} */
+
+/**
+ * @name    NB-IoT SARA module
+ * @{
+ */
+#define NB_IOT_ENABLE_PIN      GPIO_PIN(PA, 27)
+
+#define NB_IOT_ENABLE_PORT     PORT->Group[PA]
+#define NB_IOT_ENABLE_MASK     (1 << 27)
+
+#define NB_IOT_ENABLE          (NB_IOT_ENABLE_PORT.OUTSET.reg = NB_IOT_ENABLE_MASK)
+#define NB_IOT_DISABLE         (NB_IOT_ENABLE_PORT.OUTCLR.reg = NB_IOT_ENABLE_MASK)
+
+#define NB_IOT_RESET_PIN       GPIO_PIN(PB, 14)
+
+#define NB_IOT_RESET_PORT      PORT->Group[PB]
+#define NB_IOT_RESET_MASK      (1 << 14)
+
+#define NB_IOT_RESET_ON        (NB_IOT_RESET_PORT.OUTSET.reg = NB_IOT_RESET_MASK)
+#define NB_IOT_RESET_OFF       (NB_IOT_RESET_PORT.OUTCLR.reg = NB_IOT_RESET_MASK)
+
+#define NB_IOT_RESET_PIN       GPIO_PIN(PB, 14)
+
+#define NB_IOT_RESET_PORT      PORT->Group[PB]
+#define NB_IOT_RESET_MASK      (1 << 14)
+
+#define NB_IOT_RESET_ON        (NB_IOT_RESET_PORT.OUTSET.reg = NB_IOT_RESET_MASK)
+#define NB_IOT_RESET_OFF       (NB_IOT_RESET_PORT.OUTCLR.reg = NB_IOT_RESET_MASK)
+
+#define NB_IOT_TX_EN_PIN       GPIO_PIN(PB, 13)
+
+#define NB_IOT_TX_EN_PORT      PORT->Group[PB]
+#define NB_IOT_TX_EN_MASK      (1 << 13)
+
+#define NB_IOT_TX_EN_ON        (NB_IOT_TX_EN_PORT.OUTSET.reg = NB_IOT_TX_EN_MASK)
+#define NB_IOT_TX_EN_OFF       (NB_IOT_TX_EN_PORT.OUTCLR.reg = NB_IOT_TX_EN_MASK)
+
+#define NB_IOT_TOGGLE_PIN       GPIO_PIN(PB, 17)
+
+#define NB_IOT_TOGGLE_PORT      PORT->Group[PB]
+#define NB_IOT_TOGGLE_MASK      (1 << 17)
+
+#define NB_IOT_TOGGLE_ON        (NB_IOT_TOGGLE_PORT.OUTSET.reg = NB_IOT_TOGGLE_MASK)
+#define NB_IOT_TOGGLE_OFF       (NB_IOT_TOGGLE_PORT.OUTCLR.reg = NB_IOT_TOGGLE_MASK)
+/** @} */
+
+/**
+ * @brief Initialize board specific hardware, including clock, LEDs and std-IO
+ */
+void board_init(void);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/sodaq-sara-aff/include/gpio_params.h
+++ b/boards/sodaq-sara-aff/include/gpio_params.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2018 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_sodaq-sara-aff
+ * @{
+ *
+ * @file
+ * @brief       Board specific configuration of direct mapped GPIOs
+ *
+ * @author      Leandro Lanzieri <leandro.lanzieri@haw-hamburg.de>
+ */
+
+#ifndef GPIO_PARAMS_H
+#define GPIO_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    GPIO pin configuration
+ */
+static const  saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name = "LED Builtin",
+        .pin  = LED0_PIN,
+        .mode = GPIO_OUT
+    },
+    {
+        .name = "LED Red",
+        .pin = LED1_PIN,
+        .mode = GPIO_OUT,
+        .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR)
+    },
+    {
+        .name = "LED Green",
+        .pin = LED2_PIN,
+        .mode = GPIO_OUT,
+        .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR)
+    },
+    {
+        .name = "LED Blue",
+        .pin = LED3_PIN,
+        .mode = GPIO_OUT,
+        .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR)
+    }
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_PARAMS_H */
+/** @} */

--- a/boards/sodaq-sara-aff/include/periph_conf.h
+++ b/boards/sodaq-sara-aff/include/periph_conf.h
@@ -1,0 +1,240 @@
+/*
+ * Copyright (C) 2017 Kees Bakker, SODAQ
+ *               2018 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_sodaq-sara-aff
+ * @{
+ *
+ * @file
+ * @brief       Configuration of CPU peripherals for the SODAQ SARA AFF boards
+ *
+ * @author      Kees Bakker <kees@sodaq.com>
+ * @author      Leandro Lanzieri <leandro.lanzieri@haw-hamburg.de>
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+#include <stdint.h>
+
+#include "cpu.h"
+#include "periph_cpu.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    External oscillator and clock configuration
+ *
+ * For selection of the used CORECLOCK, we have implemented two choices:
+ *
+ * - usage of the PLL fed by the internal 8MHz oscillator divided by 8
+ * - usage of the internal 8MHz oscillator directly, divided by N if needed
+ *
+ *
+ * The PLL option allows for the usage of a wider frequency range and a more
+ * stable clock with less jitter. This is why we use this option as default.
+ *
+ * The target frequency is computed from the PLL multiplier and the PLL divisor.
+ * Use the following formula to compute your values:
+ *
+ * CORECLOCK = ((PLL_MUL + 1) * 1MHz) / PLL_DIV
+ *
+ * NOTE: The PLL circuit does not run with less than 32MHz while the maximum PLL
+ *       frequency is 96MHz. So PLL_MULL must be between 31 and 95!
+ *
+ *
+ * The internal Oscillator used directly can lead to a slightly better power
+ * efficiency to the cost of a less stable clock. Use this option when you know
+ * what you are doing! The actual core frequency is adjusted as follows:
+ *
+ * CORECLOCK = 8MHz / DIV
+ *
+ * NOTE: A core clock frequency below 1MHz is not recommended
+ *
+ * @{
+ */
+#define CLOCK_USE_PLL       (1)
+
+#if CLOCK_USE_PLL
+/* edit these values to adjust the PLL output frequency */
+#define CLOCK_PLL_MUL       (47U)               /* must be >= 31 & <= 95 */
+#define CLOCK_PLL_DIV       (1U)                /* adjust to your needs */
+/* generate the actual used core clock frequency */
+#define CLOCK_CORECLOCK     (((CLOCK_PLL_MUL + 1) * 1000000U) / CLOCK_PLL_DIV)
+#else
+/* edit this value to your needs */
+#define CLOCK_DIV           (1U)
+/* generate the actual core clock frequency */
+#define CLOCK_CORECLOCK     (8000000 / CLOCK_DIV)
+#endif
+/** @} */
+
+/**
+ * @name Timer peripheral configuration
+ * @{
+ */
+#define TIMER_NUMOF         (2U)
+#define TIMER_0_EN          1
+#define TIMER_1_EN          1
+
+/* Timer 0 configuration */
+#define TIMER_0_DEV         TC3->COUNT16
+#define TIMER_0_CHANNELS    2
+#define TIMER_0_MAX_VALUE   (0xffff)
+#define TIMER_0_ISR         isr_tc3
+
+/* Timer 1 configuration */
+#define TIMER_1_DEV         TC4->COUNT32
+#define TIMER_1_CHANNELS    2
+#define TIMER_1_MAX_VALUE   (0xffffffff)
+#define TIMER_1_ISR         isr_tc4
+/** @} */
+
+/**
+ * @name UART configuration
+ * @{
+ * See Table 7-1 of the SAM D21 Datasheet (p. 29)
+ */
+static const uart_conf_t uart_config[] = {
+    {
+        .dev      = &SERCOM5->USART,
+        .rx_pin   = GPIO_PIN(PB, 30),  /* D0, RX Pin */
+        .tx_pin   = GPIO_PIN(PB, 31),  /* D1, TX Pin */
+        .mux      = GPIO_MUX_D,
+        .rx_pad   = UART_PAD_RX_1,
+        .tx_pad   = UART_PAD_TX_0,
+        .flags    = UART_FLAG_NONE,
+        .gclk_src = GCLK_CLKCTRL_GEN_GCLK0
+    },
+    {
+        .dev      = &SERCOM0->USART,
+        .rx_pin   = GPIO_PIN(PA,5),
+        .tx_pin   = GPIO_PIN(PA,6),
+        .mux      = GPIO_MUX_D,
+        .rx_pad   = UART_PAD_RX_1,
+        .tx_pad   = UART_PAD_TX_2,
+        .flags    = UART_FLAG_NONE,
+        .gclk_src = GCLK_CLKCTRL_GEN_GCLK0
+    },
+};
+
+/* interrupt function name mapping */
+#define UART_0_ISR          isr_sercom5
+#define UART_1_ISR          isr_sercom0
+
+#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+/** @} */
+
+/**
+ * @name ADC configuration
+ * @{
+ */
+#define ADC_0_EN                           1
+#define ADC_MAX_CHANNELS                   19
+/* ADC 0 device configuration */
+#define ADC_0_DEV                          ADC
+#define ADC_0_IRQ                          ADC_IRQn
+
+/* ADC 0 Default values */
+#define ADC_0_CLK_SOURCE                   0 /* GCLK_GENERATOR_0 */
+#define ADC_0_PRESCALER                    ADC_CTRLB_PRESCALER_DIV512
+
+#define ADC_0_NEG_INPUT                    ADC_INPUTCTRL_MUXNEG_GND
+#define ADC_0_GAIN_FACTOR_DEFAULT          ADC_INPUTCTRL_GAIN_1X
+#define ADC_0_REF_DEFAULT                  ADC_REFCTRL_REFSEL_INT1V
+
+static const adc_conf_chan_t adc_channels[] = {
+    /* port, pin, muxpos */
+    {GPIO_PIN(PB, 0), ADC_INPUTCTRL_MUXPOS_PIN8},     /* A0 */
+    {GPIO_PIN(PB, 1), ADC_INPUTCTRL_MUXPOS_PIN9},     /* A1 */
+    {GPIO_PIN(PB, 2), ADC_INPUTCTRL_MUXPOS_PIN10},    /* A2 */
+    {GPIO_PIN(PB, 3), ADC_INPUTCTRL_MUXPOS_PIN11},    /* A3 */
+    {GPIO_PIN(PA, 8), ADC_INPUTCTRL_MUXPOS_PIN16},    /* A4 */
+    {GPIO_PIN(PA, 9), ADC_INPUTCTRL_MUXPOS_PIN17},    /* A5 */
+    {GPIO_PIN(PA, 10), ADC_INPUTCTRL_MUXPOS_PIN18},   /* GROVE1/A6 */
+    {GPIO_PIN(PA, 11), ADC_INPUTCTRL_MUXPOS_PIN19},   /* GROVE2/A7 */
+    {GPIO_PIN(PB, 5), ADC_INPUTCTRL_MUXPOS_PIN13},    /* BAT_VOLT/A8 */
+    {GPIO_PIN(PA, 2), ADC_INPUTCTRL_MUXPOS_PIN0},     /* D2/DAC */
+    {GPIO_PIN(PA, 3), ADC_INPUTCTRL_MUXPOS_PIN1},     /* AREF */
+};
+
+#define ADC_0_CHANNELS                     (11)
+#define ADC_NUMOF                          ADC_0_CHANNELS
+/** @} */
+
+/**
+ * @name SPI configuration
+ * @{
+ */
+static const spi_conf_t spi_config[] = {
+    {
+        .dev      = &SERCOM3->SPI,
+        .miso_pin = GPIO_PIN(PA, 22),
+        .mosi_pin = GPIO_PIN(PA, 20),
+        .clk_pin  = GPIO_PIN(PA, 21),
+        .miso_mux = GPIO_MUX_C,
+        .mosi_mux = GPIO_MUX_D,
+        .clk_mux  = GPIO_MUX_D,
+        .miso_pad = SPI_PAD_MISO_0,
+        .mosi_pad = SPI_PAD_MOSI_2_SCK_3
+    }
+};
+
+#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+/** @} */
+
+/**
+ * @name I2C configuration
+ * @{
+ */
+static const i2c_conf_t i2c_config[] = {
+    {
+        .dev      = &(SERCOM1->I2CM),
+        .speed    = I2C_SPEED_NORMAL,
+        .scl_pin  = GPIO_PIN(PA, 17),
+        .sda_pin  = GPIO_PIN(PA, 16),
+        .mux      = GPIO_MUX_C,
+        .gclk_src = GCLK_CLKCTRL_GEN_GCLK0,
+        .flags    = I2C_FLAG_NONE
+    }
+};
+#define I2C_NUMOF          (sizeof(i2c_config) / sizeof(i2c_config[0]))
+
+/** @} */
+
+/**
+ * @name RTC configuration
+ * @{
+ */
+#define RTC_NUMOF           (1U)
+#define RTC_DEV             RTC->MODE2
+/** @} */
+
+/**
+ * @name RTT configuration
+ * @{
+ */
+#define RTT_NUMOF           (1U)
+#define RTT_DEV             RTC->MODE0
+#define RTT_IRQ             RTC_IRQn
+#define RTT_IRQ_PRIO        10
+#define RTT_ISR             isr_rtc
+#define RTT_MAX_VALUE       (0xffffffff)
+#define RTT_FREQUENCY       (32768U)    /* in Hz. For changes see `rtt.c` */
+#define RTT_RUNSTDBY        (1)         /* Keep RTT running in sleep states */
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_CONF_H */
+/** @} */

--- a/examples/lua_REPL/Makefile
+++ b/examples/lua_REPL/Makefile
@@ -23,9 +23,9 @@ BOARD_INSUFFICIENT_MEMORY := blackpill bluepill calliope-mini cc2650-launchpad \
                              saml21-xpro samr21-xpro samr30-xpro \
                              seeeduino_arch-pro sensebox_samd21 slstk3401a \
                              sltb001a slwstk6220a sodaq-autonomo sodaq-explorer \
-                             sodaq-one stk3600 stm32f3discovery yunjia-nrf51822 \
-                             esp8266-esp-12x esp8266-olimex-mod esp8266-sparkfun-thing \
-                             firefly
+                             sodaq-one sodaq-sara-aff stk3600 stm32f3discovery \
+                             yunjia-nrf51822 esp8266-esp-12x esp8266-olimex-mod \
+                             esp8266-sparkfun-thing firefly
 
 BOARD_BLACKLIST := arduino-duemilanove arduino-mega2560 arduino-uno \
                    chronos hifive1 jiminy-mega256rfr2 mega-xplained mips-malta \

--- a/tests/unittests/Makefile
+++ b/tests/unittests/Makefile
@@ -69,6 +69,7 @@ BOARD_INSUFFICIENT_MEMORY := airfy-beacon \
                              sodaq-autonomo \
                              sodaq-explorer \
                              sodaq-one \
+                             sodaq-sara-aff \
                              spark-core \
                              stk3600 \
                              stm32f0discovery \


### PR DESCRIPTION
### Contribution description
This PR adds the initial support for the SODAQ SARA AFF boards ([R410M](https://support.sodaq.com/sodaq-one/sodaq-sara-r410m/) and [N211](https://support.sodaq.com/sodaq-one/sara/)).

The hardware includes:
- ublox SARA R4xx/N2xx NB-IoT module
- ublox SAM M8Q GPS module
- LSM303AGR accelerometer & magnetometer module
- Solar charge controller

Right now we don't have drivers for the on-board modules.

### Testing procedure
Follow the instructions in the *Flash the board* section of the documentation to test this.

### Issues/PRs references
None
