### PR TITLE
gnrc_netapi: move author tag into file context

### DIFF
--- a/sys/include/net/gnrc/netapi.h
+++ b/sys/include/net/gnrc/netapi.h
@@ -21,6 +21,9 @@
  * @file
  * @brief       Generic interface to communicate with GNRC modules
  *
+ * @author      Martine Lenders <mlenders@inf.fu-berlin.de>
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ *
  * @defgroup    net_gnrc_netapi_mbox   Mailbox IPC extension
  * @ingroup     net_gnrc_netapi
  * @brief       @ref core_mbox "Mailbox IPC" extension for @ref net_gnrc_netapi
@@ -51,8 +54,6 @@
  * USEMODULE += gnrc_netapi_callbacks
  * ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
  * @}
- * @author      Martine Lenders <mlenders@inf.fu-berlin.de>
- * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
  */
 
 #ifndef NET_GNRC_NETAPI_H


### PR DESCRIPTION
### Contribution description
Browsing through https://doc.riot-os.org, I noticed that `GNRC_NETAPI_MSG_TYPE_RCV` somehow got the authorship for the module. This fixes that

### Testing procedure
`make doc` and have a look at `doc/doxygen/html/group__net__gnrc__netapi.html#ga57b7e8cf32c12beecc9b84ca2cc073b5` and  `doc/doxygen/html/netapi_8h.html#details` before and after applying this patch.

### Issues/PRs references
—