### PR TITLE
gnrc_netapi: declare `data` for set function as const

### DIFF
--- a/sys/include/net/gnrc/netapi.h
+++ b/sys/include/net/gnrc/netapi.h
@@ -204,7 +204,7 @@ int gnrc_netapi_get(kernel_pid_t pid, netopt_t opt, uint16_t context,
  *                      wrong.
  */
 int gnrc_netapi_set(kernel_pid_t pid, netopt_t opt, uint16_t context,
-                    void *data, size_t data_len);
+                    const void *data, size_t data_len);
 
 #ifdef __cplusplus
 }

--- a/sys/net/gnrc/netapi/gnrc_netapi.c
+++ b/sys/net/gnrc/netapi/gnrc_netapi.c
@@ -163,8 +163,10 @@ int gnrc_netapi_get(kernel_pid_t pid, netopt_t opt, uint16_t context,
 }
 
 int gnrc_netapi_set(kernel_pid_t pid, netopt_t opt, uint16_t context,
-                    void *data, size_t data_len)
+                    const void *data, size_t data_len)
 {
+    /* disregard const pointer. This *should* be safe and any modification
+     * to `data` should be considered a bug */
     return _get_set(pid, GNRC_NETAPI_MSG_TYPE_SET, opt, context,
-                    data, data_len);
+                    (void *)data, data_len);
 }


### PR DESCRIPTION
### Contribution description
Addresses #10436 as discussed there. This adds a few by to the GNRC codesize on some platforms though (tested with `nrf52dk`).

### Testing procedure
`ifconfig` in `gnrc_networking` still be able to modify any option without crash.


### Issues/PRs references
Resolves #10436