### PR TITLE
makefile/utils: Add a function for checking that a string is not empty.

### DIFF
--- a/makefiles/utils/checks.mk
+++ b/makefiles/utils/checks.mk
@@ -1,0 +1,11 @@
+# Utilities to produce errors inside Make
+# Use this functions to produce friendlier error messages.
+
+# Produce an error if the value is empty
+#
+# Parameters
+#	value: a string which should not be empty
+#	message: The error message to display.
+# Returns:
+#	the first argument, if it is not empty.
+ensure_value = $(if $(1),$(1),$(error $(2)))

--- a/makefiles/utils/test-checks.mk
+++ b/makefiles/utils/test-checks.mk
@@ -1,0 +1,7 @@
+include checks.mk
+
+test-ensure_value:
+	@test "$@" = "$(call ensure_value,$@,"This should not fail")"
+
+test-ensure_value-negative:
+	@echo $(call ensure_value,$^,"This should fail")

--- a/tests/build_system_utils/Makefile
+++ b/tests/build_system_utils/Makefile
@@ -1,0 +1,33 @@
+BOARD_WHITELIST = native
+
+include ../Makefile.tests_common
+include $(RIOTBASE)/Makefile.include
+
+
+# Test utils commands
+define command_should_fail
+$1 2>/dev/null && { echo "Command '$1' should have failed but did not" >&2; $1; exit 1; } || true
+endef
+
+define command_should_succeed
+$1 || { echo "Command '$1' failed" >&2; $1; exit 1; }
+endef
+
+
+MAKEFILES_UTILS = $(RIOTMAKE)/utils
+
+TESTS = test-ensure_value test-ensure_value-negative
+
+# Tests will be run both in the host machine and in `docker`
+all: build-system-utils-tests
+
+build-system-utils-tests: $(TESTS)
+.PHONY: build-system-utils-tests $(TESTS)
+
+
+# tests for 'ensure_value'
+test-ensure_value:
+	$(Q)$(call command_should_succeed,"$(MAKE)" -C $(MAKEFILES_UTILS) -f test-checks.mk test-ensure_value)
+
+test-ensure_value-negative:
+	$(Q)$(call command_should_fail,"$(MAKE)" -C $(MAKEFILES_UTILS) -f test-checks.mk test-ensure_value-negative)

--- a/tests/build_system_utils/README.md
+++ b/tests/build_system_utils/README.md
@@ -1,0 +1,14 @@
+Build system utils tests
+========================
+
+This test checks the build system 'utils' functions declared in
+`makefiles/utils`.
+
+The test output says nothing in case of success.
+
+Note
+----
+
+It should not be necessary to compile but this simplifies the integration in
+murdock for the moment. Also there will be other tests that may need to check
+the result of the compilation.

--- a/tests/build_system_utils/main.c
+++ b/tests/build_system_utils/main.c
@@ -1,0 +1,25 @@
+/*
+ * Copyright (C) 2018 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser General
+ * Public License v2.1. See the file LICENSE in the top level directory for more
+ * details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Empty main file
+ *
+ * @author      Gaëtan Harter <gaetan.harter@fu-berlin.de>
+ *
+ * @}
+ */
+
+int main(void)
+{
+    /* The important rules are in the Makefile */
+    return 0;
+}


### PR DESCRIPTION
### Contribution description

A call to `$(call ensure_value,x,y)` will fail with message y if x is empty, and otherwise return x. This can be useto write more compact makefiles, while still producing friendly error messages.

### Testing procedure

I should provide an automated test for this, in the meantime:

```
$ cd makefiles/util
$ make -f test-checks.mk test-ensure_value
test-ensure_value
$ make -f test-checks.mk test-ensure_value-negative
test-checks.mk:7: *** "This should fail".  Stop.
```

### Issues/PRs references

Split from #10342.
