### PR TITLE
makefiles: remove exports so that PORT is not evaluated if it's not needed.

### DIFF
--- a/boards/cc2538dk/Makefile.include
+++ b/boards/cc2538dk/Makefile.include
@@ -23,11 +23,11 @@ export RESET = $(RIOTBOARD)/$(BOARD)/dist/reset.sh
 export PROGRAMMER ?= cc2538-bsl
 
 ifeq ($(PROGRAMMER),cc2538-bsl)
-  export FLASHER = $(RIOTTOOLS)/cc2538-bsl/cc2538-bsl.py
-  export FFLAGS  = -p "$(PORT)" -e -w -v $(HEXFILE)
+  FLASHER = $(RIOTTOOLS)/cc2538-bsl/cc2538-bsl.py
+  FFLAGS  = -p "$(PORT)" -e -w -v $(HEXFILE)
 else ifeq ($(PROGRAMMER),jlink)
-  export FLASHER = $(RIOTBOARD)/$(BOARD)/dist/flash.sh
-  export FFLAGS  = $(BINDIR) $(HEXFILE)
+  FLASHER = $(RIOTBOARD)/$(BOARD)/dist/flash.sh
+  FFLAGS  = $(BINDIR) $(HEXFILE)
 endif
 
 OFLAGS = --gap-fill 0xff

--- a/makefiles/murdock.inc.mk
+++ b/makefiles/murdock.inc.mk
@@ -3,7 +3,7 @@
 #
 
 # (HACK) get actual flash binary from FFLAGS.
-FLASHFILE:=$(filter $(HEXFILE) $(ELFFILE:.elf=.bin) $(ELFFILE),$(FFLAGS))
+FLASHFILE = $(filter $(HEXFILE) $(ELFFILE:.elf=.bin) $(ELFFILE),$(FFLAGS))
 
 #
 # This target will run "make test" on the CI cluster.

--- a/makefiles/tools/serial.inc.mk
+++ b/makefiles/tools/serial.inc.mk
@@ -8,15 +8,13 @@ endif
 ifeq ($(PORT),)
   $(info Warning: no PORT set!)
 endif
-export PORT
-
 export BAUD ?= 115200
 
 RIOT_TERMINAL ?= pyterm
 ifeq ($(RIOT_TERMINAL),pyterm)
-    export TERMPROG  ?= $(RIOTTOOLS)/pyterm/pyterm
-    export TERMFLAGS ?= -p "$(PORT)" -b "$(BAUD)"
+    TERMPROG  ?= $(RIOTTOOLS)/pyterm/pyterm
+    TERMFLAGS ?= -p "$(PORT)" -b "$(BAUD)"
 else ifeq ($(RIOT_TERMINAL),picocom)
-    export TERMPROG  ?= picocom
-    export TERMFLAGS ?= --nolock --imap lfcrlf --echo --baud "$(BAUD)" "$(PORT)"
+    TERMPROG  ?= picocom
+    TERMFLAGS ?= --nolock --imap lfcrlf --echo --baud "$(BAUD)" "$(PORT)"
 endif

--- a/makefiles/vars.inc.mk
+++ b/makefiles/vars.inc.mk
@@ -69,7 +69,7 @@ export WERROR                # Treat all compiler warnings as errors if set to 1
 export GITCACHE              # path to git-cache executable
 export GIT_CACHE_DIR         # path to git-cache cache directory
 export FLASHER               # The command to call on "make flash".
-export FFLAGS                # The parameters to supply to FLASHER.
+# FFLAGS                	 # The parameters to supply to FLASHER.
 export FLASH_ADDR            # Define an offset to flash code into ROM memory.
 # TERMPROG                   # The command to call on "make term".
 # TERMFLAGS                  # Additional parameters to supply to TERMPROG.

--- a/makefiles/vars.inc.mk
+++ b/makefiles/vars.inc.mk
@@ -71,9 +71,9 @@ export GIT_CACHE_DIR         # path to git-cache cache directory
 export FLASHER               # The command to call on "make flash".
 export FFLAGS                # The parameters to supply to FLASHER.
 export FLASH_ADDR            # Define an offset to flash code into ROM memory.
-export TERMPROG              # The command to call on "make term".
-export TERMFLAGS             # Additional parameters to supply to TERMPROG.
-export PORT                  # The port to connect the TERMPROG to.
+# TERMPROG                   # The command to call on "make term".
+# TERMFLAGS                  # Additional parameters to supply to TERMPROG.
+# PORT                       # The port to connect the TERMPROG to.
 export ELFFILE               # The unstripped result of the compilation.
 export HEXFILE               # The stripped result of the compilation.
 export DEBUGGER              # The command to call on "make debug", usually a script starting the GDB front-end.


### PR DESCRIPTION
### Contribution description

Remove instances of `:=` and export that were causing $(PORT) to be evaluated where it was not needed.

This is needed for #10342 (it verifies if port is not set). If `term` is not specified as a target, then PORT is not evaluated and no error will be produced.

### Testing procedure

If I'm not mistaken, the test for this is already carried out by murdock.

### Issues/PRs references

Split from: #10342
