### PR TITLE
gnrc_netapi: optimize code-size

### DIFF
--- a/sys/include/net/gnrc/netapi.h
+++ b/sys/include/net/gnrc/netapi.h
@@ -104,6 +104,44 @@ typedef struct {
 } gnrc_netapi_opt_t;
 
 /**
+ * @brief   Shortcut function for sending @ref GNRC_NETAPI_MSG_TYPE_SND or
+ *          @ref GNRC_NETAPI_MSG_TYPE_RCV messages
+ *
+ * @param[in] pid       PID of the targeted network module
+ * @param[in] pkt       pointer into the packet buffer holding the data to send
+ * @param[in] type      type of the message to send. Must be either
+ *                      @ref GNRC_NETAPI_MSG_TYPE_SND or
+ *                      @ref GNRC_NETAPI_MSG_TYPE_RCV
+ *
+ * @return              1 if packet was successfully delivered
+ * @return              -1 on error (invalid PID or no space in queue)
+ */
+int _gnrc_netapi_send_recv(kernel_pid_t pid, gnrc_pktsnip_t *pkt, uint16_t type);
+
+/**
+ * @brief   Shortcut function for sending @ref GNRC_NETAPI_MSG_TYPE_GET or
+ *          @ref GNRC_NETAPI_MSG_TYPE_SET messages and parsing the returned
+ *          @ref GNRC_NETAPI_MSG_TYPE_ACK message
+ *
+ * @param[in] pid       PID of the targeted network module
+ * @param[in] opt       option to get
+ * @param[in] context   (optional) context to the given option
+ * @param[in] data      pointer to buffer for reading the option's value
+ * @param[in] data_len  (maximum) number of bytes in @p data
+ * @param[in] type      type of the message to send. Must be either
+ *                      @ref GNRC_NETAPI_MSG_TYPE_GET or
+ *                      @ref GNRC_NETAPI_MSG_TYPE_SET
+ *
+ * @return              value returned by the @ref GNRC_NETAPI_MSG_TYPE_ACK message i.e. the actual
+ *                      length of the resulting data on success, a negative errno on error. The
+ *                      actual error value is for the implementation to decide but should be
+ *                      sensible to indicate what went wrong.
+ */
+int _gnrc_netapi_get_set(kernel_pid_t pid, netopt_t opt, uint16_t context,
+                         void *data, size_t data_len, uint16_t type);
+
+
+/**
  * @brief   Shortcut function for sending @ref GNRC_NETAPI_MSG_TYPE_SND messages
  *
  * @param[in] pid       PID of the targeted network module
@@ -112,7 +150,10 @@ typedef struct {
  * @return              1 if packet was successfully delivered
  * @return              -1 on error (invalid PID or no space in queue)
  */
-int gnrc_netapi_send(kernel_pid_t pid, gnrc_pktsnip_t *pkt);
+static inline int gnrc_netapi_send(kernel_pid_t pid, gnrc_pktsnip_t *pkt)
+{
+    return _gnrc_netapi_send_recv(pid, pkt, GNRC_NETAPI_MSG_TYPE_SND);
+}
 
 /**
  * @brief   Sends @p cmd to all subscribers to (@p type, @p demux_ctx).
@@ -152,7 +193,10 @@ static inline int gnrc_netapi_dispatch_send(gnrc_nettype_t type, uint32_t demux_
  * @return              1 if packet was successfully delivered
  * @return              -1 on error (invalid PID or no space in queue)
  */
-int gnrc_netapi_receive(kernel_pid_t pid, gnrc_pktsnip_t *pkt);
+static inline int gnrc_netapi_receive(kernel_pid_t pid, gnrc_pktsnip_t *pkt)
+{
+    return _gnrc_netapi_send_recv(pid, pkt, GNRC_NETAPI_MSG_TYPE_RCV);
+}
 
 /**
  * @brief   Sends a @ref GNRC_NETAPI_MSG_TYPE_RCV command to all subscribers to
@@ -185,8 +229,12 @@ static inline int gnrc_netapi_dispatch_receive(gnrc_nettype_t type, uint32_t dem
  *                      actual error value is for the implementation to decide but should be
  *                      sensible to indicate what went wrong.
  */
-int gnrc_netapi_get(kernel_pid_t pid, netopt_t opt, uint16_t context,
-                    void *data, size_t max_len);
+static inline int gnrc_netapi_get(kernel_pid_t pid, netopt_t opt,
+                                  uint16_t context, void *data, size_t max_len)
+{
+    return _gnrc_netapi_get_set(pid, opt, context, data, max_len,
+                                GNRC_NETAPI_MSG_TYPE_GET);
+}
 
 /**
  * @brief   Shortcut function for sending @ref GNRC_NETAPI_MSG_TYPE_SET messages and
@@ -203,8 +251,15 @@ int gnrc_netapi_get(kernel_pid_t pid, netopt_t opt, uint16_t context,
  *                      implementation to decide but should be sensible to indicate what went
  *                      wrong.
  */
-int gnrc_netapi_set(kernel_pid_t pid, netopt_t opt, uint16_t context,
-                    const void *data, size_t data_len);
+static inline int gnrc_netapi_set(kernel_pid_t pid, netopt_t opt,
+                                  uint16_t context, const void *data,
+                                  size_t data_len)
+{
+    /* disregard const pointer. This *should* be safe and any modification
+     * to `data` should be considered a bug */
+    return _gnrc_netapi_get_set(pid, opt, context, (void *)data, data_len,
+                                GNRC_NETAPI_MSG_TYPE_SET);
+}
 
 #ifdef __cplusplus
 }

--- a/sys/net/gnrc/netapi/gnrc_netapi.c
+++ b/sys/net/gnrc/netapi/gnrc_netapi.c
@@ -27,20 +27,8 @@
 #define ENABLE_DEBUG    (0)
 #include "debug.h"
 
-/**
- * @brief   Unified function for getting and setting netapi options
- *
- * @param[in] pid       PID of the targeted thread
- * @param[in] type      specify if option is to be set or get
- * @param[in] opt       option to set or get
- * @param[in] data      data to set or pointer to buffer for reading options
- * @param[in] data_len  size of the given buffer
- *
- * @return              the value from the received ACK message
- */
-static inline int _get_set(kernel_pid_t pid, uint16_t type,
-                           netopt_t opt, uint16_t context,
-                           void *data, size_t data_len)
+int _gnrc_netapi_get_set(kernel_pid_t pid, netopt_t opt, uint16_t context,
+                         void *data, size_t data_len, uint16_t type)
 {
     msg_t cmd;
     msg_t ack;
@@ -60,7 +48,7 @@ static inline int _get_set(kernel_pid_t pid, uint16_t type,
     return (int)ack.content.value;
 }
 
-static inline int _snd_rcv(kernel_pid_t pid, uint16_t type, gnrc_pktsnip_t *pkt)
+int _gnrc_netapi_send_recv(kernel_pid_t pid, gnrc_pktsnip_t *pkt, uint16_t type)
 {
     msg_t msg;
     /* set the outgoing message's fields */
@@ -106,7 +94,8 @@ int gnrc_netapi_dispatch(gnrc_nettype_t type, uint32_t demux_ctx,
             int release = 0;
             switch (sendto->type) {
                 case GNRC_NETREG_TYPE_DEFAULT:
-                    if (_snd_rcv(sendto->target.pid, cmd, pkt) < 1) {
+                    if (_gnrc_netapi_send_recv(sendto->target.pid, pkt,
+                                               cmd) < 1) {
                         /* unable to dispatch packet */
                         release = 1;
                     }
@@ -133,7 +122,7 @@ int gnrc_netapi_dispatch(gnrc_nettype_t type, uint32_t demux_ctx,
                 gnrc_pktbuf_release(pkt);
             }
 #else
-            if (_snd_rcv(sendto->target.pid, cmd, pkt) < 1) {
+            if (_gnrc_netapi_send_recv(sendto->target.pid, pkt, cmd) < 1) {
                 /* unable to dispatch packet */
                 gnrc_pktbuf_release(pkt);
             }
@@ -143,30 +132,4 @@ int gnrc_netapi_dispatch(gnrc_nettype_t type, uint32_t demux_ctx,
     }
 
     return numof;
-}
-
-int gnrc_netapi_send(kernel_pid_t pid, gnrc_pktsnip_t *pkt)
-{
-    return _snd_rcv(pid, GNRC_NETAPI_MSG_TYPE_SND, pkt);
-}
-
-int gnrc_netapi_receive(kernel_pid_t pid, gnrc_pktsnip_t *pkt)
-{
-    return _snd_rcv(pid, GNRC_NETAPI_MSG_TYPE_RCV, pkt);
-}
-
-int gnrc_netapi_get(kernel_pid_t pid, netopt_t opt, uint16_t context,
-                    void *data, size_t data_len)
-{
-    return _get_set(pid, GNRC_NETAPI_MSG_TYPE_GET, opt, context,
-                    data, data_len);
-}
-
-int gnrc_netapi_set(kernel_pid_t pid, netopt_t opt, uint16_t context,
-                    const void *data, size_t data_len)
-{
-    /* disregard const pointer. This *should* be safe and any modification
-     * to `data` should be considered a bug */
-    return _get_set(pid, GNRC_NETAPI_MSG_TYPE_SET, opt, context,
-                    (void *)data, data_len);
 }


### PR DESCRIPTION
### Contribution description
While I was working on  #10438, I noticed that the `gnrc_netapi` module can be optimized a little bit.


### Testing procedure
Sending (`udp send <ip> <port> <payload>`), receiving (`udp server start <port>`), and setting (`ifconfig <if> set` or `ifconfig <if> [-]<flag>`) and getting (`ifconfig <if>`) options should still work in `gnrc_networking`

### Issues/PRs references
None