### PR TITLE
netdev: add stubs for get/set not implemented

### DIFF
--- a/drivers/include/net/netdev.h
+++ b/drivers/include/net/netdev.h
@@ -195,6 +195,7 @@ extern "C" {
 #endif
 
 #include <stdint.h>
+#include <errno.h>
 
 #include "iolist.h"
 #include "net/netopt.h"
@@ -412,6 +413,47 @@ typedef struct netdev_driver {
     int (*set)(netdev_t *dev, netopt_t opt,
                const void *value, size_t value_len);
 } netdev_driver_t;
+
+/**
+ * @brief   Convenience function for declaring get() as not supported in general
+ *
+ * @param[in] dev           ignored
+ * @param[in] opt           ignored
+ * @param[in] value         ignored
+ * @param[in] max_len       ignored
+ *
+ * @return  always returns `-ENOTSUP`
+ */
+static inline int netdev_get_notsup(netdev_t *dev, netopt_t opt,
+                                    void *value, size_t max_len)
+{
+    (void)dev;
+    (void)opt;
+    (void)value;
+    (void)max_len;
+    return -ENOTSUP;
+}
+
+/**
+ * @brief   Convenience function for declaring set() as not supported in general
+ *
+ * @param[in] dev           ignored
+ * @param[in] opt           ignored
+ * @param[in] value         ignored
+ * @param[in] value_len     ignored
+ *
+ * @return  always returns `-ENOTSUP`
+ */
+static inline int netdev_set_notsup(netdev_t *dev, netopt_t opt,
+                                    const void *value, size_t value_len)
+{
+    (void)dev;
+    (void)opt;
+    (void)value;
+    (void)value_len;
+    return -ENOTSUP;
+}
+
 
 #ifdef __cplusplus
 }

--- a/drivers/slipdev/slipdev.c
+++ b/drivers/slipdev/slipdev.c
@@ -188,23 +188,13 @@ static int _get(netdev_t *netdev, netopt_t opt, void *value, size_t max_len)
     }
 }
 
-static int _set(netdev_t *netdev, netopt_t opt, const void *value,
-                size_t value_len)
-{
-    (void)netdev;
-    (void)opt;
-    (void)value;
-    (void)value_len;
-    return -ENOTSUP;
-}
-
 static const netdev_driver_t slip_driver = {
     .send = _send,
     .recv = _recv,
     .init = _init,
     .isr = _isr,
     .get = _get,
-    .set = _set,
+    .set = netdev_set_notsup,
 };
 
 void slipdev_setup(slipdev_t *dev, const slipdev_params_t *params)

--- a/pkg/nordic_softdevice_ble/src/gnrc_nordic_ble_6lowpan.c
+++ b/pkg/nordic_softdevice_ble/src/gnrc_nordic_ble_6lowpan.c
@@ -230,16 +230,6 @@ static int _netdev_get(netdev_t *netdev, netopt_t opt,
     return res;
 }
 
-static int _netdev_set(netdev_t *netdev, netopt_t opt,
-                       const void *value, size_t value_len)
-{
-    (void)netdev;
-    (void)opt;
-    (void)value;
-    (void)value_len;
-    return -ENOTSUP;
-}
-
 static int _netif_send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
 {
     (void)netif;
@@ -282,7 +272,7 @@ static const netdev_driver_t _ble_netdev_driver = {
     .init = _netdev_init,
     .isr  =  NULL,
     .get  = _netdev_get,
-    .set  = _netdev_set,
+    .set  = netdev_set_notsup,
 };
 
 static netdev_t _ble_dummy_dev = {


### PR DESCRIPTION
### Contribution description
Selected `netdev` driver implementations do not implement the `get()` and/or `set()` functions of the `netdev` interface. This PR provides two convenience functions for these cases, so there is no need to write the 'return always -ENOTSUP' functions over and over...

For ref: the same approach is also used by SAUL.

### Testing procedure
IMO a successful buildtest should be sufficient, right?!

### Issues/PRs references
none