### PR TITLE
boards: add feature periph_gpio_irq to lobaro-lorabox

### DIFF
--- a/boards/lobaro-lorabox/Makefile.features
+++ b/boards/lobaro-lorabox/Makefile.features
@@ -1,5 +1,5 @@
 # Put defined MCU peripherals here (in alphabetical order)
-FEATURES_PROVIDED += periph_gpio
+FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_spi


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

The board wasn't adapted to the split of periph_gpio and periph_gpio_irq, this adds the missing feature.


### Testing procedure

Compile `tests/buttons` on master, you'll get an error/warning due to the missing feature.
With this PR you don't 😄 


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
