### PR TITLE
pkg/nimble: Add `ble_hs_stop.c` to makefile

### DIFF
--- a/pkg/nimble/nimble.host.mk
+++ b/pkg/nimble/nimble.host.mk
@@ -26,6 +26,7 @@ SRC += ble_hs_mqueue.c
 SRC += ble_hs_misc.c
 SRC += ble_hs_pvcy.c
 SRC += ble_hs_startup.c
+SRC += ble_hs_stop.c
 SRC += ble_ibeacon.c
 SRC += ble_l2cap.c
 SRC += ble_l2cap_coc.c


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

This file (`ble_hs_stop.c`) was added to NimBLE in this PR: https://github.com/apache/mynewt-nimble/pull/216.  This PR adds an entry for this file to the `pkg/nimble/nimble.host.mk` Makefile.

Without this change, an attempt to build the nimble package fails with a linker error, as seen here: https://travis-ci.org/apache/mynewt-nimble/jobs/458153788

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

Simply ensure the `nimble_gatt` example builds, e.g.,
```
cd examples/nimble_gatt && make
```

### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
