### PR TITLE
cpu/esp8266: Fix i2c buses array #ifdef

### DIFF
--- a/cpu/esp8266/periph/i2c.c
+++ b/cpu/esp8266/periph/i2c.c
@@ -75,21 +75,21 @@ typedef struct
 
 static _i2c_bus_t _i2c_bus[] =
 {
-  #if defined(I2C0_SDA) && defined(I2C0_SDA)
+  #if defined(I2C0_SDA) && defined(I2C0_SCL)
   {
     .speed = I2C0_SPEED,
     .sda = I2C0_SDA,
     .scl = I2C0_SCL
   },
   #endif
-  #if defined(I2C1_SDA) && defined(I2C1_SDA)
+  #if defined(I2C1_SDA) && defined(I2C1_SCL)
   {
     .speed = I2C1_SPEED,
     .sda = I2C1_SDA,
     .scl = I2C1_SCL
   },
   #endif
-  #if defined(I2C2_SDA) && defined(I2C2_SDA)
+  #if defined(I2C2_SDA) && defined(I2C2_SCL)
   {
     .speed = I2C2_SPEED,
     .sda = I2C2_SDA,


### PR DESCRIPTION
### Contribution description
The i2c bus array for the esp8266 is formed in compile time depending on whether the i2c pins are defined on the board for that usage or not. I noticed that the condition to add an element to the array only checks if the `I2Cx_SDA` pin is defined (probably just a copy & paste mistake). This PR changed that and checks if both `I2Cx_SDA` and `I2C_SCL` pins are defined.

The of this is minor because if `I2Cx_SCL` if not defined compilation will fail while trying to assign `.scl = I2Cx_SCL`.

### Testing procedure
While compiling `tests/periph_i2c` with `I2C0_SCL` defined:
- In master the following error should appear:
`i2c.c:82:12: error: 'I2C0_SCL' undeclared here (not in a function)`
- With this PR the following error should appear:
`/i2c.c:740:31: error: array subscript is above array bounds [-Werror=array-bounds]`

### Issues/PRs references
