### PR TITLE
dist/testbed-support: add frdm-kw41z in iotlab archis

### DIFF
--- a/dist/testbed-support/makefile.iotlab.single.inc.mk
+++ b/dist/testbed-support/makefile.iotlab.single.inc.mk
@@ -68,6 +68,7 @@ IOTLAB_NODE_AUTO_NUM ?= 1
 IOTLAB_ARCHI_arduino-zero   = arduino-zero:xbee
 IOTLAB_ARCHI_b-l072z-lrwan1 = st-lrwan1:sx1276
 IOTLAB_ARCHI_b-l475e-iot01a = st-iotnode:multi
+IOTLAB_ARCHI_frdm-kw41z     = frdm-kw41z:multi
 IOTLAB_ARCHI_iotlab-a8-m3   = a8:at86rf231
 IOTLAB_ARCHI_iotlab-m3      = m3:at86rf231
 IOTLAB_ARCHI_microbit       = microbit:ble


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR adds frdm-kw41z board in the list of architectures provided by IoT-LAB.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->

1. Book a frdm-kw41z on IoT-LAB:
```
$ iotlab-experiment submit -n pr_frdm_kw41z -d 20 -l 1,archi=frdm-kw41z:multi+site=saclay
$ iotlab-experiment wait
```
2. Build, flash, term it with any application using the RIOT build system:
```
$ make BOARD=frdm-kw41z IOTLAB_NODE=auto-ssh -C examples/default/ flash term
```


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
