### PR TITLE
boards/msba2: Do not set PORT.

### DIFF
--- a/boards/common/msba2/Makefile.include
+++ b/boards/common/msba2/Makefile.include
@@ -4,7 +4,11 @@ export CPU = lpc2387
 FLASHER = lpc2k_pgm
 
 # configure serial interface
-export TERMFLAGS += -tg -p "$(PORT)"
+PORT_LINUX ?= /dev/ttyUSB0
+# This does not make a lot of sense, but it has the same value as the previous code
+PORT_DARWIN ?= /dev/ttyUSB0
+
+TERMFLAGS += -tg -p "$(PORT)"
 include $(RIOTMAKE)/tools/serial.inc.mk
 
 export CFLAGS_CPU   = -mcpu=arm7tdmi-s
@@ -21,10 +25,7 @@ export LINKFLAGS += -Wl,--gc-sections
 # use the nano-specs of Newlib when available
 USEMODULE += newlib_nano
 
-ifeq ($(PORT),)
-  export PORT = /dev/ttyUSB0
-endif
-export FFLAGS = $(PORT) $(HEXFILE)
+FFLAGS = $(PORT) $(HEXFILE)
 
 INCLUDES += -I$(RIOTBOARD)/common/msba2/include
 


### PR DESCRIPTION
### Contribution description

Boards should not set PORT and should not have code conditional on PORT as that causes PORT to be evaluated and the build to fail even if this varible is not needed.

Exporting has the same effect.

This fixes the MSBA2 board by declaring PORT_LINUX and PORT_DARWIN instead. PORT_DARWIN is obviously wrong, but it is broken with or without this PR.

### Testing procedure

CI should test this for you.

### Issues/PRs references

Needed by #10342 so it does not fail.
See also #10440 .
