### PR TITLE
net/gnrc_netif: opt of _ipv6_get_iid()

### DIFF
--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -826,6 +826,14 @@ int gnrc_netif_ipv6_get_iid(gnrc_netif_t *netif, eui64_t *eui64)
 {
 #if GNRC_NETIF_L2ADDR_MAXLEN > 0
     if (netif->flags & GNRC_NETIF_FLAGS_HAS_L2ADDR) {
+        /* the device driver abstraction should be able to provide us with the
+         * IPV6_IID, so we try this first */
+        int res = netif->dev->driver->get(netif->dev, NETOPT_IPV6_IID,
+                                          eui64, sizeof(eui64_t));
+        if (res == sizeof(eui64_t)) {
+            return 0;
+        }
+
         switch (netif->device_type) {
 #ifdef MODULE_NETDEV_ETH
             case NETDEV_TYPE_ETHERNET:
@@ -887,7 +895,8 @@ int gnrc_netif_ipv6_get_iid(gnrc_netif_t *netif, eui64_t *eui64)
                 break;
         }
     }
-#endif
+#endif /* GNRC_NETIF_L2ADDR_MAXLEN > 0 */
+
     return -ENOTSUP;
 }
 


### PR DESCRIPTION
### Contribution description
While integrating NimBLE into GNRC, I am working my way through `gnrc_netif`, trying to implement it for NimBLE. Looking at the `gnrc_netif` code, there is quite some room for optimization...

I could not find anything about this on a quick search - so if I am addressing something that is already addressed somewhere else, simply ignore my renting and close this PR :-)

This PR focuses on the `gnrc_netif_ipv6_get_iid()` function: why are we duplicating all the generating code here, even on multiple layers? Event inside this one function there is a whole code block of 8 lines duplicated...

So to row back: as far as I can see, almost all(?) netdev implementations are actually allowing to get the IID through the `NETOPT_IPV6_IID` option. So why don't we just use that here?

This PR takes a first step, by using the `NETOPT_IPV6_IID` option to get the IID from the netdev device. If successful, we are done. If not, we proceed with the existing code. 

As a follow up I would imagine, we should be able to get rid of the whole `else` part by only depending on getting `NETOPT_IPV6_IID`, right?! This would save quite some unnecessary link layer dependencies into netif. And not to mention some saved ROM :-)

### Testing procedure
Run some tests using the `gnrc_networking` example for different link layer devices, checking the generated link local addresses carefully.

### Issues/PRs references
none