### PR TITLE
examples/{javascript/lua}: correctly declare rules to embed scripts.

### DIFF
--- a/examples/javascript/Makefile
+++ b/examples/javascript/Makefile
@@ -35,21 +35,21 @@ endif
 # Add the package for Jerryscript
 USEPKG += jerryscript
 
-include $(RIOTBASE)/Makefile.include
+JS_PATH = $(BINDIR)/js/$(MODULE)
 
-JS_PATH := $(BINDIR)/js/$(MODULE)
 # add directory of generated *.js.h files to include path
 CFLAGS += -I$(JS_PATH)
 
 # generate .js.h header files of .js files
 JS = $(wildcard *.js)
-JS_H := $(JS:%.js=$(JS_PATH)/%.js.h)
+JS_H = $(JS:%.js=$(JS_PATH)/%.js.h)
+
+BUILDDEPS += $(JS_H) $(JS_PATH)/
+
+include $(RIOTBASE)/Makefile.include
 
 $(JS_PATH)/:
-	@mkdir -p $@
+	$(Q)mkdir -p $@
 
-$(JS_H): | $(JS_PATH)/
-$(JS_H): $(JS_PATH)/%.js.h: %.js
-	xxd -i $< | sed 's/^unsigned/const unsigned/g' > $@
-
-$(RIOTBUILD_CONFIG_HEADER_C): $(JS_H)
+$(JS_H): $(JS_PATH)/%.js.h: %.js | $(JS_PATH)/
+	$(Q)xxd -i $< | sed 's/^unsigned/const unsigned/g' > $@

--- a/examples/lua_REPL/Makefile
+++ b/examples/lua_REPL/Makefile
@@ -51,13 +51,7 @@ CFLAGS += -DTHREAD_STACKSIZE_MAIN='(THREAD_STACKSIZE_DEFAULT+7000)'
 
 USEPKG += lua
 
-include $(RIOTBASE)/Makefile.include
-
-# The code below generates a header file from any .lua scripts in the
-# example directory. The header file contains a byte array of the
-# ASCII characters in the .lua script.
-
-LUA_PATH := $(BINDIR)/lua
+LUA_PATH = $(BINDIR)/lua
 
 # add directory of generated *.lua.h files to include path
 CFLAGS += -I$(LUA_PATH)
@@ -65,16 +59,20 @@ CFLAGS += -I$(LUA_PATH)
 # generate .lua.h header files of .lua files
 LUA = $(wildcard *.lua)
 
-LUA_H := $(LUA:%.lua=$(LUA_PATH)/%.lua.h)
+LUA_H = $(LUA:%.lua=$(LUA_PATH)/%.lua.h)
+
+BUILDDEPS += $(LUA_H) $(LUA_PATH)/
+
+include $(RIOTBASE)/Makefile.include
+
+# The code below generates a header file from any .lua scripts in the
+# example directory. The header file contains a byte array of the
+# ASCII characters in the .lua script.
 
 $(LUA_PATH)/:
-	@mkdir -p $@
+	$(Q)mkdir -p $@
 
 # FIXME: This way of embedding lua code is not robust. A proper script will
 #        be included later.
-
-$(LUA_H): | $(LUA_PATH)/
-$(LUA_H): $(LUA_PATH)/%.lua.h: %.lua
-	xxd -i $< | sed 's/^unsigned/const unsigned/g' > $@
-
-$(RIOTBUILD_CONFIG_HEADER_C): $(LUA_H)
+$(LUA_H): $(LUA_PATH)/%.lua.h: %.lua | $(LUA_PATH)/
+	$(Q)xxd -i $< | sed 's/^unsigned/const unsigned/g' > $@

--- a/examples/lua_basic/Makefile
+++ b/examples/lua_basic/Makefile
@@ -36,13 +36,7 @@ endif
 
 USEPKG += lua
 
-include $(RIOTBASE)/Makefile.include
-
-# The code below generates a header file from any .lua scripts in the
-# example directory. The header file contains a byte array of the
-# ASCII characters in the .lua script.
-
-LUA_PATH := $(BINDIR)/lua
+LUA_PATH = $(BINDIR)/lua
 
 # add directory of generated *.lua.h files to include path
 CFLAGS += -I$(LUA_PATH)
@@ -50,14 +44,20 @@ CFLAGS += -I$(LUA_PATH)
 # generate .lua.h header files of .lua files
 LUA = $(wildcard *.lua)
 
-LUA_H := $(LUA:%.lua=$(LUA_PATH)/%.lua.h)
+LUA_H = $(LUA:%.lua=$(LUA_PATH)/%.lua.h)
+
+BUILDDEPS += $(LUA_H) $(LUA_PATH)/
+
+include $(RIOTBASE)/Makefile.include
+
+# The code below generates a header file from any .lua scripts in the
+# example directory. The header file contains a byte array of the
+# ASCII characters in the .lua script.
 
 $(LUA_PATH)/:
-	@mkdir -p $@
+	$(Q)mkdir -p $@
 
-$(LUA_H): | $(LUA_PATH)/
-$(LUA_H): $(LUA_PATH)/%.lua.h: %.lua
-
-	xxd -i $< | sed 's/^unsigned/const unsigned/g' > $@
-
-$(RIOTBUILD_CONFIG_HEADER_C): $(LUA_H)
+# FIXME: This way of embedding lua code is not robust. A proper script will
+#        be included later.
+$(LUA_H): $(LUA_PATH)/%.lua.h: %.lua | $(LUA_PATH)/
+	$(Q)xxd -i $< | sed 's/^unsigned/const unsigned/g' > $@


### PR DESCRIPTION
### Contribution description

There are some hacky hacks in the build systems so that one can do
```
make -j clean all
```
that is, `clean` and `all` at the same time with parallelism, and not have both conflicts.

Script demos (lua, js) have to add new targets to compile scripts into the app. These were not correctly declared and caused simultaneous cleaning and building to fail.

Aside from this, the declarations were not well done in general. Adding the script targets to RIOTBUILD_CONFIG_HEADER is a hack, the correct variable is BUILDDEPS.

### Testing procedure

For each package, run `make -j clean all`. It should build.

### Issues/PRs references

This bug is exposed by #10344 (not because of any logical reason, only because of the hackyness required to have "make clean all" work).