### PR TITLE
boards/common/stm32f103c8: Fixed I2C configuration

### DIFF
--- a/boards/common/stm32f103c8/include/periph_conf.h
+++ b/boards/common/stm32f103c8/include/periph_conf.h
@@ -162,8 +162,8 @@ static const i2c_conf_t i2c_config[] = {
     {
         .dev            = I2C1,
         .speed          = I2C_SPEED_NORMAL,
-        .scl_pin        = GPIO_PIN(PORT_B, 8),
-        .sda_pin        = GPIO_PIN(PORT_B, 9),
+        .scl_pin        = GPIO_PIN(PORT_B, 6),
+        .sda_pin        = GPIO_PIN(PORT_B, 7),
         .bus            = APB1,
         .rcc_mask       = RCC_APB1ENR_I2C1EN,
         .clk            = CLOCK_APB1,


### PR DESCRIPTION
### Contribution description
In commit e90f2b439e37db7cce0bb929932aaef847830e24 the I2C config has been adapted to the new I2C API. However, the pins of I2C_DEV(0) have been changed from PB6 and PB7 to PB8 and PB9. While PB8 and PB9 also can be used for I2C1 by remapping I2C1, this is not done. As a result, I2C1 was unusable. This commit restores the default I2C1 pins for I2C_DEV(0), resulting in I2C_DEV(0) becoming usable again.

### Testing procedure
Testing can be done using `tests/periph_i2c` and either an I2C slave device or an logic analyzer. Either connect the I2C device or the logic analyzer to the I2C1 interface:

- Before this PR: `scl = PB8`, `sda = PB9`
- After this PR: `scl = PB6`, `sda = PB7`

In the shell type:
 - `i2c_acquire 0`
 - `i2c_write_byte 0 42 13 0` (or something that makes sense to the attached I2C device)

Before this PR the second command will result in RIOT getting stuck in an endless loop and the logic analyzer will detect no level change on either SCL or SDA pin. With the PR the command should complete. When using a logic analyzer the command will report a  transmission failure as no I2C device responds, but the logic analyzer will show valid I2C communication. With an I2C device and a command that makes sense to it the communication should succeed.

### Issues/PRs references

None