### PR TITLE
gnrc_ndp: make compilable for router without ARSM

### DIFF
--- a/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
+++ b/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c
@@ -528,6 +528,9 @@ void gnrc_ndp_rtr_adv_send(gnrc_netif_t *netif, const ipv6_addr_t *src,
         if (netif->flags & GNRC_NETIF_FLAGS_IPV6_ADV_CUR_HL) {
             cur_hl = netif->cur_hl;
         }
+#if GNRC_IPV6_NIB_CONF_ARSM
+        /* netif->ipv6.reach_time_base is only available with Address Resolution
+         * State Machine */
         if (netif->flags & GNRC_NETIF_FLAGS_IPV6_ADV_REACH_TIME) {
             if (netif->ipv6.reach_time_base > (3600 * MS_PER_SEC)) {
                 /* reach_time > 1 hour */
@@ -537,6 +540,7 @@ void gnrc_ndp_rtr_adv_send(gnrc_netif_t *netif, const ipv6_addr_t *src,
                 reach_time = netif->ipv6.reach_time_base;
             }
         }
+#endif /* GNRC_IPV6_NIB_CONF_ARSM */
         if (netif->flags & GNRC_NETIF_FLAGS_IPV6_ADV_RETRANS_TIMER) {
             retrans_timer = netif->ipv6.retrans_time;
         }


### PR DESCRIPTION
### Contribution description
While it is an edge case in our configuration it is technically possible for a (6Lo) router not to maintain an address resolution state machine (ARSM). This fix allows for that with the `gnrc_ndp` module.

### Testing procedure
Compile an application with `gnrc_ipv6_router_default` and `gnrc_sixlowpan_default` (not `gnrc_sixlowpan_router_default`). Since `gnrc_ipv6_router_default` + an IEEE 802.15.4 device pulls in the `gnrc_sixlowpan_router_default` dependency, I suggest to use an application with an Ethernet device instead and to add `gnrc_sixlowpan_default` by hand. Without this fix you will get

```
/home/mlenders/Repositories/RIOT-OS/RIOT/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c: In function 'gnrc_ndp_rtr_adv_send':
/home/mlenders/Repositories/RIOT-OS/RIOT/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c:535:28: error: 'gnrc_netif_ipv6_t {aka struct <anonymous>}' has no member named 'reach_time_base'
             if (netif->ipv6.reach_time_base > (3600 * MS_PER_SEC)) {
                            ^
/home/mlenders/Repositories/RIOT-OS/RIOT/sys/net/gnrc/network_layer/ndp/gnrc_ndp.c:540:41: error: 'gnrc_netif_ipv6_t {aka struct <anonymous>}' has no member named 'reach_time_base'
                 reach_time = netif->ipv6.reach_time_base;
                                         ^
```

### Issues/PRs references
None