### PR TITLE
pkg/tinycrypt: update commit hash after upstream rewrote history

### DIFF
--- a/pkg/tinycrypt/Makefile
+++ b/pkg/tinycrypt/Makefile
@@ -1,6 +1,6 @@
 PKG_NAME=tinycrypt
 PKG_URL=https://github.com/01org/tinycrypt
-PKG_VERSION=3ea1a609e7aff9f2d8d13803e1076b7a8e551804
+PKG_VERSION=6a22712bebbf2fc60d9fc6192dddefd5ad1933e3
 PKG_LICENSE=BSD-3-Clause
 
 .PHONY: all


### PR DESCRIPTION
### Contribution description

Upstream rewrote history in master which changed our reference commit from

    https://github.com/01org/tinycrypt/commit/3ea1a609e7aff9f2d8d13803e1076b7a8e551804

to

    https://github.com/01org/tinycrypt/commit/6a22712bebbf2fc60d9fc6192dddefd5ad1933e3

Diff can be verified to be empty with:

    https://github.com/01org/tinycrypt/compare/6a22712bebbf2fc60d9fc6192dddefd5ad1933e3...3ea1a609e7aff9f2d8d13803e1076b7a8e551804

### Testing procedure

Murdock should build without failure to find `tinycrypt` commit.
And verify the commits content are the same.


### Issues/PRs references

Main issue about upstream changing history is done in https://github.com/RIOT-OS/RIOT/issues/10468