### PR TITLE
boards/flash.sh: rename HEXFILE to BINFILE

### DIFF
--- a/boards/cc2538dk/dist/flash.sh
+++ b/boards/cc2538dk/dist/flash.sh
@@ -8,12 +8,12 @@
 # @author Hauke Petersen <hauke.petersen@fu-berlin.de>
 
 BINDIR=$1
-HEXFILE=$2
+BINFILE=$2
 FLASHADDR=200000
 
 # setup JLink command file
 echo "speed 1000" > $BINDIR/burn.seg
-echo "loadbin $HEXFILE $FLASHADDR" >> $BINDIR/burn.seg
+echo "loadbin $BINFILE $FLASHADDR" >> $BINDIR/burn.seg
 echo "r" >> $BINDIR/burn.seg
 echo "g" >> $BINDIR/burn.seg
 echo "exit" >> $BINDIR/burn.seg

--- a/boards/common/remote/dist/flash.sh
+++ b/boards/common/remote/dist/flash.sh
@@ -8,12 +8,12 @@
 # @author Hauke Petersen <hauke.petersen@fu-berlin.de>
 
 BINDIR=$1
-HEXFILE=$2
+BINFILE=$2
 FLASHADDR=200000
 
 # setup JLink command file
 echo "speed 1000" > $BINDIR/burn.seg
-echo "loadbin $HEXFILE $FLASHADDR" >> $BINDIR/burn.seg
+echo "loadbin $BINFILE $FLASHADDR" >> $BINDIR/burn.seg
 echo "r" >> $BINDIR/burn.seg
 echo "g" >> $BINDIR/burn.seg
 echo "exit" >> $BINDIR/burn.seg


### PR DESCRIPTION
### Contribution description

Flasher are doing 'loadbin' so use BINFILE name.

In `Makefile.include` it is already setting HEXFILE to BINFILE

https://github.com/RIOT-OS/RIOT/blob/ce8815f4d1af13ef21528c8140a226b3b24143d0/boards/cc2538dk/Makefile.include#L34
https://github.com/RIOT-OS/RIOT/blob/ce8815f4d1af13ef21528c8140a226b3b24143d0/boards/common/remote/Makefile.include#L28

### Testing procedure

Try flashing for `cc2538dk` or boards depending on `remote/common`:

You should get the same output for `master` and this PR with:

```
PROGRAMMER=jlink BOARD=cc2538dk make --no-print-directory -C examples/hello-world/ flash-only FLASHER='bash -x $(RIOTBOARD)/$(BOARD)/dist/flash.sh'
```


**WARNING**: by testing this, I noticed boards depending on `remote/common` cannot flash using `PROGRAMMER==jlink` since

~https://github.com/RIOT-OS/RIOT/commit/4bcb353f89d93a125ee889ae312e66e006514426#diff-5143693651d6b10f67f159d2f8f11d47~ EDIT issue was even older it was already broken by https://github.com/RIOT-OS/RIOT/commit/8d07c01085a78aec70f3b11f94bfe252bf35a991#diff-9f122f733b5127db6637053c7f2bbd4f

I should do a PR to fix this before this one…

PR in https://github.com/RIOT-OS/RIOT/pull/10472


### Issues/PRs references

Split from these PRs that try to declare `BINFILE` and `FLASHFILE` variables

* https://github.com/RIOT-OS/RIOT/pull/8838
* https://github.com/RIOT-OS/RIOT/pull/9514
* Depends on https://github.com/RIOT-OS/RIOT/pull/10472 for testing