### PR TITLE
boards/common/remote: fix mis-migrated path for flash/reset

### DIFF
--- a/boards/common/remote/Makefile.include
+++ b/boards/common/remote/Makefile.include
@@ -16,11 +16,11 @@ ifeq ($(PROGRAMMER),cc2538-bsl)
   export FLASHER = $(RIOTTOOLS)/cc2538-bsl/cc2538-bsl.py
   export FFLAGS  = -p "$(PORT_BSL)" -e -w -v -b 115200 $(HEXFILE)
 else ifeq ($(PROGRAMMER),jlink)
-  export FLASHER = $(RIOTBOARD)/$(BOARD)/dist/flash.sh
+  export FLASHER = $(RIOTBOARD)/common/remote/dist/flash.sh
   export FFLAGS  = $(BINDIR) $(HEXFILE)
-  export DEBUGGER = $(RIOTBOARD)/$(BOARD)/dist/debug.sh
+  export DEBUGGER = $(RIOTBOARD)/common/remote/dist/debug.sh
   export DEBUGSERVER = JLinkGDBServer -device CC2538SF53
-  export RESET = $(RIOTBOARD)/$(BOARD)/dist/reset.sh
+  export RESET = $(RIOTBOARD)/common/remote/dist/reset.sh
   export RESET_FLAGS = $(BINDIR)
 endif
 


### PR DESCRIPTION
### Contribution description

The path to flash/reset/debug was not migrated correctly when moving to
`remote-common` (even before `common/remote`).


### Testing procedure

Trying `reset`, `flash-only`, `debug` should use the file in `boards/common/remote/dist` when using `PROGRAMMER=jlink` for boards depending on `common/remote`.

Here it fails as JlinkExe is not found which shows the right script is used.

```
PORT=/dev/null PROGRAMMER=jlink BOARD=remote-reva make --no-print-directory -C examples/hello-world/ reset
/home/harter/work/git/RIOT/boards/common/remote/dist/reset.sh /home/harter/work/git/RIOT/examples/hello-world/bin/remote-reva
/home/harter/work/git/RIOT/boards/common/remote/dist/reset.sh: 16: /home/harter/work/git/RIOT/boards/common/remote/dist/reset.sh: JLinkExe: not found
```

```
PORT=/dev/null PROGRAMMER=jlink BOARD=remote-reva make --no-print-directory -C examples/hello-world/ flash-only
/home/harter/work/git/RIOT/boards/common/remote/dist/flash.sh /home/harter/work/git/RIOT/examples/hello-world/bin/remote-reva /home/harter/work/git/RIOT/examples/hello-world/bin/remote-reva/hello-world.bin
/home/harter/work/git/RIOT/boards/common/remote/dist/flash.sh: 22: /home/harter/work/git/RIOT/boards/common/remote/dist/flash.sh: JLinkExe: not found
```

```
PORT=/dev/null PROGRAMMER=jlink BOARD=remote-reva make --no-print-directory -C examples/hello-world/ debug
/home/harter/work/git/RIOT/boards/common/remote/dist/debug.sh /home/harter/work/git/RIOT/examples/hello-world/bin/remote-reva /home/harter/work/git/RIOT/examples/hello-world/bin/remote-reva/hello-world.elf
/home/harter/work/git/RIOT/examples/hello-world/../../Makefile.include:539: recipe for target 'debug' failed
```

In master the script is not found as using the wrong path:

```
PORT=/dev/null PROGRAMMER=jlink BOARD=remote-reva make --no-print-directory -C examples/hello-world/ reset
Reset program /home/harter/work/git/RIOT/boards/remote-reva/dist/reset.sh is required but not found in PATH.  Aborting.
/home/harter/work/git/RIOT/examples/hello-world/../../Makefile.include:551: recipe for target 'reset' failed
make: *** [reset] Error 1

PORT=/dev/null PROGRAMMER=jlink BOARD=remote-reva make --no-print-directory -C examples/hello-world/ flash-only 
Flash program /home/harter/work/git/RIOT/boards/remote-reva/dist/flash.sh is required but not found in PATH.  Aborting.
/home/harter/work/git/RIOT/examples/hello-world/../../Makefile.include:520: recipe for target 'flash' failed
make: *** [flash] Error 1

PORT=/dev/null PROGRAMMER=jlink BOARD=remote-reva make --no-print-directory -C examples/hello-world/ debug
Debug program /home/harter/work/git/RIOT/boards/remote-reva/dist/debug.sh is required but not found in PATH.  Aborting.
/home/harter/work/git/RIOT/examples/hello-world/../../Makefile.include:539: recipe for target 'debug' failed
```


### Issues/PRs references

Found while testing https://github.com/RIOT-OS/RIOT/pull/10471
