### PR TITLE
board/*/flash.sh: get file to flash from command line

### DIFF
--- a/boards/calliope-mini/Makefile.include
+++ b/boards/calliope-mini/Makefile.include
@@ -10,7 +10,7 @@ PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 PROGRAMMER ?= fscopy
 
 ifeq (fscopy,$(PROGRAMMER))
-  export FFLAGS =
+  export FFLAGS = $(HEXFILE)
   export DEBUGGER_FLAGS =
 
   export FLASHER = $(RIOTBOARD)/$(BOARD)/dist/flash.sh

--- a/boards/calliope-mini/dist/flash.sh
+++ b/boards/calliope-mini/dist/flash.sh
@@ -18,6 +18,8 @@ OS=`uname`
 DID_MOUNT=false
 NAME="MINI"
 
+HEXFILE=$1
+
 # set the mount path depending on the OS
 if [ ${OS} = "Linux" ]
 then

--- a/boards/mbed_lpc1768/Makefile.include
+++ b/boards/mbed_lpc1768/Makefile.include
@@ -6,7 +6,7 @@ export DEBUGGER =
 export DEBUGSERVER =
 
 HEXFILE = $(BINFILE)
-export FFLAGS =
+export FFLAGS = $(HEXFILE)
 export DEBUGGER_FLAGS =
 
 # define the default port depending on the host OS

--- a/boards/mbed_lpc1768/dist/flash.sh
+++ b/boards/mbed_lpc1768/dist/flash.sh
@@ -21,6 +21,8 @@
 OS=`uname`
 DID_MOUNT=false
 
+BINFILE=$1
+
 # set the mount path depending on the OS
 if [ ${OS} = "Linux" ]
 then
@@ -55,7 +57,7 @@ fi
 # remove old binary
 rm -f ${MOUNT}/*.bin
 # copy new binary to device
-cp ${HEXFILE} ${MOUNT}
+cp ${BINFILE} ${MOUNT}
 # make sure hexfile was written
 sync
 

--- a/boards/microbit/Makefile.include
+++ b/boards/microbit/Makefile.include
@@ -10,7 +10,7 @@ PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
 PROGRAMMER ?= fscopy
 
 ifeq (fscopy,$(PROGRAMMER))
-  export FFLAGS =
+  export FFLAGS = $(HEXFILE)
   export DEBUGGER_FLAGS =
 
   export FLASHER = $(RIOTBOARD)/$(BOARD)/dist/flash.sh

--- a/boards/microbit/dist/flash.sh
+++ b/boards/microbit/dist/flash.sh
@@ -18,6 +18,8 @@ OS=`uname`
 DID_MOUNT=false
 NAME="MICROBIT"
 
+HEXFILE=$1
+
 # set the mount path depending on the OS
 if [ ${OS} = "Linux" ]
 then


### PR DESCRIPTION
### Contribution description

For the `flash.sh` flasher, get the file to flash from command line instead of environment variable

This is a prepare step to move to having a `FLASHFILE` variable.


### Testing procedure

Flash with the given boards as it is hard to test only the output.
Or review the changes and check to put debug in the flash scripts.

I self tested `calliope-mini` and `mbed_lpc1768` in https://github.com/RIOT-OS/RIOT/pull/8838#issuecomment-382414904 but it is not an external test.

### Issues/PRs references

Split from https://github.com/RIOT-OS/RIOT/pull/8838