### PR TITLE
opencm904/flash: get arguments from cli

### DIFF
--- a/boards/opencm904/Makefile.include
+++ b/boards/opencm904/Makefile.include
@@ -8,7 +8,7 @@ export DEBUGGER =
 export DEBUGSERVER =
 
 HEXFILE = $(BINFILE)
-export FFLAGS =
+export FFLAGS = $(PORT) $(HEXFILE)
 export DEBUGGER_FLAGS =
 
 # define the default port depending on the host OS

--- a/boards/opencm904/dist/robotis-loader.py
+++ b/boards/opencm904/dist/robotis-loader.py
@@ -57,13 +57,9 @@ else:
 
 
 # Reading command line
-# if len(sys.argv) != 3:
-#     exit('! Usage: robotis-loader.py <serial-port> <binary>')
-# pgm, port, binary = sys.argv
-
-pgm = sys.argv[0]
-port = os.environ["PORT"]
-binary = os.environ["HEXFILE"]
+if len(sys.argv) != 3:
+    exit('! Usage: robotis-loader.py <serial-port> <binary>')
+pgm, port, binary = sys.argv
 
 
 def progressBar(percent, precision=65):


### PR DESCRIPTION
### Contribution description

Prepares from having `FLASHFILE` variable.


### Testing procedure


Try flashing for the board:

```
BOARD=opencm904 make --no-print-directory -C examples/hello-world/ flash
Building application "hello-world" for "opencm904" with MCU "stm32f1".

"make" -C /home/harter/work/git/RIOT/boards/opencm904
"make" -C /home/harter/work/git/RIOT/core
"make" -C /home/harter/work/git/RIOT/cpu/stm32f1
"make" -C /home/harter/work/git/RIOT/cpu/cortexm_common
"make" -C /home/harter/work/git/RIOT/cpu/cortexm_common/periph
"make" -C /home/harter/work/git/RIOT/cpu/stm32_common
"make" -C /home/harter/work/git/RIOT/cpu/stm32_common/periph
"make" -C /home/harter/work/git/RIOT/cpu/stm32f1/periph
"make" -C /home/harter/work/git/RIOT/drivers
"make" -C /home/harter/work/git/RIOT/drivers/periph_common
"make" -C /home/harter/work/git/RIOT/sys
"make" -C /home/harter/work/git/RIOT/sys/auto_init
"make" -C /home/harter/work/git/RIOT/sys/isrpipe
"make" -C /home/harter/work/git/RIOT/sys/newlib_syscalls_default
"make" -C /home/harter/work/git/RIOT/sys/pm_layered
"make" -C /home/harter/work/git/RIOT/sys/stdio_uart
"make" -C /home/harter/work/git/RIOT/sys/tsrb
   text    data     bss     dec     hex filename
   8412     140    2620   11172    2ba4 /home/harter/work/git/RIOT/examples/hello-world/bin/opencm904/hello-world.elf
/home/harter/work/git/RIOT/boards/opencm904/dist/robotis-loader.py /dev/ttyACM0 /home/harter/work/git/RIOT/examples/hello-world/bin/opencm904/hello-world.bin
~~ Robotis loader ~~

Please, make sure to connect the USB cable WHILE holding down the "USER SW" button.
Status LED should stay lit and the board should be able to load the program.

* Opening /home/harter/work/git/RIOT/examples/hello-world/bin/opencm904/hello-world.bin, size=8552
* Resetting the board
* Connecting...
* Download signal transmitted, waiting...
# Not actually flashing as I do not have the board
```

You can see that the binfile is correctly read, you can also print `port` to compare the value.

And it should have the same behavior has in master.

The changes were already tested by @astralien3000 in https://github.com/RIOT-OS/RIOT/pull/8838#issuecomment-384668928

### Issues/PRs references

Split from https://github.com/RIOT-OS/RIOT/pull/8838
