### PR TITLE
boards/any silabs: Allow selecting OpenOCD

### DIFF
--- a/boards/common/silabs/Makefile.include
+++ b/boards/common/silabs/Makefile.include
@@ -1,2 +1,13 @@
 INCLUDES += -I$(RIOTBOARD)/common/silabs/include
 INCLUDES += -I$(RIOTBOARD)/common/silabs/drivers/include
+
+PROGRAMMER ?= jlink
+
+export JLINK_DEVICE ?= ${CPU_MODEL}
+export OPENOCD_CONFIG ?= board/efm32.cfg
+
+ifeq ($(PROGRAMMER),jlink)
+  include $(RIOTMAKE)/tools/jlink.inc.mk
+else ifeq ($(PROGRAMMER),openocd)
+  include $(RIOTMAKE)/tools/openocd.inc.mk
+endif

--- a/boards/common/slwstk6000b/Makefile.include
+++ b/boards/common/slwstk6000b/Makefile.include
@@ -13,7 +13,6 @@ include $(RIOTMAKE)/tools/serial.inc.mk
 
 # setup JLink for flashing
 export JLINK_DEVICE := $(MODULE_JLINK_DEVICE)
-include $(RIOTMAKE)/tools/jlink.inc.mk
 
 # include board common
 include $(RIOTBOARD)/common/silabs/Makefile.include

--- a/boards/slstk3401a/Makefile.include
+++ b/boards/slstk3401a/Makefile.include
@@ -6,9 +6,7 @@ PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 include $(RIOTMAKE)/tools/serial.inc.mk
 
 # setup JLink for flashing
-export JLINK_DEVICE := $(CPU_MODEL)
 export JLINK_PRE_FLASH = r
-include $(RIOTMAKE)/tools/jlink.inc.mk
 
 # include board common
 include $(RIOTBOARD)/common/silabs/Makefile.include

--- a/boards/slstk3402a/Makefile.include
+++ b/boards/slstk3402a/Makefile.include
@@ -6,9 +6,7 @@ PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 include $(RIOTMAKE)/tools/serial.inc.mk
 
 # setup JLink for flashing
-export JLINK_DEVICE := $(CPU_MODEL)
 export JLINK_PRE_FLASH = r
-include $(RIOTMAKE)/tools/jlink.inc.mk
 
 # include board common
 include $(RIOTBOARD)/common/silabs/Makefile.include

--- a/boards/sltb001a/Makefile.include
+++ b/boards/sltb001a/Makefile.include
@@ -8,7 +8,6 @@ include $(RIOTMAKE)/tools/serial.inc.mk
 # setup JLink for flashing
 export JLINK_DEVICE := EFR32MG1PxxxF256
 export JLINK_PRE_FLASH = r
-include $(RIOTMAKE)/tools/jlink.inc.mk
 
 # include board common
 include $(RIOTBOARD)/common/silabs/Makefile.include

--- a/boards/stk3600/Makefile.include
+++ b/boards/stk3600/Makefile.include
@@ -5,9 +5,5 @@ PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 # setup serial terminal
 include $(RIOTMAKE)/tools/serial.inc.mk
 
-# setup JLink for flashing
-export JLINK_DEVICE := $(CPU_MODEL)
-include $(RIOTMAKE)/tools/jlink.inc.mk
-
 # include board common
 include $(RIOTBOARD)/common/silabs/Makefile.include

--- a/boards/stk3700/Makefile.include
+++ b/boards/stk3700/Makefile.include
@@ -12,6 +12,7 @@ ifeq ($(PROGRAMMER),jlink)
   export JLINK_DEVICE := $(CPU_MODEL)
   include $(RIOTMAKE)/tools/jlink.inc.mk
 else ifeq ($(PROGRAMMER),openocd)
+  export OPENOCD_CONFIG := board/efm32.cfg
   include $(RIOTMAKE)/tools/openocd.inc.mk
 endif
 

--- a/boards/stk3700/Makefile.include
+++ b/boards/stk3700/Makefile.include
@@ -5,16 +5,5 @@ PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 # setup serial terminal
 include $(RIOTMAKE)/tools/serial.inc.mk
 
-PROGRAMMER ?= jlink
-
-ifeq ($(PROGRAMMER),jlink)
-  # setup JLink for flashing
-  export JLINK_DEVICE := $(CPU_MODEL)
-  include $(RIOTMAKE)/tools/jlink.inc.mk
-else ifeq ($(PROGRAMMER),openocd)
-  export OPENOCD_CONFIG := board/efm32.cfg
-  include $(RIOTMAKE)/tools/openocd.inc.mk
-endif
-
 # include board common
 include $(RIOTBOARD)/common/silabs/Makefile.include

--- a/boards/stk3700/Makefile.include
+++ b/boards/stk3700/Makefile.include
@@ -5,9 +5,15 @@ PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 # setup serial terminal
 include $(RIOTMAKE)/tools/serial.inc.mk
 
-# setup JLink for flashing
-export JLINK_DEVICE := $(CPU_MODEL)
-include $(RIOTMAKE)/tools/jlink.inc.mk
+PROGRAMMER ?= jlink
+
+ifeq ($(PROGRAMMER),jlink)
+  # setup JLink for flashing
+  export JLINK_DEVICE := $(CPU_MODEL)
+  include $(RIOTMAKE)/tools/jlink.inc.mk
+else ifeq ($(PROGRAMMER),openocd)
+  include $(RIOTMAKE)/tools/openocd.inc.mk
+endif
 
 # include board common
 include $(RIOTBOARD)/common/silabs/Makefile.include

--- a/boards/stk3700/dist/openocd.cfg
+++ b/boards/stk3700/dist/openocd.cfg
@@ -1,0 +1,1 @@
+source [find board/efm32.cfg]

--- a/boards/stk3700/dist/openocd.cfg
+++ b/boards/stk3700/dist/openocd.cfg
@@ -1,1 +1,0 @@
-source [find board/efm32.cfg]

--- a/dist/tools/openocd/openocd.sh
+++ b/dist/tools/openocd/openocd.sh
@@ -13,6 +13,11 @@
 #
 # Global environment variables used:
 # OPENOCD:             OpenOCD command name, default: "openocd"
+#                      Care must be taken when specifying an OpenOCD version in
+#                      its build directory, as it does not look up its own
+#                      configuration files relative to the executable -- the
+#                      scripts directory needs to be passed in like this:
+#                      `OPENOCD="~/openocd/src/openocd -s ~/openocd/tcl"`.
 # OPENOCD_CONFIG:      OpenOCD configuration file name,
 #                      default: "${BOARDSDIR}/${BOARD}/dist/openocd.cfg"
 #

--- a/dist/tools/openocd/openocd.sh
+++ b/dist/tools/openocd/openocd.sh
@@ -4,7 +4,8 @@
 #
 # This script is supposed to be called from RIOTs make system,
 # as it depends on certain environment variables. An OpenOCD
-# configuration file must be present in a the boards dist folder.
+# configuration file must be present in a the boards dist folder
+# or be given as "board/[...].cfg" to use an OpenOCD shipped configuration.
 #
 # Any extra command line arguments after the command name are passed on the
 # openocd command line after the configuration file name but before any other
@@ -133,7 +134,7 @@ fi
 # a couple of tests for certain configuration options
 #
 test_config() {
-    if [ ! -f "${OPENOCD_CONFIG}" ]; then
+    if [ ! -f "${OPENOCD_CONFIG}" ] && [[ ! "${OPENOCD_CONFIG}" == board/* ]] ; then
         echo "Error: Unable to locate OpenOCD configuration file"
         echo "       (${OPENOCD_CONFIG})"
         exit 1


### PR DESCRIPTION
### Contribution description

This adds support for flashing and debugging an STK3700 board using the OpenOCD debugger.

OpenOCD support for those chips and board is good in 0.10, all it needs is the hint that it's possible. I've used the seemingly common PROGRAMMER=... idiom to allow picking one's tools.

### Testing procedure

In any example (I'm using saul), run `make BOARD=stk3700 PROGRAMMER=openocd flash term`

### PR scope

I've only changed the behavior I could test. If someone can confirm that OpenOCD works with Leopard Gecko boards (STK3600) as well, I can apply the same changes there as well.

In principle, the same works also for sltb001a, but that requires an OpenOCD git master version (actually only 1y old, but they haven't had a release since then) -- if requiring an unreleased OpenOCD version (for the non-default programmer) is OK, I'd add that there as well.

(Those changes would well go in one commit as their Makefile.include files are virtually identical.)