### PR TITLE
boards/nrf51: remove ADC_NUMOF define when not needed

### DIFF
--- a/boards/calliope-mini/include/periph_conf.h
+++ b/boards/calliope-mini/include/periph_conf.h
@@ -91,15 +91,6 @@ static const i2c_conf_t i2c_config[] = {
 /** @} */
 
 /**
- * @name    ADC configuration
- *
- * The configuration consists simply of a list of channels that should be used
- * @{
- */
-#define ADC_NUMOF          (0)
-/** @} */
-
-/**
  * @name    PWM configuration
  * @{
  */

--- a/boards/microbit/include/periph_conf.h
+++ b/boards/microbit/include/periph_conf.h
@@ -96,15 +96,6 @@ static const i2c_conf_t i2c_config[] = {
 #define I2C_NUMOF           (sizeof(i2c_config) / sizeof(i2c_config[0]))
 /** @} */
 
-/**
- * @name   ADC configuration
- *
- * The configuration consists simply of a list of channels that should be used
- * @{
- */
-#define ADC_NUMOF          (0)
-/** @} */
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/nrf51dongle/include/periph_conf.h
+++ b/boards/nrf51dongle/include/periph_conf.h
@@ -40,15 +40,6 @@ extern "C" {
 #define UART_PIN_CTS        10
 /** @} */
 
-/**
- * @name   ADC configuration
- *
- * The configuration consists simply of a list of channels that should be used
- * @{
- */
-#define ADC_NUMOF          (0)
-/** @} */
-
 #ifdef __cplusplus
 }
 #endif

--- a/boards/nrf6310/include/periph_conf.h
+++ b/boards/nrf6310/include/periph_conf.h
@@ -68,16 +68,6 @@ static const spi_conf_t spi_config[] = {
 #define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
 /** @} */
 
-/**
- * @name    ADC configuration
- *
- * The configuration consists simply of a list of channels that should be used
- * @{
- */
-#define ADC_NUMOF          (0)
-/** @} */
-
-
 #ifdef __cplusplus
 }
 #endif


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is removing the ADC define from nrf51 based boards that don't provide this feature (yet).

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

If Murdock passes, it should be all good.


<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Found with @haukepetersen's review in #10409 (see https://github.com/RIOT-OS/RIOT/pull/10409#discussion_r236325297).

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
