### PR TITLE
frdm: Use configuration for OpenOCD 0.10.0 or newer by default

### DIFF
--- a/boards/common/frdm/Makefile.include
+++ b/boards/common/frdm/Makefile.include
@@ -8,10 +8,10 @@ export DEBUG_ADAPTER ?= dap
 #export DEBUG_ADAPTER ?= jlink
 
 # OpenOCD v0.10.0 and newer have built-in support for disabling the Kinetis
-# watchdog automatically. However, current stable releases of Ubuntu and Debian
-# have only version 0.9.0 and older OpenOCD packages (Ubuntu 17.04, Debian Jessie)
-# Set this to 0 to avoid the extra manual step of disabling the watchdog.
-export USE_OLD_OPENOCD ?= 1
+# watchdog automatically. Some older releases of Ubuntu and Debian have only
+# version 0.9.0 or earlier OpenOCD packages (Ubuntu 17.04, Debian Jessie)
+# Set this to 1 if you are using one of these older releases.
+USE_OLD_OPENOCD ?= 0
 
 ifeq (1,$(USE_OLD_OPENOCD))
 # We need special handling of the watchdog if we want to speed up the flash

--- a/boards/frdm-kw41z/Makefile.include
+++ b/boards/frdm-kw41z/Makefile.include
@@ -2,10 +2,6 @@
 export CPU = kinetis
 export CPU_MODEL = mkw41z512vht4
 
-# OpenOCD v0.10.0-dev (current development version) or later is required for
-# flashing KW41Z devices
-# See http://openocd.zylin.com/#/c/4104/ for the upstreaming process
-export USE_OLD_OPENOCD ?= 0
 # This board comes with OpenSDA configured for JLink compatibility
 export DEBUG_ADAPTER ?= jlink
 


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Changes the default setting for the variable USE_OLD_OPENOCD to 0. This variable should be set to 1 only if running OpenOCD 0.9.0 or older. Most distros have moved on to OpenOCD 0.10.0 now.


### Testing procedure

Requires a frdm-k22f or frdm-k64f board. (The frdm-kw41z already forces USE_OLD_OPENOCD=0 because of missing support for that CPU in older versions.)
Build and flash an application for BOARD=frdm-k22f or BOARD=frdm-k64f using `make flash` without any extra environment settings. 
Verify that flashing succeeds and the application runs.

### Issues/PRs references

