### PR TITLE
openocd: Use reset halt when starting debug-server

### DIFF
--- a/boards/b-l072z-lrwan1/Makefile.include
+++ b/boards/b-l072z-lrwan1/Makefile.include
@@ -12,8 +12,5 @@ include $(RIOTMAKE)/tools/serial.inc.mk
 # this board has an on-board ST-link adapter
 export DEBUG_ADAPTER ?= stlink
 
-# call a 'reset halt' command before starting the debugger
-export OPENOCD_DBG_START_CMD = -c 'reset halt'
-
 # this board uses openocd
 include $(RIOTMAKE)/tools/openocd.inc.mk

--- a/boards/common/iotlab/Makefile.include
+++ b/boards/common/iotlab/Makefile.include
@@ -10,10 +10,6 @@ PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbserial*B)))
 export BAUD = 500000
 include $(RIOTMAKE)/tools/serial.inc.mk
 
-# call a 'reset halt' command before starting the debugger
-# it is required as `connect_assert_srst` is set
-export OPENOCD_DBG_START_CMD = -c 'reset halt'
-
 # this board uses openocd
 include $(RIOTMAKE)/tools/openocd.inc.mk
 

--- a/boards/common/stm32f103c8/Makefile.include
+++ b/boards/common/stm32f103c8/Makefile.include
@@ -37,9 +37,5 @@ else
   export DEBUG_ADAPTER ?= stlink
   export STLINK_VERSION ?= 2
 
-  # call a 'reset halt' command before starting the debugger
-  # it is required as `connect_assert_srst` is set
-  export OPENOCD_DBG_START_CMD = -c 'reset halt'
-
   include $(RIOTMAKE)/tools/openocd.inc.mk
 endif

--- a/dist/tools/openocd/openocd.sh
+++ b/dist/tools/openocd/openocd.sh
@@ -86,10 +86,10 @@
 # Debugger flags, will be passed to sh -c, remember to escape any quotation signs.
 # Use ${DBG_DEFAULT_FLAGS} to insert the default flags anywhere in the string
 : ${DBG_FLAGS:=${DBG_DEFAULT_FLAGS} ${DBG_EXTRA_FLAGS}}
-# Initial target state when using debug, by default a 'halt' request is sent to
-# the target when starting a debug session. 'reset halt' can also be used
+# Initial target state when using debug, by default a 'reset halt' request is
+# sent to the target when starting a debug session. 'halt' can also be used
 # depending on the type of target.
-: ${OPENOCD_DBG_START_CMD:=-c 'halt'}
+: ${OPENOCD_DBG_START_CMD:="-c 'reset halt'"}
 # command used to reset the board
 : ${OPENOCD_CMD_RESET_RUN:="-c 'reset run'"}
 # This is an optional offset to the base address that can be used to flash an
@@ -311,7 +311,7 @@ do_debugserver() {
             -c 'gdb_port ${GDB_PORT}' \
             -c 'init' \
             -c 'targets' \
-            -c 'halt'"
+            ${OPENOCD_DBG_START_CMD}"
 }
 
 do_reset() {


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Makes the debug-server start up more robust, especially when combined with `reset_config connect_assert_srst` in the OpenOCD configuration.

### Testing procedure

With any board with an onboard debugger interface and using OpenOCD:
```
make debug-server
```
Verify that the OpenOCD instance can connect to the board and that the application running is halted (e.g. does not respond to UART shell commands anymore, software controlled LEDs stop blinking etc.)

in a different terminal:

```
make debug
```
(This will attempt to start another instance of openocd, but that will fail since the same UDP port is already used by the running debug-server instance)

See that GDB works as expected:
```
continue
```
Verify that the application is running.

Press CTRL+C in GDB, verify that GDB has managed to halt the application.

### Issues/PRs references

