### PR TITLE
tools/pyterm: catch serial.Exception when serial port is busy

### DIFF
--- a/dist/tools/pyterm/pyterm
+++ b/dist/tools/pyterm/pyterm
@@ -247,6 +247,9 @@ class SerCmd(cmd.Cmd):
                 self.logger.error("Cannot connect to serial port {}: {}"
                                   .format(self.port, e.strerror))
                 sys.exit(1)
+            except serial.SerialException as e:
+                self.logger.error("%s", e.strerror)
+                sys.exit(1)
 
         # wait until connection is established and fire startup
         # commands to the node


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is fixing an exception not being catched when the serial port is not ready and one tries to open the terminal using pyterm (e.g make term).

This happens when opening a terminal right after flashing a board that has just been plugged.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Plug the board
- Build an application, let's say `default`:
```
make BOARD=samr21-xpro -C examples/default
```
- Unplug the board, then re-plug it
- Flash the firmware and open a terminal:
```
make BOARD=samr21-xpro -C examples/default flash term
```

Without this PR, the exception is not catched and the traceback is printed, which is not nice:
```
[...]
  39824	    508	   6044	  46376	   b528	/home/aabadie/softs/src/riot/RIOT/examples/default/bin/samr21-xpro/default.elf
/home/aabadie/softs/src/riot/RIOT/dist/tools/edbg/edbg  -t atmel_cm0p -b -v -p -f /home/aabadie/softs/src/riot/RIOT/examples/default/bin/samr21-xpro/default.bin
Debugger: ATMEL EDBG CMSIS-DAP ATML2127031800004957 01.1A.00FB (S)
Target: SAM R21G18A (Rev C)
Programming................................................................................................................................................................. done.
Verification................................................................................................................................................................. done.
/home/aabadie/softs/src/riot/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200"
2018-11-27 16:53:31,554 - INFO # Connect to serial port /dev/ttyACM0
Traceback (most recent call last):
  File "/home/aabadie/softs/src/riot/RIOT/dist/tools/pyterm/pyterm", line 815, in <module>
    myshell.cmdloop("Welcome to pyterm!\nType '/exit' to exit.")
  File "/usr/lib/python2.7/cmd.py", line 109, in cmdloop
    self.preloop()
  File "/home/aabadie/softs/src/riot/RIOT/dist/tools/pyterm/pyterm", line 245, in preloop
    self.serial_connect()
  File "/home/aabadie/softs/src/riot/RIOT/dist/tools/pyterm/pyterm", line 611, in serial_connect
    self.ser = serial.Serial(port=self.port, dsrdtr=0, rtscts=0)
  File "/usr/lib/python2.7/dist-packages/serial/serialutil.py", line 240, in __init__
    self.open()
  File "/usr/lib/python2.7/dist-packages/serial/serialposix.py", line 268, in open
    raise SerialException(msg.errno, "could not open port {}: {}".format(self._port, msg))
serial.serialutil.SerialException: [Errno 16] could not open port /dev/ttyACM0: [Errno 16] Device or resource busy: '/dev/ttyACM0'
/home/aabadie/softs/src/riot/RIOT/examples/default/../../Makefile.include:529: recipe for target 'term' failed
make: *** [term] Error 1
make: Leaving directory '/home/aabadie/softs/src/riot/RIOT/examples/default'
```

With this PR the serial.Exception is catched and only the error message is displayed:
```
[...]
   text	   data	    bss	    dec	    hex	filename
  39852	    508	   6044	  46404	   b544	/home/aabadie/softs/src/riot/RIOT/examples/default/bin/samr21-xpro/default.elf
/home/aabadie/softs/src/riot/RIOT/dist/tools/edbg/edbg  -t atmel_cm0p -b -v -p -f /home/aabadie/softs/src/riot/RIOT/examples/default/bin/samr21-xpro/default.bin
Debugger: ATMEL EDBG CMSIS-DAP ATML2127031800004957 01.1A.00FB (S)
Target: SAM R21G18A (Rev C)
Programming................................................................................................................................................................. done.
Verification................................................................................................................................................................. done.
/home/aabadie/softs/src/riot/RIOT/dist/tools/pyterm/pyterm -p "/dev/ttyACM0" -b "115200"
2018-11-27 16:55:19,143 - INFO # Connect to serial port /dev/ttyACM0
2018-11-27 16:55:19,143 - ERROR # Cannot connect to serial port /dev/ttyACM0: could not open port /dev/ttyACM0: [Errno 16] Device or resource busy: '/dev/ttyACM0'
/home/aabadie/softs/src/riot/RIOT/examples/default/../../Makefile.include:529: recipe for target 'term' failed
make: *** [term] Error 1
make: Leaving directory '/home/aabadie/softs/src/riot/RIOT/examples/default'
```

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
