### PR TITLE
atmega: fix periph timer configuration

### DIFF
--- a/boards/common/arduino-atmega/include/periph_conf.h
+++ b/boards/common/arduino-atmega/include/periph_conf.h
@@ -49,7 +49,8 @@ extern "C" {
  * @{
  */
 #ifdef CPU_ATMEGA328P
-#define TIMER_NUMOF         (2U)
+#define TIMER_NUMOF         (1U)
+#define TIMER_CHANNELS      (2)
 
 #define TIMER_0             MEGA_TIMER1
 #define TIMER_0_MASK        &TIMSK1
@@ -60,6 +61,7 @@ extern "C" {
 
 #ifdef CPU_ATMEGA2560
 #define TIMER_NUMOF         (2U)
+#define TIMER_CHANNELS      (3)
 
 #define TIMER_0             MEGA_TIMER1
 #define TIMER_0_MASK        &TIMSK1

--- a/cpu/atmega_common/periph/timer.c
+++ b/cpu/atmega_common/periph/timer.c
@@ -33,11 +33,6 @@
 #include "debug.h"
 
 /**
- * @brief   All timers have three channels
- */
-#define CHANNELS (3)
-
-/**
  * @brief   We have 5 possible prescaler values
  */
 #define PRESCALE_NUMOF (5U)
@@ -137,7 +132,7 @@ int timer_init(tim_t tim, unsigned long freq, timer_cb_t cb, void *arg)
 
 int timer_set_absolute(tim_t tim, int channel, unsigned int value)
 {
-    if (channel >= CHANNELS) {
+    if (channel >= TIMER_CHANNELS) {
         return -1;
     }
 
@@ -150,7 +145,7 @@ int timer_set_absolute(tim_t tim, int channel, unsigned int value)
 
 int timer_clear(tim_t tim, int channel)
 {
-    if (channel >= CHANNELS) {
+    if (channel >= TIMER_CHANNELS) {
         return -1;
     }
 


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

- correct number of timers for atmega328p from 2 to 1
- correct number of timer channels for atmega328p from 3 to 2
- adapt atmega periph timer implementation accordingly

look at the data sheet of the atmega328p you'll find that timer1 has only 2 compare registers, while timer1 on the atmega2560 has 3 compare registers -> channels.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

In theory: run `tests/periph_timer` for Arduino-uno, however that is not possible without modifying the test to make it fit and run on that board. But you could use an mega2560 to verify that is still working too.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
