### PR TITLE
gnrc_netif: assume `netif->ops->init()` to be set to at least a default

### DIFF
--- a/cpu/esp_common/esp-now/esp_now_gnrc.c
+++ b/cpu/esp_common/esp-now/esp_now_gnrc.c
@@ -192,6 +192,7 @@ err:
 }
 
 static const gnrc_netif_ops_t _esp_now_ops = {
+    .init = gnrc_netif_default_init,
     .send = _send,
     .recv = _recv,
     .get = gnrc_netif_get_from_netdev,

--- a/cpu/nrf5x_common/radio/nrfmin/nrfmin_gnrc.c
+++ b/cpu/nrf5x_common/radio/nrfmin/nrfmin_gnrc.c
@@ -173,6 +173,7 @@ static gnrc_pktsnip_t *gnrc_nrfmin_recv(gnrc_netif_t *dev)
 }
 
 static const gnrc_netif_ops_t gnrc_nrfmin_ops = {
+    .init = gnrc_netif_default_init,
     .send = gnrc_nrfmin_send,
     .recv = gnrc_nrfmin_recv,
     .get = gnrc_netif_get_from_netdev,

--- a/drivers/cc1xxx_common/gnrc_netif_cc1xxx.c
+++ b/drivers/cc1xxx_common/gnrc_netif_cc1xxx.c
@@ -159,6 +159,7 @@ static int cc1xxx_adpt_send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
 }
 
 static const gnrc_netif_ops_t cc1xxx_netif_ops = {
+    .init = gnrc_netif_default_init,
     .send = cc1xxx_adpt_send,
     .recv = cc1xxx_adpt_recv,
     .get = gnrc_netif_get_from_netdev,

--- a/drivers/xbee/gnrc_xbee.c
+++ b/drivers/xbee/gnrc_xbee.c
@@ -160,6 +160,7 @@ static int xbee_adpt_send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
 }
 
 static const gnrc_netif_ops_t _xbee_ops = {
+    .init = gnrc_netif_default_init,
     .send = xbee_adpt_send,
     .recv = xbee_adpt_recv,
     .get = gnrc_netif_get_from_netdev,

--- a/pkg/nimble/netif/nimble_netif.c
+++ b/pkg/nimble/netif/nimble_netif.c
@@ -90,6 +90,7 @@ static void _netif_init(gnrc_netif_t *netif)
 {
     (void)netif;
 
+    gnrc_netif_default_init(netif);
     /* save the threads context pointer, so we can set its flags */
     _netif_thread = (thread_t *)thread_get(thread_getpid());
 

--- a/pkg/nordic_softdevice_ble/src/gnrc_nordic_ble_6lowpan.c
+++ b/pkg/nordic_softdevice_ble/src/gnrc_nordic_ble_6lowpan.c
@@ -258,7 +258,7 @@ static void _netif_msg_handler(gnrc_netif_t *netif, msg_t *msg)
 }
 
 static const gnrc_netif_ops_t _ble_ops = {
-    .init = NULL,
+    .init = gnrc_netif_default_init,
     .send = _netif_send,
     .recv = _netif_recv,
     .get = gnrc_netif_get_from_netdev,

--- a/sys/include/net/gnrc/netif.h
+++ b/sys/include/net/gnrc/netif.h
@@ -435,6 +435,15 @@ static inline int gnrc_netif_ipv6_group_leave(const gnrc_netif_t *netif,
 }
 
 /**
+ * @brief   Default operation for gnrc_netif_ops_t::init()
+ *
+ * @note    Can also be used to be called *before* a custom operation.
+ *
+ * @param[in] netif     The network interface.
+ */
+void gnrc_netif_default_init(gnrc_netif_t *netif);
+
+/**
  * @brief   Default operation for gnrc_netif_ops_t::get()
  *
  * @note    Can also be used to be called *after* a custom operation.

--- a/sys/include/net/gnrc/netif.h
+++ b/sys/include/net/gnrc/netif.h
@@ -131,10 +131,13 @@ struct gnrc_netif_ops {
      *
      * @param[in] netif The network interface.
      *
-     * This is called after the default settings were set, right before the
-     * interface's thread starts receiving messages. It is not necessary to lock
-     * the interface's mutex gnrc_netif_t::mutex, since the thread will already
-     * lock it. Leave NULL if you do not need any special initialization.
+     * This is called after the network device's initial configuration, right
+     * before the interface's thread starts receiving messages. It is not
+     * necessary to lock the interface's mutex gnrc_netif_t::mutex, since it is
+     * already locked. Set to @ref gnrc_netif_default_init() if you do not need
+     * any special initialization. If you do need special initialization, it is
+     * recommended to call @ref gnrc_netif_default_init() at the start of the
+     * custom initialization function set here.
      */
     void (*init)(gnrc_netif_t *netif);
 

--- a/sys/net/gnrc/link_layer/gomach/gomach.c
+++ b/sys/net/gnrc/link_layer/gomach/gomach.c
@@ -2108,6 +2108,7 @@ static void _gomach_init(gnrc_netif_t *netif)
 {
     netdev_t *dev;
 
+    gnrc_netif_default_init(netif);
     dev = netif->dev;
     dev->event_callback = _gomach_event_cb;
 

--- a/sys/net/gnrc/link_layer/lwmac/lwmac.c
+++ b/sys/net/gnrc/link_layer/lwmac/lwmac.c
@@ -901,6 +901,7 @@ static void _lwmac_init(gnrc_netif_t *netif)
 {
     netdev_t *dev;
 
+    gnrc_netif_default_init(netif);
     dev = netif->dev;
     dev->event_callback = _lwmac_event_cb;
 

--- a/sys/net/gnrc/netif/ethernet/gnrc_netif_ethernet.c
+++ b/sys/net/gnrc/netif/ethernet/gnrc_netif_ethernet.c
@@ -37,6 +37,7 @@ static gnrc_pktsnip_t *_recv(gnrc_netif_t *netif);
 static char addr_str[ETHERNET_ADDR_LEN * 3];
 
 static const gnrc_netif_ops_t ethernet_ops = {
+    .init = gnrc_netif_default_init,
     .send = _send,
     .recv = _recv,
     .get = gnrc_netif_get_from_netdev,

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -1361,7 +1361,6 @@ static void *_gnrc_netif_thread(void *args)
     _test_options(netif);
 #endif
     netif->cur_hl = GNRC_NETIF_DEFAULT_HL;
-    gnrc_netif_default_init(netif);
     if (netif->ops->init) {
         netif->ops->init(netif);
     }

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -1196,14 +1196,6 @@ static void _init_from_device(gnrc_netif_t *netif)
     _update_l2addr_from_dev(netif);
 }
 
-void gnrc_netif_default_init(gnrc_netif_t *netif)
-{
-    _init_from_device(netif);
-#ifdef MODULE_GNRC_IPV6_NIB
-    gnrc_ipv6_nib_init_iface(netif);
-#endif
-}
-
 static void _configure_netdev(netdev_t *dev)
 {
     /* Enable RX- and TX-complete interrupts */
@@ -1221,6 +1213,8 @@ static void _configure_netdev(netdev_t *dev)
 }
 
 #ifdef DEVELHELP
+static bool options_tested = false;
+
 /* checks if a device supports all required options and functions */
 static void _test_options(gnrc_netif_t *netif)
 {
@@ -1322,8 +1316,21 @@ static void _test_options(gnrc_netif_t *netif)
 #endif  /* GNRC_IPV6_NIB_CONF_6LN */
     }
 #endif /* (GNRC_NETIF_L2ADDR_MAXLEN > 0) */
+    options_tested = true;
 }
 #endif /* DEVELHELP */
+
+void gnrc_netif_default_init(gnrc_netif_t *netif)
+{
+    _init_from_device(netif);
+#ifdef DEVELHELP
+    _test_options(netif);
+#endif
+    netif->cur_hl = GNRC_NETIF_DEFAULT_HL;
+#ifdef MODULE_GNRC_IPV6_NIB
+    gnrc_ipv6_nib_init_iface(netif);
+#endif
+}
 
 static void *_gnrc_netif_thread(void *args)
 {
@@ -1357,13 +1364,10 @@ static void *_gnrc_netif_thread(void *args)
         return NULL;
     }
     _configure_netdev(dev);
-#ifdef DEVELHELP
-    _test_options(netif);
+    netif->ops->init(netif);
+#if DEVELHELP
+    assert(options_tested);
 #endif
-    netif->cur_hl = GNRC_NETIF_DEFAULT_HL;
-    if (netif->ops->init) {
-        netif->ops->init(netif);
-    }
 #ifdef MODULE_NETSTATS_L2
     memset(&netif->stats, 0, sizeof(netstats_t));
 #endif

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -1196,6 +1196,14 @@ static void _init_from_device(gnrc_netif_t *netif)
     _update_l2addr_from_dev(netif);
 }
 
+static void _init(gnrc_netif_t *netif)
+{
+    _init_from_device(netif);
+#ifdef MODULE_GNRC_IPV6_NIB
+    gnrc_ipv6_nib_init_iface(netif);
+#endif
+}
+
 static void _configure_netdev(netdev_t *dev)
 {
     /* Enable RX- and TX-complete interrupts */
@@ -1349,14 +1357,11 @@ static void *_gnrc_netif_thread(void *args)
         return NULL;
     }
     _configure_netdev(dev);
-    _init_from_device(netif);
 #ifdef DEVELHELP
     _test_options(netif);
 #endif
     netif->cur_hl = GNRC_NETIF_DEFAULT_HL;
-#ifdef MODULE_GNRC_IPV6_NIB
-    gnrc_ipv6_nib_init_iface(netif);
-#endif
+    _init(netif);
     if (netif->ops->init) {
         netif->ops->init(netif);
     }

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -1196,7 +1196,7 @@ static void _init_from_device(gnrc_netif_t *netif)
     _update_l2addr_from_dev(netif);
 }
 
-static void _init(gnrc_netif_t *netif)
+void gnrc_netif_default_init(gnrc_netif_t *netif)
 {
     _init_from_device(netif);
 #ifdef MODULE_GNRC_IPV6_NIB
@@ -1361,7 +1361,7 @@ static void *_gnrc_netif_thread(void *args)
     _test_options(netif);
 #endif
     netif->cur_hl = GNRC_NETIF_DEFAULT_HL;
-    _init(netif);
+    gnrc_netif_default_init(netif);
     if (netif->ops->init) {
         netif->ops->init(netif);
     }

--- a/sys/net/gnrc/netif/gnrc_netif_raw.c
+++ b/sys/net/gnrc/netif/gnrc_netif_raw.c
@@ -28,6 +28,7 @@ static int _send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt);
 static gnrc_pktsnip_t *_recv(gnrc_netif_t *netif);
 
 static const gnrc_netif_ops_t raw_ops = {
+    .init = gnrc_netif_default_init,
     .send = _send,
     .recv = _recv,
     .get = gnrc_netif_get_from_netdev,

--- a/sys/net/gnrc/netif/ieee802154/gnrc_netif_ieee802154.c
+++ b/sys/net/gnrc/netif/ieee802154/gnrc_netif_ieee802154.c
@@ -32,6 +32,7 @@ static int _send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt);
 static gnrc_pktsnip_t *_recv(gnrc_netif_t *netif);
 
 static const gnrc_netif_ops_t ieee802154_ops = {
+    .init = gnrc_netif_default_init,
     .send = _send,
     .recv = _recv,
     .get = gnrc_netif_get_from_netdev,

--- a/tests/gnrc_ipv6_ext_frag/Makefile.ci
+++ b/tests/gnrc_ipv6_ext_frag/Makefile.ci
@@ -5,6 +5,8 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-nano \
     arduino-uno \
     atmega328p \
+    blackpill \
+    bluepill \
     hifive1 \
     hifive1b \
     i-nucleo-lrwan1 \

--- a/tests/gnrc_ndp/main.c
+++ b/tests/gnrc_ndp/main.c
@@ -1221,6 +1221,7 @@ static int _test_netif_set(gnrc_netif_t *netif, const gnrc_netapi_opt_t *opt)
 }
 
 static const gnrc_netif_ops_t _test_netif_ops = {
+    .init = gnrc_netif_default_init,
     .send = _test_netif_send,
     .recv = _test_netif_recv,
     .get = gnrc_netif_get_from_netdev,

--- a/tests/gnrc_netif/main.c
+++ b/tests/gnrc_netif/main.c
@@ -106,6 +106,7 @@ static void _set_up(void)
 static inline void _test_init(gnrc_netif_t *netif)
 {
     (void)netif;
+    gnrc_netif_default_init(netif);
     init_called = true;
 }
 


### PR DESCRIPTION
### Contribution description
See https://github.com/RIOT-OS/RIOT/pull/10371#pullrequestreview-174909604

### Testing procedure
This should be tested very well and if the following is still compiling and working:
- [x] GNRC over CC110x (e.g. with `gnrc_networking` on `msba2`)
- [x] GNRC over Ethernet (e.g. with `gnrc_networking` on `native`)
- [x] GNRC over IEEE 802.15.4 (e.g. `gnrc_networking` on `iotlab-m3`)
- [x] GNRC over Xbee (e.g. `gnrc_networking` on `arduino-zero` with `xbee`)
- [x] GNRC over `nordic_softdevice_ble` (e.g. `gnrc_networking` on `nrf52dk` with `nordic_softdevice_ble`)
- [ ] GNRC over `nimble` (e.g. `gnrc_networking` on `nrf52dk` with `nimble` [default])
- [x] GNRC over RAW (e.g. `gnrc_border_router` with `slipdev` instead of `ethos`) (tested on `b-l072z-lrwan1` with `sx127x`)
- [x] `examples/gnrc_networking_mac` with GoMacH
- [x] `examples/gnrc_networking_mac` with LWMAC
- [x] `tests/gnrc_ndp`
- [x] `tests/gnrc_netif`

### Issues/PRs references
Based on a question raised in https://github.com/RIOT-OS/RIOT/pull/10371