### PR TITLE
kinetis: Allow FOPT settings other than 0xff 

### DIFF
--- a/cpu/kinetis/dist/check-fcfield-elf.sh
+++ b/cpu/kinetis/dist/check-fcfield-elf.sh
@@ -9,16 +9,16 @@
 # @author       Johann Fischer <j.fischer@phytec.de>
 
 ELFFILE=$1
+ACTUAL_FCFIELD=$(arm-none-eabi-objdump -j.fcfield -s "${ELFFILE}"  | awk '/^ 0400 / {print $2 $3 $4 $5}')
+# Allow any FOPT flags configuration (".." in the pattern)
+EXPECTED_FCFIELD="^fffffffffffffffffffffffffe..ffff$"
 
-RETVAL=$(arm-none-eabi-readelf -x .fcfield $ELFFILE  | awk '/0x00000400/ {print $2 $3 $4 $5}')
-UNLOCKED_FCFIELD="fffffffffffffffffffffffffeffffff"
-
-if [ "$RETVAL" != "$UNLOCKED_FCFIELD" ]; then
+if ! printf '%s' "${ACTUAL_FCFIELD}" | grep -q "${EXPECTED_FCFIELD}" ; then
     echo "Danger of bricking the device during flash!"
-    echo "Flash configuration field of $ELFFILE:"
-    arm-none-eabi-readelf -x .fcfield $ELFFILE
+    echo "Flash configuration field of ${ELFFILE}:"
+    arm-none-eabi-objdump -j.fcfield -s "${ELFFILE}"
     echo "Abort flash procedure!"
     exit 1
 fi
-echo "$ELFFILE is fine."
+echo "${ELFFILE} is fine."
 exit 0

--- a/cpu/kinetis/dist/check-fcfield-hex.sh
+++ b/cpu/kinetis/dist/check-fcfield-hex.sh
@@ -23,9 +23,10 @@ FCFIELD_END='0x410'
 FCFIELD_AWK_REGEX='^ 0400 '
 
 ACTUAL_FCFIELD=$(arm-none-eabi-objdump --start-address=${FCFIELD_START} --stop-address=${FCFIELD_END} ${HEXFILE} -s | awk -F' ' "/${FCFIELD_AWK_REGEX}/ { print \$2 \$3 \$4 \$5; }")
-EXPECTED_FCFIELD="fffffffffffffffffffffffffeffffff"
+# Allow any FOPT flags configuration (".." in the pattern)
+EXPECTED_FCFIELD="^fffffffffffffffffffffffffe..ffff$"
 
-if [ "${ACTUAL_FCFIELD}" != "${EXPECTED_FCFIELD}" ]; then
+if ! printf '%s' "${ACTUAL_FCFIELD}" | grep -q "${EXPECTED_FCFIELD}"; then
     echo "Danger of bricking the device during flash!"
     echo "Flash configuration field of ${HEXFILE}:"
     arm-none-eabi-objdump --start-address=${FCFIELD_START} --stop-address=${FCFIELD_END} ${HEXFILE} -s

--- a/cpu/kinetis/fcfield.c
+++ b/cpu/kinetis/fcfield.c
@@ -21,6 +21,14 @@
  */
 
 #include <stdint.h>
+#include "cpu.h"
+#include "board.h"
+
+/* See the corresponding CPU reference manual for the meaning of the FOPT boot
+ * configuration bits. */
+#ifndef KINETIS_FOPT
+#define KINETIS_FOPT 0xff
+#endif
 
 /* fcfield table */
 __attribute__((weak, used, section(".fcfield")))
@@ -38,7 +46,7 @@ const uint8_t flash_configuration_field[] = {
     0xff,    /* non-volatile p-flash protection 0 - low register, offset: 0xa */
     0xff,    /* non-volatile p-flash protection 0 - high register, offset: 0xb */
     0xfe,    /* non-volatile flash security register, offset: 0xc */
-    0xff,    /* non-volatile flash option register, offset: 0xd */
+    KINETIS_FOPT, /* FOPT non-volatile flash option register, offset: 0xd */
     0xff,    /* non-volatile eeram protection register, offset: 0xe */
     0xff,    /* non-volatile d-flash protection register, offset: 0xf */
 };


### PR DESCRIPTION
### Contribution description

The FOPT byte is a bitfield within the flash configuration field in Kinetis CPUs. The meaning of the bits in the FOPT field are CPU model specific, but in general they provide configuration for settings which may need to be applied before the actual firmware application is started, such as disabling NMI or reducing the default clock frequency for low power boot.
Previously we have forced this byte to all ones, but some boards will require modified FOPT settings to even boot so this PR makes the FOPT field configurable via a macro definition.
The fcfield checking scripts are updated to still verify that all security related bits in the field are set to safe values to avoid unintentional lock-out, but the FOPT bits are now allowed to be anything.

### Testing procedure

Build any application for a Kinetis board. Flash and verify that the application runs without issues.

### Issues/PRs references

Required by #9012 to disable the ROM bootloader