### PR TITLE
periph/i2c: Add precondition on i2c_acquire for i2c bus access

### DIFF
--- a/drivers/include/periph/i2c.h
+++ b/drivers/include/periph/i2c.h
@@ -243,6 +243,8 @@ int i2c_release(i2c_t dev);
  * @note    This function is using a repeated start sequence for reading from
  *          the specified register address.
  *
+ * @pre     i2c_acquire must be called before accessing the bus
+ *
  * @param[in]  dev          I2C peripheral device
  * @param[in]  reg          register address to read from (8- or 16-bit,
  *                          right-aligned)
@@ -269,6 +271,8 @@ int i2c_read_reg(i2c_t dev, uint16_t addr, uint16_t reg,
  * @note    This function is using a repeated start sequence for reading from
  *          the specified register address.
  *
+ * @pre     i2c_acquire must be called before accessing the bus
+ *
  * @param[in]  dev          I2C peripheral device
  * @param[in]  reg          register address to read from (8- or 16-bit,
  *                          right-aligned)
@@ -294,6 +298,8 @@ int i2c_read_regs(i2c_t dev, uint16_t addr, uint16_t reg,
  * @note    This function is using a repeated start sequence for reading from
  *          the specified register address.
  *
+ * @pre     i2c_acquire must be called before accessing the bus
+ *
  * @param[in]  dev          I2C peripheral device
  * @param[in]  addr         7-bit or 10-bit device address (right-aligned)
  * @param[out] data         memory location to store received data
@@ -316,6 +322,8 @@ int i2c_read_byte(i2c_t dev, uint16_t addr, void *data, uint8_t flags);
  * @note    This function is using a repeated start sequence for reading from
  *          the specified register address.
  *
+ * @pre     i2c_acquire must be called before accessing the bus
+ *
  * @param[in]  dev          I2C peripheral device
  * @param[in]  addr         7-bit or 10-bit device address (right-aligned)
  * @param[out] data         memory location to store received data
@@ -337,6 +345,8 @@ int i2c_read_bytes(i2c_t dev, uint16_t addr,
 /**
  * @brief   Convenience function for writing a single byte onto the bus
  *
+ * @pre     i2c_acquire must be called before accessing the bus
+ *
  * @param[in] dev           I2C peripheral device
  * @param[in] addr          7-bit or 10-bit device address (right-aligned)
  * @param[in] data          byte to write to the device
@@ -354,6 +364,8 @@ int i2c_write_byte(i2c_t dev, uint16_t addr, uint8_t data, uint8_t flags);
 
 /**
  * @brief   Convenience function for writing several bytes onto the bus
+ *
+ * @pre     i2c_acquire must be called before accessing the bus
  *
  * @param[in] dev           I2C peripheral device
  * @param[in] addr          7-bit or 10-bit device address (right-aligned)
@@ -379,6 +391,8 @@ int i2c_write_bytes(i2c_t dev, uint16_t addr, const void *data,
  * @note    This function is using a repeated start sequence for writing to the
  *          specified register address.
  *
+ * @pre     i2c_acquire must be called before accessing the bus
+ *
  * @param[in]  dev          I2C peripheral device
  * @param[in]  reg          register address to read from (8- or 16-bit,
  *                          right-aligned)
@@ -402,6 +416,8 @@ int i2c_write_reg(i2c_t dev, uint16_t addr, uint16_t reg,
  *
  * @note    This function is using a repeated start sequence for writing to the
  *          specified register address.
+ *
+ * @pre     i2c_acquire must be called before accessing the bus
  *
  * @param[in]  dev          I2C peripheral device
  * @param[in]  reg          register address to read from (8- or 16-bit,


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

It was suggested in https://github.com/RIOT-OS/RIOT/issues/10269#issuecomment-440932744 that the documentation regarding the requirement to call i2c_acquire before any I2C bus access is not visible enough. This PR adds a precondition note to all i2c_read/write functions saying that i2c_acquire must be called first.


### Testing procedure

make doc
verify the docs for the periph I2C interface are OK.


### Issues/PRs references

#10269 