### PR TITLE
mcuboot.mk: Add mcuboot targets to BUILDDEPS.

### DIFF
--- a/makefiles/mcuboot.mk
+++ b/makefiles/mcuboot.mk
@@ -12,6 +12,8 @@ MCUBOOT_BIN_MD5 ?= 0c71a0589bd3709fc2d90f07a0035ce7
 
 export IMAGE_HDR_SIZE ?= 512
 
+$(MCUBOOT_KEYFILE) $(MCUBOOT_BIN): $(filter clean, $(MAKECMDGOALS))
+
 mcuboot-create-key: $(MCUBOOT_KEYFILE)
 
 ifeq ($(BINDIR)/key.pem,$(MCUBOOT_KEYFILE))


### PR DESCRIPTION
### _Read this before reviewing_

The first two commits are taken from #10461 and are __not__ part of this PR. They are there just to force an error.

### Contribution description

The mcuboot targets were not being added to BUILDDEPS and so the mcuboot targets was being made simultaneous with the clean. See the failed murdock output from #10461.

### Testing procedure

In `tests/mcuboot` run

~`BUILD_IN_DOCKER=1 DOCKER="sudo docker" make clean all`~

EDIT: the test command is running this merged with #10461 

```
make -C tests/mcuboot clean all -j
```


### Issues/PRs references

This is one of the issues derived from #10459 .