### PR TITLE
periph/timer: add timer_max and timer_diff API calls

### DIFF
--- a/cpu/atmega_common/periph/timer.c
+++ b/cpu/atmega_common/periph/timer.c
@@ -21,6 +21,7 @@
  */
 
 #include <avr/interrupt.h>
+#include <stdint.h>
 
 #include "board.h"
 #include "cpu.h"
@@ -257,6 +258,13 @@ unsigned int timer_read(tim_t tim)
     unsigned result = ctx[tim].dev->CNT;
     irq_restore(state);
     return result;
+}
+
+unsigned int timer_max(tim_t dev)
+{
+    (void)dev;
+    /* all atmega timers are configured to be 16bits */
+    return UINT16_MAX;
 }
 
 void timer_stop(tim_t tim)

--- a/cpu/cc2538/periph/timer.c
+++ b/cpu/cc2538/periph/timer.c
@@ -322,6 +322,20 @@ unsigned int timer_read(tim_t tim)
     }
 }
 
+unsigned int timer_max(tim_t tim)
+{
+    DEBUG("%s(%u)\n", __FUNCTION__, tim);
+
+    if (tim >= TIMER_NUMOF) {
+        return 0;
+    }
+
+    if (timer_config[tim].cfg == GPTMCFG_32_BIT_TIMER) {
+        return UINT32_MAX;
+    }
+    return UINT16_MAX;
+}
+
 /*
  * For stopping the counting of all channels.
  */

--- a/cpu/cc26xx_cc13xx/periph/timer.c
+++ b/cpu/cc26xx_cc13xx/periph/timer.c
@@ -22,6 +22,7 @@
 
 #include <stdlib.h>
 #include <stdio.h>
+#include <stdint.h>
 
 #include "assert.h"
 #include "board.h"
@@ -209,6 +210,18 @@ unsigned int timer_read(tim_t tim)
         return dev(tim)->TAV;
     }
     return LOAD_VALUE - (dev(tim)->TAV & 0xFFFF);
+}
+
+unsigned int timer_max(tim_t tim)
+{
+    DEBUG("timer_max(%u)\n", tim);
+    if (tim >= TIMER_NUMOF) {
+        return 0;
+    }
+    if (timer_config[tim].cfg == GPT_CFG_32T) {
+        return UINT32_MAX;
+    }
+    return UINT16_MAX;
 }
 
 void timer_stop(tim_t tim)

--- a/cpu/efm32/periph/timer.c
+++ b/cpu/efm32/periph/timer.c
@@ -20,6 +20,8 @@
  * @}
  */
 
+#include <stdint.h>
+
 #include "cpu.h"
 #include "log.h"
 #include "assert.h"
@@ -239,6 +241,12 @@ unsigned int timer_read(tim_t dev)
     else {
         return (unsigned int) TIMER_CounterGet(timer_config[dev].timer.dev);
     }
+}
+
+unsigned int timer_max(tim_t dev)
+{
+    (void)dev;
+    return UINT16_MAX;
 }
 
 void timer_stop(tim_t dev)

--- a/cpu/esp32/include/periph_cpu.h
+++ b/cpu/esp32/include/periph_cpu.h
@@ -517,6 +517,10 @@ typedef struct {
 /** Timer used for system time */
 #define TIMER_SYSTEM    TIMERG0.hw_timer[0]
 
+/**
+ * @brief   Prevent shared timer functions from being used
+ */
+#define PERIPH_TIMER_PROVIDES_SET
 /** @} */
 
 /**

--- a/cpu/esp32/include/periph_cpu.h
+++ b/cpu/esp32/include/periph_cpu.h
@@ -521,12 +521,6 @@ typedef struct {
  * @brief   Prevent shared timer functions from being used
  */
 #define PERIPH_TIMER_PROVIDES_SET
-/** @} */
-
-/**
- * @brief   Prevent shared timer functions from being used
- */
-#define PERIPH_TIMER_PROVIDES_SET
 
 /**
  * @name   UART configuration

--- a/cpu/esp32/include/periph_cpu.h
+++ b/cpu/esp32/include/periph_cpu.h
@@ -517,6 +517,8 @@ typedef struct {
 /** Timer used for system time */
 #define TIMER_SYSTEM    TIMERG0.hw_timer[0]
 
+/** @} */
+
 /**
  * @brief   Prevent shared timer functions from being used
  */

--- a/cpu/esp32/periph/timer.c
+++ b/cpu/esp32/periph/timer.c
@@ -22,6 +22,9 @@
  * WARNING! enable debugging will have timing side effects and can lead
  * to timer underflows, system crashes or system dead locks in worst case.
  */
+
+#include <stdint.h>
+
 #define ENABLE_DEBUG (0)
 #include "debug.h"
 
@@ -322,6 +325,12 @@ unsigned int IRAM timer_read(tim_t dev)
     #endif
 }
 
+unsigned int IRAM timer_max(tim_t dev)
+{
+    (void)dev;
+
+    return UINT32_MAX;
+}
 void IRAM timer_start(tim_t dev)
 {
     DEBUG("%s dev=%u @%u\n", __func__, dev, system_get_time());
@@ -518,6 +527,13 @@ unsigned int IRAM timer_read(tim_t dev)
     (void)dev;
 
     return system_get_time ();
+}
+
+unsigned int IRAM timer_max(tim_t dev)
+{
+    (void)dev;
+
+    return UINT32_MAX;
 }
 
 void IRAM timer_start(tim_t dev)

--- a/cpu/esp8266/periph/timer.c
+++ b/cpu/esp8266/periph/timer.c
@@ -199,6 +199,12 @@ unsigned int IRAM timer_read(tim_t dev)
     return phy_get_mactime ();
 }
 
+unsigned int /* IRAM */ timer_max(tim_t dev)
+{
+    (void)dev;
+    return HW_TIMER_DELTA_MAX;
+}
+
 void IRAM timer_start(tim_t dev)
 {
     DEBUG("%s dev=%u @%u\n", __func__, dev, phy_get_mactime());
@@ -462,6 +468,12 @@ unsigned int IRAM timer_read(tim_t dev)
     (void)dev;
 
     return phy_get_mactime ();
+}
+
+unsigned int /* IRAM */ timer_max(tim_t dev)
+{
+    (void)dev;
+    return OS_TIMER_DELTA_MAX;
 }
 
 void IRAM timer_start(tim_t dev)

--- a/cpu/ezr32wg/periph/timer.c
+++ b/cpu/ezr32wg/periph/timer.c
@@ -19,6 +19,8 @@
  * @}
  */
 
+#include <stdint.h>
+
 #include "cpu.h"
 #include "periph/timer.h"
 #include "periph_conf.h"
@@ -105,6 +107,12 @@ int timer_clear(tim_t dev, int channel)
 unsigned int timer_read(tim_t dev)
 {
     return (unsigned int)timer_config[dev].timer->CNT;
+}
+
+unsigned int timer_max(tim_t dev)
+{
+    (void)dev;
+    return UINT16_MAX;
 }
 
 void timer_stop(tim_t dev)

--- a/cpu/fe310/periph/timer.c
+++ b/cpu/fe310/periph/timer.c
@@ -17,6 +17,7 @@
  * @}
  */
 
+#include <stdint.h>
 #include <stdlib.h>
 #include <unistd.h>
 
@@ -131,6 +132,14 @@ unsigned int timer_read(tim_t dev)
 
     /* Read current timer value */
     return (unsigned int) lo;
+}
+
+unsigned int timer_max(tim_t dev)
+{
+    if (dev != 0) {
+        return 0;
+    }
+    return UINT32_MAX;
 }
 
 void timer_start(tim_t dev)

--- a/cpu/kinetis/periph/timer.c
+++ b/cpu/kinetis/periph/timer.c
@@ -24,6 +24,7 @@
  * @}
  */
 
+#include <stdint.h>
 #include <stdlib.h>
 
 #include "cpu.h"
@@ -713,6 +714,23 @@ unsigned int timer_read(tim_t dev)
         case TIMER_LPTMR:
             return lptmr_read(_lptmr_index(dev));
 #endif
+        default:
+            return 0;
+    }
+}
+
+unsigned int timer_max(tim_t dev)
+{
+    if ((unsigned int)dev >= TIMER_NUMOF) {
+        /* invalid timer */
+        return 0;
+    }
+    /* demultiplex to handle two types of hardware timers */
+    switch (_timer_variant(dev)) {
+        case TIMER_PIT:
+            return UINT32_MAX;
+        case TIMER_LPTMR:
+            return UINT16_MAX;
         default:
             return 0;
     }

--- a/cpu/lm4f120/periph/timer.c
+++ b/cpu/lm4f120/periph/timer.c
@@ -241,6 +241,14 @@ unsigned int timer_read(tim_t dev)
     return scaled_value;
 }
 
+unsigned int timer_max(tim_t dev)
+{
+    if (dev < TIMER_NUMOF) {
+        return UINT32_MAX;
+    }
+    return 0;
+}
+
 void timer_start(tim_t dev)
 {
     unsigned int timer_base;

--- a/cpu/lpc1768/periph/timer.c
+++ b/cpu/lpc1768/periph/timer.c
@@ -105,6 +105,14 @@ unsigned int timer_read(tim_t dev)
     return 0;
 }
 
+unsigned int timer_max(tim_t dev)
+{
+    if (dev == TIMER_0) {
+        return UINT32_MAX;
+    }
+    return 0;
+}
+
 void timer_start(tim_t dev)
 {
     if (dev == TIMER_0) {

--- a/cpu/lpc23xx/periph/timer.c
+++ b/cpu/lpc23xx/periph/timer.c
@@ -214,6 +214,14 @@ unsigned int timer_read(tim_t tim)
     return (unsigned int)(get_dev(tim)->TC);
 }
 
+unsigned int timer_max(tim_t tim)
+{
+    if (tim >= TIMER_NUMOF) {
+        return 0;
+    }
+    return UINT32_MAX;
+}
+
 void timer_start(tim_t tim)
 {
     get_dev(tim)->TCR = 1;

--- a/cpu/mips_pic32_common/periph/timer.c
+++ b/cpu/mips_pic32_common/periph/timer.c
@@ -22,6 +22,7 @@
 #include <mips/regdef.h>
 #include <mips/asm.h>
 #include <string.h>
+#include <stdint.h>
 
 #include <periph/timer.h>
 #include "cpu_conf.h"
@@ -203,6 +204,15 @@ unsigned int timer_read(tim_t dev)
     (void)dev;
 
     return counter;
+}
+
+unsigned int timer_max(tim_t dev)
+{
+    assert(dev == 0);
+
+    (void)dev;
+
+    return UINT32_MAX;
 }
 
 void timer_start(tim_t dev)

--- a/cpu/msp430fxyz/periph/timer.c
+++ b/cpu/msp430fxyz/periph/timer.c
@@ -25,6 +25,8 @@
  * @}
  */
 
+#include <stdint.h>
+
 #include "cpu.h"
 #include "periph_cpu.h"
 #include "periph_conf.h"
@@ -92,6 +94,14 @@ unsigned int timer_read(tim_t dev)
 {
     (void)dev;
     return (unsigned int)TIMER_BASE->R;
+}
+
+unsigned int timer_max(tim_t dev)
+{
+    if (dev != 0) {
+        return 0;
+    }
+    return UINT16_MAX;
 }
 
 void timer_start(tim_t dev)

--- a/cpu/native/periph/timer.c
+++ b/cpu/native/periph/timer.c
@@ -202,3 +202,11 @@ unsigned int timer_read(tim_t dev)
 
     return ts2ticks(&t) - time_null;
 }
+
+unsigned int timer_max(tim_t dev)
+{
+    if (dev < TIMER_NUMOF) {
+        return UINT32_MAX;
+    }
+    return 0;
+}

--- a/cpu/nrf5x_common/periph/timer.c
+++ b/cpu/nrf5x_common/periph/timer.c
@@ -23,6 +23,8 @@
  * @}
  */
 
+#include <stdint.h>
+
 #include "periph/timer.h"
 
 #define F_TIMER             (16000000U)     /* the timer is clocked at 16MHz */
@@ -123,6 +125,15 @@ unsigned int timer_read(tim_t tim)
 {
     dev(tim)->TASKS_CAPTURE[timer_config[tim].channels] = 1;
     return dev(tim)->CC[timer_config[tim].channels];
+}
+
+unsigned int timer_max(tim_t tim)
+{
+    /* make sure the given timer is valid */
+    if (tim < TIMER_NUMOF) {
+        return UINT32_MAX;
+    }
+    return 0;
 }
 
 void timer_start(tim_t tim)

--- a/cpu/nrf5x_common/periph/timer.c
+++ b/cpu/nrf5x_common/periph/timer.c
@@ -131,7 +131,24 @@ unsigned int timer_max(tim_t tim)
 {
     /* make sure the given timer is valid */
     if (tim < TIMER_NUMOF) {
-        return UINT32_MAX;
+        switch (timer_config[tim].bitmode)
+        {
+        case TIMER_BITMODE_BITMODE_32Bit:
+            return UINT32_MAX;
+            break;
+        case TIMER_BITMODE_BITMODE_24Bit:
+            return 0x00FFFFFF;
+            break;
+        case TIMER_BITMODE_BITMODE_16Bit:
+            return UINT16_MAX;
+            break;
+        case TIMER_BITMODE_BITMODE_08Bit:
+            return UINT8_MAX;
+            break;
+        default:
+            return UINT32_MAX;
+            break;
+        }
     }
     return 0;
 }

--- a/cpu/sam0_common/periph/timer.c
+++ b/cpu/sam0_common/periph/timer.c
@@ -324,6 +324,22 @@ unsigned int timer_read(tim_t tim)
     return dev(tim)->COUNT.reg;
 }
 
+unsigned int timer_max(tim_t dev)
+{
+    switch (dev) {
+#if TIMER_0_EN
+    case TIMER_0:
+        return TIMER_0_MAX_VALUE;
+#endif
+#if TIMER_1_EN
+    case TIMER_1:
+        return TIMER_1_MAX_VALUE;
+#endif
+    default:
+        return 0;
+    }
+}
+
 void timer_stop(tim_t tim)
 {
     dev(tim)->CTRLA.bit.ENABLE = 0;

--- a/cpu/sam3/periph/timer.c
+++ b/cpu/sam3/periph/timer.c
@@ -19,6 +19,7 @@
  * @}
  */
 
+#include <stdint.h>
 #include <stdlib.h>
 #include <stdio.h>
 
@@ -147,6 +148,12 @@ int timer_clear(tim_t tim, int channel)
 unsigned int timer_read(tim_t tim)
 {
     return dev(tim)->TC_CHANNEL[0].TC_CV;
+}
+
+unsigned int timer_max(tim_t tim)
+{
+    (void)tim;
+    return UINT32_MAX;
 }
 
 void timer_start(tim_t tim)

--- a/cpu/stm32/periph/timer.c
+++ b/cpu/stm32/periph/timer.c
@@ -189,6 +189,15 @@ int timer_clear(tim_t tim, int channel)
     return 0;
 }
 
+unsigned int timer_max(tim_t tim)
+{
+    /* check if device is valid */
+    if (tim >= TIMER_NUMOF) {
+        return 0;
+    }
+    return timer_config[tim].max;
+}
+
 unsigned int timer_read(tim_t tim)
 {
     return (unsigned int)dev(tim)->CNT;

--- a/drivers/include/periph/timer.h
+++ b/drivers/include/periph/timer.h
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2014-2015 Freie Universität Berlin
+ *               2018 HAW Hamburg
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -28,6 +29,7 @@
  * @brief       Low-level timer peripheral driver interface definitions
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author      Sebastian Meiling <s@mlng.net>
  */
 
 #ifndef PERIPH_TIMER_H
@@ -197,6 +199,15 @@ int timer_clear(tim_t dev, int channel);
  */
 unsigned int timer_read(tim_t dev);
 
+/**
+ * @brief Get the timers maximal counter value.
+ *
+ * @param[in] dev           the timer to get the max value for
+ *
+ * @return                  the timers max value
+ * @return                  0 on error
+ */
+unsigned int timer_max(tim_t dev);
 /**
  * @brief Start the given timer
  *

--- a/drivers/include/periph/timer.h
+++ b/drivers/include/periph/timer.h
@@ -208,6 +208,24 @@ unsigned int timer_read(tim_t dev);
  * @return                  0 on error
  */
 unsigned int timer_max(tim_t dev);
+
+/**
+ * @brief Compare two timer values and return the difference
+ *
+ * Depending on the timer configuration the difference of two time values cannot
+ * be calculated by simple substraction, but needs to consider the max value the
+ * timer can reach. For instance, if the timer is set to 16-Bits running on a
+ * 32-Bits platform.
+ *
+ * @param[in] dev           the timer to compare values for
+ * @param[in] begin         first time value
+ * @param[in] until         second time value
+ *
+ * @return                  time difference, i.e., `until - begin`
+ * @return                  0 on error
+ */
+unsigned int timer_diff(tim_t dev, unsigned int begin, unsigned int until);
+
 /**
  * @brief Start the given timer
  *

--- a/drivers/periph_common/timer.c
+++ b/drivers/periph_common/timer.c
@@ -1,5 +1,6 @@
 /*
  * Copyright (C) 2017 Freie Universität Berlin
+ *               2018 HAW Hamburg
  *
  * This file is subject to the terms and conditions of the GNU Lesser
  * General Public License v2.1. See the file LICENSE in the top level
@@ -14,6 +15,7 @@
  * @brief       Shared peripheral timer code
  *
  * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ * @author      Sebastian Meiling <s@mlng.net>
  *
  * @}
  */
@@ -30,3 +32,12 @@ int timer_set(tim_t dev, int channel, unsigned int timeout)
     return res;
 }
 #endif
+
+unsigned int timer_diff(tim_t dev, unsigned int begin, unsigned int until)
+{
+    unsigned int diff = 0;
+    if (dev < TIMER_NUMOF) {
+        diff = (until - begin) & timer_max(dev);
+    }
+    return diff;
+}

--- a/tests/periph_timer_diff/Makefile
+++ b/tests/periph_timer_diff/Makefile
@@ -23,13 +23,23 @@ BOARDS_TIMER_32kHz := \
     frdm-k22f \
     #
 
+BOARDS_TIMER_CLOCK_CORECLOCK := \
+  cc2538dk \
+  openmote-b \
+  openmote-cc2538 \
+  remote-reva \
+  remote-revb \
+  #
+
 ifneq (,$(filter $(BOARDS_TIMER_25kHz),$(BOARD)))
-  TIMER_SPEED ?= 250000ul
+  TIMER_SPEED ?= 250000
 else ifneq (,$(filter $(BOARDS_TIMER_32kHz),$(BOARD)))
-  TIMER_SPEED ?= 32768ul
+  TIMER_SPEED ?= 32768
+else ifneq (,$(filter $(BOARDS_TIMER_CLOCK_CORECLOCK),$(BOARD)))
+  TIMER_SPEED ?= CLOCK_CORECLOCK
 endif
 
-TIMER_SPEED ?= 1000000ul
+TIMER_SPEED ?= 1000000
 
 CFLAGS += -DTIMER_SPEED=$(TIMER_SPEED)
 include $(RIOTBASE)/Makefile.include

--- a/tests/periph_timer_diff/Makefile
+++ b/tests/periph_timer_diff/Makefile
@@ -1,0 +1,35 @@
+include ../Makefile.tests_common
+
+FEATURES_REQUIRED = periph_timer
+
+TEST_ON_CI_WHITELIST += all
+
+BOARDS_TIMER_25kHz := \
+    arduino-duemilanove \
+    arduino-leonardo \
+    arduino-mega2560 \
+    arduino-uno \
+    atmega256rfr2-xpro \
+    atmega328p \
+    waspmote-pro \
+    #
+
+BOARDS_TIMER_32kHz := \
+    hifive1 \
+    hifive1b \
+    %-kw41z \
+    openlabs-kw41z-mini \
+    frdm-k64f \
+    frdm-k22f \
+    #
+
+ifneq (,$(filter $(BOARDS_TIMER_25kHz),$(BOARD)))
+  TIMER_SPEED ?= 250000ul
+else ifneq (,$(filter $(BOARDS_TIMER_32kHz),$(BOARD)))
+  TIMER_SPEED ?= 32768ul
+endif
+
+TIMER_SPEED ?= 1000000ul
+
+CFLAGS += -DTIMER_SPEED=$(TIMER_SPEED)
+include $(RIOTBASE)/Makefile.include

--- a/tests/periph_timer_diff/README.md
+++ b/tests/periph_timer_diff/README.md
@@ -1,0 +1,8 @@
+# About
+
+This test compares the difference of two timer values t0 and t1 using timer_diff
+function and a simple subtraction, i.e., `t1 - t0`. Depending on the platform
+and timer configuration both values can differ, for instance when running a
+timer in 16-Bit mode/width on a 32-Bit platform.
+
+The test is run for all enabled timers, but only for the first channel.

--- a/tests/periph_timer_diff/main.c
+++ b/tests/periph_timer_diff/main.c
@@ -1,0 +1,118 @@
+/*
+ * Copyright (C) 2015 Freie Universität Berlin
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       Peripheral timer test application
+ *
+ * @author      Hauke Petersen <hauke.petersen@fu-berlin.de>
+ *
+ * @}
+ */
+
+#include <stdbool.h>
+#include <stdio.h>
+#include <stdint.h>
+#include <stdlib.h>
+
+#include "periph/timer.h"
+
+/**
+ * @brief   Make sure, the maximum number of timers is defined
+ */
+#ifndef TIMER_NUMOF
+#error "TIMER_NUMOF not defined!"
+#endif
+
+#define MAX_LOOPS   (10U)
+#define TIMEOUT     (20000U)
+
+static volatile unsigned fired;
+static volatile uint32_t sw_count;
+static volatile unsigned timevals[MAX_LOOPS];
+
+static void cb(void *arg, int chan)
+{
+    (void) chan;
+    timevals[fired] = timer_read(TIMER_DEV((unsigned)arg));
+    fired++;
+    if (fired < MAX_LOOPS) {
+        timer_set(TIMER_DEV((unsigned)arg), 0, TIMEOUT);
+    }
+}
+
+static int test_timer(unsigned num)
+{
+    printf("\n*** Testing TIMER_%u ***\n", num);
+    /* reset state */
+    sw_count = 0;
+    fired = 0;
+    for (unsigned i = 0; i < MAX_LOOPS; i++) {
+        timevals[i] = 0;
+    }
+    printf(" _init(%u, %lu, cb, args)\n", num, TIMER_SPEED);
+    /* initialize and halt timer */
+    if (timer_init(TIMER_DEV(num), TIMER_SPEED, cb, (void *)(num)) < 0) {
+        puts("WARN: incompatible timer speed?");
+        return 1;
+    }
+    /* stop timer */
+    timer_stop(TIMER_DEV(num));
+    /* set first timeout */
+    printf(" _set(%u, 0, %u)\n", num, TIMEOUT);
+    if (timer_set(TIMER_DEV(num), 0, TIMEOUT) < 0) {
+        puts("FAIL: cannot set timer!");
+        return 0;
+    }
+    /* (re)start timer */
+    timer_start(TIMER_DEV(num));
+    /* wait for all channels to fire */
+    do {
+        ++sw_count;
+    } while (fired < MAX_LOOPS);
+    bool match = true;
+    /* collect results */
+    printf("  fired %u , offset %u [us]\n\n", fired, TIMEOUT);
+    printf(";num, begin, until, timer_diff, simple_diff\n");
+    for (unsigned i = 1; i < fired; i++) {
+        unsigned tdiff = timer_diff(TIMER_DEV(num), timevals[i-1], timevals[i]);
+        unsigned sdiff = (timevals[i] - timevals[i-1]);
+        if (tdiff != sdiff) {
+            match = false;
+        }
+        printf(" %u, %u, %u, %u, %u\n", i, timevals[i-1], timevals[i], tdiff, sdiff);
+    }
+    printf("\n  Note: timer_max is %s UINT_MAX.\n",
+           ((match) ? "equal to" : "less than"));
+    return 1;
+}
+
+int main(void)
+{
+    int res = 0;
+
+    printf("TIMER_NUMOF=%i\n", TIMER_NUMOF);
+    printf("TIMER_SPEED=%lu\n", TIMER_SPEED);
+
+    /* test all configured timers */
+    for (unsigned i = 0; i < TIMER_NUMOF; i++) {
+        res += test_timer(i);
+    }
+    /* draw conclusion */
+    if (res == TIMER_NUMOF) {
+        puts("\n[SUCCESS]");
+    }
+    else {
+        puts("\n[ERROR]");
+    }
+
+    return 0;
+}

--- a/tests/periph_timer_diff/tests/01-run.py
+++ b/tests/periph_timer_diff/tests/01-run.py
@@ -1,0 +1,26 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2016 Kaspar Schleiser <kaspar@schleiser.de>
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import sys
+from testrunner import run
+
+
+def testfunc(child):
+    child.expect(r'TIMER_NUMOF=(\d+)')
+    timer_numof = int(child.match.group(1))
+    child.expect(r'TIMER_SPEED=(\d+)')
+    timer_speed = int(child.match.group(1))
+    for timer in range(timer_numof):
+        child.expect_exact('*** Testing TIMER_{} ***'.format(timer))
+        child.expect_exact(' _init({}, {}, cb, args)'.format(timer, timer_speed))
+        child.expect(r' _set\(\d+, \d+, \d+\)')
+    child.expect('[SUCCESS]')
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc))


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

- Introduce a new API call to get the maximal timer (counter) value
    taking into account the actual configuration of the underlying low
    level timer peripheral. This is a helper function for higher layer
    libs or apps which are unaware of timer and platform specifics, for
    instance when running a 16-Bit timer on a 32-Bit platform the max
    value UINT16_MAX and not UINT32_MAX.

- Introducing a generic helper function to calculate the time difference
    of two values with respect to the actual timer configuration, e.g. 16
    or 32Bit. This utilises the platform specific timer_max call.

- add test application for timer_diff 
### Testing procedure

run `tests/periph_timer_diff` for you favourite board, use one with 16 and 32 bit timers like samr21-xpro to see the issue and improvement of this PR. Here some sample output:

```
2018-11-28 11:45:14,639 - INFO # main(): This is RIOT! (Version: 2018.10-RC1-332-gdbeaf-pr/periph/timer_max)
2018-11-28 11:45:14,640 - INFO # TIMER_NUMOF=2
2018-11-28 11:45:14,642 - INFO # TIMER_SPEED=1000000
2018-11-28 11:45:14,642 - INFO # 
2018-11-28 11:45:14,644 - INFO # *** Testing TIMER_0 ***
2018-11-28 11:45:14,646 - INFO #  _init(0, 1000000, cb, args)
2018-11-28 11:45:14,648 - INFO #  _set(0, 0, 20000)
2018-11-28 11:45:14,832 - INFO #   fired 10 , offset 20000 [us]
2018-11-28 11:45:14,832 - INFO # 
2018-11-28 11:45:14,836 - INFO # ;num, begin, until, timer_diff, simple_diff
2018-11-28 11:45:14,838 - INFO #  1, 2, 20013, 20011, 20011
2018-11-28 11:45:14,841 - INFO #  2, 20013, 40024, 20011, 20011
2018-11-28 11:45:14,844 - INFO #  3, 40024, 60035, 20011, 20011
2018-11-28 11:45:14,847 - INFO #  4, 60035, 14510, 20011, 4294921771
2018-11-28 11:45:14,850 - INFO #  5, 14510, 34521, 20011, 20011
2018-11-28 11:45:14,853 - INFO #  6, 34521, 54532, 20011, 20011
2018-11-28 11:45:14,856 - INFO #  7, 54532, 9007, 20011, 4294921771
2018-11-28 11:45:14,859 - INFO #  8, 9007, 29018, 20011, 20011
2018-11-28 11:45:14,862 - INFO #  9, 29018, 49029, 20011, 20011
2018-11-28 11:45:14,862 - INFO # 
2018-11-28 11:45:14,866 - INFO #   Note: timer_max is less than UINT_MAX.
2018-11-28 11:45:14,866 - INFO # 
2018-11-28 11:45:14,868 - INFO # *** Testing TIMER_1 ***
2018-11-28 11:45:14,870 - INFO #  _init(1, 1000000, cb, args)
2018-11-28 11:45:14,872 - INFO #  _set(1, 0, 20000)
2018-11-28 11:45:15,056 - INFO #   fired 10 , offset 20000 [us]
2018-11-28 11:45:15,056 - INFO # 
2018-11-28 11:45:15,060 - INFO # ;num, begin, until, timer_diff, simple_diff
2018-11-28 11:45:15,062 - INFO #  1, 2, 20014, 20012, 20012
2018-11-28 11:45:15,065 - INFO #  2, 20014, 40026, 20012, 20012
2018-11-28 11:45:15,068 - INFO #  3, 40026, 60038, 20012, 20012
2018-11-28 11:45:15,071 - INFO #  4, 60038, 80050, 20012, 20012
2018-11-28 11:45:15,074 - INFO #  5, 80050, 100062, 20012, 20012
2018-11-28 11:45:15,077 - INFO #  6, 100062, 120074, 20012, 20012
2018-11-28 11:45:15,080 - INFO #  7, 120074, 140086, 20012, 20012
2018-11-28 11:45:15,083 - INFO #  8, 140086, 160098, 20012, 20012
2018-11-28 11:45:15,086 - INFO #  9, 160098, 180110, 20012, 20012
2018-11-28 11:45:15,086 - INFO # 
2018-11-28 11:45:15,089 - INFO #   Note: timer_max is equal to UINT_MAX.
2018-11-28 11:45:15,090 - INFO # 
2018-11-28 11:45:15,091 - INFO # [SUCCESS]
```

For `TIMER_0`  you see messed up values in row 4 and 7 which is due to timer rollover and incorrect subtraction assuming 32Bits.

### Issues/PRs references

- replaces #9900
- could be handy for #9283

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->