### PR TITLE
gnrc_netif: introduce distinction if an interface supports 6Lo or if it performs ND according to RFC 6775

### DIFF
--- a/sys/include/net/gnrc/netif/flags.h
+++ b/sys/include/net/gnrc/netif/flags.h
@@ -119,6 +119,13 @@ enum {
 #define GNRC_NETIF_FLAGS_6LO_BACKBONE              (0x00000800U)
 
 /**
+ * @brief   This interface represents a 6Lo node (6LN) according to RFC 6775
+ *
+ * @see [RFC 6775, section 2](https://tools.ietf.org/html/rfc6775#section-2)
+ */
+#define GNRC_NETIF_FLAGS_6LN                       (0x00001000U)
+
+/**
  * @brief   Network interface is configured in raw mode
  */
 #define GNRC_NETIF_FLAGS_RAWMODE                   (0x00010000U)

--- a/sys/include/net/gnrc/netif/internal.h
+++ b/sys/include/net/gnrc/netif/internal.h
@@ -496,6 +496,14 @@ static inline int gnrc_netif_get_eui64(gnrc_netif_t *netif, eui64_t *eui64)
     return -ENOTSUP;
 }
 
+/**
+ * @brief   Initializes an interface as 6LN according to RFC 6775 and according
+ *          to its gnrc_netif_t::device_type
+ *
+ * @param[in] netif The network interface to initialize as 6LN
+ */
+void gnrc_netif_init_6ln(gnrc_netif_t *netif);
+
 #if defined(MODULE_GNRC_IPV6) || defined(DOXYGEN)
 /**
  * @brief   Initialize IPv6 MTU and other packet length related members of

--- a/sys/include/net/gnrc/netif/internal.h
+++ b/sys/include/net/gnrc/netif/internal.h
@@ -330,6 +330,22 @@ static inline bool gnrc_netif_is_rtr_adv(const gnrc_netif_t *netif)
 #endif
 
 /**
+ * @brief   Checks if the interface uses a protocol that requires 6Lo to run
+ *
+ * @attention   Requires prior locking
+ * @note        Assumed to be true, when @ref GNRC_NETIF_NUMOF == 1 and
+ *              @ref net_gnrc_sixlowpan module is included (and
+ *              @ref GNRC_IPV6_NIB_CONF_6LN is not 0, otherwise assumed to be
+ *              false).
+ *
+ * @param[in] netif the network interface
+ *
+ * @return  true, if the interface represents a 6LN
+ * @return  false, if the interface does not represent a 6LN
+ */
+#define gnrc_netif_is_6lo(netif)    gnrc_netif_is_6ln(netif)
+
+/**
  * @brief   Checks if the interface represents a 6Lo node (6LN) according to
  *          RFC 6775
  *

--- a/sys/include/net/gnrc/netif/internal.h
+++ b/sys/include/net/gnrc/netif/internal.h
@@ -334,26 +334,29 @@ static inline bool gnrc_netif_is_rtr_adv(const gnrc_netif_t *netif)
  *
  * @attention   Requires prior locking
  * @note        Assumed to be true, when @ref GNRC_NETIF_NUMOF == 1 and
- *              @ref net_gnrc_sixlowpan module is included (and
- *              @ref GNRC_IPV6_NIB_CONF_6LN is not 0, otherwise assumed to be
- *              false).
+ *              @ref net_gnrc_sixlowpan module is included. When the
+ *              @ref net_gnrc_sixlowpan module is not included, it is assumed
+ *              to be false.
  *
  * @param[in] netif the network interface
  *
  * @return  true, if the interface represents a 6LN
  * @return  false, if the interface does not represent a 6LN
  */
-#define gnrc_netif_is_6lo(netif)    gnrc_netif_is_6ln(netif)
+#if ((GNRC_NETIF_NUMOF > 1) && defined(MODULE_GNRC_SIXLOWPAN)) || defined(DOXYGEN)
+bool gnrc_netif_is_6lo(const gnrc_netif_t *netif);
+#elif (GNRC_NETIF_NUMOF == 1) && defined(MODULE_GNRC_SIXLOWPAN)
+#define gnrc_netif_is_6lo(netif)                (true)
+#else
+#define gnrc_netif_is_6lo(netif)                (false)
+#endif
 
 /**
  * @brief   Checks if the interface represents a 6Lo node (6LN) according to
  *          RFC 6775
  *
  * @attention   Requires prior locking
- * @note        Assumed to be true, when @ref GNRC_NETIF_NUMOF == 1 and
- *              @ref net_gnrc_sixlowpan module is included (and
- *              @ref GNRC_IPV6_NIB_CONF_6LN is not 0, otherwise assumed to be
- *              false).
+ * @note        Assumed to be false, when @ref GNRC_IPV6_NIB_CONF_6LN is 0.
  *
  * @param[in] netif the network interface
  *
@@ -362,10 +365,11 @@ static inline bool gnrc_netif_is_rtr_adv(const gnrc_netif_t *netif)
  * @return  true, if the interface represents a 6LN
  * @return  false, if the interface does not represent a 6LN
  */
-#if (GNRC_NETIF_NUMOF > 1) || !defined(MODULE_GNRC_SIXLOWPAN) || defined(DOXYGEN)
-bool gnrc_netif_is_6ln(const gnrc_netif_t *netif);
-#elif GNRC_IPV6_NIB_CONF_6LN
-#define gnrc_netif_is_6ln(netif)                (true)
+#if GNRC_IPV6_NIB_CONF_6LN || defined(DOXYGEN)
+static inline bool gnrc_netif_is_6ln(const gnrc_netif_t *netif)
+{
+    return (netif->flags & GNRC_NETIF_FLAGS_6LN);
+}
 #else
 #define gnrc_netif_is_6ln(netif)                (false)
 #endif

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -109,7 +109,7 @@ int gnrc_netif_get_from_netdev(gnrc_netif_t *netif, gnrc_netapi_opt_t *opt)
         case NETOPT_6LO:
             assert(opt->data_len == sizeof(netopt_enable_t));
             *((netopt_enable_t *)opt->data) =
-                    (netopt_enable_t)gnrc_netif_is_6ln(netif);
+                    (netopt_enable_t)gnrc_netif_is_6lo(netif);
             res = sizeof(netopt_enable_t);
             break;
         case NETOPT_HOP_LIMIT:

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -1093,8 +1093,8 @@ static ipv6_addr_t *_src_addr_selection(gnrc_netif_t *netif,
 }
 #endif  /* MODULE_GNRC_IPV6 */
 
-#if (GNRC_NETIF_NUMOF > 1) || !defined(MODULE_GNRC_SIXLOWPAN)
-bool gnrc_netif_is_6ln(const gnrc_netif_t *netif)
+#if (GNRC_NETIF_NUMOF > 1) && defined(MODULE_GNRC_SIXLOWPAN)
+bool gnrc_netif_is_6lo(const gnrc_netif_t *netif)
 {
     switch (netif->device_type) {
 #ifdef MODULE_GNRC_SIXLOENC
@@ -1110,7 +1110,7 @@ bool gnrc_netif_is_6ln(const gnrc_netif_t *netif)
             return false;
     }
 }
-#endif  /* (GNRC_NETIF_NUMOF > 1) || !defined(MODULE_GNRC_SIXLOWPAN) */
+#endif  /* (GNRC_NETIF_NUMOF > 1) && defined(MODULE_GNRC_SIXLOWPAN) */
 
 static void _update_l2addr_from_dev(gnrc_netif_t *netif)
 {

--- a/sys/net/gnrc/netif/gnrc_netif_device_type.c
+++ b/sys/net/gnrc/netif/gnrc_netif_device_type.c
@@ -86,6 +86,32 @@ int gnrc_netif_eui64_from_addr(const gnrc_netif_t *netif,
     return -ENOTSUP;
 }
 
+void gnrc_netif_init_6ln(gnrc_netif_t *netif)
+{
+    switch (netif->device_type) {
+        case NETDEV_TYPE_IEEE802154: {
+            /* see https://tools.ietf.org/html/rfc6775#section-5.2 */
+            uint16_t src_len = IEEE802154_LONG_ADDRESS_LEN;
+            gnrc_netapi_opt_t opt = { .opt = NETOPT_SRC_LEN,
+                                      .data = &src_len,
+                                      .data_len = sizeof(src_len) };
+
+            /* XXX we are supposed to be in interface context here, so use driver
+             * directly everything else would deadlock anyway */
+            netif->ops->set(netif, &opt);
+        }
+        /* intentionally falls through */
+        case NETDEV_TYPE_BLE:
+        case NETDEV_TYPE_NRFMIN:
+#if GNRC_IPV6_NIB_CONF_6LN
+            netif->flags |= GNRC_NETIF_FLAGS_6LN;
+#endif  /* GNRC_IPV6_NIB_CONF_6LN */
+            /* intentionally falls through */
+        default:
+            break;
+    }
+}
+
 #ifdef MODULE_GNRC_IPV6
 void gnrc_netif_ipv6_init_mtu(gnrc_netif_t *netif)
 {

--- a/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
+++ b/sys/net/gnrc/network_layer/ipv6/gnrc_ipv6.c
@@ -276,7 +276,7 @@ static void _send_to_iface(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
 #endif
 
 #ifdef MODULE_GNRC_SIXLOWPAN
-    if (gnrc_netif_is_6ln(netif)) {
+    if (gnrc_netif_is_6lo(netif)) {
         DEBUG("ipv6: send to 6LoWPAN instead\n");
         if (!gnrc_netapi_dispatch_send(GNRC_NETTYPE_SIXLOWPAN, GNRC_NETREG_DEMUX_CTX_ALL, pkt)) {
             DEBUG("ipv6: no 6LoWPAN thread found\n");

--- a/sys/net/gnrc/network_layer/ipv6/nib/nib.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/nib.c
@@ -111,20 +111,10 @@ void gnrc_ipv6_nib_init_iface(gnrc_netif_t *netif)
     netif->ipv6.aac_mode = GNRC_NETIF_AAC_AUTO;
 #endif  /* GNRC_IPV6_NIB_CONF_SLAAC || GNRC_IPV6_NIB_CONF_6LN */
     _init_iface_router(netif);
+    gnrc_netif_init_6ln(netif);
 #if GNRC_IPV6_NIB_CONF_6LN
     netif->ipv6.rs_sent = 0;
 #endif  /* GNRC_IPV6_NIB_CONF_6LN */
-    if (netif->device_type == NETDEV_TYPE_IEEE802154) {
-        /* see https://tools.ietf.org/html/rfc6775#section-5.2 */
-        uint16_t src_len = IEEE802154_LONG_ADDRESS_LEN;
-        gnrc_netapi_opt_t opt = { .opt = NETOPT_SRC_LEN,
-                                  .data = &src_len,
-                                  .data_len = sizeof(src_len) };
-
-        /* XXX we are supposed to be in interface context here, so use driver
-         * directly everything else would deadlock anyway */
-        netif->ops->set(netif, &opt);
-    }
     netif->ipv6.na_sent = 0;
     if (gnrc_netif_ipv6_group_join_internal(netif,
                                             &ipv6_addr_all_nodes_link_local) < 0) {

--- a/tests/gnrc_ipv6_nib_6ln/Makefile.ci
+++ b/tests/gnrc_ipv6_nib_6ln/Makefile.ci
@@ -6,6 +6,8 @@ BOARD_INSUFFICIENT_MEMORY := \
     arduino-uno \
     chronos \
     i-nucleo-lrwan1 \
+    msb-430 \
+    msb-430h \
     nucleo-f030r8 \
     nucleo-f031k6 \
     nucleo-f042k6 \


### PR DESCRIPTION
### Contribution description
This splits the semantic of `gnrc_netif_is_6ln()` into two check functions:
1. Is the interface a 6Lo interface (i.e. does it require 6Lo to communicate with IPv6 over it)
2. Is the interface performing 6Lo-ND as specified in RFC 6775.

It also fixes some logical inconclusions (check if interface is 6Lo when 6Lo is not compiled in wtf?) for the  compile-time optimizations of those functions.

### Testing procedure
It should be checked:

- does it still compile as an IPv6 non-routing host (e.g. by using `examples/gcoap` on native)
- does it still compile as an IPv6 routing host (e.g. by using `examples/gnrc_networking` on native)
- does it still compile in (non-routing) 6LN config (e.g. by using `examples/gcoap` on `samr21-xpro`)
- does it still compile in 6LR config (e.g. by using `examples/gcoap` on `samr21-xpro`)
- are there significant size differences between the master versions of those builds and the version in this PR (due to the change of the compile-time optimization)
- does it still work as expected:
   - [x] a non-routing, non-6LN host should start sending multicast RS, if SLAAC is activated a NS with source `::` should be sent, when a packet is sent a NS for address resolution should be sent
   - [x] a routing host, non-6LN should start sending multicast RA and except for the sending of NS should behave exactaly as a non-routing host
   - [x] a non-routing 6LN should start sending multicast RS, packets to link-local addresses should be resolved by not sending an NS first but by reverting the IID of the address back to the L2 address.
   - [x] a 6LR should do the same and start answering RS with a unicast RA as soon as it receives a RA from an upstream router
   - [x] a 6LBR should answer RS with a unicast RA.

### Issues/PRs references
None