### PR TITLE
pkg: disable compiler warning for jerryscript and nimble

### DIFF
--- a/pkg/jerryscript/Makefile.jerryscript
+++ b/pkg/jerryscript/Makefile.jerryscript
@@ -4,6 +4,10 @@ JERRYHEAP  ?= 16
 
 EXT_CFLAGS :=-D__TARGET_RIOT
 
+ifeq ($(TOOLCHAIN)_$(BOARD),llvm_native)
+  EXT_CFLAGS :=-D__TARGET_RIOT -Wno-conversion
+endif
+
 .PHONY: libjerry riot-jerry flash clean
 
 # all: libjerry riot-jerry

--- a/pkg/nimble/Makefile
+++ b/pkg/nimble/Makefile
@@ -15,6 +15,7 @@ ifeq (llvm,$(TOOLCHAIN))
 # tell LLVM/clang not to be so pedantic with this.
   CFLAGS += -Wno-unused-function
   CFLAGS += -Wno-sometimes-uninitialized
+  CFLAGS += -Wno-address-of-packed-member
 else
   CFLAGS += -Wno-unused-but-set-variable
 endif


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This is (hopefully) a quick fix to make Murdock build jerryscript with LLVM again, since the update of the Murdock-workers to Ubuntu-Bionic all builds fail.

Added a second quick fix for the nimble package

### Testing procedure

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
