### PR TITLE
gnrc_mac: fix header includes

### DIFF
--- a/sys/include/net/gnrc/gomach/types.h
+++ b/sys/include/net/gnrc/gomach/types.h
@@ -24,7 +24,6 @@
 
 #include "kernel_types.h"
 #include "xtimer.h"
-#include "net/gnrc.h"
 #include "net/gnrc/gomach/hdr.h"
 
 #ifdef __cplusplus

--- a/sys/include/net/gnrc/mac/types.h
+++ b/sys/include/net/gnrc/mac/types.h
@@ -25,7 +25,7 @@
 #include <stdbool.h>
 
 #include "kernel_types.h"
-#include "net/gnrc.h"
+#include "net/gnrc/pkt.h"
 #include "net/gnrc/priority_pktqueue.h"
 #include "net/ieee802154.h"
 #include "net/gnrc/mac/mac.h"

--- a/sys/net/gnrc/link_layer/lwmac/lwmac.c
+++ b/sys/net/gnrc/link_layer/lwmac/lwmac.c
@@ -29,6 +29,7 @@
 #include "random.h"
 #include "periph/rtt.h"
 #include "net/gnrc/netif.h"
+#include "net/gnrc/netif/hdr.h"
 #include "net/gnrc/netif/internal.h"
 #include "net/gnrc/netif/ieee802154.h"
 #include "net/netdev/ieee802154.h"

--- a/tests/unittests/tests-gnrc_mac_internal/tests-gnrc_mac_internal.c
+++ b/tests/unittests/tests-gnrc_mac_internal/tests-gnrc_mac_internal.c
@@ -15,7 +15,8 @@
 
 #include "embUnit.h"
 
-#include "net/gnrc/pkt.h"
+#include "net/gnrc/pktbuf.h"
+#include "net/gnrc/netif/hdr.h"
 #include "net/gnrc/mac/internal.h"
 
 #include "unittests-constants.h"


### PR DESCRIPTION
### Contribution description
The inclusion of `net/gnrc.h` in `net/gnrc/mac/types.h` header makes it impossible to include the `net/gnrc/netif.h` header within `net/gnrc/netif/hdr.h` (which we want to do in #10500), due to `net/gnrc/mac/types.h` being included with `net/gnrc/netif/mac.h` (which is included in `net/gnrc/netif.h`)

### Testing procedure
`examples/gnrc_networking_mac` should still be able to run with default configuration (GoMacH) and LWMAC configuration:

https://github.com/RIOT-OS/RIOT/blob/fdde802bd7fb258588bdbc3317a1ac40d0990aea/examples/gnrc_networking_mac/Makefile#L38-L41

`tests/unittests` (`tests-gnrc_mac_internal`) should still compilable and being able to run.

### Issues/PRs references
Preparation step for #10500