### PR TITLE
pkg/jerryscript: compile with "-Wno-comparison"

### DIFF
--- a/pkg/jerryscript/Makefile.jerryscript
+++ b/pkg/jerryscript/Makefile.jerryscript
@@ -2,7 +2,7 @@ BUILD_DIR  ?= $(CURDIR)/riot
 
 JERRYHEAP  ?= 16
 
-EXT_CFLAGS :=-D__TARGET_RIOT
+EXT_CFLAGS :=-D__TARGET_RIOT -Wno-conversion
 
 .PHONY: libjerry riot-jerry flash clean
 


### PR DESCRIPTION
### Contribution description

Fixes compile error with clang 6.0.0:

```
/tmp/dwq.0.3904292209592788/45b4e8be9caeab3af295ce6a0a31ba5a/build/pkg/jerryscript/jerry-ext/arg/arg-transform-functions.c:135:14: error: implicit conversion loses floating-point precision: 'double' to 'float' [-Werror,-Wconversion]
  if (isnan (*d))
      ~~~~~~~^~~
/usr/include/math.h:644:46: note: expanded from macro 'isnan'
#  define isnan(x) __MATH_TG ((x), __isnan, (x))
                   ~~~~~~~~~~~~~~~~~~~~~~~~~~^~~
/usr/include/math.h:559:16: note: expanded from macro '__MATH_TG'
   ? FUNC ## f ARGS                             \
     ~~~~~~~~~ ^~~~
1 error generated.
```
