### PR TITLE
 pkg/nimble: Remove warning suppressions, add patches

### DIFF
--- a/pkg/nimble/Makefile
+++ b/pkg/nimble/Makefile
@@ -14,7 +14,6 @@ ifeq (llvm,$(TOOLCHAIN))
 # `nimble/controller/src/ble_ll_adv.c` isn't used in our compilation path, so
 # tell LLVM/clang not to be so pedantic with this.
   CFLAGS += -Wno-unused-function
-  CFLAGS += -Wno-sometimes-uninitialized
 else
   CFLAGS += -Wno-unused-but-set-variable
 endif

--- a/pkg/nimble/Makefile
+++ b/pkg/nimble/Makefile
@@ -15,7 +15,6 @@ ifeq (llvm,$(TOOLCHAIN))
 # tell LLVM/clang not to be so pedantic with this.
   CFLAGS += -Wno-unused-function
   CFLAGS += -Wno-sometimes-uninitialized
-  CFLAGS += -Wno-address-of-packed-member
 else
   CFLAGS += -Wno-unused-but-set-variable
 endif

--- a/pkg/nimble/patches/0001-L2CAP-sm-do-not-discard-alignment-information.patch
+++ b/pkg/nimble/patches/0001-L2CAP-sm-do-not-discard-alignment-information.patch
@@ -1,0 +1,86 @@
+From 5986ec94d49cb4121e37114def029255e2b73b05 Mon Sep 17 00:00:00 2001
+From: Juan Carrano <j.carrano@fu-berlin.de>
+Date: Thu, 29 Nov 2018 13:40:36 +0100
+Subject: [PATCH] L2CAP sm: do not discard alignment information.
+
+ble_sm_gen_ediv and ble_sm_gen_master_id_rand took a simple pointer to
+integers, but were being called with pointers to members of a packed
+struct. This discarded the alignment information.
+
+Not only did it produce an error with clang's -Wno-address-of-packed-member,
+but it may also cause an error in a platform with alignment requirements.
+
+The solution was to modify both procedures to take a pointer to the whole
+structure instead of only the members.
+---
+ nimble/host/src/ble_sm.c | 16 ++++++++--------
+ 1 file changed, 8 insertions(+), 8 deletions(-)
+
+diff --git a/nimble/host/src/ble_sm.c b/nimble/host/src/ble_sm.c
+index c2cf97aa..09b33bf5 100644
+--- a/nimble/host/src/ble_sm.c
++++ b/nimble/host/src/ble_sm.c
+@@ -261,19 +261,19 @@ ble_sm_gen_pair_rand(uint8_t *pair_rand)
+ }
+ 
+ static int
+-ble_sm_gen_ediv(uint16_t *ediv)
++ble_sm_gen_ediv(struct ble_sm_master_id *master_id)
+ {
+     int rc;
+ 
+ #if MYNEWT_VAL(BLE_HS_DEBUG)
+     if (ble_sm_dbg_next_ediv_set) {
+         ble_sm_dbg_next_ediv_set = 0;
+-        *ediv = ble_sm_dbg_next_ediv;
++        master_id->ediv = ble_sm_dbg_next_ediv;
+         return 0;
+     }
+ #endif
+ 
+-    rc = ble_hs_hci_util_rand(ediv, sizeof *ediv);
++    rc = ble_hs_hci_util_rand(&master_id->ediv, sizeof master_id->ediv);
+     if (rc != 0) {
+         return rc;
+     }
+@@ -282,19 +282,19 @@ ble_sm_gen_ediv(uint16_t *ediv)
+ }
+ 
+ static int
+-ble_sm_gen_master_id_rand(uint64_t *master_id_rand)
++ble_sm_gen_master_id_rand(struct ble_sm_master_id *master_id)
+ {
+     int rc;
+ 
+ #if MYNEWT_VAL(BLE_HS_DEBUG)
+     if (ble_sm_dbg_next_master_id_rand_set) {
+         ble_sm_dbg_next_master_id_rand_set = 0;
+-        *master_id_rand = ble_sm_dbg_next_master_id_rand;
++        master_id->rand_val = ble_sm_dbg_next_master_id_rand;
+         return 0;
+     }
+ #endif
+ 
+-    rc = ble_hs_hci_util_rand(master_id_rand, sizeof *master_id_rand);
++    rc = ble_hs_hci_util_rand(&master_id->rand_val, sizeof master_id->rand_val);
+     if (rc != 0) {
+         return rc;
+     }
+@@ -2051,12 +2051,12 @@ ble_sm_key_exch_exec(struct ble_sm_proc *proc, struct ble_sm_result *res,
+             goto err;
+         }
+ 
+-        rc = ble_sm_gen_ediv(&master_id->ediv);
++        rc = ble_sm_gen_ediv(master_id);
+         if (rc != 0) {
+             os_mbuf_free_chain(txom);
+             goto err;
+         }
+-        rc = ble_sm_gen_master_id_rand(&master_id->rand_val);
++        rc = ble_sm_gen_master_id_rand(master_id);
+         if (rc != 0) {
+             os_mbuf_free_chain(txom);
+             goto err;
+-- 
+2.19.2
+


### PR DESCRIPTION
### Contribution description

This is a "slowfix" for the quickfix introduced in #10503 .

#### Pointer alignment

This is the most serious one.

Nimble contains a couple of casts that discard alignment information. This causes a warning with clang's -Wno-address-of-packed-member.

A previous PR (#10503) supressed that warning. This commit re-enables them and provides a patch to fix the offending code.

The fix has been submitted upstream, see apache/mynewt-nimble#252

#### The other warning.

The -Wno-sometimes-uninitialized suppression seems to no longer be necessary. Removing it as it may mask a real bug.

If the problem reappears, and if the comment is correct about it being only in an unused function, then instead of adding the CFLAG, _it should be fixed locally via a patch_.

### Testing procedure

Compile with LLVM. You should see no warning. I tried Arch Linux and our Docker image:

in `examples/nimble_gatt`:

```
$ BUILD_IN_DOCKER=1 DOCKER="sudo docker" TOOLCHAIN=llvm make all
$ make clean
$ TOOLCHAIN=llvm make all
```

### Issues/PRs references

Partially reverts #10503.
Upstream PR: apache/mynewt-nimble#252
