### PR TITLE
pkg/nordic_softdevice_ble: Use MAC48 as hardware address

### DIFF
--- a/pkg/nordic_softdevice_ble/src/ble-core.c
+++ b/pkg/nordic_softdevice_ble/src/ble-core.c
@@ -46,6 +46,7 @@
  */
 #include <stdbool.h>
 #include <stdint.h>
+#include <string.h>
 
 //#include "boards.h"
 //#include "nordic_common.h"
@@ -109,8 +110,9 @@ ble_stack_init(void)
  * @brief Return device EUI64 MAC address
  * @param addr pointer to a buffer to store the address
  */
+#include "ble-mac.h"
 void
-ble_get_mac(uint8_t addr[8])
+ble_get_mac(uint8_t addr[6])
 {
   uint32_t err_code;
   ble_gap_addr_t ble_addr;
@@ -118,7 +120,8 @@ ble_get_mac(uint8_t addr[8])
   err_code = sd_ble_gap_address_get(&ble_addr);
   APP_ERROR_CHECK(err_code);
 
-  IPV6_EUI64_CREATE_FROM_EUI48(addr, ble_addr.addr, ble_addr.addr_type);
+  ble_eui48(addr, ble_addr.addr,
+            ble_addr.addr_type == BLE_GAP_ADDR_TYPE_PUBLIC);
 }
 /*---------------------------------------------------------------------------*/
 /**

--- a/pkg/nordic_softdevice_ble/src/ble-core.h
+++ b/pkg/nordic_softdevice_ble/src/ble-core.h
@@ -70,11 +70,11 @@ void ble_advertising_init(const char *name);
 void ble_advertising_start(void);
 
 /**
- * @brief Return device EUI64 MAC address
+ * @brief Return device MAC address
  *
  * @param addr pointer to a buffer to store the address
  */
-void ble_get_mac(uint8_t addr[8]);
+void ble_get_mac(uint8_t addr[6]);
 
 #ifdef __cplusplus
 }

--- a/pkg/nordic_softdevice_ble/src/gnrc_nordic_ble_6lowpan.c
+++ b/pkg/nordic_softdevice_ble/src/gnrc_nordic_ble_6lowpan.c
@@ -45,6 +45,7 @@
 #include "msg.h"
 #include "thread.h"
 
+#include "net/eui48.h"
 #include "net/gnrc.h"
 #include "net/gnrc/netif.h"
 #include "net/gnrc/nettype.h"
@@ -104,15 +105,15 @@ static void _handle_raw_sixlowpan(ble_mac_inbuf_t *inbuf)
         return;
     }
 
-    gnrc_netif_hdr_init(netif_hdr->data, BLE_SIXLOWPAN_L2_ADDR_LEN, BLE_SIXLOWPAN_L2_ADDR_LEN);
-    gnrc_netif_hdr_set_src_addr(netif_hdr->data, inbuf->src, BLE_SIXLOWPAN_L2_ADDR_LEN);
-    gnrc_netif_hdr_set_dst_addr(netif_hdr->data, _ble_netif->l2addr, BLE_SIXLOWPAN_L2_ADDR_LEN);
+    gnrc_netif_hdr_init(netif_hdr->data, BLE_L2_ADDR_LEN, BLE_L2_ADDR_LEN);
+    gnrc_netif_hdr_set_src_addr(netif_hdr->data, inbuf->src, BLE_L2_ADDR_LEN);
+    gnrc_netif_hdr_set_dst_addr(netif_hdr->data, _ble_netif->l2addr, BLE_L2_ADDR_LEN);
     ((gnrc_netif_hdr_t *)netif_hdr->data)->if_pid = _ble_netif->pid;
 
-    DEBUG("_handle_raw_sixlowpan(): received packet from %02x:%02x:%02x:%02x:%02x:%02x:%02x:%02x "
+    DEBUG("_handle_raw_sixlowpan(): received packet from %02x:%02x:%02x:%02x:%02x:%02x "
             "of length %d\n",
-            inbuf->src[0], inbuf->src[1], inbuf->src[2], inbuf->src[3], inbuf->src[4],
-            inbuf->src[5], inbuf->src[6], inbuf->src[7], inbuf->len);
+            inbuf->src[0], inbuf->src[1], inbuf->src[2],
+            inbuf->src[3], inbuf->src[4], inbuf->src[5], inbuf->len);
 #if defined(MODULE_OD) && ENABLE_DEBUG
     od_hex_dump(inbuf->payload, inbuf->len, OD_WIDTH_DEFAULT);
 #endif
@@ -183,7 +184,7 @@ static int _netdev_init(netdev_t *dev)
     _ble_netif = dev->context;
     ble_stack_init();
     ble_mac_init(_ble_mac_callback);
-    _ble_netif->l2addr_len = BLE_SIXLOWPAN_L2_ADDR_LEN;
+    _ble_netif->l2addr_len = BLE_L2_ADDR_LEN;
     ble_get_mac(_ble_netif->l2addr);
     ble_advertising_init("RIOT BLE");
     ble_advertising_start();
@@ -198,15 +199,15 @@ static int _netdev_get(netdev_t *netdev, netopt_t opt,
 
     (void)netdev;
     switch (opt) {
-        case NETOPT_ADDRESS_LONG:
-            assert(max_len >= BLE_SIXLOWPAN_L2_ADDR_LEN);
-            memcpy(value, _ble_netif->l2addr, BLE_SIXLOWPAN_L2_ADDR_LEN);
-            res = BLE_SIXLOWPAN_L2_ADDR_LEN;
+        case NETOPT_ADDRESS:
+            assert(max_len >= BLE_L2_ADDR_LEN);
+            memcpy(value, _ble_netif->l2addr, BLE_L2_ADDR_LEN);
+            res = BLE_L2_ADDR_LEN;
             break;
         case NETOPT_ADDR_LEN:
         case NETOPT_SRC_LEN:
             assert(max_len == sizeof(uint16_t));
-            *((uint16_t *)value) = BLE_SIXLOWPAN_L2_ADDR_LEN;
+            *((uint16_t *)value) = BLE_L2_ADDR_LEN;
             res = sizeof(uint16_t);
             break;
         case NETOPT_PROTO:
@@ -220,9 +221,8 @@ static int _netdev_get(netdev_t *netdev, netopt_t opt,
             res = sizeof(uint16_t);
             break;
         case NETOPT_IPV6_IID:
-            memcpy(value, _ble_netif->l2addr, BLE_SIXLOWPAN_L2_ADDR_LEN);
-            value[0] ^= IPV6_IID_FLIP_VALUE;
-            res = BLE_SIXLOWPAN_L2_ADDR_LEN;
+            eui48_to_ipv6_iid((eui64_t *)value, (eui48_t *)_ble_netif->l2addr);
+            res = sizeof(uint64_t);
             break;
         default:
             break;

--- a/sys/net/gnrc/netif/gnrc_netif_device_type.c
+++ b/sys/net/gnrc/netif/gnrc_netif_device_type.c
@@ -42,9 +42,11 @@ int gnrc_netif_ipv6_iid_from_addr(const gnrc_netif_t *netif,
 #if GNRC_NETIF_L2ADDR_MAXLEN > 0
     if (netif->flags & GNRC_NETIF_FLAGS_HAS_L2ADDR) {
         switch (netif->device_type) {
-#if defined(MODULE_NETDEV_ETH) || defined(MODULE_ESP_NOW)
+#if defined(MODULE_NETDEV_ETH) || defined(MODULE_ESP_NOW) || \
+    defined(MODULE_NORDIC_SOFTDEVICE_BLE)
             case NETDEV_TYPE_ETHERNET:
             case NETDEV_TYPE_ESP_NOW:
+            case NETDEV_TYPE_BLE:
                 if (addr_len == sizeof(eui48_t)) {
                     eui48_to_ipv6_iid(iid, (const eui48_t *)addr);
                     return sizeof(eui64_t);
@@ -62,17 +64,6 @@ int gnrc_netif_ipv6_iid_from_addr(const gnrc_netif_t *netif,
                     return -EINVAL;
                 }
 #endif  /* defined(MODULE_NETDEV_IEEE802154) || defined(MODULE_XBEE) */
-#ifdef MODULE_NORDIC_SOFTDEVICE_BLE
-            case NETDEV_TYPE_BLE:
-                if (addr_len == sizeof(eui64_t)) {
-                    memcpy(iid, addr, sizeof(eui64_t));
-                    iid->uint8[0] ^= 0x02;
-                    return sizeof(eui64_t);
-                }
-                else {
-                    return -EINVAL;
-                }
-#endif  /* MODULE_NORDIC_SOFTDEVICE_BLE */
 #if defined(MODULE_CC110X) || defined(MODULE_NRFMIN)
             case NETDEV_TYPE_CC110X:
             case NETDEV_TYPE_NRFMIN:
@@ -105,9 +96,11 @@ int gnrc_netif_ipv6_iid_to_addr(const gnrc_netif_t *netif, const eui64_t *iid,
 {
     assert(netif->flags & GNRC_NETIF_FLAGS_HAS_L2ADDR);
     switch (netif->device_type) {
-#if defined(MODULE_NETDEV_ETH) || defined(MODULE_ESP_NOW)
+#if defined(MODULE_NETDEV_ETH) || defined(MODULE_ESP_NOW) || \
+    defined(MODULE_NORDIC_SOFTDEVICE_BLE)
         case NETDEV_TYPE_ETHERNET:
         case NETDEV_TYPE_ESP_NOW:
+        case NETDEV_TYPE_BLE:
             eui48_from_ipv6_iid((eui48_t *)addr, iid);
             return sizeof(eui48_t);
 #endif  /* defined(MODULE_NETDEV_ETH) || defined(MODULE_ESP_NOW) */
@@ -125,12 +118,6 @@ int gnrc_netif_ipv6_iid_to_addr(const gnrc_netif_t *netif, const eui64_t *iid,
             addr[1] = iid->uint8[7];
             return sizeof(uint16_t);
 #endif  /* MODULE_NETDEV_IEEE802154 */
-#ifdef MODULE_NORDIC_SOFTDEVICE_BLE
-        case NETDEV_TYPE_BLE:
-            memcpy(addr, iid, sizeof(eui64_t));
-            addr[0] ^= 0x02;
-            return sizeof(eui64_t);
-#endif  /* MODULE_NORDIC_SOFTDEVICE_BLE */
 #ifdef MODULE_CC110X
         case NETDEV_TYPE_CC110X:
             addr[0] = iid->uint8[7];


### PR DESCRIPTION
### Contribution description
This is just a compatibility issue waiting to happen as soon as there is support for a more standard-compliant implementation of BLE (like e.g. NimBLE ;-)).

### Testing procedure
`gnrc_networking` should still work with `nordic_softdevice_ble` (see [README](https://github.com/RIOT-OS/RIOT/blob/master/pkg/nordic_softdevice_ble/README-BLE-6LoWPAN.md)). I don't currently have the hardware at hand to test, so I pushed untested.

### Issues/PRs references
#10521 and should also help with @haukepetersen's NimBLE to GNRC integration work.

![gnrc_netif/gnrc_sixlowpan_iphc BLE capability](http://page.mi.fu-berlin.de/mlenders/netif_ble.svg)