### PR TITLE
 gnrc: remove ESP-Now related code-duplication

### DIFF
--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -835,8 +835,9 @@ int gnrc_netif_ipv6_get_iid(gnrc_netif_t *netif, eui64_t *eui64)
         }
 
         switch (netif->device_type) {
-#ifdef MODULE_NETDEV_ETH
+#if defined(MODULE_NETDEV_ETH) || defined(MODULE_ESP_NOW)
             case NETDEV_TYPE_ETHERNET:
+            case NETDEV_TYPE_ESP_NOW:
                 assert(netif->l2addr_len == ETHERNET_ADDR_LEN);
                 eui64->uint8[0] = netif->l2addr[0] ^ 0x02;
                 eui64->uint8[1] = netif->l2addr[1];
@@ -876,18 +877,6 @@ int gnrc_netif_ipv6_get_iid(gnrc_netif_t *netif, eui64_t *eui64)
             case NETDEV_TYPE_CC110X:
             case NETDEV_TYPE_NRFMIN:
                 _create_iid_from_short(netif, eui64);
-                return 0;
-#endif
-#if defined(MODULE_ESP_NOW)
-            case NETDEV_TYPE_ESP_NOW:
-                eui64->uint8[0] = netif->l2addr[0] ^ 0x02;
-                eui64->uint8[1] = netif->l2addr[1];
-                eui64->uint8[2] = netif->l2addr[2];
-                eui64->uint8[3] = 0xff;
-                eui64->uint8[4] = 0xfe;
-                eui64->uint8[5] = netif->l2addr[3];
-                eui64->uint8[6] = netif->l2addr[4];
-                eui64->uint8[7] = netif->l2addr[5];
                 return 0;
 #endif
             default:

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-6ln.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-6ln.c
@@ -40,8 +40,9 @@ static inline uint8_t _reverse_iid(const ipv6_addr_t *dst,
                                    const gnrc_netif_t *netif, uint8_t *l2addr)
 {
     switch (netif->device_type) {
-#ifdef MODULE_NETDEV_ETH
+#if defined(MODULE_NETDEV_ETH) || defined(MODULE_ESP_NOW)
         case NETDEV_TYPE_ETHERNET:
+        case NETDEV_TYPE_ESP_NOW:
             l2addr[0] = dst->u8[8] ^ 0x02;
             l2addr[1] = dst->u8[9];
             l2addr[2] = dst->u8[10];
@@ -49,7 +50,7 @@ static inline uint8_t _reverse_iid(const ipv6_addr_t *dst,
             l2addr[4] = dst->u8[14];
             l2addr[5] = dst->u8[15];
             return ETHERNET_ADDR_LEN;
-#endif  /* MODULE_NETDEV_ETH */
+#endif  /* defined(MODULE_NETDEV_ETH) || defined(MODULE_ESP_NOW) */
 #if defined(MODULE_NETDEV_IEEE802154) || defined(MODULE_XBEE)
         case NETDEV_TYPE_IEEE802154:
             /* assume address was based on EUI-64
@@ -69,16 +70,6 @@ static inline uint8_t _reverse_iid(const ipv6_addr_t *dst,
             l2addr[0] = dst->u8[15];
             return sizeof(uint8_t);
 #endif  /* MODULE_CC110X */
-#ifdef MODULE_ESP_NOW
-        case NETDEV_TYPE_ESP_NOW:
-            l2addr[0] = dst->u8[8] ^ 0x02;
-            l2addr[1] = dst->u8[9];
-            l2addr[2] = dst->u8[10];
-            l2addr[3] = dst->u8[13];
-            l2addr[4] = dst->u8[14];
-            l2addr[5] = dst->u8[15];
-            return ETHERNET_ADDR_LEN;
-#endif  /* MODULE_ESP_NOW */
         default:
             (void)dst;
             (void)l2addr;

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-arsm.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-arsm.c
@@ -183,11 +183,12 @@ static inline unsigned _get_l2addr_len(gnrc_netif_t *netif,
             (void)opt;
             return sizeof(uint8_t);
 #endif  /* MODULE_CC110X */
-#ifdef MODULE_NETDEV_ETH
+#if defined(MODULE_NETDEV_ETH) || defined(MODULE_ESP_NOW)
         case NETDEV_TYPE_ETHERNET:
+        case NETDEV_TYPE_ESP_NOW:
             (void)opt;
             return ETHERNET_ADDR_LEN;
-#endif  /* MODULE_NETDEV_ETH */
+#endif  /* defined(MODULE_NETDEV_ETH) || defined(MODULE_ESP_NOW) */
 #ifdef MODULE_NRFMIN
         case NETDEV_TYPE_NRFMIN:
             (void)opt;
@@ -204,11 +205,6 @@ static inline unsigned _get_l2addr_len(gnrc_netif_t *netif,
                     return 0U;
             }
 #endif  /* defined(MODULE_NETDEV_IEEE802154) || defined(MODULE_XBEE) */
-#ifdef MODULE_ESP_NOW
-        case NETDEV_TYPE_ESP_NOW:
-            (void)opt;
-            return ETHERNET_ADDR_LEN;
-#endif  /* MODULE_ESP_NOW */
         default:
             (void)opt;
             return 0U;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
ESP-Now addresses seem to be basically EUI-48s (at least in the way they are converted into an IPv6 IID). So there is no reason to create code duplication for it.

### Testing procedure
IPv6 over ESP-Now should still work.

### Issues/PRs references
Follow-up on #10509.