### PR TITLE
tests/periph_timer: adapt for atmega based boards

### DIFF
--- a/tests/periph_timer/Makefile
+++ b/tests/periph_timer/Makefile
@@ -6,4 +6,11 @@ FEATURES_REQUIRED = periph_timer
 
 TEST_ON_CI_WHITELIST += all
 
+ifneq (,$(filter arduino-duemilanove arduino-mega2560 arduino-uno waspmote-pro,$(BOARD)))
+  TIMER_SPEED ?= 250000
+endif
+
+TIMER_SPEED ?= 1000000
+
+CFLAGS += -DTIMER_SPEED=$(TIMER_SPEED)
 include $(RIOTBASE)/Makefile.include

--- a/tests/periph_timer/README.md
+++ b/tests/periph_timer/README.md
@@ -1,0 +1,17 @@
+# Periph Timer Test
+
+## About
+
+This application will test all configured peripheral timers of the target
+platform. For each timer, it will set each channel with an incrementing
+timeout: CH0 is set to 5ms, CH1 to 10ms, CH2 to 15ms and so on.
+
+## Expected Result
+
+The output should show that every channel fired after an evenly distributed
+amount of time, i.e. the diff values should be equal (with some jitter...).
+
+## Note
+
+This test does however **NOT** show whether the timeouts and diffs were correct
+in relation to the expected real-time; use e.g. tests/xtimer_msg for this.

--- a/tests/periph_timer/main.c
+++ b/tests/periph_timer/main.c
@@ -32,7 +32,6 @@
 #endif
 
 #define MAX_CHANNELS        (10U)
-#define TIM_SPEED           (1000000ul) /* try to run with 1MHz */
 #define CHAN_OFFSET         (5000U)     /* fire every 5ms */
 #define COOKIE              (100U)      /* for checking if arg is passed */
 
@@ -61,7 +60,7 @@ static int test_timer(unsigned num)
     }
 
     /* initialize and halt timer */
-    if (timer_init(TIMER_DEV(num), TIM_SPEED, cb, (void *)(COOKIE * num)) < 0) {
+    if (timer_init(TIMER_DEV(num), TIMER_SPEED, cb, (void *)(COOKIE * num)) < 0) {
         printf("TIMER_%u: ERROR on initialization - skipping\n\n", num);
         return 0;
     }

--- a/tests/periph_timer/main.c
+++ b/tests/periph_timer/main.c
@@ -115,16 +115,6 @@ int main(void)
     int res = 0;
 
     puts("\nTest for peripheral TIMERs\n");
-    puts("This test will test all configured peripheral timers of the\n"
-         "targeted platform. For each timer, it will set each channel with\n"
-         "an incrementing timeout. CH0 set to 5ms, CH1 to 10ms, CH2 to 15ms\n"
-         "and so on.\n"
-         "In the output you should see that every channel fired, after an\n"
-         "evenly distributed amount of time -> the shown diff values should\n"
-         "be pretty much equal (to some jitter...)\n"
-         "This test does however NOT show, if the timeouts were correct in\n"
-         "relation to the expected real-time ~ use e.g. tests/xtimer_msg for\n"
-         "this.\n\n");
 
     printf("Available timers: %i\n", TIMER_NUMOF);
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

- optimise binary size to fit on Arduino-uno by moving test description from code to README
- set TIMER_SPEED to 250kHz for atmega based boards


### Testing procedure

compile and flash `tests/periph_timer` for arduino-uno, also try any other atmega based board, e.g. arduino-mega2560. On master they all fail, with this PR they should succeed.


### Issues/PRs references

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
