### PR TITLE
gnrc_sixlowpan_iphc: allow address compression for non-IEEE802.15.4

### DIFF
--- a/sys/include/net/gnrc/netif/hdr.h
+++ b/sys/include/net/gnrc/netif/hdr.h
@@ -21,9 +21,11 @@
 #ifndef NET_GNRC_NETIF_HDR_H
 #define NET_GNRC_NETIF_HDR_H
 
+#include <errno.h>
 #include <string.h>
 #include <stdint.h>
 
+#include "net/gnrc/netif/internal.h"
 #include "net/gnrc/pkt.h"
 #include "net/gnrc/pktbuf.h"
 #include "net/gnrc/netif.h"
@@ -196,6 +198,65 @@ static inline void gnrc_netif_hdr_set_dst_addr(gnrc_netif_hdr_t *hdr, uint8_t *a
 
     memcpy(((uint8_t *)(hdr + 1)) + hdr->src_l2addr_len, addr, addr_len);
 }
+
+#if defined(MODULE_GNRC_IPV6) || defined(DOXYGEN)
+/**
+ * @brief   Converts the source address of a given @ref net_gnrc_netif_hdr to
+ *          an IPv6 IID
+ *
+ * @note    @p netif is intentionally required to be provided so that the caller
+ *          needs to retrieve it from gnrc_netif_hdr_t::if_pid of @p hdr only
+ *          once instead of this function retrieving it at every call.
+ *
+ * @pre `netif->pid == hdr->if_pid`
+ *
+ * @param[in] netif A network interface. gnrc_netif_t::pid must be equal to
+ *                  gnrc_netif_hdr_t::if_pid of @p hdr.
+ * @param[in] hdr   Header to convert source address from.
+ * @param[out] iid  The IID based on gnrc_netif_t::device_type.
+ *
+ * @return  same as gnrc_netif_ipv6_iid_from_addr().
+ */
+static inline int gnrc_netif_hdr_ipv6_iid_from_src(const gnrc_netif_t *netif,
+                                                   const gnrc_netif_hdr_t *hdr,
+                                                   eui64_t *iid)
+{
+    return gnrc_netif_ipv6_iid_from_addr(netif,
+                                         gnrc_netif_hdr_get_src_addr(hdr),
+                                         hdr->src_l2addr_len,
+                                         iid);
+}
+
+/**
+ * @brief   Converts the destination address of a given @ref net_gnrc_netif_hdr
+ *          to an IPv6 IID
+ *
+ * @note    @p netif is intentionally required to be provided so that the caller
+ *          needs to retrieve it from gnrc_netif_hdr_t::if_pid of @p hdr only
+ *          once instead of this function retrieving it at every call.
+ *
+ * @pre `netif->pid == hdr->if_pid`
+ *
+ * @param[in] netif A network interface. gnrc_netif_t::pid must be equal to
+ *                  gnrc_netif_hdr_t::if_pid of @p hdr.
+ * @param[in] hdr   Header to convert destination address from.
+ * @param[out] iid  The IID based on gnrc_netif_t::device_type.
+ *
+ * @return  same as gnrc_netif_ipv6_iid_from_addr().
+ */
+static inline int gnrc_netif_hdr_ipv6_iid_from_dst(const gnrc_netif_t *netif,
+                                                   const gnrc_netif_hdr_t *hdr,
+                                                   eui64_t *iid)
+{
+    return gnrc_netif_ipv6_iid_from_addr(netif,
+                                         gnrc_netif_hdr_get_dst_addr(hdr),
+                                         hdr->dst_l2addr_len,
+                                         iid);
+}
+#else   /* defined(MODULE_GNRC_IPV6) || defined(DOXYGEN) */
+#define gnrc_netif_hdr_ipv6_iid_from_src(netif, hdr, iid)   (-ENOTSUP);
+#define gnrc_netif_hdr_ipv6_iid_from_dst(netif, hdr, iid)   (-ENOTSUP);
+#endif  /* defined(MODULE_GNRC_IPV6) || defined(DOXYGEN) */
 
 /**
  * @brief   Builds a generic network interface header for sending and

--- a/sys/net/gnrc/network_layer/sixlowpan/iphc/gnrc_sixlowpan_iphc.c
+++ b/sys/net/gnrc/network_layer/sixlowpan/iphc/gnrc_sixlowpan_iphc.c
@@ -19,9 +19,9 @@
 #include <stdbool.h>
 
 #include "byteorder.h"
-#include "net/ieee802154.h"
 #include "net/ipv6/hdr.h"
 #include "net/gnrc.h"
+#include "net/gnrc/netif/internal.h"
 #include "net/gnrc/sixlowpan.h"
 #include "net/gnrc/sixlowpan/ctx.h"
 #include "net/gnrc/sixlowpan/frag.h"
@@ -232,6 +232,7 @@ void gnrc_sixlowpan_iphc_recv(gnrc_pktsnip_t *sixlo, void *rbuf_ptr,
     assert(sixlo != NULL);
     gnrc_pktsnip_t *ipv6, *netif;
     gnrc_netif_hdr_t *netif_hdr;
+    gnrc_netif_t *iface;
     ipv6_hdr_t *ipv6_hdr;
     uint8_t *iphc_hdr = sixlo->data;
     size_t payload_offset = SIXLOWPAN_IPHC_HDR_LEN;
@@ -331,6 +332,7 @@ void gnrc_sixlowpan_iphc_recv(gnrc_pktsnip_t *sixlo, void *rbuf_ptr,
     netif = gnrc_pktsnip_search_type(sixlo, GNRC_NETTYPE_NETIF);
     assert(netif != NULL);
     netif_hdr = netif->data;
+    iface = gnrc_netif_hdr_get_netif(netif_hdr);
     switch (iphc_hdr[IPHC2_IDX] & (SIXLOWPAN_IPHC2_SAC | SIXLOWPAN_IPHC2_SAM)) {
 
         case IPHC_SAC_SAM_FULL:
@@ -354,9 +356,13 @@ void gnrc_sixlowpan_iphc_recv(gnrc_pktsnip_t *sixlo, void *rbuf_ptr,
             break;
 
         case IPHC_SAC_SAM_L2:
-            ieee802154_get_iid((eui64_t *)(&ipv6_hdr->src.u64[1]),
-                               gnrc_netif_hdr_get_src_addr(netif_hdr),
-                               netif_hdr->src_l2addr_len);
+            if (gnrc_netif_hdr_ipv6_iid_from_src(
+                        iface, netif_hdr, (eui64_t *)(&ipv6_hdr->src.u64[1])
+                    ) < 0) {
+                DEBUG("6lo iphc: could not get source's IID\n");
+                _recv_error_release(sixlo, ipv6, rbuf);
+                return;
+            }
             ipv6_addr_set_link_local_prefix(&ipv6_hdr->src);
             break;
 
@@ -384,9 +390,13 @@ void gnrc_sixlowpan_iphc_recv(gnrc_pktsnip_t *sixlo, void *rbuf_ptr,
 
         case IPHC_SAC_SAM_CTX_L2:
             assert(ctx != NULL);
-            ieee802154_get_iid((eui64_t *)(&ipv6_hdr->src.u64[1]),
-                               gnrc_netif_hdr_get_src_addr(netif_hdr),
-                               netif_hdr->src_l2addr_len);
+            if (gnrc_netif_hdr_ipv6_iid_from_src(
+                        iface, netif_hdr, (eui64_t *)(&ipv6_hdr->src.u64[1])
+                    ) < 0) {
+                DEBUG("6lo iphc: could not get source's IID\n");
+                _recv_error_release(sixlo, ipv6, rbuf);
+                return;
+            }
             ipv6_addr_init_prefix(&ipv6_hdr->src, &ctx->prefix,
                                   ctx->prefix_len);
             break;
@@ -433,9 +443,13 @@ void gnrc_sixlowpan_iphc_recv(gnrc_pktsnip_t *sixlo, void *rbuf_ptr,
             break;
 
         case IPHC_M_DAC_DAM_U_L2:
-            ieee802154_get_iid((eui64_t *)(&ipv6_hdr->dst.u64[1]),
-                               gnrc_netif_hdr_get_dst_addr(netif_hdr),
-                               netif_hdr->dst_l2addr_len);
+            if (gnrc_netif_hdr_ipv6_iid_from_dst(
+                        iface, netif_hdr, (eui64_t *)(&ipv6_hdr->dst.u64[1])
+                    ) < 0) {
+                DEBUG("6lo iphc: could not get destination's IID\n");
+                _recv_error_release(sixlo, ipv6, rbuf);
+                return;
+            }
             ipv6_addr_set_link_local_prefix(&ipv6_hdr->dst);
             break;
 
@@ -456,9 +470,13 @@ void gnrc_sixlowpan_iphc_recv(gnrc_pktsnip_t *sixlo, void *rbuf_ptr,
             break;
 
         case IPHC_M_DAC_DAM_U_CTX_L2:
-            ieee802154_get_iid((eui64_t *)(&ipv6_hdr->dst.u64[1]),
-                               gnrc_netif_hdr_get_dst_addr(netif_hdr),
-                               netif_hdr->dst_l2addr_len);
+            if (gnrc_netif_hdr_ipv6_iid_from_dst(
+                        iface, netif_hdr, (eui64_t *)(&ipv6_hdr->dst.u64[1])
+                    ) < 0) {
+                DEBUG("6lo iphc: could not get destination's IID\n");
+                _recv_error_release(sixlo, ipv6, rbuf);
+                return;
+            }
             ipv6_addr_init_prefix(&ipv6_hdr->dst, &ctx->prefix,
                                   ctx->prefix_len);
             break;
@@ -641,6 +659,7 @@ void gnrc_sixlowpan_iphc_send(gnrc_pktsnip_t *pkt, void *ctx, unsigned page)
     assert(pkt != NULL);
     gnrc_netif_hdr_t *netif_hdr = pkt->data;
     ipv6_hdr_t *ipv6_hdr;
+    gnrc_netif_t *iface = gnrc_netif_hdr_get_netif(netif_hdr);
     uint8_t *iphc_hdr;
     gnrc_sixlowpan_ctx_t *src_ctx = NULL, *dst_ctx = NULL;
     gnrc_pktsnip_t *dispatch, *ptr = pkt->next;
@@ -816,18 +835,14 @@ void gnrc_sixlowpan_iphc_send(gnrc_pktsnip_t *pkt, void *ctx, unsigned page)
             eui64_t iid;
             iid.uint64.u64 = 0;
 
-            if ((netif_hdr->src_l2addr_len == 2) ||
-                (netif_hdr->src_l2addr_len == 4) ||
-                (netif_hdr->src_l2addr_len == 8)) {
-                /* prefer to create IID from netif header if available */
-                ieee802154_get_iid(&iid, gnrc_netif_hdr_get_src_addr(netif_hdr),
-                                   netif_hdr->src_l2addr_len);
+            gnrc_netif_acquire(iface);
+            if (gnrc_netif_ipv6_get_iid(iface, &iid) < 0) {
+                DEBUG("6lo iphc: could not get interface's IID\n");
+                gnrc_netif_release(iface);
+                gnrc_pktbuf_release(pkt);
+                return;
             }
-            else {
-                /* but take from driver otherwise */
-                gnrc_netapi_get(netif_hdr->if_pid, NETOPT_IPV6_IID, 0, &iid,
-                                sizeof(eui64_t));
-            }
+            gnrc_netif_release(iface);
 
             if ((ipv6_hdr->src.u64[1].u64 == iid.uint64.u64) ||
                 _context_overlaps_iid(src_ctx, &ipv6_hdr->src, &iid)) {
@@ -941,8 +956,11 @@ void gnrc_sixlowpan_iphc_send(gnrc_pktsnip_t *pkt, void *ctx, unsigned page)
             }
         }
 
-        ieee802154_get_iid(&iid, gnrc_netif_hdr_get_dst_addr(netif_hdr),
-                           netif_hdr->dst_l2addr_len);
+        if (gnrc_netif_hdr_ipv6_iid_from_dst(iface, netif_hdr, &iid) < 0) {
+            DEBUG("6lo iphc: could not get destination's IID\n");
+            gnrc_pktbuf_release(pkt);
+            return;
+        }
 
         if ((ipv6_hdr->dst.u64[1].u64 == iid.uint64.u64) ||
             _context_overlaps_iid(dst_ctx, &(ipv6_hdr->dst), &iid)) {


### PR DESCRIPTION
### Contribution description
This should allow @haukepetersen to use NimBLE with GNRC's 6Lo ;-).

### Testing procedure
Run GNRC on top of NimBLE. IPv6 address compression should not break the addresses anymore ;-). If someone wants to revive #4861 that would also be an option for testing.

### Issues/PRs references
Depends on #10500 and #10520.

![gnrc_netif/gnrc_sixlowpan_iphc BLE capability](http://page.mi.fu-berlin.de/mlenders/netif_ble.svg)