### PR TITLE
ethernet: make input parameter const

### DIFF
--- a/sys/include/net/ethernet.h
+++ b/sys/include/net/ethernet.h
@@ -58,7 +58,7 @@ extern "C" {
  * @param[in] mac       A 48-bit MAC address. Is expected to be at least
  *                      @ref ETHERNET_ADDR_LEN long.
  */
-static inline void ethernet_get_iid(eui64_t *eui64, uint8_t *mac)
+static inline void ethernet_get_iid(eui64_t *eui64, const uint8_t *mac)
 {
     eui64->uint8[0] = mac[0] ^ 0x02;
     eui64->uint8[1] = mac[1];


### PR DESCRIPTION
### Contribution description
Small API change to make the input parameter of `ethernet_get_iid()` `const`.

### Testing procedure
`gnrc_networking` should still configure the link-local addresses for the interface correctly on an Ethernet-based platform (`ethernet_get_iid()` is used by `netdev_eth`).

### Issues/PRs references
None, but I want to make the usage in #10513 simpler.