### PR TITLE
 gnrc_netif: centralize device-type-specific functions

### DIFF
--- a/sys/include/net/gnrc/netif.h
+++ b/sys/include/net/gnrc/netif.h
@@ -46,6 +46,7 @@
 #endif
 #include "net/ndp.h"
 #include "net/netdev.h"
+#include "net/netopt.h"
 #include "rmutex.h"
 
 #ifdef __cplusplus

--- a/sys/include/net/gnrc/netif/internal.h
+++ b/sys/include/net/gnrc/netif/internal.h
@@ -22,6 +22,7 @@
 #define NET_GNRC_NETIF_INTERNAL_H
 
 #include "net/gnrc/netif.h"
+#include "net/netopt.h"
 
 #ifdef MODULE_GNRC_IPV6_NIB
 #include "net/gnrc/ipv6/nib/conf.h"
@@ -414,6 +415,17 @@ static inline bool gnrc_netif_is_6lbr(const gnrc_netif_t *netif)
  *              need adaptions for your port
  * @{
  */
+/**
+ * @brief   Get the default link-layer address option for the given
+ *          gnrc_netif_t::device_type of a network interface
+ *
+ * @param[in] netif     The network interface to get the default link-layer
+ *                      address option for.
+ *
+ * @return  Either @ref NETOPT_ADDRESS or @ref NETOPT_ADDRESS_LONG.
+ */
+netopt_t gnrc_netif_get_l2addr_opt(const gnrc_netif_t *netif);
+
 #if defined(MODULE_GNRC_IPV6) || defined(DOXYGEN)
 /**
  * @brief   Converts a given hardware address to an IPv6 IID.

--- a/sys/include/net/gnrc/netif/internal.h
+++ b/sys/include/net/gnrc/netif/internal.h
@@ -495,9 +495,40 @@ static inline int gnrc_netif_ipv6_get_iid(gnrc_netif_t *netif, eui64_t *iid)
     (void)iid;
     return -ENOTSUP;
 }
+
+/**
+ * @brief   Derives the length of the link-layer address in an NDP link-layer
+ *          address option from that option's length field and the given device
+ *          type.
+ *
+ * @note    If an RFC exists that specifies how IPv6 operates over a link-layer,
+ *          this function usually implements the section "Unicast Address
+ *          Mapping".
+ *
+ * @see [RFC 4861, section 4.6.1](https://tools.ietf.org/html/rfc4861#section-4.6.1)
+ *
+ * @pre `netif->flags & GNRC_NETIF_FLAGS_HAS_L2ADDR`
+ *
+ * @attention   When `NDEBUG` is not defined, the node fails with an assertion
+ *              instead of returning `-ENOTSUP`
+ *
+ * @param[in] netif The network interface @p opt was received on within an NDP
+ *                  message.
+ * @param[in] opt   An NDP source/target link-layer address option.
+ *
+ * @return  Length of the link-layer address in @p opt on success
+ * @return  `-ENOTSUP`, when implementation does not know how to derive the
+ *          length of the link-layer address from @p opt's length field based
+ *          on gnrc_netif_t::device_type of @p netif.
+ * @return  `-EINVAL` if `opt->len` was an invalid value for the given
+ *          gnrc_netif_t::device_type of @p netif.
+ */
+int gnrc_netif_ndp_addr_len_from_l2ao(gnrc_netif_t *netif,
+                                      const ndp_opt_t *opt);
 #else   /* defined(MODULE_GNRC_IPV6) || defined(DOXYGEN) */
-#define gnrc_netif_ipv6_iid_from_addr(netif, addr, addr_len, iid) (-ENOTSUP)
-#define gnrc_netif_ipv6_iid_to_addr(netif, iid, addr)         (-ENOTSUP)
+#define gnrc_netif_ipv6_iid_from_addr(netif, addr, addr_len, iid)   (-ENOTSUP)
+#define gnrc_netif_ipv6_iid_to_addr(netif, iid, addr)               (-ENOTSUP)
+#define gnrc_netif_ndp_addr_len_from_l2ao(netif, opt)               (-ENOTSUP)
 #define gnrc_netif_ipv6_get_iid(netif, iid)                         (-ENOTSUP)
 #endif  /* defined(MODULE_GNRC_IPV6) || defined(DOXYGEN) */
 /** @} */

--- a/sys/include/net/gnrc/netif/internal.h
+++ b/sys/include/net/gnrc/netif/internal.h
@@ -403,6 +403,17 @@ static inline bool gnrc_netif_is_6lbr(const gnrc_netif_t *netif)
 #define gnrc_netif_is_6lbr(netif)               (false)
 #endif
 
+/**
+ * @name    Device type based function
+ *
+ * These functions' behavior is based around the gnrc_netif_t::device_type of
+ * an interface.
+ *
+ * @attention   Special care needs to be taken for those functions when porting
+ *              a new network device type or link-layer protocol: They might
+ *              need adaptions for your port
+ * @{
+ */
 #if defined(MODULE_GNRC_IPV6) || defined(DOXYGEN)
 /**
  * @brief   Converts a given hardware address to an IPv6 IID.
@@ -489,6 +500,7 @@ static inline int gnrc_netif_ipv6_get_iid(gnrc_netif_t *netif, eui64_t *iid)
 #define gnrc_netif_ipv6_iid_to_addr(netif, iid, addr)         (-ENOTSUP)
 #define gnrc_netif_ipv6_get_iid(netif, iid)                         (-ENOTSUP)
 #endif  /* defined(MODULE_GNRC_IPV6) || defined(DOXYGEN) */
+/** @} */
 
 #ifdef __cplusplus
 }

--- a/sys/include/net/gnrc/netif/internal.h
+++ b/sys/include/net/gnrc/netif/internal.h
@@ -428,6 +428,14 @@ netopt_t gnrc_netif_get_l2addr_opt(const gnrc_netif_t *netif);
 
 #if defined(MODULE_GNRC_IPV6) || defined(DOXYGEN)
 /**
+ * @brief   Initialize IPv6 MTU and other packet length related members of
+ *          @ref gnrc_netif_t based on gnrc_netif_t::device_type
+ *
+ * @param[in,out] netif The network interface to initialize the MTU for.
+ */
+void gnrc_netif_ipv6_init_mtu(gnrc_netif_t *netif);
+
+/**
  * @brief   Converts a given hardware address to an IPv6 IID.
  *
  * @attention When the link-layer of the interface has link-layer addresses, and
@@ -538,6 +546,7 @@ static inline int gnrc_netif_ipv6_get_iid(gnrc_netif_t *netif, eui64_t *iid)
 int gnrc_netif_ndp_addr_len_from_l2ao(gnrc_netif_t *netif,
                                       const ndp_opt_t *opt);
 #else   /* defined(MODULE_GNRC_IPV6) || defined(DOXYGEN) */
+#define gnrc_netif_ipv6_init_mtu(netif)                             (void)netif
 #define gnrc_netif_ipv6_iid_from_addr(netif, addr, addr_len, iid)   (-ENOTSUP)
 #define gnrc_netif_ipv6_iid_to_addr(netif, iid, addr)               (-ENOTSUP)
 #define gnrc_netif_ndp_addr_len_from_l2ao(netif, opt)               (-ENOTSUP)

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -1136,60 +1136,7 @@ static void _init_from_device(gnrc_netif_t *netif)
     (void)res;
     assert(res == sizeof(tmp));
     netif->device_type = (uint8_t)tmp;
-    switch (netif->device_type) {
-#if defined(MODULE_NETDEV_IEEE802154) || defined(MODULE_NRFMIN) || \
-    defined(MODULE_XBEE) || defined(MODULE_ESP_NOW) || \
-    defined(MODULE_GNRC_SIXLOENC)
-        case NETDEV_TYPE_IEEE802154:
-        case NETDEV_TYPE_NRFMIN:
-#ifdef MODULE_GNRC_SIXLOWPAN_IPHC
-            netif->flags |= GNRC_NETIF_FLAGS_6LO_HC;
-#endif
-            /* intentionally falls through */
-        case NETDEV_TYPE_ESP_NOW:
-#ifdef MODULE_GNRC_IPV6
-            res = dev->driver->get(dev, NETOPT_MAX_PACKET_SIZE, &tmp, sizeof(tmp));
-            assert(res == sizeof(tmp));
-#ifdef MODULE_GNRC_SIXLOWPAN
-            netif->ipv6.mtu = IPV6_MIN_MTU;
-            netif->sixlo.max_frag_size = tmp;
-#else
-            netif->ipv6.mtu = tmp;
-#endif
-#endif
-            break;
-#endif  /* MODULE_NETDEV_IEEE802154 */
-#ifdef MODULE_NETDEV_ETH
-        case NETDEV_TYPE_ETHERNET:
-#ifdef MODULE_GNRC_IPV6
-            netif->ipv6.mtu = ETHERNET_DATA_LEN;
-#endif
-#if defined(MODULE_GNRC_SIXLOWPAN_IPHC) && defined(MODULE_GNRC_SIXLOENC)
-            netif->flags |= GNRC_NETIF_FLAGS_6LO_HC;
-#endif
-            break;
-#endif
-#ifdef MODULE_NORDIC_SOFTDEVICE_BLE
-        case NETDEV_TYPE_BLE:
-            netif->ipv6.mtu = IPV6_MIN_MTU;
-#ifdef MODULE_GNRC_SIXLOWPAN_IPHC
-            netif->flags |= GNRC_NETIF_FLAGS_6LO_HC;
-#endif
-            break;
-#endif
-        default:
-#ifdef MODULE_GNRC_IPV6
-            res = dev->driver->get(dev, NETOPT_MAX_PACKET_SIZE, &tmp, sizeof(tmp));
-            if (res < 0) {
-                /* assume maximum possible transition unit */
-                netif->ipv6.mtu = UINT16_MAX;
-            }
-            else {
-                netif->ipv6.mtu = tmp;
-            }
-#endif
-            break;
-    }
+    gnrc_netif_ipv6_init_mtu(netif);
     _update_l2addr_from_dev(netif);
 }
 

--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -1109,27 +1109,8 @@ static void _update_l2addr_from_dev(gnrc_netif_t *netif)
 {
     netdev_t *dev = netif->dev;
     int res;
-    netopt_t opt = NETOPT_ADDRESS;
+    netopt_t opt = gnrc_netif_get_l2addr_opt(netif);
 
-    switch (netif->device_type) {
-#if defined(MODULE_NETDEV_IEEE802154) || defined(MODULE_XBEE) \
-    || defined(MODULE_NORDIC_SOFTDEVICE_BLE)
-        case NETDEV_TYPE_BLE:
-        case NETDEV_TYPE_IEEE802154: {
-                uint16_t tmp;
-
-                res = dev->driver->get(dev, NETOPT_SRC_LEN, &tmp, sizeof(tmp));
-                assert(res == sizeof(tmp));
-                netif->l2addr_len = (uint8_t)tmp;
-                if (tmp == IEEE802154_LONG_ADDRESS_LEN) {
-                    opt = NETOPT_ADDRESS_LONG;
-                }
-            }
-            break;
-#endif
-        default:
-            break;
-    }
     res = dev->driver->get(dev, opt, netif->l2addr,
                            sizeof(netif->l2addr));
     if (res != -ENOTSUP) {

--- a/sys/net/gnrc/netif/gnrc_netif_device_type.c
+++ b/sys/net/gnrc/netif/gnrc_netif_device_type.c
@@ -21,6 +21,35 @@
 #include "net/eui48.h"
 #include "net/ieee802154.h"
 
+netopt_t gnrc_netif_get_l2addr_opt(const gnrc_netif_t *netif)
+{
+    netopt_t res = NETOPT_ADDRESS;
+
+    switch (netif->device_type) {
+#if defined(MODULE_NETDEV_IEEE802154) || defined(MODULE_XBEE) || \
+    defined(MODULE_NORDIC_SOFTDEVICE_BLE)
+        case NETDEV_TYPE_IEEE802154:
+        case NETDEV_TYPE_BLE: {
+                netdev_t *dev = netif->dev;
+                int r;
+                uint16_t tmp;
+
+                r = dev->driver->get(dev, NETOPT_SRC_LEN, &tmp, sizeof(tmp));
+                assert(r == sizeof(tmp));
+                assert(r <= ((int)UINT8_MAX));
+                (void)r;
+                if (tmp == IEEE802154_LONG_ADDRESS_LEN) {
+                    res = NETOPT_ADDRESS_LONG;
+                }
+            }
+            break;
+#endif
+        default:
+            break;
+    }
+    return res;
+}
+
 #ifdef MODULE_GNRC_IPV6
 #if defined(MODULE_CC110X) || defined(MODULE_NRFMIN)
 static void _create_iid_from_short(const uint8_t *addr, size_t addr_len,


### PR DESCRIPTION
### Contribution description
This moves all remaining  `switch (netif->device_type)`-like functions to `gnrc_netif_device_type.c` and also applies the warning mechanisms introduced in #10513. The hope is that if a new device type is implemented the implementor will stumble over these functions basically immediately.

### Testing procedure
Pinging a global address with `gnrc_networking` via a `gnrc_border_router` should still work for

- [x] Ethernet (here just two `gnrc_networking` examples with one having `ifconfig <if> -rtr_adv` and the other a global address configured by hand should be enough)
- [x] IEEE 802.15.4
- [ ] Nordic BLE softdevice
- [ ] ~~cc110x~~ (see https://github.com/RIOT-OS/RIOT/issues/10723)
- [ ] ~~nrfmin~~ (see https://github.com/RIOT-OS/RIOT/issues/10723)
- [ ] ~~ESP NOW~~ (see https://github.com/RIOT-OS/RIOT/issues/10723)

After pinging the global address of the other node, the neighbor cache (`nib neigh`) of the border router (or advertising router - so the one were you *didn't* type `ifconfig <if> -rtr_adv`) should contain the other node's global address with the correct link-layer address

### Issues/PRs references
Depends on ~~#10513~~ (merged)

![gnrc_netif/gnrc_sixlowpan_iphc BLE capability](http://page.mi.fu-berlin.de/mlenders/netif_ble.svg)