### PR TITLE
drivers/adcxx1c: improve error handling

### DIFF
--- a/drivers/adcxx1c/adcxx1c_saul.c
+++ b/drivers/adcxx1c/adcxx1c_saul.c
@@ -26,7 +26,9 @@
 
 static int read_adc(const void *dev, phydat_t *res)
 {
-    adcxx1c_read_raw((const adcxx1c_t *)dev, res->val);
+    if (adcxx1c_read_raw((const adcxx1c_t *)dev, res->val)) {
+        return -ECANCELED;
+    }
 
     res->unit = UNIT_NONE;
     res->scale = 0;

--- a/drivers/adcxx1c/adcxx1c_saul.c
+++ b/drivers/adcxx1c/adcxx1c_saul.c
@@ -26,7 +26,7 @@
 
 static int read_adc(const void *dev, phydat_t *res)
 {
-    if (adcxx1c_read_raw((const adcxx1c_t *)dev, res->val)) {
+    if (adcxx1c_read_raw((const adcxx1c_t *)dev, &res->val[0])) {
         return -ECANCELED;
     }
 


### PR DESCRIPTION

### Contribution description

ADCxx1C driver was not handling error properly. Most of the i2c error were ignored.
This adds errror checking and make use of LOG_* to print logs. It also return `-ECANCELED` in SAUL wrapper in case of error.

### Testing procedure

Normal flow (without i2c errors) still works, tested with `examples/default` and `tests/driver_adcxx1c`.
