### PR TITLE
periph/adc: support for ADC extension API 

### DIFF
--- a/boards/common/arduino-mkr/include/periph_conf.h
+++ b/boards/common/arduino-mkr/include/periph_conf.h
@@ -163,7 +163,7 @@ static const pwm_conf_t pwm_config[] = {
 #define ADC_0_GAIN_FACTOR_DEFAULT          ADC_INPUTCTRL_GAIN_1X
 #define ADC_0_REF_DEFAULT                  ADC_REFCTRL_REFSEL_INT1V
 
-static const adc_conf_chan_t adc_channels[] = {
+static const adc_conf_chan_t adc_config[] = {
     /* port, pin, muxpos */
     {GPIO_PIN(PA, 2), ADC_INPUTCTRL_MUXPOS_PIN0},     /* A0 */
     {GPIO_PIN(PB, 2), ADC_INPUTCTRL_MUXPOS_PIN10},    /* A1 */

--- a/boards/feather-m0/include/periph_conf.h
+++ b/boards/feather-m0/include/periph_conf.h
@@ -169,7 +169,7 @@ static const pwm_conf_t pwm_config[] = {
 #define ADC_0_GAIN_FACTOR_DEFAULT          ADC_INPUTCTRL_GAIN_1X
 #define ADC_0_REF_DEFAULT                  ADC_REFCTRL_REFSEL_INT1V
 
-static const adc_conf_chan_t adc_channels[] = {
+static const adc_conf_chan_t adc_config[] = {
     /* port, pin, muxpos */
     { GPIO_PIN(PA, 2), ADC_INPUTCTRL_MUXPOS_PIN0 },     /* A0 */
     { GPIO_PIN(PB, 8), ADC_INPUTCTRL_MUXPOS_PIN2 },     /* A1 */

--- a/boards/samd21-xpro/include/periph_conf.h
+++ b/boards/samd21-xpro/include/periph_conf.h
@@ -294,7 +294,7 @@ static const i2c_conf_t i2c_config[] = {
 #define ADC_0_GAIN_FACTOR_DEFAULT          ADC_INPUTCTRL_GAIN_1X
 #define ADC_0_REF_DEFAULT                  ADC_REFCTRL_REFSEL_INT1V
 
-static const adc_conf_chan_t adc_channels[] = {
+static const adc_conf_chan_t adc_config[] = {
     /* port, pin, muxpos */
     {GPIO_PIN(PB, 0), ADC_INPUTCTRL_MUXPOS_PIN8},      /* EXT1, pin 3 */
     {GPIO_PIN(PB, 1), ADC_INPUTCTRL_MUXPOS_PIN9},      /* EXT1, pin 4 */

--- a/boards/saml21-xpro/include/periph_conf.h
+++ b/boards/saml21-xpro/include/periph_conf.h
@@ -152,7 +152,7 @@ static const i2c_conf_t i2c_config[] = {
 #define ADC_0_CLK_SOURCE                   0 /* GCLK_GENERATOR_0 */
 #define ADC_0_PRESCALER                    ADC_CTRLB_PRESCALER_DIV256
 
-static const adc_conf_chan_t adc_channels[] = {
+static const adc_conf_chan_t adc_config[] = {
     /* port, pin, muxpos */
     {GPIO_PIN(PA, 10), ADC_INPUTCTRL_MUXPOS(ADC_INPUTCTRL_MUXPOS_AIN18)},
     {GPIO_PIN(PA, 11), ADC_INPUTCTRL_MUXPOS(ADC_INPUTCTRL_MUXPOS_AIN19)},

--- a/boards/samr21-xpro/include/periph_conf.h
+++ b/boards/samr21-xpro/include/periph_conf.h
@@ -265,7 +265,7 @@ static const i2c_conf_t i2c_config[] = {
 #define ADC_0_GAIN_FACTOR_DEFAULT          ADC_INPUTCTRL_GAIN_1X
 #define ADC_0_REF_DEFAULT                  ADC_REFCTRL_REFSEL_INT1V
 
-static const adc_conf_chan_t adc_channels[] = {
+static const adc_conf_chan_t adc_config[] = {
     /* port, pin, muxpos */
     {GPIO_PIN(PA, 6), ADC_INPUTCTRL_MUXPOS_PIN6},      /* EXT1, pin 3 */
     {GPIO_PIN(PA, 7), ADC_INPUTCTRL_MUXPOS_PIN7},      /* EXT1, pin 4 */

--- a/boards/samr30-xpro/include/periph_conf.h
+++ b/boards/samr30-xpro/include/periph_conf.h
@@ -135,7 +135,7 @@ static const i2c_conf_t i2c_config[] = {
 #define ADC_0_CLK_SOURCE                        0 /* GCLK_GENERATOR_0 */
 #define ADC_0_PRESCALER                         ADC_CTRLB_PRESCALER_DIV256
 
-static const adc_conf_chan_t adc_channels[] = {
+static const adc_conf_chan_t adc_config[] = {
     /* port, pin, muxpos */
     {GPIO_PIN(PA, 6), ADC_INPUTCTRL_MUXPOS(ADC_INPUTCTRL_MUXPOS_AIN6)}, /* EXT1, pin 3 */
     {GPIO_PIN(PA, 7), ADC_INPUTCTRL_MUXPOS(ADC_INPUTCTRL_MUXPOS_AIN7)}, /* EXT1, pin 4 */

--- a/boards/sensebox_samd21/include/periph_conf.h
+++ b/boards/sensebox_samd21/include/periph_conf.h
@@ -204,7 +204,7 @@ static const i2c_conf_t i2c_config[] = {
 #define ADC_0_REF_DEFAULT                  ADC_REFCTRL_REFSEL_INT1V
 
 /* Digital pins (1 to 6) on the board can be configured as analog inputs */
-static const adc_conf_chan_t adc_channels[] = {
+static const adc_conf_chan_t adc_config[] = {
     /* port, pin, muxpos */
     { GPIO_PIN(PA, 4), ADC_INPUTCTRL_MUXPOS_PIN4 },     /* Digital 1 */
     { GPIO_PIN(PA, 5), ADC_INPUTCTRL_MUXPOS_PIN5 },     /* Digital 2 */

--- a/boards/sodaq-explorer/include/periph_conf.h
+++ b/boards/sodaq-explorer/include/periph_conf.h
@@ -156,7 +156,7 @@ static const uart_conf_t uart_config[] = {
 #define ADC_0_GAIN_FACTOR_DEFAULT          ADC_INPUTCTRL_GAIN_1X
 #define ADC_0_REF_DEFAULT                  ADC_REFCTRL_REFSEL_INT1V
 
-static const adc_conf_chan_t adc_channels[] = {
+static const adc_conf_chan_t adc_config[] = {
     /* port, pin, muxpos */
     {GPIO_PIN(PB, 0), ADC_INPUTCTRL_MUXPOS_PIN8},     /* A0 */
     {GPIO_PIN(PB, 1), ADC_INPUTCTRL_MUXPOS_PIN9},     /* A1 */

--- a/boards/sodaq-one/include/periph_conf.h
+++ b/boards/sodaq-one/include/periph_conf.h
@@ -149,7 +149,7 @@ static const uart_conf_t uart_config[] = {
 #define ADC_0_GAIN_FACTOR_DEFAULT          ADC_INPUTCTRL_GAIN_1X
 #define ADC_0_REF_DEFAULT                  ADC_REFCTRL_REFSEL_INT1V
 
-static const adc_conf_chan_t adc_channels[] = {
+static const adc_conf_chan_t adc_config[] = {
     /* port, pin, muxpos */
     {GPIO_PIN(PA, 2), ADC_INPUTCTRL_MUXPOS_PIN0},     /* A0 */
     {GPIO_PIN(PA, 3), ADC_INPUTCTRL_MUXPOS_PIN1},     /* A1 */

--- a/cpu/atmega_common/periph/adc.c
+++ b/cpu/atmega_common/periph/adc.c
@@ -44,7 +44,7 @@ static inline void _done(void)
     mutex_unlock(&lock);
 }
 
-int adc_init(adc_t line)
+int adc_init_ll(adc_t line)
 {
     /* check if the line is valid */
     if (line >= ADC_NUMOF) {
@@ -99,7 +99,7 @@ int adc_init(adc_t line)
     return 0;
 }
 
-int adc_sample(adc_t line, adc_res_t res)
+int adc_sample_ll(adc_t line, adc_res_t res)
 {
     int sample = 0;
 

--- a/cpu/atmega_common/periph/adc.c
+++ b/cpu/atmega_common/periph/adc.c
@@ -44,7 +44,7 @@ static inline void _done(void)
     mutex_unlock(&lock);
 }
 
-int adc_init_ll(adc_t line)
+int adc_init_cpu(adc_t line)
 {
     /* check if the line is valid */
     if (line >= ADC_NUMOF) {
@@ -99,7 +99,7 @@ int adc_init_ll(adc_t line)
     return 0;
 }
 
-int adc_sample_ll(adc_t line, adc_res_t res)
+int adc_sample_cpu(adc_t line, adc_res_t res)
 {
     int sample = 0;
 

--- a/cpu/cc2538/periph/adc.c
+++ b/cpu/cc2538/periph/adc.c
@@ -34,7 +34,7 @@
 
 static cc2538_soc_adc_t *soc_adc = (cc2538_soc_adc_t *)SOC_ADC_BASE;
 
-int adc_init(adc_t line)
+int adc_init_ll(adc_t line)
 {
     if (line >= ADC_NUMOF) {
         DEBUG("adc_init: invalid ADC line (%d)!\n", line);
@@ -51,7 +51,7 @@ int adc_init(adc_t line)
     return 0;
 }
 
-int adc_sample(adc_t line, adc_res_t res)
+int adc_sample_ll(adc_t line, adc_res_t res)
 {
     /* check if adc line valid */
     if (line >= ADC_NUMOF) {

--- a/cpu/cc2538/periph/adc.c
+++ b/cpu/cc2538/periph/adc.c
@@ -34,7 +34,7 @@
 
 static cc2538_soc_adc_t *soc_adc = (cc2538_soc_adc_t *)SOC_ADC_BASE;
 
-int adc_init_ll(adc_t line)
+int adc_init_cpu(adc_t line)
 {
     if (line >= ADC_NUMOF) {
         DEBUG("adc_init: invalid ADC line (%d)!\n", line);
@@ -51,7 +51,7 @@ int adc_init_ll(adc_t line)
     return 0;
 }
 
-int adc_sample_ll(adc_t line, adc_res_t res)
+int adc_sample_cpu(adc_t line, adc_res_t res)
 {
     /* check if adc line valid */
     if (line >= ADC_NUMOF) {

--- a/cpu/efm32/periph/adc.c
+++ b/cpu/efm32/periph/adc.c
@@ -30,7 +30,7 @@
 
 static mutex_t adc_lock[ADC_DEV_NUMOF];
 
-int adc_init(adc_t line)
+int adc_init_ll(adc_t line)
 {
     /* check if line is valid */
     if (line >= ADC_NUMOF) {
@@ -59,7 +59,7 @@ int adc_init(adc_t line)
     return 0;
 }
 
-int adc_sample(adc_t line, adc_res_t res)
+int adc_sample_ll(adc_t line, adc_res_t res)
 {
     /* resolutions larger than 12 bits are not supported */
     if (res >= ADC_MODE_UNDEF(0)) {

--- a/cpu/efm32/periph/adc.c
+++ b/cpu/efm32/periph/adc.c
@@ -30,7 +30,7 @@
 
 static mutex_t adc_lock[ADC_DEV_NUMOF];
 
-int adc_init_ll(adc_t line)
+int adc_init_cpu(adc_t line)
 {
     /* check if line is valid */
     if (line >= ADC_NUMOF) {
@@ -59,7 +59,7 @@ int adc_init_ll(adc_t line)
     return 0;
 }
 
-int adc_sample_ll(adc_t line, adc_res_t res)
+int adc_sample_cpu(adc_t line, adc_res_t res)
 {
     /* resolutions larger than 12 bits are not supported */
     if (res >= ADC_MODE_UNDEF(0)) {

--- a/cpu/esp32/periph/adc.c
+++ b/cpu/esp32/periph/adc.c
@@ -171,7 +171,7 @@ static bool _adc_conf_check(void);
 static void _adc_module_init(void);
 static bool _adc_module_initialized  = false;
 
-int adc_init(adc_t line)
+int adc_init_ll(adc_t line)
 {
     CHECK_PARAM_RET (line < adc_chn_num, -1)
 
@@ -274,7 +274,7 @@ int adc_init(adc_t line)
 }
 
 
-int adc_sample(adc_t line, adc_res_t res)
+int adc_sample_ll(adc_t line, adc_res_t res)
 {
     CHECK_PARAM_RET (line < adc_chn_num, -1)
     CHECK_PARAM_RET (res <= ADC_RES_12BIT, -1)
@@ -351,7 +351,7 @@ int adc_vref_to_gpio25 (void)
         return -1;
     }
 
-    if (adc_init(line) == 0)
+    if (adc_init_ll(line) == 0)
     {
         uint8_t rtcio = _gpio_rtcio_map[adc_pins[line]];
         RTCCNTL.bias_conf.dbg_atten = 0;

--- a/cpu/esp32/periph/adc.c
+++ b/cpu/esp32/periph/adc.c
@@ -171,7 +171,7 @@ static bool _adc_conf_check(void);
 static void _adc_module_init(void);
 static bool _adc_module_initialized  = false;
 
-int adc_init_ll(adc_t line)
+int adc_init_cpu(adc_t line)
 {
     CHECK_PARAM_RET (line < adc_chn_num, -1)
 
@@ -274,7 +274,7 @@ int adc_init_ll(adc_t line)
 }
 
 
-int adc_sample_ll(adc_t line, adc_res_t res)
+int adc_sample_cpu(adc_t line, adc_res_t res)
 {
     CHECK_PARAM_RET (line < adc_chn_num, -1)
     CHECK_PARAM_RET (res <= ADC_RES_12BIT, -1)
@@ -351,7 +351,7 @@ int adc_vref_to_gpio25 (void)
         return -1;
     }
 
-    if (adc_init_ll(line) == 0)
+    if (adc_init_cpu(line) == 0)
     {
         uint8_t rtcio = _gpio_rtcio_map[adc_pins[line]];
         RTCCNTL.bias_conf.dbg_atten = 0;

--- a/cpu/esp8266/periph/adc.c
+++ b/cpu/esp8266/periph/adc.c
@@ -33,7 +33,7 @@
 
 #if defined(ADC_NUMOF) && ADC_NUMOF > 0
 
-int adc_init_ll(adc_t line)
+int adc_init_cpu(adc_t line)
 {
     CHECK_PARAM_RET (line < ADC_NUMOF, -1)
 
@@ -42,7 +42,7 @@ int adc_init_ll(adc_t line)
 }
 
 
-int adc_sample_ll(adc_t line, adc_res_t res)
+int adc_sample_cpu(adc_t line, adc_res_t res)
 {
     CHECK_PARAM_RET (line < ADC_NUMOF, -1)
     CHECK_PARAM_RET (res == ADC_RES_10BIT, -1)

--- a/cpu/esp8266/periph/adc.c
+++ b/cpu/esp8266/periph/adc.c
@@ -33,7 +33,7 @@
 
 #if defined(ADC_NUMOF) && ADC_NUMOF > 0
 
-int adc_init(adc_t line)
+int adc_init_ll(adc_t line)
 {
     CHECK_PARAM_RET (line < ADC_NUMOF, -1)
 
@@ -42,7 +42,7 @@ int adc_init(adc_t line)
 }
 
 
-int adc_sample(adc_t line, adc_res_t res)
+int adc_sample_ll(adc_t line, adc_res_t res)
 {
     CHECK_PARAM_RET (line < ADC_NUMOF, -1)
     CHECK_PARAM_RET (res == ADC_RES_10BIT, -1)

--- a/cpu/kinetis/periph/adc.c
+++ b/cpu/kinetis/periph/adc.c
@@ -151,7 +151,7 @@ int kinetis_adc_calibrate(ADC_Type *dev)
     return 0;
 }
 
-int adc_init_ll(adc_t line)
+int adc_init_cpu(adc_t line)
 {
     /* make sure the given line is valid */
     if (line >= ADC_NUMOF) {
@@ -207,7 +207,7 @@ int adc_init_ll(adc_t line)
     return res;
 }
 
-int adc_sample_ll(adc_t line, adc_res_t res)
+int adc_sample_cpu(adc_t line, adc_res_t res)
 {
     int sample;
 

--- a/cpu/kinetis/periph/adc.c
+++ b/cpu/kinetis/periph/adc.c
@@ -151,7 +151,7 @@ int kinetis_adc_calibrate(ADC_Type *dev)
     return 0;
 }
 
-int adc_init(adc_t line)
+int adc_init_ll(adc_t line)
 {
     /* make sure the given line is valid */
     if (line >= ADC_NUMOF) {
@@ -207,7 +207,7 @@ int adc_init(adc_t line)
     return res;
 }
 
-int adc_sample(adc_t line, adc_res_t res)
+int adc_sample_ll(adc_t line, adc_res_t res)
 {
     int sample;
 

--- a/cpu/lm4f120/periph/adc.c
+++ b/cpu/lm4f120/periph/adc.c
@@ -80,7 +80,7 @@ static inline void done(void)
     mutex_unlock(&lock);
 }
 
-int adc_init(adc_t line)
+int adc_init_ll(adc_t line)
 {
     /* make sure the given ADC line is valid */
     if (line >= ADC_NUMOF) {
@@ -100,7 +100,7 @@ int adc_init(adc_t line)
     return 0;
 }
 
-int adc_sample(adc_t line, adc_res_t res)
+int adc_sample_ll(adc_t line, adc_res_t res)
 {
     int value[2];
 

--- a/cpu/lm4f120/periph/adc.c
+++ b/cpu/lm4f120/periph/adc.c
@@ -80,7 +80,7 @@ static inline void done(void)
     mutex_unlock(&lock);
 }
 
-int adc_init_ll(adc_t line)
+int adc_init_cpu(adc_t line)
 {
     /* make sure the given ADC line is valid */
     if (line >= ADC_NUMOF) {
@@ -100,7 +100,7 @@ int adc_init_ll(adc_t line)
     return 0;
 }
 
-int adc_sample_ll(adc_t line, adc_res_t res)
+int adc_sample_cpu(adc_t line, adc_res_t res)
 {
     int value[2];
 

--- a/cpu/nrf51/periph/adc.c
+++ b/cpu/nrf51/periph/adc.c
@@ -47,7 +47,7 @@ static inline void done(void)
     mutex_unlock(&lock);
 }
 
-int adc_init_ll(adc_t line)
+int adc_init_cpu(adc_t line)
 {
     if (line >= ADC_NUMOF) {
         return -1;
@@ -55,7 +55,7 @@ int adc_init_ll(adc_t line)
     return 0;
 }
 
-int adc_sample_ll(adc_t line, adc_res_t res)
+int adc_sample_cpu(adc_t line, adc_res_t res)
 {
     int val;
 

--- a/cpu/nrf51/periph/adc.c
+++ b/cpu/nrf51/periph/adc.c
@@ -47,7 +47,7 @@ static inline void done(void)
     mutex_unlock(&lock);
 }
 
-int adc_init(adc_t line)
+int adc_init_ll(adc_t line)
 {
     if (line >= ADC_NUMOF) {
         return -1;
@@ -55,7 +55,7 @@ int adc_init(adc_t line)
     return 0;
 }
 
-int adc_sample(adc_t line, adc_res_t res)
+int adc_sample_ll(adc_t line, adc_res_t res)
 {
     int val;
 

--- a/cpu/nrf52/periph/adc.c
+++ b/cpu/nrf52/periph/adc.c
@@ -67,7 +67,7 @@ static inline void done(void)
     mutex_unlock(&lock);
 }
 
-int adc_init(adc_t line)
+int adc_init_ll(adc_t line)
 {
     if (line >= ADC_NUMOF) {
         return -1;
@@ -103,7 +103,7 @@ int adc_init(adc_t line)
     return 0;
 }
 
-int adc_sample(adc_t line, adc_res_t res)
+int adc_sample_ll(adc_t line, adc_res_t res)
 {
     assert(line < ADC_NUMOF);
 

--- a/cpu/nrf52/periph/adc.c
+++ b/cpu/nrf52/periph/adc.c
@@ -67,7 +67,7 @@ static inline void done(void)
     mutex_unlock(&lock);
 }
 
-int adc_init_ll(adc_t line)
+int adc_init_cpu(adc_t line)
 {
     if (line >= ADC_NUMOF) {
         return -1;
@@ -103,7 +103,7 @@ int adc_init_ll(adc_t line)
     return 0;
 }
 
-int adc_sample_ll(adc_t line, adc_res_t res)
+int adc_sample_cpu(adc_t line, adc_res_t res)
 {
     assert(line < ADC_NUMOF);
 

--- a/cpu/sam0_common/periph/adc.c
+++ b/cpu/sam0_common/periph/adc.c
@@ -153,8 +153,8 @@ static int _adc_configure(adc_res_t res)
 int adc_init_ll(adc_t line)
 {
     _prep();
-    gpio_init(adc_channels[line].pin, GPIO_IN);
-    gpio_init_mux(adc_channels[line].pin, GPIO_MUX_B);
+    gpio_init(adc_config[line].pin, GPIO_IN);
+    gpio_init_mux(adc_config[line].pin, GPIO_MUX_B);
     _done();
     return 0;
 }
@@ -173,9 +173,9 @@ int adc_sample_ll(adc_t line, adc_res_t res)
     }
 #ifdef CPU_SAMD21
     ADC_0_DEV->INPUTCTRL.reg = ADC_0_GAIN_FACTOR_DEFAULT |
-                               adc_channels[line].muxpos | ADC_0_NEG_INPUT;
+                               adc_config[line].muxpos | ADC_0_NEG_INPUT;
 #else /* CPU_SAML21 */
-    ADC_0_DEV->INPUTCTRL.reg = adc_channels[line].muxpos | ADC_0_NEG_INPUT;
+    ADC_0_DEV->INPUTCTRL.reg = adc_config[line].muxpos | ADC_0_NEG_INPUT;
 #endif
     while (_adc_syncing()) {}
     /* Start the conversion */

--- a/cpu/sam0_common/periph/adc.c
+++ b/cpu/sam0_common/periph/adc.c
@@ -150,7 +150,7 @@ static int _adc_configure(adc_res_t res)
     return 0;
 }
 
-int adc_init(adc_t line)
+int adc_init_ll(adc_t line)
 {
     _prep();
     gpio_init(adc_channels[line].pin, GPIO_IN);
@@ -159,7 +159,7 @@ int adc_init(adc_t line)
     return 0;
 }
 
-int adc_sample(adc_t line, adc_res_t res)
+int adc_sample_ll(adc_t line, adc_res_t res)
 {
     if (line >= ADC_NUMOF) {
         DEBUG("adc: line arg not applicable\n");

--- a/cpu/sam0_common/periph/adc.c
+++ b/cpu/sam0_common/periph/adc.c
@@ -150,7 +150,7 @@ static int _adc_configure(adc_res_t res)
     return 0;
 }
 
-int adc_init_ll(adc_t line)
+int adc_init_cpu(adc_t line)
 {
     _prep();
     gpio_init(adc_config[line].pin, GPIO_IN);
@@ -159,7 +159,7 @@ int adc_init_ll(adc_t line)
     return 0;
 }
 
-int adc_sample_ll(adc_t line, adc_res_t res)
+int adc_sample_cpu(adc_t line, adc_res_t res)
 {
     if (line >= ADC_NUMOF) {
         DEBUG("adc: line arg not applicable\n");

--- a/cpu/sam3/periph/adc.c
+++ b/cpu/sam3/periph/adc.c
@@ -49,7 +49,7 @@ static inline void done(void)
     mutex_unlock(&lock);
 }
 
-int adc_init(adc_t line)
+int adc_init_ll(adc_t line)
 {
     assert(line < ADC_NUMOF);
 
@@ -68,7 +68,7 @@ int adc_init(adc_t line)
     return 0;
 }
 
-int adc_sample(adc_t line, adc_res_t res)
+int adc_sample_ll(adc_t line, adc_res_t res)
 {
     assert(line < ADC_NUMOF);
 

--- a/cpu/sam3/periph/adc.c
+++ b/cpu/sam3/periph/adc.c
@@ -49,7 +49,7 @@ static inline void done(void)
     mutex_unlock(&lock);
 }
 
-int adc_init_ll(adc_t line)
+int adc_init_cpu(adc_t line)
 {
     assert(line < ADC_NUMOF);
 
@@ -68,7 +68,7 @@ int adc_init_ll(adc_t line)
     return 0;
 }
 
-int adc_sample_ll(adc_t line, adc_res_t res)
+int adc_sample_cpu(adc_t line, adc_res_t res)
 {
     assert(line < ADC_NUMOF);
 

--- a/cpu/stm32f0/periph/adc.c
+++ b/cpu/stm32f0/periph/adc.c
@@ -52,7 +52,7 @@ static inline void done(void)
     mutex_unlock(&lock);
 }
 
-int adc_init(adc_t line)
+int adc_init_ll(adc_t line)
 {
     /* make sure the given line is valid */
     if (line >= ADC_NUMOF) {
@@ -75,7 +75,7 @@ int adc_init(adc_t line)
     return 0;
 }
 
-int adc_sample(adc_t line,  adc_res_t res)
+int adc_sample_ll(adc_t line,  adc_res_t res)
 {
     int sample;
 

--- a/cpu/stm32f0/periph/adc.c
+++ b/cpu/stm32f0/periph/adc.c
@@ -52,7 +52,7 @@ static inline void done(void)
     mutex_unlock(&lock);
 }
 
-int adc_init_ll(adc_t line)
+int adc_init_cpu(adc_t line)
 {
     /* make sure the given line is valid */
     if (line >= ADC_NUMOF) {
@@ -75,7 +75,7 @@ int adc_init_ll(adc_t line)
     return 0;
 }
 
-int adc_sample_ll(adc_t line,  adc_res_t res)
+int adc_sample_cpu(adc_t line,  adc_res_t res)
 {
     int sample;
 

--- a/cpu/stm32f1/periph/adc.c
+++ b/cpu/stm32f1/periph/adc.c
@@ -65,7 +65,7 @@ static inline void done(adc_t line)
     mutex_unlock(&locks[adc_config[line].dev]);
 }
 
-int adc_init_ll(adc_t line)
+int adc_init_cpu(adc_t line)
 {
     uint32_t clk_div = 2;
 
@@ -125,7 +125,7 @@ int adc_init_ll(adc_t line)
     return 0;
 }
 
-int adc_sample_ll(adc_t line, adc_res_t res)
+int adc_sample_cpu(adc_t line, adc_res_t res)
 {
     int sample;
 

--- a/cpu/stm32f1/periph/adc.c
+++ b/cpu/stm32f1/periph/adc.c
@@ -65,7 +65,7 @@ static inline void done(adc_t line)
     mutex_unlock(&locks[adc_config[line].dev]);
 }
 
-int adc_init(adc_t line)
+int adc_init_ll(adc_t line)
 {
     uint32_t clk_div = 2;
 
@@ -125,7 +125,7 @@ int adc_init(adc_t line)
     return 0;
 }
 
-int adc_sample(adc_t line, adc_res_t res)
+int adc_sample_ll(adc_t line, adc_res_t res)
 {
     int sample;
 

--- a/cpu/stm32f2/periph/adc.c
+++ b/cpu/stm32f2/periph/adc.c
@@ -70,7 +70,7 @@ static inline void done(adc_t line)
     mutex_unlock(&locks[adc_config[line].dev]);
 }
 
-int adc_init(adc_t line)
+int adc_init_ll(adc_t line)
 {
     uint32_t clk_div = 2;
 
@@ -111,7 +111,7 @@ int adc_init(adc_t line)
     return 0;
 }
 
-int adc_sample(adc_t line, adc_res_t res)
+int adc_sample_ll(adc_t line, adc_res_t res)
 {
     int sample;
 

--- a/cpu/stm32f2/periph/adc.c
+++ b/cpu/stm32f2/periph/adc.c
@@ -70,7 +70,7 @@ static inline void done(adc_t line)
     mutex_unlock(&locks[adc_config[line].dev]);
 }
 
-int adc_init_ll(adc_t line)
+int adc_init_cpu(adc_t line)
 {
     uint32_t clk_div = 2;
 
@@ -111,7 +111,7 @@ int adc_init_ll(adc_t line)
     return 0;
 }
 
-int adc_sample_ll(adc_t line, adc_res_t res)
+int adc_sample_cpu(adc_t line, adc_res_t res)
 {
     int sample;
 

--- a/cpu/stm32f4/periph/adc.c
+++ b/cpu/stm32f4/periph/adc.c
@@ -64,7 +64,7 @@ static inline void done(adc_t line)
     mutex_unlock(&locks[adc_config[line].dev]);
 }
 
-int adc_init_ll(adc_t line)
+int adc_init_cpu(adc_t line)
 {
     uint32_t clk_div = 2;
 
@@ -94,7 +94,7 @@ int adc_init_ll(adc_t line)
     return 0;
 }
 
-int adc_sample_ll(adc_t line, adc_res_t res)
+int adc_sample_cpu(adc_t line, adc_res_t res)
 {
     int sample;
 

--- a/cpu/stm32f4/periph/adc.c
+++ b/cpu/stm32f4/periph/adc.c
@@ -64,7 +64,7 @@ static inline void done(adc_t line)
     mutex_unlock(&locks[adc_config[line].dev]);
 }
 
-int adc_init(adc_t line)
+int adc_init_ll(adc_t line)
 {
     uint32_t clk_div = 2;
 
@@ -94,7 +94,7 @@ int adc_init(adc_t line)
     return 0;
 }
 
-int adc_sample(adc_t line, adc_res_t res)
+int adc_sample_ll(adc_t line, adc_res_t res)
 {
     int sample;
 

--- a/cpu/stm32l0/periph/adc.c
+++ b/cpu/stm32l0/periph/adc.c
@@ -87,7 +87,7 @@ static void _disable_adc(void)
     }
 }
 
-int adc_init(adc_t line)
+int adc_init_ll(adc_t line)
 {
     /* make sure the given line is valid */
     if (line >= ADC_NUMOF) {
@@ -123,7 +123,7 @@ int adc_init(adc_t line)
     return 0;
 }
 
-int adc_sample(adc_t line,  adc_res_t res)
+int adc_sample_ll(adc_t line,  adc_res_t res)
 {
     int sample;
 

--- a/cpu/stm32l0/periph/adc.c
+++ b/cpu/stm32l0/periph/adc.c
@@ -87,7 +87,7 @@ static void _disable_adc(void)
     }
 }
 
-int adc_init_ll(adc_t line)
+int adc_init_cpu(adc_t line)
 {
     /* make sure the given line is valid */
     if (line >= ADC_NUMOF) {
@@ -123,7 +123,7 @@ int adc_init_ll(adc_t line)
     return 0;
 }
 
-int adc_sample_ll(adc_t line,  adc_res_t res)
+int adc_sample_cpu(adc_t line,  adc_res_t res)
 {
     int sample;
 

--- a/cpu/stm32l1/periph/adc.c
+++ b/cpu/stm32l1/periph/adc.c
@@ -101,7 +101,7 @@ static void adc_set_sample_time(uint8_t time)
     ADC1->SMPR3 = reg32;
 }
 
-int adc_init_ll(adc_t line)
+int adc_init_cpu(adc_t line)
 {
     /* check if the line is valid */
     if (line >= ADC_NUMOF) {
@@ -152,7 +152,7 @@ int adc_init_ll(adc_t line)
     return 0;
 }
 
-int adc_sample_ll(adc_t line, adc_res_t res)
+int adc_sample_cpu(adc_t line, adc_res_t res)
 {
     int sample;
 

--- a/cpu/stm32l1/periph/adc.c
+++ b/cpu/stm32l1/periph/adc.c
@@ -101,7 +101,7 @@ static void adc_set_sample_time(uint8_t time)
     ADC1->SMPR3 = reg32;
 }
 
-int adc_init(adc_t line)
+int adc_init_ll(adc_t line)
 {
     /* check if the line is valid */
     if (line >= ADC_NUMOF) {
@@ -152,7 +152,7 @@ int adc_init(adc_t line)
     return 0;
 }
 
-int adc_sample(adc_t line, adc_res_t res)
+int adc_sample_ll(adc_t line, adc_res_t res)
 {
     int sample;
 

--- a/cpu/stm32l4/periph/adc.c
+++ b/cpu/stm32l4/periph/adc.c
@@ -103,7 +103,7 @@ static inline int _pin_num(gpio_t pin)
     return (pin & 0x0f);
 }
 
-int adc_init_ll(adc_t line)
+int adc_init_cpu(adc_t line)
 {
     /* check if the line is valid */
     if (line >= ADC_NUMOF) {
@@ -179,7 +179,7 @@ int adc_init_ll(adc_t line)
     return 0;
 }
 
-int adc_sample_ll(adc_t line, adc_res_t res)
+int adc_sample_cpu(adc_t line, adc_res_t res)
 {
     int sample;
 

--- a/cpu/stm32l4/periph/adc.c
+++ b/cpu/stm32l4/periph/adc.c
@@ -103,7 +103,7 @@ static inline int _pin_num(gpio_t pin)
     return (pin & 0x0f);
 }
 
-int adc_init(adc_t line)
+int adc_init_ll(adc_t line)
 {
     /* check if the line is valid */
     if (line >= ADC_NUMOF) {
@@ -179,7 +179,7 @@ int adc_init(adc_t line)
     return 0;
 }
 
-int adc_sample(adc_t line, adc_res_t res)
+int adc_sample_ll(adc_t line, adc_res_t res)
 {
     int sample;
 

--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -148,6 +148,10 @@ ifneq (,$(filter ethos,$(USEMODULE)))
   USEMODULE += tsrb
 endif
 
+ifneq (,$(filter extend_adc,$(USEMODULE)))
+  USEMODULE += extend
+endif
+
 ifneq (,$(filter feetech,$(USEMODULE)))
   USEMODULE += uart_half_duplex
 endif

--- a/drivers/Makefile.include
+++ b/drivers/Makefile.include
@@ -74,6 +74,10 @@ ifneq (,$(filter encx24j600,$(USEMODULE)))
   USEMODULE_INCLUDES += $(RIOTBASE)/drivers/encx24j600/include
 endif
 
+ifneq (,$(filter extend,$(USEMODULE)))
+  USEMODULE_INCLUDES += $(RIOTBASE)/drivers/extend/include
+endif
+
 ifneq (,$(filter feetech,$(USEMODULE)))
   USEMODULE_INCLUDES += $(RIOTBASE)/drivers/feetech/include
 endif

--- a/drivers/extend/Makefile
+++ b/drivers/extend/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/drivers/extend/adc_notsup.c
+++ b/drivers/extend/adc_notsup.c
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2018 Gunar Schorcht
+ * Copyright (C) 2018 Acutam Automation, LLC
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_extend_adc
+ *
+ * @{
+ *
+ * @file
+ * @brief       ADC extension not-supported functions
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ * @author      Matthew Blue <matthew.blue.neuro@gmail.com>
+ *
+ * @}
+ */
+
+#if MODULE_EXTEND_ADC
+
+#include "periph/adc.h"
+#include "extend/adc.h"
+
+#define ENABLE_DEBUG (0)
+#include "debug.h"
+
+int adc_ext_init_notsup(void *dev, adc_t line)
+{
+    (void)dev;
+    (void)line;
+
+    DEBUG("[%s] call for dev %p line %u\n", __func__, dev, line);
+    return -1;
+}
+
+int adc_ext_sample_notsup(void *dev, adc_t line, adc_res_t res)
+{
+    (void)dev;
+    (void)line;
+
+    DEBUG("[%s] call for dev %p line %u res %u\n", __func__, dev, line, res);
+    return -1;
+}
+
+unsigned int adc_ext_channels_notsup(void *dev)
+{
+    (void)dev;
+
+    DEBUG("[%s] call for dev %p\n", __func__, dev);
+    return 0;
+}
+
+/* not-supported driver */
+const adc_ext_driver_t adc_ext_notsup_driver = {
+    .init = adc_ext_init_notsup,
+    .sample = adc_ext_sample_notsup,
+    .channels = adc_ext_channels_notsup
+};
+#endif /* MODULE_EXTEND_ADC */

--- a/drivers/extend/adc_redir.c
+++ b/drivers/extend/adc_redir.c
@@ -1,0 +1,92 @@
+/*
+ * Copyright (C) 2018 Gunar Schorcht
+ * Copyright (C) 2018 Acutam Automation, LLC
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_extend_adc
+ *
+ * @{
+ *
+ * @file
+ * @brief       ADC extension redirection functions
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ * @author      Matthew Blue <matthew.blue.neuro@gmail.com>
+ *
+ * @}
+ */
+
+#if MODULE_EXTEND_ADC
+
+#include "periph/adc.h"
+#include "extend/adc.h"
+#include "adc_ext_conf.h"
+
+#define ENABLE_DEBUG (0)
+#include "debug.h"
+
+adc_ext_t *adc_ext_entry(adc_t line)
+{
+    if (line == ADC_UNDEF) {
+        return NULL;
+    }
+
+    adc_t devnum = adc_ext_dev(line);
+
+    DEBUG("[%s] list entry is %u\n", __func__, devnum);
+
+    /* device is greater than number of listed entries */
+    if (devnum >= (sizeof(adc_ext_list) / sizeof(adc_ext_list[0]))) {
+        return NULL;
+    }
+
+    /* Cast to discard const */
+    return (adc_ext_t *)&adc_ext_list[devnum];
+}
+
+int adc_init_redir(adc_t line)
+{
+    adc_ext_t *entry = adc_ext_entry(line);
+
+    if (entry == NULL) {
+        DEBUG("[%s] ext entry doesn't exist for %X\n", __func__, line);
+        return -1;
+    }
+
+    line = adc_ext_line(line);
+
+    return entry->driver->init(entry->dev, line);
+}
+
+int adc_sample_redir(adc_t line, adc_res_t res)
+{
+    adc_ext_t *entry = adc_ext_entry(line);
+
+    if (entry == NULL) {
+        DEBUG("[%s] ext entry doesn't exist for %X\n", __func__, line);
+        return -1;
+    }
+
+    line = adc_ext_line(line);
+
+    return entry->driver->sample(entry->dev, line, res);
+}
+
+unsigned int adc_channels_redir(adc_t line)
+{
+    adc_ext_t *entry = adc_ext_entry(line);
+
+    if (entry == NULL) {
+        DEBUG("[%s] ext entry doesn't exist for %X\n", __func__, line);
+        return 0;
+    }
+
+    return entry->driver->channels(entry->dev);
+}
+
+#endif /* MODULE_EXTEND_ADC */

--- a/drivers/extend/include/adc_ext_conf.h
+++ b/drivers/extend/include/adc_ext_conf.h
@@ -1,0 +1,56 @@
+/*
+ * Copyright (C) 2018 Gunar Schorcht
+ * Copyright (C) 2018 Acutam Automation, LLC
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_extend_adc
+ *
+ * @{
+ *
+ * @file
+ * @brief       ADC extension default / example list
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ * @author      Matthew Blue <matthew.blue.neuro@gmail.com>
+ *
+ * @}
+ */
+
+#ifndef ADC_EXT_CONF_H
+#define ADC_EXT_CONF_H
+
+#include <stddef.h>
+
+#include "extend/adc.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Reference the driver struct
+ */
+extern adc_ext_driver_t adc_ext_notsup_driver;
+
+/**
+ * @brief   ADC expansion default list if not defined
+ */
+static const adc_ext_t adc_ext_list[] =
+{
+    {
+        .driver = &adc_ext_notsup_driver,
+        .dev = NULL,
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ADC_EXT_CONF_H */
+/** @} */

--- a/drivers/include/extend/adc.h
+++ b/drivers/include/extend/adc.h
@@ -1,0 +1,141 @@
+/*
+ * Copyright (C) 2018 Gunar Schorcht
+ * Copyright (C) 2018 Acutam Automation, LLC
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    drivers_extend_adc ADC extension
+ * @ingroup     drivers_extend
+ * @brief       ADC peripheral extension handling
+ *
+ * The ADC extension interface makes handling of non-CPU ADC devices invisible
+ * to code using the ADC periph API (periph/adc.h). This is accomplished by
+ * reserving part of the range of values of adc_t. When a call to the ADC API
+ * uses a line that falls within this range, it is parsed into a device ID that
+ * is looked up in the ADC extension list and the call is redirected to the
+ * corresponding device.
+ *
+ * @{
+ *
+ * @file
+ * @brief       ADC extension interface definitions
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ * @author      Matthew Blue <matthew.blue.neuro@gmail.com>
+ */
+
+#ifndef EXTEND_ADC_H
+#define EXTEND_ADC_H
+
+#include <limits.h>
+#include <stdint.h>
+
+#include "periph_conf.h"
+#include "periph/adc.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#ifndef ADC_EXT_DEV_MASK
+/**
+ * @brief   Set device mask in adc_t
+ */
+#define ADC_EXT_DEV_MASK (adc_t)((UINT_MAX << ADC_EXT_DEV_LOC) & ADC_EXT_THRESH)
+#endif
+
+#ifndef ADC_EXT_LINE_MASK
+/**
+ * @brief   Set line mask in adc_t
+ */
+#define ADC_EXT_LINE_MASK (adc_t)(~(UINT_MAX << ADC_EXT_DEV_LOC))
+#endif
+
+/**
+ * @brief   Callback typedef for adc_init
+ *
+ * @see #adc_init
+ */
+typedef int (*adc_ext_init_t)(void *dev, adc_t line);
+
+/**
+ * @brief   Callback typedef for adc_sample
+ *
+ * @see #adc_sample
+ */
+typedef int (*adc_ext_sample_t)(void *dev, adc_t line, adc_res_t res);
+
+/**
+ * @brief   Callback typedef for adc_channels
+ *
+ * @see #adc_channels
+ */
+typedef unsigned int (*adc_ext_channels_t)(void *dev);
+
+/**
+ * @brief   Default not supported functions
+ * @{
+ */
+int adc_ext_init_notsup(void *dev, adc_t line);
+int adc_ext_sample_notsup(void *dev, adc_t line, adc_res_t res);
+unsigned int adc_ext_channels(void *dev);
+/** @} */
+
+/**
+ * @brief   ADC extension driver entry
+ */
+typedef struct adc_ext_driver {
+    adc_ext_init_t const init;          /**< callback for adc_ext_init */
+    adc_ext_sample_t const sample;      /**< callback for adc_ext_sample */
+    adc_ext_channels_t const channels;  /**< callback for adc_ext_channels */
+} adc_ext_driver_t;
+
+/**
+ * @brief   ADC extension list entry
+ */
+typedef struct adc_ext {
+    adc_ext_driver_t const *driver;     /**< pointer to driver */
+    void *dev;                          /**< pointer to device descriptor */
+} adc_ext_t;
+
+/**
+ * @brief   Find an entry in the extension list by ADC line number
+ *
+ * @param[in]   line    ADC to look up
+ * @return      pointer to the list entry
+ * @return      NULL if no device is listed
+ */
+adc_ext_t *adc_ext_entry(adc_t line);
+
+/**
+ * @brief   Strip encoding from a ADC and return device number
+ *
+ * @param[in]   line    ADC to strip
+ * @return      device number
+ */
+static inline adc_t adc_ext_dev(adc_t line)
+{
+    return ((line & ADC_EXT_DEV_MASK) >> ADC_EXT_DEV_LOC);
+}
+
+/**
+ * @brief   Strip encoding from a ADC and return line number
+ *
+ * @param[in]   line    ADC to strip
+ * @return      line number
+ */
+static inline adc_t adc_ext_line(adc_t line)
+{
+    return (line & ADC_EXT_LINE_MASK);
+}
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* EXTEND_ADC_H */
+/** @} */

--- a/drivers/include/extend/doc.txt
+++ b/drivers/include/extend/doc.txt
@@ -1,0 +1,22 @@
+/*
+ * Copyright (C) 2018 Acutam Automation, LLC
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    drivers_extend Peripheral Driver Extension Interface
+ * @ingroup     drivers
+ * @brief       Peripheral extensions for intercepting API calls and redirecting
+ *              to non-peripheral drivers
+ *
+ * The extension interface makes handling of non-CPU devices invisible to code
+ * using the periph APIs (periph/*.h). This is accomplished by reserving part of
+ * the range of values of that API's identifier. When a call to the periph API
+ * uses an identifier that falls within this range, it is parsed into a device
+ * ID that is looked up in an extension list and the call is redirected to the
+ * corresponding device.
+ *
+ */

--- a/drivers/include/periph/adc.h
+++ b/drivers/include/periph/adc.h
@@ -119,14 +119,14 @@ typedef enum {
 #endif
 
 /**
- * @brief   Low-level versions of the ADC functions
+ * @brief   Low-level versions of the ADC functions provided by the CPU
  *
  * These are for cpu adc.c implementation and should not be called directly.
  * @{
  */
-int adc_init_ll(adc_t line);
-int adc_sample_ll(adc_t line, adc_res_t res);
-unsigned int adc_channels_ll(void);
+int adc_init_cpu(adc_t line);
+int adc_sample_cpu(adc_t line, adc_res_t res);
+unsigned int adc_channels_cpu(void);
 /** @} */
 
 #if MODULE_EXTEND_ADC || DOXYGEN
@@ -161,7 +161,7 @@ static inline int adc_init(adc_t line)
     }
 #endif
 #ifdef MODULE_PERIPH_ADC
-    return adc_init_ll(line);
+    return adc_init_cpu(line);
 #else
     return -1;
 #endif
@@ -189,7 +189,7 @@ static inline int adc_sample(adc_t line, adc_res_t res)
     }
 #endif
 #ifdef MODULE_PERIPH_ADC
-    return adc_sample_ll(line, res);
+    return adc_sample_cpu(line, res);
 #else
     return -1;
 #endif

--- a/makefiles/pseudomodules.inc.mk
+++ b/makefiles/pseudomodules.inc.mk
@@ -120,6 +120,9 @@ PSEUDOMODULES += stm32_periph_%
 PSEUDOMODULES += periph_%
 NO_PSEUDOMODULES += periph_common
 
+# periph extention interface pseudomodules
+PSEUDOMODULES += extend_%
+
 # Submodules and auto-init code provided by Skald
 PSEUDOMODULES += auto_init_skald
 PSEUDOMODULES += skald_ibeacon

--- a/tests/extend_adc/Makefile
+++ b/tests/extend_adc/Makefile
@@ -6,6 +6,3 @@ TEST_ON_CI_WHITELIST += all
 
 include ./Makefile.include
 include $(RIOTBASE)/Makefile.include
-
-test:
-	./tests/01-run.py

--- a/tests/extend_adc/Makefile
+++ b/tests/extend_adc/Makefile
@@ -1,0 +1,11 @@
+include ../Makefile.tests_common
+
+USEMODULE += extend_adc
+
+TEST_ON_CI_WHITELIST += all
+
+include ./Makefile.include
+include $(RIOTBASE)/Makefile.include
+
+test:
+	./tests/01-run.py

--- a/tests/extend_adc/Makefile.include
+++ b/tests/extend_adc/Makefile.include
@@ -1,0 +1,2 @@
+# include test specific includes
+export INCLUDES += -I$(CURDIR)/include

--- a/tests/extend_adc/include/adc_ext_conf.h
+++ b/tests/extend_adc/include/adc_ext_conf.h
@@ -1,0 +1,64 @@
+/*
+ * Copyright (C) 2018 Gunar Schorcht
+ * Copyright (C) 2018 Acutam Automation, LLC
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ *
+ * @{
+ *
+ * @file
+ * @brief       ADC extension test list
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ * @author      Matthew Blue <matthew.blue.neuro@gmail.com>
+ *
+ * @}
+ */
+
+#ifndef ADC_EXT_CONF_H
+#define ADC_EXT_CONF_H
+
+#include <stddef.h>
+
+#include "extend/adc.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Reference the driver structs
+ *
+ * @{
+ */
+extern adc_ext_driver_t tests_extend_adc_driver;
+extern adc_ext_driver_t adc_ext_notsup_driver;
+/** @} */
+
+/**
+ * @brief   ADC extension test list
+ */
+static const adc_ext_t adc_ext_list[] =
+{
+    {
+        .driver = &tests_extend_adc_driver,
+        .dev = (void *)0xbeef,
+    },
+    {
+        .driver = &adc_ext_notsup_driver,
+        .dev = NULL,
+    },
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* ADC_EXT_CONF_H */
+/** @} */

--- a/tests/extend_adc/main.c
+++ b/tests/extend_adc/main.c
@@ -1,0 +1,125 @@
+/*
+ * Copyright (C) 2018 Gunar Schorcht
+ * Copyright (C) 2018 Acutam Automation, LLC
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     tests
+ * @{
+ *
+ * @file
+ * @brief       ADC extension test routine
+ *
+ * @author      Gunar Schorcht <gunar@schorcht.net>
+ * @author      Matthew Blue <matthew.blue.neuro@gmail.com>
+ * @}
+ */
+
+#include <stdio.h>
+
+#include "extend/adc.h"
+#include "periph/adc.h"
+
+/* ADC extension test functions */
+int test_adc_init(void *dev, adc_t chn);
+int test_adc_sample(void *dev, adc_t chn, adc_res_t res);
+unsigned int test_adc_channels(void *dev);
+
+/* ADC extension test driver */
+const adc_ext_driver_t tests_extend_adc_driver = {
+    .init = test_adc_init,
+    .sample = test_adc_sample,
+    .channels = test_adc_channels,
+};
+
+int test_adc_init(void *dev, adc_t chn)
+{
+    printf("\t%s dev=0x%04x chn=%u\n", __func__, (uint16_t)(uintptr_t)dev, chn);
+    return 0;
+}
+
+int test_adc_sample(void *dev, adc_t chn, adc_res_t res)
+{
+    printf("\t%s dev=0x%04x chn=%u res=%u\n",
+           __func__, (uint16_t)(uintptr_t)dev, chn, res);
+    return 128 * chn;
+}
+
+unsigned int test_adc_channels(void *dev)
+{
+    printf("\t%s dev=0x%04x\n", __func__, (uint16_t)(uintptr_t)dev);
+    return 4;
+}
+
+int main(void)
+{
+    adc_t chn;
+
+    puts("ADC extension test routine");
+    puts("\nRunning ADC functions for internal device");
+
+    adc_t num = adc_channels(ADC_LINE(0));
+    printf("- Number of ADC channels: %d\n", num);
+
+    for (chn = 0; chn < num; chn++) {
+        printf("- Init ADC channel %u\n", chn);
+        if (adc_init(ADC_LINE(chn))) {
+            puts("[FAILED]");
+            return 1;
+        }
+        int sample = adc_sample(ADC_LINE(chn), ADC_RES_10BIT);
+        printf("- Sample of ADC channel %u: %d\n", chn, sample);
+    }
+
+    puts("\nRunning ADC functions for extension test device");
+
+    num = adc_channels(ADC_EXT_LINE(0, 0));
+    printf("- Number of ADC channels: %d\n", num);
+
+    for (chn = 0; chn < num; chn++) {
+        printf("- Init ADC channel %u\n", chn);
+        if (adc_init(ADC_EXT_LINE(0, chn))) {
+            puts("[FAILED]");
+            return 1;
+        }
+        int sample = adc_sample(ADC_EXT_LINE(0, chn), ADC_RES_10BIT);
+        printf("- Sample of ADC channel %u: %d\n", chn, sample);
+    }
+
+    puts("\nRunning ADC functions for extension notsup device");
+    puts("(they should not print output)");
+
+    for (chn = 0; chn < num; chn++) {
+        printf("- notsup adc.h functions on channel %u\n",
+            (unsigned int)chn);
+
+        if (!adc_init(ADC_EXT_LINE(1, chn))) {
+            puts("[FAILED]");
+            return 1;
+        }
+
+        if (adc_sample(ADC_EXT_LINE(1, chn), ADC_RES_10BIT) >= 0) {
+            puts("[FAILED]");
+            return 1;
+        }
+    }
+
+    puts("\nChecking that all channels in range have init error using notsup");
+    puts("(lack of init error implies improper redirection)");
+
+    for (chn = 0; chn <= ADC_EXT_LINE_MASK; chn +=16) {
+        if (adc_init(ADC_EXT_LINE(1, chn)) >= 0) {
+            printf("init succeeded on channel %u\n", chn);
+            puts("[FAILED]");
+            return 1;
+        }
+    }
+
+    puts("[SUCCESS]");
+
+    return 0;
+}

--- a/tests/extend_adc/tests/01-run.py
+++ b/tests/extend_adc/tests/01-run.py
@@ -1,0 +1,42 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2018 Acutam Automation, LLC
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import os
+import sys
+
+
+def testfunc(child):
+    child.expect_exact("ADC extension test routine")
+    child.expect_exact('Running ADC functions for internal device')
+    child.expect_exact('- Number of ADC channels: ')
+    i = child.readline()
+    for _ in range(int(i)):
+        child.expect('- Init ADC channel \d+')
+        child.expect('- Sample of ADC channel \d+: \d+')
+    child.expect_exact('Running ADC functions for extension test device')
+    child.expect_exact('test_adc_channels dev=0xbeef')
+    child.expect_exact('- Number of ADC channels: ')
+    c = child.readline('\d+')
+    for _ in range(int(c)):
+        child.expect('- Init ADC channel \d+')
+        child.expect('test_adc_init dev=0xbeef chn=\d+')
+        child.expect('test_adc_sample dev=0xbeef chn=\d+')
+        child.expect('- Sample of ADC channel \d+: \d+')
+    child.expect_exact("Running ADC functions for extension notsup device")
+    child.expect_exact("(they should not print output)")
+    for _ in range(4):
+        child.expect('- notsup adc.h functions on channel \d+')
+    child.expect_exact("Checking that all channels in range have init error using notsup")
+    child.expect_exact("(lack of init error implies improper redirection)")
+    child.expect_exact("[SUCCESS]")
+
+
+if __name__ == "__main__":
+    sys.path.append(os.path.join(os.environ['RIOTBASE'], 'dist/tools/testrunner'))
+    from testrunner import run
+    sys.exit(run(testfunc))


### PR DESCRIPTION
### Contribution description

This is an implementation of the extension API as proposed in #9582 for ADC extensions. It corresponds to the implementation of the GPIO extension API in #9860 and #9958. The PR contains the following contributions:

- Low level function prototypes `adc_*_ll` in `drivers/include/periph.h`.
- Changes of `adc_*` functions to redirect a function call either to the low level functions `adc_*_ll` or to the `adc_ext_*` function provided by an ADC extension device driver.
- New inline function `adc_channels` which returns the number of channels of a device, in case of MCU channels simply `ADC_NUMOF`. This new function makes it possible to get the information from a certain device how many channels it has and allows to iterate over the all channels of all devices.
- Changes of low level function `adc_*_ll` for all CPUs that support ADC channels.
- Boards that base on SAM0 (SAMD21, SAML21) MCU the ADC channel configuration `adc_channels` was renamed to `adc_config` to solve conflicts with the new function `adc_channels`.

The ADC extension API does not require feature `periph_adc` which makes it possible to extend boards that do not provide ADC capabilities by the MCU by external ADC modules.

### Testing procedure

A test case is provided that implements a soft-driver for the ADC extension interface. The test case uses this driver to confirm that interception and redirection of the API call are working properly. This has been tested and is working properly on esp8266-esp-12x, esp32-wroom-32 and arduino-mega2560.

To test only the ADC extension API use 
```
make  flash test -C tests/extend_adc BOARD=...
```
To test the ADC extension API together with internal ADC channels use
```
USEMODULE=periph_adc make  flash test -C tests/extend_adc BOARD=...
```
In that case feature `periph_adc` is required of course.

### Issues/PRs references

Implements #9582 
Corresponds to #9860 and #9958 

The changes in the `makefiles/pseudomodules.mk` and  in `drivers/Makefile.include` made to get it working are the same as in #9958. These changes might be removed once #9958 is merged.