### PR TITLE
jlink: get flash and debug files from cli

### DIFF
--- a/dist/tools/jlink/jlink.sh
+++ b/dist/tools/jlink/jlink.sh
@@ -18,23 +18,25 @@
 #
 # The script supports the following actions:
 #
-# flash:        flash a given hex file to the target.
-#               hexfile is expected in ihex format and is pointed to
-#               by BINFILE environment variable
+# flash:        flash <binfile>
+#
+#               flash given binary format file to the target.
 #
 #               options:
-#               BINFILE: path to the binary file that is flashed
+#               <binfile>:      path to the binary file that is flashed
 #
-# debug:        starts JLink as GDB server in the background and
+# debug:        debug <elffile>
+#
+#               starts JLink as GDB server in the background and
 #               connects to the server with the GDB client specified by
 #               the board (DBG environment variable)
 #
 #               options:
+#               <elffile>:      path to the ELF file to debug
 #               GDB_PORT:       port opened for GDB connections
 #               TELNET_PORT:    port opened for telnet connections
 #               DBG:            debugger client command, default: 'gdb -q'
 #               TUI:            if TUI!=null, the -tui option will be used
-#               ELFFILE:        path to the ELF file to debug
 #
 # debug-server: starts JLink as GDB server, but does not connect to
 #               to it with any frontend. This might be useful when using
@@ -88,10 +90,10 @@ test_config() {
     fi
 }
 
-test_hexfile() {
-    if [ ! -f "${HEXFILE}" ]; then
-        echo "Error: Unable to locate HEXFILE"
-        echo "       (${HEXFILE})"
+test_binfile() {
+    if [ ! -f "${BINFILE}" ]; then
+        echo "Error: Unable to locate BINFILE"
+        echo "       (${BINFILE})"
         exit 1
     fi
 }
@@ -145,16 +147,17 @@ test_term() {
 # now comes the actual actions
 #
 do_flash() {
+    BINFILE=$1
     test_config
     test_serial
-    test_hexfile
+    test_binfile
     # clear any existing contents in burn file
     /bin/echo -n "" > ${BINDIR}/burn.seg
     # create temporary burn file
     if [ ! -z "${JLINK_PRE_FLASH}" ]; then
         printf "${JLINK_PRE_FLASH}\n" >> ${BINDIR}/burn.seg
     fi
-    echo "loadbin ${HEXFILE} ${FLASH_ADDR}" >> ${BINDIR}/burn.seg
+    echo "loadbin ${BINFILE} ${FLASH_ADDR}" >> ${BINDIR}/burn.seg
     if [ ! -z "${JLINK_POST_FLASH}" ]; then
         printf "${JLINK_POST_FLASH}\n" >> ${BINDIR}/burn.seg
     fi
@@ -169,6 +172,7 @@ do_flash() {
 }
 
 do_debug() {
+    ELFFILE=$1
     test_config
     test_serial
     test_elffile
@@ -275,5 +279,7 @@ case "${ACTION}" in
     ;;
   *)
     echo "Usage: $0 {flash|debug|debug-server|reset}"
+    echo "          flash <binfile>"
+    echo "          debug <elffile>"
     ;;
 esac

--- a/makefiles/tools/jlink.inc.mk
+++ b/makefiles/tools/jlink.inc.mk
@@ -5,7 +5,7 @@ export RESET = $(RIOTTOOLS)/jlink/jlink.sh
 
 HEXFILE = $(BINFILE)
 
-export FFLAGS ?= flash
-export DEBUGGER_FLAGS ?= debug
+export FFLAGS ?= flash $(HEXFILE)
+export DEBUGGER_FLAGS ?= debug $(ELFFILE)
 export DEBUGSERVER_FLAGS ?= debug-server
 export RESET_FLAGS ?= reset


### PR DESCRIPTION
### Contribution description

Get BINFILE and ELFFILE from command line instead of environment variable.

Rename 'HEXFILE' to 'BINFILE' in the script as the binary file is used.
The documentation was already talking about 'BINFILE' but 'BINFILE'
was never exported by the build system and it was using 'HEXFILE' in the
implementation.

### Testing procedure

I cannot test flashing as I do not have boards or a Jlink flasher.
A real verification would also be great.

A partial test is to compare the content of `burn.seg` that should be the same:

```
cat examples/hello-world/bin/ikea-tradfri/burn.seg
loadbin /home/harter/work/git/RIOT/examples/hello-world/bin/ikea-tradfri/hello-world.bin 0x0
r
g
exit
```


My test is to check the executed command:

``` bash
BOARD=ikea-tradfri make --no-print-directory -C examples/hello-world/  flash-only FLASHER='bash -x $(RIOTTOOLS)/jlink/jlink.sh'
make[1]: Nothing to be done for 'Makefile.include'.
bash -x /home/harter/work/git/RIOT/dist/tools/jlink/jlink.sh flash /home/harter/work/git/RIOT/examples/hello-world/bin/ikea-tradfri/hello-world.bin
+ _GDB_PORT=3333
+ _TELNET_PORT=4444
+ _JLINK=JLinkExe
+ _JLINK_SERVER=JLinkGDBServer
+ _JLINK_IF=SWD
+ _JLINK_SPEED=2000
+ _JLINK_TERMPROG=/home/harter/work/git/RIOT/dist/tools/pyterm/pyterm
+ _JLINK_TERMFLAGS='-ts 19021'
+ ACTION=flash
+ shift
+ case "${ACTION}" in
+ echo '### Flashing Target ###'
### Flashing Target ###
+ echo '### Flashing at address 0x0 ###'
### Flashing at address 0x0 ###
+ do_flash /home/harter/work/git/RIOT/examples/hello-world/bin/ikea-tradfri/hello-world.bin
+ BINFILE=/home/harter/work/git/RIOT/examples/hello-world/bin/ikea-tradfri/hello-world.bin
+ test_config
+ '[' -z '' ']'
+ JLINK=JLinkExe
+ '[' -z '' ']'
+ JLINK_SERVER=JLinkGDBServer
+ '[' -z '' ']'
+ JLINK_IF=SWD
+ '[' -z '' ']'
+ JLINK_SPEED=2000
+ '[' -z EFR32MG1PxxxF256 ']'
+ '[' -z 0x0 ']'
+ test_serial
+ '[' -n '' ']'
+ test_binfile
+ '[' '!' -f /home/harter/work/git/RIOT/examples/hello-world/bin/ikea-tradfri/hello-world.bin ']'
+ /bin/echo -n ''
+ '[' '!' -z '' ']'
+ echo 'loadbin /home/harter/work/git/RIOT/examples/hello-world/bin/ikea-tradfri/hello-world.bin 0x0'
+ '[' '!' -z '' ']'
+ cat /home/harter/work/git/RIOT/dist/tools/jlink/reset.seg
+ sh -c 'JLinkExe                      -device '\''EFR32MG1PxxxF256'\''                     -speed '\''2000'\''                     -if '\''SWD'\''                     -jtagconf -1,-1                     -commandfile '\''/home/harter/work/git/RIOT/examples/hello-world/bin/ikea-tradfri/burn.seg'\'''
SEGGER J-Link Commander V6.40 (Compiled Oct 26 2018 15:08:38)
DLL version V6.40, compiled Oct 26 2018 15:08:28


J-Link Command File read successfully.
Processing script file...

J-Link connection not established yet but required for command.
Connecting to J-Link via USB...FAILED: Cannot connect to J-Link via USB.

J-Link connection not established yet but required for command.
Connecting to J-Link via USB...FAILED: Cannot connect to J-Link via USB.

J-Link connection not established yet but required for command.
Connecting to J-Link via USB...FAILED: Cannot connect to J-Link via USB.


Script processing completed.

```

The difference with master is the following, which has nothing related to the actual flashing command but show `binfile` taken from argument.

``` diff
2c2
< bash -x /home/harter/work/git/RIOT/dist/tools/jlink/jlink.sh flash
---
> bash -x /home/harter/work/git/RIOT/dist/tools/jlink/jlink.sh flash /home/harter/work/git/RIOT/examples/hello-world/bin/ikea-tradfri/hello-world.bin
18c18,19
< + do_flash
---
> + do_flash /home/harter/work/git/RIOT/examples/hello-world/bin/ikea-tradfri/hello-world.bin
> + BINFILE=/home/harter/work/git/RIOT/examples/hello-world/bin/ikea-tradfri/hello-world.bin
32c33
< + test_hexfile
---
> + test_binfile
```

Same check for `debug`:


``` bash
BOARD=ikea-tradfri make --no-print-directory -C examples/hello-world/  debug DEBUGGER='bash -x $(RIOTTOOLS)/jlink/jlink.sh'
make[1]: Nothing to be done for 'Makefile.include'.
bash -x /home/harter/work/git/RIOT/dist/tools/jlink/jlink.sh debug /home/harter/work/git/RIOT/examples/hello-world/bin/ikea-tradfri/hello-world.elf
+ _GDB_PORT=3333
+ _TELNET_PORT=4444
+ _JLINK=JLinkExe
+ _JLINK_SERVER=JLinkGDBServer
+ _JLINK_IF=SWD
+ _JLINK_SPEED=2000
+ _JLINK_TERMPROG=/home/harter/work/git/RIOT/dist/tools/pyterm/pyterm
+ _JLINK_TERMFLAGS='-ts 19021'
+ ACTION=debug
+ shift
+ case "${ACTION}" in
+ echo '### Starting Debugging ###'
### Starting Debugging ###
+ do_debug /home/harter/work/git/RIOT/examples/hello-world/bin/ikea-tradfri/hello-world.elf
+ ELFFILE=/home/harter/work/git/RIOT/examples/hello-world/bin/ikea-tradfri/hello-world.elf
+ test_config
+ '[' -z '' ']'
+ JLINK=JLinkExe
+ '[' -z '' ']'
+ JLINK_SERVER=JLinkGDBServer
+ '[' -z '' ']'
+ JLINK_IF=SWD
+ '[' -z '' ']'
+ JLINK_SPEED=2000
+ '[' -z EFR32MG1PxxxF256 ']'
+ '[' -z 0x0 ']'
+ test_serial
+ '[' -n '' ']'
+ test_elffile
+ '[' '!' -f /home/harter/work/git/RIOT/examples/hello-world/bin/ikea-tradfri/hello-world.elf ']'
+ test_ports
+ '[' -z '' ']'
+ GDB_PORT=3333
+ '[' -z '' ']'
+ TELNET_PORT=4444
+ test_tui
+ '[' -n '' ']'
+ test_dbg
+ '[' -z '' ']'
+ DBG=arm-none-eabi-gdb
+ DBG_PID=0
+ arm-none-eabi-gdb -q -ex 'tar ext :3333' /home/harter/work/git/RIOT/examples/hello-world/bin/ikea-tradfri/hello-world.elf
+ sh -c 'JLinkGDBServer                             -device '\''EFR32MG1PxxxF256'\''                            -speed '\''2000'\''                            -if '\''SWD'\''                            -port '\''3333'\''                            -telnetport '\''4444'\'''
SEGGER J-Link GDB Server V6.40 Command Line Version

JLinkARM.dll V6.40 (DLL compiled Oct 26 2018 15:08:28)

Command line: -device EFR32MG1PxxxF256 -speed 2000 -if SWD -port 3333 -telnetport 4444
-----GDB Server start settings-----
GDBInit file:                  none
GDB Server Listening port:     3333
SWO raw output listening port: 2332
Terminal I/O port:             4444
Accept remote connection:      yes
Generate logfile:              off
Verify download:               off
Init regs on start:            off
Silent mode:                   off
Single run mode:               off
Target connection timeout:     0 ms
------J-Link related settings------
J-Link Host interface:         USB
J-Link script:                 none
J-Link settings file:          none
------Target related settings------
Target device:                 EFR32MG1PxxxF256
Target interface:              SWD
Target interface speed:        2000kHz
Target endian:                 little

Connecting to J-Link...
Reading symbols from /home/harter/work/git/RIOT/examples/hello-world/bin/ikea-tradfri/hello-world.elf...done.
Connecting to J-Link failed. Connected correctly?
GDBServer will be closed...
Shutting down...
Could not connect to J-Link.
Please check power, connection and settings.
```

And the output diff with master also has nothing related to the executed debug commands but show `elffile` taken from argument:

``` diff
2c2
< bash -x /home/harter/work/git/RIOT/dist/tools/jlink/jlink.sh debug
---
> bash -x /home/harter/work/git/RIOT/dist/tools/jlink/jlink.sh debug /home/harter/work/git/RIOT/examples/hello-world/bin/ikea-tradfri/hello-world.elf
16c16,17
< + do_debug
---
> + do_debug /home/harter/work/git/RIOT/examples/hello-world/bin/ikea-tradfri/hello-world.elf
> + ELFFILE=/home/harter/work/git/RIOT/examples/hello-world/bin/ikea-tradfri/hello-world.elf
```

### Issues/PRs references

https://github.com/RIOT-OS/RIOT/pull/8838