### PR TITLE
cpu/esp8266: fix of adc_res_t

### DIFF
--- a/cpu/esp8266/include/periph_cpu.h
+++ b/cpu/esp8266/include/periph_cpu.h
@@ -28,16 +28,6 @@ extern "C" {
 #endif
 
 /**
- * @brief   Override the ADC resolution configuration
- * @{
- */
-#define HAVE_ADC_RES_T
-typedef enum {
-    ADC_RES_10BIT      /* only one resolution is supported */
-} adc_res_t;
-/** @} */
-
-/**
  * @brief   Length of the CPU_ID in octets
  */
 #define CPUID_LEN           (4U)


### PR DESCRIPTION
### Contribution description

esp8266 overrides in `periph_cpu.h` the default declaration of `adc_res_t` from `periph/adc.h` with only one resolution.

This gives compilation errors if an application uses other resolutions. According to the documentation, `adc_sample` should return -1 if the resolution is not supported. 

All other CPUs override `adc_res`_t either to add new resolutions or to mark resolutions as unsupported. But they all allow to use them at the interface.

Therefore, esp8266 uses now the default declaration of `adc_res_t` and returns -1 if a resolution is used in `adc_sample` that is not supported.

### Testing procedure

Use the test application `periph/adc` and terminal program with any esp8266 board to observe the output of the ADC line.
```
make flash BOARD=esp8266-esp-12x -C tests/periph_adc/
```

### Issues/PRs references
