### PR TITLE
cpu/esp32: fix of adc_res_t

### DIFF
--- a/cpu/esp32/include/periph_cpu.h
+++ b/cpu/esp32/include/periph_cpu.h
@@ -206,10 +206,14 @@ typedef enum {
  */
 #define HAVE_ADC_RES_T
 typedef enum {
-    ADC_RES_9BIT = 0,       /**< ADC resolution: 9 bit */
-    ADC_RES_10BIT,          /**< ADC resolution: 10 bit */
-    ADC_RES_11BIT,          /**< ADC resolution: 11 bit */
-    ADC_RES_12BIT,          /**< ADC resolution: 12 bit */
+    ADC_RES_6BIT  = 0xf0,   /**< ADC resolution: 6 bit is not supported */
+    ADC_RES_8BIT  = 0xf1,   /**< ADC resolution: 8 bit is not supported  */
+    ADC_RES_9BIT  = 0,      /**< ADC resolution: 9 bit */
+    ADC_RES_10BIT = 1,      /**< ADC resolution: 10 bit */
+    ADC_RES_11BIT = 2,      /**< ADC resolution: 11 bit */
+    ADC_RES_12BIT = 3,      /**< ADC resolution: 12 bit */
+    ADC_RES_14BIT = 0xf2,   /**< ADC resolution: 14 bit is not supported */
+    ADC_RES_16BIT = 0xf3,   /**< ADC resolution: 16 bit is not supported */
 } adc_res_t;
 /** @} */
 


### PR DESCRIPTION
### Contribution description

esp32 overrides in `periph_cpu.h` the default declaration of `adc_res_t` from `periph/adc.h` with a definition with only four resolutions
- two new platform specific resolutions and
- two resolutions defined by the default declaration of `adc_res_t`.

This gives compilation errors if an application uses other resolutions. According to the documentation, `adc_sample` should return -1 if the resolution is not supported.

All other CPUs override `adc_res_t` either to add new resolutions or to mark resolutions as unsupported. But they all allow to use them at the interface. 

Therefore, esp32 overrides now the declaration of adc_res_t with
- all resolutions that are defined by the default declaration of adc_res_t and
- two new platform specific resolutions.

It returns -1 if a resolution is used in `adc_sample` that is not supported.

### Testing procedure

Use the test application `periph/adc` and terminal program with any esp32 board to observe the output of defined ADC lines.
```
make flash BOARD=esp32-wroom-32 -C tests/periph_adc/
```

### Issues/PRs references
