### PR TITLE
 cc2538_rf: Don't use netdev_ieee802154_t for link layer address

### DIFF
--- a/drivers/kw2xrf/kw2xrf_getset.c
+++ b/drivers/kw2xrf/kw2xrf_getset.c
@@ -25,6 +25,8 @@
 #include "kw2xrf_reg.h"
 #include "kw2xrf_getset.h"
 #include "kw2xrf_intern.h"
+#include "byteorder.h"
+
 
 #define ENABLE_DEBUG (0)
 #include "debug.h"
@@ -305,7 +307,8 @@ uint64_t kw2xrf_get_addr_long(kw2xrf_t *dev)
     kw2xrf_read_iregs(dev, MKW2XDMI_MACLONGADDRS0_0, ap,
                       IEEE802154_LONG_ADDRESS_LEN);
 
-    return addr;
+    /* Address is always read as little endian and API specifies big endian */
+    return byteorder_swapll(addr);
 }
 
 int8_t kw2xrf_get_cca_threshold(kw2xrf_t *dev)

--- a/drivers/kw2xrf/kw2xrf_getset.c
+++ b/drivers/kw2xrf/kw2xrf_getset.c
@@ -296,7 +296,11 @@ void kw2xrf_set_addr_long(kw2xrf_t *dev, uint64_t addr)
 
 uint16_t kw2xrf_get_addr_short(kw2xrf_t *dev)
 {
-    return (dev->netdev.short_addr[0] << 8) | dev->netdev.short_addr[1];
+    uint16_t addr;
+    uint8_t *ap = (uint8_t *)(&addr);
+    kw2xrf_read_iregs(dev, MKW2XDMI_MACSHORTADDRS0_LSB, ap,
+                      IEEE802154_SHORT_ADDRESS_LEN);
+    return byteorder_swaps(addr);
 }
 
 uint64_t kw2xrf_get_addr_long(kw2xrf_t *dev)

--- a/drivers/kw2xrf/kw2xrf_netdev.c
+++ b/drivers/kw2xrf/kw2xrf_netdev.c
@@ -258,6 +258,20 @@ int _get(netdev_t *netdev, netopt_t opt, void *value, size_t len)
     }
 
     switch (opt) {
+        case NETOPT_ADDRESS:
+            if (len < sizeof(uint16_t)) {
+                return -EOVERFLOW;
+            }
+            *((uint16_t *)value) = kw2xrf_get_addr_short(dev);
+            return sizeof(uint16_t);
+
+        case NETOPT_ADDRESS_LONG:
+            if (len < sizeof(uint64_t)) {
+                return -EOVERFLOW;
+            }
+            *((uint64_t *)value) = kw2xrf_get_addr_long(dev);
+            return sizeof(uint64_t);
+
         case NETOPT_STATE:
             if (len < sizeof(netopt_state_t)) {
                 return -EOVERFLOW;

--- a/drivers/kw2xrf/kw2xrf_netdev.c
+++ b/drivers/kw2xrf/kw2xrf_netdev.c
@@ -399,7 +399,7 @@ static int _set(netdev_t *netdev, netopt_t opt, const void *value, size_t len)
             }
             else {
                 kw2xrf_set_addr_short(dev, *((uint16_t *)value));
-                /* don't set res to set netdev_ieee802154_t::short_addr */
+                res = sizeof(uint16_t);
             }
             break;
 
@@ -409,7 +409,7 @@ static int _set(netdev_t *netdev, netopt_t opt, const void *value, size_t len)
             }
             else {
                 kw2xrf_set_addr_long(dev, *((uint64_t *)value));
-                /* don't set res to set netdev_ieee802154_t::short_addr */
+                res = sizeof(uint64_t);
             }
             break;
 


### PR DESCRIPTION
### Contribution description

This PR modifies the behaviour of the kw2xrf driver to not propagate the link layer address to the netdev_ieee802154_t struct. This helps the goal of separating the netdev and the ieee802154_t layer by another bit. The end goal is to remove the short and long address from the netdev_ieee802154_t struct and match the behaviour of the ethernet drivers.

The performance impact of this change should be negligible, the NETOPT_ADDRESS(_LONG) call is only used on initialization and by the ifconfig command.

### Testing procedure

Please test whether:
 - ifconfig still shows the correct link layer addresses. These should not have changed between this PR and master.
 - ping still works. This to verify that the link layer address is also properly configured in the radio, if the ping echo/reply fails, the address filter of the radio might be configured in the wrong endianness.

### Issues/PRs references

Another small step for #7736 