### PR TITLE
kw2xrf: Don't use netdev_ieee802154_t for channel

### DIFF
--- a/drivers/kw2xrf/kw2xrf_getset.c
+++ b/drivers/kw2xrf/kw2xrf_getset.c
@@ -135,8 +135,6 @@ int kw2xrf_set_channel(kw2xrf_t *dev, uint8_t channel)
     kw2xrf_write_dreg(dev, MKW2XDM_PLL_FRAC0_LSB, (uint8_t)pll_frac_lt[tmp]);
     kw2xrf_write_dreg(dev, MKW2XDM_PLL_FRAC0_MSB, (uint8_t)(pll_frac_lt[tmp] >> 8));
 
-    dev->netdev.chan = channel;
-
     if (old_seq) {
         kw2xrf_set_sequence(dev, old_seq);
     }

--- a/drivers/kw2xrf/kw2xrf_netdev.c
+++ b/drivers/kw2xrf/kw2xrf_netdev.c
@@ -318,6 +318,13 @@ int _get(netdev_t *netdev, netopt_t opt, void *value, size_t len)
                 !!(dev->netdev.flags & KW2XRF_OPT_AUTOCCA);
             return sizeof(netopt_enable_t);
 
+        case NETOPT_CHANNEL:
+            if (len < sizeof(uint16_t)) {
+                return -EOVERFLOW;
+            }
+            *((uint16_t *)value) = kw2xrf_get_channel(dev);
+            return sizeof(uint16_t);
+
         case NETOPT_TX_POWER:
             if (len < sizeof(int16_t)) {
                 return -EOVERFLOW;

--- a/drivers/kw2xrf/kw2xrf_netdev.c
+++ b/drivers/kw2xrf/kw2xrf_netdev.c
@@ -427,8 +427,7 @@ static int _set(netdev_t *netdev, netopt_t opt, const void *value, size_t len)
                     res = -EINVAL;
                     break;
                 }
-                dev->netdev.chan = chan;
-                /* don't set res to set netdev_ieee802154_t::chan */
+                res = sizeof(uint16_t);
             }
             break;
 


### PR DESCRIPTION
### Contribution description

This PR modifies the behaviour of the kw2xrf driver to not propagate the channel to the netdev_ieee802154_t struct. This helps the goal of separating the netdev and the ieee802154_t layer by another bit. The end goal is to remove the channel from the netdev_ieee802154_t struct.

The performance impact of this change should be negligible, the NETOPT_CHANNEL call is only used by the ifconfig command.

### Testing procedure

Please test whether:

 - ifconfig still shows the correct channel. These should not have changed between this PR and master. 

Unable to test this myself at the moment, somebody is blocking access to the phynode@saclay :-)

### Issues/PRs references

Part of #7736 