### PR TITLE
netdev_ieee802154: fix IID getter

### DIFF
--- a/drivers/netdev_ieee802154/netdev_ieee802154.c
+++ b/drivers/netdev_ieee802154/netdev_ieee802154.c
@@ -33,18 +33,20 @@ static int _get_iid(netdev_ieee802154_t *dev, eui64_t *value, size_t max_len)
 {
     (void)max_len;
 
-    uint8_t *addr;
+    uint8_t addr[IEEE802154_LONG_ADDRESS_LEN];
     uint16_t addr_len;
 
     assert(max_len >= sizeof(eui64_t));
 
-    if (dev->flags & NETDEV_IEEE802154_SRC_MODE_LONG) {
-        addr_len = IEEE802154_LONG_ADDRESS_LEN;
-        addr = dev->long_addr;
+    dev->netdev.driver->get(&dev->netdev, NETOPT_SRC_LEN, &addr_len,
+                            sizeof(addr_len));
+    if (addr_len == IEEE802154_LONG_ADDRESS_LEN) {
+        dev->netdev.driver->get(&dev->netdev, NETOPT_ADDRESS_LONG, addr,
+                                addr_len);
     }
     else {
-        addr_len = IEEE802154_SHORT_ADDRESS_LEN;
-        addr = dev->short_addr;
+        dev->netdev.driver->get(&dev->netdev, NETOPT_ADDRESS, addr,
+                                addr_len);
     }
     ieee802154_get_iid(value, addr, addr_len);
 


### PR DESCRIPTION
### Contribution description
With #10455 the IID may be gotten from the device again. However, following the current refactoring efforts regarding the `netdev_ieee802154` layer, the devices don't necessarily store the address in the `netdev_ieee802154_t` struct anymore. So we need to access the address using the driver's `get` function here instead.

### Testing procedure
`kw2xrf` in #10534 should show the correct IID again.

### Issues/PRs references
Follow-up to #10455.