### PR TITLE
tests: adapt embunit TEST_ASSERT_EQUAL_STRING

### DIFF
--- a/sys/include/embUnit/AssertImpl.h
+++ b/sys/include/embUnit/AssertImpl.h
@@ -46,8 +46,8 @@ void assertImplementationCStr(const char *expected,const char *actual, long line
 
 #define TEST_ASSERT_EQUAL_STRING(expected_, actual_) \
     do { \
-        __typeof__(expected_) ____expected__ = expected_; \
-        __typeof__(actual_) ____actual__ = actual_; \
+        const char *____expected__ = expected_; \
+        const char *____actual__ = actual_; \
         if (stdimpl_strcmp(____expected__, ____actual__) != 0) { \
             assertImplementationCStr(____expected__, ____actual__, __LINE__, RIOT_FILE_RELATIVE); \
             return; \

--- a/tests/embunit/Makefile
+++ b/tests/embunit/Makefile
@@ -1,0 +1,9 @@
+include ../Makefile.tests_common
+
+USEMODULE += embunit
+
+INCLUDES += -I$(RIOTBASE)/tests/unittests/common
+
+TEST_ON_CI_WHITELIST += all
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/embunit/main.c
+++ b/tests/embunit/main.c
@@ -1,0 +1,58 @@
+/*
+ * Copyright (C) 2018 HAW Hamburg
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+ /**
+  * @ingroup    tests
+  * @{
+  *
+  * @file
+  * @brief      Unit tests for embUnit
+  *
+  * @author     Sebastian Meiling <s@mlng.net>
+  */
+
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+
+#include "assert.h"
+#include "embUnit.h"
+
+#define TEST_STRING_7   ("7")
+
+static const char *num = "7";
+
+static void test_string_macro(void)
+{
+    TEST_ASSERT_EQUAL_STRING(TEST_STRING_7, num);
+}
+
+static void test_string_array(void)
+{
+    int digit = 7;
+    char should_be[2] = { '0' + digit, 0 };
+    TEST_ASSERT_EQUAL_STRING(should_be, num);
+}
+
+TestRef test_embunit(void)
+{
+    EMB_UNIT_TESTFIXTURES(fixtures) {
+        new_TestFixture(test_string_macro),
+        new_TestFixture(test_string_array)
+    };
+
+    EMB_UNIT_TESTCALLER(tests_embunit, NULL, NULL, fixtures);
+    return (TestRef) & tests_embunit;
+}
+
+int main(void)
+{
+    TESTS_START();
+    TESTS_RUN(test_embunit());
+    TESTS_END();
+}

--- a/tests/embunit/tests/01-run.py
+++ b/tests/embunit/tests/01-run.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+
+# Copyright (C) 2017 Freie Universität Berlin
+#
+# This file is subject to the terms and conditions of the GNU Lesser
+# General Public License v2.1. See the file LICENSE in the top level
+# directory for more details.
+
+import sys
+from testrunner import run
+
+
+def testfunc(child):
+    child.expect(r'OK \(\d+ tests\)')
+
+
+if __name__ == "__main__":
+    sys.exit(run(testfunc))


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Changes the embUnit macro `TEST_ASSERT_EQUAL_STRING` to work properly with any char array, currently it fails for certain cases with:

```Make
error: invalid initializer
```

This also adds a test application to verify this.

### Testing procedure

compile and run `tests/embunit` with this PR and on master, e.g. `git rebase -i master` and drop the first commit of this PR then rerun the test. 


### Issues/PRs references

taken from and required for #8312