### PR TITLE
openocd: get flash and debug files from cli

### DIFF
--- a/boards/hifive1/dist/flasher.sh
+++ b/boards/hifive1/dist/flasher.sh
@@ -19,15 +19,18 @@
 #
 # The script supports the following actions:
 #
-# flash:        flash a given ELF file to the target.
+# flash:        flash <image_file>
+#               flash given file to the target.
 #
 #               options:
-#               IMAGE_FILE: Filename of the file that will be flashed
+#               <image_file>:   Filename of the file that will be flashed
 #               PRE_FLASH_CHECK_SCRIPT: a command to run before flashing to
-#               verify the integrity of the image to be flashed. ELFFILE is
+#               verify the integrity of the image to be flashed. <image_file> is
 #               passed as a command line argument to this command.
-#               Even though the file name variable is named ELFFILE, flashing
-#               works with any file format recognized by OpenOCD (elf, ihex, s19, bin).
+#
+#               Flashing works with any file format recognized by OpenOCD
+#               (elf, ihex, s19, bin).
+#
 #
 # @author       Hauke Peteresen <hauke.petersen@fu-berlin.de>
 # @author       Joakim Nohlgård <joakim.nohlgard@eistec.se>
@@ -42,10 +45,6 @@
 # Default offset is 0, meaning the image will be flashed at the address that it
 # was linked at.
 : ${IMAGE_OFFSET:=0}
-# Image file used for flashing. Must be in a format that OpenOCD can handle (ELF,
-# Intel hex, S19, or raw binary)
-# Default is to use $ELFFILE
-: ${IMAGE_FILE:=${ELFFILE}}
 # Type of image, leave empty to let OpenOCD automatically detect the type from
 # the file (default).
 # Valid values: elf, hex, s19, bin (see OpenOCD manual for more information)
@@ -84,6 +83,7 @@ test_imagefile() {
 # now comes the actual actions
 #
 do_flash() {
+    IMAGE_FILE=$1
     test_config
     test_imagefile
     if [ -n "${PRE_FLASH_CHECK_SCRIPT}" ]; then
@@ -119,14 +119,15 @@ do_flash() {
 # parameter dispatching
 #
 ACTION="$1"
+shift # pop $1 from $@
 
 case "${ACTION}" in
   flash)
     echo "### Flashing Target ###"
-    do_flash
+    do_flash "$@"
     ;;
   *)
-    echo "Usage: $0 flash"
+    echo "Usage: $0 flash <flashfile>"
     exit 2
     ;;
 esac

--- a/boards/seeeduino_arch-pro/Makefile.include
+++ b/boards/seeeduino_arch-pro/Makefile.include
@@ -11,7 +11,7 @@ include $(RIOTMAKE)/tools/serial.inc.mk
 DEBUG_ADAPTER ?= dap
 
 # this board uses openocd
-export IMAGE_FILE = $(HEXFILE)
+FFLAGS ?= flash $(HEXFILE)
 include $(RIOTMAKE)/tools/openocd.inc.mk
 
 # generate image checksum from hex file

--- a/dist/tools/openocd/openocd.sh
+++ b/dist/tools/openocd/openocd.sh
@@ -17,30 +17,33 @@
 #
 # The script supports the following actions:
 #
-# flash:        flash a given ELF file to the target.
+# flash:        flash <image_file>
+#               flash given file to the target.
 #
 #               options:
-#               IMAGE_FILE: Filename of the file that will be flashed
+#               <image_file>:   Filename of the file that will be flashed
 #               PRE_FLASH_CHECK_SCRIPT: a command to run before flashing to
-#               verify the integrity of the image to be flashed. ELFFILE is
+#               verify the integrity of the image to be flashed. <image_file> is
 #               passed as a command line argument to this command.
-#               Even though the file name variable is named ELFFILE, flashing
-#               works with any file format recognized by OpenOCD (elf, ihex, s19, bin).
 #
-# debug:        starts OpenOCD as GDB server in the background and
+#               Flashing works with any file format recognized by OpenOCD
+#               (elf, ihex, s19, bin).
+#
+# debug:        debug <elfile>
+#               starts OpenOCD as GDB server in the background and
 #               connects to the server with the GDB client specified by
 #               the board
 #
 #               options:
+#               <elffile>:      path to the file to debug, must be in a format
+#                               recognized by GDB (preferably ELF, it will not
+#                               work with .bin, .hex or .s19 because they lack
+#                               symbol information)
 #               GDB_PORT:       port opened for GDB connections
 #               TCL_PORT:       port opened for TCL connections
 #               TELNET_PORT:    port opened for telnet connections
 #               DBG:            debugger client command, default: 'gdb -q'
 #               TUI:            if TUI!=null, the -tui option will be used
-#               ELFFILE:        path to the file to debug, must be in a format
-#                               recognized by GDB (preferably ELF, it will not
-#                               work with .bin, .hex or .s19 because they lack
-#                               symbol information)
 #
 # debug-server: starts OpenOCD as GDB server, but does not connect to
 #               to it with any frontend. This might be useful when using
@@ -93,10 +96,6 @@
 # Default offset is 0, meaning the image will be flashed at the address that it
 # was linked at.
 : ${IMAGE_OFFSET:=0}
-# Image file used for flashing. Must be in a format that OpenOCD can handle (ELF,
-# Intel hex, S19, or raw binary)
-# Default is to use $ELFFILE
-: ${IMAGE_FILE:=${ELFFILE}}
 # Type of image, leave empty to let OpenOCD automatically detect the type from
 # the file (default).
 # Valid values: elf, hex, s19, bin (see OpenOCD manual for more information)
@@ -210,6 +209,7 @@ _flash_address() {
 # now comes the actual actions
 #
 do_flash() {
+    IMAGE_FILE=$1
     test_config
     test_imagefile
     if [ -n "${PRE_FLASH_CHECK_SCRIPT}" ]; then
@@ -256,6 +256,7 @@ do_flash() {
 }
 
 do_debug() {
+    ELFFILE=$1
     test_config
     test_elffile
     # temporary file that saves OpenOCD pid
@@ -330,15 +331,16 @@ do_reset() {
 # parameter dispatching
 #
 ACTION="$1"
+shift # pop $1 from $@
 
 case "${ACTION}" in
   flash)
     echo "### Flashing Target ###"
-    do_flash
+    do_flash "$@"
     ;;
   debug)
     echo "### Starting Debugging ###"
-    do_debug
+    do_debug "$@"
     ;;
   debug-server)
     echo "### Starting GDB Server ###"
@@ -350,6 +352,8 @@ case "${ACTION}" in
     ;;
   *)
     echo "Usage: $0 {flash|debug|debug-server|reset}"
+    echo "          flash <flashfile>"
+    echo "          debug <elffile>"
     exit 2
     ;;
 esac

--- a/makefiles/tools/openocd.inc.mk
+++ b/makefiles/tools/openocd.inc.mk
@@ -3,8 +3,8 @@ export DEBUGGER = $(RIOTTOOLS)/openocd/openocd.sh
 export DEBUGSERVER = $(RIOTTOOLS)/openocd/openocd.sh
 export RESET ?= $(RIOTTOOLS)/openocd/openocd.sh
 
-export FFLAGS ?= flash
-export DEBUGGER_FLAGS ?= debug
+export FFLAGS ?= flash $(ELFFILE)
+export DEBUGGER_FLAGS ?= debug $(ELFFILE)
 export DEBUGSERVER_FLAGS ?= debug-server
 export RESET_FLAGS ?= reset
 


### PR DESCRIPTION
### Contribution description

Get FLASH_FILE and ELFFILE from command line instead of environment variable.

The documentation was claiming ELFFILE was given as a command line argument
already, but is was not.

EDIT: this also includes `hifive1` specific flasher based on openocd as they share `FFLAGS`.

### Testing procedure

I tested on `iotlab-m3` with `flash` and `debug`.
I also ran the command for the `seeeduino_arch-pro` has it had specific changes.

I checked and no `boards | Makefile.include` is setting `IMAGE_FILE` anymore too.


#### iotlab-m3 check

To get a more verbose comparison I used:

```
BOARD=iotlab-m3 make --no-print-directory -C examples/default/ flash-only FLASHER='bash -x $(RIOTTOOLS)/openocd/openocd.sh'

BOARD=iotlab-m3 make --no-print-directory -C examples/default/ debug DEBUGGER='bash -x $(RIOTTOOLS)/openocd/openocd.sh'
```

The difference for flash between master and this PR was this one (without the `speed` and `time` diff)

``` diff
1c1
< bash -x /home/harter/work/git/RIOT/dist/tools/openocd/openocd.sh flash
---
> bash -x /home/harter/work/git/RIOT/dist/tools/openocd/openocd.sh flash /home/harter/work/git/RIOT/examples/default/bin/iotlab-m3/default.elf
17d16
< + : /home/harter/work/git/RIOT/examples/default/bin/iotlab-m3/default.elf
19a19
> + shift
23c23,24
< + do_flash
---
> + do_flash /home/harter/work/git/RIOT/examples/default/bin/iotlab-m3/default.elf
> + IMAGE_FILE=/home/harter/work/git/RIOT/examples/default/bin/iotlab-m3/default.elf
```

and for debug, after removing the difference for the `tmp` directory name:

``` diff
1c1
< bash -x /home/harter/work/git/RIOT/dist/tools/openocd/openocd.sh debug
---
> bash -x /home/harter/work/git/RIOT/dist/tools/openocd/openocd.sh debug /home/harter/work/git/RIOT/examples/default/bin/iotlab-m3/default.elf
17d16
< + : /home/harter/work/git/RIOT/examples/default/bin/iotlab-m3/default.elf
19a19
> + shift
23c23,24
< + do_debug
---
> + do_debug /home/harter/work/git/RIOT/examples/default/bin/iotlab-m3/default.elf
> + ELFFILE=/home/harter/work/git/RIOT/examples/default/bin/iotlab-m3/default.elf
```

#### seeeduino_arch-pro check

For the `seeeduino_arch-pro` it is using the `hexfile` as is master. The command output was this one (without the board):

``` diff
1c1
< bash -x /home/harter/work/git/RIOT/dist/tools/openocd/openocd.sh flash
---
> bash -x /home/harter/work/git/RIOT/dist/tools/openocd/openocd.sh flash /home/harter/work/git/RIOT/examples/default/bin/seeeduino_arch-pro/default.hex
17d16
< + : /home/harter/work/git/RIOT/examples/default/bin/seeeduino_arch-pro/default.hex
19a19
> + shift
23c23,24
< + do_flash
---
> + do_flash /home/harter/work/git/RIOT/examples/default/bin/seeeduino_arch-pro/default.hex
> + IMAGE_FILE=/home/harter/work/git/RIOT/examples/default/bin/seeeduino_arch-pro/default.hex
```

#### hifive1 check

``` diff
2c2
< bash -x /home/harter/work/git/worktree/riot_master/boards/hifive1/dist/flasher.sh flash
---
> bash -x /home/harter/work/git/worktree/riot_master/boards/hifive1/dist/flasher.sh flash /home/harter/work/git/worktree/riot_master/examples/default/bin/hifive1/default.elf
6d5
< + : /home/harter/work/git/worktree/riot_master/examples/default/bin/hifive1/default.elf
8a8
> + shift
12c12,13
< + do_flash
---
> + do_flash /home/harter/work/git/worktree/riot_master/examples/default/bin/hifive1/default.elf
> + IMAGE_FILE=/home/harter/work/git/worktree/riot_master/examples/default/bin/hifive1/default.elf
```

### Issues/PRs references

Split out of https://github.com/RIOT-OS/RIOT/pull/8838