### PR TITLE
shell_commands/ifconfig: mark TENTATIVE addresses correctly

### DIFF
--- a/sys/shell/commands/sc_gnrc_netif.c
+++ b/sys/shell/commands/sc_gnrc_netif.c
@@ -362,16 +362,22 @@ static void _netif_list_ipv6(ipv6_addr_t *addr, uint8_t flags)
     if (flags & GNRC_NETIF_IPV6_ADDRS_FLAGS_ANYCAST) {
         printf(" [anycast]");
     }
-    switch (flags & GNRC_NETIF_IPV6_ADDRS_FLAGS_STATE_MASK) {
-        case GNRC_NETIF_IPV6_ADDRS_FLAGS_STATE_TENTATIVE:
-            printf("  TNT");
-            break;
-        case GNRC_NETIF_IPV6_ADDRS_FLAGS_STATE_DEPRECATED:
-            printf("  DPR");
-            break;
-        case GNRC_NETIF_IPV6_ADDRS_FLAGS_STATE_VALID:
-            printf("  VAL");
-            break;
+    if (flags & GNRC_NETIF_IPV6_ADDRS_FLAGS_STATE_TENTATIVE) {
+        printf("  TNT[%u]",
+               flags & GNRC_NETIF_IPV6_ADDRS_FLAGS_STATE_TENTATIVE);
+    }
+    else {
+        switch (flags & GNRC_NETIF_IPV6_ADDRS_FLAGS_STATE_MASK) {
+            case GNRC_NETIF_IPV6_ADDRS_FLAGS_STATE_DEPRECATED:
+                printf("  DPR");
+                break;
+            case GNRC_NETIF_IPV6_ADDRS_FLAGS_STATE_VALID:
+                printf("  VAL");
+                break;
+            default:
+                printf("  UNK");
+                break;
+        }
     }
     line_thresh = _newline(0U, line_thresh);
 }


### PR DESCRIPTION
### Contribution description
TENTATIVE addresses currently are not shown as such at the moment when typing `ifconfig` (because they are a value -- number of NS retransmissions -- within the flag field rather than just a flag). This fixes that.

### Testing procedure
Copy and paste the following into a running native instance of `gnrc_networking` (including all newlines ;-)):

```
reboot
ifconfig

```

The output should contain a line that should match the following regex:

```
inet6 addr: fe80::[a-f0-9:]+  scope: local  TNT\[\d\]
```

Without this PR it should only output

```
inet6 addr: fe80::[a-f0-9:]+  scope: local
```

After waiting for a second and typing `ifconfig` again it now should match (in both versions)

```
inet6 addr: fe80::[a-f0-9:]+  scope: local  VAL
```

### Issues/PRs references
None