### PR TITLE
Makefile.include: remove functionality to build with another version.

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -146,8 +146,6 @@ ifeq ($(WPEDANTIC),1)
   CFLAGS += -Wpedantic
 endif
 
-ifneq (10,$(if $(RIOT_VERSION),1,0)$(if $(__RIOTBUILD_FLAG),1,0))
-
 # Provide a shallow sanity check. You cannot call `make` in a module directory.
 export __RIOTBUILD_FLAG := RIOT
 
@@ -649,35 +647,6 @@ ifneq (, $(filter all flash, $(if $(MAKECMDGOALS), $(MAKECMDGOALS), all)))
   ifneq (, $(EXPECT_ERRORS))
     $(shell $(COLOR_ECHO) "\n\n$(COLOR_RED)EXPECT ERRORS!$(COLOR_RESET)\n\n" 1>&2)
   endif
-
-endif
-
-else # RIOT_VERSION
-
-  export __RIOTBUILD_FLAG := RIOT
-
-  NUM_RIOT_VERSION := $(shell cd $(RIOTBASE) && git rev-parse --verify --short "$(RIOT_VERSION)" 2>/dev/null)
-  ifeq (, $(NUM_RIOT_VERSION))
-    $(error The supplied RIOT_VERSION=$(RIOT_VERSION) is invalid!)
-  endif
-
-  all $(filter-out clean, $(MAKECMDGOALS)): ..delegate
-  ifneq (, $(filter clean, $(MAKECMDGOALS)))
-    all $(filter-out clean, $(MAKECMDGOALS)): clean
-  endif
-
-  clean:
-	-$(Q)rm -rf $(BINDIR)
-
-  $(BINDIR)/riot-version/$(NUM_RIOT_VERSION)/Makefile.include:
-	$(Q)rm -rf $(@D)
-	$(Q)mkdir -p $(@D)
-	$(Q)cd $(RIOTBASE) && git archive --format=tar $(NUM_RIOT_VERSION) | ( cd $(@D) && tar x 1>&2 )
-
-  ..delegate: $(BINDIR)/riot-version/$(NUM_RIOT_VERSION)/Makefile.include
-	@$(COLOR_ECHO) '$(COLOR_GREEN)Using RIOT_VERSION=$(NUM_RIOT_VERSION)$(COLOR_RESET)' 1>&2
-	@$(COLOR_ECHO)
-	$(MAKE) RIOTBASE=$(<D) $(filter-out clean, $(MAKECMDGOALS))
 
 endif
 


### PR DESCRIPTION
### Contribution description

Makefile.include contained logic to clone a different RIOT version and build the application against it. This can be easily achieved by making a git worktree and overriding RIOTBASE, without adding any complexity to our makefiles. Therefore, the feature is being removed.

### Testing procedure

CI will test that nothing got broken.
