### PR TITLE
gnrc_netif: reset IPv6 config on reset and address change

### DIFF
--- a/sys/include/net/gnrc/netif/ipv6.h
+++ b/sys/include/net/gnrc/netif/ipv6.h
@@ -68,6 +68,12 @@ extern "C" {
  * @brief   Address is an anycast address
  */
 #define GNRC_NETIF_IPV6_ADDRS_FLAGS_ANYCAST                (0x20U)
+
+/**
+ * @brief   Address was configured automatically and is based on the interface's
+ *          IID.
+ */
+#define GNRC_NETIF_IPV6_ADDRS_FLAGS_AUTO                   (0x40U)
 /** @} */
 
 /**

--- a/sys/net/gnrc/application_layer/uhcpc/gnrc_uhcpc.c
+++ b/sys/net/gnrc/application_layer/uhcpc/gnrc_uhcpc.c
@@ -85,7 +85,8 @@ void uhcp_handle_prefix(uint8_t *prefix, uint8_t prefix_len, uint16_t lifetime, 
         return;
     }
 
-    gnrc_netapi_set(gnrc_wireless_interface, NETOPT_IPV6_ADDR, (64 << 8),
+    gnrc_netapi_set(gnrc_wireless_interface, NETOPT_IPV6_ADDR,
+                    (64 << 8) | GNRC_NETIF_IPV6_ADDRS_FLAGS_AUTO,
                     prefix, sizeof(ipv6_addr_t));
 #if defined(MODULE_GNRC_IPV6_NIB) && GNRC_IPV6_NIB_CONF_6LBR && \
     GNRC_IPV6_NIB_CONF_MULTIHOP_P6C

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
@@ -32,7 +32,8 @@ void _auto_configure_addr(gnrc_netif_t *netif, const ipv6_addr_t *pfx,
 {
     ipv6_addr_t addr = IPV6_ADDR_UNSPECIFIED;
     int idx;
-    uint8_t flags = GNRC_NETIF_IPV6_ADDRS_FLAGS_STATE_TENTATIVE;
+    uint8_t flags = GNRC_NETIF_IPV6_ADDRS_FLAGS_STATE_TENTATIVE | \
+                    GNRC_NETIF_IPV6_ADDRS_FLAGS_AUTO;
 
     DEBUG("nib: add address based on %s/%u automatically to interface %u\n",
           ipv6_addr_to_str(addr_str, pfx, sizeof(addr_str)),

--- a/sys/shell/commands/sc_gnrc_netif.c
+++ b/sys/shell/commands/sc_gnrc_netif.c
@@ -373,6 +373,12 @@ static void _netif_list_ipv6(ipv6_addr_t *addr, uint8_t flags)
             printf("  VAL");
             break;
     }
+    if (flags & GNRC_NETIF_IPV6_ADDRS_FLAGS_AUTO) {
+        printf(" (AUTO)");
+    }
+    else {
+        printf(" (MANUAL)");
+    }
     line_thresh = _newline(0U, line_thresh);
 }
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Just an idea I had while debugging the behavior of the `cc2538_rf` in #10537. This resets the IPv6 specific part of an interface whenever the interface is reseted or its link-layer address is changed.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Run `gnrc_networking` on a platform of your choice, the IID of an IPv6 address should change as soon as you change the interface's link-layer address it is based on:

```
ifconfig <if> set addr[_long] <new l2addr>
ifconfig
```


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
