### PR TITLE
gnrc/netif: build source files only on demand

### DIFF
--- a/sys/net/gnrc/netif/Makefile
+++ b/sys/net/gnrc/netif/Makefile
@@ -1,3 +1,14 @@
 MODULE := gnrc_netif
 
+SRC += _netif.c
+SRC += gnrc_netif.c
+SRC += gnrc_netif_raw.c
+
+ifndef (,$(filter netdev_ieee802154,$(USEMODULE)))
+  SRC += gnrc_netif_ieee802154.c
+endif
+ifndef (,$(filter netdev_ethernet,$(USEMODULE)))
+  SRC += gnrc_netif_ethernet.c
+endif
+
 include $(RIOTBASE)/Makefile.base

--- a/sys/net/gnrc/netif/gnrc_netif_ethernet.c
+++ b/sys/net/gnrc/netif/gnrc_netif_ethernet.c
@@ -17,7 +17,6 @@
 
 #include <string.h>
 
-#ifdef MODULE_NETDEV_ETH
 #include "net/ethernet/hdr.h"
 #include "net/gnrc.h"
 #include "net/gnrc/netif/ethernet.h"
@@ -248,8 +247,5 @@ safe_out:
     gnrc_pktbuf_release(pkt);
     return NULL;
 }
-#else   /* MODULE_NETDEV_ETH */
-typedef int dont_be_pedantic;
-#endif  /* MODULE_NETDEV_ETH */
 
 /** @} */

--- a/sys/net/gnrc/netif/gnrc_netif_ieee802154.c
+++ b/sys/net/gnrc/netif/gnrc_netif_ieee802154.c
@@ -28,7 +28,6 @@
 #include "od.h"
 #endif
 
-#ifdef MODULE_NETDEV_IEEE802154
 static int _send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt);
 static gnrc_pktsnip_t *_recv(gnrc_netif_t *netif);
 
@@ -263,7 +262,5 @@ static int _send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
     gnrc_pktbuf_release(pkt);
     return res;
 }
-#else   /* MODULE_NETDEV_IEEE802154 */
-typedef int dont_be_pedantic;
-#endif  /* MODULE_NETDEV_IEEE802154 */
+
 /** @} */


### PR DESCRIPTION
### Contribution description
When reviewing #10513, I found that the source file handling for gnrc netif was quite hacky. This PR should fix that.

### Testing procedure
Build `examples/gnrc_networking` for ethernet and ieee802.15.4 devices. Also build it for some other config not using either. In other words: inspect the output of the buildtest...

### Issues/PRs references
none