### PR TITLE
Makefile.include: flash: do not peek into MAKECMDGOALS.

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -511,16 +511,19 @@ distclean:
 	-@for i in $(USEPKG) ; do "$(MAKE)" -C $(RIOTPKG)/$$i distclean ; done
 	-@rm -rf $(BINDIRBASE)
 
-# if make target != 'flash-only', add target 'all' to ensure build before flash
-ifeq (,$(filter flash-only, $(MAKECMDGOALS)))
-  BUILD_BEFORE_FLASH = all
-endif
+define flash-recipe
+  $(call check_cmd,$(FLASHER),Flash program)
+  $(FLASHER) $(FFLAGS)
+endef
 
-flash: $(BUILD_BEFORE_FLASH) $(FLASHDEPS)
-	$(call check_cmd,$(FLASHER),Flash program)
-	$(FLASHER) $(FFLAGS)
+# Do not add dependencies to "flash" directly, use FLASHDEPS, as this is shared
+# with flash-only too
 
-flash-only: flash
+flash: all $(FLASHDEPS)
+	$(flash-recipe)
+
+flash-only: $(FLASHDEPS)
+	$(flash-recipe)
 
 preflash: $(BUILD_BEFORE_FLASH)
 	$(PREFLASHER) $(PREFFLAGS)

--- a/boards/common/frdm/Makefile.include
+++ b/boards/common/frdm/Makefile.include
@@ -23,8 +23,7 @@ export OPENOCD_PRE_VERIFY_CMDS += \
   -c 'resume 0x20000000'
 export OPENOCD_EXTRA_INIT
 
-.PHONY: flash
-flash: $(RIOTCPU)/$(CPU)/dist/wdog-disable.bin
+FLASHDEPS += $(RIOTCPU)/$(CPU)/dist/wdog-disable.bin
 
 export OPENOCD_CONFIG ?= $(RIOTBOARD)/common/frdm/dist/old-openocd-$(CPU_FAMILY).cfg
 endif

--- a/boards/mulle/Makefile.include
+++ b/boards/mulle/Makefile.include
@@ -58,8 +58,7 @@ export OPENOCD_PRE_VERIFY_CMDS += \
   -c 'resume 0x20000000'
 export PRE_FLASH_CHECK_SCRIPT = $(RIOTCPU)/$(CPU)/dist/check-fcfield-elf.sh
 
-.PHONY: flash
-flash: $(RIOTCPU)/$(CPU)/dist/wdog-disable.bin
+FLASHDEPS += $(RIOTCPU)/$(CPU)/dist/wdog-disable.bin
 
 # this board uses openocd
 include $(RIOTMAKE)/tools/openocd.inc.mk

--- a/boards/pba-d-01-kw2x/Makefile.include
+++ b/boards/pba-d-01-kw2x/Makefile.include
@@ -10,8 +10,7 @@ export CPU_MODEL ?= mkw21d256vha5
 PORT_LINUX ?= /dev/ttyACM0
 PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.usbmodem*)))
 
-.PHONY: flash
-flash: $(RIOTCPU)/$(CPU)/dist/wdog-disable.bin
+FLASHDEPS += $(RIOTCPU)/$(CPU)/dist/wdog-disable.bin
 
 # We need special handling of the watchdog if we want to speed up the flash
 # verification by using the MCU to compute the image checksum after flashing.


### PR DESCRIPTION
### Contribution description

When flash-only was introduced (in #8373), the `flash` rule was made conditionally dependent on `all` by looking for `flash-only` in MAKECMDGOALS. This was done to avoid code duplication.

There's a cleaner way, by using [canned recipes](https://www.gnu.org/software/make/manual/html_node/Canned-Recipes.html).

### Testing procedure

Go to any example and type `make flash-only` and `make flash`. You don't even need to have the board connected.

In the first case it should not attempt to make all and in the second it should.

### Issues/PRs references

Refactor of #8373.
