### PR TITLE
gnrc_netif: make link-layer specific operations proper submodules

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -146,6 +146,12 @@ endif
 ifneq (,$(filter gnrc_netif,$(USEMODULE)))
   USEMODULE += netif
   USEMODULE += fmt
+  ifneq (,$(filter netdev_ieee802154,$(USEMODULE)))
+    USEMODULE += gnrc_netif_ieee802154
+  endif
+  ifneq (,$(filter netdev_eth,$(USEMODULE)))
+    USEMODULE += gnrc_netif_ethernet
+  endif
 endif
 
 ifneq (,$(filter ieee802154 nrfmin,$(USEMODULE)))

--- a/sys/net/gnrc/Makefile
+++ b/sys/net/gnrc/Makefile
@@ -34,7 +34,7 @@ endif
 ifneq (,$(filter gnrc_netapi,$(USEMODULE)))
   DIRS += netapi
 endif
-ifneq (,$(filter gnrc_netif,$(USEMODULE)))
+ifneq (,$(filter gnrc_netif gnrc_netif_%,$(USEMODULE)))
     DIRS += netif
 endif
 ifneq (,$(filter gnrc_netif_hdr,$(USEMODULE)))

--- a/sys/net/gnrc/Makefile
+++ b/sys/net/gnrc/Makefile
@@ -37,9 +37,6 @@ endif
 ifneq (,$(filter gnrc_netif gnrc_netif_%,$(USEMODULE)))
     DIRS += netif
 endif
-ifneq (,$(filter gnrc_netif_hdr,$(USEMODULE)))
-  DIRS += netif/hdr
-endif
 ifneq (,$(filter gnrc_netreg,$(USEMODULE)))
   DIRS += netreg
 endif

--- a/sys/net/gnrc/netif/Makefile
+++ b/sys/net/gnrc/netif/Makefile
@@ -1,3 +1,10 @@
 MODULE := gnrc_netif
 
+ifneq (,$(filter gnrc_netif_ethernet,$(USEMODULE)))
+  DIRS += ethernet
+endif
+ifneq (,$(filter gnrc_netif_ieee802154,$(USEMODULE)))
+  DIRS += ieee802154
+endif
+
 include $(RIOTBASE)/Makefile.base

--- a/sys/net/gnrc/netif/Makefile
+++ b/sys/net/gnrc/netif/Makefile
@@ -6,5 +6,8 @@ endif
 ifneq (,$(filter gnrc_netif_ieee802154,$(USEMODULE)))
   DIRS += ieee802154
 endif
+ifneq (,$(filter gnrc_netif_hdr,$(USEMODULE)))
+  DIRS += hdr
+endif
 
 include $(RIOTBASE)/Makefile.base

--- a/sys/net/gnrc/netif/ethernet/Makefile
+++ b/sys/net/gnrc/netif/ethernet/Makefile
@@ -1,0 +1,3 @@
+MODULE := gnrc_netif_ethernet
+
+include $(RIOTBASE)/Makefile.base

--- a/sys/net/gnrc/netif/ethernet/gnrc_netif_ethernet.c
+++ b/sys/net/gnrc/netif/ethernet/gnrc_netif_ethernet.c
@@ -17,7 +17,6 @@
 
 #include <string.h>
 
-#ifdef MODULE_NETDEV_ETH
 #include "net/ethernet/hdr.h"
 #include "net/gnrc.h"
 #include "net/gnrc/netif/ethernet.h"
@@ -248,8 +247,5 @@ safe_out:
     gnrc_pktbuf_release(pkt);
     return NULL;
 }
-#else   /* MODULE_NETDEV_ETH */
-typedef int dont_be_pedantic;
-#endif  /* MODULE_NETDEV_ETH */
 
 /** @} */

--- a/sys/net/gnrc/netif/ieee802154/Makefile
+++ b/sys/net/gnrc/netif/ieee802154/Makefile
@@ -1,0 +1,3 @@
+MODULE := gnrc_netif_ieee802154
+
+include $(RIOTBASE)/Makefile.base

--- a/sys/net/gnrc/netif/ieee802154/gnrc_netif_ieee802154.c
+++ b/sys/net/gnrc/netif/ieee802154/gnrc_netif_ieee802154.c
@@ -28,7 +28,6 @@
 #include "od.h"
 #endif
 
-#ifdef MODULE_NETDEV_IEEE802154
 static int _send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt);
 static gnrc_pktsnip_t *_recv(gnrc_netif_t *netif);
 
@@ -263,7 +262,4 @@ static int _send(gnrc_netif_t *netif, gnrc_pktsnip_t *pkt)
     gnrc_pktbuf_release(pkt);
     return res;
 }
-#else   /* MODULE_NETDEV_IEEE802154 */
-typedef int dont_be_pedantic;
-#endif  /* MODULE_NETDEV_IEEE802154 */
 /** @} */


### PR DESCRIPTION
### Contribution description
This is a cleaner alternative to #10546 build-system-wise. Instead of making the inclusion of source files dependent on external modules, the link-layer specific implementations of `gnrc_netif` operations are moved to their own (sub-)modules and the combination (`gnrc_netif`, `netdev_x`) made dependent on `gnrc_netif_x`.

### Testing procedure
`make buildtest` (or Murdock ;-)) for `gnrc_networking` should pass.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Alternative to #10546.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
