### PR TITLE
make: fix BUILD_IN_DOCKER when RIOT is submodule

### DIFF
--- a/makefiles/docker.inc.mk
+++ b/makefiles/docker.inc.mk
@@ -91,7 +91,7 @@ DOCKER_VOLUMES_AND_ENV += $(if $(wildcard $(GIT_CACHE_DIR)),-e GIT_CACHE_DIR=$(D
 
 # Handle worktree by mounting the git common dir in the same location
 _is_git_worktree = $(shell grep '^gitdir: ' $(RIOTBASE)/.git 2>/dev/null)
-GIT_WORKTREE_COMMONDIR = $(shell git rev-parse --git-common-dir)
+GIT_WORKTREE_COMMONDIR = $(abspath $(shell git rev-parse --git-common-dir))
 DOCKER_VOLUMES_AND_ENV += $(if $(_is_git_worktree),-v $(GIT_WORKTREE_COMMONDIR):$(GIT_WORKTREE_COMMONDIR))
 
 # This will execute `make $(DOCKER_MAKECMDGOALS)` inside a Docker container.


### PR DESCRIPTION


<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This removes a non-working mount point when using BUILD_IN_DOCKER for an
external application where RIOTBASE is a submodule within the apps repo.

Actually I'm not sure why the removed lines are in place anyway, because they are only used *when* RIOT is a submodule, however they likely never worked.

### Testing procedure

Try to build an application with `BUILD_IN_DOCKER=1` which has RIOT as a submodule within its repo and uses that as `RIOTBASE`. Take for instance this https://github.com/inetrg/vslab-riot and you'll get the following error:

```
cd /tmp
git clone https://github.com/inetrg/vslab-riot
cd vslab-riot
BUILD_IN_DOCKER=1 DOCKER="sudo docker" make -C src/
Launching build container using image "riot/riotbuild:latest".
sudo docker run --rm -t -u "$(id -u)" \
    -v '/tmp/vslab-riot/RIOT:/data/riotbuild/riotbase' \
    -v '/tmp/vslab-riot/RIOT/cpu:/data/riotbuild/riotcpu' \
    -v '/tmp/vslab-riot/RIOT/boards:/data/riotbuild/riotboard' \
    -v '/tmp/vslab-riot/RIOT/makefiles:/data/riotbuild/riotmake' \
    -v '/tmp/vslab-riot:/data/riotbuild/riotproject' \
    -v /etc/localtime:/etc/localtime:ro \
    -e 'RIOTBASE=/data/riotbuild/riotbase' \
    -e 'CCACHE_BASEDIR=/data/riotbuild/riotbase' \
    -e 'RIOTCPU=/data/riotbuild/riotcpu' \
    -e 'RIOTBOARD=/data/riotbuild/riotboard' \
    -e 'RIOTMAKE=/data/riotbuild/riotmake' \
    -e 'RIOTPROJECT=/data/riotbuild/riotproject' \
      -v src/.git:src/.git \
     \
    -w '/data/riotbuild/riotproject/src/' \
    'riot/riotbuild:latest' make
docker: Error response from daemon: invalid volume specification: 'src/.git:src/.git': invalid mount config for type "volume": invalid mount path: 'src/.git' mount path must be absolute.
See 'docker run --help'.
make: *** [..in-docker-container] Error 125
```

It works when you clone RIOT separately and specify `RIOTBASE` accordingly, e.g.

```
cd /tmp
git clone https://github.com/RIOT-OS/RIOT
cd /tmp/vslab-riot
RIOTBASE=/tmp/RIOT BUILD_IN_DOCKER=1 make -C src
```

### Issues/PRs references

