### PR TITLE
eclipse.inc.mk: Split eclipse support into it's own file.

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -565,15 +565,8 @@ objdump:
 	$(call check_cmd,$(OBJDUMP),Objdump program)
 	$(OBJDUMP) $(OBJDUMPFLAGS) $(ELFFILE) | less
 
-# Generate an XML file containing all macro definitions and include paths for
-# use in Eclipse CDT
-.PHONY: eclipsesym eclipsesym.xml
-eclipsesym: $(CURDIR)/eclipsesym.xml
-eclipsesym.xml: $(CURDIR)/eclipsesym.xml
-
-$(CURDIR)/eclipsesym.xml: FORCE
-	$(Q)printf "%s\n" $(CC) $(CFLAGS_WITH_MACROS) $(INCLUDES) | \
-		$(RIOTTOOLS)/eclipsesym/cmdline2xml.sh > $@
+# Support Eclipse IDE.
+include $(RIOTMAKE)/eclipse.inc.mk
 
 # Export variables used throughout the whole make system:
 include $(RIOTMAKE)/vars.inc.mk

--- a/makefiles/eclipse.inc.mk
+++ b/makefiles/eclipse.inc.mk
@@ -1,0 +1,9 @@
+# Generate an XML file containing all macro definitions and include paths for
+# use in Eclipse CDT
+.PHONY: eclipsesym eclipsesym.xml
+eclipsesym: $(CURDIR)/eclipsesym.xml
+eclipsesym.xml: eclipsesym
+
+$(CURDIR)/eclipsesym.xml: FORCE
+	$(Q)printf "%s\n" $(CC) $(CFLAGS_WITH_MACROS) $(INCLUDES) | \
+		$(RIOTTOOLS)/eclipsesym/cmdline2xml.sh > $@


### PR DESCRIPTION
### Contribution description

To keep Makefile.include clean and to be consistent with other tools, the Eclipse IDE support is put in a separate file.

### Testing procedure

```sh
$ make -C examples/hello-world eclipsesym
$ file examples/hello-world/eclipsesym.xml
examples/hello-world/eclipsesym.xml: XML 1.0 document, ASCII text
```
