### PR TITLE
tests/xtimer_now64_continuity|xtimer_usleep: disable running test on native

### DIFF
--- a/tests/xtimer_now64_continuity/Makefile
+++ b/tests/xtimer_now64_continuity/Makefile
@@ -3,6 +3,7 @@ include ../Makefile.tests_common
 USEMODULE += fmt
 USEMODULE += xtimer
 
-TEST_ON_CI_WHITELIST += all
+# This test randomly fails on `native` so disable it from CI
+TEST_ON_CI_WHITELIST += samr21-xpro
 
 include $(RIOTBASE)/Makefile.include

--- a/tests/xtimer_usleep/Makefile
+++ b/tests/xtimer_usleep/Makefile
@@ -2,7 +2,8 @@ include ../Makefile.tests_common
 
 USEMODULE += xtimer
 
-TEST_ON_CI_WHITELIST += all
+# This test randomly fails on `native` so disable it from CI
+TEST_ON_CI_WHITELIST += samr21-xpro
 
 # Port and pin configuration for probing with oscilloscope
 # Port number should be found in port enum e.g in cpu/include/periph_cpu.h


### PR DESCRIPTION
### Contribution description

The tests randomly fail for unrelated PRs. Expecting real-time timing on
native is not really possible. Maybe it could be fixed but it currently
triggers many false positive.

The justification is all PRs that need to be retriggered because of these tests randomly failing.

### Testing procedure

The tests should not be run by murdock anymore

### Issues/PRs references

Some failed tests:

https://ci.riot-os.org/RIOT-OS/RIOT/10513/7ac4b118c995a4fe54ad17e33de40b41a73de004/output/compile/tests/xtimer_now64_continuity/native:gnu.txt
https://ci.riot-os.org/RIOT-OS/RIOT/10343/7c9ef1e9e023d2deb55a5c787ec1326a90a94a4a/output/compile/tests/xtimer_usleep/native:gnu.txt