### PR TITLE
 Makefile.include: require make version 4.

### DIFF
--- a/Makefile.include
+++ b/Makefile.include
@@ -1,3 +1,12 @@
+MATCH_MAKE_VERSION = 4.%
+
+ifeq (,$(filter $(MATCH_MAKE_VERSION),$(MAKE_VERSION)))
+  $(warning GNU Make $(MAKE_VERSION) is DEPRECATED in RIOT. Support for \
+	    versions less than $(MATCH_MAKE_VERSION) will be removed in \
+	    release 2020.01. Please upgrade your system to use GNU Make \
+	    $(MATCH_MAKE_VERSION) or later.)
+endif
+
 # 'Makefile.include' directory, must be evaluated before other 'include'
 _riotbase := $(dir $(lastword $(MAKEFILE_LIST)))
 


### PR DESCRIPTION
### Contribution description

Old versions of GNU Make (especially on OSX) are a pain to deal with. This commit introduces a warning when such an old version is found. The goal is that in the future the warning will be turned into an error. For that I can open a PR, which we don't merge, and is tagged for a future release.

Complying with version 4.x is easy on OSX by using homebrew, and on Linux, even Debian stable has the required version.

### Testing procedure

The test PR allows you to see what happens when you have an old version (it sets the version to 5, which does not exist at the moment.) Just go to any example and type `make`.

If you do the same without the test PR no warning is emitted.

### Issues/PRs references

The old version of make in vanilla OSX is blocking the introduction of rules to make directories.
Old make does not support `?=` in canned recipes.