### PR TITLE
boards/particle-{xenon,argon,boron}: add initial support

### DIFF
--- a/boards/common/particle-mesh/Makefile
+++ b/boards/common/particle-mesh/Makefile
@@ -1,0 +1,3 @@
+MODULE = boards_common_particle_mesh
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/common/particle-mesh/Makefile.dep
+++ b/boards/common/particle-mesh/Makefile.dep
@@ -1,0 +1,11 @@
+ifneq (,$(filter saul_default,$(USEMODULE)))
+  USEMODULE += saul_gpio
+endif
+
+ifneq (,$(filter gnrc_netdev_default netdev_default,$(USEMODULE)))
+  ifeq (,$(filter nrfmin,$(USEMODULE)))
+    USEMODULE += nrf802154
+  endif
+endif
+
+include $(RIOTBOARD)/common/nrf52/Makefile.dep

--- a/boards/common/particle-mesh/Makefile.features
+++ b/boards/common/particle-mesh/Makefile.features
@@ -1,0 +1,9 @@
+# Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_i2c
+FEATURES_PROVIDED += periph_spi
+FEATURES_PROVIDED += periph_uart
+
+# Various other features (if any)
+FEATURES_PROVIDED += radio_nrf802154
+
+include $(RIOTBOARD)/common/nrf52/Makefile.features

--- a/boards/common/particle-mesh/Makefile.include
+++ b/boards/common/particle-mesh/Makefile.include
@@ -1,0 +1,24 @@
+export CPU_MODEL = nrf52840xxaa
+
+# set default port depending on operating system
+PORT_LINUX ?= /dev/ttyUSB0
+PORT_DARWIN ?= $(firstword $(sort $(wildcard /dev/tty.SLAB_USBtoUART*)))
+
+# add the common header files to the include path
+INCLUDES += -I$(RIOTBOARD)/common/particle-mesh/include
+
+# This board uses a DAP-Link programmer
+# Flashing support is provided through pyocd (default) and openocd.
+# For openocd, a version built against the development branch and containing
+# the support for nrf52 cpu is required.
+PROGRAMMER ?= pyocd
+ifeq (pyocd,$(PROGRAMMER))
+  # The board is not recognized automatically by pyocd, so the CPU target
+  # option is passed explicitly
+  export FLASH_TARGET_TYPE ?= -t nrf52840
+  include $(RIOTMAKE)/tools/pyocd.inc.mk
+else ifeq (openocd,$(PROGRAMMER))
+  DEBUG_ADAPTER ?= dap
+endif
+
+include $(RIOTBOARD)/common/nrf52/Makefile.include

--- a/boards/common/particle-mesh/board.c
+++ b/boards/common/particle-mesh/board.c
@@ -1,0 +1,38 @@
+/*
+ * Copyright (C) 2018 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_common_particle-mesh
+ * @{
+ *
+ * @file
+ * @brief       Common board initialization for the Particle Mesh
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ * @}
+ */
+
+#include "cpu.h"
+#include "board.h"
+
+#include "periph/gpio.h"
+
+void board_init(void)
+{
+    /* initialize the boards LEDs */
+    gpio_init(LED0_PIN, GPIO_OUT);
+    gpio_set(LED0_PIN);
+    gpio_init(LED1_PIN, GPIO_OUT);
+    gpio_set(LED1_PIN);
+    gpio_init(LED2_PIN, GPIO_OUT);
+    gpio_set(LED2_PIN);
+
+    /* initialize the CPU */
+    cpu_init();
+}

--- a/boards/common/particle-mesh/doc.txt
+++ b/boards/common/particle-mesh/doc.txt
@@ -1,0 +1,53 @@
+/**
+@defgroup    boards_common_particle-mesh Particle Mesh common
+@ingroup     boards
+@brief       Common support for the Particle Mesh boards family (Xenon, Argon, Boron)
+
+### General information
+
+[Particle Mesh](https://www.particle.io/mesh/) are mesh-ready development kits.
+Depending on the board type (Xenon, Argon, Boron), it provides access to
+multiple communication protocols: BLE, 802.15.4, WiFi, LTE.
+
+### Flash the board
+
+Using the [Particle Mesh debugger](https://docs.particle.io/datasheets/accessories/mesh-accessories/#debugger),
+the board can be flashed with PyOCD programmer via a DAPLink.
+
+PyOCD can be installed using Python package manager:
+```
+    pip install pyocd --user -U
+```
+
+To flash the board, use `BOARD=<board name>` (with board name in {particle-argon,
+particle-boron, particle-xenon}) with the `make` command.<br/>
+Example with `hello-world` application:
+```
+    make BOARD=particle-xenon -C examples/hello-world flash
+```
+
+In this case, OpenOCD can also be used. For the moment, the latest stable
+version of OpenOCD (0.10) doesn't contain any support for nrf52 but versions
+built against the actual development version can be used.
+
+To flash the board with OpenOCD, use the `PROGRAMMER` variable:
+```
+    PROGRAMMER=openocd make BOARD=<board name> -C examples/hello-world flash
+```
+
+### Reset the board
+
+The on-board reset button doesn't work, so to trigger a reset of the board, use
+the `reset` target with `make`:
+```
+    make BOARD=<board name> -C examples/hello-world reset
+```
+
+### Accessing STDIO via UART
+
+The STDIO is not accessible via the USB port.
+
+To access the STDIO of RIOT, a FTDI to USB converter needs to be plugged to
+the RX/TX pins on the board.
+
+ */

--- a/boards/common/particle-mesh/include/board.h
+++ b/boards/common/particle-mesh/include/board.h
@@ -1,0 +1,69 @@
+/*
+ * Copyright (C) 2018 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_common_particle-mesh
+ * @{
+ *
+ * @file
+ * @brief       Common board specific configuration for the Particle Mesh
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ */
+
+#ifndef BOARD_H
+#define BOARD_H
+
+#include "cpu.h"
+#include "board_common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    LED pin configuration
+ * @{
+ */
+#define LED0_PIN            GPIO_PIN(0, 13)
+#define LED1_PIN            GPIO_PIN(0, 14)
+#define LED2_PIN            GPIO_PIN(0, 15)
+
+#define LED_PORT            (NRF_P0)
+#define LED0_MASK           (1 << 13)
+#define LED1_MASK           (1 << 14)
+#define LED2_MASK           (1 << 15)
+#define LED_MASK            (LED0_MASK | LED1_MASK | LED2_MASK)
+
+#define LED0_ON             (LED_PORT->OUTCLR = LED0_MASK)
+#define LED0_OFF            (LED_PORT->OUTSET = LED0_MASK)
+#define LED0_TOGGLE         (LED_PORT->OUT   ^= LED0_MASK)
+
+#define LED1_ON             (LED_PORT->OUTCLR = LED1_MASK)
+#define LED1_OFF            (LED_PORT->OUTSET = LED1_MASK)
+#define LED1_TOGGLE         (LED_PORT->OUT   ^= LED1_MASK)
+
+#define LED2_ON             (LED_PORT->OUTCLR = LED2_MASK)
+#define LED2_OFF            (LED_PORT->OUTSET = LED2_MASK)
+#define LED2_TOGGLE         (LED_PORT->OUT   ^= LED2_MASK)
+/** @} */
+
+/**
+ * @name    Button pin configuration
+ * @{
+ */
+#define BTN0_PIN            GPIO_PIN(0, 11)
+#define BTN0_MODE           GPIO_IN_PU
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* BOARD_H */
+/** @} */

--- a/boards/common/particle-mesh/include/gpio_params.h
+++ b/boards/common/particle-mesh/include/gpio_params.h
@@ -1,0 +1,66 @@
+/*
+ * Copyright (C) 2018 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_common_particle-mesh
+ * @{
+ *
+ * @file
+ * @brief       Configuration of SAUL mapped GPIO pins
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ */
+
+#ifndef GPIO_PARAMS_H
+#define GPIO_PARAMS_H
+
+#include "board.h"
+#include "saul/periph.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief    LED configuration
+ */
+static const  saul_gpio_params_t saul_gpio_params[] =
+{
+    {
+        .name  = "Led Red",
+        .pin   = LED0_PIN,
+        .mode  = GPIO_OUT,
+        .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
+    },
+    {
+        .name  = "Led Green",
+        .pin   = LED1_PIN,
+        .mode  = GPIO_OUT,
+        .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
+    },
+    {
+        .name  = "Led Blue",
+        .pin   = LED2_PIN,
+        .mode  = GPIO_OUT,
+        .flags = (SAUL_GPIO_INVERTED | SAUL_GPIO_INIT_CLEAR),
+    },
+    {
+        .name  = "MODE Button",
+        .pin   = BTN0_PIN,
+        .mode  = BTN0_MODE,
+        .flags = SAUL_GPIO_INVERTED,
+    },
+};
+
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* GPIO_PARAMS_H */
+/** @} */

--- a/boards/common/particle-mesh/include/periph_conf_common.h
+++ b/boards/common/particle-mesh/include/periph_conf_common.h
@@ -1,0 +1,67 @@
+/*
+ * Copyright (C) 2018 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_common_particle-mesh
+ * @{
+ *
+ * @file
+ * @brief       Common peripheral configuration for the Particle Mesh
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ */
+
+#ifndef PERIPH_CONF_COMMON_H
+#define PERIPH_CONF_COMMON_H
+
+#include "periph_cpu.h"
+#include "cfg_clock_32_1.h"
+#include "cfg_rtt_default.h"
+#include "cfg_timer_default.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    SPI configuration
+ * @{
+ */
+static const spi_conf_t spi_config[] = {
+    {
+        .dev  = NRF_SPI0,
+        .sclk = 15,
+        .mosi = 13,
+        .miso = 14
+    }
+};
+
+#define SPI_NUMOF           (sizeof(spi_config) / sizeof(spi_config[0]))
+/** @} */
+
+/**
+ * @name    I2C configuration
+ * @{
+ */
+static const i2c_conf_t i2c_config[] = {
+    {
+        .dev = NRF_TWIM1,
+        .scl = 27,
+        .sda = 26,
+        .speed = I2C_SPEED_NORMAL
+    }
+};
+#define I2C_NUMOF           (sizeof(i2c_config) / sizeof(i2c_config[0]))
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_CONF_COMMON_H */

--- a/boards/particle-argon/Makefile
+++ b/boards/particle-argon/Makefile
@@ -1,0 +1,5 @@
+MODULE = board
+
+DIRS = $(RIOTBOARD)/common/particle-mesh
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/particle-argon/Makefile.dep
+++ b/boards/particle-argon/Makefile.dep
@@ -1,0 +1,1 @@
+include $(RIOTBOARD)/common/particle-mesh/Makefile.dep

--- a/boards/particle-argon/Makefile.features
+++ b/boards/particle-argon/Makefile.features
@@ -1,0 +1,1 @@
+include $(RIOTBOARD)/common/particle-mesh/Makefile.features

--- a/boards/particle-argon/Makefile.include
+++ b/boards/particle-argon/Makefile.include
@@ -1,0 +1,3 @@
+USEMODULE += boards_common_particle_mesh
+
+include $(RIOTBOARD)/common/particle-mesh/Makefile.include

--- a/boards/particle-argon/doc.txt
+++ b/boards/particle-argon/doc.txt
@@ -1,0 +1,25 @@
+/**
+@defgroup    boards_particle-argon Particle Argon
+@ingroup     boards
+@brief       Support for the Particle Argon
+
+### General information
+
+[Particle Argon](https://docs.particle.io/argon/) is a mesh-ready development kit
+that provides access to multiple communication protocols: BLE, 802.15.4 and WiFi.
+
+<img src="https://docs.particle.io/assets/images/argon/argon-top.png"
+     alt="pinout" style="height:300px;"/>
+
+### Block diagrams and datasheets
+
+<img src="https://docs.particle.io/assets/images/argon/argon-block-diagram.png"
+     alt="pinout" style="height:800px;"/>
+
+The board datasheet is available [here](https://docs.particle.io/assets/pdfs/datasheets/argon-datasheet.pdf)
+
+### Flash the board
+
+See the `Flashing` section in @ref boards_common_particle-mesh.
+
+ */

--- a/boards/particle-argon/include/periph_conf.h
+++ b/boards/particle-argon/include/periph_conf.h
@@ -1,0 +1,63 @@
+/*
+ * Copyright (C) 2019 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_particle-argon
+ * @{
+ *
+ * @file
+ * @brief       Peripheral configuration for the Particle Argon
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+#include "periph_cpu.h"
+#include "periph_conf_common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    UART configuration
+ * @{
+ */
+static const uart_conf_t uart_config[] = {
+    {
+        .dev        = NRF_UARTE0,
+        .rx_pin     = GPIO_PIN(0,8),
+        .tx_pin     = GPIO_PIN(0,6),
+        .rts_pin    = (uint8_t)GPIO_UNDEF,
+        .cts_pin    = (uint8_t)GPIO_UNDEF,
+        .irqn       = UARTE0_UART0_IRQn,
+    },
+    {
+        .dev        = NRF_UARTE1,
+        .rx_pin     = GPIO_PIN(1,5),
+        .tx_pin     = GPIO_PIN(1,4),
+        .rts_pin    = GPIO_PIN(1,6),
+        .cts_pin    = GPIO_PIN(1,7),
+        .irqn       = UARTE1_IRQn,
+    },
+};
+
+#define UART_0_ISR          (isr_uart0)
+#define UART_1_ISR          (isr_uarte1)
+
+#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_CONF_H */

--- a/boards/particle-boron/Makefile
+++ b/boards/particle-boron/Makefile
@@ -1,0 +1,5 @@
+MODULE = board
+
+DIRS = $(RIOTBOARD)/common/particle-mesh
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/particle-boron/Makefile.dep
+++ b/boards/particle-boron/Makefile.dep
@@ -1,0 +1,1 @@
+include $(RIOTBOARD)/common/particle-mesh/Makefile.dep

--- a/boards/particle-boron/Makefile.features
+++ b/boards/particle-boron/Makefile.features
@@ -1,0 +1,1 @@
+include $(RIOTBOARD)/common/particle-mesh/Makefile.features

--- a/boards/particle-boron/Makefile.include
+++ b/boards/particle-boron/Makefile.include
@@ -1,0 +1,3 @@
+USEMODULE += boards_common_particle_mesh
+
+include $(RIOTBOARD)/common/particle-mesh/Makefile.include

--- a/boards/particle-boron/doc.txt
+++ b/boards/particle-boron/doc.txt
@@ -1,0 +1,25 @@
+/**
+@defgroup    boards_particle-boron Particle Boron
+@ingroup     boards
+@brief       Support for the Particle Boron
+
+### General information
+
+[Particle Boron](https://docs.particle.io/boron/) is a mesh-ready development kit
+that provides access to multiple communication protocols: BLE, 802.15.4 and LTE.
+
+<img src="https://docs.particle.io/assets/images/boron/boron-top.png"
+     alt="pinout" style="height:300px;"/>
+
+### Block diagrams and datasheets
+
+<img src="https://docs.particle.io/assets/images/boron/boron-block-diagram.png"
+     alt="pinout" style="height:800px;"/>
+
+The board datasheet is available [here](https://docs.particle.io/assets/pdfs/datasheets/boron-datasheet.pdf)
+
+### Flash the board
+
+See the `Flashing` section in @ref boards_common_particle-mesh.
+
+ */

--- a/boards/particle-boron/include/periph_conf.h
+++ b/boards/particle-boron/include/periph_conf.h
@@ -1,0 +1,62 @@
+/*
+ * Copyright (C) 2019 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_particle-boron
+ * @{
+ *
+ * @file
+ * @brief       Peripheral configuration for the Particle Boron
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+#include "periph_cpu.h"
+#include "periph_conf_common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    UART configuration
+ * @{
+ */
+static const uart_conf_t uart_config[] = {
+    {
+        .dev        = NRF_UARTE0,
+        .rx_pin     = GPIO_PIN(0,8),
+        .tx_pin     = GPIO_PIN(0,6),
+        .rts_pin    = (uint8_t)GPIO_UNDEF,
+        .cts_pin    = (uint8_t)GPIO_UNDEF,
+        .irqn       = UARTE0_UART0_IRQn,
+    },
+    {
+        .dev        = NRF_UARTE1,
+        .rx_pin     = GPIO_PIN(1,4),
+        .tx_pin     = GPIO_PIN(1,5),
+        .rts_pin    = GPIO_PIN(1,7),
+        .cts_pin    = GPIO_PIN(1,6),
+        .irqn       = UARTE1_IRQn,
+    },
+};
+
+#define UART_0_ISR          (isr_uart0)
+#define UART_1_ISR          (isr_uarte1)
+
+#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+/** @} */
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_CONF_H */

--- a/boards/particle-xenon/Makefile
+++ b/boards/particle-xenon/Makefile
@@ -1,0 +1,5 @@
+MODULE = board
+
+DIRS = $(RIOTBOARD)/common/particle-mesh
+
+include $(RIOTBASE)/Makefile.base

--- a/boards/particle-xenon/Makefile.dep
+++ b/boards/particle-xenon/Makefile.dep
@@ -1,0 +1,1 @@
+include $(RIOTBOARD)/common/particle-mesh/Makefile.dep

--- a/boards/particle-xenon/Makefile.features
+++ b/boards/particle-xenon/Makefile.features
@@ -1,0 +1,1 @@
+include $(RIOTBOARD)/common/particle-mesh/Makefile.features

--- a/boards/particle-xenon/Makefile.include
+++ b/boards/particle-xenon/Makefile.include
@@ -1,0 +1,3 @@
+USEMODULE += boards_common_particle_mesh
+
+include $(RIOTBOARD)/common/particle-mesh/Makefile.include

--- a/boards/particle-xenon/doc.txt
+++ b/boards/particle-xenon/doc.txt
@@ -1,0 +1,25 @@
+/**
+@defgroup    boards_particle-xenon Particle Xenon
+@ingroup     boards
+@brief       Support for the Particle Xenon
+
+### General information
+
+[Particle Xenon](https://docs.particle.io/xenon/) is a mesh-ready development kit
+that provides access to multiple communication protocols: BLE, 802.15.4.
+
+<img src="https://docs.particle.io/assets/images/xenon/xenon-top.png"
+     alt="pinout" style="height:300px;"/>
+
+### Block diagrams and datasheets
+
+<img src="https://docs.particle.io/assets/images/xenon/xenon-block-diagram.png"
+     alt="pinout" style="height:800px;"/>
+
+The board datasheet is available [here](https://docs.particle.io/assets/pdfs/datasheets/xenon-datasheet.pdf)
+
+### Flash the board
+
+See the `Flashing` section in @ref boards_common_particle-mesh.
+
+ */

--- a/boards/particle-xenon/include/periph_conf.h
+++ b/boards/particle-xenon/include/periph_conf.h
@@ -1,0 +1,54 @@
+/*
+ * Copyright (C) 2019 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     boards_particle-xenon
+ * @{
+ *
+ * @file
+ * @brief       Peripheral configuration for the Particle Xenon
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ */
+
+#ifndef PERIPH_CONF_H
+#define PERIPH_CONF_H
+
+#include "periph_cpu.h"
+#include "periph_conf_common.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    UART configuration
+ * @{
+ */
+static const uart_conf_t uart_config[] = {
+    {
+        .dev        = NRF_UARTE0,
+        .rx_pin     = GPIO_PIN(0,8),
+        .tx_pin     = GPIO_PIN(0,6),
+        .rts_pin    = (uint8_t)GPIO_UNDEF,
+        .cts_pin    = (uint8_t)GPIO_UNDEF,
+        .irqn       = UARTE0_UART0_IRQn,
+    },
+};
+
+#define UART_0_ISR          (isr_uart0)
+
+#define UART_NUMOF          (sizeof(uart_config) / sizeof(uart_config[0]))
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* PERIPH_CONF_H */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR adds support for the [Particle Mesh development kit](https://www.particle.io/mesh/). I backed the project several month ago and received the boards this week.

The port is minimal: it just adds support for the nrf52840 and map some available pins. Since the WiFi, LTE drivers are not yet supported by RIOT, nothing is provided for them.

To flash the board, the default configuration is to use one of their accessories: the debugger. It provides a DAPLink interface to flash and debug the boards. Since OpenOCD 0.10 doesn't work with this version of the CPU, the default programmer configured is PyOCD (see #9847 for details).

The programming pins are exposed, so it's certainly possible to use another external tool (Segger JLink, etc) but I haven't tried.

One also needs an USB to UART converter to access the debug console.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Plug an USB to UART converter and the debugger to the board
- Build and flash any application:
```
make BOARD=particle-mesh -C examples/default flash term
```
- Enjoy!

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

This PR is based on #9847 to flash the board, #10279 is also required in order to minimize code duplication.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
