### PR TITLE
makefiles/docker: fix docker build on osx

### DIFF
--- a/makefiles/docker.inc.mk
+++ b/makefiles/docker.inc.mk
@@ -94,7 +94,7 @@ DOCKER_OVERRIDE_CMDLINE := $(strip $(DOCKER_OVERRIDE_CMDLINE))
 	    -v '$(RIOTBOARD):$(DOCKER_BUILD_ROOT)/riotboard' \
 	    -v '$(RIOTMAKE):$(DOCKER_BUILD_ROOT)/riotmake' \
 	    -v '$(RIOTPROJECT):$(DOCKER_BUILD_ROOT)/riotproject' \
-	    -v /etc/localtime:/etc/localtime:ro \
+	    -v $(realpath /etc/localtime):/etc/localtime:ro \
 	    -e 'RIOTBASE=$(DOCKER_BUILD_ROOT)/riotbase' \
 	    -e 'CCACHE_BASEDIR=$(DOCKER_BUILD_ROOT)/riotbase' \
 	    -e 'RIOTCPU=$(DOCKER_BUILD_ROOT)/riotcpu' \


### PR DESCRIPTION
### Contribution description

On OSX, when running make BUILD_IN_DOCKER=1, it fails with the following error
```
docker: Error response from daemon: Mounts denied:
The path /etc/localtime
is not shared from OS X and is not known to Docker.
You can configure shared paths from Docker -> Preferences... -> File Sharing.
See https://docs.docker.com/docker-for-mac/osxfs/#namespaces for more info.
```

/etc/localtime is not shared by default. Even after adding it to the shared file list, it still doesn't work because of the symlink. This patch resolves any symlinks which on OSX go to files under /private which are by default shared.

### Testing procedure
This was run on OSX and showed that there were no issues.

### Issues/PRs references
Fixes #10287 
