### PR TITLE
gnrc/netif/internal: fix copy-paste error

### DIFF
--- a/sys/include/net/gnrc/netif/internal.h
+++ b/sys/include/net/gnrc/netif/internal.h
@@ -467,8 +467,8 @@ int gnrc_netif_ipv6_iid_from_addr(const gnrc_netif_t *netif,
 int gnrc_netif_ipv6_iid_to_addr(const gnrc_netif_t *netif, const eui64_t *iid,
                                 uint8_t *addr);
 #else   /* defined(MODULE_GNRC_IPV6) || defined(DOXYGEN) */
-#define gnrc_netif_ipv6_iid_to_addr(netif, addr, addr_len, iid) (-ENOTSUP)
-#define gnrc_netif_ipv6_iid_from_addr(netif, iid, addr)         (-ENOTSUP)
+#define gnrc_netif_ipv6_iid_from_addr(netif, addr, addr_len, iid) (-ENOTSUP)
+#define gnrc_netif_ipv6_iid_to_addr(netif, iid, addr)         (-ENOTSUP)
 #endif  /* defined(MODULE_GNRC_IPV6) || defined(DOXYGEN) */
 
 #ifdef __cplusplus


### PR DESCRIPTION
### Contribution description
#10513 introduced a small error for the case that no IPv6 is compiled in: `gnrc_netif_ipv6_iid_from_addr()` and `gnrc_netif_ipv6_iid_to_addr()` are supposed to be defined to a static `-ENOTSUP` in that case - but there names where switched around, so that we get compile errors complaining about the wrong number of parameters...

### Testing procedure
At least on my local machine, building `ccn-lite-relay` failed for native. With this PR it does not fail anymore... But I wonder how Murdock was able to build that example when doing the build-test for #10513...

### Issues/PRs references
#10513