### PR TITLE
makefiles/docker: fix mounting localtime on OSX

### DIFF
--- a/makefiles/docker.inc.mk
+++ b/makefiles/docker.inc.mk
@@ -94,6 +94,11 @@ _is_git_worktree = $(shell grep '^gitdir: ' $(RIOTBASE)/.git 2>/dev/null)
 GIT_WORKTREE_COMMONDIR = $(shell git rev-parse --git-common-dir)
 DOCKER_VOLUMES_AND_ENV += $(if $(_is_git_worktree),-v $(GIT_WORKTREE_COMMONDIR):$(GIT_WORKTREE_COMMONDIR))
 
+# Resolve symlink of /etc/localtime to its real path
+# This is a workaround for docker on macOS, for more information see:
+# https://github.com/docker/for-mac/issues/2396
+ETC_LOCALTIME = $(realpath /etc/localtime)
+
 # This will execute `make $(DOCKER_MAKECMDGOALS)` inside a Docker container.
 # We do not push the regular $(MAKECMDGOALS) to the container's make command in
 # order to only perform building inside the container and defer executing any
@@ -109,7 +114,7 @@ DOCKER_VOLUMES_AND_ENV += $(if $(_is_git_worktree),-v $(GIT_WORKTREE_COMMONDIR):
 	    -v '$(RIOTBOARD):$(DOCKER_BUILD_ROOT)/riotboard' \
 	    -v '$(RIOTMAKE):$(DOCKER_BUILD_ROOT)/riotmake' \
 	    -v '$(RIOTPROJECT):$(DOCKER_BUILD_ROOT)/riotproject' \
-	    -v /etc/localtime:/etc/localtime:ro \
+	    -v '$(ETC_LOCALTIME):/etc/localtime:ro' \
 	    -e 'RIOTBASE=$(DOCKER_BUILD_ROOT)/riotbase' \
 	    -e 'CCACHE_BASEDIR=$(DOCKER_BUILD_ROOT)/riotbase' \
 	    -e 'RIOTCPU=$(DOCKER_BUILD_ROOT)/riotcpu' \


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

Mounting `/etc/localtime` directly does not work on macOS (anymore).
However, by resolving the symlink to its real path docker can handle
the mount on macOS again - should also work with Linux.


### Testing procedure

Try to run `BUILD_IN_DOCKER=1 make -C tests/minimal` on macOS, which will fail with one or the other error regarding either that `/etc` is not shared and hence not accessible by docker, or if you do add it to the list of shared folders, it will fail with mounting `/etc/localtime` into docker. With this PR it works again.


### Issues/PRs references

Fixes #10287.

