### PR TITLE
gnrc_netif: make _get_iid() just wrapper around _iid_from_addr()

### DIFF
--- a/sys/net/gnrc/netif/gnrc_netif.c
+++ b/sys/net/gnrc/netif/gnrc_netif.c
@@ -177,9 +177,7 @@ int gnrc_netif_get_from_netdev(gnrc_netif_t *netif, gnrc_netapi_opt_t *opt)
             break;
         case NETOPT_IPV6_IID:
             assert(opt->data_len >= sizeof(eui64_t));
-            if (gnrc_netif_ipv6_get_iid(netif, opt->data) == 0) {
-                res = sizeof(eui64_t);
-            }
+            res = gnrc_netif_ipv6_get_iid(netif, opt->data);
             break;
         case NETOPT_MAX_PACKET_SIZE:
             if (opt->context == GNRC_NETTYPE_IPV6) {
@@ -805,28 +803,6 @@ int gnrc_netif_ipv6_group_idx(gnrc_netif_t *netif, const ipv6_addr_t *addr)
     idx = _group_idx(netif, addr);
     gnrc_netif_release(netif);
     return idx;
-}
-
-int gnrc_netif_ipv6_get_iid(gnrc_netif_t *netif, eui64_t *eui64)
-{
-#if GNRC_NETIF_L2ADDR_MAXLEN > 0
-    if (netif->flags & GNRC_NETIF_FLAGS_HAS_L2ADDR) {
-        /* the device driver abstraction should be able to provide us with the
-         * IPV6_IID, so we try this first */
-        int res = netif->dev->driver->get(netif->dev, NETOPT_IPV6_IID,
-                                          eui64, sizeof(eui64_t));
-        if (res == sizeof(eui64_t)) {
-            return 0;
-        }
-        res = gnrc_netif_ipv6_iid_from_addr(netif,
-                                            netif->l2addr, netif->l2addr_len,
-                                            eui64);
-        if (res > 0) {
-            return 0;
-        }
-    }
-#endif /* GNRC_NETIF_L2ADDR_MAXLEN > 0 */
-    return -ENOTSUP;
 }
 
 static inline bool _addr_anycast(const gnrc_netif_t *netif, unsigned idx)

--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-slaac.c
@@ -108,7 +108,7 @@ static bool _try_addr_reconfiguration(gnrc_netif_t *netif)
     eui64_t orig_iid;
     bool remove_old = false, hwaddr_reconf;
 
-    if (gnrc_netif_ipv6_get_iid(netif, &orig_iid) == 0) {
+    if (gnrc_netif_ipv6_get_iid(netif, &orig_iid) > 0) {
         remove_old = true;
     }
     /* seize netif to netif thread since _try_l2addr_reconfiguration uses

--- a/tests/gnrc_netif/main.c
+++ b/tests/gnrc_netif/main.c
@@ -651,10 +651,12 @@ static void test_ipv6_get_iid(void)
     eui64_t res;
     uint16_t ieee802154_l2addr_len = 2U;
 
-    TEST_ASSERT_EQUAL_INT(0, gnrc_netif_ipv6_get_iid(ethernet_netif, &res));
+    TEST_ASSERT_EQUAL_INT(sizeof(eui64_t),
+                          gnrc_netif_ipv6_get_iid(ethernet_netif, &res));
     TEST_ASSERT_EQUAL_INT(0, memcmp(&res, &ethernet_ipv6_ll.u64[1],
                                     sizeof(res)));
-    TEST_ASSERT_EQUAL_INT(0, gnrc_netif_ipv6_get_iid(ieee802154_netif, &res));
+    TEST_ASSERT_EQUAL_INT(sizeof(eui64_t),
+                          gnrc_netif_ipv6_get_iid(ieee802154_netif, &res));
     TEST_ASSERT_EQUAL_INT(0, memcmp(&res, &ieee802154_ipv6_ll_long.u64[1],
                                     sizeof(res)));
     TEST_ASSERT_EQUAL_INT(sizeof(ieee802154_l2addr_len),
@@ -662,7 +664,8 @@ static void test_ipv6_get_iid(void)
                                           NETOPT_SRC_LEN, 0,
                                           &ieee802154_l2addr_len,
                                           sizeof(ieee802154_l2addr_len)));
-    TEST_ASSERT_EQUAL_INT(0, gnrc_netif_ipv6_get_iid(ieee802154_netif, &res));
+    TEST_ASSERT_EQUAL_INT(sizeof(eui64_t),
+                          gnrc_netif_ipv6_get_iid(ieee802154_netif, &res));
     TEST_ASSERT_EQUAL_INT(0, memcmp(&res, &ieee802154_eui64_short, sizeof(res)));
     /* reset to source length 8 */
     ieee802154_l2addr_len = 8U;


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This way the IID generation gets much simplified and code duplication is avoided since it removes GNRC's requirement for `NETOPT_IPV6_IID` (we can't remove it from the devices just yet, since OpenThread and lwIP are also using it, and also some tests.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
`gnrc_networking` should still show the same IPv6 address with `ifconfig`

### Issues/PRs references
"Reverts" #10455. GNRC-specific alternative to #10537.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
