### PR TITLE
tests: compile-tests should only be executed in building machine

### DIFF
--- a/tests/cortexm_common_ldscript/Makefile
+++ b/tests/cortexm_common_ldscript/Makefile
@@ -27,7 +27,10 @@ include $(RIOTBASE)/Makefile.include
 COMPILE_TESTS  = test-elffile-overflow test-elffile-fw_rom_length
 COMPILE_TESTS += tests-offsets tests-fw_rom_len tests-rom-overflow
 
+# The tests should only be executed in build environment
+ifneq ($(BUILD_IN_DOCKER),1)
 all: compile-tests
+endif
 
 compile-tests: $(COMPILE_TESTS)
 .PHONY: compile-tests $(COMPILE_TESTS)

--- a/tests/libc_newlib/Makefile
+++ b/tests/libc_newlib/Makefile
@@ -7,7 +7,10 @@ include $(RIOTBASE)/Makefile.include
 
 # Compile time tests
 .PHONY: compile-test test-newlib-nano
+# The tests should only be executed in build environment
+ifneq ($(BUILD_IN_DOCKER),1)
 all: compile-test
+endif
 
 ifneq (,$(filter newlib,$(USEMODULE)))
   COMPILE_TESTS += test-newlib

--- a/tests/libc_newlib/Makefile
+++ b/tests/libc_newlib/Makefile
@@ -29,6 +29,7 @@ endif
 # https://github.com/32bitmicro/newlib-nano-1.0/blob/f157c994b9a2c4bd8d0cfe9fe8fdd9cd54f8c63b/newlib/README.nano#L32
 
 test-newlib: $(ELFFILE)
+	$(Q)test -f $^
 	$(Q)\
 	PRINTF_ADDR=$$($(NM) $^ | sed -n '/ printf$$/ s/ .*//p');\
 	IPRINTF_ADDR=$$($(NM) $^ | sed -n '/ iprintf$$/ s/ .*//p');\


### PR DESCRIPTION
### Contribution description

When building with `BUILD_IN_DOCKER` the `compile-tests` were also tried to be executed on the host machine which had concurrency issues when done in parallel and also fails if you do not have the toolchain.

I also inlined added a change that verify the test file exists as the test would silently compare the error string instead of the real output.

### Testing procedure

Using the first commit only:

On a clean environment these both fail:

```
BUILD_IN_DOCKER=1 DOCKER="sudo docker" BOARD=samr21-xpro make -C tests/cortexm_common_ldscript/ -j clean all
BUILD_IN_DOCKER=1 DOCKER="sudo docker" BOARD=samr21-xpro make -C tests/libc_newlib/ -j clean all
```

And with the following, the tests are executed both in docker and the build machine

```
BUILD_IN_DOCKER=1 DOCKER="sudo docker" BOARD=samr21-xpro make -C tests/libc_newlib/ all
...
Test: comparing addresses of 'printf' and 'iprintf' symbols
[SUCCESS] '0000158c' = '0000158c' is True
Test: comparing addresses of 'printf' and 'iprintf' symbols
[SUCCESS] '0000158c' = '0000158c' is True
make: Leaving directory '/home/harter/work/git/RIOT/tests/libc_newlib'
```

### Issues/PRs references

Found while building in docker on a machine without toolchain and also again during https://github.com/RIOT-OS/RIOT/pull/10344 testing.