### PR TITLE
murdock: implement test result caching

### DIFF
--- a/.murdock
+++ b/.murdock
@@ -7,11 +7,12 @@ export RIOT_CI_BUILD=1
 export STATIC_TESTS=${STATIC_TESTS:-1}
 export CFLAGS_DBG=""
 export DLCACHE_DIR=${DLCACHE_DIR:-~/.dlcache}
+export ENABLE_TEST_CACHE=${ENABLE_TEST_CACHE:-1}
 
 NIGHTLY=${NIGHTLY:-0}
 RUN_TESTS=${RUN_TESTS:-${NIGHTLY}}
 
-DWQ_ENV="-E BOARDS -E APPS -E NIGHTLY -E RUN_TESTS"
+DWQ_ENV="-E BOARDS -E APPS -E NIGHTLY -E RUN_TESTS -E ENABLE_TEST_CACHE -E TEST_HASH"
 
 check_label() {
     local label="${1}"
@@ -22,6 +23,10 @@ check_label() {
 
 [ "$RUN_TESTS" != "1" ] && {
     check_label "CI: run tests" && RUN_TESTS=1
+}
+
+[ "$ENABLE_TEST_CACHE" = "1" ] && {
+    check_label "CI: disable test cache" && export ENABLE_TEST_CACHE=0
 }
 
 error() {
@@ -138,6 +143,30 @@ print_worker() {
         echo "-- running on worker ${DWQ_WORKER} thread ${DWQ_WORKER_THREAD}, build number $DWQ_WORKER_BUILDNUM."
 }
 
+test_hash_calc() {
+    local bindir=$1
+
+    # Why two times cut?
+    # "test-input-hash.sha1" contains a list of lines containing
+    # "<hash> <filename>" on each line.
+    # We need to filter out the filename, as it contains the full path name,
+    # which differs depending on the build machine.
+    #
+    # After piping through sha1sum, we get "<hash> -". " -" has to go so we save the
+    # hassle of escaping the resulting hash.
+
+    cat ${bindir}/test-input-hash.sha1 | cut -f1 -d' ' | sha1sum | cut -f1 -d' '
+}
+
+test_cache_get() {
+    test "${ENABLE_TEST_CACHE}" = "1" || return 1
+    test -n "$(redis-cli get $1)" > /dev/null
+}
+
+test_cache_put() {
+    redis-cli set "$1" ok
+}
+
 # compile one app for one board with one toolchain. delete intermediates.
 compile() {
     local appdir=$1
@@ -167,7 +196,7 @@ compile() {
 
     # compile
     CCACHE_BASEDIR="$(pwd)" BOARD=$board TOOLCHAIN=$toolchain RIOT_CI_BUILD=1 \
-        make -C${appdir} clean all -j${JOBS:-4}
+        make -C${appdir} clean all test-input-hash -j${JOBS:-4}
     RES=$?
 
     # run tests
@@ -178,8 +207,15 @@ compile() {
                     BOARD=$board make -C${appdir} test
                     RES=$?
                 elif is_in_list "$board" "$TEST_BOARDS_AVAILABLE"; then
-                    BOARD=$board TOOLCHAIN=$toolchain make -C${appdir} test-murdock
-                    RES=$?
+                    test_hash=$(test_hash_calc "$BINDIR")
+                    echo "-- test_hash=$test_hash"
+                    if test_cache_get $test_hash; then
+                        echo "-- skipping test due to positive cache hit"
+                    else
+                        BOARD=$board TOOLCHAIN=$toolchain TEST_HASH=$test_hash \
+                            make -C${appdir} test-murdock
+                        RES=$?
+                    fi
                 fi
             fi
         fi
@@ -224,6 +260,14 @@ run_test() {
     echo "-- executing tests for $appdir on $board (compiled with $toolchain toolchain):"
     hook run_test_pre
     BOARD=$board TOOLCHAIN=${toolchain} make -C$appdir flash-only test
+    RES=$?
+
+    if [ $RES -eq 0 -a -n "$TEST_HASH" ]; then
+        echo -n "-- saving test result to cache: "
+        test_cache_put $TEST_HASH
+    fi
+
+    return $RES
 }
 
 # execute static tests

--- a/Makefile.include
+++ b/Makefile.include
@@ -580,6 +580,15 @@ test: $(TEST_DEPS)
 test/available:
 	$(Q)test -n "$(strip $(TESTS))"
 
+# this target only makes sense if an ELFFILE is actually created, thus guard by
+# RIOTNOLINK="".
+ifeq (,$(RIOTNOLINK))
+test-input-hash: $(TESTS) $(ELFFILE)
+	sha1sum $^ > $(BINDIR)/test-input-hash.sha1
+else
+test-input-hash:
+	true
+endif
 
 # Default OBJDUMPFLAGS for platforms which do not specify it:
 OBJDUMPFLAGS ?= -S -D -h


### PR DESCRIPTION
### Contribution description

This PR adds simple test result caching to Murdock.
The goal is to speed up PR builds with "CI: run tests" set by skipping test applications that have not changed (and would thus have the same result).

Whenever a test is about to be executed on hardware, a hash of the application's binary and all of it's tests is generated. That hash is then looked up in a Redis instance. If the hash exists, the test is skipped.
After a successful test run, the hash is inserted into Redis.
Negative results are never cached.
The cache is not consulted (all test are run) should the label "CI: disable test cache" be set on a PR.
The caching logic is integrated in a way that if anything regarding caching fails (e.g., Redis down), the cache is simply skipped.

This is marked RFC as I'd like some feedback on the approach and its implementation.
There are some open questions:
- this will not catch changes to testrunner. Is there an easy workaround, or is that acceptable?
- this should probably be disabled for the nightlies?

It is also marked WIP as there's ~~no Redis instance running on the Murdock master, yet.~~ (resolved)
*edit* ~~It is also missing on the workers.~~ (resolved)

### Testing procedure

- run tests on this PR
- run tests again. all tests should be skipped. 
- set "CI: disable test cache"
- run tests again. all tests should be executed again

- make a test fail
- run tests again twice, make sure the failed test is re-run every time

- change a test or a tested binary. run tests again, making sure the test is executed