### PR TITLE
 drivers/i2c: Fix i2c api issues

### DIFF
--- a/drivers/include/periph/i2c.h
+++ b/drivers/include/periph/i2c.h
@@ -388,8 +388,8 @@ int i2c_write_bytes(i2c_t dev, uint16_t addr, const void *data,
  * @brief   Convenience function for writing one byte to a given
  *          register address
  *
- * @note    This function is using a repeated start sequence for writing to the
- *          specified register address.
+ * @note    This function is using a continuous sequence for writing to the
+ *          specified register address. It first writes the register then data.
  *
  * @pre     i2c_acquire must be called before accessing the bus
  *
@@ -414,8 +414,8 @@ int i2c_write_reg(i2c_t dev, uint16_t addr, uint16_t reg,
 /**
  * @brief   Convenience function for writing data to a given register address
  *
- * @note    This function is using a repeated start sequence for writing to the
- *          specified register address.
+ * @note    This function is using a continuous sequence for writing to the
+ *          specified register address. It first writes the register then data.
  *
  * @pre     i2c_acquire must be called before accessing the bus
  *

--- a/drivers/periph_common/i2c.c
+++ b/drivers/periph_common/i2c.c
@@ -17,6 +17,7 @@
  *
  * @}
  */
+#include <errno.h>
 
 #include "board.h"
 #include "cpu.h"
@@ -36,6 +37,9 @@ int i2c_read_reg(i2c_t dev, uint16_t addr, uint16_t reg,
 int i2c_read_regs(i2c_t dev, uint16_t addr, uint16_t reg,
                   void *data, size_t len, uint8_t flags)
 {
+    if (flags & (I2C_NOSTOP | I2C_NOSTART)) {
+        return -EOPNOTSUPP;
+    }
     /* First set ADDR and register with no stop */
     int ret = i2c_write_bytes(dev, addr, &reg, (flags & I2C_REG16) ? 2 : 1,
                               flags | I2C_NOSTOP);
@@ -69,6 +73,9 @@ int i2c_write_reg(i2c_t dev, uint16_t addr, uint16_t reg,
 int i2c_write_regs(i2c_t dev, uint16_t addr, uint16_t reg,
                    const void *data, size_t len, uint8_t flags)
 {
+    if (flags & (I2C_NOSTOP | I2C_NOSTART)) {
+        return -EOPNOTSUPP;
+    }
     /* First set ADDR and register with no stop */
     int ret = i2c_write_bytes(dev, addr, &reg, (flags & I2C_REG16) ? 2 : 1,
                               flags | I2C_NOSTOP);


### PR DESCRIPTION
### Contribution description
This was discovered by the HiL testing.

This PR fixes some issues regarding the i2c API.  It updates documentation to reflect implementation and intent.  It also prevents improper flags from being set in the common i2c driver implementation.


### Testing procedure
Read the documentation and maybe try to i2c_read_regs or i2c_write_regs with a board that uses the common implementation (samr21) and receive ENOTSUPPORTED error message.  

### Issues/PRs references
Fixes ##10559.