### PR TITLE
sys/auto_init: alphabetical order for SHT3x fixed

### DIFF
--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -437,6 +437,10 @@ void auto_init(void)
     extern void auto_init_pulse_counter(void);
     auto_init_pulse_counter();
 #endif
+#ifdef MODULE_SHT3X
+    extern void auto_init_sht3x(void);
+    auto_init_sht3x();
+#endif
 #ifdef MODULE_SI114X
     extern void auto_init_si114x(void);
     auto_init_si114x();
@@ -468,11 +472,6 @@ void auto_init(void)
 #ifdef MODULE_VEML6070
     extern void auto_init_veml6070(void);
     auto_init_veml6070();
-#endif
-
-#ifdef MODULE_SHT3X
-    extern void auto_init_sht3x(void);
-    auto_init_sht3x();
 #endif
 
 #endif /* MODULE_AUTO_INIT_SAUL */


### PR DESCRIPTION
### Contribution description

This PR fixes the alphabetical order in `sys/auto_init/auto_init.c` for the SHT3x driver which was merged with PR #10012. 

### Testing procedure

Compilation of `test/saul` with the `sht3x` module has to pass for any board that supports I2C
```
USEMODULE= USEMODULE=sht3x make -C tests/saul BOARD=arduino-mkr1000
```

### Issues/PRs references

SHT3x driver was added with PR #10012.