### PR TITLE
boards/microbit: fix typo in flash script

### DIFF
--- a/boards/microbit/dist/flash.sh
+++ b/boards/microbit/dist/flash.sh
@@ -63,5 +63,5 @@ then
 fi
 
 echo ""
-echo "UPLOAD SUCCESFUL"
+echo "UPLOAD SUCCESSFUL"
 echo ""


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR fixes an obvious typo in the flash script of the microbit board: SUCCESFUL => SUCCES**S**FUL.

It can be merged when CI is green.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Build and flash a firmware on the microbit. It has to be plugged to your computer.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
