### PR TITLE
core/clist: add missing function to table in doc

### DIFF
--- a/core/include/clist.h
+++ b/core/include/clist.h
@@ -21,9 +21,12 @@
  * operation            | runtime | description
  * ---------------------|---------|---------------
  * clist_lpush()        | O(1)    | insert as head (leftmost node)
+ * clist_lpeek()        | O(1)    | get the head without removing it
  * clist_lpop()         | O(1)    | remove and return head (leftmost node)
  * clist_rpush()        | O(1)    | append as tail (rightmost node)
+ * clist_rpeek()        | O(1)    | get the tail without removing it
  * clist_rpop()         | O(n)    | remove and return tail (rightmost node)
+ * clist_lpoprpush()    | O(1)    | move first element to the end of the list
  * clist_find()         | O(n)    | find and return node
  * clist_find_before()  | O(n)    | find node return node pointing to node
  * clist_remove()       | O(n)    | remove and return node


### PR DESCRIPTION
### Contribution description
When working with `clist.h`, I noticed that some functions were not included in the overview table in the beginning of the doxygen header. As I like that table as quick reference, I added the (some) missing functions.

### Testing procedure
doc changes only, so successful buildtest is all we need.

### Issues/PRs references
none