### PR TITLE
tests/bench_runtime_coreapis: improve pexpect autotest

### DIFF
--- a/tests/bench_runtime_coreapis/tests/01-run.py
+++ b/tests/bench_runtime_coreapis/tests/01-run.py
@@ -12,10 +12,21 @@ from testrunner import run
 
 # The default timeout is not enough for this test on some of the slower boards
 TIMEOUT = 30
+BENCHMARK_REGEXP = r"\s+{func}:\s+\d+us\s+---\s+\d*\.*\d+us per call\s+---\s+\d+ calls per sec"
 
 
 def testfunc(child):
-    child.expect_exact('[SUCCESS]', timeout=TIMEOUT)
+    child.expect_exact('Runtime of Selected Core API functions')
+    child.expect(BENCHMARK_REGEXP.format(func="nop loop"))
+    child.expect(BENCHMARK_REGEXP.format(func=r"mutex_init\(\)"))
+    child.expect(BENCHMARK_REGEXP.format(func="mutex lock/unlock"), timeout=TIMEOUT)
+    child.expect(BENCHMARK_REGEXP.format(func=r"thread_flags_set\(\)"))
+    child.expect(BENCHMARK_REGEXP.format(func="thread flags set/wait any"), timeout=TIMEOUT)
+    child.expect(BENCHMARK_REGEXP.format(func="thread flags set/wait all"), timeout=TIMEOUT)
+    child.expect(BENCHMARK_REGEXP.format(func="thread flags set/wait one"), timeout=TIMEOUT)
+    child.expect(BENCHMARK_REGEXP.format(func=r"msg_try_receive\(\)"))
+    child.expect(BENCHMARK_REGEXP.format(func=r"msg_avail\(\)"))
+    child.expect_exact('[SUCCESS]')
 
 
 if __name__ == "__main__":

--- a/tests/bench_runtime_coreapis/tests/01-run.py
+++ b/tests/bench_runtime_coreapis/tests/01-run.py
@@ -6,8 +6,8 @@
 # General Public License v2.1. See the file LICENSE in the top level
 # directory for more details.
 
-import os
 import sys
+from testrunner import run
 
 
 # The default timeout is not enough for this test on some of the slower boards
@@ -19,6 +19,4 @@ def testfunc(child):
 
 
 if __name__ == "__main__":
-    sys.path.append(os.path.join(os.environ['RIOTTOOLS'], 'testrunner'))
-    from testrunner import run
     sys.exit(run(testfunc))


### PR DESCRIPTION

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR fixes a `tests/bench_runtime_coreapis` application failure when the `test` target is run on the microbit board.

To achieve this, the pexpect autotest script of `tests/bench_runtime_coreapis` application is improved by using a regexp to check the displayed line of each benchmarked function.

The timeout value is still required in the `pexpect` call for some function (thread_flags_wait_any or thread_flags_wait_all mainly).

In the meantime, I made some cleanup in the python script: the `testrunner.run` can be imported globally, there's no need for updating the system path from the script. This was changed and can be applied in a separate commit if required by the reviewer.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Check that it works on native:
```
$ make BOARD=native -C tests/bench_runtime_coreapis all test
```
- To test on hardware, start an experiment on the microbit board available on IoT-LAB, you can also request other architecture for a more complete test:
```
$ iotlab-experiment submit -n test_pr -d 60 -l saclay,microbit,1 -l saclay,m3,1 -l saclay,nrf52dk,1
$ iotlab-experiment wait
```
- Run the test on each board:
```
$ make BOARD=iotlab-m3 IOTLAB_NODE=auto-ssh -C tests/bench_runtime_coreapis flash test
$ make BOARD=nrf52dk IOTLAB_NODE=auto-ssh -C tests/bench_runtime_coreapis flash test
$ make BOARD=microbit IOTLAB_NODE=auto-ssh -C tests/bench_runtime_coreapis flash test
```

It should work in all cases.

You can also verify that it fails for the microbit on master.

If you want to try locally on a microbit, you have to use the openocd programmer:
```
$ PROGRAMMER=openocd make BOARD=microbit -C tests/bench_runtime_coreapis flash test
```
Otherwise, there are issues with the application starting to print before the terminal is attached to the board. And this ends up in a failing pexpect experience.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
