### PR TITLE
tests/pkg_libcose: increase timeout of autotest

### DIFF
--- a/tests/pkg_libcose/tests/01-run.py
+++ b/tests/pkg_libcose/tests/01-run.py
@@ -11,10 +11,15 @@ import sys
 from testrunner import run
 
 
+# on real hardware, this test application can take several minutes to
+# complete (~4min on microbit)
+HW_TIMEOUT = 300
+
+
 def testfunc(child):
     board = os.environ['BOARD']
     # Increase timeout on "real" hardware
-    timeout = 120 if board is not 'native' else -1
+    timeout = HW_TIMEOUT if board is not 'native' else -1
     child.expect('OK \(\d+ tests\)', timeout=timeout)
 
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This is just increasing the timeout of the pkg_libcose tests application pexpect script to 300s. This is because it takes about 4 minutes to complete on a microbit.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Start an experiment on _the_ microbit of IoT-LAB:
```
$ iotlab-experiment submit -n test_pr -d 60 -l saclay,microbit,1
$ iotlab-experiment wait
```
- Build/flash/test the `tests/pkg_libcose` application on it:
```
$ make BOARD=microbit IOTLAB_NODE=auto-ssh -C tests/pkg_libcose flash test
```

With this PR it should pass, on master it returns a timeout.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
