### PR TITLE
tests/libfixmath_unittests: extend timeout in autotest

### DIFF
--- a/tests/libfixmath_unittests/tests/01-run.py
+++ b/tests/libfixmath_unittests/tests/01-run.py
@@ -10,8 +10,8 @@ import sys
 from testrunner import run
 
 # Float and print operations are slow on boards
-# Got 80 iotlab-m3 and 250 on samr21-xpro
-TIMEOUT = 300
+# Got 80 iotlab-m3, 250 on samr21-xpro and 640 on microbit
+TIMEOUT = 1000
 
 
 def testfunc(child):


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR increases the pexpect timeout in the `tests/libfixmath_unittests` autotest. Indeed, it takes up to 640s to complete on microbit.

The value of 1000 was taken arbitrarily based on the time it takes for the microbit.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Start an experiment on _the_ microbit of IoT-LAB:
```
$ iotlab-experiment submit -n test_pr -d 60 -l saclay,microbit,1
$ iotlab-experiment wait
```
- Build/flash/test the `tests/pkg_libfixmath_unittests` application on it:
```
$ make BOARD=microbit IOTLAB_NODE=auto-ssh -C tests/pkg_libfixmath_unittests flash test
```

With this PR it should pass, on master it returns a timeout.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
