### PR TITLE
gcoap/example: add comment on resource order

### DIFF
--- a/examples/gcoap/gcoap_cli.c
+++ b/examples/gcoap/gcoap_cli.c
@@ -34,7 +34,7 @@ static void _resp_handler(unsigned req_state, coap_pkt_t* pdu,
 static ssize_t _stats_handler(coap_pkt_t* pdu, uint8_t *buf, size_t len, void *ctx);
 static ssize_t _riot_board_handler(coap_pkt_t* pdu, uint8_t *buf, size_t len, void *ctx);
 
-/* CoAP resources */
+/* CoAP resources. Must be sorted by path (ASCII order). */
 static const coap_resource_t _resources[] = {
     { "/cli/stats", COAP_GET | COAP_PUT, _stats_handler, NULL },
     { "/riot/board", COAP_GET, _riot_board_handler, NULL },


### PR DESCRIPTION
It took me an hour to find this unexpected behavior, when I added my own resources....

<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

add comment to prevent other ppl to waste time.

### Testing procedure

no

### Issues/PRs references

according to nanocoap/example: fix resource order #9919