### PR TITLE
netopt: deprecate getting NETOPT_IPV6_IID from netdev

### DIFF
--- a/sys/include/net/netopt.h
+++ b/sys/include/net/netopt.h
@@ -100,6 +100,9 @@ typedef enum {
      *          RFC 4291, section 2.5.1
      *      </a>
      *
+     * @deprecated  Do not implement this in a network device. Other APIs
+     *              utilizing [netopt](@ref net_netopt) may still implement it.
+     *
      * The generation of the interface identifier is dependent on the link-layer.
      * Please refer to the appropriate IPv6 over `<link>` specification for
      * further implementation details (such as


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
As noted in https://github.com/RIOT-OS/RIOT/pull/10537#pullrequestreview-182224260 we want to move away from `NETOPT_IPV6_IID` being provided by the network device. As such this adds a deprecation note to `NETOPT_IPV6_IID`, that it should not be implemented in `netdev` anymore (other interfaces utilizing `netopt` - such as `gnrc_netapi` - may still implement it).
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Compile with `make doc`. `NETOPT_IPV6_IID` and the deprecation note should show up in `doc/doxygen/html/deprecated.html`.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None, but only really takes effect after #10589 and its dependents got merged.
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
