### PR TITLE
 lwip: use l2util_ipv6_iid_from_addr() instead of NETOPT_IPV6_IID

### DIFF
--- a/Makefile.dep
+++ b/Makefile.dep
@@ -434,6 +434,7 @@ endif
 
 ifneq (,$(filter lwip_sixlowpan,$(USEMODULE)))
   USEMODULE += lwip_ipv6_autoconfig
+  USEMODULE += l2util
 endif
 
 ifneq (,$(filter lwip_ipv6_autoconfig lwip_ipv6_mld,$(USEMODULE)))

--- a/pkg/lwip/contrib/netdev/lwip_netdev.c
+++ b/pkg/lwip/contrib/netdev/lwip_netdev.c
@@ -156,7 +156,9 @@ err_t lwip_netdev_init(struct netif *netif)
              * with full IIDs, so let's do it ourselves */
             addr = &(netif->ip6_addr[0]);
             /* addr->addr is a uint32_t array */
-            if (netdev->driver->get(netdev, NETOPT_IPV6_IID, &addr->addr[2], sizeof(eui64_t)) < 0) {
+            if (l2util_ipv6_iid_from_addr(dev_type,
+                                          netif->hwaddr, netif->hwaddr_len,
+                                          (eui64_t *)&addr->addr[2]) < 0) {
                 return ERR_IF;
             }
             ipv6_addr_set_link_local_prefix((ipv6_addr_t *)&addr->addr[0]);


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Ports lwIP to use the new `l2util` module instead of getting the IPv6 IID from the network device.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
`tests/lwip` should still work on an `iotlab-m3`. The link-local addresses should stay the same as in current master (or be the same as on `gnrc_networking`).
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Depends on #10589. Implements lwIP according to the added deprecation note from #10595.

![gnrc_netif/gnrc_sixlowpan_iphc BLE capability](http://page.mi.fu-berlin.de/mlenders/netif_ble.svg)
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
