### PR TITLE
tests: remove NETOPT_IPV6_IID get() from driver_at86rf2xx test

### DIFF
--- a/tests/driver_at86rf2xx/cmd.c
+++ b/tests/driver_at86rf2xx/cmd.c
@@ -35,7 +35,6 @@ static int send(int iface, le_uint16_t dst_pan, uint8_t *dst_addr,
 int ifconfig_list(int idx)
 {
     int res;
-    uint8_t array_val[_MAX_ADDR_LEN];
     netdev_ieee802154_t *dev = (netdev_ieee802154_t *)(&devs[idx]);
 
     int (*get)(netdev_t *, netopt_t, void *, size_t) = dev->netdev.driver->get;
@@ -69,13 +68,6 @@ int ifconfig_list(int idx)
         return 1;
     }
     printf(", Max.Payload: %u", (unsigned)u16_val);
-
-    res = get((netdev_t *)dev, NETOPT_IPV6_IID, array_val, sizeof(array_val));
-    if (res > 0) {
-        printf("\n           IPv6 IID: ");
-        print_addr(array_val, res);
-    }
-
     printf("\n           Channel: %u", dev->chan);
 
     res = get((netdev_t *)dev, NETOPT_CHANNEL_PAGE, &u16_val, sizeof(u16_val));


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Prepares `at86rf2xx` for the deprecation of `NETOPT_IPV6_IID` in netdev (see #10595).
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
The test should still compile and run.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
#10595 is related
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
