### PR TITLE
openthread: use l2util_ipv6_iid_from_addr() instead of NETOPT_IPV6_IID

### DIFF
--- a/pkg/openthread/Makefile.dep
+++ b/pkg/openthread/Makefile.dep
@@ -5,6 +5,7 @@ endif
 
 ifneq (,$(filter openthread_contrib,$(USEMODULE)))
   USEMODULE += openthread_contrib_netdev
+  USEMODULE += l2util
   USEMODULE += xtimer
   FEATURES_REQUIRED += cpp
 endif

--- a/pkg/openthread/contrib/platform_radio.c
+++ b/pkg/openthread/contrib/platform_radio.c
@@ -25,6 +25,7 @@
 #include "net/ethernet/hdr.h"
 #include "net/ethertype.h"
 #include "net/ieee802154.h"
+#include "net/l2util.h"
 #include "net/netdev/ieee802154.h"
 #include "openthread/config.h"
 #include "openthread/openthread.h"
@@ -457,8 +458,13 @@ otError otPlatRadioEnergyScan(otInstance *aInstance, uint8_t aScanChannel, uint1
 
 void otPlatRadioGetIeeeEui64(otInstance *aInstance, uint8_t *aIeee64Eui64)
 {
-    (void) aInstance;
-    _dev->driver->get(_dev, NETOPT_IPV6_IID, aIeee64Eui64, sizeof(eui64_t));
+    uint8_t addr[IEEE802154_LONG_ADDRESS_LEN];
+
+    (void)aInstance;
+    _dev->driver->get(_dev, NETOPT_ADDRESS_LONG, addr, sizeof(addr));
+    l2util_ipv6_iid_from_addr(NETDEV_TYPE_IEEE802154,
+                              addr, sizeof(eui64_t),
+                              (eui64_t *)aIeee64Eui64);
 }
 
 int8_t otPlatRadioGetReceiveSensitivity(otInstance *aInstance)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
Ports OpenThread to use the new `l2util` module instead of getting the IPv6 IID from the network device.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
`examples/openthread` should still work on an `iotlab-m3`. The link-local addresses should stay the same as in current master (or be the same as on `gnrc_networking`).
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Depends on #10589. Implements OpenThread according to the added deprecation note from #10595.

![gnrc_netif/gnrc_sixlowpan_iphc BLE capability](http://page.mi.fu-berlin.de/mlenders/netif_ble.svg)
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
