### PR TITLE
tests/pkg_micro-ecc*: increase expect timeout

### DIFF
--- a/tests/pkg_micro-ecc-with-hwrng/tests/01-run.py
+++ b/tests/pkg_micro-ecc-with-hwrng/tests/01-run.py
@@ -4,6 +4,9 @@ import sys
 from testrunner import run
 
 
+TIMEOUT = 300
+
+
 def testfunc(child):
     child.expect_exact('micro-ecc compiled!')
     child.expect_exact('Testing 16 random private key pairs and signature '
@@ -13,4 +16,4 @@ def testfunc(child):
 
 
 if __name__ == "__main__":
-    sys.exit(run(testfunc, timeout=60))
+    sys.exit(run(testfunc, timeout=TIMEOUT))

--- a/tests/pkg_micro-ecc/tests/01-run.py
+++ b/tests/pkg_micro-ecc/tests/01-run.py
@@ -4,6 +4,9 @@ import sys
 from testrunner import run
 
 
+TIMEOUT = 120
+
+
 def testfunc(child):
     child.expect_exact('micro-ecc compiled!')
     child.expect_exact('Testing 16 random private key pairs and signature '
@@ -13,4 +16,4 @@ def testfunc(child):
 
 
 if __name__ == "__main__":
-    sys.exit(run(testfunc, timeout=60))
+    sys.exit(run(testfunc, timeout=TIMEOUT))


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR increases the pexpect timeout of `tests/pkg_micro-ecc` and `tests/pkg_micro-ecc-with-hwrng` autotests. Indeed, it fails with a timeout on microbit or nrf51dk.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->

### Testing procedure

- Start an experiment on _the_ microbit of IoT-LAB:
```
$ iotlab-experiment submit -n test_pr -d 60 -l saclay,microbit,1
$ iotlab-experiment wait
```
- Build/flash/test the `tests/pkg_libfixmath_unittests` application on it:
```
$ make BOARD=microbit IOTLAB_NODE=auto-ssh -C tests/pkg_micro-ecc flash test
$ make BOARD=microbit IOTLAB_NODE=auto-ssh -C tests/pkg_micro-ecc-with-hwrng flash test
```

With this PR it should pass, on master it returns a timeout.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
