### PR TITLE
tests/pthread_condition_variable: increase timeout

### DIFF
--- a/tests/pthread_condition_variable/tests/01-run.py
+++ b/tests/pthread_condition_variable/tests/01-run.py
@@ -4,6 +4,12 @@ import sys
 from testrunner import run
 
 
+# This test can take some time to complete when testing on hardware (e.g
+# on samr21-xpro) and the default timeout (10s) is not enough.
+# For example, it takes about 2 minutes to complete on a microbit.
+TIMEOUT = 150
+
+
 def testfunc(child):
     child.expect('START')
     child.expect('condition fulfilled.')
@@ -11,6 +17,4 @@ def testfunc(child):
 
 
 if __name__ == "__main__":
-    # This test can take some time to complete when testing on hardware (e.g
-    # on samr21-xpro) and the default timeout (10s) is not enough.
-    sys.exit(run(testfunc, timeout=60))
+    sys.exit(run(testfunc, timeout=TIMEOUT))


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR increases the pexpect timeout in the `tests/pthread_condition_variable` autotest.

The value of 1000 was taken arbitrarily based on the time it takes for the microbit.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Start an experiment on _the_ microbit of IoT-LAB:
```
$ iotlab-experiment submit -n test_pr -d 60 -l saclay,microbit,1
$ iotlab-experiment wait
```
- Build/flash/test the `tests/pthread_condition_variable` application on it:
```
$ make BOARD=microbit IOTLAB_NODE=auto-ssh -C tests/pthread_condition_variable flash test
```

With this PR it should pass, on master it returns a timeout.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
