### PR TITLE
cpu/esp32: Fixes the maximum packet size of 255 bytes in the esp_eth netdev driver of ESP32 mcu.

### DIFF
--- a/cpu/esp32/esp-eth/esp_eth_netdev.c
+++ b/cpu/esp32/esp-eth/esp_eth_netdev.c
@@ -262,8 +262,8 @@ static int _esp_eth_recv(netdev_t *netdev, void *buf, size_t len, void *info)
         /* return the packet */
 
         if (dev->rx_len > len) {
-            LOG_TAG_ERROR("esp_eth", "Not enough space in receive buffer "
-                          "for %d byte\n", dev->rx_len);
+        /* buffer is smaller than the number of received bytes */
+        DEBUG("%s: Not enough space in receive buffer for %d bytes\n",
             mutex_unlock(&dev->dev_lock);
             return -ENOBUFS;
         }

--- a/cpu/esp32/esp-eth/esp_eth_netdev.c
+++ b/cpu/esp32/esp-eth/esp_eth_netdev.c
@@ -243,7 +243,7 @@ static int _esp_eth_recv(netdev_t *netdev, void *buf, size_t len, void *info)
 
     mutex_lock(&dev->dev_lock);
 
-    uint8_t size = dev->rx_len;
+    int size = dev->rx_len;
 
     if (!buf && !len) {
         /* return the size without dropping received data */

--- a/cpu/esp32/esp-eth/esp_eth_netdev.h
+++ b/cpu/esp32/esp-eth/esp_eth_netdev.h
@@ -37,11 +37,11 @@ typedef struct
 {
     netdev_t netdev;                    /**< netdev parent struct */
 
-    uint8_t rx_len;                     /**< number of bytes received */
-    uint8_t rx_buf[ETHERNET_DATA_LEN];  /**< receive buffer */
+    uint16_t rx_len;                     /**< number of bytes received */
+    uint16_t tx_len;                     /**< number of bytes in transmit buffer */
 
-    uint8_t tx_len;                     /**< number of bytes in transmit buffer */
-    uint8_t tx_buf[ETHERNET_DATA_LEN];  /**< transmit buffer */
+    uint8_t  rx_buf[ETHERNET_DATA_LEN];  /**< receive buffer */
+    uint8_t  tx_buf[ETHERNET_DATA_LEN];  /**< transmit buffer */
 
     uint32_t event;                     /**< received event */
     bool     link_up;                   /**< indicates whether link is up */


### PR DESCRIPTION
### Contribution description

This PR fixes the following problems:
- Mainly it fixes the problem described in issue #10594 that packets with a size > 255 bytes  cannot be received.
- In addition, it replaces `LOG_ERROR` by `DEBUG` when receive buffer is to small in `_recv` to avoid error messages for an usual case
- In addition, the `_recv` function is restructured to return `-ENOBUFS` if the receive buffer is too small, and in all other cases, the size of the packet or the bytes read.

### Testing procedure

Compile and flash `example/gnrc_networking` for an ESP32 board with an Ethernet interface and activate the `esp_eth` module, e.g.,
```
USEMODULE=esp_eth make flash -C examples/gnrc_networking BOARD=esp32-olimex-evb
```
After flashing, just ping any link local address from RIOT shell with an ICMP data size greater than 255 byte, e.g.
```
ping6 fe80::345b:6598:1369:5bf4 1232
```

### Issues/PRs references

Fixes #10594