### PR TITLE
Deprecate saul_reg_rm

### DIFF
--- a/sys/include/saul_reg.h
+++ b/sys/include/saul_reg.h
@@ -72,6 +72,16 @@ int saul_reg_add(saul_reg_t *dev);
 /**
  * @brief   Unregister a device from the SAUL registry
  *
+ * @warning   Removing the device at runtime can send applications that have
+ *            looked up that device into invalid states, and should thus be
+ *            avoided.
+ *
+ * @warning   This function must only be used by drivers that advise developers
+ *            using them on how to prevent race conditions when using SAUL.
+ *
+ * @deprecated This function will be removed soon as it is practically unusable
+ *             for the above reasons.
+ *
  * @param[in] dev       pointer to a registry entry
  *
  * @return      0 on success


### PR DESCRIPTION
The race condition rules fo rusing and unregistering saul_reg_t items are currently unclear:

(To summarize the current behavior: An application can query the registry and receive a saul_reg_t* pointer. Drivers provide the required saul_reg_t, and register and unregister the pointers. Executing a read or write on a saul_reg_t *x is roughtly `x->read(x, result)`).

When an application has found a saul_reg_t*, how long may it use it? Or: When may a driver saul_reg_rm something? If the deregistration happens after the application has looked it up but before it has read from it, the application calls an address that might be anything.

While we can for sure come up with a technical solution to this, I doubt that it's worth the overhead (either in terms of memory and runtime for a simple solution, or in terms of working time and code changes for an elaborate one). Therefore I propose this clarification in the saul_reg_rm documentation.

### Contribution description

This documents saul_reg_rm in such a way that whoever uses it can only do that if the application has additional awareness of it (eg. by prescribing that find to read needs to happen in a critical section, while some mutex is held, or only in therads with a certain priority), practically limiting it to application-specific drivers.

### Testing procedure
Not applicable (documentation only)

### Issues/PRs references

I stumbled on this while working on <https://github.com/RIOT-OS/RIOT/issues/9799>; there, such issues are made visible by the language. With this clarification in place, I could justify wrapping lookup results, as opposed to disabling interrupts from the lookup until the read is done.

### Alternatives

* Introduce a read-write-lock that needs to be held for read between find and read, and for write by saul_reg_rm.
  * Overhead in compiled code / memory / runtime could be eliminated by introducing a build-time flag (?) that disables the saul_reg_rm function and all of that locking stuff.
* Prescribe a general mechanism that applies to all SAUL sensors (eg. "make all queries criticals sections")
* Put the onus on the application and state that it needs to make sure to know all its sensors' requirements (similar to the proposed; mainly shifts blame if it does go wrong)
* Do nothing / recommend that found sensors be read "in a timely manner" and hope it never happens.