### PR TITLE
tests/posix_semaphore: increase timeout margin

### DIFF
--- a/tests/posix_semaphore/main.c
+++ b/tests/posix_semaphore/main.c
@@ -239,6 +239,10 @@ void test3(void)
 #ifdef BOARD_NATIVE
 /* native can sometime take more time to respond as it is not real time */
 #define TEST4_TIMEOUT_EXCEEDED_MARGIN (300)
+#elif CPU_FAM_NRF51
+/* nrf51 based boards needs a slightly higher margin value. Using 105us makes
+ test4 result more reliable. */
+#define TEST4_TIMEOUT_EXCEEDED_MARGIN (105)
 #else
 #define TEST4_TIMEOUT_EXCEEDED_MARGIN (100)
 #endif /* BOARD_NATIVE */


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR increases the timeout margin used in the `tests/posix_semaphore` test: on nrf51 boards the timeout can be slightly above 100100us. Using 120us margin seems enough.


<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Start an experiment on _the_ microbit of IoT-LAB (you can also try on a nrf51dk):
```
$ iotlab-experiment submit -n test_pr -d 60 -l saclay,microbit,1
$ iotlab-experiment wait
```
- Build/flash/test the `tests/posix_semaphore` application on it:
```
$ make BOARD=microbit IOTLAB_NODE=auto-ssh -C tests/posix_semaphore flash test
```

With this PR it should pass, on master it returns a timeout.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
