### PR TITLE
cpu/stm32f1: Fix i2c for stm32f1 based boards

### DIFF
--- a/boards/common/stm32f103c8/include/periph_conf.h
+++ b/boards/common/stm32f103c8/include/periph_conf.h
@@ -155,7 +155,8 @@ static const uart_conf_t uart_config[] = {
 /** @} */
 
 /**
- * @name I2C configuration
+ * @name    I2C configuration
+ * @note    This board may require external pullup resistors for i2c operation.
  * @{
  */
 static const i2c_conf_t i2c_config[] = {

--- a/boards/nucleo-f103rb/include/periph_conf.h
+++ b/boards/nucleo-f103rb/include/periph_conf.h
@@ -144,7 +144,8 @@ static const uart_conf_t uart_config[] = {
 /** @} */
 
 /**
- * @name I2C configuration
+ * @name    I2C configuration
+ * @note    This board may require external pullup resistors for i2c operation.
  * @{
  */
 static const i2c_conf_t i2c_config[] = {

--- a/cpu/stm32_common/periph/i2c_2.c
+++ b/cpu/stm32_common/periph/i2c_2.c
@@ -109,6 +109,14 @@ void i2c_init(i2c_t dev)
     gpio_init(i2c_config[dev].scl_pin, GPIO_OD_PU);
     gpio_init(i2c_config[dev].sda_pin, GPIO_OD_PU);
 #ifdef CPU_FAM_STM32F1
+    /* This is needed in case the remapped pins are used */
+    if (i2c_config[dev].scl_pin == GPIO_PIN(PORT_B, 8) ||
+        i2c_config[dev].sda_pin == GPIO_PIN(PORT_B, 9)) {
+        /* The remapping periph clock must first be enabled */
+        RCC->APB2ENR |= RCC_APB2ENR_AFIOEN;
+        /* Then the remap can occur */
+        AFIO->MAPR |= AFIO_MAPR_I2C1_REMAP;
+    }
     gpio_init_af(i2c_config[dev].scl_pin, GPIO_AF_OUT_OD);
     gpio_init_af(i2c_config[dev].sda_pin, GPIO_AF_OUT_OD);
 #else


### PR DESCRIPTION
### Contribution description
This was discovered by the HiL testing.

This PR adds remapping if PB8 or PB9 are being used for i2c.  Previously the remapping didn't occur and would cause errors when trying to use this configuration.  This should only effect stm32F1XX based boards.  It also updated documentation to indicate pullup resistors are needed.  With this something like the nucleo-f103rb should now work.

### Testing procedure
Try to use the i2c on a nucleo-f103rb in master and with this PR.  It should at least respond (though the cpu implementation may not be correct)

### Issues/PRs references
fixes #10395
