### PR TITLE
core/kernel_defines.h: add ARG_UNUSED macro

### DIFF
--- a/core/include/kernel_defines.h
+++ b/core/include/kernel_defines.h
@@ -71,6 +71,13 @@
 #endif
 
 /**
+ * @def   ARG_UNUSED
+ * @brief Tell the compiler that the given function argument is not used
+ *        in the scope of the function.
+ */
+#define ARG_UNUSED(x) (void)(x)
+
+/**
  * @def CONST
  * @brief A function declared as *CONST* is #PURE and also not allowed to
  *        examine global memory. I.e. a *CONST* function cannot even


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description
This PR adds the ARG_UNUSED macro, available in several C projects (Zephyr, etc).
This:
```
void function(void *arg)
{
    /* arg variable is not used */
    (void) arg;
    ...
}
```
Becomes this:
```
void function(void *arg)
{
    /* arg variable is not used */
    ARG_UNUSED(arg);
    ...
}
```

This makes the code look more clear IMO.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure
Apply this patch with `git apply file.patch`

file.patch:
```
diff --git a/examples/ipc_pingpong/main.c b/examples/ipc_pingpong/main.c
index 655ff39a7..874bcb0af 100644
--- a/examples/ipc_pingpong/main.c
+++ b/examples/ipc_pingpong/main.c
@@ -26,7 +26,7 @@
 
 void *second_thread(void *arg)
 {
-    (void) arg;
+    ARG_UNUSED(arg);
 
     printf("2nd thread started, pid: %" PRIkernel_pid "\n", thread_getpid());
     msg_t m;
```

Compile the `ipc_pingpong` example with `ipc_pingpong`. Check there are no `unused variable` errors.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
None so far
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
