### PR TITLE
cpu/stm32_common/uart: Prevent uart from sending if not initialized

### DIFF
--- a/cpu/stm32_common/periph/uart.c
+++ b/cpu/stm32_common/periph/uart.c
@@ -145,7 +145,12 @@ static inline void wait_for_tx_complete(uart_t uart)
 void uart_write(uart_t uart, const uint8_t *data, size_t len)
 {
     assert(uart < UART_NUMOF);
-
+#if DEVELHELP
+    /* If tx is not enabled don't try to send */
+    if (!(dev(uart)->CR1 & USART_CR1_TE)) {
+        return;
+    }
+#endif
 #ifdef MODULE_PERIPH_DMA
     if (!len) {
         return;


### PR DESCRIPTION
### Contribution description
Due to the stdio getting called after periph_init the uart may send before initialized.
This adds a simple check so the uart does not get into a locked-up state.

### Testing procedure

Use an stm32F1, F2, F4, or L0
Enable debug in tests/periph_i2c/main.c
Write a DEBUG message in the init.
`BOARD=<selected board from above> make flash term -C tests/periph_i2c/`
`help` 
you should see a result, on master you won't and it will get locked up.

### Issues/PRs references
fixes #10614
discussed in #10608