### PR TITLE
gnrc_netif: add config macros to config doc group

### DIFF
--- a/sys/include/net/gnrc/netif/conf.h
+++ b/sys/include/net/gnrc/netif/conf.h
@@ -7,7 +7,9 @@
  */
 
 /**
- * @ingroup net_gnrc_netif
+ * @defgroup    net_gnrc_netif_conf GNRC network interface configurations
+ * @ingroup     net_gnrc_netif
+ * @ingroup     config
  * @{
  *
  * @file


### PR DESCRIPTION
### Contribution description
See #10566

### Testing procedure
Compile documentation. A new group for the configuration macros of `gnrc_netif` should show up both in the `config` group doc as well in the doc of `gnrc_netif`.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Addresses #10566 in part