### PR TITLE
gnrc_ipv6: add config macros to config doc group

### DIFF
--- a/sys/include/net/gnrc/ipv6.h
+++ b/sys/include/net/gnrc/ipv6.h
@@ -46,6 +46,13 @@
 extern "C" {
 #endif
 
+
+/**
+ * @defgroup    net_gnrc_ipv6_conf  GNRC IPv6 compile configurations
+ * @ingroup     net_gnrc_ipv6
+ * @ingroup     config
+ * @{
+ */
 /**
  * @brief   Default stack size to use for the IPv6 thread
  */
@@ -85,6 +92,7 @@ extern "C" {
  */
 #define GNRC_IPV6_STATIC_LLADDR
 #endif /* DOXYGEN */
+/** @} */
 
 /**
  * @brief   The PID to the IPv6 thread.

--- a/sys/include/net/gnrc/ipv6/blacklist.h
+++ b/sys/include/net/gnrc/ipv6/blacklist.h
@@ -31,11 +31,18 @@ extern "C" {
 #endif
 
 /**
+ * @defgroup    net_gnrc_ipv6_blacklist_conf GNRC IPv6 address blacklisting compile configurations
+ * @ingroup     net_gnrc_ipv6_blacklist
+ * @ingroup     config
+ * @{
+ */
+/**
  * Maximum size of the blacklist.
  */
 #ifndef GNRC_IPV6_BLACKLIST_SIZE
 #define GNRC_IPV6_BLACKLIST_SIZE    (8)
 #endif
+/** @} */
 
 /**
  * @brief   Adds an IPv6 address to the blacklist.

--- a/sys/include/net/gnrc/ipv6/nib/conf.h
+++ b/sys/include/net/gnrc/ipv6/nib/conf.h
@@ -7,8 +7,9 @@
  */
 
 /**
- * @defgroup    net_gnrc_ipv6_nib_conf  Configuration macros
+ * @defgroup    net_gnrc_ipv6_nib_conf  GNRC IPv6 NIB compile configurations
  * @ingroup     net_gnrc_ipv6_nib
+ * @ingroup     config
  * @brief       Configuration macros for neighbor information base
  * @{
  *

--- a/sys/include/net/gnrc/ipv6/whitelist.h
+++ b/sys/include/net/gnrc/ipv6/whitelist.h
@@ -29,11 +29,18 @@ extern "C" {
 #endif
 
 /**
+ * @defgroup    net_gnrc_ipv6_whitelist_conf GNRC IPv6 address whitelisting compile configurations
+ * @ingroup     net_gnrc_ipv6_whitelist
+ * @ingroup     config
+ * @{
+ */
+/**
  * Maximum size of the whitelist.
  */
 #ifndef GNRC_IPV6_WHITELIST_SIZE
 #define GNRC_IPV6_WHITELIST_SIZE    (8)
 #endif
+/** @} */
 
 /**
  * @brief   Adds an IPv6 address to the whitelist.


### PR DESCRIPTION
### Contribution description
See #10566

### Testing procedure
Compile documentation. A new group for the configuration macros of `gnrc_ipv6` should show up both in the `config` group doc as well in the doc of the respective `gnrc_ipv6` (sub-)modules changed here.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Addresses #10566 in part