### PR TITLE
lora: add lora and loramac config macros to config doc group

### DIFF
--- a/sys/include/net/lora.h
+++ b/sys/include/net/lora.h
@@ -29,7 +29,8 @@ extern "C" {
 #endif
 
 /**
- * @name    LoRa modulation default values
+ * @defgroup net_lora_conf  LoRa modulation compile configurations
+ * @ingroup  config
  * @{
  */
 #ifndef LORA_FREQUENCY_RESOLUTION_DEFAULT

--- a/sys/include/net/lora.h
+++ b/sys/include/net/lora.h
@@ -38,7 +38,7 @@ extern "C" {
 #define LORA_FREQUENCY_RESOLUTION_DEFAULT      (61.03515625)
 #endif
 #ifndef LORA_PREAMBLE_LENGTH_DEFAULT
-/**< @brief Preamble length, same for Tx and Rx */
+/** @brief Preamble length, same for Tx and Rx */
 #define LORA_PREAMBLE_LENGTH_DEFAULT           (8U)
 #endif
 #ifndef LORA_SYMBOL_TIMEOUT_DEFAULT

--- a/sys/include/net/lora.h
+++ b/sys/include/net/lora.h
@@ -33,58 +33,71 @@ extern "C" {
  * @ingroup  config
  * @{
  */
-#ifndef LORA_FREQUENCY_RESOLUTION_DEFAULT
 /** @brief Frequency resolution in Hz */
+#ifndef LORA_FREQUENCY_RESOLUTION_DEFAULT
 #define LORA_FREQUENCY_RESOLUTION_DEFAULT      (61.03515625)
 #endif
-#ifndef LORA_PREAMBLE_LENGTH_DEFAULT
+
 /** @brief Preamble length, same for Tx and Rx */
+#ifndef LORA_PREAMBLE_LENGTH_DEFAULT
 #define LORA_PREAMBLE_LENGTH_DEFAULT           (8U)
 #endif
-#ifndef LORA_SYMBOL_TIMEOUT_DEFAULT
+
 /** @brief Symbols timeout (s) */
+#ifndef LORA_SYMBOL_TIMEOUT_DEFAULT
 #define LORA_SYMBOL_TIMEOUT_DEFAULT            (10U)
 #endif
-#ifndef LORA_BW_DEFAULT
+
 /** @brief Set default bandwidth to 125kHz */
+#ifndef LORA_BW_DEFAULT
 #define LORA_BW_DEFAULT                        (LORA_BW_125_KHZ)
 #endif
-#ifndef LORA_SF_DEFAULT
+
 /** @brief Set default spreading factor to 12 */
+#ifndef LORA_SF_DEFAULT
 #define LORA_SF_DEFAULT                        (LORA_SF12)
 #endif
-#ifndef LORA_CR_DEFAULT
+
 /** @brief Set default coding rate to 8 */
+#ifndef LORA_CR_DEFAULT
 #define LORA_CR_DEFAULT                        (LORA_CR_4_8)
 #endif
-#ifndef LORA_FIX_LENGTH_PAYLOAD_ON_DEFAULT
+
 /** @brief Set fixed payload length on */
+#ifndef LORA_FIX_LENGTH_PAYLOAD_ON_DEFAULT
 #define LORA_FIX_LENGTH_PAYLOAD_ON_DEFAULT     (false)
 #endif
-#ifndef LORA_IQ_INVERTED_DEFAULT
+
 /** @brief Set inverted IQ on */
+#ifndef LORA_IQ_INVERTED_DEFAULT
 #define LORA_IQ_INVERTED_DEFAULT               (false)
 #endif
-#ifndef LORA_FREQUENCY_HOPPING_DEFAULT
+
 /** @brief Frequency hopping on */
+#ifndef LORA_FREQUENCY_HOPPING_DEFAULT
 #define LORA_FREQUENCY_HOPPING_DEFAULT         (false)
 #endif
-#ifndef LORA_FREQUENCY_HOPPING_PERIOD_DEFAULT
+
 /** @brief Frequency hopping period */
+#ifndef LORA_FREQUENCY_HOPPING_PERIOD_DEFAULT
 #define LORA_FREQUENCY_HOPPING_PERIOD_DEFAULT  (0U)
 #endif
-#ifndef LORA_FIXED_HEADER_LEN_MODE_DEFAULT
+
 /** @brief Set fixed header length mode (implicit header) */
+#ifndef LORA_FIXED_HEADER_LEN_MODE_DEFAULT
 #define LORA_FIXED_HEADER_LEN_MODE_DEFAULT     (false)
 #endif
-#ifndef LORA_PAYLOAD_CRC_ON_DEFAULT
+
 /** @brief Enable payload CRC, optional */
+#ifndef LORA_PAYLOAD_CRC_ON_DEFAULT
 #define LORA_PAYLOAD_CRC_ON_DEFAULT            (true)
 #endif
-#ifndef LORA_PAYLOAD_LENGTH_DEFAULT
+
 /** @brief Set payload length, unused with implicit header */
+#ifndef LORA_PAYLOAD_LENGTH_DEFAULT
 #define LORA_PAYLOAD_LENGTH_DEFAULT            (0U)
 #endif
+
 /** @} */
 
 /**

--- a/sys/include/net/loramac.h
+++ b/sys/include/net/loramac.h
@@ -30,7 +30,8 @@ extern "C" {
 #endif
 
 /**
- * @name    LoRaMAC default parameters
+ * @defgroup net_loramac_conf   LoRaMAC compile configurations
+ * @ingroup config
  * @{
  */
 /**


### PR DESCRIPTION
### Contribution description
See #10566 

I also moved some `@brief` tags outside of the `#ifndef` block for consistency, and fixed a minor issue with an extra `<` character in a doxygen tag.

### Testing procedure
Compile documentation. Two new group for the configuration macros of `net_lora` and `net_loramac`should show up both in the `config` group doc as well in the doc of the respective `net_lora` and `net_loramac` (sub-)modules changed here.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Addresses #10566 in part