### PR TITLE
Add support for "External PA/LNA Control" in mrf24j40 driver (useful …

### DIFF
--- a/drivers/include/mrf24j40.h
+++ b/drivers/include/mrf24j40.h
@@ -116,6 +116,16 @@ extern "C" {
 #define MRF24J40_MAX_FRAME_RETRIES      (3U)        /**< Number of frame retries (fixed) */
 
 /**
+ * @brief Enable external PA/LNA control
+ *
+ * Increase RSSI for MRF24J40MC/MD/ME devices. No effect on MRF24J40MA.
+ * For more information, please refer to section 4.2 of MRF24J40 datasheet.
+ */
+#ifndef MRF24J40_USE_EXT_PA_LNA
+#define MRF24J40_USE_EXT_PA_LNA         (0U)
+#endif
+
+/**
  * @brief   struct holding all params needed for device initialization
  */
 typedef struct mrf24j40_params {

--- a/drivers/mrf24j40/include/mrf24j40_registers.h
+++ b/drivers/mrf24j40/include/mrf24j40_registers.h
@@ -453,6 +453,16 @@ extern "C" {
 #define MRF24J40_SLPCON1_SLPCLKDIV0     (0x01)
 /** @} */
 
+/**
+ * @name    Bitfield definitions for the TESTMODE register (0x22F)
+ * @{
+ */
+#define MRF24J40_TESTMODE_RSSIWAIT1     (0x10)
+#define MRF24J40_TESTMODE_RSSIWAIT0     (0x08)
+#define MRF24J40_TESTMODE_TESTMODE2     (0x04)
+#define MRF24J40_TESTMODE_TESTMODE1     (0x02)
+#define MRF24J40_TESTMODE_TESTMODE0     (0x01)
+/** @} */
 
 #ifdef __cplusplus
 }

--- a/drivers/mrf24j40/mrf24j40_internal.c
+++ b/drivers/mrf24j40/mrf24j40_internal.c
@@ -87,6 +87,11 @@ void mrf24j40_init(mrf24j40_t *dev)
     mrf24j40_reg_write_short(dev, MRF24J40_REG_BBREG2, MRF25J40_BBREG2_CCAMODE1 );
     mrf24j40_reg_write_short(dev, MRF24J40_REG_CCAEDTH, 0x60);
     mrf24j40_reg_write_short(dev, MRF24J40_REG_BBREG6, MRF24J40_BBREG6_RSSIMODE2 );
+#if MRF24J40_USE_EXT_PA_LNA
+    mrf24j40_reg_write_long(dev, MRF24J40_REG_TESTMODE, (MRF24J40_TESTMODE_TESTMODE2 |
+                                                         MRF24J40_TESTMODE_TESTMODE1 |
+                                                         MRF24J40_TESTMODE_TESTMODE0));
+#endif
 
     /* Enable immediate sleep mode */
     mrf24j40_reg_write_short(dev, MRF24J40_REG_WAKECON, MRF24J40_WAKECON_IMMWAKE);


### PR DESCRIPTION
Hi,

I had some issues to transmit packets with my MRF24J40MD transceiver. It turned to come from the lack of support of the 'TESTMODE' register to enable the support for "External PA/LNA Control" (see section 4.2 of MRF24J40 datasheet).

As it's my first PR, I'm open to any suggestion if my code does not fully complies with RIOT standards.

### Contribution description

I added a new macro called "MRF24J40_USE_EXT_PA_LNA" to handle MRF24J40MD/ME transceivers. During the initialization of the MRF24J40 (mrf24j40_init()), the bits TESTMODE0, TESTMODE1, TESTMODE2 are set to 1 in the register if the macro is passed in the Makefile of the application as a CFLAGS. By default, the macro is ignored.

Example :
```
USEMODULE += mrf24j40
CFLAGS += -DMRF24J40_USE_EXT_PA_LNA=1
```

### Testing procedure

I tested my modifications on a Nucleo-F303RE with a MRF24J40MD wired to it and a 802.15.4 Sniffer (TI CC2531EMK) to check the RSSI.

Without the modification, the measured average RSSI for emissions are about -65dBm.
With the modification, the measured average RSSI for emissions are about -15dBm.

### Issues/PRs references

n/a
