### PR TITLE
ieee802154: add config macros to config doc group

### DIFF
--- a/sys/include/net/ieee802154.h
+++ b/sys/include/net/ieee802154.h
@@ -112,9 +112,9 @@ extern const uint8_t ieee802154_addr_bcast[IEEE802154_ADDR_BCAST_LEN];
 /** @} */
 
 /**
+ * @defgroup net_ieee802154_conf    IEEE802.15.4 compile configurations
+ * @ingroup  config
  * @{
- * @name    Default values
- * @brief   Default values for devices to choose
  */
 #ifndef IEEE802154_DEFAULT_SUBGHZ_CHANNEL
 #define IEEE802154_DEFAULT_SUBGHZ_CHANNEL   (5U)

--- a/sys/include/net/ieee802154.h
+++ b/sys/include/net/ieee802154.h
@@ -116,24 +116,39 @@ extern const uint8_t ieee802154_addr_bcast[IEEE802154_ADDR_BCAST_LEN];
  * @ingroup  config
  * @{
  */
+/**
+ * @brief IEEE802.15.4 default sub-GHZ channel
+ */
 #ifndef IEEE802154_DEFAULT_SUBGHZ_CHANNEL
 #define IEEE802154_DEFAULT_SUBGHZ_CHANNEL   (5U)
 #endif
 
+/**
+ * @brief IEEE802.15.4 default channel
+ */
 #ifndef IEEE802154_DEFAULT_CHANNEL
 #define IEEE802154_DEFAULT_CHANNEL          (26U)
 #endif
 
+/**
+ * @brief IEEE802.15.4 default sub-GHZ page
+ */
 #ifndef IEEE802154_DEFAULT_SUBGHZ_PAGE
 #define IEEE802154_DEFAULT_SUBGHZ_PAGE      (2U)
 #endif
 
+/**
+ * @brief IEEE802.15.4 default PANID
+ */
 #ifndef IEEE802154_DEFAULT_PANID
 #define IEEE802154_DEFAULT_PANID            (0x0023U)
 #endif
 
+/**
+ * @brief IEEE802.15.4 default TX power (in dBm)
+ */
 #ifndef IEEE802154_DEFAULT_TXPOWER
-#define IEEE802154_DEFAULT_TXPOWER          (0) /* in dBm */
+#define IEEE802154_DEFAULT_TXPOWER          (0)
 #endif
 /** @} */
 


### PR DESCRIPTION
### Contribution description
See #10566 

I also added some `@brief` tags to these macros, and moved the `/* in dBm */` comment to the brief of `IEEE802154_DEFAULT_TXPOWER`

### Testing procedure
Compile documentation. A new group for the configuration macros of `net_ieee802154` should show up both in the `config` group doc as well in the doc of the respective `net_ieee802154` (sub-)module changed here.
<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references
Addresses #10566 in part