### PR TITLE
gnrc_ipv6_nib: don't ignore PL for route

### DIFF
--- a/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.c
+++ b/sys/net/gnrc/network_layer/ipv6/nib/_nib-internal.c
@@ -594,8 +594,7 @@ int _nib_get_route(const ipv6_addr_t *dst, gnrc_pktsnip_t *pkt,
           (void *)pkt);
     _nib_offl_entry_t *offl = _nib_offl_get_match(dst);
 
-    if ((offl == NULL) || (offl->mode == _PL)) {
-        /* give default router precedence over PLE */
+    if (offl == NULL) {
         _nib_dr_entry_t *router = _nib_drl_get_dr();
 
         if ((router == NULL) && (offl == NULL)) {


### PR DESCRIPTION
 ### Contribution description
When pinging to a prefix for which there is a prefix list entry on the node (so no next hop) but a default route, a packet to a non-existent address under that prefix results in the packet being forwarded to the default route instead (see [this thread on the devel mailing list](https://lists.riot-os.org/pipermail/devel/2018-December/006049.html)). This fixes it, so the node tries address resolution on the interface the prefix list entry is associated to.

### Testing procedure
Flash the `gnrc_border_router` example and try to ping a non-existent address *from the host* under the prefix advertised by the UHCP server (e.g. `2001:db8::1234`). Without this fix you will get `Hop limit exceeded` messages, since the package circles over the ethos interface (which is the default route of the border router) until the hop limit exceeds. With this PR, neighbor solicitations to the solicited nodes multicast address of `2001:db8::1234` (`ff02::1:ff00:1234`) go out the WPAN interface.

### Issues/PRs references
None
