### PR TITLE
 gnrc_netif: remove superfluous GNRC_NETIF_FLAGS_MAC_*

### DIFF
--- a/sys/include/net/gnrc/netif/flags.h
+++ b/sys/include/net/gnrc/netif/flags.h
@@ -119,17 +119,6 @@ enum {
 #define GNRC_NETIF_FLAGS_6LO_BACKBONE              (0x00000800U)
 
 /**
- * @brief   Mask for @ref gnrc_mac_tx_feedback_t
- */
-#define GNRC_NETIF_FLAGS_MAC_TX_FEEDBACK_MASK      (0x00006000U)
-
-/**
- * @brief   Flag to track if a transmission might have corrupted a received
- *          packet
- */
-#define GNRC_NETIF_FLAGS_MAC_RX_STARTED            (0x00008000U)
-
-/**
  * @brief   Network interface is configured in raw mode
  */
 #define GNRC_NETIF_FLAGS_RAWMODE                   (0x00010000U)

--- a/sys/include/net/gnrc/netif/flags.h
+++ b/sys/include/net/gnrc/netif/flags.h
@@ -128,7 +128,6 @@ enum {
  *          packet
  */
 #define GNRC_NETIF_FLAGS_MAC_RX_STARTED            (0x00008000U)
-/** @} */
 
 /**
  * @brief   Network interface is configured in raw mode


### PR DESCRIPTION
### Contribution description
They are also defined in `net/gnrc/netif/mac.h` and those are the ones
used by the current `gnrc_mac` implementations.

Also removes a premature closing of the flags doxygen group

### Testing procedure
`make doc` should still work, `flags_8h.html` shows all flags in the right group.


### Issues/PRs references
None
<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
