### PR TITLE
sys/shell: ensure character is flushed when echoing.

### DIFF
--- a/sys/shell/shell.c
+++ b/sys/shell/shell.c
@@ -44,6 +44,13 @@ static void _putchar(int c) {
 #endif
 #endif
 
+static void flush_if_needed(void)
+{
+#ifdef MODULE_NEWLIB
+    fflush(stdout);
+#endif
+}
+
 static shell_command_handler_t find_handler(const shell_command_t *command_list, char *command)
 {
     const shell_command_t *command_lists[] = {
@@ -265,6 +272,7 @@ static int readline(char *buf, size_t size)
             _putchar(c);
 #endif
         }
+        flush_if_needed();
     }
 }
 
@@ -275,9 +283,7 @@ static inline void print_prompt(void)
     _putchar(' ');
 #endif
 
-#ifdef MODULE_NEWLIB
-    fflush(stdout);
-#endif
+    flush_if_needed();
 }
 
 void shell_run(const shell_command_t *shell_commands, char *line_buf, int len)


### PR DESCRIPTION
### Contribution description

When using a serial terminal without local echo, the current line would not get updated as the user typed because the shell module's readline() was not flushing each character.

This commit fixes that behavior. For additional clarity, fflush is turned into a macro (flush_if_needed) which expands to either a call to fflush() or empty, according to the standard library used.

This also fixes the erase/line editing behavior (the delete characters were not being flushed either.)

### Testing procedure

Test that the shell is not broken by running 

```
make -C tests/shell all flash
make -C tests/shell test
```

To test echo, I used miniterm.py (from pyserial) but any terminal with raw mode and no local echo should do:

```
$ miniterm.py --raw --eol CRLF /dev/ttyACM0 115200
```

Type a command. I used the 'test/shell' application. 

Without this patch: you won't see anything on the screen until you type enter.

With this patch: you will see characters show up as you type. If you press backspace you will see the characters disappear too.

### References

Mentioned by @neiljay  in the mailing list some months ago: https://lists.riot-os.org/pipermail/devel/2018-July/005823.html