### PR TITLE
sys/shell: Removed unneeded cpp directives

### DIFF
--- a/sys/shell/commands/sc_sht1x.c
+++ b/sys/shell/commands/sc_sht1x.c
@@ -20,8 +20,6 @@
  * @}
  */
 
-#ifdef MODULE_SHT1X
-
 #include <stdio.h>
 #include <stdint.h>
 #include <stdlib.h>
@@ -374,5 +372,3 @@ int _sht_config_handler(int argc, char **argv)
     print_config(&sht1x_devs[dev_num]);
     return 0;
 }
-
-#endif


### PR DESCRIPTION
### Contribution description
As minor as the title suggests.

### Testing procedure
Check if the SHT1X shell command still works, e.g. on the MSB-A2.

### Issues/PRs references
None