### PR TITLE
drivers/mcp9808: add temperature driver

### DIFF
--- a/drivers/Makefile.dep
+++ b/drivers/Makefile.dep
@@ -266,6 +266,10 @@ ifneq (,$(filter mag3110,$(USEMODULE)))
   FEATURES_REQUIRED += periph_i2c
 endif
 
+ifneq (,$(filter mcp9808,$(USEMODULE)))
+  FEATURES_REQUIRED += periph_i2c
+endif
+
 ifneq (,$(filter mma7660,$(USEMODULE)))
   FEATURES_REQUIRED += periph_i2c
 endif

--- a/drivers/Makefile.include
+++ b/drivers/Makefile.include
@@ -162,6 +162,10 @@ ifneq (,$(filter mag3110,$(USEMODULE)))
   USEMODULE_INCLUDES += $(RIOTBASE)/drivers/mag3110/include
 endif
 
+ifneq (,$(filter mcp9808,$(USEMODULE)))
+  USEMODULE_INCLUDES += $(RIOTBASE)/drivers/mcp9808/include
+endif
+
 ifneq (,$(filter mma7660,$(USEMODULE)))
   USEMODULE_INCLUDES += $(RIOTBASE)/drivers/mma7660/include
 endif

--- a/drivers/include/mcp9808.h
+++ b/drivers/include/mcp9808.h
@@ -1,0 +1,131 @@
+/*
+ * Copyright (C) 2018 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @defgroup    drivers_mcp9808 MCP9808 temperature sensor
+ * @ingroup     drivers_sensors
+ * @ingroup     drivers_saul
+ * @brief       Device driver interface for the MCP9808 temperature sensor
+ *
+ * This driver support the following features:
+ * - Set temperature resolution during init. Resolution can only be defined
+ *   using the default parameters of a sensor.
+ * - Use polling to read ambient temperature
+ * - Shutdown and wake up of the sensor
+ *
+ * See the [datasheet](http://ww1.microchip.com/downloads/en/DeviceDoc/25095A.pdf)
+ * for details.
+ *
+ * This driver provides @ref drivers_saul capabilities.
+ * @{
+ *
+ * @file
+ * @brief       Device driver interface for the MCP9808 sensor.
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ */
+
+#ifndef MCP9808_H
+#define MCP9808_H
+
+#include "saul.h"
+#include "periph/i2c.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @brief   Resolution of measured ambient temperature
+ */
+typedef enum {
+    MCP9808_RES_0_5 = 0,            /**< 0.5°C */
+    MCP9808_RES_0_25,               /**< 0.25°C */
+    MCP9808_RES_0_125,              /**< 0.125°C */
+    MCP9808_RES_0_0625              /**< 0.0625°C (default) */
+} mcp9808_resolution_t;
+
+/**
+ * @brief   Device initialization parameters
+ */
+typedef struct {
+    i2c_t i2c_dev;                      /**< I2C device which is used */
+    uint8_t i2c_addr;                   /**< I2C address */
+    mcp9808_resolution_t resolution;    /**< temperature resolution */
+} mcp9808_params_t;
+
+/**
+ * @brief   Device descriptor for the MCP9808 sensor
+ */
+typedef struct {
+    mcp9808_params_t params;        /**< Device initialization parameters */
+} mcp9808_t;
+
+/**
+ * @brief   Status and error return codes
+ */
+enum {
+    MCP9808_OK = 0,                 /**< everything was fine */
+    MCP9808_ERR_NODEV,              /**< did not detect MCP9808 */
+    MCP9808_ERR_I2C,                /**< error when reading/writing over I2C */
+};
+
+/**
+ * @brief   Initialize the given MCP9808 device
+ *
+ * @param[out] dev          Initialized device descriptor of MCP9808 device
+ * @param[in]  params       Initialization parameters
+ *
+ * @return                  MCP9808_OK on success
+ * @return                  -MCP9808_ERR_NODEV if not a MCP9808 at given address
+ * @return                  -MCP9808_ERR_I2C if an error occured on I2C bus.
+ */
+int mcp9808_init(mcp9808_t *dev, const mcp9808_params_t *params);
+
+/**
+ * @brief   Read temperature value from the given MCP9808 device, returned in d°C
+ *
+ * @param[in] dev           Device descriptor of MCP9808 device
+ * @@param[out] temperature Temperature in d°C
+
+ * @return                  MCP9808_OK on success
+ * @return                  -MCP9808_ERR_I2C if an error occured on I2C bus.
+ */
+int mcp9808_read_temperature(const mcp9808_t *dev, int16_t *temperature);
+
+/**
+ * @brief   Wake up the device.
+ *
+ * After calling this function a delay of 250ms must be used before reading
+ * the temperature.
+ *
+ * @param[in] dev           Device descriptor of MCP9808 device
+
+ * @return                  MCP9808_OK on success
+ * @return                  -MCP9808_ERR_I2C if an error occured on I2C bus.
+ */
+int mcp9808_wakeup(const mcp9808_t *dev);
+
+/**
+ * @brief   Shutdown the device
+ *
+ * Calling this function will put the device in very low power mode.
+ *
+ * @param[in] dev           Device descriptor of MCP9808 device
+
+ * @return                  MCP9808_OK on success
+ * @return                  -MCP9808_ERR_I2C if an error occured on I2C bus.
+ */
+int mcp9808_shutdown(const mcp9808_t *dev);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MCP9808_H */
+/** @} */

--- a/drivers/include/mcp9808.h
+++ b/drivers/include/mcp9808.h
@@ -91,7 +91,7 @@ int mcp9808_init(mcp9808_t *dev, const mcp9808_params_t *params);
  * @brief   Read temperature value from the given MCP9808 device, returned in d°C
  *
  * @param[in] dev           Device descriptor of MCP9808 device
- * @@param[out] temperature Temperature in d°C
+ * @param[out] temperature  Temperature in d°C
 
  * @return                  MCP9808_OK on success
  * @return                  -MCP9808_ERR_I2C if an error occured on I2C bus.

--- a/drivers/mcp9808/Makefile
+++ b/drivers/mcp9808/Makefile
@@ -1,0 +1,1 @@
+include $(RIOTBASE)/Makefile.base

--- a/drivers/mcp9808/include/mcp9808_constants.h
+++ b/drivers/mcp9808/include/mcp9808_constants.h
@@ -1,0 +1,83 @@
+/*
+ * Copyright (C) 2018 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_mcp9808
+ * @brief       Internal addresses, registers, constants for the MCP9808 sensor.
+ * @{
+ *
+ * @file
+ * @brief       Internal addresses, registers, constants for the MCP9808 sensor.
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ */
+
+#ifndef MCP9808_CONSTANTS_H
+#define MCP9808_CONSTANTS_H
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    MCP9808 I2C address
+ * @{
+ */
+/**
+ * @brief  Device address (7 bit address)
+ *
+ * Last 3 bits must match A2, A1 and A0 pins configuration (default is to have
+ * all to 0).
+*/
+#define MCP9808_ADDR                    (0x18)
+/** @} */
+
+/**
+ * @name    MCP9808 constants
+ * @{
+ */
+#define MCP9808_DEVICE_ID               (0x04)
+/** @} */
+
+/**
+ * @name    MCP9808 register addresses
+ * @{
+ */
+#define MCP9808_REG_CONFIG              (0x01)
+#define MCP9808_REG_T_UPPER             (0x02)
+#define MCP9808_REG_T_LOWER             (0x03)
+#define MCP9808_REG_T_CRIT              (0x04)
+#define MCP9808_REG_T_AMBIENT           (0x05)
+#define MCP9808_REG_MANUFACTURER_ID     (0x06)
+#define MCP9808_REG_DEVICE_ID_REV       (0x07)
+#define MCP9808_REG_RESOLUTION          (0x08)
+/** @} */
+
+/**
+ * @name    MCP9808 config register bits
+ * @{
+ */
+#define MCP9808_REG_CONFIG_MASK         (0x07FF)
+#define MCP9808_REG_CONFIG_T_HYST       (0x0600)
+#define MCP9808_REG_CONFIG_SHDN         (0x0100)
+#define MCP9808_REG_CONFIG_CRIT_LOCK    (0x0080)
+#define MCP9808_REG_CONFIG_WIN_LOCK     (0x0040)
+#define MCP9808_REG_CONFIG_INT_CLEAR    (0x0020)
+#define MCP9808_REG_CONFIG_ALERT_STAT   (0x0010)
+#define MCP9808_REG_CONFIG_ALERT_CNT    (0x0008)
+#define MCP9808_REG_CONFIG_ALERT_SEL    (0x0004)
+#define MCP9808_REG_CONFIG_ALERT_POL    (0x0002)
+#define MCP9808_REG_CONFIG_ALERT_MOD    (0x0001)
+/** @} */
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MCP9808_CONSTANTS_H */
+/** @} */

--- a/drivers/mcp9808/include/mcp9808_params.h
+++ b/drivers/mcp9808/include/mcp9808_params.h
@@ -1,0 +1,76 @@
+/*
+ * Copyright (C) 2018 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_mcp9808
+ *
+ * @{
+ * @file
+ * @brief       Default configuration for MCP9808
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ */
+
+#ifndef MCP9808_PARAMS_H
+#define MCP9808_PARAMS_H
+
+#include "board.h"
+#include "mcp9808.h"
+#include "mcp9808_constants.h"
+#include "saul_reg.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+/**
+ * @name    Set default configuration parameters for the MCP9808
+ * @{
+ */
+#ifndef MCP9808_PARAM_I2C_DEV
+#define MCP9808_PARAM_I2C_DEV       I2C_DEV(0)
+#endif
+#ifndef MCP9808_PARAM_I2C_ADDR
+#define MCP9808_PARAM_I2C_ADDR      MCP9808_ADDR
+#endif
+#ifndef MCP9808_PARAM_RESOLUTION
+#define MCP9808_PARAM_RESOLUTION    MCP9808_RES_0_0625
+#endif
+
+#ifndef MCP9808_PARAMS
+#define MCP9808_PARAMS              { .i2c_dev    = MCP9808_PARAM_I2C_DEV,  \
+                                      .i2c_addr   = MCP9808_PARAM_I2C_ADDR, \
+                                      .resolution = MCP9808_PARAM_RESOLUTION }
+#endif
+#ifndef MCP9808_SAUL_INFO
+#define MCP9808_SAUL_INFO           { .name = "mcp9808" }
+#endif
+/**@}*/
+
+/**
+ * @brief   Configure MCP9808
+ */
+static const mcp9808_params_t mcp9808_params[] =
+{
+    MCP9808_PARAMS
+};
+
+/**
+ * @brief   Configure SAUL registry entries
+ */
+static const saul_reg_info_t mcp9808_saul_info[] =
+{
+    MCP9808_SAUL_INFO
+};
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif /* MCP9808_PARAMS_H */
+/** @} */

--- a/drivers/mcp9808/mcp9808.c
+++ b/drivers/mcp9808/mcp9808.c
@@ -1,0 +1,168 @@
+/*
+ * Copyright (C) 2018 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_mcp9808
+ * @{
+ *
+ * @file
+ * @brief       Device driver implementation for the MCP9808 temperature sensor.
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ * @}
+ */
+
+#include <math.h>
+
+#include "log.h"
+#include "mcp9808.h"
+#include "mcp9808_constants.h"
+#include "mcp9808_params.h"
+#include "periph/i2c.h"
+
+#define ENABLE_DEBUG        (0)
+#include "debug.h"
+
+#define DEV_I2C      (dev->params.i2c_dev)
+#define DEV_ADDR     (dev->params.i2c_addr)
+
+int _read16(const mcp9808_t *dev, uint8_t pointer, uint16_t *reg)
+{
+    /* Acquire exclusive access */
+    i2c_acquire(DEV_I2C);
+    uint8_t buf[2];
+    if (i2c_read_regs(DEV_I2C, DEV_ADDR, pointer, &buf, 2, 0) != 0) {
+        DEBUG("[mcp9808] Error: cannot read register 0x%02X\n", pointer);
+        i2c_release(DEV_I2C);
+        return -MCP9808_ERR_I2C;
+    }
+
+    *reg = (buf[0] << 8) | buf[1];
+
+    /* Release I2C device */
+    i2c_release(DEV_I2C);
+
+    return MCP9808_OK;
+}
+
+int _write16(const mcp9808_t *dev, uint8_t pointer, uint16_t *reg)
+{
+    uint8_t buf[2];
+    buf[0] = (uint8_t)((*reg) >> 8);
+    buf[1] = (uint8_t)(*reg);
+    if (i2c_write_regs(DEV_I2C, DEV_ADDR, pointer, &buf, 2, 0) != 0) {
+        DEBUG("[mcp9808] Error: cannot write register 0x%02X\n", pointer);
+        i2c_release(DEV_I2C);
+        return -MCP9808_ERR_I2C;
+    }
+
+    /* Release I2C device */
+    i2c_release(DEV_I2C);
+
+    return MCP9808_OK;
+}
+
+int mcp9808_init(mcp9808_t *dev, const mcp9808_params_t *params)
+{
+    dev->params = *params;
+
+    /* Acquire exclusive access */
+    i2c_acquire(DEV_I2C);
+
+    /* Check device ID */
+    uint8_t checkid;
+    i2c_read_reg(DEV_I2C, DEV_ADDR, MCP9808_REG_DEVICE_ID_REV, &checkid, 0);
+    if (checkid != MCP9808_DEVICE_ID) {
+        DEBUG("[mcp9808] Error: wrong device ID 0x%02X\n", checkid);
+        i2c_release(DEV_I2C);
+        return -MCP9808_ERR_NODEV;
+    }
+
+    /* Reset config register to default values */
+    uint16_t init = 0;
+    if (_write16(dev, MCP9808_REG_CONFIG, &init) != MCP9808_OK) {
+        DEBUG("[mcp9808] Error: cannot write config register\n");
+        return -MCP9808_ERR_I2C;
+    }
+
+    /* Write measure resolution */
+    if (i2c_write_reg(DEV_I2C, DEV_ADDR, MCP9808_REG_RESOLUTION,
+                      dev->params.resolution, 0) != 0) {
+        DEBUG("[mcp9808] Error: cannot read resolution register\n");
+        i2c_release(DEV_I2C);
+        return -MCP9808_ERR_I2C;
+    }
+
+    /* Release I2C device */
+    i2c_release(DEV_I2C);
+
+    DEBUG("[mcp9808] Initialization succeeded\n");
+
+    return MCP9808_OK;
+}
+
+int mcp9808_read_temperature(const mcp9808_t *dev, int16_t *temperature)
+{
+    uint16_t ta;
+    if (_read16(dev, MCP9808_REG_T_AMBIENT, &ta) != MCP9808_OK) {
+        DEBUG("[mcp9808] Error: cannot read ambient temperature register\n");
+        return -MCP9808_ERR_I2C;
+    }
+
+    /* convert temperature to d°C */
+    uint8_t ub = (uint8_t)(ta >> 8) & 0x1f; /* clear flag bits */
+    uint8_t lb = (uint8_t)ta;
+    DEBUG("[mcp9808] UB: 0x%02X, LB:0x%02X\n", ub, lb);
+    if ((ub & 0x10) == 0x10) { /* TA < 0°C */
+        ub = ub & 0x0f; /* Clear SIGN */
+        *temperature = 256 - ((ub * 160) + ((lb * 10) / 16));
+    } else { /* TA >= 0°C */
+        *temperature = ((ub * 160) + ((lb * 10) / 16));
+    }
+
+    DEBUG("[mcp9808] Computed T: %i\n", *temperature);
+
+    return MCP9808_OK;
+}
+
+int mcp9808_wakeup(const mcp9808_t *dev)
+{
+    uint16_t config;
+    if (_read16(dev, MCP9808_REG_CONFIG, &config) != MCP9808_OK) {
+        DEBUG("[mcp9808] Error: cannot read config register\n");
+        return -MCP9808_ERR_I2C;
+    }
+
+    config &= ~MCP9808_REG_CONFIG_SHDN;
+    DEBUG("[mcp9808] wake_up: setting config to 0x%04X\n", config);
+    if (_write16(dev, MCP9808_REG_CONFIG, &config) != MCP9808_OK) {
+        DEBUG("[mcp9808] Error: cannot write config register\n");
+        return -MCP9808_ERR_I2C;
+    }
+
+    return MCP9808_OK;
+}
+
+int mcp9808_shutdown(const mcp9808_t *dev)
+{
+    uint16_t config;
+    if (_read16(dev, MCP9808_REG_CONFIG, &config) != MCP9808_OK) {
+        DEBUG("[mcp9808] Error: cannot read config register\n");
+        return -MCP9808_ERR_I2C;
+    }
+
+    config |= MCP9808_REG_CONFIG_SHDN;
+    DEBUG("[mcp9808] shutdown: setting config to 0x%04X\n", config);
+    if (_write16(dev, MCP9808_REG_CONFIG, &config) != MCP9808_OK) {
+        DEBUG("[mcp9808] Error: cannot write config register\n");
+        return -MCP9808_ERR_I2C;
+    }
+
+    return MCP9808_OK;
+}

--- a/drivers/mcp9808/mcp9808_saul.c
+++ b/drivers/mcp9808/mcp9808_saul.c
@@ -1,0 +1,41 @@
+/*
+ * Copyright (C) 2018 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     drivers_mcp9808
+ * @{
+ *
+ * @file
+ * @brief       SAUL adaption for MCP9808 device
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ * @}
+ */
+
+#include <string.h>
+
+#include "saul.h"
+#include "mcp9808.h"
+
+static int read_temperature(const void *dev, phydat_t *res)
+{
+    if (mcp9808_read_temperature((const mcp9808_t *)dev, &res->val[0]) == MCP9808_OK) {
+        res->unit = UNIT_TEMP_C;
+        res->scale = -1;
+        return 1;
+    }
+
+    return -ECANCELED;
+}
+
+const saul_driver_t mcp9808_temperature_saul_driver = {
+    .read = read_temperature,
+    .write = saul_notsup,
+    .type = SAUL_SENSE_TEMP
+};

--- a/sys/auto_init/auto_init.c
+++ b/sys/auto_init/auto_init.c
@@ -413,6 +413,10 @@ void auto_init(void)
     extern void auto_init_mag3110(void);
     auto_init_mag3110();
 #endif
+#ifdef MODULE_MCP9808
+    extern void auto_init_mcp9808(void);
+    auto_init_mcp9808();
+#endif
 #ifdef MODULE_MMA7660
     extern void auto_init_mma7660(void);
     auto_init_mma7660();

--- a/sys/auto_init/saul/auto_init_mcp9808.c
+++ b/sys/auto_init/saul/auto_init_mcp9808.c
@@ -1,0 +1,80 @@
+/*
+ * Copyright (C) 2018 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup     sys_auto_init_saul
+ * @{
+ *
+ * @file
+ * @brief       Auto initialization of MCP9808 driver.
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ * @}
+ */
+
+#ifdef MODULE_MCP9808
+
+#include "assert.h"
+#include "log.h"
+#include "saul_reg.h"
+#include "mcp9808.h"
+#include "mcp9808_params.h"
+
+/**
+ * @brief   Define the number of configured sensors
+ */
+#define MCP9808_NUM      (sizeof(mcp9808_params) / sizeof(mcp9808_params[0]))
+
+/**
+ * @brief   Allocation of memory for device descriptors
+ */
+static mcp9808_t mcp9808_devs[MCP9808_NUM];
+
+/**
+ * @brief   Memory for the SAUL registry entries
+ */
+static saul_reg_t saul_entries[MCP9808_NUM];
+
+/**
+ * @brief   Define the number of saul info
+ */
+#define MCP9808_INFO_NUM (sizeof(mcp9808_saul_info) / sizeof(mcp9808_saul_info[0]))
+
+/**
+ * @name    Reference the driver structs.
+ * @{
+ */
+extern const saul_driver_t mcp9808_temperature_saul_driver;
+/** @} */
+
+void auto_init_mcp9808(void)
+{
+    assert(MCP9808_INFO_NUM == MCP9808_NUM);
+
+    for (unsigned i = 0; i < MCP9808_NUM; i++) {
+        LOG_DEBUG("[auto_init_saul] initializing mcp9808 #%u\n", i);
+
+        if (mcp9808_init(&mcp9808_devs[i],
+                         &mcp9808_params[i]) != MCP9808_OK) {
+            LOG_ERROR("[auto_init_saul] error initializing mcp9808 #%u\n", i);
+            continue;
+        }
+
+        /* temperature */
+        saul_entries[i].dev = &(mcp9808_devs[i]);
+        saul_entries[i].name = mcp9808_saul_info[i].name;
+        saul_entries[i].driver = &mcp9808_temperature_saul_driver;
+
+        /* register to saul */
+        saul_reg_add(&(saul_entries[i]));
+    }
+}
+#else
+typedef int dont_be_pedantic;
+#endif /* MODULE_MCP9808 */

--- a/tests/driver_mcp9808/Makefile
+++ b/tests/driver_mcp9808/Makefile
@@ -1,0 +1,6 @@
+include ../Makefile.tests_common
+
+USEMODULE += mcp9808
+USEMODULE += xtimer
+
+include $(RIOTBASE)/Makefile.include

--- a/tests/driver_mcp9808/Readme.md
+++ b/tests/driver_mcp9808/Readme.md
@@ -1,0 +1,8 @@
+## About
+
+This is a test application for the MCP9808 Temperature sensor.
+
+## Usage
+
+The application will initialize the MCP9808 sensor and display to stdout the
+temperature measured every 2 seconds.

--- a/tests/driver_mcp9808/main.c
+++ b/tests/driver_mcp9808/main.c
@@ -1,0 +1,72 @@
+/*
+ * Copyright (C) 2018 Inria
+ *
+ * This file is subject to the terms and conditions of the GNU Lesser
+ * General Public License v2.1. See the file LICENSE in the top level
+ * directory for more details.
+ */
+
+/**
+ * @ingroup tests
+ * @{
+ *
+ * @file
+ * @brief       Test application for the MCP9808 pressure and temperature sensor
+ *
+ * @author      Alexandre Abadie <alexandre.abadie@inria.fr>
+ *
+ * @}
+ */
+
+#include <stdio.h>
+#include <inttypes.h>
+
+#include "mcp9808.h"
+#include "mcp9808_params.h"
+#include "xtimer.h"
+#include "board.h"
+
+
+static mcp9808_t dev;
+
+int main(void)
+{
+    int result;
+
+    puts("MCP9808 test application\n");
+
+    result = mcp9808_init(&dev, &mcp9808_params[0]);
+    if (result == -MCP9808_ERR_NODEV) {
+        puts("[Error] The sensor did not answer correctly on the given address");
+        return 1;
+    }
+
+    puts("Initialization successful\n");
+
+    int16_t temperature = 0;
+    while (1) {
+        if (mcp9808_wakeup(&dev) != MCP9808_OK) {
+            puts("[Error] The sensor cannot be wake up");
+            return 1;
+        }
+
+        /* 250ms delay is required after device wake up */
+        xtimer_usleep(250 * US_PER_MS);
+
+        /* Read temperature in d°C */
+        if (mcp9808_read_temperature(&dev, &temperature) != MCP9808_OK) {
+            puts("[Error] Cannot read ambient temperature");
+            return 1;
+        }
+
+        if (mcp9808_shutdown(&dev) != MCP9808_OK) {
+            puts("[Error] The sensor cannot be shutdown");
+            return 1;
+        }
+
+        printf("Temperature [d°C]: %i\n", (int)temperature);
+        xtimer_sleep(2);
+    }
+
+    return 0;
+}


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR add support for the [Microchip MCP9808](http://ww1.microchip.com/downloads/en/DeviceDoc/25095A.pdf) temperature sensor. The sensor uses I2C bus to communicate with a microcontroller.

The driver supports:
- basic polling
- wakeup/shutdown of the device for minimal power consumption
- saul interface

A test application is provided.

Interrupt mode could be added later but I wanted the driver to remain simple in a first PR.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

- Grab a MCP9808 and wire it to a board
- Build and flash the test application:
```
$ make BOARD=arduino-zero -C tests/driver_mcp9808 flash term
```
- Watch the temperature values being displayed every 2 seconds.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

None

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
