### PR TITLE
 sys/shell: correctly detect and handle long lines

### DIFF
--- a/sys/shell/shell.c
+++ b/sys/shell/shell.c
@@ -276,6 +276,11 @@ static int readline(char *buf, size_t size)
         /* DOS newlines are handled like hitting enter twice, but empty lines are ignored. */
         /* Ctrl-C cancels the current line. */
         if (c == '\r' || c == '\n' || c == ETX) {
+            if (c == ETX) {
+                curr_pos = 0;
+                length_exceeded = 0;
+            }
+
             buf[curr_pos] = '\0';
 #ifndef SHELL_NO_ECHO
             _putchar('\r');

--- a/tests/shell/Makefile
+++ b/tests/shell/Makefile
@@ -21,4 +21,7 @@ BOARD_INSUFFICIENT_MEMORY := arduino-duemilanove \
 
 APP_SHELL_FMT ?= NONE
 
+# needed to correctly test long lines
+RIOT_TERMINAL ?= socat
+
 include $(RIOTBASE)/Makefile.include

--- a/tests/shell/main.c
+++ b/tests/shell/main.c
@@ -56,7 +56,17 @@ static int print_echo(int argc, char **argv)
     return 0;
 }
 
+static int print_shell_bufsize(int argc, char **argv)
+{
+    (void) argc;
+    (void) argv;
+    printf("%d\n", SHELL_DEFAULT_BUFSIZE);
+
+    return 0;
+}
+
 static const shell_command_t shell_commands[] = {
+    { "bufsize", "Get the shell's buffer size", print_shell_bufsize },
     { "start_test", "starts a test", print_teststart },
     { "end_test", "ends a test", print_testend },
     { "echo", "prints the input command", print_echo },

--- a/tests/shell/tests/01-run.py
+++ b/tests/shell/tests/01-run.py
@@ -7,6 +7,7 @@
 # directory for more details.
 
 import sys
+import os
 from testrunner import run
 
 
@@ -50,21 +51,36 @@ CMDS = (
     ('help', EXPECTED_HELP),
     ('echo a string', ('\"echo\"\"a\"\"string\"')),
     ('ps', EXPECTED_PS),
-    ('garbage1234'+CONTROL_C, ('>')),  # test cancelling a line
     ('help', EXPECTED_HELP),
     ('reboot', ('test_shell.'))
 )
 
+PROMPT = '> '
+
+ON_NATIVE = os.environ['BOARD'] == 'native'
+
 
 def check_cmd(child, cmd, expected):
+    child.expect(PROMPT)
     child.sendline(cmd)
     for line in expected:
         child.expect_exact(line)
 
 
 def testfunc(child):
+    # Avoid sending en extra empty line on native.
+    if ON_NATIVE:
+        child.crlf = '\n'
+
     # check startup message
     child.expect('test_shell.')
+
+    # test cancelling a line
+    child.expect(PROMPT)
+    child.sendline('garbage1234'+CONTROL_C)
+    garbage_expected = 'garbage1234\r\r\n> '
+    garbage_received = child.read(len(garbage_expected))
+    assert garbage_expected == garbage_received
 
     # loop other defined commands and expected output
     for cmd, expected in CMDS:

--- a/tests/shell/tests/01-run.py
+++ b/tests/shell/tests/01-run.py
@@ -73,7 +73,21 @@ def testfunc(child):
         child.crlf = '\n'
 
     # check startup message
-    child.expect('test_shell.')
+    child.expect('test_shell.\r\n')
+    child.sendline('')
+
+    child.sendline('bufsize')
+    child.expect('([0-9]+)\r\n')
+
+    bufsize = int(child.match[1])
+
+    child.expect(PROMPT)
+
+    # check a long line
+    child.sendline("_"*bufsize + "verylong")
+    # this is dirty hack to work around a bug in the uart (#10634)
+    child.sendline()
+    child.expect('shell: maximum line length exceeded')
 
     # test cancelling a line
     child.expect(PROMPT)

--- a/tests/shell/tests/01-run.py
+++ b/tests/shell/tests/01-run.py
@@ -84,9 +84,17 @@ def testfunc(child):
     child.expect(PROMPT)
 
     # check a long line
-    child.sendline("_"*bufsize + "verylong")
-    # this is dirty hack to work around a bug in the uart (#10634)
-    child.sendline()
+    longline = "_"*bufsize + "verylong"
+    if ON_NATIVE:
+        child.sendline(longline)
+    else:
+        # this is dirty hack to work around a bug in the uart (#10634)
+        for c in longline:
+            child.write(c)
+            child.flush()
+        child.sendline()
+        child.sendline()
+
     child.expect('shell: maximum line length exceeded')
 
     # test cancelling a line


### PR DESCRIPTION
### Contribution description

The numeric value for EOF is (-1). This caused the shell to return the same code when EOF was encountered and when the line lenght was exceeded. Additionally, if the line length is exceeded, the correct behaviour is to consume the remaining characters until the end of the line, to prevent the following line from containing (potentially dangerous) garbage.

### Testing procedure

The first commit adds a test to `tests/shell`. It adds a command to retrieve buffer size and then forces an extremely long line. This is failing right now because of a bug in the shell.

Murdock should be checking this, but you can do it locally by checkout both commits and running

```
BOARD=some_board make -C tests/shell flash test
```
In each one. The first one fails and the second succeeds.

I can switch the order of the commits if keeping a working history is important.

### Issues/PRs references

Testing was made specially difficult because of #10634 .
Part of  #12105 
