### PR TITLE
cpu/nrf5x: move periph_gpio/periph_gpio_irq at an even more common level

### DIFF
--- a/boards/common/nrf52/Makefile.features
+++ b/boards/common/nrf52/Makefile.features
@@ -1,5 +1,4 @@
 # Put defined MCU peripherals here (in alphabetical order)
-FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_timer
 

--- a/cpu/nrf51/Makefile.features
+++ b/cpu/nrf51/Makefile.features
@@ -1,3 +1,1 @@
-FEATURES_PROVIDED += periph_gpio periph_gpio_irq
-
 -include $(RIOTCPU)/nrf5x_common/Makefile.features

--- a/cpu/nrf5x_common/Makefile.features
+++ b/cpu/nrf5x_common/Makefile.features
@@ -1,6 +1,7 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_cpuid
 FEATURES_PROVIDED += periph_flashpage
+FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_hwrng
 
 # Various other features (if any)


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR removes the FEATURES_PROVIDED += periph_gpio periph_gpio_irq from nrf52 boards level and move the one defined in cpu/nrf51 to cpu/nrf5x_common. Making it available to all nrf based cpus.

Since @haukepetersen is thinking this is the way to do it. See https://github.com/RIOT-OS/RIOT/pull/10279#discussion_r239736518

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

If Murdock is green, everything should be fine

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Follow-up of #10279

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
