### PR TITLE
boards*: move periph_gpio and periph_gpio_irq features from boards to cpu for STM32

### DIFF
--- a/boards/b-l072z-lrwan1/Makefile.features
+++ b/boards/b-l072z-lrwan1/Makefile.features
@@ -1,5 +1,4 @@
 # Put defined MCU peripherals here (in alphabetical order)
-FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_spi

--- a/boards/b-l475e-iot01a/Makefile.features
+++ b/boards/b-l475e-iot01a/Makefile.features
@@ -1,5 +1,4 @@
 # Put defined MCU peripherals here (in alphabetical order)
-FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_spi

--- a/boards/common/iotlab/Makefile.features
+++ b/boards/common/iotlab/Makefile.features
@@ -1,5 +1,4 @@
 # Put defined MCU peripherals here (in alphabetical order)
-FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi

--- a/boards/common/stm32f103c8/Makefile.features
+++ b/boards/common/stm32f103c8/Makefile.features
@@ -1,6 +1,5 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
-FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_spi

--- a/boards/f4vi1/Makefile.features
+++ b/boards/f4vi1/Makefile.features
@@ -1,7 +1,6 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
-FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 
 # The board MPU family (used for grouping by the CI system)
 FEATURES_MCU_GROUP = cortex_m4_1

--- a/boards/fox/Makefile.features
+++ b/boards/fox/Makefile.features
@@ -1,5 +1,4 @@
 # Put defined MCU peripherals here (in alphabetical order)
-FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi

--- a/boards/limifrog-v1/Makefile.features
+++ b/boards/limifrog-v1/Makefile.features
@@ -1,5 +1,4 @@
 # Put defined MCU peripherals here (in alphabetical order)
-FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer

--- a/boards/lobaro-lorabox/Makefile.features
+++ b/boards/lobaro-lorabox/Makefile.features
@@ -1,5 +1,4 @@
 # Put defined MCU peripherals here (in alphabetical order)
-FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_spi

--- a/boards/maple-mini/Makefile.features
+++ b/boards/maple-mini/Makefile.features
@@ -1,5 +1,4 @@
 # Put defined MCU peripherals here (in alphabetical order)
-FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer

--- a/boards/msbiot/Makefile.features
+++ b/boards/msbiot/Makefile.features
@@ -1,7 +1,6 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_dac
-FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_spi

--- a/boards/nucleo-f030r8/Makefile.features
+++ b/boards/nucleo-f030r8/Makefile.features
@@ -1,6 +1,5 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
-FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_timer

--- a/boards/nucleo-f031k6/Makefile.features
+++ b/boards/nucleo-f031k6/Makefile.features
@@ -1,6 +1,5 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
-FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_spi

--- a/boards/nucleo-f042k6/Makefile.features
+++ b/boards/nucleo-f042k6/Makefile.features
@@ -1,6 +1,5 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
-FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_spi

--- a/boards/nucleo-f070rb/Makefile.features
+++ b/boards/nucleo-f070rb/Makefile.features
@@ -1,6 +1,5 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
-FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc

--- a/boards/nucleo-f072rb/Makefile.features
+++ b/boards/nucleo-f072rb/Makefile.features
@@ -1,6 +1,5 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
-FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_timer

--- a/boards/nucleo-f091rc/Makefile.features
+++ b/boards/nucleo-f091rc/Makefile.features
@@ -1,6 +1,5 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
-FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc

--- a/boards/nucleo-f103rb/Makefile.features
+++ b/boards/nucleo-f103rb/Makefile.features
@@ -1,5 +1,4 @@
 # Put defined MCU peripherals here (in alphabetical order)
-FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_rtt
 FEATURES_PROVIDED += periph_spi

--- a/boards/nucleo-f207zg/Makefile.features
+++ b/boards/nucleo-f207zg/Makefile.features
@@ -1,5 +1,4 @@
 # Put defined MCU peripherals here (in alphabetical order)
-FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc

--- a/boards/nucleo-f302r8/Makefile.features
+++ b/boards/nucleo-f302r8/Makefile.features
@@ -1,5 +1,4 @@
 # Put defined MCU peripherals here (in alphabetical order)
-FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc

--- a/boards/nucleo-f303k8/Makefile.features
+++ b/boards/nucleo-f303k8/Makefile.features
@@ -1,5 +1,4 @@
 # Put defined MCU peripherals here (in alphabetical order)
-FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_spi

--- a/boards/nucleo-f303re/Makefile.features
+++ b/boards/nucleo-f303re/Makefile.features
@@ -1,5 +1,4 @@
 # Put defined MCU peripherals here (in alphabetical order)
-FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc

--- a/boards/nucleo-f303ze/Makefile.features
+++ b/boards/nucleo-f303ze/Makefile.features
@@ -1,5 +1,4 @@
 # Put defined MCU peripherals here (in alphabetical order)
-FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_spi

--- a/boards/nucleo-f334r8/Makefile.features
+++ b/boards/nucleo-f334r8/Makefile.features
@@ -1,5 +1,4 @@
 # Put defined MCU peripherals here (in alphabetical order)
-FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_spi

--- a/boards/nucleo-f401re/Makefile.features
+++ b/boards/nucleo-f401re/Makefile.features
@@ -1,7 +1,6 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_i2c
-FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_spi

--- a/boards/nucleo-f410rb/Makefile.features
+++ b/boards/nucleo-f410rb/Makefile.features
@@ -1,7 +1,6 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_i2c
-FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer

--- a/boards/nucleo-f411re/Makefile.features
+++ b/boards/nucleo-f411re/Makefile.features
@@ -1,7 +1,6 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_i2c
-FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_spi

--- a/boards/nucleo-f412zg/Makefile.features
+++ b/boards/nucleo-f412zg/Makefile.features
@@ -1,6 +1,5 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
-FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc

--- a/boards/nucleo-f413zh/Makefile.features
+++ b/boards/nucleo-f413zh/Makefile.features
@@ -1,7 +1,6 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_dma
-FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc

--- a/boards/nucleo-f429zi/Makefile.features
+++ b/boards/nucleo-f429zi/Makefile.features
@@ -1,6 +1,5 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
-FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc

--- a/boards/nucleo-f446re/Makefile.features
+++ b/boards/nucleo-f446re/Makefile.features
@@ -1,7 +1,6 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_i2c
-FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_spi

--- a/boards/nucleo-f446ze/Makefile.features
+++ b/boards/nucleo-f446ze/Makefile.features
@@ -1,5 +1,4 @@
 # Put defined MCU peripherals here (in alphabetical order)
-FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc

--- a/boards/nucleo-f722ze/Makefile.features
+++ b/boards/nucleo-f722ze/Makefile.features
@@ -1,5 +1,4 @@
 # Put defined MCU peripherals here (in alphabetical order)
-FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_timer

--- a/boards/nucleo-f746zg/Makefile.features
+++ b/boards/nucleo-f746zg/Makefile.features
@@ -1,5 +1,4 @@
 # Put defined MCU peripherals here (in alphabetical order)
-FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart

--- a/boards/nucleo-f767zi/Makefile.features
+++ b/boards/nucleo-f767zi/Makefile.features
@@ -1,5 +1,4 @@
 # Put defined MCU peripherals here (in alphabetical order)
-FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart

--- a/boards/nucleo-l031k6/Makefile.features
+++ b/boards/nucleo-l031k6/Makefile.features
@@ -1,6 +1,5 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
-FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_spi

--- a/boards/nucleo-l053r8/Makefile.features
+++ b/boards/nucleo-l053r8/Makefile.features
@@ -1,5 +1,4 @@
 # Put defined MCU peripherals here (in alphabetical order)
-FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_spi

--- a/boards/nucleo-l073rz/Makefile.features
+++ b/boards/nucleo-l073rz/Makefile.features
@@ -1,6 +1,5 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
-FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_lpuart
 FEATURES_PROVIDED += periph_pwm

--- a/boards/nucleo-l152re/Makefile.features
+++ b/boards/nucleo-l152re/Makefile.features
@@ -1,7 +1,6 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_dac
-FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc

--- a/boards/nucleo-l432kc/Makefile.features
+++ b/boards/nucleo-l432kc/Makefile.features
@@ -1,5 +1,4 @@
 # Put defined MCU peripherals here (in alphabetical order)
-FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_spi

--- a/boards/nucleo-l433rc/Makefile.features
+++ b/boards/nucleo-l433rc/Makefile.features
@@ -1,5 +1,4 @@
 # Put defined MCU peripherals here (in alphabetical order)
-FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_lpuart
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc

--- a/boards/nucleo-l452re/Makefile.features
+++ b/boards/nucleo-l452re/Makefile.features
@@ -1,5 +1,4 @@
 # Put defined MCU peripherals here (in alphabetical order)
-FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_rtt

--- a/boards/nucleo-l476rg/Makefile.features
+++ b/boards/nucleo-l476rg/Makefile.features
@@ -1,6 +1,5 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
-FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc

--- a/boards/nucleo-l496zg/Makefile.features
+++ b/boards/nucleo-l496zg/Makefile.features
@@ -1,5 +1,4 @@
 # Put defined MCU peripherals here (in alphabetical order)
-FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_rtt

--- a/boards/nz32-sc151/Makefile.features
+++ b/boards/nz32-sc151/Makefile.features
@@ -1,7 +1,6 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_dac
-FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc

--- a/boards/opencm904/Makefile.features
+++ b/boards/opencm904/Makefile.features
@@ -1,5 +1,4 @@
 # Put defined MCU peripherals here (in alphabetical order)
-FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 

--- a/boards/spark-core/Makefile.features
+++ b/boards/spark-core/Makefile.features
@@ -1,5 +1,4 @@
 # Put defined MCU peripherals here (in alphabetical order)
-FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_uart

--- a/boards/stm32f0discovery/Makefile.features
+++ b/boards/stm32f0discovery/Makefile.features
@@ -1,6 +1,5 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
-FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer

--- a/boards/stm32f3discovery/Makefile.features
+++ b/boards/stm32f3discovery/Makefile.features
@@ -1,6 +1,5 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_dac
-FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc

--- a/boards/stm32f429i-disc1/Makefile.features
+++ b/boards/stm32f429i-disc1/Makefile.features
@@ -1,5 +1,4 @@
 # Put defined MCU peripherals here (in alphabetical order)
-FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_spi
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart

--- a/boards/stm32f4discovery/Makefile.features
+++ b/boards/stm32f4discovery/Makefile.features
@@ -1,7 +1,6 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
 FEATURES_PROVIDED += periph_dac
-FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc

--- a/boards/stm32f769i-disco/Makefile.features
+++ b/boards/stm32f769i-disco/Makefile.features
@@ -1,5 +1,4 @@
 # Put defined MCU peripherals here (in alphabetical order)
-FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart

--- a/boards/stm32l476g-disco/Makefile.features
+++ b/boards/stm32l476g-disco/Makefile.features
@@ -1,5 +1,4 @@
 # Put defined MCU peripherals here (in alphabetical order)
-FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_timer
 FEATURES_PROVIDED += periph_uart
 

--- a/boards/ublox-c030-u201/Makefile.features
+++ b/boards/ublox-c030-u201/Makefile.features
@@ -1,6 +1,5 @@
 # Put defined MCU peripherals here (in alphabetical order)
 FEATURES_PROVIDED += periph_adc
-FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_rtc
 FEATURES_PROVIDED += periph_spi

--- a/cpu/stm32_common/Makefile.features
+++ b/cpu/stm32_common/Makefile.features
@@ -1,4 +1,5 @@
 FEATURES_PROVIDED += periph_cpuid
+FEATURES_PROVIDED += periph_gpio periph_gpio_irq
 FEATURES_PROVIDED += puf_sram
 
 ifneq (,$(filter $(BOARDS_WITHOUT_HWRNG),$(BOARD)))


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR is similar to #10434 but applied to STM32 based boards.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

If Murdock is OK, it should be fine.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

Related to #10434  and #10636.

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
