### PR TITLE
net/nanocoap: fix includes for nanocoap sock

### DIFF
--- a/examples/nanocoap_server/main.c
+++ b/examples/nanocoap_server/main.c
@@ -19,9 +19,7 @@
 
 #include <stdio.h>
 
-#include "net/nanocoap.h"
 #include "net/nanocoap_sock.h"
-
 #include "xtimer.h"
 
 #define COAP_INBUF_SIZE (256U)

--- a/sys/include/net/nanocoap_sock.h
+++ b/sys/include/net/nanocoap_sock.h
@@ -23,6 +23,7 @@
 #include <stdint.h>
 #include <unistd.h>
 
+#include "net/nanocoap.h"
 #include "net/sock/udp.h"
 
 #ifdef __cplusplus

--- a/sys/net/application_layer/nanocoap/sock.c
+++ b/sys/net/application_layer/nanocoap/sock.c
@@ -22,7 +22,7 @@
 #include <string.h>
 #include <stdio.h>
 
-#include "net/nanocoap.h"
+#include "net/nanocoap_sock.h"
 #include "net/sock/udp.h"
 
 #define ENABLE_DEBUG (0)


### PR DESCRIPTION
### Contribution description
This PR is a simple fix for a missing includes in nanocoap sock -- the header and implementation files. `nanocoap_sock.h` neglected to include `nanocoap.h`, which clearly is necessary. This issue was masked because the only use of `nanocoap_sock.h` was in the nanocoap_server example, and it explicitly included `nanocoap.h`. which is unnecessary.

This PR also fixes nanocoap's `sock.c` to include `nanocoap_sock.h` as well, as it implements the declarations in the header.

### Testing procedure
It should be enough to compile the nanocoap_server example. You could also try to build #10640, which now depends on this PR and includes `nanocoap_sock.h`.

### Issues/PRs references
none