### PR TITLE
boards/esp32: UART configuration fix

### DIFF
--- a/boards/esp32-mh-et-live-minikit/include/periph_conf.h
+++ b/boards/esp32-mh-et-live-minikit/include/periph_conf.h
@@ -148,8 +148,8 @@
  *
  * @{
  */
-#define UART0_TXD   GPIO10 /**< direct I/O pin for UART_DEV(0) TxD, can't be changed */
-#define UART0_RXD   GPIO9  /**< direct I/O pin for UART_DEV(0) RxD, can't be changed */
+#define UART0_TXD   GPIO1  /**< direct I/O pin for UART_DEV(0) TxD, can't be changed */
+#define UART0_RXD   GPIO3  /**< direct I/O pin for UART_DEV(0) RxD, can't be changed */
 
 #if FLASH_MODE_DOUT || FLASH_MODE_DIO || DOXYGEN
 #ifndef UART1_TXD

--- a/boards/esp32-wroom-32/include/periph_conf.h
+++ b/boards/esp32-wroom-32/include/periph_conf.h
@@ -179,8 +179,8 @@ extern "C" {
  *
  * @{
  */
-#define UART0_TXD   GPIO10 /**< direct I/O pin for UART_DEV(0) TxD, can't be changed */
-#define UART0_RXD   GPIO9  /**< direct I/O pin for UART_DEV(0) RxD, can't be changed */
+#define UART0_TXD   GPIO1  /**< direct I/O pin for UART_DEV(0) TxD, can't be changed */
+#define UART0_RXD   GPIO3  /**< direct I/O pin for UART_DEV(0) RxD, can't be changed */
 
 #if FLASH_MODE_DOUT || FLASH_MODE_DIO || DOXYGEN
 #ifndef UART1_TXD

--- a/boards/esp32-wrover-kit/include/periph_conf.h
+++ b/boards/esp32-wrover-kit/include/periph_conf.h
@@ -203,8 +203,8 @@
  * UART_DEV(2) is not available.<br>
  * @{
  */
-#define UART0_TXD   GPIO10 /**< direct I/O pin for UART_DEV(0) TxD, can't be changed */
-#define UART0_RXD   GPIO9  /**< direct I/O pin for UART_DEV(0) RxD, can't be changed */
+#define UART0_TXD   GPIO1  /**< direct I/O pin for UART_DEV(0) TxD, can't be changed */
+#define UART0_RXD   GPIO3  /**< direct I/O pin for UART_DEV(0) RxD, can't be changed */
 /** @} */
 
 


### PR DESCRIPTION
### Contribution description

Fixes the UART pin configuration for UART_DEV(0).

### Testing procedure

Since this configuration is defined for documentation purposes only, the change has no impact on the code. There is nothing to test.