### PR TITLE
boards/esp32: changes the approach for peripheral configurations in ESP32 board definitions

### DIFF
--- a/boards/common/esp32/include/periph_conf_common.h
+++ b/boards/common/esp32/include/periph_conf_common.h
@@ -127,7 +127,7 @@ static const i2c_conf_t i2c_config[] = {
  *
  * @note I2C_NUMOF definition must not be changed.
  */
-#define I2C_NUMOF   (i2c_bus_num)
+#define I2C_NUMOF   (sizeof(i2c_config) / sizeof(i2c_config[0]))
 
 /** @} */
 

--- a/boards/common/esp32/include/periph_conf_common.h
+++ b/boards/common/esp32/include/periph_conf_common.h
@@ -47,6 +47,11 @@ extern "C" {
 #endif
 
 /**
+ * @brief   Static array with declared ADC channels
+ */
+static const gpio_t adc_channels[] = ADC_GPIOS;
+
+/**
  * @brief Number of GPIOs declared as ADC channels
  *
  * The number of GPIOs that are declared as ADC channels is determined from
@@ -54,7 +59,7 @@ extern "C" {
  *
  * @note ADC_NUMOF definition must not be changed.
  */
-#define ADC_NUMOF   (adc_chn_num)
+#define ADC_NUMOF   (sizeof(adc_channels) / sizeof(adc_channels[0]))
 /** @} */
 
 /**
@@ -74,6 +79,11 @@ extern "C" {
 #endif
 
 /**
+ * @brief   Static array with declared DAC channels
+ */
+static const gpio_t dac_channels[] = DAC_GPIOS;
+
+/**
  * @brief Number of GPIOs declared as DAC channels
  *
  * The number of GPIOs that are declared as DAC channels is determined from
@@ -81,14 +91,33 @@ extern "C" {
  *
  * @note DAC_NUMOF definition must not be changed.
  */
-#define DAC_NUMOF   (dac_chn_num)
+#define DAC_NUMOF   (sizeof(dac_channels) / sizeof(dac_channels[0]))
 /** @} */
-
 
 /**
  * @name   I2C configuration
  * @{
  */
+
+/**
+ * @brief   Static array with configuration for declared I2C devices
+ */
+static const i2c_conf_t i2c_config[] = {
+    #if defined(I2C0_SCL) && defined(I2C0_SDA) && defined(I2C0_SPEED)
+    {
+        .speed = I2C0_SPEED,
+        .scl = I2C0_SCL,
+        .sda = I2C0_SDA,
+    },
+    #endif
+    #if defined(I2C1_SCL) && defined(I2C1_SDA) && defined(I2C1_SPEED)
+    {
+        .speed = I2C1_SPEED,
+        .scl = I2C1_SCL,
+        .sda = I2C1_SDA,
+    },
+    #endif
+};
 
 /**
  * @brief Number of I2C interfaces

--- a/boards/common/esp32/include/periph_conf_common.h
+++ b/boards/common/esp32/include/periph_conf_common.h
@@ -193,7 +193,7 @@ static const spi_conf_t spi_config[] = {
         .cs = SPI1_CS0,
     },
 #endif
-};    
+};
 
 /**
  * @brief Number of SPI interfaces

--- a/boards/common/esp32/include/periph_conf_common.h
+++ b/boards/common/esp32/include/periph_conf_common.h
@@ -192,6 +192,35 @@ static const spi_conf_t spi_config[] = {
  * @name   UART configuration
  */
 
+#ifndef UART0_TXD
+#define UART0_TXD   (GPIO1)  /**< TxD of UART_DEV(0) used on all ESP32 boards */
+#endif
+#ifndef UART0_RXD
+#define UART0_RXD   (GPIO3)  /**< RxD of UART_DEV(0) used on all ESP32 boards */
+#endif
+
+/**
+ * @brief   Static array with configuration for declared I2C devices
+ */
+static const uart_conf_t uart_config[] = {
+    {
+        .txd = UART0_TXD,
+        .rxd = UART0_RXD,
+    },
+    #if defined(UART1_TXD) && defined(UART1_RXD)
+    {
+        .txd = UART1_TXD,
+        .rxd = UART1_RXD,
+    },
+    #endif
+    #if defined(UART2_TXD) && defined(UART2_RXD)
+    {
+        .txd = UART2_TXD,
+        .rxd = UART2_RXD,
+    },
+    #endif
+};
+
 /**
  * @brief Number of UART interfaces
  *

--- a/boards/common/esp32/include/periph_conf_common.h
+++ b/boards/common/esp32/include/periph_conf_common.h
@@ -137,6 +137,19 @@ static const i2c_conf_t i2c_config[] = {
  */
 
 /**
+ * @brief   Static array of GPIOs that can be used as channels of PWM0
+ */
+#ifdef PWM0_GPIOS
+static const gpio_t pwm0_channels[] = PWM0_GPIOS;
+#endif
+/**
+ * @brief   Static array of GPIOs that can be used as channels of PWM0
+ */
+#ifdef PWM1_GPIOS
+static const gpio_t pwm1_channels[] = PWM1_GPIOS;
+#endif
+
+/**
  * @brief   Number of PWM devices
  *
  * The number of PWM devices is determined from the PWM0_GPIOS and PWM1_GPIOS
@@ -144,7 +157,13 @@ static const i2c_conf_t i2c_config[] = {
  *
  * @note PWM_NUMOF definition must not be changed.
  */
-#define PWM_NUMOF   (pwm_dev_num)
+#if defined(PWM0_GPIOS) && defined(PWM1_GPIOS)
+#define PWM_NUMOF  (2)
+#elif defined(PWM0_GPIOS) || defined(PWM1_GPIOS)
+#define PWM_NUMOF  (1)
+#else
+#define PWM_NUMOF  (0)
+#endif
 
 /** @} */
 

--- a/boards/common/esp32/include/periph_conf_common.h
+++ b/boards/common/esp32/include/periph_conf_common.h
@@ -153,6 +153,30 @@ static const i2c_conf_t i2c_config[] = {
  */
 
 /**
+ * @brief   Static array with configuration for declared I2C devices
+ */
+static const spi_conf_t spi_config[] = {
+#ifdef SPI0_CTRL
+    {
+        .ctrl = SPI0_CTRL,
+        .sck = SPI0_SCK,
+        .mosi = SPI0_MOSI,
+        .miso = SPI0_MISO,
+        .cs = SPI0_CS0,
+    },
+#endif
+#ifdef SPI1_CTRL
+    {
+        .ctrl = SPI1_CTRL,
+        .sck = SPI1_SCK,
+        .mosi = SPI1_MOSI,
+        .miso = SPI1_MISO,
+        .cs = SPI1_CS0,
+    },
+#endif
+};    
+
+/**
  * @brief Number of SPI interfaces
  *
  * The number of SPI interfaces is determined from board-specific peripheral
@@ -160,7 +184,7 @@ static const i2c_conf_t i2c_config[] = {
  *
  * @note SPI_NUMOF definition must not be changed.
  */
-#define SPI_NUMOF   (spi_bus_num)
+#define SPI_NUMOF   (sizeof(spi_config) / sizeof(spi_config[0]))
 
 /** @} */
 

--- a/boards/esp32-olimex-evb/Makefile.features
+++ b/boards/esp32-olimex-evb/Makefile.features
@@ -2,8 +2,6 @@
 include $(RIOTBOARD)/common/esp32/Makefile.features
 
 # additional features provided by the board (no ADC and no DAC)
-FEATURES_PROVIDED += periph_adc
-FEATURES_PROVIDED += periph_dac
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_spi

--- a/boards/esp32-wrover-kit/Makefile.features
+++ b/boards/esp32-wrover-kit/Makefile.features
@@ -3,7 +3,6 @@ include $(RIOTBOARD)/common/esp32/Makefile.features
 
 # additional features provided by the board
 FEATURES_PROVIDED += periph_adc
-FEATURES_PROVIDED += periph_dac
 FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_spi

--- a/boards/esp32-wrover-kit/include/periph_conf.h
+++ b/boards/esp32-wrover-kit/include/periph_conf.h
@@ -122,7 +122,7 @@
  */
 #ifndef PWM0_GPIOS
 #if !MODULE_ESP32_WROVER_KIT_CAMERA || DOXYGEN
-#define PWM0_GPIOS  { LED0_PIN, LED2_PIN } /**< only available when camera is not connected */
+#define PWM0_GPIOS  { GPIO0, GPIO4 } /**< only available when camera is not connected */
 #else
 #define PWM0_GPIOS  { }
 #endif

--- a/cpu/esp32/Makefile.dep
+++ b/cpu/esp32/Makefile.dep
@@ -52,6 +52,7 @@ endif
 
 ifneq (,$(filter esp_i2c_hw,$(USEMODULE)))
     USEMODULE += xtimer
+    USEMODULE += core_thread_flags
 else
     # PLEASE NOTE: because of the very poor and faulty hardware implementation
     # we use software implementation by default for the moment (if module

--- a/cpu/esp32/include/periph_cpu.h
+++ b/cpu/esp32/include/periph_cpu.h
@@ -464,6 +464,14 @@ typedef struct {
  *
  * @{
  */
+
+/**
+ * @brief   UART configuration structure type
+ */
+typedef struct {
+    gpio_t txd;             /**< GPIO used as TxD pin */
+    gpio_t rxd;             /**< GPIO used as RxD pin */
+} uart_conf_t;
 /** @} */
 
 

--- a/cpu/esp32/include/periph_cpu.h
+++ b/cpu/esp32/include/periph_cpu.h
@@ -40,6 +40,21 @@ extern "C" {
 #define CPUID_LEN           (7U)
 
 /**
+ * @name   GPIO configuration
+ * @{
+ */
+
+/**
+ * @brief   Override the default gpio_t type definition
+ *
+ * This is required here to have gpio_t defined in this file.
+ * @{
+ */
+#define HAVE_GPIO_T
+typedef unsigned int gpio_t;
+/** @} */
+
+/**
  * @brief   Available ports on the ESP32
  * @{
  */
@@ -134,6 +149,7 @@ typedef enum {
     GPIO_IN_OD,     /**< input and open-drain output */
     GPIO_IN_OD_PU   /**< input and open-drain output */
 } gpio_mode_t;
+/** @} */
 /** @} */
 
 /**

--- a/cpu/esp32/include/periph_cpu.h
+++ b/cpu/esp32/include/periph_cpu.h
@@ -393,8 +393,24 @@ extern const unsigned pwm_dev_num;
  * definitions of SPIn_*.
  */
 
-/** Number of SPI interfaces determined from SPI_* definitions */
-extern const unsigned spi_bus_num;
+/**
+ * @brief   SPI controller used for peripheral interfaces
+ */
+typedef enum {
+    HSPI = 2,         /**< HSPI interface controller */
+    VSPI = 3,         /**< VSPI interface controller */
+} spi_ctrl_t;
+
+/**
+ * @brief   SPI configuration structure type
+ */
+typedef struct {
+    spi_ctrl_t ctrl;        /**< SPI controller used for the interface */
+    gpio_t sck;             /**< GPIO used as SCK pin */
+    gpio_t mosi;            /**< GPIO used as MOSI pin */
+    gpio_t miso;            /**< GPIO used as MISO pin */
+    gpio_t cs;              /**< GPIO used as CS0 pin */
+} spi_conf_t;
 
 #define PERIPH_SPI_NEEDS_TRANSFER_BYTE  /**< requires function spi_transfer_byte */
 #define PERIPH_SPI_NEEDS_TRANSFER_REG   /**< requires function spi_transfer_reg */

--- a/cpu/esp32/include/periph_cpu.h
+++ b/cpu/esp32/include/periph_cpu.h
@@ -232,9 +232,6 @@ typedef enum {
  */
 #define ADC_NUMOF_MAX   16
 
-/** Number of ADC channels determined from ADC_GPIOS */
-extern const unsigned adc_chn_num;
-
 /** @} */
 
 /**
@@ -265,9 +262,6 @@ extern const unsigned adc_chn_num;
  * @brief  Number of DAC cahnnels that could be used at maximum.
  */
 #define DAC_NUMOF_MAX   2
-
-/** Number of DAC channels determined from DAC_GPIOS */
-extern const unsigned dac_chn_num;
 
 /** @} */
 

--- a/cpu/esp32/include/periph_cpu.h
+++ b/cpu/esp32/include/periph_cpu.h
@@ -347,12 +347,14 @@ typedef struct {
  */
 
 /**
+ * @brief   Maximum number of PWM devices
+ */
+#define PWM_NUMOF_MAX           (2)
+
+/**
  * @brief   Maximum number of channels per PWM device.
  */
 #define PWM_CHANNEL_NUM_DEV_MAX (6)
-
-/** Number of PWM devices determined from PWM0_GPIOS and PWM1_GPIOS. */
-extern const unsigned pwm_dev_num;
 
 /** @} */
 

--- a/cpu/esp32/include/periph_cpu.h
+++ b/cpu/esp32/include/periph_cpu.h
@@ -55,20 +55,68 @@ typedef unsigned int gpio_t;
 /** @} */
 
 /**
- * @brief   Available ports on the ESP32
+ * @brief   Definition of a fitting UNDEF value
  * @{
  */
-#define PORT_GPIO 0       /**< port GPIO */
+#define GPIO_UNDEF          (0xffffffff)
+/** @} */
+
+/**
+ * @brief   Define a CPU specific GPIO pin generator macro
+ * @{
+ */
+#define GPIO_PIN(x, y)      ((x & 0) | y)
+/** @} */
+
+/**
+ * @brief   Available GPIO ports on ESP32
+ * @{
+ */
+#define PORT_GPIO           (0)
 /** @} */
 
 /**
  * @brief   Define CPU specific number of GPIO pins
  * @{
  */
-#define GPIO_PIN_NUMOF  40
-#ifndef GPIO_PIN_COUNT
-#define GPIO_PIN_COUNT  GPIO_PIN_NUMOF
-#endif
+#define GPIO_PIN_NUMOF      (40)
+/** @} */
+
+/**
+ * @brief   Override mode flank selection values
+ *
+ * @{
+ */
+#define HAVE_GPIO_FLANK_T
+typedef enum {
+    GPIO_NONE    = 0,
+    GPIO_RISING  = 1,        /**< emit interrupt on rising flank  */
+    GPIO_FALLING = 2,        /**< emit interrupt on falling flank */
+    GPIO_BOTH    = 3,        /**< emit interrupt on both flanks   */
+    GPIO_LOW     = 4,        /**< emit interrupt on low level     */
+    GPIO_HIGH    = 5         /**< emit interrupt on low level     */
+} gpio_flank_t;
+
+/** @} */
+
+/**
+ * @brief   Override GPIO modes
+ *
+ * @{
+ */
+#define HAVE_GPIO_MODE_T
+typedef enum {
+    GPIO_IN,        /**< input */
+    GPIO_IN_PD,     /**< input with pull-down */
+    GPIO_IN_PU,     /**< input with pull-up */
+    GPIO_OUT,       /**< output */
+    GPIO_OD,        /**< open-drain output */
+    GPIO_OD_PU,     /**< open-drain output with pull-up */
+    GPIO_IN_OUT,    /**< input and output */
+    GPIO_IN_OD,     /**< input and open-drain output */
+    GPIO_IN_OD_PU   /**< input and open-drain output */
+} gpio_mode_t;
+/** @} */
 /** @} */
 
 /**
@@ -113,43 +161,6 @@ typedef unsigned int gpio_t;
 #define GPIO37      (GPIO_PIN(PORT_GPIO,37))
 #define GPIO38      (GPIO_PIN(PORT_GPIO,38))
 #define GPIO39      (GPIO_PIN(PORT_GPIO,39))
-/** @} */
-
-/**
- * @brief   Override mode flank selection values
- *
- * @{
- */
-#define HAVE_GPIO_FLANK_T
-typedef enum {
-    GPIO_NONE    = 0,
-    GPIO_RISING  = 1,        /**< emit interrupt on rising flank  */
-    GPIO_FALLING = 2,        /**< emit interrupt on falling flank */
-    GPIO_BOTH    = 3,        /**< emit interrupt on both flanks   */
-    GPIO_LOW     = 4,        /**< emit interrupt on low level     */
-    GPIO_HIGH    = 5         /**< emit interrupt on low level     */
-} gpio_flank_t;
-
-/** @} */
-
-/**
- * @brief   Override GPIO modes
- *
- * @{
- */
-#define HAVE_GPIO_MODE_T
-typedef enum {
-    GPIO_IN,        /**< input */
-    GPIO_IN_PD,     /**< input with pull-down */
-    GPIO_IN_PU,     /**< input with pull-up */
-    GPIO_OUT,       /**< output */
-    GPIO_OD,        /**< open-drain output */
-    GPIO_OD_PU,     /**< open-drain output with pull-up */
-    GPIO_IN_OUT,    /**< input and output */
-    GPIO_IN_OD,     /**< input and open-drain output */
-    GPIO_IN_OD_PU   /**< input and open-drain output */
-} gpio_mode_t;
-/** @} */
 /** @} */
 
 /**
@@ -363,8 +374,8 @@ typedef struct {
  *
  * ESP32 has four SPI controllers:
  *
- * - controller SPI0 is reserved for caching the flash memory
- * - controller SPI1 is reserved for external memories like flash and PSRAM
+ * - controller SPI0 is reserved for caching the flash memory (CPSI)
+ * - controller SPI1 is reserved for external memories like flash and PSRAM (FSPI)
  * - controller SPI2 realizes interface HSPI that can be used for peripherals
  * - controller SPI3 realizes interface VSPI that can be used for peripherals
  *
@@ -386,17 +397,15 @@ typedef struct {
  * - SPIn_CS0, the GPIO used as CS signal when the cs parameter in spi_aquire
  *   is GPIO_UNDEF,
  *
- * where n can be 0 or 1.
- *
- * @note The configuration of the SPI interfaces SPI_DEV(n) should be in
- * continuous ascending order of n.
+ * where n can be 0 or 1. If they are not defined, the according SPI interface
+ * SPI_DEV(n) is not used.
  *
  * SPI_NUMOF is determined automatically from the board-specific peripheral
  * definitions of SPIn_*.
  */
 
 /**
- * @brief   SPI controller used for peripheral interfaces
+ * @brief   SPI controllers that can be used for peripheral interfaces
  */
 typedef enum {
     HSPI = 2,         /**< HSPI interface controller */
@@ -449,20 +458,20 @@ typedef struct {
  * configuration and is always available. All ESP32 boards use it as standard
  * configuration for the console.
  *
- * UART_DEV(0).TXD      GPIO1
- * UART_DEV(0).RXD      GPIO3
+ *      UART_DEV(0).TXD      GPIO1
+ *      UART_DEV(0).RXD      GPIO3
  *
  * The pin configuration of UART_DEV(1) and UART_DEV(2) are defined in
  * board specific peripheral configuration by
  *
- * UARTn_TXD, the GPIO used as TxD signal, and
- * UARTn_RXD, the GPIO used as RxD signal,
+ * - UARTn_TXD, the GPIO used as TxD signal, and
+ * - UARTn_RXD, the GPIO used as RxD signal,
  *
- * where n can be 2 or 3. If they are not defined, the UART interface
+ * where n can be 1 or 2. If they are not defined, the according UART interface
  * UART_DEV(n) is not used.
  *
  * UART_NUMOF is determined automatically from the board-specific peripheral
- * definitions of UARTn_TXD and UARTn_RXD.
+ * definitions of UARTn_*.
  *
  * @{
  */
@@ -474,8 +483,8 @@ typedef struct {
     gpio_t txd;             /**< GPIO used as TxD pin */
     gpio_t rxd;             /**< GPIO used as RxD pin */
 } uart_conf_t;
-/** @} */
 
+/** @} */
 
 #ifdef __cplusplus
 }

--- a/cpu/esp32/include/periph_cpu.h
+++ b/cpu/esp32/include/periph_cpu.h
@@ -289,8 +289,30 @@ typedef enum {
  * @{
  */
 
-/** Number of I2C interfaces determined from I2Cn_* definitions */
-extern const unsigned i2c_bus_num;
+/**
+ * @brief    Override I2C clock speed values
+ *
+ * This is required here to have i2c_speed_t defined in this file.
+ * @{
+ */
+#define HAVE_I2C_SPEED_T
+typedef enum {
+    I2C_SPEED_LOW = 0,      /**< 10 kbit/s */
+    I2C_SPEED_NORMAL,       /**< 100 kbit/s */
+    I2C_SPEED_FAST,         /**< 400 kbit/s */
+    I2C_SPEED_FAST_PLUS,    /**< 1 Mbit/s */
+    I2C_SPEED_HIGH,         /**< not supported */
+} i2c_speed_t;
+/** @} */
+
+/**
+ * @brief   I2C configuration structure type
+ */
+typedef struct {
+    i2c_speed_t speed;      /**< I2C bus speed */
+    gpio_t scl;             /**< GPIO used as SCL pin */
+    gpio_t sda;             /**< GPIO used as SDA pin */
+} i2c_conf_t;
 
 #define PERIPH_I2C_NEED_READ_REG    /**< i2c_read_reg required */
 #define PERIPH_I2C_NEED_READ_REGS   /**< i2c_read_regs required */

--- a/cpu/esp32/periph/adc.c
+++ b/cpu/esp32/periph/adc.c
@@ -159,13 +159,15 @@ static bool _adc2_ctrl_initialized = false;
 #endif /* defined(ADC_GPIOS) || defined(DAC_GPIOS) */
 
 #if defined(ADC_GPIOS)
+static const unsigned adc_chn_num = ADC_NUMOF;
+
 static bool _adc_conf_check(void);
 static void _adc_module_init(void);
 static bool _adc_module_initialized  = false;
 
 int adc_init(adc_t line)
 {
-    CHECK_PARAM_RET (line < ADC_NUMOF, -1)
+    CHECK_PARAM_RET (line < adc_chn_num, -1)
 
     if (!_adc_module_initialized) {
         /* do some configuration checks */
@@ -268,7 +270,7 @@ int adc_init(adc_t line)
 
 int adc_sample(adc_t line, adc_res_t res)
 {
-    CHECK_PARAM_RET (line < ADC_NUMOF, -1)
+    CHECK_PARAM_RET (line < adc_chn_num, -1)
     CHECK_PARAM_RET (res <= ADC_RES_12BIT, -1)
 
     uint8_t rtcio = _gpio_rtcio_map[adc_channels[line]];
@@ -312,7 +314,7 @@ int adc_sample(adc_t line, adc_res_t res)
 
 int adc_set_attenuation(adc_t line, adc_attenuation_t atten)
 {
-    CHECK_PARAM_RET (line < ADC_NUMOF, -1)
+    CHECK_PARAM_RET (line < adc_chn_num, -1)
 
     uint8_t rtcio = _gpio_rtcio_map[adc_channels[line]];
 
@@ -331,7 +333,7 @@ int adc_vref_to_gpio25 (void)
 {
     /* determine ADC line for GPIO25 */
     adc_t line = ADC_UNDEF;
-    for (unsigned i = 0; i < ADC_NUMOF; i++) { \
+    for (unsigned i = 0; i < adc_chn_num; i++) { \
         if (adc_channels[i] == GPIO25) { \
             line = i;
             break;
@@ -362,7 +364,7 @@ int adc_vref_to_gpio25 (void)
 
 static bool _adc_conf_check(void)
 {
-    for (unsigned i = 0; i < ADC_NUMOF; i++) {
+    for (unsigned i = 0; i < adc_chn_num; i++) {
         if (_gpio_rtcio_map[adc_channels[i]] == RTCIO_NA) {
             LOG_TAG_ERROR("adc", "GPIO%d cannot be used as ADC line\n",
                           adc_channels[i]);
@@ -389,12 +391,13 @@ static void _adc_module_init(void)
 
 #if defined(DAC_GPIOS)
 
+static const unsigned dac_chn_num = DAC_NUMOF;
 static bool _dac_conf_check(void);
 static bool _dac_module_initialized  = false;
 
 int8_t dac_init (dac_t line)
 {
-    CHECK_PARAM_RET (line < DAC_NUMOF, DAC_NOLINE)
+    CHECK_PARAM_RET (line < dac_chn_num, DAC_NOLINE)
 
     if (!_dac_module_initialized) {
         /* do some configuration checks */
@@ -455,23 +458,23 @@ int8_t dac_init (dac_t line)
 
 void dac_set (dac_t line, uint16_t value)
 {
-    CHECK_PARAM (line < DAC_NUMOF);
+    CHECK_PARAM (line < dac_chn_num);
     RTCIO.pad_dac[_gpio_rtcio_map[dac_channels[line]] - RTCIO_DAC1].dac = value >> 8;
 }
 
 void dac_poweroff (dac_t line)
 {
-    CHECK_PARAM (line < DAC_NUMOF);
+    CHECK_PARAM (line < dac_chn_num);
 }
 
 void dac_poweron (dac_t line)
 {
-    CHECK_PARAM (line < DAC_NUMOF);
+    CHECK_PARAM (line < dac_chn_num);
 }
 
 static bool _dac_conf_check(void)
 {
-    for (unsigned i = 0; i < DAC_NUMOF; i++) {
+    for (unsigned i = 0; i < dac_chn_num; i++) {
         if (_gpio_rtcio_map[dac_channels[i]] != RTCIO_DAC1 &&
             _gpio_rtcio_map[dac_channels[i]] != RTCIO_DAC2) {
             LOG_TAG_ERROR("dac", "GPIO%d cannot be used as DAC line\n",
@@ -626,7 +629,7 @@ int rtcio_config_sleep_mode (gpio_t pin, bool mode, bool input)
 void adc_print_config(void) {
     ets_printf("\tADC\t\tpins=[ ");
     #if defined(ADC_GPIOS)
-    for (unsigned i = 0; i < ADC_NUMOF; i++) {
+    for (unsigned i = 0; i < adc_chn_num; i++) {
         ets_printf("%d ", adc_channels[i]);
     }
     #endif /* defined(ADC_GPIOS) */
@@ -634,7 +637,7 @@ void adc_print_config(void) {
 
     ets_printf("\tDAC\t\tpins=[ ");
     #if defined(DAC_GPIOS)
-    for (unsigned i = 0; i < DAC_NUMOF; i++) {
+    for (unsigned i = 0; i < dac_chn_num; i++) {
         ets_printf("%d ", dac_channels[i]);
     }
     #endif /* defined(DAC_GPIOS) */

--- a/cpu/esp32/periph/i2c_sw.c
+++ b/cpu/esp32/periph/i2c_sw.c
@@ -699,9 +699,9 @@ static /* IRAM */ int _i2c_read_byte(_i2c_bus_t* bus, uint8_t *byte, bool ack)
 
 void i2c_print_config(void)
 {
-    for (unsigned bus = 0; bus < I2C_NUMOF; bus++) {
+    for (unsigned dev = 0; dev < I2C_NUMOF; dev++) {
         ets_printf("\tI2C_DEV(%d)\tscl=%d sda=%d\n",
-                   bus, _i2c_bus[bus].scl, _i2c_bus[bus].sda);
+                   dev, i2c_config[dev].scl, i2c_config[dev].sda);
     }
 }
 

--- a/cpu/esp32/periph/i2c_sw.c
+++ b/cpu/esp32/periph/i2c_sw.c
@@ -688,7 +688,7 @@ static /* IRAM */ int _i2c_read_byte(_i2c_bus_t* bus, uint8_t *byte, bool ack)
         if (res != 0) {
             return res;
         }
-        *byte = (*byte << 1) | bit;
+        *byte = (*byte << 1) | (bit ? 1 : 0);
     }
 
     /* write acknowledgement flag */

--- a/cpu/esp32/periph/i2c_sw.c
+++ b/cpu/esp32/periph/i2c_sw.c
@@ -77,28 +77,7 @@ typedef struct
 
 } _i2c_bus_t;
 
-static _i2c_bus_t _i2c_bus[] =
-{
-  #if defined(I2C0_SCL) && defined(I2C0_SDA) && defined(I2C0_SPEED)
-  {
-    .speed = I2C0_SPEED,
-    .sda   = I2C0_SDA,
-    .scl   = I2C0_SCL,
-    .lock  = MUTEX_INIT
-  },
-  #endif
-  #if defined(I2C1_SCL) && defined(I2C1_SDA) && defined(I2C1_SPEED)
-  {
-    .speed = I2C1_SPEED,
-    .sda   = I2C1_SDA,
-    .scl   = I2C1_SCL,
-    .lock  = MUTEX_INIT
-  },
-  #endif
-};
-
-/* the number of I2C bus devices used */
-const unsigned i2c_bus_num = sizeof(_i2c_bus) / sizeof(_i2c_bus[0]);
+static _i2c_bus_t _i2c_bus[I2C_NUMOF] = {};
 
 /* to ensure that I2C is always optimized with -O2 to use the defined delays */
 #pragma GCC optimize ("O2")
@@ -140,12 +119,18 @@ static void _i2c_clear (_i2c_bus_t* bus);
 
 void i2c_init(i2c_t dev)
 {
-    CHECK_PARAM (dev < i2c_bus_num)
+    CHECK_PARAM (dev < I2C_NUMOF)
 
-    if (_i2c_bus[dev].speed == I2C_SPEED_HIGH) {
+    if (i2c_config[dev].speed == I2C_SPEED_HIGH) {
         LOG_TAG_INFO("i2c", "I2C_SPEED_HIGH is not supported\n");
         return;
     }
+
+    mutex_init(&_i2c_bus[dev].lock);
+
+    _i2c_bus[dev].scl   = i2c_config[dev].scl;
+    _i2c_bus[dev].sda   = i2c_config[dev].sda;
+    _i2c_bus[dev].speed = i2c_config[dev].speed;
 
     _i2c_bus[dev].dev     = dev;
     _i2c_bus[dev].scl_bit = BIT(_i2c_bus[dev].scl); /* store bit mask for faster access */
@@ -195,7 +180,7 @@ void i2c_init(i2c_t dev)
 
 int i2c_acquire(i2c_t dev)
 {
-    CHECK_PARAM_RET (dev < i2c_bus_num, -1)
+    CHECK_PARAM_RET (dev < I2C_NUMOF, -1)
 
     mutex_lock(&_i2c_bus[dev].lock);
     return 0;
@@ -203,7 +188,7 @@ int i2c_acquire(i2c_t dev)
 
 int i2c_release(i2c_t dev)
 {
-    CHECK_PARAM_RET (dev < i2c_bus_num, -1)
+    CHECK_PARAM_RET (dev < I2C_NUMOF, -1)
 
     mutex_unlock(&_i2c_bus[dev].lock);
     return 0;
@@ -214,7 +199,7 @@ int /* IRAM */ i2c_read_bytes(i2c_t dev, uint16_t addr, void *data, size_t len, 
     DEBUG ("%s: dev=%u addr=%02x data=%p len=%d flags=%01x\n",
            __func__, dev, addr, data, len, flags);
 
-    CHECK_PARAM_RET (dev < i2c_bus_num, -EINVAL);
+    CHECK_PARAM_RET (dev < I2C_NUMOF, -EINVAL);
     CHECK_PARAM_RET (len > 0, -EINVAL);
     CHECK_PARAM_RET (data != NULL, -EINVAL);
 
@@ -275,7 +260,7 @@ int /* IRAM */ i2c_write_bytes(i2c_t dev, uint16_t addr, const void *data, size_
     DEBUG ("%s: dev=%u addr=%02x data=%p len=%d flags=%01x\n",
            __func__, dev, addr, data, len, flags);
 
-    CHECK_PARAM_RET (dev < i2c_bus_num, -EINVAL);
+    CHECK_PARAM_RET (dev < I2C_NUMOF, -EINVAL);
     CHECK_PARAM_RET (len > 0, -EINVAL);
     CHECK_PARAM_RET (data != NULL, -EINVAL);
 
@@ -714,7 +699,7 @@ static /* IRAM */ int _i2c_read_byte(_i2c_bus_t* bus, uint8_t *byte, bool ack)
 
 void i2c_print_config(void)
 {
-    for (unsigned bus = 0; bus < i2c_bus_num; bus++) {
+    for (unsigned bus = 0; bus < I2C_NUMOF; bus++) {
         ets_printf("\tI2C_DEV(%d)\tscl=%d sda=%d\n",
                    bus, _i2c_bus[bus].scl, _i2c_bus[bus].sda);
     }

--- a/cpu/esp32/periph/pwm.c
+++ b/cpu/esp32/periph/pwm.c
@@ -40,7 +40,6 @@
 
 #if defined(PWM0_GPIOS) || defined(PWM1_GPIOS)
 
-#define PWM_NUMOF_MAX (2)           /* maximum number of PWM devices */
 #define PWM_CLK       (160000000UL) /* base clock of PWM devices */
 #define PWM_CPS_MAX   (10000000UL)  /* maximum cycles per second supported */
 #define PWM_CPS_MIN   (2500UL)      /* minumum cycles per second supported */
@@ -101,8 +100,8 @@ static const struct _pwm_hw_t _pwm_hw[] =
         .mod = PERIPH_PWM0_MODULE,
         .int_src = ETS_PWM0_INTR_SOURCE,
         .signal_group = PWM0_OUT0A_IDX,
-        .gpio_num = sizeof(_pwm_channel_gpios_0) >> 2,
-        .gpios = _pwm_channel_gpios_0,
+        .gpio_num = sizeof(pwm0_channels) / sizeof(pwm0_channels[0]),
+        .gpios = pwm0_channels,
     },
     #endif
     #ifdef PWM1_GPIOS
@@ -111,14 +110,11 @@ static const struct _pwm_hw_t _pwm_hw[] =
         .mod = PERIPH_PWM1_MODULE,
         .int_src = ETS_PWM1_INTR_SOURCE,
         .signal_group = PWM1_OUT0A_IDX,
-        .gpio_num = sizeof(_pwm_channel_gpios_1) >> 2,
-        .gpios = _pwm_channel_gpios_1,
+        .gpio_num = sizeof(pwm1_channels) / sizeof(pwm1_channels[0]),
+        .gpios = pwm1_channels,
     },
     #endif
 };
-
-/* the number of PWM devices used */
-const unsigned pwm_dev_num = sizeof(_pwm_hw) / sizeof(_pwm_hw[0]);
 
 /* data structure dynamic channel configuration */
 typedef struct {
@@ -146,7 +142,7 @@ uint32_t pwm_init(pwm_t pwm, pwm_mode_t mode, uint32_t freq, uint16_t res)
 {
     DEBUG ("%s pwm=%u mode=%u freq=%u, res=%u\n", __func__, pwm, mode, freq, res);
 
-    CHECK_PARAM_RET (pwm < pwm_dev_num, 0);
+    CHECK_PARAM_RET (pwm < PWM_NUMOF, 0);
     CHECK_PARAM_RET (freq > 0, 0);
 
     if (_pwm_init_first_time) {
@@ -203,7 +199,7 @@ uint32_t pwm_init(pwm_t pwm, pwm_mode_t mode, uint32_t freq, uint16_t res)
 
 uint8_t pwm_channels(pwm_t pwm)
 {
-    CHECK_PARAM_RET (pwm < pwm_dev_num, 0);
+    CHECK_PARAM_RET (pwm < PWM_NUMOF, 0);
 
     return _pwm_hw[pwm].gpio_num;
 }
@@ -212,7 +208,7 @@ void pwm_set(pwm_t pwm, uint8_t channel, uint16_t value)
 {
     DEBUG("%s pwm=%u channel=%u value=%u\n", __func__, pwm, channel, value);
 
-    CHECK_PARAM (pwm < pwm_dev_num);
+    CHECK_PARAM (pwm < PWM_NUMOF);
     CHECK_PARAM (channel < _pwm_dev[pwm].chn_num);
     CHECK_PARAM (value <= _pwm_dev[pwm].res);
 
@@ -287,14 +283,14 @@ void pwm_set(pwm_t pwm, uint8_t channel, uint16_t value)
 
 void pwm_poweron(pwm_t pwm)
 {
-    CHECK_PARAM (pwm < pwm_dev_num);
+    CHECK_PARAM (pwm < PWM_NUMOF);
     periph_module_enable(_pwm_hw[pwm].mod);
     _pwm_start(pwm);
 }
 
 void pwm_poweroff(pwm_t pwm)
 {
-    CHECK_PARAM (pwm < pwm_dev_num);
+    CHECK_PARAM (pwm < PWM_NUMOF);
     _pwm_stop (pwm);
     periph_module_disable(_pwm_hw[pwm].mod);
 }
@@ -385,7 +381,7 @@ static void _pwm_start(pwm_t pwm)
     }
 
     /* sync all timers */
-    for (unsigned i = 0; i < pwm_dev_num; i++) {
+    for (unsigned i = 0; i < PWM_NUMOF; i++) {
         _pwm_hw[i].regs->timer[0].sync.sync_sw = ~_pwm_hw[i].regs->timer[0].sync.sync_sw;
     }
 }
@@ -399,13 +395,13 @@ static void _pwm_stop(pwm_t pwm)
 /* do some static initialization and configuration checks */
 static bool _pwm_configuration(void)
 {
-    if (pwm_dev_num > PWM_NUMOF_MAX) {
+    if (PWM_NUMOF > PWM_NUMOF_MAX) {
         LOG_TAG_ERROR("pwm", "%d PWM devices were defined, only %d PWM are "
-                      "supported\n", pwm_dev_num, PWM_NUMOF_MAX);
+                      "supported\n", PWM_NUMOF, PWM_NUMOF_MAX);
         return false;
     }
 
-    for (unsigned i = 0; i < pwm_dev_num; i++) {
+    for (unsigned i = 0; i < PWM_NUMOF; i++) {
         if (_pwm_hw[i].gpio_num > PWM_CHANNEL_NUM_DEV_MAX) {
             LOG_TAG_ERROR("pwm", "Number of PWM channels of device %d is %d, "
                           "at maximum only %d channels per PWM device are "
@@ -415,8 +411,8 @@ static bool _pwm_configuration(void)
         }
     }
     bool multiple_used = false;
-    for (unsigned i = 0; i < pwm_dev_num; i++) {
-        for (unsigned j = 0; j < pwm_dev_num; j++) {
+    for (unsigned i = 0; i < PWM_NUMOF; i++) {
+        for (unsigned j = 0; j < PWM_NUMOF; j++) {
             if (i != j) {
                 for (unsigned k = 0; k < _pwm_hw[i].gpio_num >> 2; k++) {
                     for (unsigned l = 0; l < _pwm_hw[j].gpio_num >> 2; l++) {
@@ -440,7 +436,7 @@ static bool _pwm_configuration(void)
 
 void pwm_print_config(void)
 {
-    for (unsigned pwm = 0; pwm < pwm_dev_num; pwm++) {
+    for (unsigned pwm = 0; pwm < PWM_NUMOF; pwm++) {
         ets_printf("\tPWM_DEV(%d)\tchannels=[ ", pwm);
         for (int i = 0; i < _pwm_hw[pwm].gpio_num; i++) {
             ets_printf("%d ", _pwm_hw[pwm].gpios[i]);

--- a/cpu/esp32/periph/spi.c
+++ b/cpu/esp32/periph/spi.c
@@ -44,11 +44,6 @@
 
 #define SPI_BLOCK_SIZE  64  /* number of bytes per SPI transfer */
 
-#define CSPI    (0)         /* controller SPI0 realizes interface CSPI */
-#define FSPI    (1)         /* controller SPI1 realizes interface FSPI */
-#define HSPI    (2)         /* controller SPI2 realizes interface HSPI */
-#define VSPI    (3)         /* controller SPI3 realizes interface VSPI */
-
 /* pins of FSI are fixed */
 #define FSPI_SCK    GPIO6
 #define FSPI_MISO   GPIO7
@@ -99,6 +94,7 @@ static struct _spi_bus_t _spi[] = {
         return error; \
     } \
 }
+
 /*
  * GPIOs that were once initialized as SPI interface pins can not be used
  * afterwards for anything else. Therefore, SPI interfaces are not initialized
@@ -128,7 +124,9 @@ void IRAM_ATTR spi_init (spi_t bus)
                     _spi[bus].signal_mosi = VSPID_OUT_IDX;
                     _spi[bus].signal_miso = VSPIQ_IN_IDX;
                     break;
-        default:    break;
+        default:    LOG_TAG_ERROR("spi", "invalid SPI interface controller "
+                                         "used for SPI_DEV(%d)\n");
+                    break;
     }
     return;
 }

--- a/cpu/esp32/periph/spi.c
+++ b/cpu/esp32/periph/spi.c
@@ -40,6 +40,8 @@
 
 #include "gpio_arch.h"
 
+#if defined(SPI0_CTRL) || defined(SPI1_CTRL)
+
 #define SPI_BLOCK_SIZE  64  /* number of bytes per SPI transfer */
 
 #define CSPI    (0)         /* controller SPI0 realizes interface CSPI */
@@ -55,13 +57,8 @@
 /** stucture which decribes all properties of one SPI bus */
 struct _spi_bus_t {
     spi_dev_t* regs;       /* pointer to register data struct of the SPI device */
-    uint8_t controller;    /* number of the controller used */
     uint8_t mod;           /* peripheral hardware module of the SPI interface */
     uint8_t int_src;       /* peripheral interrupt source used by the SPI device */
-    uint8_t pin_sck;       /* SCK pin */
-    uint8_t pin_mosi;      /* MOSI pin */
-    uint8_t pin_miso;      /* MISO pin */
-    uint8_t pin_cs;        /* CS pin */
     uint8_t signal_sck;    /* SCK signal from the controller */
     uint8_t signal_mosi;   /* MOSI signal from the controller */
     uint8_t signal_miso;   /* MISO signal to the controller */
@@ -73,11 +70,6 @@ struct _spi_bus_t {
 static struct _spi_bus_t _spi[] = {
     #ifdef SPI0_CTRL
     {
-        .controller = SPI0_CTRL,
-        .pin_cs = SPI0_CS0,
-        .pin_sck  = SPI0_SCK,
-        .pin_mosi = SPI0_MOSI,
-        .pin_miso = SPI0_MISO,
         .initialized = false,
         .pins_initialized = false,
         .lock = MUTEX_INIT
@@ -85,11 +77,6 @@ static struct _spi_bus_t _spi[] = {
     #endif
     #ifdef SPI1_CTRL
     {
-        .controller = SPI1_CTRL,
-        .pin_cs = SPI1_CS0,
-        .pin_sck  = SPI1_SCK,
-        .pin_mosi = SPI1_MOSI,
-        .pin_miso = SPI1_MISO,
         .initialized = false,
         .pins_initialized = false,
         .lock = MUTEX_INIT
@@ -97,11 +84,8 @@ static struct _spi_bus_t _spi[] = {
     #endif
 };
 
-/* the number of SPI bus devices used */
-const unsigned spi_bus_num = sizeof(_spi) / sizeof(_spi[0]);
-
 #define CHECK_SPI_DEV(bus) { \
-    CHECK_PARAM(bus < spi_bus_num); \
+    CHECK_PARAM(bus < SPI_NUMOF); \
     if (_spi[bus].regs == NULL) { \
         LOG_TAG_ERROR("spi", "SPI_DEV(%d) is not available\n", bus); \
         return; \
@@ -109,7 +93,7 @@ const unsigned spi_bus_num = sizeof(_spi) / sizeof(_spi[0]);
 }
 
 #define CHECK_SPI_DEV_RET(bus,error) { \
-    CHECK_PARAM_RET(bus < spi_bus_num, error); \
+    CHECK_PARAM_RET(bus < SPI_NUMOF, error); \
     if (_spi[bus].regs == NULL) { \
         LOG_TAG_ERROR("spi", "SPI_DEV(%d) is not available\n", bus); \
         return error; \
@@ -127,9 +111,9 @@ const unsigned spi_bus_num = sizeof(_spi) / sizeof(_spi[0]);
 
 void IRAM_ATTR spi_init (spi_t bus)
 {
-    CHECK_PARAM(bus < spi_bus_num);
+    CHECK_PARAM(bus < SPI_NUMOF);
 
-    switch (_spi[bus].controller) {
+    switch (spi_config[bus].ctrl) {
         case HSPI:  _spi[bus].regs = &SPI2;
                     _spi[bus].mod = PERIPH_HSPI_MODULE;
                     _spi[bus].int_src = ETS_SPI2_INTR_SOURCE;
@@ -166,10 +150,10 @@ static void _spi_init_internal (spi_t bus)
     spi_init_pins(bus);
 
     /* check whether pins could be initialized, otherwise return */
-    if (gpio_get_pin_usage(_spi[bus].pin_sck) != _SPI &&
-        gpio_get_pin_usage(_spi[bus].pin_miso) != _SPI &&
-        gpio_get_pin_usage(_spi[bus].pin_mosi) != _SPI &&
-        gpio_get_pin_usage(_spi[bus].pin_cs) != _SPI) {
+    if (gpio_get_pin_usage(spi_config[bus].sck) != _SPI &&
+        gpio_get_pin_usage(spi_config[bus].miso) != _SPI &&
+        gpio_get_pin_usage(spi_config[bus].mosi) != _SPI &&
+        gpio_get_pin_usage(spi_config[bus].cs) != _SPI) {
         return;
     }
 
@@ -224,31 +208,31 @@ void spi_init_pins(spi_t bus)
        as SPI pins */
     if (bus != SPI_DEV(2)) {
         /* if not already initialized as SPI, try to initialize the pins */
-        if (gpio_init (_spi[bus].pin_sck, GPIO_OUT) ||
-            gpio_init (_spi[bus].pin_mosi, GPIO_OUT) ||
-            gpio_init (_spi[bus].pin_miso, GPIO_IN)) {
+        if (gpio_init (spi_config[bus].sck, GPIO_OUT) ||
+            gpio_init (spi_config[bus].mosi, GPIO_OUT) ||
+            gpio_init (spi_config[bus].miso, GPIO_IN)) {
             LOG_TAG_ERROR("spi",
                           "SPI_DEV(%d) pins could not be initialized\n", bus);
             return;
         }
-        if (spi_init_cs(bus, _spi[bus].pin_cs) != SPI_OK) {
+        if (spi_init_cs(bus, spi_config[bus].cs) != SPI_OK) {
             LOG_TAG_ERROR("spi",
                           "SPI_DEV(%d) CS signal could not be initialized\n",
                           bus);
             return;
         }
         /* store the usage type in GPIO table */
-        gpio_set_pin_usage(_spi[bus].pin_sck, _SPI);
-        gpio_set_pin_usage(_spi[bus].pin_mosi, _SPI);
-        gpio_set_pin_usage(_spi[bus].pin_miso, _SPI);
+        gpio_set_pin_usage(spi_config[bus].sck, _SPI);
+        gpio_set_pin_usage(spi_config[bus].mosi, _SPI);
+        gpio_set_pin_usage(spi_config[bus].miso, _SPI);
 
         /* connect SCK and MOSI pins to the output signal through the GPIO matrix */
-        GPIO.func_out_sel_cfg[_spi[bus].pin_sck].func_sel = _spi[bus].signal_sck;
-        GPIO.func_out_sel_cfg[_spi[bus].pin_mosi].func_sel = _spi[bus].signal_mosi;
+        GPIO.func_out_sel_cfg[spi_config[bus].sck].func_sel = _spi[bus].signal_sck;
+        GPIO.func_out_sel_cfg[spi_config[bus].mosi].func_sel = _spi[bus].signal_mosi;
         /* connect MISO input signal to the MISO pin through the GPIO matrix */
         GPIO.func_in_sel_cfg[_spi[bus].signal_miso].sig_in_sel = 1;
         GPIO.func_in_sel_cfg[_spi[bus].signal_miso].sig_in_inv = 0;
-        GPIO.func_in_sel_cfg[_spi[bus].signal_miso].func_sel = _spi[bus].pin_miso;
+        GPIO.func_in_sel_cfg[_spi[bus].signal_miso].func_sel = spi_config[bus].miso;
     }
     else {
         LOG_TAG_WARNING("spi", "Using SPI_DEV(2) is dangerous\n");
@@ -298,7 +282,7 @@ int IRAM_ATTR spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t clk
     }
 
     /* if parameter cs is GPIO_UNDEF, the default CS pin is used */
-    cs = (cs == GPIO_UNDEF) ? _spi[bus].pin_cs : cs;
+    cs = (cs == GPIO_UNDEF) ? spi_config[bus].cs : cs;
 
     /* if the CS pin used is not yet initialized, we do it now */
     if (gpio_get_pin_usage(cs) != _SPI && spi_init_cs(bus, cs) != SPI_OK) {
@@ -354,7 +338,7 @@ int IRAM_ATTR spi_acquire(spi_t bus, spi_cs_t cs, spi_mode_t mode, spi_clk_t clk
     /* SPI clock is derived from APB clock by dividers */
     _spi[bus].regs->clock.clk_equ_sysclk = 0;
 
-    /* set SPI clock deviders */
+    /* set SPI clock dividers */
     _spi[bus].regs->clock.clkdiv_pre = spi_clkdiv_pre;
     _spi[bus].regs->clock.clkcnt_n = spi_clkcnt_N;
     _spi[bus].regs->clock.clkcnt_h = (spi_clkcnt_N+1)/2-1;
@@ -378,12 +362,12 @@ static const char* _spi_names[] = { "CSPI", "FSPI", "HSPI", "VSPI"  };
 
 void spi_print_config(void)
 {
-    for (unsigned bus = 0; bus < spi_bus_num; bus++) {
-        ets_printf("\tSPI_DEV(%d)\t%s ", bus, _spi_names[_spi[bus].controller]);
-        ets_printf("sck=%d " , _spi[bus].pin_sck);
-        ets_printf("miso=%d ", _spi[bus].pin_miso);
-        ets_printf("mosi=%d ", _spi[bus].pin_mosi);
-        ets_printf("cs=%d\n" , _spi[bus].pin_cs);
+    for (unsigned bus = 0; bus < SPI_NUMOF; bus++) {
+        ets_printf("\tSPI_DEV(%d)\t%s ", bus, _spi_names[spi_config[bus].ctrl]);
+        ets_printf("sck=%d " , spi_config[bus].sck);
+        ets_printf("miso=%d ", spi_config[bus].miso);
+        ets_printf("mosi=%d ", spi_config[bus].mosi);
+        ets_printf("cs=%d\n" , spi_config[bus].cs);
     }
 }
 
@@ -453,7 +437,7 @@ static void IRAM_ATTR _spi_buf_transfer(uint8_t bus, const void *out, void *in, 
 }
 
 void IRAM_ATTR spi_transfer_bytes(spi_t bus, spi_cs_t cs, bool cont,
-                             const void *out, void *in, size_t len)
+                                  const void *out, void *in, size_t len)
 {
     CHECK_SPI_DEV(bus);
 
@@ -474,7 +458,7 @@ void IRAM_ATTR spi_transfer_bytes(spi_t bus, spi_cs_t cs, bool cont,
     }
     #endif
 
-    gpio_clear (cs != SPI_CS_UNDEF ? cs : _spi[bus].pin_cs);
+    gpio_clear (cs != SPI_CS_UNDEF ? cs : spi_config[bus].cs);
 
     size_t blocks = len / SPI_BLOCK_SIZE;
     uint8_t tail = len % SPI_BLOCK_SIZE;
@@ -493,7 +477,7 @@ void IRAM_ATTR spi_transfer_bytes(spi_t bus, spi_cs_t cs, bool cont,
                           in  ? (uint8_t *)in + blocks * SPI_BLOCK_SIZE : NULL, tail);
     }
     if (!cont) {
-        gpio_set (cs != SPI_CS_UNDEF ? cs : _spi[bus].pin_cs);
+        gpio_set (cs != SPI_CS_UNDEF ? cs : spi_config[bus].cs);
     }
 
     #if ENABLE_DEBUG
@@ -506,3 +490,5 @@ void IRAM_ATTR spi_transfer_bytes(spi_t bus, spi_cs_t cs, bool cont,
     }
     #endif
 }
+
+#endif /* defined(SPI0_CTRL) || defined(SPI1_CTRL) */

--- a/cpu/esp32/periph/uart.c
+++ b/cpu/esp32/periph/uart.c
@@ -127,12 +127,12 @@ int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
         gpio_set_pin_usage(uart_config[uart].rxd, _UART);
 
         /* connect TxD pin to the TxD output signal through the GPIO matrix */
-        GPIO.func_out_sel_cfg[uart_config[uart].txd].func_sel = __uarts[uart].signal_txd;
+        GPIO.func_out_sel_cfg[uart_config[uart].txd].func_sel = _uarts[uart].signal_txd;
 
         /* connect RxD input signal to the RxD pin through the GPIO matrix */
-        GPIO.func_in_sel_cfg[__uarts[uart].signal_rxd].sig_in_sel = 1;
-        GPIO.func_in_sel_cfg[__uarts[uart].signal_rxd].sig_in_inv = 0;
-        GPIO.func_in_sel_cfg[__uarts[uart].signal_rxd].func_sel = uart_config[uart].rxd;
+        GPIO.func_in_sel_cfg[_uarts[uart].signal_rxd].sig_in_sel = 1;
+        GPIO.func_in_sel_cfg[_uarts[uart].signal_rxd].sig_in_inv = 0;
+        GPIO.func_in_sel_cfg[_uarts[uart].signal_rxd].func_sel = uart_config[uart].rxd;
     }
     _uarts[uart].baudrate = baudrate;
 

--- a/cpu/esp32/periph/uart.c
+++ b/cpu/esp32/periph/uart.c
@@ -119,8 +119,8 @@ int uart_init(uart_t uart, uint32_t baudrate, uart_rx_cb_t rx_cb, void *arg)
         }
 
         /* try to initialize the pins as GPIOs first */
-        if (gpio_init (uart_config[uart].txd, GPIO_OUT) ||
-            gpio_init (uart_config[uart].rxd, GPIO_IN)) {
+        if (gpio_init (uart_config[uart].rxd, GPIO_IN) ||
+            gpio_init (uart_config[uart].txd, GPIO_OUT)) {
             return -1;
         }
 
@@ -161,7 +161,7 @@ void uart_poweron (uart_t uart)
     CHECK_PARAM (uart < UART_NUMOF);
 
     periph_module_enable(_uarts[uart].mod);
-    __uart_config(uart);
+    _uart_config(uart);
 }
 
 void uart_poweroff (uart_t uart)
@@ -184,7 +184,7 @@ void uart_print_config(void)
 {
     for (unsigned uart = 0; uart < UART_NUMOF; uart++) {
         ets_printf("\tUART_DEV(%d)\ttxd=%d rxd=%d\n", uart,
-                   _uarts[uart].pin_txd, _uarts[uart].pin_rxd);
+                   uart_config[uart].txd, uart_config[uart].rxd);
     }
 }
 


### PR DESCRIPTION
### Contribution description

This PR changes the approach of peripheral configurations for ADC, DAC, I2C, SPI and UART in board definitions to the usual RIOT approach. With these changes, peripheral configurations use static const arrays in the `boards/esp32*/periph_conf.h` files and define the `*_NUMOF` macros using the size of these static array.

The static configuration arrays contain only definitions that can be changed by the board definition or the application. They do not contain any MCU implementation detail. The board definitions use preprocessor defines as before to fill these static configuration arrays. This makes it possible to override all configurations either with the make command or application specific configuration files.

### Testing procedure

Compilation and test with the most common ESP32 board should be executed
```
make BOARD=esp32-wroom-32 -C tests/periph_adc flash test
make BOARD=esp32-wroom-32 -C tests/periph_dac flash test
make BOARD=esp32-wroom-32 -C tests/periph_i2c flash test
make BOARD=esp32-wroom-32 -C tests/periph_pwm flash test
make BOARD=esp32-wroom-32 -C tests/periph_spi flash test
make BOARD=esp32-wroom-32 -C tests/periph_uart flash test
```
In addition to the tests above, the PR has been already tested with `tests/driver_lis3dh` and SPI as well as `tests/driver_lis3mdl` and I2C.

### Issues/PRs references

This PR contains also the changes already provided by PRs #10643 and #10641.
