### PR TITLE
boards/nucleo-l433rc: add I2C configuration

### DIFF
--- a/boards/nucleo-l433rc/Makefile.features
+++ b/boards/nucleo-l433rc/Makefile.features
@@ -1,4 +1,5 @@
 # Put defined MCU peripherals here (in alphabetical order)
+FEATURES_PROVIDED += periph_i2c
 FEATURES_PROVIDED += periph_lpuart
 FEATURES_PROVIDED += periph_pwm
 FEATURES_PROVIDED += periph_rtc

--- a/boards/nucleo-l433rc/include/periph_conf.h
+++ b/boards/nucleo-l433rc/include/periph_conf.h
@@ -203,6 +203,29 @@ static const spi_conf_t spi_config[] = {
 /** @} */
 
 /**
+ * @name I2C configuration
+ * @{
+ */
+static const i2c_conf_t i2c_config[] = {
+    {
+        .dev            = I2C1,
+        .speed          = I2C_SPEED_NORMAL,
+        .scl_pin        = GPIO_PIN(PORT_B, 8),
+        .sda_pin        = GPIO_PIN(PORT_B, 7),
+        .scl_af         = GPIO_AF4,
+        .sda_af         = GPIO_AF4,
+        .bus            = APB1,
+        .rcc_mask       = RCC_APB1ENR1_I2C1EN,
+        .irqn           = I2C1_ER_IRQn
+    },
+};
+
+#define I2C_0_ISR           isr_i2c1_er
+
+#define I2C_NUMOF           (sizeof(i2c_config) / sizeof(i2c_config[0]))
+/** @} */
+
+/**
  * @name    RTT configuration
  *
  * On the STM32Lx platforms, we always utilize the LPTIM1.


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

### Contribution description

This PR configure one I2C peripheral for the nucleo-l433rc. I needed it for testing #10610 on L4 on this board and was too lazy for looking for an other one already configured.

<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


### Testing procedure

Build and flash any application that requires I2C, it should work. The I2C is configured to use SDA/SCL pins from the Arduino pinout.

<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


### Issues/PRs references

I needed it for testing #10610 

<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
