### PR TITLE
Improved docs on module name uniqueness

### DIFF
--- a/doc/doxygen/src/creating-modules.md
+++ b/doc/doxygen/src/creating-modules.md
@@ -37,7 +37,8 @@ application's Makefile.
 ### Pitfalls ###
 
 The `MODULE` name should be unique or build breaks as modules overwrite the
-same output file.
+same output file. This might for example lead to `undefined reference to` errors
+in the linker which can be hard to track down.
 
 This problem happened in the past for:
 


### PR DESCRIPTION
<!--
The RIOT community cares a lot about code quality.
Therefore, before describing what your contribution is about, we would like
you to make sure that your modifications are compliant with the RIOT
coding conventions, see https://github.com/RIOT-OS/RIOT/wiki/Coding-conventions.
-->

I ran into `undefined reference to` errors and it was hard for me to track these down to two modules overwriting each others files. Maybe I can save someone else some time with this additional hint.
<!--
Put here the description of your contribution:
- describe which part(s) of RIOT is (are) involved
- if it's a bug fix, describe the bug that it solves and how it is solved
- you can also give more information to reviewers about how to test your changes
-->


<!--
Details steps to test your contribution:
- which test/example to compile for which board and is there a 'test' command
- how to know that it was not working/available in master
- the expected success test output
-->


<!--
Examples: Fixes #1234. See also #5678. Depends on PR #9876.

Please use keywords (e.g., fixes, resolve) with the links to the issues you
resolved, this way they will be automatically closed when your pull request
is merged. See https://help.github.com/articles/closing-issues-using-keywords/.
-->
